### PR TITLE
Editorial: Model execution context as a record

### DIFF
--- a/esmeta-ignore.json
+++ b/esmeta-ignore.json
@@ -8,6 +8,5 @@
   "FunctionBody[0,0].EvaluateFunctionBody",
   "FunctionDeclarationInstantiation",
   "GetViewByteLength",
-  "Record[SourceTextModuleRecord].ExecuteModule",
   "TypedArrayLength"
 ]

--- a/esmeta-ignore.json
+++ b/esmeta-ignore.json
@@ -8,7 +8,6 @@
   "FunctionBody[0,0].EvaluateFunctionBody",
   "FunctionDeclarationInstantiation",
   "GetViewByteLength",
-  "Record[SourceTextModuleRecord].ExecuteModule",
   "SnapToInteger",
   "TypedArrayLength"
 ]

--- a/spec.html
+++ b/spec.html
@@ -11764,7 +11764,7 @@
     <h1>Execution Contexts</h1>
     <p>An <dfn variants="execution contexts">execution context</dfn> is a specification device that is used to track the runtime evaluation of code by an ECMAScript implementation. At any point in time, there is at most one execution context per agent that is actually executing code. This is known as the agent's <dfn id="running-execution-context" variants="running execution contexts">running execution context</dfn>. All references to the running execution context in this specification denote the running execution context of the surrounding agent.</p>
     <p>The <dfn id="execution-context-stack" variants="execution context stacks">execution context stack</dfn> is used to track execution contexts. The running execution context is always the top element of this stack. A new execution context is created whenever control is transferred from the executable code associated with the currently running execution context to executable code that is not associated with that execution context. The newly created execution context is pushed onto the stack and becomes the running execution context.</p>
-    <p>Each execution context is represented as an ExecutionContext Record, with at least the fields listed in <emu-xref href="#table-state-components-for-all-execution-contexts"></emu-xref>.</p>
+    <p>Each execution context is represented as an <dfn variants="ExecutionContext Records">ExecutionContext Record</dfn>, with at least the fields listed in <emu-xref href="#table-state-components-for-all-execution-contexts"></emu-xref>.</p>
     <emu-table id="table-state-components-for-all-execution-contexts" caption="ExecutionContext Record Fields" oldids="table-22">
       <table>
         <thead>

--- a/spec.html
+++ b/spec.html
@@ -4576,7 +4576,7 @@
         <dl class="header">
         </dl>
         <emu-alg>
-          1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+          1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
           1. Assert: _privateEnv_ is not *null*.
           1. Let _privateName_ be ResolvePrivateIdentifier(_privateEnv_, _privateIdentifier_).
           1. Return the Reference Record { [[Base]]: _baseValue_, [[ReferencedName]]: _privateName_, [[Strict]]: *true*, [[ThisValue]]: ~empty~ }.
@@ -11704,10 +11704,10 @@
         1. Perform CreateIntrinsics(_realm_).
         1. Set _realm_.[[AgentSignifier]] to AgentSignifier().
         1. Set _realm_.[[TemplateMap]] to a new empty List.
-        1. Let _newContext_ be a new execution context.
-        1. Set the Function of _newContext_ to *null*.
-        1. Set the Realm of _newContext_ to _realm_.
-        1. Set the ScriptOrModule of _newContext_ to *null*.
+        1. Let _newContext_ be a new ExecutionContext Record.
+        1. Set _newContext_.[[Function]] to *null*.
+        1. Set _newContext_.[[Realm]] to _realm_.
+        1. Set _newContext_.[[ScriptOrModule]] to *null*.
         1. Push _newContext_ onto the execution context stack; _newContext_ is now the running execution context.
         1. If the host requires use of a specific object to serve as _realm_'s global object, then
           1. Let _global_ be such an object created in a host-defined manner.
@@ -11764,22 +11764,28 @@
     <h1>Execution Contexts</h1>
     <p>An <dfn variants="execution contexts">execution context</dfn> is a specification device that is used to track the runtime evaluation of code by an ECMAScript implementation. At any point in time, there is at most one execution context per agent that is actually executing code. This is known as the agent's <dfn id="running-execution-context" variants="running execution contexts">running execution context</dfn>. All references to the running execution context in this specification denote the running execution context of the surrounding agent.</p>
     <p>The <dfn id="execution-context-stack" variants="execution context stacks">execution context stack</dfn> is used to track execution contexts. The running execution context is always the top element of this stack. A new execution context is created whenever control is transferred from the executable code associated with the currently running execution context to executable code that is not associated with that execution context. The newly created execution context is pushed onto the stack and becomes the running execution context.</p>
-    <p>An execution context contains whatever implementation specific state is necessary to track the execution progress of its associated code. Each execution context has at least the state components listed in <emu-xref href="#table-state-components-for-all-execution-contexts"></emu-xref>.</p>
-    <emu-table id="table-state-components-for-all-execution-contexts" caption="State Components for All Execution Contexts" oldids="table-22">
+    <p>Each execution context is represented as an ExecutionContext Record, with at least the fields listed in <emu-xref href="#table-state-components-for-all-execution-contexts"></emu-xref>.</p>
+    <emu-table id="table-state-components-for-all-execution-contexts" caption="ExecutionContext Record Fields" oldids="table-22">
       <table>
         <thead>
           <tr>
             <th>
-              Component
+              Field Name
             </th>
             <th>
-              Purpose
+              Value Type
+            </th>
+            <th>
+              Meaning
             </th>
           </tr>
         </thead>
         <tr>
           <td>
-            code evaluation state
+            [[CodeEvaluationState]]
+          </td>
+          <td>
+            implementation-specific
           </td>
           <td>
             Any state needed to perform, suspend, and resume evaluation of the code associated with this execution context.
@@ -11787,15 +11793,21 @@
         </tr>
         <tr>
           <td>
-            Function
+            [[Function]]
           </td>
           <td>
-            If this execution context is evaluating the code of a function object, then the value of this component is that function object. If the context is evaluating the code of a |Script| or |Module|, the value is *null*.
+            a function object or *null*
+          </td>
+          <td>
+            If this execution context is evaluating the code of a function object, then the value of this field is that function object. If the context is evaluating the code of a |Script| or |Module|, the value is *null*.
           </td>
         </tr>
         <tr>
           <td>
-            Realm
+            [[Realm]]
+          </td>
+          <td>
+            a Realm Record
           </td>
           <td>
             The Realm Record from which associated code accesses ECMAScript resources.
@@ -11803,32 +11815,41 @@
         </tr>
         <tr>
           <td>
-            ScriptOrModule
+            [[ScriptOrModule]]
           </td>
           <td>
-            The Module Record or Script Record from which associated code originates. If there is no originating script or module, as is the case for the original execution context created in InitializeHostDefinedRealm, the value is *null*.
+            a Module Record, a Script Record, or *null*
+          </td>
+          <td>
+            The Module Record or Script Record from which associated code originates. If there is no originating script or module, as is the case for the original ExecutionContext Record created in InitializeHostDefinedRealm, the value is *null*.
           </td>
         </tr>
       </table>
     </emu-table>
     <p>Evaluation of code by the running execution context may be suspended at various points defined within this specification. Once the running execution context has been suspended a different execution context may become the running execution context and commence evaluating its code. At some later time a suspended execution context may again become the running execution context and continue evaluating its code at the point where it had previously been suspended. Transition of the running execution context status among execution contexts usually occurs in stack-like last-in/first-out manner. However, some ECMAScript features require non-LIFO transitions of the running execution context.</p>
-    <p>The value of the Realm component of the running execution context is also called <dfn id="current-realm">the current Realm Record</dfn>. The value of the Function component of the running execution context is also called the <dfn id="active-function-object">active function object</dfn>.</p>
-    <p><dfn id="ecmascript-code-execution-context" variants="ECMAScript code execution context">ECMAScript code execution contexts</dfn> have the additional state components listed in <emu-xref href="#table-additional-state-components-for-ecmascript-code-execution-contexts"></emu-xref>.</p>
-    <emu-table id="table-additional-state-components-for-ecmascript-code-execution-contexts" caption="Additional State Components for ECMAScript Code Execution Contexts" oldids="table-23">
+    <p>The value of the running execution context's [[Realm]] field is also called <dfn id="current-realm">the current Realm Record</dfn>. The value of the running execution context's [[Function]] field is also called the <dfn id="active-function-object">active function object</dfn>.</p>
+    <p><dfn id="ecmascript-code-execution-context" variants="ECMAScript code ExecutionContext Record">ECMAScript code ExecutionContext Records</dfn> have the additional fields listed in <emu-xref href="#table-additional-state-components-for-ecmascript-code-execution-contexts"></emu-xref>.</p>
+    <emu-table id="table-additional-state-components-for-ecmascript-code-execution-contexts" caption="Additional Fields of ECMAScript Code ExecutionContext Records" oldids="table-23">
       <table>
         <thead>
           <tr>
             <th>
-              Component
+              Field Name
             </th>
             <th>
-              Purpose
+              Value Type
+            </th>
+            <th>
+              Meaning
             </th>
           </tr>
         </thead>
         <tr>
           <td>
-            LexicalEnvironment
+            [[LexicalEnvironment]]
+          </td>
+          <td>
+            an Environment Record
           </td>
           <td>
             Identifies the Environment Record used to resolve identifier references made by code within this execution context.
@@ -11836,7 +11857,10 @@
         </tr>
         <tr>
           <td>
-            VariableEnvironment
+            [[VariableEnvironment]]
+          </td>
+          <td>
+            an Environment Record
           </td>
           <td>
             Identifies the Environment Record that holds bindings created by |VariableStatement|s within this execution context.
@@ -11844,7 +11868,10 @@
         </tr>
         <tr>
           <td>
-            PrivateEnvironment
+            [[PrivateEnvironment]]
+          </td>
+          <td>
+            a PrivateEnvironment Record or *null*
           </td>
           <td>
             Identifies the PrivateEnvironment Record that holds Private Names created by |ClassElement|s in the nearest containing class. *null* if there is no containing class.
@@ -11852,23 +11879,28 @@
         </tr>
       </table>
     </emu-table>
-    <p>The LexicalEnvironment and VariableEnvironment components of an execution context are always Environment Records.</p>
-    <p>Execution contexts representing the evaluation of Generators have the additional state components listed in <emu-xref href="#table-additional-state-components-for-generator-execution-contexts"></emu-xref>.</p>
-    <emu-table id="table-additional-state-components-for-generator-execution-contexts" caption="Additional State Components for Generator Execution Contexts" oldids="table-24">
+    <p>ExecutionContext Records representing the evaluation of Generators have the additional fields listed in <emu-xref href="#table-additional-state-components-for-generator-execution-contexts"></emu-xref>.</p>
+    <emu-table id="table-additional-state-components-for-generator-execution-contexts" caption="Additional Fields of Generator ExecutionContext Records" oldids="table-24">
       <table>
         <thead>
           <tr>
             <th>
-              Component
+              Field Name
             </th>
             <th>
-              Purpose
+              Value Type
+            </th>
+            <th>
+              Meaning
             </th>
           </tr>
         </thead>
         <tr>
           <td>
-            Generator
+            [[Generator]]
+          </td>
+          <td>
+            an Object
           </td>
           <td>
             The Generator that this execution context is evaluating.
@@ -11876,7 +11908,7 @@
         </tr>
       </table>
     </emu-table>
-    <p>In most situations only the running execution context (the top of the execution context stack) is directly manipulated by algorithms within this specification. Hence when the terms “LexicalEnvironment”, and “VariableEnvironment” are used without qualification they are in reference to those components of the running execution context.</p>
+    <p>In most situations only the running execution context (the top of the execution context stack) is directly manipulated by algorithms within this specification.</p>
     <p>An execution context is purely a specification mechanism and need not correspond to any particular artefact of an ECMAScript implementation. It is impossible for ECMAScript code to directly access or observe an execution context.</p>
 
     <emu-clause id="sec-getactivescriptormodule" type="abstract operation">
@@ -11888,9 +11920,9 @@
 
       <emu-alg>
         1. If the execution context stack is empty, return *null*.
-        1. Let _ec_ be the topmost execution context on the execution context stack whose ScriptOrModule component is not *null*.
-        1. If no such execution context exists, return *null*.
-        1. Return _ec_'s ScriptOrModule.
+        1. Let _ec_ be the topmost ExecutionContext Record on the execution context stack whose [[ScriptOrModule]] field is not *null*.
+        1. If no such ExecutionContext Record exists, return *null*.
+        1. Return _ec_.[[ScriptOrModule]].
       </emu-alg>
     </emu-clause>
 
@@ -11907,7 +11939,7 @@
       </dl>
       <emu-alg>
         1. If _env_ is not present or _env_ is *undefined*, then
-          1. Set _env_ to the running execution context's LexicalEnvironment.
+          1. Set _env_ to the running execution context's [[LexicalEnvironment]].
         1. Assert: _env_ is an Environment Record.
         1. Let _strict_ be IsStrict(the syntactic production that is being evaluated).
         1. Return ? GetIdentifierReference(_env_, _name_, _strict_).
@@ -11924,7 +11956,7 @@
         <dd>It finds the Environment Record that currently supplies the binding of the keyword `this`.</dd>
       </dl>
       <emu-alg>
-        1. Let _env_ be the running execution context's LexicalEnvironment.
+        1. Let _env_ be the running execution context's [[LexicalEnvironment]].
         1. [id="step-getthisenvironment-loop"] Repeat,
           1. Let _exists_ be _env_.HasThisBinding().
           1. If _exists_ is *true*, return _env_.
@@ -11941,7 +11973,7 @@
       <h1>ResolveThisBinding ( ): either a normal completion containing an ECMAScript language value or a throw completion</h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It determines the binding of the keyword `this` using the LexicalEnvironment of the running execution context.</dd>
+        <dd>It determines the binding of the keyword `this` using the running execution context's [[LexicalEnvironment]].</dd>
       </dl>
       <emu-alg>
         1. Let _envRec_ be GetThisEnvironment().
@@ -11953,7 +11985,7 @@
       <h1>GetNewTarget ( ): an Object or *undefined*</h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It determines the NewTarget value using the LexicalEnvironment of the running execution context.</dd>
+        <dd>It determines the NewTarget value using the running execution context's [[LexicalEnvironment]].</dd>
       </dl>
       <emu-alg>
         1. Let _envRec_ be GetThisEnvironment().
@@ -11977,7 +12009,7 @@
     <emu-clause id="sec-runsuspendedcontext" type="abstract operation">
       <h1>
         RunSuspendedContext (
-          _context_: an execution context,
+          _context_: an ExecutionContext Record,
           _completionRecord_: a Completion Record,
         ): either a normal completion containing either an ECMAScript language value or ~unused~, or an abrupt completion
       </h1>
@@ -12021,18 +12053,18 @@
     <p>At any particular time, _scriptOrModule_ (a Script Record, a Module Record, or *null*) is the <dfn id="job-activescriptormodule">active script or module</dfn> if all of the following conditions are true:</p>
     <ul>
       <li>GetActiveScriptOrModule() is _scriptOrModule_.</li>
-      <li>If _scriptOrModule_ is a Script Record or Module Record, let _ec_ be the topmost execution context on the execution context stack whose ScriptOrModule component is _scriptOrModule_. The Realm component of _ec_ is _scriptOrModule_.[[Realm]].</li>
+      <li>If _scriptOrModule_ is a Script Record or Module Record, let _ec_ be the topmost ExecutionContext Record on the execution context stack whose [[ScriptOrModule]] field is _scriptOrModule_. _ec_.[[Realm]] is _scriptOrModule_.[[Realm]].</li>
     </ul>
 
     <p>At any particular time, an execution is <dfn id="job-preparedtoevaluatecode">prepared to evaluate ECMAScript code</dfn> if all of the following conditions are true:</p>
     <ul>
       <li>The execution context stack is not empty.</li>
-      <li>The Realm component of the topmost execution context on the execution context stack is a Realm Record.</li>
+      <li>The [[Realm]] field of the topmost ExecutionContext Record on the execution context stack is a Realm Record.</li>
     </ul>
 
     <emu-note>
-      <p>Host environments may prepare an execution to evaluate code by pushing execution contexts onto the execution context stack. The specific steps are implementation-defined.</p>
-      <p>The specific choice of Realm is up to the host environment. This initial execution context and Realm is only in use before any callback function is invoked. When a callback function related to a Job, like a Promise handler, is invoked, the invocation pushes its own execution context and Realm.</p>
+      <p>Host environments may prepare an execution to evaluate code by pushing ExecutionContext Records onto the execution context stack. The specific steps are implementation-defined.</p>
+      <p>The specific choice of Realm is up to the host environment. This initial ExecutionContext Record and Realm is only in use before any callback function is invoked. When a callback function related to a Job, like a Promise handler, is invoked, the invocation pushes its own ExecutionContext Record and Realm.</p>
     </emu-note>
 
     <p>Particular kinds of Jobs have additional conformance requirements.</p>
@@ -13373,21 +13405,21 @@
           PrepareForOrdinaryCall (
             _func_: an ECMAScript function object,
             _newTarget_: an Object or *undefined*,
-          ): an execution context
+          ): an ExecutionContext Record
         </h1>
         <dl class="header">
         </dl>
         <emu-alg>
           1. Let _callerContext_ be the running execution context.
-          1. Let _calleeContext_ be a new ECMAScript code execution context.
-          1. Set the Function of _calleeContext_ to _func_.
+          1. Let _calleeContext_ be a new ECMAScript code ExecutionContext Record.
+          1. Set _calleeContext_.[[Function]] to _func_.
           1. Let _calleeRealm_ be _func_.[[Realm]].
-          1. Set the Realm of _calleeContext_ to _calleeRealm_.
-          1. Set the ScriptOrModule of _calleeContext_ to _func_.[[ScriptOrModule]].
+          1. Set _calleeContext_.[[Realm]] to _calleeRealm_.
+          1. Set _calleeContext_.[[ScriptOrModule]] to _func_.[[ScriptOrModule]].
           1. Let _localEnv_ be NewFunctionEnvironment(_func_, _newTarget_).
-          1. Set the LexicalEnvironment of _calleeContext_ to _localEnv_.
-          1. Set the VariableEnvironment of _calleeContext_ to _localEnv_.
-          1. Set the PrivateEnvironment of _calleeContext_ to _func_.[[PrivateEnvironment]].
+          1. Set _calleeContext_.[[LexicalEnvironment]] to _localEnv_.
+          1. Set _calleeContext_.[[VariableEnvironment]] to _localEnv_.
+          1. Set _calleeContext_.[[PrivateEnvironment]] to _func_.[[PrivateEnvironment]].
           1. If _callerContext_ is not already suspended, suspend _callerContext_.
           1. Push _calleeContext_ onto the execution context stack; _calleeContext_ is now the running execution context.
           1. NOTE: Any exception objects produced after this point are associated with _calleeRealm_.
@@ -13399,7 +13431,7 @@
         <h1>
           OrdinaryCallBindThis (
             _func_: an ECMAScript function object,
-            _calleeContext_: an execution context,
+            _calleeContext_: an ExecutionContext Record,
             _thisArgument_: an ECMAScript language value,
           ): ~unused~
         </h1>
@@ -13409,7 +13441,7 @@
           1. Let _thisMode_ be _func_.[[ThisMode]].
           1. If _thisMode_ is ~lexical~, return ~unused~.
           1. Let _calleeRealm_ be _func_.[[Realm]].
-          1. Let _localEnv_ be the LexicalEnvironment of _calleeContext_.
+          1. Let _localEnv_ be _calleeContext_.[[LexicalEnvironment]].
           1. If _thisMode_ is ~strict~, then
             1. Let _thisValue_ be _thisArgument_.
           1. Else,
@@ -13531,7 +13563,7 @@
           1. If _initializeResult_ is an abrupt completion, then
             1. Remove _calleeContext_ from the execution context stack and restore _callerContext_ as the running execution context.
             1. Return ? _initializeResult_.
-        1. Let _constructorEnv_ be the LexicalEnvironment of _calleeContext_.
+        1. Let _constructorEnv_ be _calleeContext_.[[LexicalEnvironment]].
         1. Let _result_ be Completion(OrdinaryCallEvaluateBody(_func_, _argumentsList_)).
         1. Remove _calleeContext_ from the execution context stack and restore _callerContext_ as the running execution context.
         1. If _result_ is a throw completion, then
@@ -13801,13 +13833,13 @@
             1. Set _argumentsObjectNeeded_ to *false*.
         1. If _strict_ is *true* or _hasParameterExpressions_ is *false*, then
           1. NOTE: Only a single Environment Record is needed for the parameters, since calls to `eval` in strict mode code cannot create new bindings which are visible outside of the `eval`.
-          1. Let _env_ be the LexicalEnvironment of _calleeContext_.
+          1. Let _env_ be _calleeContext_.[[LexicalEnvironment]].
         1. Else,
           1. NOTE: A separate Environment Record is needed to ensure that bindings created by direct eval calls in the formal parameter list are outside the environment where parameters are declared.
-          1. Let _calleeEnv_ be the LexicalEnvironment of _calleeContext_.
+          1. Let _calleeEnv_ be _calleeContext_.[[LexicalEnvironment]].
           1. Let _env_ be NewDeclarativeEnvironment(_calleeEnv_).
-          1. Assert: The VariableEnvironment of _calleeContext_ and _calleeEnv_ are the same Environment Record.
-          1. Set the LexicalEnvironment of _calleeContext_ to _env_.
+          1. Assert: _calleeContext_.[[VariableEnvironment]] and _calleeEnv_ are the same Environment Record.
+          1. Set _calleeContext_.[[LexicalEnvironment]] to _env_.
         1. For each String _paramName_ of _parameterNames_, do
           1. Let _alreadyDeclared_ be ! _env_.HasBinding(_paramName_).
           1. NOTE: Early errors ensure that duplicate parameter names can only occur in non-strict functions that do not have parameter default values or rest parameters.
@@ -13849,7 +13881,7 @@
         1. Else,
           1. NOTE: A separate Environment Record is needed to ensure that closures created by expressions in the formal parameter list do not have visibility of declarations in the function body.
           1. Let _varEnv_ be NewDeclarativeEnvironment(_env_).
-          1. Set the VariableEnvironment of _calleeContext_ to _varEnv_.
+          1. Set _calleeContext_.[[VariableEnvironment]] to _varEnv_.
           1. Let _instantiatedVarNames_ be a new empty List.
           1. For each element _n_ of _varNames_, do
             1. If _instantiatedVarNames_ does not contain _n_, then
@@ -13874,14 +13906,14 @@
                   1. Perform ! _varEnv_.InitializeBinding(_funcName_, *undefined*).
                   1. Append _funcName_ to _instantiatedVarNames_.
                 1. [id="step-functiondeclarationinstantiation-alt-funcdecl-eval"] When the |FunctionDeclaration| _fnDecl_ is evaluated, perform the following steps in place of the |FunctionDeclaration| Evaluation algorithm provided in <emu-xref href="#sec-function-definitions-runtime-semantics-evaluation"></emu-xref>:
-                  1. Let _fEnv_ be the running execution context's VariableEnvironment.
-                  1. Let _bEnv_ be the running execution context's LexicalEnvironment.
+                  1. Let _fEnv_ be the running execution context's [[VariableEnvironment]].
+                  1. Let _bEnv_ be the running execution context's [[LexicalEnvironment]].
                   1. Let _fObj_ be ! _bEnv_.GetBindingValue(_funcName_, *false*).
                   1. Perform ! _fEnv_.SetMutableBinding(_funcName_, _fObj_, *false*).
                   1. Return ~unused~.
           1. Let _lexEnv_ be NewDeclarativeEnvironment(_varEnv_).
           1. NOTE: Non-strict functions use a separate Environment Record for top-level lexical declarations so that a direct eval can determine whether any var scoped declarations introduced by the eval code conflict with pre-existing top-level lexically scoped declarations. This is not needed for strict functions because a strict direct eval always places all declarations into a new Environment Record.
-        1. Set the LexicalEnvironment of _calleeContext_ to _lexEnv_.
+        1. Set _calleeContext_.[[LexicalEnvironment]] to _lexEnv_.
         1. Let _lexDeclarations_ be the LexicallyScopedDeclarations of _code_.
         1. For each element _lexDecl_ of _lexDeclarations_, do
           1. NOTE: A lexically declared name cannot be the same as a function/generator declaration, formal parameter, or a var name. Lexically declared names are only instantiated here but not initialized.
@@ -13890,7 +13922,7 @@
               1. Perform ! _lexEnv_.CreateImmutableBinding(_dn_, *true*).
             1. Else,
               1. Perform ! _lexEnv_.CreateMutableBinding(_dn_, *false*).
-        1. Let _privateEnv_ be the PrivateEnvironment of _calleeContext_.
+        1. Let _privateEnv_ be _calleeContext_.[[PrivateEnvironment]].
         1. For each Parse Node _fnDecl_ of _functionsToInitialize_, do
           1. Let _fn_ be the sole element of the BoundNames of _fnDecl_.
           1. Let _fo_ be InstantiateFunctionObject of _fnDecl_ with arguments _lexEnv_ and _privateEnv_.
@@ -13962,11 +13994,11 @@
       <emu-alg>
         1. Let _callerContext_ be the running execution context.
         1. If _callerContext_ is not already suspended, suspend _callerContext_.
-        1. Let _calleeContext_ be a new execution context.
-        1. Set the Function of _calleeContext_ to _func_.
+        1. Let _calleeContext_ be a new ExecutionContext Record.
+        1. Set _calleeContext_.[[Function]] to _func_.
         1. Let _calleeRealm_ be _func_.[[Realm]].
-        1. Set the Realm of _calleeContext_ to _calleeRealm_.
-        1. Set the ScriptOrModule of _calleeContext_ to *null*.
+        1. Set _calleeContext_.[[Realm]] to _calleeRealm_.
+        1. Set _calleeContext_.[[ScriptOrModule]] to *null*.
         1. Perform any necessary implementation-defined initialization of _calleeContext_.
         1. Push _calleeContext_ onto the execution context stack; _calleeContext_ is now the running execution context.
         1. If _func_.[[Async]] is *true*, then
@@ -20465,7 +20497,7 @@
         1. Let _rRef_ be ? Evaluation of |ShiftExpression|.
         1. Let _rVal_ be ? GetValue(_rRef_).
         1. If _rVal_ is not an Object, throw a *TypeError* exception.
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Assert: _privateEnv_ is not *null*.
         1. Let _privateName_ be ResolvePrivateIdentifier(_privateEnv_, _privateIdentifier_).
         1. If PrivateElementFind(_rVal_, _privateName_) is ~empty~, return *false*.
@@ -21424,16 +21456,16 @@
       </emu-alg>
       <emu-grammar>Block : `{` StatementList `}`</emu-grammar>
       <emu-alg>
-        1. Let _oldEnv_ be the running execution context's LexicalEnvironment.
+        1. Let _oldEnv_ be the running execution context's [[LexicalEnvironment]].
         1. Let _blockEnv_ be NewDeclarativeEnvironment(_oldEnv_).
         1. Perform BlockDeclarationInstantiation(|StatementList|, _blockEnv_).
-        1. Set the running execution context's LexicalEnvironment to _blockEnv_.
+        1. Set the running execution context's [[LexicalEnvironment]] to _blockEnv_.
         1. Let _blockValue_ be Completion(Evaluation of |StatementList|).
-        1. Set the running execution context's LexicalEnvironment to _oldEnv_.
+        1. Set the running execution context's [[LexicalEnvironment]] to _oldEnv_.
         1. Return ? _blockValue_.
       </emu-alg>
       <emu-note>
-        <p>No matter how control leaves the |Block| the LexicalEnvironment is always restored to its former state.</p>
+        <p>No matter how control leaves the |Block| the [[LexicalEnvironment]] is always restored to its former state.</p>
       </emu-note>
       <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
       <emu-alg>
@@ -21468,7 +21500,7 @@
       <p>It performs the following steps when called:</p>
       <emu-alg>
         1. Let _declarations_ be the LexicallyScopedDeclarations of _code_.
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. For each element _decl_ of _declarations_, do
           1. For each element _dn_ of the BoundNames of _decl_, do
             1. If IsConstantDeclaration of _decl_ is *true*, then
@@ -21501,7 +21533,7 @@
     <emu-clause id="sec-let-and-const-declarations">
       <h1>Let and Const Declarations</h1>
       <emu-note>
-        <p>`let` and `const` declarations define variables that are scoped to the running execution context's LexicalEnvironment. The variables are created when their containing Environment Record is instantiated but may not be accessed in any way until the variable's |LexicalBinding| is evaluated. A variable defined by a |LexicalBinding| with an |Initializer| is assigned the value of its |Initializer|'s |AssignmentExpression| when the |LexicalBinding| is evaluated, not when the variable is created. If a |LexicalBinding| in a `let` declaration does not have an |Initializer| the variable is assigned the value *undefined* when the |LexicalBinding| is evaluated.</p>
+        <p>`let` and `const` declarations define variables that are scoped to the running execution context's [[LexicalEnvironment]]. The variables are created when their containing Environment Record is instantiated but may not be accessed in any way until the variable's |LexicalBinding| is evaluated. A variable defined by a |LexicalBinding| with an |Initializer| is assigned the value of its |Initializer|'s |AssignmentExpression| when the |LexicalBinding| is evaluated, not when the variable is created. If a |LexicalBinding| in a `let` declaration does not have an |Initializer| the variable is assigned the value *undefined* when the |LexicalBinding| is evaluated.</p>
       </emu-note>
       <h2>Syntax</h2>
       <emu-grammar type="definition">
@@ -21577,7 +21609,7 @@
         <emu-alg>
           1. Let _rhs_ be ? Evaluation of |Initializer|.
           1. Let _value_ be ? GetValue(_rhs_).
-          1. Let _env_ be the running execution context's LexicalEnvironment.
+          1. Let _env_ be the running execution context's [[LexicalEnvironment]].
           1. Return ? BindingInitialization of |BindingPattern| with arguments _value_ and _env_.
         </emu-alg>
       </emu-clause>
@@ -21586,7 +21618,7 @@
     <emu-clause id="sec-variable-statement">
       <h1>Variable Statement</h1>
       <emu-note>
-        <p>A `var` statement declares variables that are scoped to the running execution context's VariableEnvironment. Var variables are created when their containing Environment Record is instantiated and are initialized to *undefined* when created. Within the scope of any VariableEnvironment a common |BindingIdentifier| may appear in more than one |VariableDeclaration| but those declarations collectively define only one variable. A variable defined by a |VariableDeclaration| with an |Initializer| is assigned the value of its |Initializer|'s |AssignmentExpression| when the |VariableDeclaration| is executed, not when the variable is created.</p>
+        <p>A `var` statement declares variables that are scoped to the running execution context's [[VariableEnvironment]]. Var variables are created when their containing Environment Record is instantiated and are initialized to *undefined* when created. Within the scope of any [[VariableEnvironment]] a common |BindingIdentifier| may appear in more than one |VariableDeclaration| but those declarations collectively define only one variable. A variable defined by a |VariableDeclaration| with an |Initializer| is assigned the value of its |Initializer|'s |AssignmentExpression| when the |VariableDeclaration| is executed, not when the variable is created.</p>
       </emu-note>
       <h2>Syntax</h2>
       <emu-grammar type="definition">
@@ -21631,7 +21663,7 @@
           1. Return ~empty~.
         </emu-alg>
         <emu-note>
-          <p>If a |VariableDeclaration| is nested within a with statement and the |BindingIdentifier| in the |VariableDeclaration| is the same as a property name of the binding object of the with statement's Object Environment Record, then step <emu-xref href="#step-vardecllist-evaluation-putvalue"></emu-xref> will assign _value_ to the property instead of assigning to the VariableEnvironment binding of the |Identifier|.</p>
+          <p>If a |VariableDeclaration| is nested within a with statement and the |BindingIdentifier| in the |VariableDeclaration| is the same as a property name of the binding object of the with statement's Object Environment Record, then step <emu-xref href="#step-vardecllist-evaluation-putvalue"></emu-xref> will assign _value_ to the property instead of assigning to the [[VariableEnvironment]] binding of the |Identifier|.</p>
         </emu-note>
         <emu-grammar>VariableDeclaration : BindingPattern Initializer</emu-grammar>
         <emu-alg>
@@ -22084,7 +22116,7 @@
         </emu-alg>
         <emu-grammar>ForStatement : `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement</emu-grammar>
         <emu-alg>
-          1. Let _oldEnv_ be the running execution context's LexicalEnvironment.
+          1. Let _oldEnv_ be the running execution context's [[LexicalEnvironment]].
           1. Let _loopEnv_ be NewDeclarativeEnvironment(_oldEnv_).
           1. Let _isConst_ be IsConstantDeclaration of |LexicalDeclaration|.
           1. Let _boundNames_ be the BoundNames of |LexicalDeclaration|.
@@ -22093,16 +22125,16 @@
               1. Perform ! _loopEnv_.CreateImmutableBinding(_dn_, *true*).
             1. Else,
               1. Perform ! _loopEnv_.CreateMutableBinding(_dn_, *false*).
-          1. Set the running execution context's LexicalEnvironment to _loopEnv_.
+          1. Set the running execution context's [[LexicalEnvironment]] to _loopEnv_.
           1. Let _forDcl_ be Completion(Evaluation of |LexicalDeclaration|).
           1. If _forDcl_ is an abrupt completion, then
-            1. Set the running execution context's LexicalEnvironment to _oldEnv_.
+            1. Set the running execution context's [[LexicalEnvironment]] to _oldEnv_.
             1. Return ? _forDcl_.
           1. If _isConst_ is *false*, let _perIterationLets_ be _boundNames_; else let _perIterationLets_ be a new empty List.
           1. If the first |Expression| is present, let _test_ be the first |Expression|; else let _test_ be ~empty~.
           1. If the second |Expression| is present, let _increment_ be the second |Expression|; else let _increment_ be ~empty~.
           1. Let _bodyResult_ be Completion(ForBodyEvaluation(_test_, _increment_, |Statement|, _perIterationLets_, _labelSet_)).
-          1. Set the running execution context's LexicalEnvironment to _oldEnv_.
+          1. Set the running execution context's [[LexicalEnvironment]] to _oldEnv_.
           1. Return ? _bodyResult_.
         </emu-alg>
       </emu-clause>
@@ -22147,7 +22179,7 @@
         </dl>
         <emu-alg>
           1. If _perIterationBindings_ has any elements, then
-            1. Let _lastIterationEnv_ be the running execution context's LexicalEnvironment.
+            1. Let _lastIterationEnv_ be the running execution context's [[LexicalEnvironment]].
             1. Let _outer_ be _lastIterationEnv_.[[OuterEnv]].
             1. Assert: _outer_ is not *null*.
             1. Let _thisIterationEnv_ be NewDeclarativeEnvironment(_outer_).
@@ -22155,7 +22187,7 @@
               1. Perform ! _thisIterationEnv_.CreateMutableBinding(_bn_, *false*).
               1. Let _lastValue_ be ? _lastIterationEnv_.GetBindingValue(_bn_, *true*).
               1. Perform ! _thisIterationEnv_.InitializeBinding(_bn_, _lastValue_).
-            1. Set the running execution context's LexicalEnvironment to _thisIterationEnv_.
+            1. Set the running execution context's [[LexicalEnvironment]] to _thisIterationEnv_.
           1. Return ~unused~.
         </emu-alg>
       </emu-clause>
@@ -22397,15 +22429,15 @@
         <dl class="header">
         </dl>
         <emu-alg>
-          1. Let _oldEnv_ be the running execution context's LexicalEnvironment.
+          1. Let _oldEnv_ be the running execution context's [[LexicalEnvironment]].
           1. If _uninitializedBoundNames_ is not empty, then
             1. Assert: _uninitializedBoundNames_ has no duplicate entries.
             1. Let _newEnv_ be NewDeclarativeEnvironment(_oldEnv_).
             1. For each String _name_ of _uninitializedBoundNames_, do
               1. Perform ! _newEnv_.CreateMutableBinding(_name_, *false*).
-            1. Set the running execution context's LexicalEnvironment to _newEnv_.
+            1. Set the running execution context's [[LexicalEnvironment]] to _newEnv_.
           1. Let _exprRef_ be Completion(Evaluation of _expr_).
-          1. Set the running execution context's LexicalEnvironment to _oldEnv_.
+          1. Set the running execution context's [[LexicalEnvironment]] to _oldEnv_.
           1. Let _exprValue_ be ? GetValue(? _exprRef_).
           1. If _iterationKind_ is ~enumerate~, then
             1. If _exprValue_ is either *undefined* or *null*, then
@@ -22437,7 +22469,7 @@
         </dl>
         <emu-alg>
           1. If _iteratorKind_ is not present, set _iteratorKind_ to ~sync~.
-          1. Let _oldEnv_ be the running execution context's LexicalEnvironment.
+          1. Let _oldEnv_ be the running execution context's [[LexicalEnvironment]].
           1. Let _iterationResult_ be *undefined*.
           1. Let _destructuring_ be IsDestructuring of _lhs_.
           1. If _destructuring_ is *true* and _lhsKind_ is ~assignment~, then
@@ -22470,7 +22502,7 @@
               1. Assert: _lhs_ is a |ForDeclaration|.
               1. Let _iterationEnv_ be NewDeclarativeEnvironment(_oldEnv_).
               1. Perform ForDeclarationBindingInstantiation of _lhs_ with argument _iterationEnv_.
-              1. Set the running execution context's LexicalEnvironment to _iterationEnv_.
+              1. Set the running execution context's [[LexicalEnvironment]] to _iterationEnv_.
               1. If _destructuring_ is *true*, then
                 1. Let _status_ be Completion(ForDeclarationBindingInitialization of _lhs_ with arguments _nextValue_ and _iterationEnv_).
               1. Else,
@@ -22479,13 +22511,13 @@
                 1. Let _lhsRef_ be ! ResolveBinding(_lhsName_).
                 1. Let _status_ be Completion(InitializeReferencedBinding(_lhsRef_, _nextValue_)).
             1. If _status_ is an abrupt completion, then
-              1. Set the running execution context's LexicalEnvironment to _oldEnv_.
+              1. Set the running execution context's [[LexicalEnvironment]] to _oldEnv_.
               1. If _iterationKind_ is ~enumerate~, return ? _status_.
               1. Assert: _iterationKind_ is ~iterate~.
               1. If _iteratorKind_ is ~async~, return ? AsyncIteratorClose(_iteratorRecord_, _status_).
               1. Return ? IteratorClose(_iteratorRecord_, _status_).
             1. Let _result_ be Completion(Evaluation of _stmt_).
-            1. Set the running execution context's LexicalEnvironment to _oldEnv_.
+            1. Set the running execution context's [[LexicalEnvironment]] to _oldEnv_.
             1. If LoopContinues(_result_, _labelSet_) is *false*, then
               1. Set _status_ to Completion(UpdateEmpty(_result_, _iterationResult_)).
               1. If _iterationKind_ is ~enumerate~, return ? _status_.
@@ -22827,15 +22859,15 @@
       <emu-alg>
         1. Let _val_ be ? Evaluation of |Expression|.
         1. Let _obj_ be ? ToObject(? GetValue(_val_)).
-        1. Let _oldEnv_ be the running execution context's LexicalEnvironment.
+        1. Let _oldEnv_ be the running execution context's [[LexicalEnvironment]].
         1. Let _newEnv_ be NewObjectEnvironment(_obj_, *true*, _oldEnv_).
-        1. Set the running execution context's LexicalEnvironment to _newEnv_.
+        1. Set the running execution context's [[LexicalEnvironment]] to _newEnv_.
         1. Let _stmtCompletion_ be Completion(Evaluation of |Statement|).
-        1. Set the running execution context's LexicalEnvironment to _oldEnv_.
+        1. Set the running execution context's [[LexicalEnvironment]] to _oldEnv_.
         1. Return ? UpdateEmpty(_stmtCompletion_, *undefined*).
       </emu-alg>
       <emu-note>
-        <p>No matter how control leaves the embedded |Statement|, whether normally or by some form of abrupt completion or exception, the LexicalEnvironment is always restored to its former state.</p>
+        <p>No matter how control leaves the embedded |Statement|, whether normally or by some form of abrupt completion or exception, the [[LexicalEnvironment]] is always restored to its former state.</p>
       </emu-note>
     </emu-clause>
   </emu-clause>
@@ -22974,16 +23006,16 @@
       <emu-alg>
         1. Let _exprRef_ be ? Evaluation of |Expression|.
         1. Let _switchValue_ be ? GetValue(_exprRef_).
-        1. Let _oldEnv_ be the running execution context's LexicalEnvironment.
+        1. Let _oldEnv_ be the running execution context's [[LexicalEnvironment]].
         1. Let _blockEnv_ be NewDeclarativeEnvironment(_oldEnv_).
         1. Perform BlockDeclarationInstantiation(|CaseBlock|, _blockEnv_).
-        1. Set the running execution context's LexicalEnvironment to _blockEnv_.
+        1. Set the running execution context's [[LexicalEnvironment]] to _blockEnv_.
         1. Let _blockResult_ be Completion(CaseBlockEvaluation of |CaseBlock| with argument _switchValue_).
-        1. Set the running execution context's LexicalEnvironment to _oldEnv_.
+        1. Set the running execution context's [[LexicalEnvironment]] to _oldEnv_.
         1. Return _blockResult_.
       </emu-alg>
       <emu-note>
-        <p>No matter how control leaves the |SwitchStatement| the LexicalEnvironment is always restored to its former state.</p>
+        <p>No matter how control leaves the |SwitchStatement| the [[LexicalEnvironment]] is always restored to its former state.</p>
       </emu-note>
       <emu-grammar>CaseClause : `case` Expression `:`</emu-grammar>
       <emu-alg>
@@ -23189,17 +23221,17 @@
       </dl>
       <emu-grammar>Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
       <emu-alg>
-        1. Let _oldEnv_ be the running execution context's LexicalEnvironment.
+        1. Let _oldEnv_ be the running execution context's [[LexicalEnvironment]].
         1. Let _catchEnv_ be NewDeclarativeEnvironment(_oldEnv_).
         1. For each element _argName_ of the BoundNames of |CatchParameter|, do
           1. Perform ! _catchEnv_.CreateMutableBinding(_argName_, *false*).
-        1. Set the running execution context's LexicalEnvironment to _catchEnv_.
+        1. Set the running execution context's [[LexicalEnvironment]] to _catchEnv_.
         1. Let _status_ be Completion(BindingInitialization of |CatchParameter| with arguments _thrownValue_ and _catchEnv_).
         1. If _status_ is an abrupt completion, then
-          1. Set the running execution context's LexicalEnvironment to _oldEnv_.
+          1. Set the running execution context's [[LexicalEnvironment]] to _oldEnv_.
           1. Return ? _status_.
         1. Let _blockCompletion_ be Completion(Evaluation of |Block|).
-        1. Set the running execution context's LexicalEnvironment to _oldEnv_.
+        1. Set the running execution context's [[LexicalEnvironment]] to _oldEnv_.
         1. Return ? _blockCompletion_.
       </emu-alg>
       <emu-grammar>Catch : `catch` Block</emu-grammar>
@@ -23207,7 +23239,7 @@
         1. Return ? Evaluation of |Block|.
       </emu-alg>
       <emu-note>
-        <p>No matter how control leaves the |Block| the LexicalEnvironment is always restored to its former state.</p>
+        <p>No matter how control leaves the |Block| the [[LexicalEnvironment]] is always restored to its former state.</p>
       </emu-note>
     </emu-clause>
 
@@ -23713,8 +23745,8 @@
       <emu-grammar>FunctionExpression : `function` `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. If _name_ is not present, set _name_ to the empty String.
-        1. Let _env_ be the LexicalEnvironment of the running execution context.
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _env_ be the running execution context's [[LexicalEnvironment]].
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Let _sourceText_ be the source text matched by |FunctionExpression|.
         1. Let _closure_ be OrdinaryFunctionCreate(%Function.prototype%, _sourceText_, |FormalParameters|, |FunctionBody|, ~non-lexical-this~, _env_, _privateEnv_).
         1. Perform SetFunctionName(_closure_, _name_).
@@ -23725,10 +23757,10 @@
       <emu-alg>
         1. Assert: _name_ is not present.
         1. Set _name_ to the StringValue of |BindingIdentifier|.
-        1. Let _outerEnv_ be the running execution context's LexicalEnvironment.
+        1. Let _outerEnv_ be the running execution context's [[LexicalEnvironment]].
         1. Let _funcEnv_ be NewDeclarativeEnvironment(_outerEnv_).
         1. Perform ! _funcEnv_.CreateImmutableBinding(_name_, *false*).
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Let _sourceText_ be the source text matched by |FunctionExpression|.
         1. Let _closure_ be OrdinaryFunctionCreate(%Function.prototype%, _sourceText_, |FormalParameters|, |FunctionBody|, ~non-lexical-this~, _funcEnv_, _privateEnv_).
         1. Perform SetFunctionName(_closure_, _name_).
@@ -23865,8 +23897,8 @@
       <emu-grammar>ArrowFunction : ArrowParameters `=>` ConciseBody</emu-grammar>
       <emu-alg>
         1. If _name_ is not present, set _name_ to the empty String.
-        1. Let _env_ be the LexicalEnvironment of the running execution context.
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _env_ be the running execution context's [[LexicalEnvironment]].
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Let _sourceText_ be the source text matched by |ArrowFunction|.
         1. [id="step-arrowfunction-evaluation-functioncreate"] Let _closure_ be OrdinaryFunctionCreate(%Function.prototype%, _sourceText_, |ArrowParameters|, |ConciseBody|, ~lexical-this~, _env_, _privateEnv_).
         1. Perform SetFunctionName(_closure_, _name_).
@@ -24003,8 +24035,8 @@
       <emu-grammar>MethodDefinition : ClassElementName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Let _propertyKey_ be ? Evaluation of |ClassElementName|.
-        1. Let _env_ be the running execution context's LexicalEnvironment.
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _env_ be the running execution context's [[LexicalEnvironment]].
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. If _functionPrototype_ is present, then
           1. Let _prototype_ be _functionPrototype_.
         1. Else,
@@ -24034,8 +24066,8 @@
       <emu-grammar>MethodDefinition : `get` ClassElementName `(` `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Let _propertyKey_ be ? Evaluation of |ClassElementName|.
-        1. Let _env_ be the running execution context's LexicalEnvironment.
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _env_ be the running execution context's [[LexicalEnvironment]].
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Let _sourceText_ be the source text matched by |MethodDefinition|.
         1. Let _formalParameterList_ be an instance of the production <emu-grammar>FormalParameters : [empty]</emu-grammar>.
         1. Let _closure_ be OrdinaryFunctionCreate(%Function.prototype%, _sourceText_, _formalParameterList_, |FunctionBody|, ~non-lexical-this~, _env_, _privateEnv_).
@@ -24050,8 +24082,8 @@
       <emu-grammar>MethodDefinition : `set` ClassElementName `(` PropertySetParameterList `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Let _propertyKey_ be ? Evaluation of |ClassElementName|.
-        1. Let _env_ be the running execution context's LexicalEnvironment.
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _env_ be the running execution context's [[LexicalEnvironment]].
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Let _sourceText_ be the source text matched by |MethodDefinition|.
         1. Let _closure_ be OrdinaryFunctionCreate(%Function.prototype%, _sourceText_, |PropertySetParameterList|, |FunctionBody|, ~non-lexical-this~, _env_, _privateEnv_).
         1. Perform MakeMethod(_closure_, _object_).
@@ -24065,8 +24097,8 @@
       <emu-grammar>GeneratorMethod : `*` ClassElementName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. Let _propertyKey_ be ? Evaluation of |ClassElementName|.
-        1. Let _env_ be the running execution context's LexicalEnvironment.
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _env_ be the running execution context's [[LexicalEnvironment]].
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Let _sourceText_ be the source text matched by |GeneratorMethod|.
         1. Let _closure_ be OrdinaryFunctionCreate(%GeneratorFunction.prototype%, _sourceText_, |UniqueFormalParameters|, |GeneratorBody|, ~non-lexical-this~, _env_, _privateEnv_).
         1. Perform MakeMethod(_closure_, _object_).
@@ -24080,8 +24112,8 @@
       </emu-grammar>
       <emu-alg>
         1. Let _propertyKey_ be ? Evaluation of |ClassElementName|.
-        1. Let _env_ be the running execution context's LexicalEnvironment.
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _env_ be the running execution context's [[LexicalEnvironment]].
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Let _sourceText_ be the source text matched by |AsyncGeneratorMethod|.
         1. Let _closure_ be OrdinaryFunctionCreate(%AsyncGeneratorFunction.prototype%, _sourceText_, |UniqueFormalParameters|, |AsyncGeneratorBody|, ~non-lexical-this~, _env_, _privateEnv_).
         1. Perform MakeMethod(_closure_, _object_).
@@ -24095,8 +24127,8 @@
       </emu-grammar>
       <emu-alg>
         1. Let _propertyKey_ be ? Evaluation of |ClassElementName|.
-        1. Let _env_ be the LexicalEnvironment of the running execution context.
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _env_ be the running execution context's [[LexicalEnvironment]].
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Let _sourceText_ be the source text matched by |AsyncMethod|.
         1. Let _closure_ be OrdinaryFunctionCreate(%AsyncFunction.prototype%, _sourceText_, |UniqueFormalParameters|, |AsyncFunctionBody|, ~non-lexical-this~, _env_, _privateEnv_).
         1. Perform MakeMethod(_closure_, _object_).
@@ -24258,8 +24290,8 @@
       <emu-grammar>GeneratorExpression : `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. If _name_ is not present, set _name_ to the empty String.
-        1. Let _env_ be the LexicalEnvironment of the running execution context.
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _env_ be the running execution context's [[LexicalEnvironment]].
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Let _sourceText_ be the source text matched by |GeneratorExpression|.
         1. Let _closure_ be OrdinaryFunctionCreate(%GeneratorFunction.prototype%, _sourceText_, |FormalParameters|, |GeneratorBody|, ~non-lexical-this~, _env_, _privateEnv_).
         1. Perform SetFunctionName(_closure_, _name_).
@@ -24271,10 +24303,10 @@
       <emu-alg>
         1. Assert: _name_ is not present.
         1. Set _name_ to the StringValue of |BindingIdentifier|.
-        1. Let _outerEnv_ be the running execution context's LexicalEnvironment.
+        1. Let _outerEnv_ be the running execution context's [[LexicalEnvironment]].
         1. Let _funcEnv_ be NewDeclarativeEnvironment(_outerEnv_).
         1. Perform ! _funcEnv_.CreateImmutableBinding(_name_, *false*).
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Let _sourceText_ be the source text matched by |GeneratorExpression|.
         1. Let _closure_ be OrdinaryFunctionCreate(%GeneratorFunction.prototype%, _sourceText_, |FormalParameters|, |GeneratorBody|, ~non-lexical-this~, _funcEnv_, _privateEnv_).
         1. Perform SetFunctionName(_closure_, _name_).
@@ -24493,8 +24525,8 @@
       </emu-grammar>
       <emu-alg>
         1. If _name_ is not present, set _name_ to the empty String.
-        1. Let _env_ be the LexicalEnvironment of the running execution context.
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _env_ be the running execution context's [[LexicalEnvironment]].
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Let _sourceText_ be the source text matched by |AsyncGeneratorExpression|.
         1. Let _closure_ be OrdinaryFunctionCreate(%AsyncGeneratorFunction.prototype%, _sourceText_, |FormalParameters|, |AsyncGeneratorBody|, ~non-lexical-this~, _env_, _privateEnv_).
         1. Perform SetFunctionName(_closure_, _name_).
@@ -24508,10 +24540,10 @@
       <emu-alg>
         1. Assert: _name_ is not present.
         1. Set _name_ to the StringValue of |BindingIdentifier|.
-        1. Let _outerEnv_ be the running execution context's LexicalEnvironment.
+        1. Let _outerEnv_ be the running execution context's [[LexicalEnvironment]].
         1. Let _funcEnv_ be NewDeclarativeEnvironment(_outerEnv_).
         1. Perform ! _funcEnv_.CreateImmutableBinding(_name_, *false*).
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Let _sourceText_ be the source text matched by |AsyncGeneratorExpression|.
         1. Let _closure_ be OrdinaryFunctionCreate(%AsyncGeneratorFunction.prototype%, _sourceText_, |FormalParameters|, |AsyncGeneratorBody|, ~non-lexical-this~, _funcEnv_, _privateEnv_).
         1. Perform SetFunctionName(_closure_, _name_).
@@ -25008,8 +25040,8 @@
         1. Let _name_ be ? Evaluation of |ClassElementName|.
         1. If |Initializer| is present, then
           1. Let _formalParameterList_ be an instance of the production <emu-grammar>FormalParameters : [empty]</emu-grammar>.
-          1. Let _env_ be the LexicalEnvironment of the running execution context.
-          1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+          1. Let _env_ be the running execution context's [[LexicalEnvironment]].
+          1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
           1. Let _sourceText_ be the empty sequence of Unicode code points.
           1. Let _initializer_ be OrdinaryFunctionCreate(%Function.prototype%, _sourceText_, _formalParameterList_, |Initializer|, ~non-lexical-this~, _env_, _privateEnv_).
           1. Perform MakeMethod(_initializer_, _homeObject_).
@@ -25033,8 +25065,8 @@
       </dl>
       <emu-grammar>ClassStaticBlock : `static` `{` ClassStaticBlockBody `}`</emu-grammar>
       <emu-alg>
-        1. Let _lex_ be the running execution context's LexicalEnvironment.
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _lex_ be the running execution context's [[LexicalEnvironment]].
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Let _sourceText_ be the empty sequence of Unicode code points.
         1. Let _formalParameters_ be an instance of the production <emu-grammar>FormalParameters : [empty]</emu-grammar>.
         1. [id="step-synthetic-class-static-block-fn"] Let _bodyFunction_ be OrdinaryFunctionCreate(%Function.prototype%, _sourceText_, _formalParameters_, |ClassStaticBlockBody|, ~non-lexical-this~, _lex_, _privateEnv_).
@@ -25118,11 +25150,11 @@
       </emu-note>
       <emu-grammar>ClassTail : ClassHeritage? `{` ClassBody? `}`</emu-grammar>
       <emu-alg>
-        1. Let _env_ be the LexicalEnvironment of the running execution context.
+        1. Let _env_ be the running execution context's [[LexicalEnvironment]].
         1. Let _classEnv_ be NewDeclarativeEnvironment(_env_).
         1. If _classBinding_ is not *undefined*, then
           1. Perform ! _classEnv_.CreateImmutableBinding(_classBinding_, *true*).
-        1. Let _outerPrivateEnvironment_ be the running execution context's PrivateEnvironment.
+        1. Let _outerPrivateEnvironment_ be the running execution context's [[PrivateEnvironment]].
         1. Let _classPrivateEnvironment_ be NewPrivateEnvironment(_outerPrivateEnvironment_).
         1. If |ClassBody| is present, then
           1. For each String _dn_ of the PrivateBoundIdentifiers of |ClassBody|, do
@@ -25135,10 +25167,10 @@
           1. Let _protoParent_ be %Object.prototype%.
           1. Let _constructorParent_ be %Function.prototype%.
         1. Else,
-          1. Set the running execution context's LexicalEnvironment to _classEnv_.
-          1. NOTE: The running execution context's PrivateEnvironment is _outerPrivateEnvironment_ when evaluating |ClassHeritage|.
+          1. Set the running execution context's [[LexicalEnvironment]] to _classEnv_.
+          1. NOTE: The running execution context's [[PrivateEnvironment]] is _outerPrivateEnvironment_ when evaluating |ClassHeritage|.
           1. Let _superclassRef_ be Completion(Evaluation of |ClassHeritage|).
-          1. Set the running execution context's LexicalEnvironment to _env_.
+          1. Set the running execution context's [[LexicalEnvironment]] to _env_.
           1. Let _superclass_ be ? GetValue(? _superclassRef_).
           1. If _superclass_ is *null*, then
             1. Let _protoParent_ be *null*.
@@ -25152,8 +25184,8 @@
         1. Let _proto_ be OrdinaryObjectCreate(_protoParent_).
         1. If |ClassBody| is not present, let _constructor_ be ~empty~.
         1. Else, let _constructor_ be the ConstructorMethod of |ClassBody|.
-        1. Set the running execution context's LexicalEnvironment to _classEnv_.
-        1. Set the running execution context's PrivateEnvironment to _classPrivateEnvironment_.
+        1. Set the running execution context's [[LexicalEnvironment]] to _classEnv_.
+        1. Set the running execution context's [[PrivateEnvironment]] to _classPrivateEnvironment_.
         1. If _constructor_ is ~empty~, then
           1. Let _defaultConstructor_ be a new Abstract Closure with no parameters that captures nothing and performs the following steps when called:
             1. Let _args_ be the List of arguments that was passed to this function by [[Call]] or [[Construct]].
@@ -25191,8 +25223,8 @@
           1. Else,
             1. Let _element_ be Completion(ClassElementEvaluation of _e_ with argument _constructorFunction_).
           1. If _element_ is an abrupt completion, then
-            1. Set the running execution context's LexicalEnvironment to _env_.
-            1. Set the running execution context's PrivateEnvironment to _outerPrivateEnvironment_.
+            1. Set the running execution context's [[LexicalEnvironment]] to _env_.
+            1. Set the running execution context's [[PrivateEnvironment]] to _outerPrivateEnvironment_.
             1. Return ? _element_.
           1. Set _element_ to ! _element_.
           1. If _element_ is a PrivateElement, then
@@ -25213,7 +25245,7 @@
             1. Else, append _element_ to _staticElements_.
           1. Else if _element_ is a ClassStaticBlockDefinition Record, then
             1. Append _element_ to _staticElements_.
-        1. Set the running execution context's LexicalEnvironment to _env_.
+        1. Set the running execution context's [[LexicalEnvironment]] to _env_.
         1. If _classBinding_ is not *undefined*, then
           1. Perform ! _classEnv_.InitializeBinding(_classBinding_, _constructorFunction_).
         1. Set _constructorFunction_.[[PrivateMethods]] to _instancePrivateMethods_.
@@ -25227,9 +25259,9 @@
             1. Assert: _elementRecord_ is a ClassStaticBlockDefinition Record.
             1. Let _result_ be Completion(Call(_elementRecord_.[[BodyFunction]], _constructorFunction_)).
           1. If _result_ is an abrupt completion, then
-            1. Set the running execution context's PrivateEnvironment to _outerPrivateEnvironment_.
+            1. Set the running execution context's [[PrivateEnvironment]] to _outerPrivateEnvironment_.
             1. Return ? _result_.
-        1. Set the running execution context's PrivateEnvironment to _outerPrivateEnvironment_.
+        1. Set the running execution context's [[PrivateEnvironment]] to _outerPrivateEnvironment_.
         1. Return _constructorFunction_.
       </emu-alg>
     </emu-clause>
@@ -25243,7 +25275,7 @@
         1. Let _className_ be the StringValue of |BindingIdentifier|.
         1. Let _sourceText_ be the source text matched by |ClassDeclaration|.
         1. Let _value_ be ? ClassDefinitionEvaluation of |ClassTail| with arguments _className_, _className_, and _sourceText_.
-        1. Let _env_ be the running execution context's LexicalEnvironment.
+        1. Let _env_ be the running execution context's [[LexicalEnvironment]].
         1. Perform ? InitializeBoundName(_className_, _value_, _env_).
         1. Return _value_.
       </emu-alg>
@@ -25281,7 +25313,7 @@
       <emu-grammar>ClassElementName : PrivateIdentifier</emu-grammar>
       <emu-alg>
         1. Let _privateIdentifier_ be the StringValue of |PrivateIdentifier|.
-        1. Let _privateEnvRec_ be the running execution context's PrivateEnvironment.
+        1. Let _privateEnvRec_ be the running execution context's [[PrivateEnvironment]].
         1. Let _names_ be _privateEnvRec_.[[Names]].
         1. Assert: Exactly one element of _names_ is a Private Name whose [[Description]] is _privateIdentifier_.
         1. Let _privateName_ be the Private Name in _names_ whose [[Description]] is _privateIdentifier_.
@@ -25408,8 +25440,8 @@
       </emu-grammar>
       <emu-alg>
         1. If _name_ is not present, set _name_ to the empty String.
-        1. Let _env_ be the LexicalEnvironment of the running execution context.
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _env_ be the running execution context's [[LexicalEnvironment]].
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Let _sourceText_ be the source text matched by |AsyncFunctionExpression|.
         1. Let _closure_ be OrdinaryFunctionCreate(%AsyncFunction.prototype%, _sourceText_, |FormalParameters|, |AsyncFunctionBody|, ~non-lexical-this~, _env_, _privateEnv_).
         1. Perform SetFunctionName(_closure_, _name_).
@@ -25421,10 +25453,10 @@
       <emu-alg>
         1. Assert: _name_ is not present.
         1. Set _name_ to the StringValue of |BindingIdentifier|.
-        1. Let _outerEnv_ be the LexicalEnvironment of the running execution context.
+        1. Let _outerEnv_ be the running execution context's [[LexicalEnvironment]].
         1. Let _funcEnv_ be NewDeclarativeEnvironment(_outerEnv_).
         1. Perform ! _funcEnv_.CreateImmutableBinding(_name_, *false*).
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Let _sourceText_ be the source text matched by |AsyncFunctionExpression|.
         1. Let _closure_ be OrdinaryFunctionCreate(%AsyncFunction.prototype%, _sourceText_, |FormalParameters|, |AsyncFunctionBody|, ~non-lexical-this~, _funcEnv_, _privateEnv_).
         1. Perform SetFunctionName(_closure_, _name_).
@@ -25579,8 +25611,8 @@
       </emu-grammar>
       <emu-alg>
         1. If _name_ is not present, set _name_ to the empty String.
-        1. Let _env_ be the LexicalEnvironment of the running execution context.
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _env_ be the running execution context's [[LexicalEnvironment]].
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Let _sourceText_ be the source text matched by |AsyncArrowFunction|.
         1. Let _parameters_ be |AsyncArrowBindingIdentifier|.
         1. Let _closure_ be OrdinaryFunctionCreate(%AsyncFunction.prototype%, _sourceText_, _parameters_, |AsyncConciseBody|, ~lexical-this~, _env_, _privateEnv_).
@@ -25592,8 +25624,8 @@
       </emu-grammar>
       <emu-alg>
         1. If _name_ is not present, set _name_ to the empty String.
-        1. Let _env_ be the LexicalEnvironment of the running execution context.
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _env_ be the running execution context's [[LexicalEnvironment]].
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Let _sourceText_ be the source text matched by |AsyncArrowFunction|.
         1. Let _head_ be the |AsyncArrowHead| that is covered by |CoverCallExpressionAndAsyncArrowHead|.
         1. Let _parameters_ be the |ArrowFormalParameters| of _head_.
@@ -25982,7 +26014,7 @@
       <dl class="header">
       </dl>
       <emu-alg>
-        1. Assert: The current execution context will not subsequently be used for the evaluation of any ECMAScript code or built-in functions. The invocation of Call subsequent to the invocation of this abstract operation will create and push a new execution context before performing any such evaluation.
+        1. Assert: The current execution context will not subsequently be used for the evaluation of any ECMAScript code or built-in functions. The invocation of Call subsequent to the invocation of this abstract operation will create and push a new ExecutionContext Record before performing any such evaluation.
         1. Discard all resources associated with the current execution context.
         1. Return ~unused~.
       </emu-alg>
@@ -26163,13 +26195,13 @@
 
       <emu-alg>
         1. Let _globalEnv_ be _scriptRecord_.[[Realm]].[[GlobalEnv]].
-        1. Let _scriptContext_ be a new ECMAScript code execution context.
-        1. Set the Function of _scriptContext_ to *null*.
-        1. Set the Realm of _scriptContext_ to _scriptRecord_.[[Realm]].
-        1. Set the ScriptOrModule of _scriptContext_ to _scriptRecord_.
-        1. Set the VariableEnvironment of _scriptContext_ to _globalEnv_.
-        1. Set the LexicalEnvironment of _scriptContext_ to _globalEnv_.
-        1. Set the PrivateEnvironment of _scriptContext_ to *null*.
+        1. Let _scriptContext_ be a new ECMAScript code ExecutionContext Record.
+        1. Set _scriptContext_.[[Function]] to *null*.
+        1. Set _scriptContext_.[[Realm]] to _scriptRecord_.[[Realm]].
+        1. Set _scriptContext_.[[ScriptOrModule]] to _scriptRecord_.
+        1. Set _scriptContext_.[[VariableEnvironment]] to _globalEnv_.
+        1. Set _scriptContext_.[[LexicalEnvironment]] to _globalEnv_.
+        1. Set _scriptContext_.[[PrivateEnvironment]] to *null*.
         1. Suspend the running execution context.
         1. Push _scriptContext_ onto the execution context stack; _scriptContext_ is now the running execution context.
         1. Let _script_ be _scriptRecord_.[[ECMAScriptCode]].
@@ -26248,8 +26280,8 @@
                       1. Perform ? CreateGlobalVarBinding(_env_, _funcName_, *false*).
                       1. Append _funcName_ to _declaredFunctionOrVarNames_.
                     1. [id="step-globaldeclarationinstantiation-alt-funcdecl-eval"] When the |FunctionDeclaration| _f_ is evaluated, perform the following steps in place of the |FunctionDeclaration| Evaluation algorithm provided in <emu-xref href="#sec-function-definitions-runtime-semantics-evaluation"></emu-xref>:
-                      1. Let _gEnv_ be the running execution context's VariableEnvironment.
-                      1. Let _bEnv_ be the running execution context's LexicalEnvironment.
+                      1. Let _gEnv_ be the running execution context's [[VariableEnvironment]].
+                      1. Let _bEnv_ be the running execution context's [[LexicalEnvironment]].
                       1. Let _fObj_ be ! _bEnv_.GetBindingValue(_funcName_, *false*).
                       1. Perform ? <emu-meta effects="user-code">_gEnv_.SetMutableBinding(_funcName_, _fObj_, *false*)</emu-meta>.
                       1. Return ~unused~.
@@ -27964,10 +27996,10 @@
                 [[Context]]
               </td>
               <td>
-                an ECMAScript code execution context or ~empty~
+                an ECMAScript code ExecutionContext Record or ~empty~
               </td>
               <td>
-                The execution context associated with this module. It is ~empty~ until the module's environment has been initialized.
+                The ExecutionContext Record associated with this module. It is ~empty~ until the module's environment has been initialized.
               </td>
             </tr>
             <tr>
@@ -28616,14 +28648,14 @@
                     1. Perform ! _env_.InitializeBinding(_in_.[[LocalName]], _namespace_).
                   1. Else,
                     1. Perform CreateImportBinding(_env_, _in_.[[LocalName]], _resolution_.[[Module]], _resolution_.[[BindingName]]).
-              1. Let _moduleContext_ be a new ECMAScript code execution context.
-              1. Set the Function of _moduleContext_ to *null*.
+              1. Let _moduleContext_ be a new ECMAScript code ExecutionContext Record.
+              1. Set _moduleContext_.[[Function]] to *null*.
               1. Assert: _module_.[[Realm]] is not *undefined*.
-              1. Set the Realm of _moduleContext_ to _module_.[[Realm]].
-              1. Set the ScriptOrModule of _moduleContext_ to _module_.
-              1. Set the VariableEnvironment of _moduleContext_ to _module_.[[Environment]].
-              1. Set the LexicalEnvironment of _moduleContext_ to _module_.[[Environment]].
-              1. Set the PrivateEnvironment of _moduleContext_ to *null*.
+              1. Set _moduleContext_.[[Realm]] to _module_.[[Realm]].
+              1. Set _moduleContext_.[[ScriptOrModule]] to _module_.
+              1. Set _moduleContext_.[[VariableEnvironment]] to _module_.[[Environment]].
+              1. Set _moduleContext_.[[LexicalEnvironment]] to _module_.[[Environment]].
+              1. Set _moduleContext_.[[PrivateEnvironment]] to *null*.
               1. Set _module_.[[Context]] to _moduleContext_.
               1. Push _moduleContext_ onto the execution context stack; _moduleContext_ is now the running execution context.
               1. Let _code_ be _module_.[[ECMAScriptCode]].
@@ -28860,12 +28892,12 @@
             </dl>
 
             <emu-alg>
-              1. Let _moduleContext_ be a new ECMAScript code execution context.
-              1. Set the Function of _moduleContext_ to *null*.
-              1. Set the Realm of _moduleContext_ to _module_.[[Realm]].
-              1. Set the ScriptOrModule of _moduleContext_ to _module_.
-              1. Set the VariableEnvironment of _moduleContext_ to _module_.[[Environment]].
-              1. Set the LexicalEnvironment of _moduleContext_ to _module_.[[Environment]].
+              1. Let _moduleContext_ be a new ECMAScript code ExecutionContext Record.
+              1. Set _moduleContext_.[[Function]] to *null*.
+              1. Set _moduleContext_.[[Realm]] to _module_.[[Realm]].
+              1. Set _moduleContext_.[[ScriptOrModule]] to _module_.
+              1. Set _moduleContext_.[[VariableEnvironment]] to _module_.[[Environment]].
+              1. Set _moduleContext_.[[LexicalEnvironment]] to _module_.[[Environment]].
               1. Suspend the running execution context.
               1. Push _moduleContext_ onto the execution context stack; _moduleContext_ is now the running execution context.
               1. Let _steps_ be _module_.[[EvaluationSteps]].
@@ -28920,7 +28952,7 @@
 
           <pre><code class="html">&lt;button type="button" onclick="import('./foo.mjs')"&gt;Click me&lt;/button&gt;</code></pre>
 
-          <p>there will be no active script or module at the time the <emu-xref href="#sec-import-calls">`import()`</emu-xref> expression runs. More generally, this can happen in any situation where the host pushes execution contexts with *null* ScriptOrModule components onto the execution context stack.</p>
+          <p>there will be no active script or module at the time the <emu-xref href="#sec-import-calls">`import()`</emu-xref> expression runs. More generally, this can happen in any situation where the host pushes an ExecutionContext Record with a *null* [[ScriptOrModule]] field onto the execution context stack.</p>
         </emu-note>
 
         <p>An implementation of HostLoadImportedModule must conform to the following requirements:</p>
@@ -29644,7 +29676,7 @@
           1. Let _value_ be ? BindingClassDeclarationEvaluation of |ClassDeclaration|.
           1. Let _className_ be the sole element of the BoundNames of |ClassDeclaration|.
           1. If _className_ is *"\*default\*"*, then
-            1. Let _env_ be the running execution context's LexicalEnvironment.
+            1. Let _env_ be the running execution context's [[LexicalEnvironment]].
             1. Perform ? InitializeBoundName(*"\*default\*"*, _value_, _env_).
           1. Return ~empty~.
         </emu-alg>
@@ -29655,7 +29687,7 @@
           1. Else,
             1. Let _rhs_ be ? Evaluation of |AssignmentExpression|.
             1. Let _value_ be ? GetValue(_rhs_).
-          1. Let _env_ be the running execution context's LexicalEnvironment.
+          1. Let _env_ be the running execution context's [[LexicalEnvironment]].
           1. Perform ? InitializeBoundName(*"\*default\*"*, _value_, _env_).
           1. Return ~empty~.
         </emu-alg>
@@ -29839,22 +29871,22 @@
           1. Let _runningContext_ be the running execution context.
           1. NOTE: If _direct_ is *true*, _runningContext_ will be the execution context that performed the direct eval. If _direct_ is *false*, _runningContext_ will be the execution context for the invocation of the `eval` function.
           1. If _direct_ is *true*, then
-            1. Let _lexEnv_ be NewDeclarativeEnvironment(_runningContext_'s LexicalEnvironment).
-            1. Let _varEnv_ be _runningContext_'s VariableEnvironment.
-            1. Let _privateEnv_ be _runningContext_'s PrivateEnvironment.
+            1. Let _lexEnv_ be NewDeclarativeEnvironment(_runningContext_.[[LexicalEnvironment]]).
+            1. Let _varEnv_ be _runningContext_.[[VariableEnvironment]].
+            1. Let _privateEnv_ be _runningContext_.[[PrivateEnvironment]].
           1. Else,
             1. Let _lexEnv_ be NewDeclarativeEnvironment(_evalRealm_.[[GlobalEnv]]).
             1. Let _varEnv_ be _evalRealm_.[[GlobalEnv]].
             1. Let _privateEnv_ be *null*.
           1. If _strictEval_ is *true*, set _varEnv_ to _lexEnv_.
           1. If _runningContext_ is not already suspended, suspend _runningContext_.
-          1. Let _evalContext_ be a new ECMAScript code execution context.
-          1. Set _evalContext_'s Function to *null*.
-          1. Set _evalContext_'s Realm to _evalRealm_.
-          1. Set _evalContext_'s ScriptOrModule to _runningContext_'s ScriptOrModule.
-          1. Set _evalContext_'s VariableEnvironment to _varEnv_.
-          1. Set _evalContext_'s LexicalEnvironment to _lexEnv_.
-          1. Set _evalContext_'s PrivateEnvironment to _privateEnv_.
+          1. Let _evalContext_ be a new ECMAScript code ExecutionContext Record.
+          1. Set _evalContext_.[[Function]] to *null*.
+          1. Set _evalContext_.[[Realm]] to _evalRealm_.
+          1. Set _evalContext_.[[ScriptOrModule]] to _runningContext_.[[ScriptOrModule]].
+          1. Set _evalContext_.[[VariableEnvironment]] to _varEnv_.
+          1. Set _evalContext_.[[LexicalEnvironment]] to _lexEnv_.
+          1. Set _evalContext_.[[PrivateEnvironment]] to _privateEnv_.
           1. Push _evalContext_ onto the execution context stack; _evalContext_ is now the running execution context.
           1. Let _result_ be Completion(EvalDeclarationInstantiation(_body_, _varEnv_, _lexEnv_, _privateEnv_, _strictEval_)).
           1. If _result_ is a normal completion, then
@@ -29866,7 +29898,7 @@
           1. Return ? _result_.
         </emu-alg>
         <emu-note>
-          <p>The eval code cannot instantiate variable or function bindings in the variable environment of the calling context that invoked the eval if either the code of the calling context or the eval code is strict mode code. Instead such bindings are instantiated in a new VariableEnvironment that is only accessible to the eval code. Bindings introduced by `let`, `const`, or `class` declarations are always instantiated in a new LexicalEnvironment.</p>
+          <p>The eval code cannot instantiate variable or function bindings in the variable environment of the calling context that invoked the eval if either the code of the calling context or the eval code is strict mode code. Instead such bindings are instantiated in a new [[VariableEnvironment]] that is only accessible to the eval code. Bindings introduced by `let`, `const`, or `class` declarations are always instantiated in a new [[LexicalEnvironment]].</p>
         </emu-note>
       </emu-clause>
 
@@ -29987,8 +30019,8 @@
                         1. Perform ! _varEnv_.InitializeBinding(_funcName_, *undefined*).
                     1. Append _funcName_ to _declaredFunctionOrVarNames_.
                   1. [id="step-evaldeclarationinstantiation-alt-funcdecl-eval"] When the |FunctionDeclaration| _f_ is evaluated, perform the following steps in place of the |FunctionDeclaration| Evaluation algorithm provided in <emu-xref href="#sec-function-definitions-runtime-semantics-evaluation"></emu-xref>:
-                    1. Let _gEnv_ be the running execution context's VariableEnvironment.
-                    1. Let _bEnv_ be the running execution context's LexicalEnvironment.
+                    1. Let _gEnv_ be the running execution context's [[VariableEnvironment]].
+                    1. Let _bEnv_ be the running execution context's [[LexicalEnvironment]].
                     1. Let _fObj_ be ! _bEnv_.GetBindingValue(_funcName_, *false*).
                     1. Perform ? <emu-meta effects="user-code">_gEnv_.SetMutableBinding(_funcName_, _fObj_, *false*)</emu-meta>.
                     1. Return ~unused~.
@@ -50525,10 +50557,10 @@ THH:mm:ss.sss
               [[GeneratorContext]]
             </td>
             <td>
-              an execution context
+              an ExecutionContext Record
             </td>
             <td>
-              The execution context that is used when executing the code of this generator.
+              The ExecutionContext Record that is used when executing the code of this generator.
             </td>
           </tr>
           <tr>
@@ -50561,17 +50593,17 @@ THH:mm:ss.sss
         <emu-alg>
           1. Assert: _generator_.[[GeneratorState]] is ~suspended-start~.
           1. Let _genContext_ be the running execution context.
-          1. Set the Generator component of _genContext_ to _generator_.
+          1. Set _genContext_.[[Generator]] to _generator_.
           1. Let _closure_ be a new Abstract Closure with no parameters that captures _generatorBody_ and performs the following steps when called:
             1. Let _acGenContext_ be the running execution context.
-            1. Let _acGenerator_ be the Generator component of _acGenContext_.
+            1. Let _acGenerator_ be _acGenContext_.[[Generator]].
             1. If _generatorBody_ is a Parse Node, then
               1. Let _result_ be Completion(Evaluation of _generatorBody_).
             1. Else,
               1. Assert: _generatorBody_ is an Abstract Closure with no parameters.
               1. Let _result_ be Completion(_generatorBody_()).
             1. Assert: If we return here, the generator either threw an exception or performed either an implicit or explicit return.
-            1. Remove _acGenContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
+            1. Remove _acGenContext_ from the execution context stack and restore the ExecutionContext Record that is at the top of the execution context stack as the running execution context.
             1. Set _acGenerator_.[[GeneratorState]] to ~completed~.
             1. NOTE: Once a generator enters the ~completed~ state it never leaves it and its associated execution context is never resumed. Any execution state associated with _acGenerator_ can be discarded at this point.
             1. If _result_ is a normal completion, then
@@ -50582,7 +50614,7 @@ THH:mm:ss.sss
               1. Assert: _result_ is a throw completion.
               1. Return ? _result_.
             1. Return NormalCompletion(CreateIteratorResultObject(_resultValue_, *true*)).
-          1. Set the code evaluation state of _genContext_ such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
+          1. Set _genContext_.[[CodeEvaluationState]] such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
           1. Set _generator_.[[GeneratorContext]] to _genContext_.
           1. Return ~unused~.
         </emu-alg>
@@ -50661,8 +50693,8 @@ THH:mm:ss.sss
         </dl>
         <emu-alg>
           1. Let _genContext_ be the running execution context.
-          1. If _genContext_ does not have a Generator component, return ~non-generator~.
-          1. Let _generator_ be the Generator component of _genContext_.
+          1. If _genContext_ does not have a [[Generator]] field, return ~non-generator~.
+          1. Let _generator_ be _genContext_.[[Generator]].
           1. If _generator_ has an [[AsyncGeneratorState]] internal slot, return ~async~.
           1. Return ~sync~.
         </emu-alg>
@@ -50681,10 +50713,10 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _genContext_ be the running execution context.
           1. Assert: _genContext_ is the execution context of a generator.
-          1. Let _generator_ be the value of the Generator component of _genContext_.
+          1. Let _generator_ be _genContext_.[[Generator]].
           1. Assert: GetGeneratorKind() is ~sync~.
           1. Set _generator_.[[GeneratorState]] to ~suspended-yield~.
-          1. Remove _genContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
+          1. Remove _genContext_ from the execution context stack and restore the ExecutionContext Record that is at the top of the execution context stack as the running execution context.
           1. Let _callerContext_ be the running execution context.
           1. Resume _callerContext_ passing NormalCompletion(_iteratorResult_). If _genContext_ is ever resumed again, let _resumptionValue_ be the Completion Record with which it is resumed.
           1. Assert: If control reaches here, then _genContext_ is the running execution context again.
@@ -50726,10 +50758,10 @@ THH:mm:ss.sss
           1. Set _generator_.[[GeneratorBrand]] to _generatorBrand_.
           1. Set _generator_.[[GeneratorState]] to ~suspended-start~.
           1. Let _callerContext_ be the running execution context.
-          1. Let _calleeContext_ be a new execution context.
-          1. Set the Function of _calleeContext_ to *null*.
-          1. Set the Realm of _calleeContext_ to the current Realm Record.
-          1. Set the ScriptOrModule of _calleeContext_ to _callerContext_'s ScriptOrModule.
+          1. Let _calleeContext_ be a new ExecutionContext Record.
+          1. Set _calleeContext_.[[Function]] to *null*.
+          1. Set _calleeContext_.[[Realm]] to the current Realm Record.
+          1. Set _calleeContext_.[[ScriptOrModule]] to _callerContext_.[[ScriptOrModule]].
           1. If _callerContext_ is not already suspended, suspend _callerContext_.
           1. Push _calleeContext_ onto the execution context stack; _calleeContext_ is now the running execution context.
           1. Perform GeneratorStart(_generator_, _closure_).
@@ -50856,8 +50888,8 @@ THH:mm:ss.sss
           </tr>
           <tr>
             <td>[[AsyncGeneratorContext]]</td>
-            <td>an execution context</td>
-            <td>The execution context that is used when executing the code of this async generator.</td>
+            <td>an ExecutionContext Record</td>
+            <td>The ExecutionContext Record that is used when executing the code of this async generator.</td>
           </tr>
           <tr>
             <td>[[AsyncGeneratorQueue]]</td>
@@ -50915,24 +50947,24 @@ THH:mm:ss.sss
         <emu-alg>
           1. Assert: _generator_.[[AsyncGeneratorState]] is ~suspended-start~.
           1. Let _genContext_ be the running execution context.
-          1. Set the Generator component of _genContext_ to _generator_.
+          1. Set _genContext_.[[Generator]] to _generator_.
           1. Let _closure_ be a new Abstract Closure with no parameters that captures _generatorBody_ and performs the following steps when called:
             1. Let _acGenContext_ be the running execution context.
-            1. Let _acGenerator_ be the Generator component of _acGenContext_.
+            1. Let _acGenerator_ be _acGenContext_.[[Generator]].
             1. If _generatorBody_ is a Parse Node, then
               1. Let _result_ be Completion(Evaluation of _generatorBody_).
             1. Else,
               1. Assert: _generatorBody_ is an Abstract Closure with no parameters.
               1. Let _result_ be Completion(_generatorBody_()).
             1. Assert: If we return here, the async generator either threw an exception or performed either an implicit or explicit return.
-            1. Remove _acGenContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
+            1. Remove _acGenContext_ from the execution context stack and restore the ExecutionContext Record that is at the top of the execution context stack as the running execution context.
             1. Set _acGenerator_.[[AsyncGeneratorState]] to ~draining-queue~.
             1. If _result_ is a normal completion, set _result_ to NormalCompletion(*undefined*).
             1. If _result_ is a return completion, set _result_ to NormalCompletion(_result_.[[Value]]).
             1. Perform AsyncGeneratorCompleteStep(_acGenerator_, _result_, *true*).
             1. Perform AsyncGeneratorDrainQueue(_acGenerator_).
             1. Return NormalCompletion(*undefined*).
-          1. Set the code evaluation state of _genContext_ such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
+          1. Set _genContext_.[[CodeEvaluationState]] such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
           1. Set _generator_.[[AsyncGeneratorContext]] to _genContext_.
           1. Set _generator_.[[AsyncGeneratorQueue]] to a new empty List.
           1. Return ~unused~.
@@ -50996,10 +51028,10 @@ THH:mm:ss.sss
           1. Else,
             1. Assert: _completion_ is a normal completion.
             1. If _realm_ is present, then
-              1. Let _oldRealm_ be the running execution context's Realm.
-              1. Set the running execution context's Realm to _realm_.
+              1. Let _oldRealm_ be the running execution context's [[Realm]].
+              1. Set the running execution context's [[Realm]] to _realm_.
               1. Let _iteratorResult_ be CreateIteratorResultObject(_value_, _done_).
-              1. Set the running execution context's Realm to _oldRealm_.
+              1. Set the running execution context's [[Realm]] to _oldRealm_.
             1. Else,
               1. Let _iteratorResult_ be CreateIteratorResultObject(_value_, _done_).
             1. Perform ! <emu-meta effects="user-code">Call(_promiseCapability_.[[Resolve]], *undefined*, « _iteratorResult_ »)</emu-meta>.
@@ -51053,12 +51085,12 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _genContext_ be the running execution context.
           1. Assert: _genContext_ is the execution context of a generator.
-          1. Let _generator_ be the value of the Generator component of _genContext_.
+          1. Let _generator_ be _genContext_.[[Generator]].
           1. Assert: GetGeneratorKind() is ~async~.
           1. Let _completion_ be NormalCompletion(_value_).
           1. Assert: The execution context stack has at least two elements.
           1. Let _previousContext_ be the second to top element of the execution context stack.
-          1. Let _previousRealm_ be _previousContext_'s Realm.
+          1. Let _previousRealm_ be _previousContext_.[[Realm]].
           1. Perform AsyncGeneratorCompleteStep(_generator_, _completion_, *false*, _previousRealm_).
           1. Let _queue_ be _generator_.[[AsyncGeneratorQueue]].
           1. If _queue_ is not empty, then
@@ -51067,7 +51099,7 @@ THH:mm:ss.sss
             1. Let _resumptionValue_ be Completion(_toYield_.[[Completion]]).
             1. Return ? AsyncGeneratorUnwrapYieldResumption(_resumptionValue_).
           1. Set _generator_.[[AsyncGeneratorState]] to ~suspended-yield~.
-          1. Remove _genContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
+          1. Remove _genContext_ from the execution context stack and restore the ExecutionContext Record that is at the top of the execution context stack as the running execution context.
           1. Let _callerContext_ be the running execution context.
           1. Resume _callerContext_ passing *undefined*. If _genContext_ is ever resumed again, let _resumptionValue_ be the Completion Record with which it is resumed.
           1. Assert: If control reaches here, then _genContext_ is the running execution context again.
@@ -51265,7 +51297,7 @@ THH:mm:ss.sss
           AsyncBlockStart (
             _promiseCapability_: a PromiseCapability Record,
             _asyncBody_: a Parse Node or an Abstract Closure with no parameters,
-            _asyncContext_: an execution context,
+            _asyncContext_: an ExecutionContext Record,
           ): ~unused~
         </h1>
         <dl class="header">
@@ -51279,7 +51311,7 @@ THH:mm:ss.sss
               1. Assert: _asyncBody_ is an Abstract Closure with no parameters.
               1. Let _result_ be Completion(_asyncBody_()).
             1. Assert: If we return here, the async function either threw an exception or performed an implicit or explicit return; all awaiting is done.
-            1. Remove _acAsyncContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
+            1. Remove _acAsyncContext_ from the execution context stack and restore the ExecutionContext Record that is at the top of the execution context stack as the running execution context.
             1. If _result_ is a normal completion, then
               1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, « *undefined* »).
             1. Else if _result_ is a return completion, then
@@ -51288,7 +51320,7 @@ THH:mm:ss.sss
               1. Assert: _result_ is a throw completion.
               1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, « _result_.[[Value]] »).
             1. [id="step-asyncblockstart-return-undefined"] Return NormalCompletion(~unused~).
-          1. Set the code evaluation state of _asyncContext_ such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
+          1. Set _asyncContext_.[[CodeEvaluationState]] such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
           1. Let _result_ be ! RunSuspendedContext(_asyncContext_, NormalCompletion(~empty~)).
           1. Assert: _result_ is ~unused~.
           1. NOTE: The possible sources of _result_ values are Await or, if the async function doesn't await anything, step <emu-xref href="#step-asyncblockstart-return-undefined"></emu-xref> above.
@@ -51318,7 +51350,7 @@ THH:mm:ss.sss
             1. Return NormalCompletion(*undefined*).
           1. Let _onRejected_ be CreateBuiltinFunction(_rejectedClosure_, 1, *""*, « »).
           1. Perform PerformPromiseThen(_promise_, _onFulfilled_, _onRejected_).
-          1. Remove _asyncContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
+          1. Remove _asyncContext_ from the execution context stack and restore the ExecutionContext Record that is at the top of the execution context stack as the running execution context.
           1. Let _callerContext_ be the running execution context.
           1. Resume _callerContext_ passing ~empty~. If _asyncContext_ is ever resumed again, let _completion_ be the Completion Record with which it is resumed.
           1. Assert: If control reaches here, then _asyncContext_ is the running execution context again.

--- a/spec.html
+++ b/spec.html
@@ -50614,7 +50614,7 @@ THH:mm:ss.sss
               1. Assert: _result_ is a throw completion.
               1. Return ? _result_.
             1. Return NormalCompletion(CreateIteratorResultObject(_resultValue_, *true*)).
-          1. Set _genContext_.[[CodeEvaluationState]] such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
+          1. Set _genContext_.[[CodeEvaluationState]] such that when evaluation is resumed for _genContext_, _closure_ will be called with no arguments.
           1. Set _generator_.[[GeneratorContext]] to _genContext_.
           1. Return ~unused~.
         </emu-alg>
@@ -50964,7 +50964,7 @@ THH:mm:ss.sss
             1. Perform AsyncGeneratorCompleteStep(_acGenerator_, _result_, *true*).
             1. Perform AsyncGeneratorDrainQueue(_acGenerator_).
             1. Return NormalCompletion(*undefined*).
-          1. Set _genContext_.[[CodeEvaluationState]] such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
+          1. Set _genContext_.[[CodeEvaluationState]] such that when evaluation is resumed for _genContext_, _closure_ will be called with no arguments.
           1. Set _generator_.[[AsyncGeneratorContext]] to _genContext_.
           1. Set _generator_.[[AsyncGeneratorQueue]] to a new empty List.
           1. Return ~unused~.
@@ -51320,7 +51320,7 @@ THH:mm:ss.sss
               1. Assert: _result_ is a throw completion.
               1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, « _result_.[[Value]] »).
             1. [id="step-asyncblockstart-return-undefined"] Return NormalCompletion(~unused~).
-          1. Set _asyncContext_.[[CodeEvaluationState]] such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
+          1. Set _asyncContext_.[[CodeEvaluationState]] such that when evaluation is resumed for _asyncContext_, _closure_ will be called with no arguments.
           1. Let _result_ be ! RunSuspendedContext(_asyncContext_, NormalCompletion(~empty~)).
           1. Assert: _result_ is ~unused~.
           1. NOTE: The possible sources of _result_ values are Await or, if the async function doesn't await anything, step <emu-xref href="#step-asyncblockstart-return-undefined"></emu-xref> above.

--- a/spec.html
+++ b/spec.html
@@ -51918,7 +51918,7 @@ THH:mm:ss.sss
             1. Let _callerContext_ be the running execution context.
             1. Resume _callerContext_, passing _resumption_.
             1. Assert: This step is never reached.
-          1. Set _genContext_.[[CodeEvaluationState]] such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
+          1. Set _genContext_.[[CodeEvaluationState]] such that when evaluation is resumed for _genContext_, _closure_ will be called with no arguments.
           1. Set _gen_.[[GeneratorContext]] to _genContext_.
           1. Return ~unused~.
         </emu-alg>
@@ -52264,7 +52264,7 @@ THH:mm:ss.sss
             1. Let _callerContext_ be the running execution context.
             1. Resume _callerContext_, passing NormalCompletion(*undefined*).
             1. Assert: This step is never reached.
-          1. Set _genContext_.[[CodeEvaluationState]] such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
+          1. Set _genContext_.[[CodeEvaluationState]] such that when evaluation is resumed for _genContext_, _closure_ will be called with no arguments.
           1. Set _gen_.[[AsyncGeneratorContext]] to _genContext_.
           1. Set _gen_.[[AsyncGeneratorQueue]] to a new empty List.
           1. Return ~unused~.
@@ -52619,7 +52619,7 @@ THH:mm:ss.sss
             1. Let _callerContext_ be the running execution context.
             1. [id="step-asyncblockstart-return-undefined"] Resume _callerContext_, passing NormalCompletion(~unused~).
             1. Assert: This step is never reached.
-          1. Set _asyncContext_.[[CodeEvaluationState]] such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
+          1. Set _asyncContext_.[[CodeEvaluationState]] such that when evaluation is resumed for _asyncContext_, _closure_ will be called with no arguments.
           1. Let _result_ be ! RunSuspendedContext(_asyncContext_, NormalCompletion(~empty~)).
           1. Assert: _result_ is ~unused~.
           1. NOTE: The possible sources of _result_ values are Await or, if the async function doesn't await anything, step <emu-xref href="#step-asyncblockstart-return-undefined"></emu-xref> above.

--- a/spec.html
+++ b/spec.html
@@ -4594,7 +4594,7 @@
         <dl class="header">
         </dl>
         <emu-alg>
-          1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+          1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
           1. Assert: _privateEnv_ is not *null*.
           1. Let _privateName_ be ResolvePrivateIdentifier(_privateEnv_, _privateIdentifier_).
           1. Return the Reference Record { [[Base]]: _baseValue_, [[ReferencedName]]: _privateName_, [[Strict]]: *true*, [[ThisValue]]: ~empty~ }.
@@ -12113,10 +12113,10 @@
         1. Perform CreateIntrinsics(_realm_).
         1. Set _realm_.[[AgentSignifier]] to AgentSignifier().
         1. Set _realm_.[[TemplateMap]] to a new empty List.
-        1. Let _newContext_ be a new execution context.
-        1. Set the Function of _newContext_ to *null*.
-        1. Set the Realm of _newContext_ to _realm_.
-        1. Set the ScriptOrModule of _newContext_ to *null*.
+        1. Let _newContext_ be a new ExecutionContext Record.
+        1. Set _newContext_.[[Function]] to *null*.
+        1. Set _newContext_.[[Realm]] to _realm_.
+        1. Set _newContext_.[[ScriptOrModule]] to *null*.
         1. Push _newContext_ onto the execution context stack; _newContext_ is now the running execution context.
         1. If the host requires use of a specific object to serve as _realm_'s global object, then
           1. Let _global_ be such an object created in a host-defined manner.
@@ -12173,22 +12173,28 @@
     <h1>Execution Contexts</h1>
     <p>An <dfn variants="execution contexts">execution context</dfn> is a specification device that is used to track the runtime evaluation of code by an ECMAScript implementation. At any point in time, there is at most one execution context per agent that is actually executing code. This is known as the agent's <dfn id="running-execution-context" variants="running execution contexts">running execution context</dfn>. All references to the running execution context in this specification denote the running execution context of the surrounding agent.</p>
     <p>The <dfn id="execution-context-stack" variants="execution context stacks">execution context stack</dfn> is used to track execution contexts. The running execution context is always the top element of this stack. A new execution context is created whenever control is transferred from the executable code associated with the currently running execution context to executable code that is not associated with that execution context. The newly created execution context is pushed onto the stack and becomes the running execution context.</p>
-    <p>An execution context contains whatever implementation specific state is necessary to track the execution progress of its associated code. Each execution context has at least the state components listed in <emu-xref href="#table-state-components-for-all-execution-contexts"></emu-xref>.</p>
-    <emu-table id="table-state-components-for-all-execution-contexts" caption="State Components for All Execution Contexts" oldids="table-22">
+    <p>Each execution context is represented as an ExecutionContext Record, with at least the fields listed in <emu-xref href="#table-state-components-for-all-execution-contexts"></emu-xref>.</p>
+    <emu-table id="table-state-components-for-all-execution-contexts" caption="ExecutionContext Record Fields" oldids="table-22">
       <table>
         <thead>
           <tr>
             <th>
-              Component
+              Field Name
             </th>
             <th>
-              Purpose
+              Value Type
+            </th>
+            <th>
+              Meaning
             </th>
           </tr>
         </thead>
         <tr>
           <td>
-            code evaluation state
+            [[CodeEvaluationState]]
+          </td>
+          <td>
+            implementation-specific
           </td>
           <td>
             Any state needed to perform, suspend, and resume evaluation of the code associated with this execution context.
@@ -12196,15 +12202,21 @@
         </tr>
         <tr>
           <td>
-            Function
+            [[Function]]
           </td>
           <td>
-            If this execution context is evaluating the code of a function object, then the value of this component is that function object. If the context is evaluating the code of a |Script| or |Module|, the value is *null*.
+            a function object or *null*
+          </td>
+          <td>
+            If this execution context is evaluating the code of a function object, then the value of this field is that function object. If the context is evaluating the code of a |Script| or |Module|, the value is *null*.
           </td>
         </tr>
         <tr>
           <td>
-            Realm
+            [[Realm]]
+          </td>
+          <td>
+            a Realm Record
           </td>
           <td>
             The Realm Record from which associated code accesses ECMAScript resources.
@@ -12212,32 +12224,41 @@
         </tr>
         <tr>
           <td>
-            ScriptOrModule
+            [[ScriptOrModule]]
           </td>
           <td>
-            The Module Record or Script Record from which associated code originates. If there is no originating script or module, as is the case for the original execution context created in InitializeHostDefinedRealm, the value is *null*.
+            a Module Record, a Script Record, or *null*
+          </td>
+          <td>
+            The Module Record or Script Record from which associated code originates. If there is no originating script or module, as is the case for the original ExecutionContext Record created in InitializeHostDefinedRealm, the value is *null*.
           </td>
         </tr>
       </table>
     </emu-table>
     <p>Evaluation of code by the running execution context may be suspended at various points defined within this specification. Once the running execution context has been suspended a different execution context may become the running execution context and commence evaluating its code. At some later time a suspended execution context may again become the running execution context and continue evaluating its code at the point where it had previously been suspended. Transition of the running execution context status among execution contexts usually occurs in stack-like last-in/first-out manner. However, some ECMAScript features require non-LIFO transitions of the running execution context.</p>
-    <p>The value of the Realm component of the running execution context is also called <dfn id="current-realm">the current Realm Record</dfn>. The value of the Function component of the running execution context is also called the <dfn id="active-function-object">active function object</dfn>.</p>
-    <p><dfn id="ecmascript-code-execution-context" variants="ECMAScript code execution context">ECMAScript code execution contexts</dfn> have the additional state components listed in <emu-xref href="#table-additional-state-components-for-ecmascript-code-execution-contexts"></emu-xref>.</p>
-    <emu-table id="table-additional-state-components-for-ecmascript-code-execution-contexts" caption="Additional State Components for ECMAScript Code Execution Contexts" oldids="table-23">
+    <p>The value of the running execution context's [[Realm]] field is also called <dfn id="current-realm">the current Realm Record</dfn>. The value of the running execution context's [[Function]] field is also called the <dfn id="active-function-object">active function object</dfn>.</p>
+    <p><dfn id="ecmascript-code-execution-context" variants="ECMAScript code ExecutionContext Record">ECMAScript code ExecutionContext Records</dfn> have the additional fields listed in <emu-xref href="#table-additional-state-components-for-ecmascript-code-execution-contexts"></emu-xref>.</p>
+    <emu-table id="table-additional-state-components-for-ecmascript-code-execution-contexts" caption="Additional Fields of ECMAScript Code ExecutionContext Records" oldids="table-23">
       <table>
         <thead>
           <tr>
             <th>
-              Component
+              Field Name
             </th>
             <th>
-              Purpose
+              Value Type
+            </th>
+            <th>
+              Meaning
             </th>
           </tr>
         </thead>
         <tr>
           <td>
-            LexicalEnvironment
+            [[LexicalEnvironment]]
+          </td>
+          <td>
+            an Environment Record
           </td>
           <td>
             Identifies the Environment Record used to resolve identifier references made by code within this execution context.
@@ -12245,7 +12266,10 @@
         </tr>
         <tr>
           <td>
-            VariableEnvironment
+            [[VariableEnvironment]]
+          </td>
+          <td>
+            an Environment Record
           </td>
           <td>
             Identifies the Environment Record that holds bindings created by |VariableStatement|s within this execution context.
@@ -12253,7 +12277,10 @@
         </tr>
         <tr>
           <td>
-            PrivateEnvironment
+            [[PrivateEnvironment]]
+          </td>
+          <td>
+            a PrivateEnvironment Record or *null*
           </td>
           <td>
             Identifies the PrivateEnvironment Record that holds Private Names created by |ClassElement|s in the nearest containing class. *null* if there is no containing class.
@@ -12261,23 +12288,28 @@
         </tr>
       </table>
     </emu-table>
-    <p>The LexicalEnvironment and VariableEnvironment components of an execution context are always Environment Records.</p>
-    <p>Execution contexts representing the evaluation of Generators have the additional state components listed in <emu-xref href="#table-additional-state-components-for-generator-execution-contexts"></emu-xref>.</p>
-    <emu-table id="table-additional-state-components-for-generator-execution-contexts" caption="Additional State Components for Generator Execution Contexts" oldids="table-24">
+    <p>ExecutionContext Records representing the evaluation of Generators have the additional fields listed in <emu-xref href="#table-additional-state-components-for-generator-execution-contexts"></emu-xref>.</p>
+    <emu-table id="table-additional-state-components-for-generator-execution-contexts" caption="Additional Fields of Generator ExecutionContext Records" oldids="table-24">
       <table>
         <thead>
           <tr>
             <th>
-              Component
+              Field Name
             </th>
             <th>
-              Purpose
+              Value Type
+            </th>
+            <th>
+              Meaning
             </th>
           </tr>
         </thead>
         <tr>
           <td>
-            Generator
+            [[Generator]]
+          </td>
+          <td>
+            an Object
           </td>
           <td>
             The Generator that this execution context is evaluating.
@@ -12285,7 +12317,7 @@
         </tr>
       </table>
     </emu-table>
-    <p>In most situations only the running execution context (the top of the execution context stack) is directly manipulated by algorithms within this specification. Hence when the terms “LexicalEnvironment”, and “VariableEnvironment” are used without qualification they are in reference to those components of the running execution context.</p>
+    <p>In most situations only the running execution context (the top of the execution context stack) is directly manipulated by algorithms within this specification.</p>
     <p>An execution context is purely a specification mechanism and need not correspond to any particular artefact of an ECMAScript implementation. It is impossible for ECMAScript code to directly access or observe an execution context.</p>
 
     <emu-clause id="sec-getactivescriptormodule" type="abstract operation">
@@ -12297,9 +12329,9 @@
 
       <emu-alg>
         1. If the execution context stack is empty, return *null*.
-        1. Let _executionContext_ be the topmost execution context on the execution context stack whose ScriptOrModule component is not *null*.
-        1. If no such execution context exists, return *null*.
-        1. Return _executionContext_'s ScriptOrModule.
+        1. Let _executionContext_ be the topmost ExecutionContext Record on the execution context stack whose [[ScriptOrModule]] field is not *null*.
+        1. If no such ExecutionContext Record exists, return *null*.
+        1. Return _executionContext_.[[ScriptOrModule]].
       </emu-alg>
     </emu-clause>
 
@@ -12316,7 +12348,7 @@
       </dl>
       <emu-alg>
         1. If _envRecord_ is not present or _envRecord_ is *undefined*, then
-          1. Set _envRecord_ to the running execution context's LexicalEnvironment.
+          1. Set _envRecord_ to the running execution context's [[LexicalEnvironment]].
         1. Assert: _envRecord_ is an Environment Record.
         1. Let _strict_ be IsStrict(the syntactic production that is being evaluated).
         1. Return ? GetIdentifierReference(_envRecord_, _name_, _strict_).
@@ -12333,7 +12365,7 @@
         <dd>It finds the Environment Record that currently supplies the binding of the keyword `this`.</dd>
       </dl>
       <emu-alg>
-        1. Let _envRecord_ be the running execution context's LexicalEnvironment.
+        1. Let _envRecord_ be the running execution context's [[LexicalEnvironment]].
         1. [id="step-getthisenvironment-loop"] Repeat,
           1. Let _exists_ be _envRecord_.HasThisBinding().
           1. If _exists_ is *true*, return _envRecord_.
@@ -12350,7 +12382,7 @@
       <h1>ResolveThisBinding ( ): either a normal completion containing an ECMAScript language value or a throw completion</h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It determines the binding of the keyword `this` using the LexicalEnvironment of the running execution context.</dd>
+        <dd>It determines the binding of the keyword `this` using the running execution context's [[LexicalEnvironment]].</dd>
       </dl>
       <emu-alg>
         1. Let _envRecord_ be GetThisEnvironment().
@@ -12362,7 +12394,7 @@
       <h1>GetNewTarget ( ): an Object or *undefined*</h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It determines the NewTarget value using the LexicalEnvironment of the running execution context.</dd>
+        <dd>It determines the NewTarget value using the running execution context's [[LexicalEnvironment]].</dd>
       </dl>
       <emu-alg>
         1. Let _envRecord_ be GetThisEnvironment().
@@ -12386,7 +12418,7 @@
     <emu-clause id="sec-runsuspendedcontext" type="abstract operation">
       <h1>
         RunSuspendedContext (
-          _context_: an execution context,
+          _context_: an ExecutionContext Record,
           _completionRecord_: a Completion Record,
         ): either a normal completion containing either an ECMAScript language value or ~unused~, or an abrupt completion
       </h1>
@@ -12416,7 +12448,7 @@
       </dl>
       <emu-alg>
         1. Let _genContext_ be the running execution context.
-        1. Remove _genContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
+        1. Remove _genContext_ from the execution context stack and restore the ExecutionContext Record that is at the top of the execution context stack as the running execution context.
         1. Let _callerContext_ be the running execution context.
         1. Resume _callerContext_, passing NormalCompletion(_value_).
         1. NOTE: The above step transfers control to _callerContext_ and pauses. The only way for it to un-pause and have control proceed to the subsequent steps in this algorithm is for _genContext_ to be resumed again, which might never happen.
@@ -12452,18 +12484,18 @@
     <p>At any particular time, _scriptOrModule_ (a Script Record, a Module Record, or *null*) is the <dfn id="job-activescriptormodule">active script or module</dfn> if all of the following conditions are true:</p>
     <ul>
       <li>GetActiveScriptOrModule() is _scriptOrModule_.</li>
-      <li>If _scriptOrModule_ is a Script Record or Module Record, let _executionContext_ be the topmost execution context on the execution context stack whose ScriptOrModule component is _scriptOrModule_. The Realm component of _executionContext_ is _scriptOrModule_.[[Realm]].</li>
+      <li>If _scriptOrModule_ is a Script Record or Module Record, let _executionContext_ be the topmost ExecutionContext Record on the execution context stack whose [[ScriptOrModule]] field is _scriptOrModule_. _executionContext_.[[Realm]] is _scriptOrModule_.[[Realm]].</li>
     </ul>
 
     <p>At any particular time, an execution is <dfn id="job-preparedtoevaluatecode">prepared to evaluate ECMAScript code</dfn> if all of the following conditions are true:</p>
     <ul>
       <li>The execution context stack is not empty.</li>
-      <li>The Realm component of the topmost execution context on the execution context stack is a Realm Record.</li>
+      <li>The [[Realm]] field of the topmost ExecutionContext Record on the execution context stack is a Realm Record.</li>
     </ul>
 
     <emu-note>
-      <p>Host environments may prepare an execution to evaluate code by pushing execution contexts onto the execution context stack. The specific steps are implementation-defined.</p>
-      <p>The specific choice of Realm is up to the host environment. This initial execution context and Realm is only in use before any callback function is invoked. When a callback function related to a Job, like a Promise handler, is invoked, the invocation pushes its own execution context and Realm.</p>
+      <p>Host environments may prepare an execution to evaluate code by pushing ExecutionContext Records onto the execution context stack. The specific steps are implementation-defined.</p>
+      <p>The specific choice of Realm is up to the host environment. This initial ExecutionContext Record and Realm is only in use before any callback function is invoked. When a callback function related to a Job, like a Promise handler, is invoked, the invocation pushes its own ExecutionContext Record and Realm.</p>
     </emu-note>
 
     <p>Particular kinds of Jobs have additional conformance requirements.</p>
@@ -13812,21 +13844,21 @@
           PrepareForOrdinaryCall (
             _func_: an ECMAScript function object,
             _newTarget_: an Object or *undefined*,
-          ): an execution context
+          ): an ExecutionContext Record
         </h1>
         <dl class="header">
         </dl>
         <emu-alg>
           1. Let _callerContext_ be the running execution context.
-          1. Let _calleeContext_ be a new ECMAScript code execution context.
-          1. Set the Function of _calleeContext_ to _func_.
+          1. Let _calleeContext_ be a new ECMAScript code ExecutionContext Record.
+          1. Set _calleeContext_.[[Function]] to _func_.
           1. Let _calleeRealm_ be _func_.[[Realm]].
-          1. Set the Realm of _calleeContext_ to _calleeRealm_.
-          1. Set the ScriptOrModule of _calleeContext_ to _func_.[[ScriptOrModule]].
+          1. Set _calleeContext_.[[Realm]] to _calleeRealm_.
+          1. Set _calleeContext_.[[ScriptOrModule]] to _func_.[[ScriptOrModule]].
           1. Let _localEnv_ be NewFunctionEnvironment(_func_, _newTarget_).
-          1. Set the LexicalEnvironment of _calleeContext_ to _localEnv_.
-          1. Set the VariableEnvironment of _calleeContext_ to _localEnv_.
-          1. Set the PrivateEnvironment of _calleeContext_ to _func_.[[PrivateEnvironment]].
+          1. Set _calleeContext_.[[LexicalEnvironment]] to _localEnv_.
+          1. Set _calleeContext_.[[VariableEnvironment]] to _localEnv_.
+          1. Set _calleeContext_.[[PrivateEnvironment]] to _func_.[[PrivateEnvironment]].
           1. If _callerContext_ is not already suspended, suspend _callerContext_.
           1. Push _calleeContext_ onto the execution context stack; _calleeContext_ is now the running execution context.
           1. NOTE: Any exception objects produced after this point are associated with _calleeRealm_.
@@ -13838,7 +13870,7 @@
         <h1>
           OrdinaryCallBindThis (
             _func_: an ECMAScript function object,
-            _calleeContext_: an execution context,
+            _calleeContext_: an ExecutionContext Record,
             _thisArg_: an ECMAScript language value,
           ): ~unused~
         </h1>
@@ -13848,7 +13880,7 @@
           1. Let _thisMode_ be _func_.[[ThisMode]].
           1. If _thisMode_ is ~lexical~, return ~unused~.
           1. Let _calleeRealm_ be _func_.[[Realm]].
-          1. Let _localEnv_ be the LexicalEnvironment of _calleeContext_.
+          1. Let _localEnv_ be _calleeContext_.[[LexicalEnvironment]].
           1. If _thisMode_ is ~strict~, then
             1. Let _thisValue_ be _thisArg_.
           1. Else,
@@ -13970,7 +14002,7 @@
           1. If _initializeResult_ is an abrupt completion, then
             1. Remove _calleeContext_ from the execution context stack and restore _callerContext_ as the running execution context.
             1. Return ? _initializeResult_.
-        1. Let _ctorEnv_ be the LexicalEnvironment of _calleeContext_.
+        1. Let _ctorEnv_ be _calleeContext_.[[LexicalEnvironment]].
         1. Let _result_ be Completion(OrdinaryCallEvaluateBody(_func_, _argList_)).
         1. Remove _calleeContext_ from the execution context stack and restore _callerContext_ as the running execution context.
         1. If _result_ is a throw completion, then
@@ -14241,13 +14273,13 @@
             1. Set _argumentsObjNeeded_ to *false*.
         1. If _strict_ is *true* or _hasParamExprs_ is *false*, then
           1. NOTE: Only a single Environment Record is needed for the parameters, since calls to `eval` in strict mode code cannot create new bindings which are visible outside of the `eval`.
-          1. Let _envRecord_ be the LexicalEnvironment of _calleeContext_.
+          1. Let _envRecord_ be _calleeContext_.[[LexicalEnvironment]].
         1. Else,
           1. NOTE: A separate Environment Record is needed to ensure that bindings created by direct eval calls in the formal parameter list are outside the environment where parameters are declared.
-          1. Let _calleeEnv_ be the LexicalEnvironment of _calleeContext_.
+          1. Let _calleeEnv_ be _calleeContext_.[[LexicalEnvironment]].
           1. Let _envRecord_ be NewDeclarativeEnvironment(_calleeEnv_).
-          1. Assert: The VariableEnvironment of _calleeContext_ and _calleeEnv_ are the same Environment Record.
-          1. Set the LexicalEnvironment of _calleeContext_ to _envRecord_.
+          1. Assert: _calleeContext_.[[VariableEnvironment]] and _calleeEnv_ are the same Environment Record.
+          1. Set _calleeContext_.[[LexicalEnvironment]] to _envRecord_.
         1. For each String _paramName_ of _paramNames_, do
           1. Let _alreadyDeclared_ be ! _envRecord_.HasBinding(_paramName_).
           1. NOTE: Early errors ensure that duplicate parameter names can only occur in non-strict functions that do not have parameter default values or rest parameters.
@@ -14289,7 +14321,7 @@
         1. Else,
           1. NOTE: A separate Environment Record is needed to ensure that closures created by expressions in the formal parameter list do not have visibility of declarations in the function body.
           1. Let _variableEnv_ be NewDeclarativeEnvironment(_envRecord_).
-          1. Set the VariableEnvironment of _calleeContext_ to _variableEnv_.
+          1. Set _calleeContext_.[[VariableEnvironment]] to _variableEnv_.
           1. Let _instantiatedVariableNames_ be a new empty List.
           1. For each element _name_ of _variableNames_, do
             1. If _instantiatedVariableNames_ does not contain _name_, then
@@ -14314,14 +14346,14 @@
                   1. Perform ! _variableEnv_.InitializeBinding(_funcName_, *undefined*).
                   1. Append _funcName_ to _instantiatedVariableNames_.
                 1. [id="step-functiondeclarationinstantiation-alt-funcdecl-eval"] When the |FunctionDeclaration| _funcDecl_ is evaluated, perform the following steps in place of the |FunctionDeclaration| Evaluation algorithm provided in <emu-xref href="#sec-function-definitions-runtime-semantics-evaluation"></emu-xref>:
-                  1. Let _funcEnv_ be the running execution context's VariableEnvironment.
-                  1. Let _blockEnv_ be the running execution context's LexicalEnvironment.
+                  1. Let _funcEnv_ be the running execution context's [[VariableEnvironment]].
+                  1. Let _blockEnv_ be the running execution context's [[LexicalEnvironment]].
                   1. Let _funcObj_ be ! _blockEnv_.GetBindingValue(_funcName_, *false*).
                   1. Perform ! _funcEnv_.SetMutableBinding(_funcName_, _funcObj_, *false*).
                   1. Return ~unused~.
           1. Let _lexicalEnv_ be NewDeclarativeEnvironment(_variableEnv_).
           1. NOTE: Non-strict functions use a separate Environment Record for top-level lexical declarations so that a direct eval can determine whether any var scoped declarations introduced by the eval code conflict with pre-existing top-level lexically scoped declarations. This is not needed for strict functions because a strict direct eval always places all declarations into a new Environment Record.
-        1. Set the LexicalEnvironment of _calleeContext_ to _lexicalEnv_.
+        1. Set _calleeContext_.[[LexicalEnvironment]] to _lexicalEnv_.
         1. Let _lexicalDecls_ be the LexicallyScopedDeclarations of _code_.
         1. For each element _lexicalDecl_ of _lexicalDecls_, do
           1. NOTE: A lexically declared name cannot be the same as a function/generator declaration, formal parameter, or a var name. Lexically declared names are only instantiated here but not initialized.
@@ -14330,7 +14362,7 @@
               1. Perform ! _lexicalEnv_.CreateImmutableBinding(_name_, *true*).
             1. Else,
               1. Perform ! _lexicalEnv_.CreateMutableBinding(_name_, *false*).
-        1. Let _privateEnv_ be the PrivateEnvironment of _calleeContext_.
+        1. Let _privateEnv_ be _calleeContext_.[[PrivateEnvironment]].
         1. For each Parse Node _funcDecl_ of _funcsToInitialize_, do
           1. Let _funcName_ be the sole element of the BoundNames of _funcDecl_.
           1. Let _funcObj_ be InstantiateFunctionObject of _funcDecl_ with arguments _lexicalEnv_ and _privateEnv_.
@@ -14402,11 +14434,11 @@
       <emu-alg>
         1. Let _callerContext_ be the running execution context.
         1. If _callerContext_ is not already suspended, suspend _callerContext_.
-        1. Let _calleeContext_ be a new execution context.
-        1. Set the Function of _calleeContext_ to _func_.
+        1. Let _calleeContext_ be a new ExecutionContext Record.
+        1. Set _calleeContext_.[[Function]] to _func_.
         1. Let _calleeRealm_ be _func_.[[Realm]].
-        1. Set the Realm of _calleeContext_ to _calleeRealm_.
-        1. Set the ScriptOrModule of _calleeContext_ to *null*.
+        1. Set _calleeContext_.[[Realm]] to _calleeRealm_.
+        1. Set _calleeContext_.[[ScriptOrModule]] to *null*.
         1. Perform any necessary implementation-defined initialization of _calleeContext_.
         1. Push _calleeContext_ onto the execution context stack; _calleeContext_ is now the running execution context.
         1. If _func_.[[Async]] is *true*, then
@@ -20942,7 +20974,7 @@
         1. Let _rightRef_ be ? Evaluation of |ShiftExpression|.
         1. Let _rightValue_ be ? GetValue(_rightRef_).
         1. If _rightValue_ is not an Object, throw a *TypeError* exception.
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Assert: _privateEnv_ is not *null*.
         1. Let _privateName_ be ResolvePrivateIdentifier(_privateEnv_, _privateIdentifier_).
         1. If PrivateElementFind(_rightValue_, _privateName_) is ~empty~, return *false*.
@@ -21901,17 +21933,17 @@
       </emu-alg>
       <emu-grammar>Block : `{` StatementList `}`</emu-grammar>
       <emu-alg>
-        1. Let _oldEnv_ be the running execution context's LexicalEnvironment.
+        1. Let _oldEnv_ be the running execution context's [[LexicalEnvironment]].
         1. Let _blockEnv_ be NewDeclarativeEnvironment(_oldEnv_).
         1. Perform BlockDeclarationInstantiation(|StatementList|, _blockEnv_).
-        1. Set the running execution context's LexicalEnvironment to _blockEnv_.
+        1. Set the running execution context's [[LexicalEnvironment]] to _blockEnv_.
         1. Let _blockValue_ be Completion(Evaluation of |StatementList|).
         1. Set _blockValue_ to Completion(DisposeResources(_blockEnv_.[[DisposableResourceStack]], _blockValue_)).
-        1. Set the running execution context's LexicalEnvironment to _oldEnv_.
+        1. Set the running execution context's [[LexicalEnvironment]] to _oldEnv_.
         1. Return ? _blockValue_.
       </emu-alg>
       <emu-note>
-        <p>No matter how control leaves the |Block| the LexicalEnvironment is always restored to its former state.</p>
+        <p>No matter how control leaves the |Block| the [[LexicalEnvironment]] is always restored to its former state.</p>
       </emu-note>
       <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
       <emu-alg>
@@ -21946,7 +21978,7 @@
       <p>It performs the following steps when called:</p>
       <emu-alg>
         1. Let _decls_ be the LexicallyScopedDeclarations of _code_.
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. For each element _decl_ of _decls_, do
           1. For each element _name_ of the BoundNames of _decl_, do
             1. If IsConstantDeclaration of _decl_ is *true*, then
@@ -21979,7 +22011,7 @@
     <emu-clause id="sec-let-and-const-declarations">
       <h1>Let, Const, Using, and Await Using Declarations</h1>
       <emu-note>
-        <p>`let`, `const`, `using`, and `await using` declarations define variables that are scoped to the running execution context's LexicalEnvironment. The variables are created when their containing Environment Record is instantiated but may not be accessed in any way until the variable's |LexicalBinding| is evaluated. A variable defined by a |LexicalBinding| with an |Initializer| is assigned the value of its |Initializer|'s |AssignmentExpression| when the |LexicalBinding| is evaluated, not when the variable is created. If a |LexicalBinding| in a `let` declaration does not have an |Initializer| the variable is assigned the value *undefined* when the |LexicalBinding| is evaluated.</p>
+        <p>`let`, `const`, `using`, and `await using` declarations define variables that are scoped to the running execution context's [[LexicalEnvironment]]. The variables are created when their containing Environment Record is instantiated but may not be accessed in any way until the variable's |LexicalBinding| is evaluated. A variable defined by a |LexicalBinding| with an |Initializer| is assigned the value of its |Initializer|'s |AssignmentExpression| when the |LexicalBinding| is evaluated, not when the variable is created. If a |LexicalBinding| in a `let` declaration does not have an |Initializer| the variable is assigned the value *undefined* when the |LexicalBinding| is evaluated.</p>
       </emu-note>
       <h2>Syntax</h2>
       <emu-grammar type="definition">
@@ -22126,7 +22158,7 @@
           1. Assert: _kind_ is ~normal~.
           1. Let _rhs_ be ? Evaluation of |Initializer|.
           1. Let _value_ be ? GetValue(_rhs_).
-          1. Let _envRecord_ be the running execution context's LexicalEnvironment.
+          1. Let _envRecord_ be the running execution context's [[LexicalEnvironment]].
           1. Return ? BindingInitialization of |BindingPattern| with arguments _value_ and _envRecord_.
         </emu-alg>
       </emu-clause>
@@ -22135,7 +22167,7 @@
     <emu-clause id="sec-variable-statement">
       <h1>Variable Statement</h1>
       <emu-note>
-        <p>A `var` statement declares variables that are scoped to the running execution context's VariableEnvironment. Var variables are created when their containing Environment Record is instantiated and are initialized to *undefined* when created. Within the scope of any VariableEnvironment a common |BindingIdentifier| may appear in more than one |VariableDeclaration| but those declarations collectively define only one variable. A variable defined by a |VariableDeclaration| with an |Initializer| is assigned the value of its |Initializer|'s |AssignmentExpression| when the |VariableDeclaration| is executed, not when the variable is created.</p>
+        <p>A `var` statement declares variables that are scoped to the running execution context's [[VariableEnvironment]]. Var variables are created when their containing Environment Record is instantiated and are initialized to *undefined* when created. Within the scope of any [[VariableEnvironment]] a common |BindingIdentifier| may appear in more than one |VariableDeclaration| but those declarations collectively define only one variable. A variable defined by a |VariableDeclaration| with an |Initializer| is assigned the value of its |Initializer|'s |AssignmentExpression| when the |VariableDeclaration| is executed, not when the variable is created.</p>
       </emu-note>
       <h2>Syntax</h2>
       <emu-grammar type="definition">
@@ -22180,7 +22212,7 @@
           1. Return ~empty~.
         </emu-alg>
         <emu-note>
-          <p>If a |VariableDeclaration| is nested within a with statement and the |BindingIdentifier| in the |VariableDeclaration| is the same as a property name of the binding object of the with statement's Object Environment Record, then step <emu-xref href="#step-vardecllist-evaluation-putvalue"></emu-xref> will assign _value_ to the property instead of assigning to the VariableEnvironment binding of the |Identifier|.</p>
+          <p>If a |VariableDeclaration| is nested within a with statement and the |BindingIdentifier| in the |VariableDeclaration| is the same as a property name of the binding object of the with statement's Object Environment Record, then step <emu-xref href="#step-vardecllist-evaluation-putvalue"></emu-xref> will assign _value_ to the property instead of assigning to the [[VariableEnvironment]] binding of the |Identifier|.</p>
         </emu-note>
         <emu-grammar>VariableDeclaration : BindingPattern Initializer</emu-grammar>
         <emu-alg>
@@ -22633,7 +22665,7 @@
         </emu-alg>
         <emu-grammar>ForStatement : `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement</emu-grammar>
         <emu-alg>
-          1. Let _oldEnv_ be the running execution context's LexicalEnvironment.
+          1. Let _oldEnv_ be the running execution context's [[LexicalEnvironment]].
           1. Let _loopEnv_ be NewDeclarativeEnvironment(_oldEnv_).
           1. Let _isConst_ be IsConstantDeclaration of |LexicalDeclaration|.
           1. Let _boundNames_ be the BoundNames of |LexicalDeclaration|.
@@ -22642,12 +22674,12 @@
               1. Perform ! _loopEnv_.CreateImmutableBinding(_name_, *true*).
             1. Else,
               1. Perform ! _loopEnv_.CreateMutableBinding(_name_, *false*).
-          1. Set the running execution context's LexicalEnvironment to _loopEnv_.
+          1. Set the running execution context's [[LexicalEnvironment]] to _loopEnv_.
           1. Let _forDecl_ be Completion(Evaluation of |LexicalDeclaration|).
           1. If _forDecl_ is an abrupt completion, then
             1. Set _forDecl_ to Completion(DisposeResources(_loopEnv_.[[DisposableResourceStack]], _forDecl_)).
             1. Assert: _forDecl_ is an abrupt completion.
-            1. Set the running execution context's LexicalEnvironment to _oldEnv_.
+            1. Set the running execution context's [[LexicalEnvironment]] to _oldEnv_.
             1. Return ? _forDecl_.
           1. If _isConst_ is *false*, let _perIterationLets_ be _boundNames_; else let _perIterationLets_ be a new empty List.
           1. If the first |Expression| is present, let _test_ be the first |Expression|; else let _test_ be ~empty~.
@@ -22655,7 +22687,7 @@
           1. Let _bodyResult_ be Completion(ForBodyEvaluation(_test_, _increment_, |Statement|, _perIterationLets_, _labelSet_)).
           1. Set _bodyResult_ to Completion(DisposeResources(_loopEnv_.[[DisposableResourceStack]], _bodyResult_)).
           1. Assert: If _bodyResult_ is a normal completion, then _bodyResult_.[[Value]] is not ~empty~.
-          1. Set the running execution context's LexicalEnvironment to _oldEnv_.
+          1. Set the running execution context's [[LexicalEnvironment]] to _oldEnv_.
           1. Return ? _bodyResult_.
         </emu-alg>
       </emu-clause>
@@ -22700,7 +22732,7 @@
         </dl>
         <emu-alg>
           1. If _perIterationBindings_ has any elements, then
-            1. Let _lastIterationEnv_ be the running execution context's LexicalEnvironment.
+            1. Let _lastIterationEnv_ be the running execution context's [[LexicalEnvironment]].
             1. Let _outer_ be _lastIterationEnv_.[[OuterEnv]].
             1. Assert: _outer_ is not *null*.
             1. Let _thisIterationEnv_ be NewDeclarativeEnvironment(_outer_).
@@ -22708,7 +22740,7 @@
               1. Perform ! _thisIterationEnv_.CreateMutableBinding(_name_, *false*).
               1. Let _lastValue_ be ? _lastIterationEnv_.GetBindingValue(_name_, *true*).
               1. Perform ! _thisIterationEnv_.InitializeBinding(_name_, _lastValue_).
-            1. Set the running execution context's LexicalEnvironment to _thisIterationEnv_.
+            1. Set the running execution context's [[LexicalEnvironment]] to _thisIterationEnv_.
           1. Return ~unused~.
         </emu-alg>
       </emu-clause>
@@ -22970,15 +23002,15 @@
         <dl class="header">
         </dl>
         <emu-alg>
-          1. Let _oldEnv_ be the running execution context's LexicalEnvironment.
+          1. Let _oldEnv_ be the running execution context's [[LexicalEnvironment]].
           1. If _uninitializedBoundNames_ is not empty, then
             1. Assert: _uninitializedBoundNames_ has no duplicate entries.
             1. Let _newEnv_ be NewDeclarativeEnvironment(_oldEnv_).
             1. For each String _name_ of _uninitializedBoundNames_, do
               1. Perform ! _newEnv_.CreateMutableBinding(_name_, *false*).
-            1. Set the running execution context's LexicalEnvironment to _newEnv_.
+            1. Set the running execution context's [[LexicalEnvironment]] to _newEnv_.
           1. Let _exprRef_ be Completion(Evaluation of _expr_).
-          1. Set the running execution context's LexicalEnvironment to _oldEnv_.
+          1. Set the running execution context's [[LexicalEnvironment]] to _oldEnv_.
           1. Let _exprValue_ be ? GetValue(? _exprRef_).
           1. If _iterationKind_ is ~enumerate~, then
             1. If _exprValue_ is either *undefined* or *null*, then
@@ -23010,7 +23042,7 @@
         </dl>
         <emu-alg>
           1. If _iteratorKind_ is not present, set _iteratorKind_ to ~sync~.
-          1. Let _oldEnv_ be the running execution context's LexicalEnvironment.
+          1. Let _oldEnv_ be the running execution context's [[LexicalEnvironment]].
           1. Let _iterationResult_ be *undefined*.
           1. If _lhsKind_ is ~lexical-binding~, then
             1. Assert: _lhs_ is a |ForDeclaration|.
@@ -23054,7 +23086,7 @@
               1. Assert: _lhs_ is a |ForDeclaration|.
               1. Let _iterationEnv_ be NewDeclarativeEnvironment(_oldEnv_).
               1. Perform ForDeclarationBindingInstantiation of _lhs_ with argument _iterationEnv_.
-              1. Set the running execution context's LexicalEnvironment to _iterationEnv_.
+              1. Set the running execution context's [[LexicalEnvironment]] to _iterationEnv_.
               1. If _destructuring_ is *true*, then
                 1. Let _status_ be Completion(ForDeclarationBindingInitialization of _lhs_ with arguments _nextValue_ and _iterationEnv_).
               1. Else,
@@ -23074,7 +23106,7 @@
               1. If _iterationEnv_ is not *undefined*, then
                 1. Set _status_ to Completion(DisposeResources(_iterationEnv_.[[DisposableResourceStack]], _status_)).
                 1. Assert: _status_ is an abrupt completion.
-              1. Set the running execution context's LexicalEnvironment to _oldEnv_.
+              1. Set the running execution context's [[LexicalEnvironment]] to _oldEnv_.
               1. If _iterationKind_ is ~enumerate~, return ? _status_.
               1. Assert: _iterationKind_ is ~iterate~.
               1. If _iteratorKind_ is ~async~, return ? AsyncIteratorClose(_iteratorRecord_, _status_).
@@ -23082,7 +23114,7 @@
             1. Let _result_ be Completion(Evaluation of _stmt_).
             1. If _iterationEnv_ is not *undefined*, then
               1. Set _result_ to Completion(DisposeResources(_iterationEnv_.[[DisposableResourceStack]], _result_)).
-            1. Set the running execution context's LexicalEnvironment to _oldEnv_.
+            1. Set the running execution context's [[LexicalEnvironment]] to _oldEnv_.
             1. If LoopContinues(_result_, _labelSet_) is *false*, then
               1. Set _status_ to Completion(UpdateEmpty(_result_, _iterationResult_)).
               1. If _iterationKind_ is ~enumerate~, return ? _status_.
@@ -23424,15 +23456,15 @@
       <emu-alg>
         1. Let _value_ be ? Evaluation of |Expression|.
         1. Let _obj_ be ? ToObject(? GetValue(_value_)).
-        1. Let _oldEnv_ be the running execution context's LexicalEnvironment.
+        1. Let _oldEnv_ be the running execution context's [[LexicalEnvironment]].
         1. Let _newEnv_ be NewObjectEnvironment(_obj_, *true*, _oldEnv_).
-        1. Set the running execution context's LexicalEnvironment to _newEnv_.
+        1. Set the running execution context's [[LexicalEnvironment]] to _newEnv_.
         1. Let _stmtCompletion_ be Completion(Evaluation of |Statement|).
-        1. Set the running execution context's LexicalEnvironment to _oldEnv_.
+        1. Set the running execution context's [[LexicalEnvironment]] to _oldEnv_.
         1. Return ? UpdateEmpty(_stmtCompletion_, *undefined*).
       </emu-alg>
       <emu-note>
-        <p>No matter how control leaves the embedded |Statement|, whether normally or by some form of abrupt completion or exception, the LexicalEnvironment is always restored to its former state.</p>
+        <p>No matter how control leaves the embedded |Statement|, whether normally or by some form of abrupt completion or exception, the [[LexicalEnvironment]] is always restored to its former state.</p>
       </emu-note>
     </emu-clause>
   </emu-clause>
@@ -23583,17 +23615,17 @@
       <emu-alg>
         1. Let _exprRef_ be ? Evaluation of |Expression|.
         1. Let _switchValue_ be ? GetValue(_exprRef_).
-        1. Let _oldEnv_ be the running execution context's LexicalEnvironment.
+        1. Let _oldEnv_ be the running execution context's [[LexicalEnvironment]].
         1. Let _blockEnv_ be NewDeclarativeEnvironment(_oldEnv_).
         1. Perform BlockDeclarationInstantiation(|CaseBlock|, _blockEnv_).
-        1. Set the running execution context's LexicalEnvironment to _blockEnv_.
+        1. Set the running execution context's [[LexicalEnvironment]] to _blockEnv_.
         1. Let _blockResult_ be Completion(CaseBlockEvaluation of |CaseBlock| with argument _switchValue_).
         1. Assert: _blockEnv_.[[DisposableResourceStack]] is an empty List.
-        1. Set the running execution context's LexicalEnvironment to _oldEnv_.
+        1. Set the running execution context's [[LexicalEnvironment]] to _oldEnv_.
         1. Return _blockResult_.
       </emu-alg>
       <emu-note>
-        <p>No matter how control leaves the |SwitchStatement| the LexicalEnvironment is always restored to its former state.</p>
+        <p>No matter how control leaves the |SwitchStatement| the [[LexicalEnvironment]] is always restored to its former state.</p>
       </emu-note>
       <emu-grammar>CaseClause : `case` Expression `:`</emu-grammar>
       <emu-alg>
@@ -23799,17 +23831,17 @@
       </dl>
       <emu-grammar>Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
       <emu-alg>
-        1. Let _oldEnv_ be the running execution context's LexicalEnvironment.
+        1. Let _oldEnv_ be the running execution context's [[LexicalEnvironment]].
         1. Let _catchEnv_ be NewDeclarativeEnvironment(_oldEnv_).
         1. For each element _argName_ of the BoundNames of |CatchParameter|, do
           1. Perform ! _catchEnv_.CreateMutableBinding(_argName_, *false*).
-        1. Set the running execution context's LexicalEnvironment to _catchEnv_.
+        1. Set the running execution context's [[LexicalEnvironment]] to _catchEnv_.
         1. Let _status_ be Completion(BindingInitialization of |CatchParameter| with arguments _thrownValue_ and _catchEnv_).
         1. If _status_ is an abrupt completion, then
-          1. Set the running execution context's LexicalEnvironment to _oldEnv_.
+          1. Set the running execution context's [[LexicalEnvironment]] to _oldEnv_.
           1. Return ? _status_.
         1. Let _blockCompletion_ be Completion(Evaluation of |Block|).
-        1. Set the running execution context's LexicalEnvironment to _oldEnv_.
+        1. Set the running execution context's [[LexicalEnvironment]] to _oldEnv_.
         1. Return ? _blockCompletion_.
       </emu-alg>
       <emu-grammar>Catch : `catch` Block</emu-grammar>
@@ -23817,7 +23849,7 @@
         1. Return ? Evaluation of |Block|.
       </emu-alg>
       <emu-note>
-        <p>No matter how control leaves the |Block| the LexicalEnvironment is always restored to its former state.</p>
+        <p>No matter how control leaves the |Block| the [[LexicalEnvironment]] is always restored to its former state.</p>
       </emu-note>
     </emu-clause>
 
@@ -24323,8 +24355,8 @@
       <emu-grammar>FunctionExpression : `function` `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. If _name_ is not present, set _name_ to the empty String.
-        1. Let _envRecord_ be the LexicalEnvironment of the running execution context.
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _envRecord_ be the running execution context's [[LexicalEnvironment]].
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Let _sourceText_ be the source text matched by |FunctionExpression|.
         1. Let _closure_ be OrdinaryFunctionCreate(%Function.prototype%, _sourceText_, |FormalParameters|, |FunctionBody|, ~non-lexical-this~, _envRecord_, _privateEnv_).
         1. Perform SetFunctionName(_closure_, _name_).
@@ -24335,10 +24367,10 @@
       <emu-alg>
         1. Assert: _name_ is not present.
         1. Set _name_ to the StringValue of |BindingIdentifier|.
-        1. Let _outerEnv_ be the running execution context's LexicalEnvironment.
+        1. Let _outerEnv_ be the running execution context's [[LexicalEnvironment]].
         1. Let _funcEnv_ be NewDeclarativeEnvironment(_outerEnv_).
         1. Perform ! _funcEnv_.CreateImmutableBinding(_name_, *false*).
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Let _sourceText_ be the source text matched by |FunctionExpression|.
         1. Let _closure_ be OrdinaryFunctionCreate(%Function.prototype%, _sourceText_, |FormalParameters|, |FunctionBody|, ~non-lexical-this~, _funcEnv_, _privateEnv_).
         1. Perform SetFunctionName(_closure_, _name_).
@@ -24380,7 +24412,7 @@
       <emu-grammar>FunctionStatementList : StatementList</emu-grammar>
       <emu-alg>
         1. Let _result_ be Completion(Evaluation of |StatementList|).
-        1. Let _env_ be the running execution context's LexicalEnvironment.
+        1. Let _env_ be the running execution context's [[LexicalEnvironment]].
         1. Assert: _env_ is a Declarative Environment Record.
         1. Return ? DisposeResources(_env_.[[DisposableResourceStack]], _result_).
       </emu-alg>
@@ -24482,8 +24514,8 @@
       <emu-grammar>ArrowFunction : ArrowParameters `=>` ConciseBody</emu-grammar>
       <emu-alg>
         1. If _name_ is not present, set _name_ to the empty String.
-        1. Let _envRecord_ be the LexicalEnvironment of the running execution context.
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _envRecord_ be the running execution context's [[LexicalEnvironment]].
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Let _sourceText_ be the source text matched by |ArrowFunction|.
         1. [id="step-arrowfunction-evaluation-functioncreate"] Let _closure_ be OrdinaryFunctionCreate(%Function.prototype%, _sourceText_, |ArrowParameters|, |ConciseBody|, ~lexical-this~, _envRecord_, _privateEnv_).
         1. Perform SetFunctionName(_closure_, _name_).
@@ -24620,8 +24652,8 @@
       <emu-grammar>MethodDefinition : ClassElementName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Let _propertyKey_ be ? Evaluation of |ClassElementName|.
-        1. Let _envRecord_ be the running execution context's LexicalEnvironment.
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _envRecord_ be the running execution context's [[LexicalEnvironment]].
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. If _proto_ is not present, set _proto_ to %Function.prototype%.
         1. Let _sourceText_ be the source text matched by |MethodDefinition|.
         1. Let _closure_ be OrdinaryFunctionCreate(_proto_, _sourceText_, |UniqueFormalParameters|, |FunctionBody|, ~non-lexical-this~, _envRecord_, _privateEnv_).
@@ -24648,8 +24680,8 @@
       <emu-grammar>MethodDefinition : `get` ClassElementName `(` `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Let _propertyKey_ be ? Evaluation of |ClassElementName|.
-        1. Let _envRecord_ be the running execution context's LexicalEnvironment.
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _envRecord_ be the running execution context's [[LexicalEnvironment]].
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Let _sourceText_ be the source text matched by |MethodDefinition|.
         1. Let _formalParamList_ be an instance of the production <emu-grammar>FormalParameters : [empty]</emu-grammar>.
         1. Let _closure_ be OrdinaryFunctionCreate(%Function.prototype%, _sourceText_, _formalParamList_, |FunctionBody|, ~non-lexical-this~, _envRecord_, _privateEnv_).
@@ -24664,8 +24696,8 @@
       <emu-grammar>MethodDefinition : `set` ClassElementName `(` PropertySetParameterList `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Let _propertyKey_ be ? Evaluation of |ClassElementName|.
-        1. Let _envRecord_ be the running execution context's LexicalEnvironment.
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _envRecord_ be the running execution context's [[LexicalEnvironment]].
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Let _sourceText_ be the source text matched by |MethodDefinition|.
         1. Let _closure_ be OrdinaryFunctionCreate(%Function.prototype%, _sourceText_, |PropertySetParameterList|, |FunctionBody|, ~non-lexical-this~, _envRecord_, _privateEnv_).
         1. Perform MakeMethod(_closure_, _obj_).
@@ -24679,8 +24711,8 @@
       <emu-grammar>GeneratorMethod : `*` ClassElementName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. Let _propertyKey_ be ? Evaluation of |ClassElementName|.
-        1. Let _envRecord_ be the running execution context's LexicalEnvironment.
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _envRecord_ be the running execution context's [[LexicalEnvironment]].
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Let _sourceText_ be the source text matched by |GeneratorMethod|.
         1. Let _closure_ be OrdinaryFunctionCreate(%GeneratorFunction.prototype%, _sourceText_, |UniqueFormalParameters|, |GeneratorBody|, ~non-lexical-this~, _envRecord_, _privateEnv_).
         1. Perform MakeMethod(_closure_, _obj_).
@@ -24694,8 +24726,8 @@
       </emu-grammar>
       <emu-alg>
         1. Let _propertyKey_ be ? Evaluation of |ClassElementName|.
-        1. Let _envRecord_ be the running execution context's LexicalEnvironment.
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _envRecord_ be the running execution context's [[LexicalEnvironment]].
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Let _sourceText_ be the source text matched by |AsyncGeneratorMethod|.
         1. Let _closure_ be OrdinaryFunctionCreate(%AsyncGeneratorFunction.prototype%, _sourceText_, |UniqueFormalParameters|, |AsyncGeneratorBody|, ~non-lexical-this~, _envRecord_, _privateEnv_).
         1. Perform MakeMethod(_closure_, _obj_).
@@ -24709,8 +24741,8 @@
       </emu-grammar>
       <emu-alg>
         1. Let _propertyKey_ be ? Evaluation of |ClassElementName|.
-        1. Let _envRecord_ be the LexicalEnvironment of the running execution context.
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _envRecord_ be the running execution context's [[LexicalEnvironment]].
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Let _sourceText_ be the source text matched by |AsyncMethod|.
         1. Let _closure_ be OrdinaryFunctionCreate(%AsyncFunction.prototype%, _sourceText_, |UniqueFormalParameters|, |AsyncFunctionBody|, ~non-lexical-this~, _envRecord_, _privateEnv_).
         1. Perform MakeMethod(_closure_, _obj_).
@@ -24872,8 +24904,8 @@
       <emu-grammar>GeneratorExpression : `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. If _name_ is not present, set _name_ to the empty String.
-        1. Let _envRecord_ be the LexicalEnvironment of the running execution context.
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _envRecord_ be the running execution context's [[LexicalEnvironment]].
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Let _sourceText_ be the source text matched by |GeneratorExpression|.
         1. Let _closure_ be OrdinaryFunctionCreate(%GeneratorFunction.prototype%, _sourceText_, |FormalParameters|, |GeneratorBody|, ~non-lexical-this~, _envRecord_, _privateEnv_).
         1. Perform SetFunctionName(_closure_, _name_).
@@ -24885,10 +24917,10 @@
       <emu-alg>
         1. Assert: _name_ is not present.
         1. Set _name_ to the StringValue of |BindingIdentifier|.
-        1. Let _outerEnv_ be the running execution context's LexicalEnvironment.
+        1. Let _outerEnv_ be the running execution context's [[LexicalEnvironment]].
         1. Let _funcEnv_ be NewDeclarativeEnvironment(_outerEnv_).
         1. Perform ! _funcEnv_.CreateImmutableBinding(_name_, *false*).
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Let _sourceText_ be the source text matched by |GeneratorExpression|.
         1. Let _closure_ be OrdinaryFunctionCreate(%GeneratorFunction.prototype%, _sourceText_, |FormalParameters|, |GeneratorBody|, ~non-lexical-this~, _funcEnv_, _privateEnv_).
         1. Perform SetFunctionName(_closure_, _name_).
@@ -25107,8 +25139,8 @@
       </emu-grammar>
       <emu-alg>
         1. If _name_ is not present, set _name_ to the empty String.
-        1. Let _envRecord_ be the LexicalEnvironment of the running execution context.
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _envRecord_ be the running execution context's [[LexicalEnvironment]].
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Let _sourceText_ be the source text matched by |AsyncGeneratorExpression|.
         1. Let _closure_ be OrdinaryFunctionCreate(%AsyncGeneratorFunction.prototype%, _sourceText_, |FormalParameters|, |AsyncGeneratorBody|, ~non-lexical-this~, _envRecord_, _privateEnv_).
         1. Perform SetFunctionName(_closure_, _name_).
@@ -25122,10 +25154,10 @@
       <emu-alg>
         1. Assert: _name_ is not present.
         1. Set _name_ to the StringValue of |BindingIdentifier|.
-        1. Let _outerEnv_ be the running execution context's LexicalEnvironment.
+        1. Let _outerEnv_ be the running execution context's [[LexicalEnvironment]].
         1. Let _funcEnv_ be NewDeclarativeEnvironment(_outerEnv_).
         1. Perform ! _funcEnv_.CreateImmutableBinding(_name_, *false*).
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Let _sourceText_ be the source text matched by |AsyncGeneratorExpression|.
         1. Let _closure_ be OrdinaryFunctionCreate(%AsyncGeneratorFunction.prototype%, _sourceText_, |FormalParameters|, |AsyncGeneratorBody|, ~non-lexical-this~, _funcEnv_, _privateEnv_).
         1. Perform SetFunctionName(_closure_, _name_).
@@ -25622,8 +25654,8 @@
         1. Let _name_ be ? Evaluation of |ClassElementName|.
         1. If |Initializer| is present, then
           1. Let _formalParamList_ be an instance of the production <emu-grammar>FormalParameters : [empty]</emu-grammar>.
-          1. Let _envRecord_ be the LexicalEnvironment of the running execution context.
-          1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+          1. Let _envRecord_ be the running execution context's [[LexicalEnvironment]].
+          1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
           1. Let _sourceText_ be the empty sequence of Unicode code points.
           1. Let _initializer_ be OrdinaryFunctionCreate(%Function.prototype%, _sourceText_, _formalParamList_, |Initializer|, ~non-lexical-this~, _envRecord_, _privateEnv_).
           1. Perform MakeMethod(_initializer_, _homeObj_).
@@ -25647,8 +25679,8 @@
       </dl>
       <emu-grammar>ClassStaticBlock : `static` `{` ClassStaticBlockBody `}`</emu-grammar>
       <emu-alg>
-        1. Let _lexicalEnv_ be the running execution context's LexicalEnvironment.
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _lexicalEnv_ be the running execution context's [[LexicalEnvironment]].
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Let _sourceText_ be the empty sequence of Unicode code points.
         1. Let _formalParams_ be an instance of the production <emu-grammar>FormalParameters : [empty]</emu-grammar>.
         1. [id="step-synthetic-class-static-block-fn"] Let _bodyFunc_ be OrdinaryFunctionCreate(%Function.prototype%, _sourceText_, _formalParams_, |ClassStaticBlockBody|, ~non-lexical-this~, _lexicalEnv_, _privateEnv_).
@@ -25671,7 +25703,7 @@
         1. Assert: _funcObj_ is a synthetic function created by ClassStaticBlockDefinitionEvaluation step <emu-xref href="#step-synthetic-class-static-block-fn"></emu-xref>.
         1. Perform ! FunctionDeclarationInstantiation(_funcObj_, « »).
         1. Let _result_ be Completion(Evaluation of |ClassStaticBlockStatementList|).
-        1. Let _envRecord_ be the running execution context's LexicalEnvironment.
+        1. Let _envRecord_ be the running execution context's [[LexicalEnvironment]].
         1. Assert: _envRecord_ is a Declarative Environment Record.
         1. Perform ? DisposeResources(_envRecord_.[[DisposableResourceStack]], _result_).
         1. Return ReturnCompletion(*undefined*).
@@ -25735,11 +25767,11 @@
       </emu-note>
       <emu-grammar>ClassTail : ClassHeritage? `{` ClassBody? `}`</emu-grammar>
       <emu-alg>
-        1. Let _envRecord_ be the LexicalEnvironment of the running execution context.
+        1. Let _envRecord_ be the running execution context's [[LexicalEnvironment]].
         1. Let _classEnv_ be NewDeclarativeEnvironment(_envRecord_).
         1. If _classBinding_ is not *undefined*, then
           1. Perform ! _classEnv_.CreateImmutableBinding(_classBinding_, *true*).
-        1. Let _outerPrivateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _outerPrivateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Let _classPrivateEnv_ be NewPrivateEnvironment(_outerPrivateEnv_).
         1. If |ClassBody| is present, then
           1. For each String _description_ of the PrivateBoundIdentifiers of |ClassBody|, do
@@ -25752,10 +25784,10 @@
           1. Let _protoParent_ be %Object.prototype%.
           1. Let _ctorParent_ be %Function.prototype%.
         1. Else,
-          1. Set the running execution context's LexicalEnvironment to _classEnv_.
-          1. NOTE: The running execution context's PrivateEnvironment is _outerPrivateEnv_ when evaluating |ClassHeritage|.
+          1. Set the running execution context's [[LexicalEnvironment]] to _classEnv_.
+          1. NOTE: The running execution context's [[PrivateEnvironment]] is _outerPrivateEnv_ when evaluating |ClassHeritage|.
           1. Let _superclassRef_ be Completion(Evaluation of |ClassHeritage|).
-          1. Set the running execution context's LexicalEnvironment to _envRecord_.
+          1. Set the running execution context's [[LexicalEnvironment]] to _envRecord_.
           1. Let _superclass_ be ? GetValue(? _superclassRef_).
           1. If _superclass_ is *null*, then
             1. Let _protoParent_ be *null*.
@@ -25769,8 +25801,8 @@
         1. Let _proto_ be OrdinaryObjectCreate(_protoParent_).
         1. If |ClassBody| is not present, let _ctor_ be ~empty~.
         1. Else, let _ctor_ be the ConstructorMethod of |ClassBody|.
-        1. Set the running execution context's LexicalEnvironment to _classEnv_.
-        1. Set the running execution context's PrivateEnvironment to _classPrivateEnv_.
+        1. Set the running execution context's [[LexicalEnvironment]] to _classEnv_.
+        1. Set the running execution context's [[PrivateEnvironment]] to _classPrivateEnv_.
         1. If _ctor_ is ~empty~, then
           1. Let _defaultCtor_ be a new Abstract Closure with no parameters that captures nothing and performs the following steps when called:
             1. Let _args_ be the List of arguments that was passed to this function by [[Call]] or [[Construct]].
@@ -25808,8 +25840,8 @@
           1. Else,
             1. Let _element_ be Completion(ClassElementEvaluation of _classElement_ with argument _ctorFunc_).
           1. If _element_ is an abrupt completion, then
-            1. Set the running execution context's LexicalEnvironment to _envRecord_.
-            1. Set the running execution context's PrivateEnvironment to _outerPrivateEnv_.
+            1. Set the running execution context's [[LexicalEnvironment]] to _envRecord_.
+            1. Set the running execution context's [[PrivateEnvironment]] to _outerPrivateEnv_.
             1. Return ? _element_.
           1. Set _element_ to ! _element_.
           1. If _element_ is a PrivateElement, then
@@ -25832,7 +25864,7 @@
             1. Append _element_ to _staticElements_.
           1. Else,
             1. Assert: _element_ is ~empty~.
-        1. Set the running execution context's LexicalEnvironment to _envRecord_.
+        1. Set the running execution context's [[LexicalEnvironment]] to _envRecord_.
         1. If _classBinding_ is not *undefined*, then
           1. Perform ! _classEnv_.InitializeBinding(_classBinding_, _ctorFunc_).
         1. Set _ctorFunc_.[[PrivateMethods]] to _instancePrivateMethods_.
@@ -25846,9 +25878,9 @@
             1. Assert: _elementRecord_ is a ClassStaticBlockDefinition Record.
             1. Let _result_ be Completion(Call(_elementRecord_.[[BodyFunction]], _ctorFunc_)).
           1. If _result_ is an abrupt completion, then
-            1. Set the running execution context's PrivateEnvironment to _outerPrivateEnv_.
+            1. Set the running execution context's [[PrivateEnvironment]] to _outerPrivateEnv_.
             1. Return ? _result_.
-        1. Set the running execution context's PrivateEnvironment to _outerPrivateEnv_.
+        1. Set the running execution context's [[PrivateEnvironment]] to _outerPrivateEnv_.
         1. Return _ctorFunc_.
       </emu-alg>
     </emu-clause>
@@ -25862,7 +25894,7 @@
         1. Let _className_ be the StringValue of |BindingIdentifier|.
         1. Let _sourceText_ be the source text matched by |ClassDeclaration|.
         1. Let _value_ be ? ClassDefinitionEvaluation of |ClassTail| with arguments _className_, _className_, and _sourceText_.
-        1. Let _envRecord_ be the running execution context's LexicalEnvironment.
+        1. Let _envRecord_ be the running execution context's [[LexicalEnvironment]].
         1. Perform ? InitializeBoundName(_className_, _value_, _envRecord_).
         1. Return _value_.
       </emu-alg>
@@ -25900,7 +25932,7 @@
       <emu-grammar>ClassElementName : PrivateIdentifier</emu-grammar>
       <emu-alg>
         1. Let _privateIdentifier_ be the StringValue of |PrivateIdentifier|.
-        1. Let _privateEnvRecord_ be the running execution context's PrivateEnvironment.
+        1. Let _privateEnvRecord_ be the running execution context's [[PrivateEnvironment]].
         1. Let _names_ be _privateEnvRecord_.[[Names]].
         1. Assert: Exactly one element of _names_ is a Private Name whose [[Description]] is _privateIdentifier_.
         1. Let _privateName_ be the Private Name in _names_ whose [[Description]] is _privateIdentifier_.
@@ -26027,8 +26059,8 @@
       </emu-grammar>
       <emu-alg>
         1. If _name_ is not present, set _name_ to the empty String.
-        1. Let _envRecord_ be the LexicalEnvironment of the running execution context.
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _envRecord_ be the running execution context's [[LexicalEnvironment]].
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Let _sourceText_ be the source text matched by |AsyncFunctionExpression|.
         1. Let _closure_ be OrdinaryFunctionCreate(%AsyncFunction.prototype%, _sourceText_, |FormalParameters|, |AsyncFunctionBody|, ~non-lexical-this~, _envRecord_, _privateEnv_).
         1. Perform SetFunctionName(_closure_, _name_).
@@ -26040,10 +26072,10 @@
       <emu-alg>
         1. Assert: _name_ is not present.
         1. Set _name_ to the StringValue of |BindingIdentifier|.
-        1. Let _outerEnv_ be the LexicalEnvironment of the running execution context.
+        1. Let _outerEnv_ be the running execution context's [[LexicalEnvironment]].
         1. Let _funcEnv_ be NewDeclarativeEnvironment(_outerEnv_).
         1. Perform ! _funcEnv_.CreateImmutableBinding(_name_, *false*).
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Let _sourceText_ be the source text matched by |AsyncFunctionExpression|.
         1. Let _closure_ be OrdinaryFunctionCreate(%AsyncFunction.prototype%, _sourceText_, |FormalParameters|, |AsyncFunctionBody|, ~non-lexical-this~, _funcEnv_, _privateEnv_).
         1. Perform SetFunctionName(_closure_, _name_).
@@ -26205,8 +26237,8 @@
       </emu-grammar>
       <emu-alg>
         1. If _name_ is not present, set _name_ to the empty String.
-        1. Let _envRecord_ be the LexicalEnvironment of the running execution context.
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _envRecord_ be the running execution context's [[LexicalEnvironment]].
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Let _sourceText_ be the source text matched by |AsyncArrowFunction|.
         1. Let _params_ be |AsyncArrowBindingIdentifier|.
         1. Let _closure_ be OrdinaryFunctionCreate(%AsyncFunction.prototype%, _sourceText_, _params_, |AsyncConciseBody|, ~lexical-this~, _envRecord_, _privateEnv_).
@@ -26218,8 +26250,8 @@
       </emu-grammar>
       <emu-alg>
         1. If _name_ is not present, set _name_ to the empty String.
-        1. Let _envRecord_ be the LexicalEnvironment of the running execution context.
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _envRecord_ be the running execution context's [[LexicalEnvironment]].
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Let _sourceText_ be the source text matched by |AsyncArrowFunction|.
         1. Let _head_ be the |AsyncArrowHead| that is covered by |CoverCallExpressionAndAsyncArrowHead|.
         1. Let _params_ be the |ArrowFormalParameters| of _head_.
@@ -26612,7 +26644,7 @@
       <dl class="header">
       </dl>
       <emu-alg>
-        1. Assert: The current execution context will not subsequently be used for the evaluation of any ECMAScript code or built-in functions. The invocation of Call subsequent to the invocation of this abstract operation will create and push a new execution context before performing any such evaluation.
+        1. Assert: The current execution context will not subsequently be used for the evaluation of any ECMAScript code or built-in functions. The invocation of Call subsequent to the invocation of this abstract operation will create and push a new ExecutionContext Record before performing any such evaluation.
         1. Discard all resources associated with the current execution context.
         1. Return ~unused~.
       </emu-alg>
@@ -26796,13 +26828,13 @@
 
       <emu-alg>
         1. Let _globalEnv_ be _scriptRecord_.[[Realm]].[[GlobalEnv]].
-        1. Let _scriptContext_ be a new ECMAScript code execution context.
-        1. Set the Function of _scriptContext_ to *null*.
-        1. Set the Realm of _scriptContext_ to _scriptRecord_.[[Realm]].
-        1. Set the ScriptOrModule of _scriptContext_ to _scriptRecord_.
-        1. Set the VariableEnvironment of _scriptContext_ to _globalEnv_.
-        1. Set the LexicalEnvironment of _scriptContext_ to _globalEnv_.
-        1. Set the PrivateEnvironment of _scriptContext_ to *null*.
+        1. Let _scriptContext_ be a new ECMAScript code ExecutionContext Record.
+        1. Set _scriptContext_.[[Function]] to *null*.
+        1. Set _scriptContext_.[[Realm]] to _scriptRecord_.[[Realm]].
+        1. Set _scriptContext_.[[ScriptOrModule]] to _scriptRecord_.
+        1. Set _scriptContext_.[[VariableEnvironment]] to _globalEnv_.
+        1. Set _scriptContext_.[[LexicalEnvironment]] to _globalEnv_.
+        1. Set _scriptContext_.[[PrivateEnvironment]] to *null*.
         1. Suspend the running execution context.
         1. Push _scriptContext_ onto the execution context stack; _scriptContext_ is now the running execution context.
         1. Let _scriptNode_ be _scriptRecord_.[[ECMAScriptCode]].
@@ -26881,8 +26913,8 @@
                       1. Perform ? CreateGlobalVarBinding(_envRecord_, _funcName_, *false*).
                       1. Append _funcName_ to _declaredFuncOrVariableNames_.
                     1. [id="step-globaldeclarationinstantiation-alt-funcdecl-eval"] When the |FunctionDeclaration| _funcDecl_ is evaluated, perform the following steps in place of the |FunctionDeclaration| Evaluation algorithm provided in <emu-xref href="#sec-function-definitions-runtime-semantics-evaluation"></emu-xref>:
-                      1. Let _globalEnv_ be the running execution context's VariableEnvironment.
-                      1. Let _blockEnv_ be the running execution context's LexicalEnvironment.
+                      1. Let _globalEnv_ be the running execution context's [[VariableEnvironment]].
+                      1. Let _blockEnv_ be the running execution context's [[LexicalEnvironment]].
                       1. Let _funcObj_ be ! _blockEnv_.GetBindingValue(_funcName_, *false*).
                       1. Perform ? <emu-meta effects="user-code">_globalEnv_.SetMutableBinding(_funcName_, _funcObj_, *false*)</emu-meta>.
                       1. Return ~unused~.
@@ -28597,10 +28629,10 @@
                 [[Context]]
               </td>
               <td>
-                an ECMAScript code execution context or ~empty~
+                an ECMAScript code ExecutionContext Record or ~empty~
               </td>
               <td>
-                The execution context associated with this module. It is ~empty~ until the module's environment has been initialized.
+                The ExecutionContext Record associated with this module. It is ~empty~ until the module's environment has been initialized.
               </td>
             </tr>
             <tr>
@@ -29249,14 +29281,14 @@
                     1. Perform ! _envRecord_.InitializeBinding(_importEntry_.[[LocalName]], _namespace_).
                   1. Else,
                     1. Perform CreateImportBinding(_envRecord_, _importEntry_.[[LocalName]], _resolution_.[[Module]], _resolution_.[[BindingName]]).
-              1. Let _moduleContext_ be a new ECMAScript code execution context.
-              1. Set the Function of _moduleContext_ to *null*.
+              1. Let _moduleContext_ be a new ECMAScript code ExecutionContext Record.
+              1. Set _moduleContext_.[[Function]] to *null*.
               1. Assert: _module_.[[Realm]] is not *undefined*.
-              1. Set the Realm of _moduleContext_ to _module_.[[Realm]].
-              1. Set the ScriptOrModule of _moduleContext_ to _module_.
-              1. Set the VariableEnvironment of _moduleContext_ to _module_.[[Environment]].
-              1. Set the LexicalEnvironment of _moduleContext_ to _module_.[[Environment]].
-              1. Set the PrivateEnvironment of _moduleContext_ to *null*.
+              1. Set _moduleContext_.[[Realm]] to _module_.[[Realm]].
+              1. Set _moduleContext_.[[ScriptOrModule]] to _module_.
+              1. Set _moduleContext_.[[VariableEnvironment]] to _module_.[[Environment]].
+              1. Set _moduleContext_.[[LexicalEnvironment]] to _module_.[[Environment]].
+              1. Set _moduleContext_.[[PrivateEnvironment]] to *null*.
               1. Set _module_.[[Context]] to _moduleContext_.
               1. Push _moduleContext_ onto the execution context stack; _moduleContext_ is now the running execution context.
               1. Let _code_ be _module_.[[ECMAScriptCode]].
@@ -29495,12 +29527,12 @@
             </dl>
 
             <emu-alg>
-              1. Let _moduleContext_ be a new ECMAScript code execution context.
-              1. Set the Function of _moduleContext_ to *null*.
-              1. Set the Realm of _moduleContext_ to _module_.[[Realm]].
-              1. Set the ScriptOrModule of _moduleContext_ to _module_.
-              1. Set the VariableEnvironment of _moduleContext_ to _module_.[[Environment]].
-              1. Set the LexicalEnvironment of _moduleContext_ to _module_.[[Environment]].
+              1. Let _moduleContext_ be a new ECMAScript code ExecutionContext Record.
+              1. Set _moduleContext_.[[Function]] to *null*.
+              1. Set _moduleContext_.[[Realm]] to _module_.[[Realm]].
+              1. Set _moduleContext_.[[ScriptOrModule]] to _module_.
+              1. Set _moduleContext_.[[VariableEnvironment]] to _module_.[[Environment]].
+              1. Set _moduleContext_.[[LexicalEnvironment]] to _module_.[[Environment]].
               1. Suspend the running execution context.
               1. Push _moduleContext_ onto the execution context stack; _moduleContext_ is now the running execution context.
               1. Let _steps_ be _module_.[[EvaluationSteps]].
@@ -29555,7 +29587,7 @@
 
           <pre><code class="html">&lt;button type="button" onclick="import('./foo.mjs')"&gt;Click me&lt;/button&gt;</code></pre>
 
-          <p>there will be no active script or module at the time the <emu-xref href="#sec-import-calls">`import()`</emu-xref> expression runs. More generally, this can happen in any situation where the host pushes execution contexts with *null* ScriptOrModule components onto the execution context stack.</p>
+          <p>there will be no active script or module at the time the <emu-xref href="#sec-import-calls">`import()`</emu-xref> expression runs. More generally, this can happen in any situation where the host pushes an ExecutionContext Record with a *null* [[ScriptOrModule]] field onto the execution context stack.</p>
         </emu-note>
 
         <p>An implementation of HostLoadImportedModule must conform to the following requirements:</p>
@@ -30279,7 +30311,7 @@
           1. Let _value_ be ? BindingClassDeclarationEvaluation of |ClassDeclaration|.
           1. Let _className_ be the sole element of the BoundNames of |ClassDeclaration|.
           1. If _className_ is *"\*default\*"*, then
-            1. Let _envRecord_ be the running execution context's LexicalEnvironment.
+            1. Let _envRecord_ be the running execution context's [[LexicalEnvironment]].
             1. Perform ? InitializeBoundName(*"\*default\*"*, _value_, _envRecord_).
           1. Return ~empty~.
         </emu-alg>
@@ -30290,7 +30322,7 @@
           1. Else,
             1. Let _rhs_ be ? Evaluation of |AssignmentExpression|.
             1. Let _value_ be ? GetValue(_rhs_).
-          1. Let _envRecord_ be the running execution context's LexicalEnvironment.
+          1. Let _envRecord_ be the running execution context's [[LexicalEnvironment]].
           1. Perform ? InitializeBoundName(*"\*default\*"*, _value_, _envRecord_).
           1. Return ~empty~.
         </emu-alg>
@@ -30477,22 +30509,22 @@
           1. Let _runningContext_ be the running execution context.
           1. NOTE: If _direct_ is *true*, _runningContext_ will be the execution context that performed the direct eval. If _direct_ is *false*, _runningContext_ will be the execution context for the invocation of the `eval` function.
           1. If _direct_ is *true*, then
-            1. Let _lexicalEnv_ be NewDeclarativeEnvironment(_runningContext_'s LexicalEnvironment).
-            1. Let _variableEnv_ be _runningContext_'s VariableEnvironment.
-            1. Let _privateEnv_ be _runningContext_'s PrivateEnvironment.
+            1. Let _lexicalEnv_ be NewDeclarativeEnvironment(_runningContext_.[[LexicalEnvironment]]).
+            1. Let _variableEnv_ be _runningContext_.[[VariableEnvironment]].
+            1. Let _privateEnv_ be _runningContext_.[[PrivateEnvironment]].
           1. Else,
             1. Let _lexicalEnv_ be NewDeclarativeEnvironment(_evalRealm_.[[GlobalEnv]]).
             1. Let _variableEnv_ be _evalRealm_.[[GlobalEnv]].
             1. Let _privateEnv_ be *null*.
           1. If _strictEval_ is *true*, set _variableEnv_ to _lexicalEnv_.
           1. If _runningContext_ is not already suspended, suspend _runningContext_.
-          1. Let _evalContext_ be a new ECMAScript code execution context.
-          1. Set _evalContext_'s Function to *null*.
-          1. Set _evalContext_'s Realm to _evalRealm_.
-          1. Set _evalContext_'s ScriptOrModule to _runningContext_'s ScriptOrModule.
-          1. Set _evalContext_'s VariableEnvironment to _variableEnv_.
-          1. Set _evalContext_'s LexicalEnvironment to _lexicalEnv_.
-          1. Set _evalContext_'s PrivateEnvironment to _privateEnv_.
+          1. Let _evalContext_ be a new ECMAScript code ExecutionContext Record.
+          1. Set _evalContext_.[[Function]] to *null*.
+          1. Set _evalContext_.[[Realm]] to _evalRealm_.
+          1. Set _evalContext_.[[ScriptOrModule]] to _runningContext_.[[ScriptOrModule]].
+          1. Set _evalContext_.[[VariableEnvironment]] to _variableEnv_.
+          1. Set _evalContext_.[[LexicalEnvironment]] to _lexicalEnv_.
+          1. Set _evalContext_.[[PrivateEnvironment]] to _privateEnv_.
           1. Push _evalContext_ onto the execution context stack; _evalContext_ is now the running execution context.
           1. Let _result_ be Completion(EvalDeclarationInstantiation(_body_, _variableEnv_, _lexicalEnv_, _privateEnv_, _strictEval_)).
           1. If _result_ is a normal completion, then
@@ -30504,7 +30536,7 @@
           1. Return ? _result_.
         </emu-alg>
         <emu-note>
-          <p>The eval code cannot instantiate variable or function bindings in the variable environment of the calling context that invoked the eval if either the code of the calling context or the eval code is strict mode code. Instead such bindings are instantiated in a new VariableEnvironment that is only accessible to the eval code. Bindings introduced by `let`, `const`, or `class` declarations are always instantiated in a new LexicalEnvironment.</p>
+          <p>The eval code cannot instantiate variable or function bindings in the variable environment of the calling context that invoked the eval if either the code of the calling context or the eval code is strict mode code. Instead such bindings are instantiated in a new [[VariableEnvironment]] that is only accessible to the eval code. Bindings introduced by `let`, `const`, or `class` declarations are always instantiated in a new [[LexicalEnvironment]].</p>
         </emu-note>
       </emu-clause>
 
@@ -30625,8 +30657,8 @@
                         1. Perform ! _variableEnv_.InitializeBinding(_funcName_, *undefined*).
                     1. Append _funcName_ to _declaredFuncOrVariableNames_.
                   1. [id="step-evaldeclarationinstantiation-alt-funcdecl-eval"] When the |FunctionDeclaration| _funcDecl_ is evaluated, perform the following steps in place of the |FunctionDeclaration| Evaluation algorithm provided in <emu-xref href="#sec-function-definitions-runtime-semantics-evaluation"></emu-xref>:
-                    1. Let _globalEnv_ be the running execution context's VariableEnvironment.
-                    1. Let _blockEnv_ be the running execution context's LexicalEnvironment.
+                    1. Let _globalEnv_ be the running execution context's [[VariableEnvironment]].
+                    1. Let _blockEnv_ be the running execution context's [[LexicalEnvironment]].
                     1. Let _funcObj_ be ! _blockEnv_.GetBindingValue(_funcName_, *false*).
                     1. Perform ? <emu-meta effects="user-code">_globalEnv_.SetMutableBinding(_funcName_, _funcObj_, *false*)</emu-meta>.
                     1. Return ~unused~.
@@ -51826,10 +51858,10 @@ THH:mm:ss.sss
               [[GeneratorContext]]
             </td>
             <td>
-              an execution context
+              an ExecutionContext Record
             </td>
             <td>
-              The execution context that is used when executing the code of this generator.
+              The ExecutionContext Record that is used when executing the code of this generator.
             </td>
           </tr>
           <tr>
@@ -51862,17 +51894,17 @@ THH:mm:ss.sss
         <emu-alg>
           1. Assert: _gen_.[[GeneratorState]] is ~suspended-start~.
           1. Let _genContext_ be the running execution context.
-          1. Set the Generator component of _genContext_ to _gen_.
+          1. Set _genContext_.[[Generator]] to _gen_.
           1. Let _closure_ be a new Abstract Closure with no parameters that captures _genBody_ and performs the following steps when called:
             1. Let _acGenContext_ be the running execution context.
-            1. Let _acGen_ be the Generator component of _acGenContext_.
+            1. Let _acGen_ be _acGenContext_.[[Generator]].
             1. If _genBody_ is a Parse Node, then
               1. Let _result_ be Completion(Evaluation of _genBody_).
             1. Else,
               1. Assert: _genBody_ is an Abstract Closure with no parameters.
               1. Let _result_ be Completion(_genBody_()).
             1. Assert: If we return here, the generator either threw an exception or performed either an implicit or explicit return.
-            1. Remove _acGenContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
+            1. Remove _acGenContext_ from the execution context stack and restore the ExecutionContext Record that is at the top of the execution context stack as the running execution context.
             1. Set _acGen_.[[GeneratorState]] to ~completed~.
             1. NOTE: Once a generator enters the ~completed~ state it never leaves it and its associated execution context is never resumed. Any execution state associated with _acGen_ can be discarded at this point.
             1. If _result_ is a throw completion, then
@@ -51886,7 +51918,7 @@ THH:mm:ss.sss
             1. Let _callerContext_ be the running execution context.
             1. Resume _callerContext_, passing _resumption_.
             1. Assert: This step is never reached.
-          1. Set the code evaluation state of _genContext_ such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
+          1. Set _genContext_.[[CodeEvaluationState]] such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
           1. Set _gen_.[[GeneratorContext]] to _genContext_.
           1. Return ~unused~.
         </emu-alg>
@@ -51965,8 +51997,8 @@ THH:mm:ss.sss
         </dl>
         <emu-alg>
           1. Let _genContext_ be the running execution context.
-          1. If _genContext_ does not have a Generator component, return ~non-generator~.
-          1. Let _gen_ be the Generator component of _genContext_.
+          1. If _genContext_ does not have a [[Generator]] field, return ~non-generator~.
+          1. Let _gen_ be _genContext_.[[Generator]].
           1. If _gen_ has an [[AsyncGeneratorState]] internal slot, return ~async~.
           1. Return ~sync~.
         </emu-alg>
@@ -51983,7 +52015,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _genContext_ be the running execution context.
           1. Assert: _genContext_ is the execution context of a generator.
-          1. Let _gen_ be the value of the Generator component of _genContext_.
+          1. Let _gen_ be _genContext_.[[Generator]].
           1. Assert: GetGeneratorKind() is ~sync~.
           1. Set _gen_.[[GeneratorState]] to ~suspended-yield~.
           1. Return ? RunCallerContext(_iteratorResult_).
@@ -52024,10 +52056,10 @@ THH:mm:ss.sss
           1. Set _gen_.[[GeneratorBrand]] to _genBrand_.
           1. Set _gen_.[[GeneratorState]] to ~suspended-start~.
           1. Let _callerContext_ be the running execution context.
-          1. Let _calleeContext_ be a new execution context.
-          1. Set the Function of _calleeContext_ to *null*.
-          1. Set the Realm of _calleeContext_ to the current Realm Record.
-          1. Set the ScriptOrModule of _calleeContext_ to _callerContext_'s ScriptOrModule.
+          1. Let _calleeContext_ be a new ExecutionContext Record.
+          1. Set _calleeContext_.[[Function]] to *null*.
+          1. Set _calleeContext_.[[Realm]] to the current Realm Record.
+          1. Set _calleeContext_.[[ScriptOrModule]] to _callerContext_.[[ScriptOrModule]].
           1. If _callerContext_ is not already suspended, suspend _callerContext_.
           1. Push _calleeContext_ onto the execution context stack; _calleeContext_ is now the running execution context.
           1. Perform GeneratorStart(_gen_, _closure_).
@@ -52154,8 +52186,8 @@ THH:mm:ss.sss
           </tr>
           <tr>
             <td>[[AsyncGeneratorContext]]</td>
-            <td>an execution context</td>
-            <td>The execution context that is used when executing the code of this async generator.</td>
+            <td>an ExecutionContext Record</td>
+            <td>The ExecutionContext Record that is used when executing the code of this async generator.</td>
           </tr>
           <tr>
             <td>[[AsyncGeneratorQueue]]</td>
@@ -52213,17 +52245,17 @@ THH:mm:ss.sss
         <emu-alg>
           1. Assert: _gen_.[[AsyncGeneratorState]] is ~suspended-start~.
           1. Let _genContext_ be the running execution context.
-          1. Set the Generator component of _genContext_ to _gen_.
+          1. Set _genContext_.[[Generator]] to _gen_.
           1. Let _closure_ be a new Abstract Closure with no parameters that captures _genBody_ and performs the following steps when called:
             1. Let _acGenContext_ be the running execution context.
-            1. Let _acGen_ be the Generator component of _acGenContext_.
+            1. Let _acGen_ be _acGenContext_.[[Generator]].
             1. If _genBody_ is a Parse Node, then
               1. Let _result_ be Completion(Evaluation of _genBody_).
             1. Else,
               1. Assert: _genBody_ is an Abstract Closure with no parameters.
               1. Let _result_ be Completion(_genBody_()).
             1. Assert: If we return here, the async generator either threw an exception or performed either an implicit or explicit return.
-            1. Remove _acGenContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
+            1. Remove _acGenContext_ from the execution context stack and restore the ExecutionContext Record that is at the top of the execution context stack as the running execution context.
             1. Set _acGen_.[[AsyncGeneratorState]] to ~draining-queue~.
             1. If _result_ is a normal completion, set _result_ to NormalCompletion(*undefined*).
             1. If _result_ is a return completion, set _result_ to NormalCompletion(_result_.[[Value]]).
@@ -52232,7 +52264,7 @@ THH:mm:ss.sss
             1. Let _callerContext_ be the running execution context.
             1. Resume _callerContext_, passing NormalCompletion(*undefined*).
             1. Assert: This step is never reached.
-          1. Set the code evaluation state of _genContext_ such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
+          1. Set _genContext_.[[CodeEvaluationState]] such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
           1. Set _gen_.[[AsyncGeneratorContext]] to _genContext_.
           1. Set _gen_.[[AsyncGeneratorQueue]] to a new empty List.
           1. Return ~unused~.
@@ -52296,10 +52328,10 @@ THH:mm:ss.sss
           1. Else,
             1. Assert: _completion_ is a normal completion.
             1. If _realm_ is present, then
-              1. Let _oldRealm_ be the running execution context's Realm.
-              1. Set the running execution context's Realm to _realm_.
+              1. Let _oldRealm_ be the running execution context's [[Realm]].
+              1. Set the running execution context's [[Realm]] to _realm_.
               1. Let _iteratorResult_ be CreateIteratorResultObject(_value_, _done_).
-              1. Set the running execution context's Realm to _oldRealm_.
+              1. Set the running execution context's [[Realm]] to _oldRealm_.
             1. Else,
               1. Let _iteratorResult_ be CreateIteratorResultObject(_value_, _done_).
             1. Perform ! <emu-meta effects="user-code">Call(_promiseCapability_.[[Resolve]], *undefined*, « _iteratorResult_ »)</emu-meta>.
@@ -52353,12 +52385,12 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _genContext_ be the running execution context.
           1. Assert: _genContext_ is the execution context of a generator.
-          1. Let _gen_ be the value of the Generator component of _genContext_.
+          1. Let _gen_ be _genContext_.[[Generator]].
           1. Assert: GetGeneratorKind() is ~async~.
           1. Let _completion_ be NormalCompletion(_arg_).
           1. Assert: The execution context stack has at least two elements.
           1. Let _previousContext_ be the second to top element of the execution context stack.
-          1. Let _previousRealm_ be _previousContext_'s Realm.
+          1. Let _previousRealm_ be _previousContext_.[[Realm]].
           1. Perform AsyncGeneratorCompleteStep(_gen_, _completion_, *false*, _previousRealm_).
           1. Let _queue_ be _gen_.[[AsyncGeneratorQueue]].
           1. If _queue_ is not empty, then
@@ -52562,7 +52594,7 @@ THH:mm:ss.sss
           AsyncBlockStart (
             _promiseCapability_: a PromiseCapability Record,
             _asyncBody_: a Parse Node or an Abstract Closure with no parameters,
-            _asyncContext_: an execution context,
+            _asyncContext_: an ExecutionContext Record,
           ): ~unused~
         </h1>
         <dl class="header">
@@ -52576,7 +52608,7 @@ THH:mm:ss.sss
               1. Assert: _asyncBody_ is an Abstract Closure with no parameters.
               1. Let _result_ be Completion(_asyncBody_()).
             1. Assert: If we return here, the async function either threw an exception or performed an implicit or explicit return; all awaiting is done.
-            1. Remove _acAsyncContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
+            1. Remove _acAsyncContext_ from the execution context stack and restore the ExecutionContext Record that is at the top of the execution context stack as the running execution context.
             1. If _result_ is a normal completion, then
               1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, « *undefined* »).
             1. Else if _result_ is a return completion, then
@@ -52587,7 +52619,7 @@ THH:mm:ss.sss
             1. Let _callerContext_ be the running execution context.
             1. [id="step-asyncblockstart-return-undefined"] Resume _callerContext_, passing NormalCompletion(~unused~).
             1. Assert: This step is never reached.
-          1. Set the code evaluation state of _asyncContext_ such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
+          1. Set _asyncContext_.[[CodeEvaluationState]] such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
           1. Let _result_ be ! RunSuspendedContext(_asyncContext_, NormalCompletion(~empty~)).
           1. Assert: _result_ is ~unused~.
           1. NOTE: The possible sources of _result_ values are Await or, if the async function doesn't await anything, step <emu-xref href="#step-asyncblockstart-return-undefined"></emu-xref> above.

--- a/spec.html
+++ b/spec.html
@@ -12173,7 +12173,7 @@
     <h1>Execution Contexts</h1>
     <p>An <dfn variants="execution contexts">execution context</dfn> is a specification device that is used to track the runtime evaluation of code by an ECMAScript implementation. At any point in time, there is at most one execution context per agent that is actually executing code. This is known as the agent's <dfn id="running-execution-context" variants="running execution contexts">running execution context</dfn>. All references to the running execution context in this specification denote the running execution context of the surrounding agent.</p>
     <p>The <dfn id="execution-context-stack" variants="execution context stacks">execution context stack</dfn> is used to track execution contexts. The running execution context is always the top element of this stack. A new execution context is created whenever control is transferred from the executable code associated with the currently running execution context to executable code that is not associated with that execution context. The newly created execution context is pushed onto the stack and becomes the running execution context.</p>
-    <p>Each execution context is represented as an ExecutionContext Record, with at least the fields listed in <emu-xref href="#table-state-components-for-all-execution-contexts"></emu-xref>.</p>
+    <p>Each execution context is represented as an <dfn variants="ExecutionContext Records">ExecutionContext Record</dfn>, with at least the fields listed in <emu-xref href="#table-state-components-for-all-execution-contexts"></emu-xref>.</p>
     <emu-table id="table-state-components-for-all-execution-contexts" caption="ExecutionContext Record Fields" oldids="table-22">
       <table>
         <thead>

--- a/spec.html
+++ b/spec.html
@@ -4623,7 +4623,7 @@
         <dl class="header">
         </dl>
         <emu-alg>
-          1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+          1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
           1. Assert: _privateEnv_ is not *null*.
           1. Let _privateName_ be ResolvePrivateIdentifier(_privateEnv_, _privateIdentifier_).
           1. Return the Reference Record { [[Base]]: _baseValue_, [[ReferencedName]]: _privateName_, [[Strict]]: *true*, [[ThisValue]]: ~empty~ }.
@@ -12163,10 +12163,10 @@
         1. Perform CreateIntrinsics(_realm_).
         1. Set _realm_.[[AgentSignifier]] to AgentSignifier().
         1. Set _realm_.[[TemplateMap]] to a new empty List.
-        1. Let _newContext_ be a new execution context.
-        1. Set the Function of _newContext_ to *null*.
-        1. Set the Realm of _newContext_ to _realm_.
-        1. Set the ScriptOrModule of _newContext_ to *null*.
+        1. Let _newContext_ be a new ExecutionContext Record.
+        1. Set _newContext_.[[Function]] to *null*.
+        1. Set _newContext_.[[Realm]] to _realm_.
+        1. Set _newContext_.[[ScriptOrModule]] to *null*.
         1. Push _newContext_ onto the execution context stack; _newContext_ is now the running execution context.
         1. If the host requires use of a specific object to serve as _realm_'s global object, then
           1. Let _global_ be such an object created in a host-defined manner.
@@ -12223,22 +12223,28 @@
     <h1>Execution Contexts</h1>
     <p>An <dfn variants="execution contexts">execution context</dfn> is a specification device that is used to track the runtime evaluation of code by an ECMAScript implementation. At any point in time, there is at most one execution context per agent that is actually executing code. This is known as the agent's <dfn id="running-execution-context" variants="running execution contexts">running execution context</dfn>. All references to the running execution context in this specification denote the running execution context of the surrounding agent.</p>
     <p>The <dfn id="execution-context-stack" variants="execution context stacks">execution context stack</dfn> is used to track execution contexts. The running execution context is always the top element of this stack. A new execution context is created whenever control is transferred from the executable code associated with the currently running execution context to executable code that is not associated with that execution context. The newly created execution context is pushed onto the stack and becomes the running execution context.</p>
-    <p>An execution context contains whatever implementation specific state is necessary to track the execution progress of its associated code. Each execution context has at least the state components listed in <emu-xref href="#table-state-components-for-all-execution-contexts"></emu-xref>.</p>
-    <emu-table id="table-state-components-for-all-execution-contexts" caption="State Components for All Execution Contexts" oldids="table-22">
+    <p>Each execution context is represented as an ExecutionContext Record, with at least the fields listed in <emu-xref href="#table-state-components-for-all-execution-contexts"></emu-xref>.</p>
+    <emu-table id="table-state-components-for-all-execution-contexts" caption="ExecutionContext Record Fields" oldids="table-22">
       <table>
         <thead>
           <tr>
             <th>
-              Component
+              Field Name
             </th>
             <th>
-              Purpose
+              Value Type
+            </th>
+            <th>
+              Meaning
             </th>
           </tr>
         </thead>
         <tr>
           <td>
-            code evaluation state
+            [[CodeEvaluationState]]
+          </td>
+          <td>
+            implementation-specific
           </td>
           <td>
             Any state needed to perform, suspend, and resume evaluation of the code associated with this execution context.
@@ -12246,15 +12252,21 @@
         </tr>
         <tr>
           <td>
-            Function
+            [[Function]]
           </td>
           <td>
-            If this execution context is evaluating the code of a function object, then the value of this component is that function object. If the context is evaluating the code of a |Script| or |Module|, the value is *null*.
+            a function object or *null*
+          </td>
+          <td>
+            If this execution context is evaluating the code of a function object, then the value of this field is that function object. If the context is evaluating the code of a |Script| or |Module|, the value is *null*.
           </td>
         </tr>
         <tr>
           <td>
-            Realm
+            [[Realm]]
+          </td>
+          <td>
+            a Realm Record
           </td>
           <td>
             The Realm Record from which associated code accesses ECMAScript resources.
@@ -12262,32 +12274,41 @@
         </tr>
         <tr>
           <td>
-            ScriptOrModule
+            [[ScriptOrModule]]
           </td>
           <td>
-            The Module Record or Script Record from which associated code originates. If there is no originating script or module, as is the case for the original execution context created in InitializeHostDefinedRealm, the value is *null*.
+            a Module Record, a Script Record, or *null*
+          </td>
+          <td>
+            The Module Record or Script Record from which associated code originates. If there is no originating script or module, as is the case for the original ExecutionContext Record created in InitializeHostDefinedRealm, the value is *null*.
           </td>
         </tr>
       </table>
     </emu-table>
     <p>Evaluation of code by the running execution context may be suspended at various points defined within this specification. Once the running execution context has been suspended a different execution context may become the running execution context and commence evaluating its code. At some later time a suspended execution context may again become the running execution context and continue evaluating its code at the point where it had previously been suspended. Transition of the running execution context status among execution contexts usually occurs in stack-like last-in/first-out manner. However, some ECMAScript features require non-LIFO transitions of the running execution context.</p>
-    <p>The value of the Realm component of the running execution context is also called <dfn id="current-realm">the current Realm Record</dfn>. The value of the Function component of the running execution context is also called the <dfn id="active-function-object">active function object</dfn>.</p>
-    <p><dfn id="ecmascript-code-execution-context" variants="ECMAScript code execution context">ECMAScript code execution contexts</dfn> have the additional state components listed in <emu-xref href="#table-additional-state-components-for-ecmascript-code-execution-contexts"></emu-xref>.</p>
-    <emu-table id="table-additional-state-components-for-ecmascript-code-execution-contexts" caption="Additional State Components for ECMAScript Code Execution Contexts" oldids="table-23">
+    <p>The value of the running execution context's [[Realm]] field is also called <dfn id="current-realm">the current Realm Record</dfn>. The value of the running execution context's [[Function]] field is also called the <dfn id="active-function-object">active function object</dfn>.</p>
+    <p><dfn id="ecmascript-code-execution-context" variants="ECMAScript code ExecutionContext Record">ECMAScript code ExecutionContext Records</dfn> have the additional fields listed in <emu-xref href="#table-additional-state-components-for-ecmascript-code-execution-contexts"></emu-xref>.</p>
+    <emu-table id="table-additional-state-components-for-ecmascript-code-execution-contexts" caption="Additional Fields of ECMAScript Code ExecutionContext Records" oldids="table-23">
       <table>
         <thead>
           <tr>
             <th>
-              Component
+              Field Name
             </th>
             <th>
-              Purpose
+              Value Type
+            </th>
+            <th>
+              Meaning
             </th>
           </tr>
         </thead>
         <tr>
           <td>
-            LexicalEnvironment
+            [[LexicalEnvironment]]
+          </td>
+          <td>
+            an Environment Record
           </td>
           <td>
             Identifies the Environment Record used to resolve identifier references made by code within this execution context.
@@ -12295,7 +12316,10 @@
         </tr>
         <tr>
           <td>
-            VariableEnvironment
+            [[VariableEnvironment]]
+          </td>
+          <td>
+            an Environment Record
           </td>
           <td>
             Identifies the Environment Record that holds bindings created by |VariableStatement|s within this execution context.
@@ -12303,7 +12327,10 @@
         </tr>
         <tr>
           <td>
-            PrivateEnvironment
+            [[PrivateEnvironment]]
+          </td>
+          <td>
+            a PrivateEnvironment Record or *null*
           </td>
           <td>
             Identifies the PrivateEnvironment Record that holds Private Names created by |ClassElement|s in the nearest containing class. *null* if there is no containing class.
@@ -12311,23 +12338,28 @@
         </tr>
       </table>
     </emu-table>
-    <p>The LexicalEnvironment and VariableEnvironment components of an execution context are always Environment Records.</p>
-    <p>Execution contexts representing the evaluation of Generators have the additional state components listed in <emu-xref href="#table-additional-state-components-for-generator-execution-contexts"></emu-xref>.</p>
-    <emu-table id="table-additional-state-components-for-generator-execution-contexts" caption="Additional State Components for Generator Execution Contexts" oldids="table-24">
+    <p>ExecutionContext Records representing the evaluation of Generators have the additional fields listed in <emu-xref href="#table-additional-state-components-for-generator-execution-contexts"></emu-xref>.</p>
+    <emu-table id="table-additional-state-components-for-generator-execution-contexts" caption="Additional Fields of Generator ExecutionContext Records" oldids="table-24">
       <table>
         <thead>
           <tr>
             <th>
-              Component
+              Field Name
             </th>
             <th>
-              Purpose
+              Value Type
+            </th>
+            <th>
+              Meaning
             </th>
           </tr>
         </thead>
         <tr>
           <td>
-            Generator
+            [[Generator]]
+          </td>
+          <td>
+            an Object
           </td>
           <td>
             The Generator that this execution context is evaluating.
@@ -12335,7 +12367,7 @@
         </tr>
       </table>
     </emu-table>
-    <p>In most situations only the running execution context (the top of the execution context stack) is directly manipulated by algorithms within this specification. Hence when the terms “LexicalEnvironment”, and “VariableEnvironment” are used without qualification they are in reference to those components of the running execution context.</p>
+    <p>In most situations only the running execution context (the top of the execution context stack) is directly manipulated by algorithms within this specification.</p>
     <p>An execution context is purely a specification mechanism and need not correspond to any particular artefact of an ECMAScript implementation. It is impossible for ECMAScript code to directly access or observe an execution context.</p>
 
     <emu-clause id="sec-getactivescriptormodule" type="abstract operation">
@@ -12347,9 +12379,9 @@
 
       <emu-alg>
         1. If the execution context stack is empty, return *null*.
-        1. Let _executionContext_ be the topmost execution context on the execution context stack whose ScriptOrModule component is not *null*.
-        1. If no such execution context exists, return *null*.
-        1. Return _executionContext_'s ScriptOrModule.
+        1. Let _executionContext_ be the topmost ExecutionContext Record on the execution context stack whose [[ScriptOrModule]] field is not *null*.
+        1. If no such ExecutionContext Record exists, return *null*.
+        1. Return _executionContext_.[[ScriptOrModule]].
       </emu-alg>
     </emu-clause>
 
@@ -12366,7 +12398,7 @@
       </dl>
       <emu-alg>
         1. If _envRecord_ is not present or _envRecord_ is *undefined*, then
-          1. Set _envRecord_ to the running execution context's LexicalEnvironment.
+          1. Set _envRecord_ to the running execution context's [[LexicalEnvironment]].
         1. Assert: _envRecord_ is an Environment Record.
         1. Let _strict_ be IsStrict(the syntactic production that is being evaluated).
         1. Return ? GetIdentifierReference(_envRecord_, _name_, _strict_).
@@ -12383,7 +12415,7 @@
         <dd>It finds the Environment Record that currently supplies the binding of the keyword `this`.</dd>
       </dl>
       <emu-alg>
-        1. Let _envRecord_ be the running execution context's LexicalEnvironment.
+        1. Let _envRecord_ be the running execution context's [[LexicalEnvironment]].
         1. [id="step-getthisenvironment-loop"] Repeat,
           1. Let _exists_ be _envRecord_.HasThisBinding().
           1. If _exists_ is *true*, return _envRecord_.
@@ -12400,7 +12432,7 @@
       <h1>ResolveThisBinding ( ): either a normal completion containing an ECMAScript language value or a throw completion</h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It determines the binding of the keyword `this` using the LexicalEnvironment of the running execution context.</dd>
+        <dd>It determines the binding of the keyword `this` using the running execution context's [[LexicalEnvironment]].</dd>
       </dl>
       <emu-alg>
         1. Let _envRecord_ be GetThisEnvironment().
@@ -12412,7 +12444,7 @@
       <h1>GetNewTarget ( ): an Object or *undefined*</h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It determines the NewTarget value using the LexicalEnvironment of the running execution context.</dd>
+        <dd>It determines the NewTarget value using the running execution context's [[LexicalEnvironment]].</dd>
       </dl>
       <emu-alg>
         1. Let _envRecord_ be GetThisEnvironment().
@@ -12436,7 +12468,7 @@
     <emu-clause id="sec-runsuspendedcontext" type="abstract operation">
       <h1>
         RunSuspendedContext (
-          _context_: an execution context,
+          _context_: an ExecutionContext Record,
           _completionRecord_: a Completion Record,
         ): either a normal completion containing either an ECMAScript language value or ~unused~, or an abrupt completion
       </h1>
@@ -12466,7 +12498,7 @@
       </dl>
       <emu-alg>
         1. Let _genContext_ be the running execution context.
-        1. Remove _genContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
+        1. Remove _genContext_ from the execution context stack and restore the ExecutionContext Record that is at the top of the execution context stack as the running execution context.
         1. Let _callerContext_ be the running execution context.
         1. Resume _callerContext_, passing NormalCompletion(_value_).
         1. NOTE: The above step transfers control to _callerContext_ and pauses. The only way for it to un-pause and have control proceed to the subsequent steps in this algorithm is for _genContext_ to be resumed again, which might never happen.
@@ -12502,18 +12534,18 @@
     <p>At any particular time, _scriptOrModule_ (a Script Record, a Module Record, or *null*) is the <dfn id="job-activescriptormodule">active script or module</dfn> if all of the following conditions are true:</p>
     <ul>
       <li>GetActiveScriptOrModule() is _scriptOrModule_.</li>
-      <li>If _scriptOrModule_ is a Script Record or Module Record, let _executionContext_ be the topmost execution context on the execution context stack whose ScriptOrModule component is _scriptOrModule_. The Realm component of _executionContext_ is _scriptOrModule_.[[Realm]].</li>
+      <li>If _scriptOrModule_ is a Script Record or Module Record, let _executionContext_ be the topmost ExecutionContext Record on the execution context stack whose [[ScriptOrModule]] field is _scriptOrModule_. _executionContext_.[[Realm]] is _scriptOrModule_.[[Realm]].</li>
     </ul>
 
     <p>At any particular time, an execution is <dfn id="job-preparedtoevaluatecode">prepared to evaluate ECMAScript code</dfn> if all of the following conditions are true:</p>
     <ul>
       <li>The execution context stack is not empty.</li>
-      <li>The Realm component of the topmost execution context on the execution context stack is a Realm Record.</li>
+      <li>The [[Realm]] field of the topmost ExecutionContext Record on the execution context stack is a Realm Record.</li>
     </ul>
 
     <emu-note>
-      <p>Host environments may prepare an execution to evaluate code by pushing execution contexts onto the execution context stack. The specific steps are implementation-defined.</p>
-      <p>The specific choice of Realm is up to the host environment. This initial execution context and Realm is only in use before any callback function is invoked. When a callback function related to a Job, like a Promise handler, is invoked, the invocation pushes its own execution context and Realm.</p>
+      <p>Host environments may prepare an execution to evaluate code by pushing ExecutionContext Records onto the execution context stack. The specific steps are implementation-defined.</p>
+      <p>The specific choice of Realm is up to the host environment. This initial ExecutionContext Record and Realm is only in use before any callback function is invoked. When a callback function related to a Job, like a Promise handler, is invoked, the invocation pushes its own ExecutionContext Record and Realm.</p>
     </emu-note>
 
     <p>Particular kinds of Jobs have additional conformance requirements.</p>
@@ -13862,21 +13894,21 @@
           PrepareForOrdinaryCall (
             _func_: an ECMAScript function object,
             _newTarget_: an Object or *undefined*,
-          ): an execution context
+          ): an ExecutionContext Record
         </h1>
         <dl class="header">
         </dl>
         <emu-alg>
           1. Let _callerContext_ be the running execution context.
-          1. Let _calleeContext_ be a new ECMAScript code execution context.
-          1. Set the Function of _calleeContext_ to _func_.
+          1. Let _calleeContext_ be a new ECMAScript code ExecutionContext Record.
+          1. Set _calleeContext_.[[Function]] to _func_.
           1. Let _calleeRealm_ be _func_.[[Realm]].
-          1. Set the Realm of _calleeContext_ to _calleeRealm_.
-          1. Set the ScriptOrModule of _calleeContext_ to _func_.[[ScriptOrModule]].
+          1. Set _calleeContext_.[[Realm]] to _calleeRealm_.
+          1. Set _calleeContext_.[[ScriptOrModule]] to _func_.[[ScriptOrModule]].
           1. Let _localEnv_ be NewFunctionEnvironment(_func_, _newTarget_).
-          1. Set the LexicalEnvironment of _calleeContext_ to _localEnv_.
-          1. Set the VariableEnvironment of _calleeContext_ to _localEnv_.
-          1. Set the PrivateEnvironment of _calleeContext_ to _func_.[[PrivateEnvironment]].
+          1. Set _calleeContext_.[[LexicalEnvironment]] to _localEnv_.
+          1. Set _calleeContext_.[[VariableEnvironment]] to _localEnv_.
+          1. Set _calleeContext_.[[PrivateEnvironment]] to _func_.[[PrivateEnvironment]].
           1. If _callerContext_ is not already suspended, suspend _callerContext_.
           1. Push _calleeContext_ onto the execution context stack; _calleeContext_ is now the running execution context.
           1. NOTE: Any exception objects produced after this point are associated with _calleeRealm_.
@@ -13888,7 +13920,7 @@
         <h1>
           OrdinaryCallBindThis (
             _func_: an ECMAScript function object,
-            _calleeContext_: an execution context,
+            _calleeContext_: an ExecutionContext Record,
             _thisArg_: an ECMAScript language value,
           ): ~unused~
         </h1>
@@ -13898,7 +13930,7 @@
           1. Let _thisMode_ be _func_.[[ThisMode]].
           1. If _thisMode_ is ~lexical~, return ~unused~.
           1. Let _calleeRealm_ be _func_.[[Realm]].
-          1. Let _localEnv_ be the LexicalEnvironment of _calleeContext_.
+          1. Let _localEnv_ be _calleeContext_.[[LexicalEnvironment]].
           1. If _thisMode_ is ~strict~, then
             1. Let _thisValue_ be _thisArg_.
           1. Else,
@@ -14020,7 +14052,7 @@
           1. If _initializeResult_ is an abrupt completion, then
             1. Remove _calleeContext_ from the execution context stack and restore _callerContext_ as the running execution context.
             1. Return ? _initializeResult_.
-        1. Let _ctorEnv_ be the LexicalEnvironment of _calleeContext_.
+        1. Let _ctorEnv_ be _calleeContext_.[[LexicalEnvironment]].
         1. Let _result_ be Completion(OrdinaryCallEvaluateBody(_func_, _argList_)).
         1. Remove _calleeContext_ from the execution context stack and restore _callerContext_ as the running execution context.
         1. If _result_ is a throw completion, return ? _result_.
@@ -14292,13 +14324,13 @@
             1. Set _argumentsObjNeeded_ to *false*.
         1. If _strict_ is *true* or _hasParamExprs_ is *false*, then
           1. NOTE: Only a single Environment Record is needed for the parameters, since calls to `eval` in strict mode code cannot create new bindings which are visible outside of the `eval`.
-          1. Let _envRecord_ be the LexicalEnvironment of _calleeContext_.
+          1. Let _envRecord_ be _calleeContext_.[[LexicalEnvironment]].
         1. Else,
           1. NOTE: A separate Environment Record is needed to ensure that bindings created by direct eval calls in the formal parameter list are outside the environment where parameters are declared.
-          1. Let _calleeEnv_ be the LexicalEnvironment of _calleeContext_.
+          1. Let _calleeEnv_ be _calleeContext_.[[LexicalEnvironment]].
           1. Let _envRecord_ be NewDeclarativeEnvironment(_calleeEnv_).
-          1. Assert: The VariableEnvironment of _calleeContext_ and _calleeEnv_ are the same Environment Record.
-          1. Set the LexicalEnvironment of _calleeContext_ to _envRecord_.
+          1. Assert: _calleeContext_.[[VariableEnvironment]] and _calleeEnv_ are the same Environment Record.
+          1. Set _calleeContext_.[[LexicalEnvironment]] to _envRecord_.
         1. For each String _paramName_ of _paramNames_, do
           1. Let _alreadyDeclared_ be ! _envRecord_.HasBinding(_paramName_).
           1. NOTE: Early errors ensure that duplicate parameter names can only occur in non-strict functions that do not have parameter default values or rest parameters.
@@ -14340,7 +14372,7 @@
         1. Else,
           1. NOTE: A separate Environment Record is needed to ensure that closures created by expressions in the formal parameter list do not have visibility of declarations in the function body.
           1. Let _variableEnv_ be NewDeclarativeEnvironment(_envRecord_).
-          1. Set the VariableEnvironment of _calleeContext_ to _variableEnv_.
+          1. Set _calleeContext_.[[VariableEnvironment]] to _variableEnv_.
           1. Let _instantiatedVariableNames_ be a new empty List.
           1. For each element _name_ of _variableNames_, do
             1. If _instantiatedVariableNames_ does not contain _name_, then
@@ -14365,14 +14397,14 @@
                   1. Perform ! _variableEnv_.InitializeBinding(_funcName_, *undefined*).
                   1. Append _funcName_ to _instantiatedVariableNames_.
                 1. [id="step-functiondeclarationinstantiation-alt-funcdecl-eval"] When the |FunctionDeclaration| _funcDecl_ is evaluated, perform the following steps in place of the |FunctionDeclaration| Evaluation algorithm provided in <emu-xref href="#sec-function-definitions-runtime-semantics-evaluation"></emu-xref>:
-                  1. Let _funcEnv_ be the running execution context's VariableEnvironment.
-                  1. Let _blockEnv_ be the running execution context's LexicalEnvironment.
+                  1. Let _funcEnv_ be the running execution context's [[VariableEnvironment]].
+                  1. Let _blockEnv_ be the running execution context's [[LexicalEnvironment]].
                   1. Let _funcObj_ be ! _blockEnv_.GetBindingValue(_funcName_, *false*).
                   1. Perform ! _funcEnv_.SetMutableBinding(_funcName_, _funcObj_, *false*).
                   1. Return ~unused~.
           1. Let _lexicalEnv_ be NewDeclarativeEnvironment(_variableEnv_).
           1. NOTE: Non-strict functions use a separate Environment Record for top-level lexical declarations so that a direct eval can determine whether any var scoped declarations introduced by the eval code conflict with pre-existing top-level lexically scoped declarations. This is not needed for strict functions because a strict direct eval always places all declarations into a new Environment Record.
-        1. Set the LexicalEnvironment of _calleeContext_ to _lexicalEnv_.
+        1. Set _calleeContext_.[[LexicalEnvironment]] to _lexicalEnv_.
         1. Let _lexicalDecls_ be the LexicallyScopedDeclarations of _code_.
         1. For each element _lexicalDecl_ of _lexicalDecls_, do
           1. NOTE: A lexically declared name cannot be the same as a function/generator declaration, formal parameter, or a var name. Lexically declared names are only instantiated here but not initialized.
@@ -14381,7 +14413,7 @@
               1. Perform ! _lexicalEnv_.CreateImmutableBinding(_name_, *true*).
             1. Else,
               1. Perform ! _lexicalEnv_.CreateMutableBinding(_name_, *false*).
-        1. Let _privateEnv_ be the PrivateEnvironment of _calleeContext_.
+        1. Let _privateEnv_ be _calleeContext_.[[PrivateEnvironment]].
         1. For each Parse Node _funcDecl_ of _funcsToInitialize_, do
           1. Let _funcName_ be the sole element of the BoundNames of _funcDecl_.
           1. Let _funcObj_ be InstantiateFunctionObject of _funcDecl_ with arguments _lexicalEnv_ and _privateEnv_.
@@ -14453,11 +14485,11 @@
       <emu-alg>
         1. Let _callerContext_ be the running execution context.
         1. If _callerContext_ is not already suspended, suspend _callerContext_.
-        1. Let _calleeContext_ be a new execution context.
-        1. Set the Function of _calleeContext_ to _func_.
+        1. Let _calleeContext_ be a new ExecutionContext Record.
+        1. Set _calleeContext_.[[Function]] to _func_.
         1. Let _calleeRealm_ be _func_.[[Realm]].
-        1. Set the Realm of _calleeContext_ to _calleeRealm_.
-        1. Set the ScriptOrModule of _calleeContext_ to *null*.
+        1. Set _calleeContext_.[[Realm]] to _calleeRealm_.
+        1. Set _calleeContext_.[[ScriptOrModule]] to *null*.
         1. Perform any necessary implementation-defined initialization of _calleeContext_.
         1. Push _calleeContext_ onto the execution context stack; _calleeContext_ is now the running execution context.
         1. If _func_.[[Async]] is *true*, then
@@ -20953,7 +20985,7 @@
         1. Let _rightRef_ be ? Evaluation of |ShiftExpression|.
         1. Let _rightValue_ be ? GetValue(_rightRef_).
         1. If _rightValue_ is not an Object, throw a *TypeError* exception.
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Assert: _privateEnv_ is not *null*.
         1. Let _privateName_ be ResolvePrivateIdentifier(_privateEnv_, _privateIdentifier_).
         1. If PrivateElementFind(_rightValue_, _privateName_) is ~empty~, return *false*.
@@ -21908,17 +21940,17 @@
       </emu-alg>
       <emu-grammar>Block : `{` StatementList `}`</emu-grammar>
       <emu-alg>
-        1. Let _oldEnv_ be the running execution context's LexicalEnvironment.
+        1. Let _oldEnv_ be the running execution context's [[LexicalEnvironment]].
         1. Let _blockEnv_ be NewDeclarativeEnvironment(_oldEnv_).
         1. Perform BlockDeclarationInstantiation(|StatementList|, _blockEnv_).
-        1. Set the running execution context's LexicalEnvironment to _blockEnv_.
+        1. Set the running execution context's [[LexicalEnvironment]] to _blockEnv_.
         1. Let _blockValue_ be Completion(Evaluation of |StatementList|).
         1. Set _blockValue_ to Completion(DisposeResources(_blockEnv_.[[DisposableResourceStack]], _blockValue_)).
-        1. Set the running execution context's LexicalEnvironment to _oldEnv_.
+        1. Set the running execution context's [[LexicalEnvironment]] to _oldEnv_.
         1. Return ? _blockValue_.
       </emu-alg>
       <emu-note>
-        <p>No matter how control leaves the |Block| the LexicalEnvironment is always restored to its former state.</p>
+        <p>No matter how control leaves the |Block| the [[LexicalEnvironment]] is always restored to its former state.</p>
       </emu-note>
       <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
       <emu-alg>
@@ -21953,7 +21985,7 @@
       <p>It performs the following steps when called:</p>
       <emu-alg>
         1. Let _decls_ be the LexicallyScopedDeclarations of _code_.
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. For each element _decl_ of _decls_, do
           1. For each element _name_ of the BoundNames of _decl_, do
             1. If IsConstantDeclaration of _decl_ is *true*, then
@@ -21986,7 +22018,7 @@
     <emu-clause id="sec-let-and-const-declarations">
       <h1>Let, Const, Using, and Await Using Declarations</h1>
       <emu-note>
-        <p>`let`, `const`, `using`, and `await using` declarations define variables that are scoped to the running execution context's LexicalEnvironment. The variables are created when their containing Environment Record is instantiated but may not be accessed in any way until the variable's |LexicalBinding| is evaluated. A variable defined by a |LexicalBinding| with an |Initializer| is assigned the value of its |Initializer|'s |AssignmentExpression| when the |LexicalBinding| is evaluated, not when the variable is created. If a |LexicalBinding| in a `let` declaration does not have an |Initializer| the variable is assigned the value *undefined* when the |LexicalBinding| is evaluated.</p>
+        <p>`let`, `const`, `using`, and `await using` declarations define variables that are scoped to the running execution context's [[LexicalEnvironment]]. The variables are created when their containing Environment Record is instantiated but may not be accessed in any way until the variable's |LexicalBinding| is evaluated. A variable defined by a |LexicalBinding| with an |Initializer| is assigned the value of its |Initializer|'s |AssignmentExpression| when the |LexicalBinding| is evaluated, not when the variable is created. If a |LexicalBinding| in a `let` declaration does not have an |Initializer| the variable is assigned the value *undefined* when the |LexicalBinding| is evaluated.</p>
       </emu-note>
       <h2>Syntax</h2>
       <emu-grammar type="definition">
@@ -22133,7 +22165,7 @@
           1. Assert: _kind_ is ~normal~.
           1. Let _rhs_ be ? Evaluation of |Initializer|.
           1. Let _value_ be ? GetValue(_rhs_).
-          1. Let _envRecord_ be the running execution context's LexicalEnvironment.
+          1. Let _envRecord_ be the running execution context's [[LexicalEnvironment]].
           1. Return ? BindingInitialization of |BindingPattern| with arguments _value_ and _envRecord_.
         </emu-alg>
       </emu-clause>
@@ -22142,7 +22174,7 @@
     <emu-clause id="sec-variable-statement">
       <h1>Variable Statement</h1>
       <emu-note>
-        <p>A `var` statement declares variables that are scoped to the running execution context's VariableEnvironment. Var variables are created when their containing Environment Record is instantiated and are initialized to *undefined* when created. Within the scope of any VariableEnvironment a common |BindingIdentifier| may appear in more than one |VariableDeclaration| but those declarations collectively define only one variable. A variable defined by a |VariableDeclaration| with an |Initializer| is assigned the value of its |Initializer|'s |AssignmentExpression| when the |VariableDeclaration| is executed, not when the variable is created.</p>
+        <p>A `var` statement declares variables that are scoped to the running execution context's [[VariableEnvironment]]. Var variables are created when their containing Environment Record is instantiated and are initialized to *undefined* when created. Within the scope of any [[VariableEnvironment]] a common |BindingIdentifier| may appear in more than one |VariableDeclaration| but those declarations collectively define only one variable. A variable defined by a |VariableDeclaration| with an |Initializer| is assigned the value of its |Initializer|'s |AssignmentExpression| when the |VariableDeclaration| is executed, not when the variable is created.</p>
       </emu-note>
       <h2>Syntax</h2>
       <emu-grammar type="definition">
@@ -22187,7 +22219,7 @@
           1. Return ~empty~.
         </emu-alg>
         <emu-note>
-          <p>If a |VariableDeclaration| is nested within a with statement and the |BindingIdentifier| in the |VariableDeclaration| is the same as a property name of the binding object of the with statement's Object Environment Record, then step <emu-xref href="#step-vardecllist-evaluation-putvalue"></emu-xref> will assign _value_ to the property instead of assigning to the VariableEnvironment binding of the |Identifier|.</p>
+          <p>If a |VariableDeclaration| is nested within a with statement and the |BindingIdentifier| in the |VariableDeclaration| is the same as a property name of the binding object of the with statement's Object Environment Record, then step <emu-xref href="#step-vardecllist-evaluation-putvalue"></emu-xref> will assign _value_ to the property instead of assigning to the [[VariableEnvironment]] binding of the |Identifier|.</p>
         </emu-note>
         <emu-grammar>VariableDeclaration : BindingPattern Initializer</emu-grammar>
         <emu-alg>
@@ -22640,7 +22672,7 @@
         </emu-alg>
         <emu-grammar>ForStatement : `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement</emu-grammar>
         <emu-alg>
-          1. Let _oldEnv_ be the running execution context's LexicalEnvironment.
+          1. Let _oldEnv_ be the running execution context's [[LexicalEnvironment]].
           1. Let _loopEnv_ be NewDeclarativeEnvironment(_oldEnv_).
           1. Let _isConst_ be IsConstantDeclaration of |LexicalDeclaration|.
           1. Let _boundNames_ be the BoundNames of |LexicalDeclaration|.
@@ -22649,12 +22681,12 @@
               1. Perform ! _loopEnv_.CreateImmutableBinding(_name_, *true*).
             1. Else,
               1. Perform ! _loopEnv_.CreateMutableBinding(_name_, *false*).
-          1. Set the running execution context's LexicalEnvironment to _loopEnv_.
+          1. Set the running execution context's [[LexicalEnvironment]] to _loopEnv_.
           1. Let _forDecl_ be Completion(Evaluation of |LexicalDeclaration|).
           1. If _forDecl_ is an abrupt completion, then
             1. Set _forDecl_ to Completion(DisposeResources(_loopEnv_.[[DisposableResourceStack]], _forDecl_)).
             1. Assert: _forDecl_ is an abrupt completion.
-            1. Set the running execution context's LexicalEnvironment to _oldEnv_.
+            1. Set the running execution context's [[LexicalEnvironment]] to _oldEnv_.
             1. Return ? _forDecl_.
           1. If _isConst_ is *false*, let _perIterationLets_ be _boundNames_; else let _perIterationLets_ be a new empty List.
           1. If the first |Expression| is present, let _test_ be the first |Expression|; else let _test_ be ~empty~.
@@ -22662,7 +22694,7 @@
           1. Let _bodyResult_ be Completion(ForBodyEvaluation(_test_, _increment_, |Statement|, _perIterationLets_, _labelSet_)).
           1. Set _bodyResult_ to Completion(DisposeResources(_loopEnv_.[[DisposableResourceStack]], _bodyResult_)).
           1. Assert: If _bodyResult_ is a normal completion, then _bodyResult_.[[Value]] is not ~empty~.
-          1. Set the running execution context's LexicalEnvironment to _oldEnv_.
+          1. Set the running execution context's [[LexicalEnvironment]] to _oldEnv_.
           1. Return ? _bodyResult_.
         </emu-alg>
       </emu-clause>
@@ -22707,7 +22739,7 @@
         </dl>
         <emu-alg>
           1. If _perIterationBindings_ has any elements, then
-            1. Let _lastIterationEnv_ be the running execution context's LexicalEnvironment.
+            1. Let _lastIterationEnv_ be the running execution context's [[LexicalEnvironment]].
             1. Let _outer_ be _lastIterationEnv_.[[OuterEnv]].
             1. Assert: _outer_ is not *null*.
             1. Let _thisIterationEnv_ be NewDeclarativeEnvironment(_outer_).
@@ -22715,7 +22747,7 @@
               1. Perform ! _thisIterationEnv_.CreateMutableBinding(_name_, *false*).
               1. Let _lastValue_ be ? _lastIterationEnv_.GetBindingValue(_name_, *true*).
               1. Perform ! _thisIterationEnv_.InitializeBinding(_name_, _lastValue_).
-            1. Set the running execution context's LexicalEnvironment to _thisIterationEnv_.
+            1. Set the running execution context's [[LexicalEnvironment]] to _thisIterationEnv_.
           1. Return ~unused~.
         </emu-alg>
       </emu-clause>
@@ -22977,15 +23009,15 @@
         <dl class="header">
         </dl>
         <emu-alg>
-          1. Let _oldEnv_ be the running execution context's LexicalEnvironment.
+          1. Let _oldEnv_ be the running execution context's [[LexicalEnvironment]].
           1. If _uninitializedBoundNames_ is not empty, then
             1. Assert: _uninitializedBoundNames_ has no duplicate entries.
             1. Let _newEnv_ be NewDeclarativeEnvironment(_oldEnv_).
             1. For each String _name_ of _uninitializedBoundNames_, do
               1. Perform ! _newEnv_.CreateMutableBinding(_name_, *false*).
-            1. Set the running execution context's LexicalEnvironment to _newEnv_.
+            1. Set the running execution context's [[LexicalEnvironment]] to _newEnv_.
           1. Let _exprRef_ be Completion(Evaluation of _expr_).
-          1. Set the running execution context's LexicalEnvironment to _oldEnv_.
+          1. Set the running execution context's [[LexicalEnvironment]] to _oldEnv_.
           1. Let _exprValue_ be ? GetValue(? _exprRef_).
           1. If _iterationKind_ is ~enumerate~, then
             1. If _exprValue_ is either *undefined* or *null*, then
@@ -23017,7 +23049,7 @@
         </dl>
         <emu-alg>
           1. If _iteratorKind_ is not present, set _iteratorKind_ to ~sync~.
-          1. Let _oldEnv_ be the running execution context's LexicalEnvironment.
+          1. Let _oldEnv_ be the running execution context's [[LexicalEnvironment]].
           1. Let _iterationResult_ be *undefined*.
           1. If _lhsKind_ is ~lexical-binding~, then
             1. Assert: _lhs_ is a |ForDeclaration|.
@@ -23061,7 +23093,7 @@
               1. Assert: _lhs_ is a |ForDeclaration|.
               1. Let _iterationEnv_ be NewDeclarativeEnvironment(_oldEnv_).
               1. Perform ForDeclarationBindingInstantiation of _lhs_ with argument _iterationEnv_.
-              1. Set the running execution context's LexicalEnvironment to _iterationEnv_.
+              1. Set the running execution context's [[LexicalEnvironment]] to _iterationEnv_.
               1. If _destructuring_ is *true*, then
                 1. Let _status_ be Completion(ForDeclarationBindingInitialization of _lhs_ with arguments _nextValue_ and _iterationEnv_).
               1. Else,
@@ -23081,7 +23113,7 @@
               1. If _iterationEnv_ is not *undefined*, then
                 1. Set _status_ to Completion(DisposeResources(_iterationEnv_.[[DisposableResourceStack]], _status_)).
                 1. Assert: _status_ is an abrupt completion.
-              1. Set the running execution context's LexicalEnvironment to _oldEnv_.
+              1. Set the running execution context's [[LexicalEnvironment]] to _oldEnv_.
               1. If _iterationKind_ is ~enumerate~, return ? _status_.
               1. Assert: _iterationKind_ is ~iterate~.
               1. If _iteratorKind_ is ~async~, return ? AsyncIteratorClose(_iteratorRecord_, _status_).
@@ -23089,7 +23121,7 @@
             1. Let _result_ be Completion(Evaluation of _stmt_).
             1. If _iterationEnv_ is not *undefined*, then
               1. Set _result_ to Completion(DisposeResources(_iterationEnv_.[[DisposableResourceStack]], _result_)).
-            1. Set the running execution context's LexicalEnvironment to _oldEnv_.
+            1. Set the running execution context's [[LexicalEnvironment]] to _oldEnv_.
             1. If LoopContinues(_result_, _labelSet_) is *false*, then
               1. Set _status_ to Completion(UpdateEmpty(_result_, _iterationResult_)).
               1. If _iterationKind_ is ~enumerate~, return ? _status_.
@@ -23431,15 +23463,15 @@
       <emu-alg>
         1. Let _value_ be ? Evaluation of |Expression|.
         1. Let _obj_ be ? ToObject(? GetValue(_value_)).
-        1. Let _oldEnv_ be the running execution context's LexicalEnvironment.
+        1. Let _oldEnv_ be the running execution context's [[LexicalEnvironment]].
         1. Let _newEnv_ be NewObjectEnvironment(_obj_, *true*, _oldEnv_).
-        1. Set the running execution context's LexicalEnvironment to _newEnv_.
+        1. Set the running execution context's [[LexicalEnvironment]] to _newEnv_.
         1. Let _stmtCompletion_ be Completion(Evaluation of |Statement|).
-        1. Set the running execution context's LexicalEnvironment to _oldEnv_.
+        1. Set the running execution context's [[LexicalEnvironment]] to _oldEnv_.
         1. Return ? UpdateEmpty(_stmtCompletion_, *undefined*).
       </emu-alg>
       <emu-note>
-        <p>No matter how control leaves the embedded |Statement|, whether normally or by some form of abrupt completion or exception, the LexicalEnvironment is always restored to its former state.</p>
+        <p>No matter how control leaves the embedded |Statement|, whether normally or by some form of abrupt completion or exception, the [[LexicalEnvironment]] is always restored to its former state.</p>
       </emu-note>
     </emu-clause>
   </emu-clause>
@@ -23590,17 +23622,17 @@
       <emu-alg>
         1. Let _exprRef_ be ? Evaluation of |Expression|.
         1. Let _switchValue_ be ? GetValue(_exprRef_).
-        1. Let _oldEnv_ be the running execution context's LexicalEnvironment.
+        1. Let _oldEnv_ be the running execution context's [[LexicalEnvironment]].
         1. Let _blockEnv_ be NewDeclarativeEnvironment(_oldEnv_).
         1. Perform BlockDeclarationInstantiation(|CaseBlock|, _blockEnv_).
-        1. Set the running execution context's LexicalEnvironment to _blockEnv_.
+        1. Set the running execution context's [[LexicalEnvironment]] to _blockEnv_.
         1. Let _blockResult_ be Completion(CaseBlockEvaluation of |CaseBlock| with argument _switchValue_).
         1. Assert: _blockEnv_.[[DisposableResourceStack]] is an empty List.
-        1. Set the running execution context's LexicalEnvironment to _oldEnv_.
+        1. Set the running execution context's [[LexicalEnvironment]] to _oldEnv_.
         1. Return _blockResult_.
       </emu-alg>
       <emu-note>
-        <p>No matter how control leaves the |SwitchStatement| the LexicalEnvironment is always restored to its former state.</p>
+        <p>No matter how control leaves the |SwitchStatement| the [[LexicalEnvironment]] is always restored to its former state.</p>
       </emu-note>
       <emu-grammar>CaseClause : `case` Expression `:`</emu-grammar>
       <emu-alg>
@@ -23806,17 +23838,17 @@
       </dl>
       <emu-grammar>Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
       <emu-alg>
-        1. Let _oldEnv_ be the running execution context's LexicalEnvironment.
+        1. Let _oldEnv_ be the running execution context's [[LexicalEnvironment]].
         1. Let _catchEnv_ be NewDeclarativeEnvironment(_oldEnv_).
         1. For each element _argName_ of the BoundNames of |CatchParameter|, do
           1. Perform ! _catchEnv_.CreateMutableBinding(_argName_, *false*).
-        1. Set the running execution context's LexicalEnvironment to _catchEnv_.
+        1. Set the running execution context's [[LexicalEnvironment]] to _catchEnv_.
         1. Let _status_ be Completion(BindingInitialization of |CatchParameter| with arguments _thrownValue_ and _catchEnv_).
         1. If _status_ is an abrupt completion, then
-          1. Set the running execution context's LexicalEnvironment to _oldEnv_.
+          1. Set the running execution context's [[LexicalEnvironment]] to _oldEnv_.
           1. Return ? _status_.
         1. Let _blockCompletion_ be Completion(Evaluation of |Block|).
-        1. Set the running execution context's LexicalEnvironment to _oldEnv_.
+        1. Set the running execution context's [[LexicalEnvironment]] to _oldEnv_.
         1. Return ? _blockCompletion_.
       </emu-alg>
       <emu-grammar>Catch : `catch` Block</emu-grammar>
@@ -23824,7 +23856,7 @@
         1. Return ? Evaluation of |Block|.
       </emu-alg>
       <emu-note>
-        <p>No matter how control leaves the |Block| the LexicalEnvironment is always restored to its former state.</p>
+        <p>No matter how control leaves the |Block| the [[LexicalEnvironment]] is always restored to its former state.</p>
       </emu-note>
     </emu-clause>
 
@@ -24330,8 +24362,8 @@
       <emu-grammar>FunctionExpression : `function` `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. If _name_ is not present, set _name_ to the empty String.
-        1. Let _envRecord_ be the LexicalEnvironment of the running execution context.
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _envRecord_ be the running execution context's [[LexicalEnvironment]].
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Let _sourceText_ be the source text matched by |FunctionExpression|.
         1. Let _closure_ be OrdinaryFunctionCreate(%Function.prototype%, _sourceText_, |FormalParameters|, |FunctionBody|, ~non-lexical-this~, _envRecord_, _privateEnv_).
         1. Perform SetFunctionName(_closure_, _name_).
@@ -24342,10 +24374,10 @@
       <emu-alg>
         1. Assert: _name_ is not present.
         1. Set _name_ to the StringValue of |BindingIdentifier|.
-        1. Let _outerEnv_ be the running execution context's LexicalEnvironment.
+        1. Let _outerEnv_ be the running execution context's [[LexicalEnvironment]].
         1. Let _funcEnv_ be NewDeclarativeEnvironment(_outerEnv_).
         1. Perform ! _funcEnv_.CreateImmutableBinding(_name_, *false*).
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Let _sourceText_ be the source text matched by |FunctionExpression|.
         1. Let _closure_ be OrdinaryFunctionCreate(%Function.prototype%, _sourceText_, |FormalParameters|, |FunctionBody|, ~non-lexical-this~, _funcEnv_, _privateEnv_).
         1. Perform SetFunctionName(_closure_, _name_).
@@ -24387,7 +24419,7 @@
       <emu-grammar>FunctionStatementList : StatementList</emu-grammar>
       <emu-alg>
         1. Let _result_ be Completion(Evaluation of |StatementList|).
-        1. Let _env_ be the running execution context's LexicalEnvironment.
+        1. Let _env_ be the running execution context's [[LexicalEnvironment]].
         1. Assert: _env_ is a Declarative Environment Record.
         1. Return ? DisposeResources(_env_.[[DisposableResourceStack]], _result_).
       </emu-alg>
@@ -24489,8 +24521,8 @@
       <emu-grammar>ArrowFunction : ArrowParameters `=>` ConciseBody</emu-grammar>
       <emu-alg>
         1. If _name_ is not present, set _name_ to the empty String.
-        1. Let _envRecord_ be the LexicalEnvironment of the running execution context.
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _envRecord_ be the running execution context's [[LexicalEnvironment]].
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Let _sourceText_ be the source text matched by |ArrowFunction|.
         1. [id="step-arrowfunction-evaluation-functioncreate"] Let _closure_ be OrdinaryFunctionCreate(%Function.prototype%, _sourceText_, |ArrowParameters|, |ConciseBody|, ~lexical-this~, _envRecord_, _privateEnv_).
         1. Perform SetFunctionName(_closure_, _name_).
@@ -24627,8 +24659,8 @@
       <emu-grammar>MethodDefinition : ClassElementName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Let _propertyKey_ be ? Evaluation of |ClassElementName|.
-        1. Let _envRecord_ be the running execution context's LexicalEnvironment.
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _envRecord_ be the running execution context's [[LexicalEnvironment]].
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. If _proto_ is not present, set _proto_ to %Function.prototype%.
         1. Let _sourceText_ be the source text matched by |MethodDefinition|.
         1. Let _closure_ be OrdinaryFunctionCreate(_proto_, _sourceText_, |UniqueFormalParameters|, |FunctionBody|, ~non-lexical-this~, _envRecord_, _privateEnv_).
@@ -24655,8 +24687,8 @@
       <emu-grammar>MethodDefinition : `get` ClassElementName `(` `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Let _propertyKey_ be ? Evaluation of |ClassElementName|.
-        1. Let _envRecord_ be the running execution context's LexicalEnvironment.
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _envRecord_ be the running execution context's [[LexicalEnvironment]].
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Let _sourceText_ be the source text matched by |MethodDefinition|.
         1. Let _formalParamList_ be an instance of the production <emu-grammar>FormalParameters : [empty]</emu-grammar>.
         1. Let _closure_ be OrdinaryFunctionCreate(%Function.prototype%, _sourceText_, _formalParamList_, |FunctionBody|, ~non-lexical-this~, _envRecord_, _privateEnv_).
@@ -24671,8 +24703,8 @@
       <emu-grammar>MethodDefinition : `set` ClassElementName `(` PropertySetParameterList `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Let _propertyKey_ be ? Evaluation of |ClassElementName|.
-        1. Let _envRecord_ be the running execution context's LexicalEnvironment.
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _envRecord_ be the running execution context's [[LexicalEnvironment]].
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Let _sourceText_ be the source text matched by |MethodDefinition|.
         1. Let _closure_ be OrdinaryFunctionCreate(%Function.prototype%, _sourceText_, |PropertySetParameterList|, |FunctionBody|, ~non-lexical-this~, _envRecord_, _privateEnv_).
         1. Perform MakeMethod(_closure_, _obj_).
@@ -24686,8 +24718,8 @@
       <emu-grammar>GeneratorMethod : `*` ClassElementName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. Let _propertyKey_ be ? Evaluation of |ClassElementName|.
-        1. Let _envRecord_ be the running execution context's LexicalEnvironment.
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _envRecord_ be the running execution context's [[LexicalEnvironment]].
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Let _sourceText_ be the source text matched by |GeneratorMethod|.
         1. Let _closure_ be OrdinaryFunctionCreate(%GeneratorFunction.prototype%, _sourceText_, |UniqueFormalParameters|, |GeneratorBody|, ~non-lexical-this~, _envRecord_, _privateEnv_).
         1. Perform MakeMethod(_closure_, _obj_).
@@ -24701,8 +24733,8 @@
       </emu-grammar>
       <emu-alg>
         1. Let _propertyKey_ be ? Evaluation of |ClassElementName|.
-        1. Let _envRecord_ be the running execution context's LexicalEnvironment.
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _envRecord_ be the running execution context's [[LexicalEnvironment]].
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Let _sourceText_ be the source text matched by |AsyncGeneratorMethod|.
         1. Let _closure_ be OrdinaryFunctionCreate(%AsyncGeneratorFunction.prototype%, _sourceText_, |UniqueFormalParameters|, |AsyncGeneratorBody|, ~non-lexical-this~, _envRecord_, _privateEnv_).
         1. Perform MakeMethod(_closure_, _obj_).
@@ -24716,8 +24748,8 @@
       </emu-grammar>
       <emu-alg>
         1. Let _propertyKey_ be ? Evaluation of |ClassElementName|.
-        1. Let _envRecord_ be the LexicalEnvironment of the running execution context.
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _envRecord_ be the running execution context's [[LexicalEnvironment]].
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Let _sourceText_ be the source text matched by |AsyncMethod|.
         1. Let _closure_ be OrdinaryFunctionCreate(%AsyncFunction.prototype%, _sourceText_, |UniqueFormalParameters|, |AsyncFunctionBody|, ~non-lexical-this~, _envRecord_, _privateEnv_).
         1. Perform MakeMethod(_closure_, _obj_).
@@ -24879,8 +24911,8 @@
       <emu-grammar>GeneratorExpression : `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. If _name_ is not present, set _name_ to the empty String.
-        1. Let _envRecord_ be the LexicalEnvironment of the running execution context.
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _envRecord_ be the running execution context's [[LexicalEnvironment]].
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Let _sourceText_ be the source text matched by |GeneratorExpression|.
         1. Let _closure_ be OrdinaryFunctionCreate(%GeneratorFunction.prototype%, _sourceText_, |FormalParameters|, |GeneratorBody|, ~non-lexical-this~, _envRecord_, _privateEnv_).
         1. Perform SetFunctionName(_closure_, _name_).
@@ -24892,10 +24924,10 @@
       <emu-alg>
         1. Assert: _name_ is not present.
         1. Set _name_ to the StringValue of |BindingIdentifier|.
-        1. Let _outerEnv_ be the running execution context's LexicalEnvironment.
+        1. Let _outerEnv_ be the running execution context's [[LexicalEnvironment]].
         1. Let _funcEnv_ be NewDeclarativeEnvironment(_outerEnv_).
         1. Perform ! _funcEnv_.CreateImmutableBinding(_name_, *false*).
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Let _sourceText_ be the source text matched by |GeneratorExpression|.
         1. Let _closure_ be OrdinaryFunctionCreate(%GeneratorFunction.prototype%, _sourceText_, |FormalParameters|, |GeneratorBody|, ~non-lexical-this~, _funcEnv_, _privateEnv_).
         1. Perform SetFunctionName(_closure_, _name_).
@@ -25114,8 +25146,8 @@
       </emu-grammar>
       <emu-alg>
         1. If _name_ is not present, set _name_ to the empty String.
-        1. Let _envRecord_ be the LexicalEnvironment of the running execution context.
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _envRecord_ be the running execution context's [[LexicalEnvironment]].
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Let _sourceText_ be the source text matched by |AsyncGeneratorExpression|.
         1. Let _closure_ be OrdinaryFunctionCreate(%AsyncGeneratorFunction.prototype%, _sourceText_, |FormalParameters|, |AsyncGeneratorBody|, ~non-lexical-this~, _envRecord_, _privateEnv_).
         1. Perform SetFunctionName(_closure_, _name_).
@@ -25129,10 +25161,10 @@
       <emu-alg>
         1. Assert: _name_ is not present.
         1. Set _name_ to the StringValue of |BindingIdentifier|.
-        1. Let _outerEnv_ be the running execution context's LexicalEnvironment.
+        1. Let _outerEnv_ be the running execution context's [[LexicalEnvironment]].
         1. Let _funcEnv_ be NewDeclarativeEnvironment(_outerEnv_).
         1. Perform ! _funcEnv_.CreateImmutableBinding(_name_, *false*).
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Let _sourceText_ be the source text matched by |AsyncGeneratorExpression|.
         1. Let _closure_ be OrdinaryFunctionCreate(%AsyncGeneratorFunction.prototype%, _sourceText_, |FormalParameters|, |AsyncGeneratorBody|, ~non-lexical-this~, _funcEnv_, _privateEnv_).
         1. Perform SetFunctionName(_closure_, _name_).
@@ -25629,8 +25661,8 @@
         1. Let _name_ be ? Evaluation of |ClassElementName|.
         1. If |Initializer| is present, then
           1. Let _formalParamList_ be an instance of the production <emu-grammar>FormalParameters : [empty]</emu-grammar>.
-          1. Let _envRecord_ be the LexicalEnvironment of the running execution context.
-          1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+          1. Let _envRecord_ be the running execution context's [[LexicalEnvironment]].
+          1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
           1. Let _sourceText_ be the empty sequence of Unicode code points.
           1. Let _initializer_ be OrdinaryFunctionCreate(%Function.prototype%, _sourceText_, _formalParamList_, |Initializer|, ~non-lexical-this~, _envRecord_, _privateEnv_).
           1. Perform MakeMethod(_initializer_, _homeObj_).
@@ -25654,8 +25686,8 @@
       </dl>
       <emu-grammar>ClassStaticBlock : `static` `{` ClassStaticBlockBody `}`</emu-grammar>
       <emu-alg>
-        1. Let _lexicalEnv_ be the running execution context's LexicalEnvironment.
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _lexicalEnv_ be the running execution context's [[LexicalEnvironment]].
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Let _sourceText_ be the empty sequence of Unicode code points.
         1. Let _formalParams_ be an instance of the production <emu-grammar>FormalParameters : [empty]</emu-grammar>.
         1. [id="step-synthetic-class-static-block-fn"] Let _bodyFunc_ be OrdinaryFunctionCreate(%Function.prototype%, _sourceText_, _formalParams_, |ClassStaticBlockBody|, ~non-lexical-this~, _lexicalEnv_, _privateEnv_).
@@ -25678,7 +25710,7 @@
         1. Assert: _funcObj_ is a synthetic function created by ClassStaticBlockDefinitionEvaluation step <emu-xref href="#step-synthetic-class-static-block-fn"></emu-xref>.
         1. Perform ! FunctionDeclarationInstantiation(_funcObj_, « »).
         1. Let _result_ be Completion(Evaluation of |ClassStaticBlockStatementList|).
-        1. Let _envRecord_ be the running execution context's LexicalEnvironment.
+        1. Let _envRecord_ be the running execution context's [[LexicalEnvironment]].
         1. Assert: _envRecord_ is a Declarative Environment Record.
         1. Perform ? DisposeResources(_envRecord_.[[DisposableResourceStack]], _result_).
         1. Return ReturnCompletion(*undefined*).
@@ -25742,11 +25774,11 @@
       </emu-note>
       <emu-grammar>ClassTail : ClassHeritage? `{` ClassBody? `}`</emu-grammar>
       <emu-alg>
-        1. Let _envRecord_ be the LexicalEnvironment of the running execution context.
+        1. Let _envRecord_ be the running execution context's [[LexicalEnvironment]].
         1. Let _classEnv_ be NewDeclarativeEnvironment(_envRecord_).
         1. If _classBinding_ is not *undefined*, then
           1. Perform ! _classEnv_.CreateImmutableBinding(_classBinding_, *true*).
-        1. Let _outerPrivateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _outerPrivateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Let _classPrivateEnv_ be NewPrivateEnvironment(_outerPrivateEnv_).
         1. If |ClassBody| is present, then
           1. For each String _description_ of the PrivateBoundIdentifiers of |ClassBody|, do
@@ -25759,10 +25791,10 @@
           1. Let _protoParent_ be %Object.prototype%.
           1. Let _ctorParent_ be %Function.prototype%.
         1. Else,
-          1. Set the running execution context's LexicalEnvironment to _classEnv_.
-          1. NOTE: The running execution context's PrivateEnvironment is _outerPrivateEnv_ when evaluating |ClassHeritage|.
+          1. Set the running execution context's [[LexicalEnvironment]] to _classEnv_.
+          1. NOTE: The running execution context's [[PrivateEnvironment]] is _outerPrivateEnv_ when evaluating |ClassHeritage|.
           1. Let _superclassRef_ be Completion(Evaluation of |ClassHeritage|).
-          1. Set the running execution context's LexicalEnvironment to _envRecord_.
+          1. Set the running execution context's [[LexicalEnvironment]] to _envRecord_.
           1. Let _superclass_ be ? GetValue(? _superclassRef_).
           1. If _superclass_ is *null*, then
             1. Let _protoParent_ be *null*.
@@ -25776,8 +25808,8 @@
         1. Let _proto_ be OrdinaryObjectCreate(_protoParent_).
         1. If |ClassBody| is not present, let _ctor_ be ~empty~.
         1. Else, let _ctor_ be the ConstructorMethod of |ClassBody|.
-        1. Set the running execution context's LexicalEnvironment to _classEnv_.
-        1. Set the running execution context's PrivateEnvironment to _classPrivateEnv_.
+        1. Set the running execution context's [[LexicalEnvironment]] to _classEnv_.
+        1. Set the running execution context's [[PrivateEnvironment]] to _classPrivateEnv_.
         1. If _ctor_ is ~empty~, then
           1. Let _defaultCtor_ be a new Abstract Closure with no parameters that captures nothing and performs the following steps when called:
             1. Let _args_ be the List of arguments that was passed to this function by [[Call]] or [[Construct]].
@@ -25815,8 +25847,8 @@
           1. Else,
             1. Let _element_ be Completion(ClassElementEvaluation of _classElement_ with argument _ctorFunc_).
           1. If _element_ is an abrupt completion, then
-            1. Set the running execution context's LexicalEnvironment to _envRecord_.
-            1. Set the running execution context's PrivateEnvironment to _outerPrivateEnv_.
+            1. Set the running execution context's [[LexicalEnvironment]] to _envRecord_.
+            1. Set the running execution context's [[PrivateEnvironment]] to _outerPrivateEnv_.
             1. Return ? _element_.
           1. Set _element_ to ! _element_.
           1. If _element_ is a PrivateElement, then
@@ -25839,7 +25871,7 @@
             1. Append _element_ to _staticElements_.
           1. Else,
             1. Assert: _element_ is ~empty~.
-        1. Set the running execution context's LexicalEnvironment to _envRecord_.
+        1. Set the running execution context's [[LexicalEnvironment]] to _envRecord_.
         1. If _classBinding_ is not *undefined*, then
           1. Perform ! _classEnv_.InitializeBinding(_classBinding_, _ctorFunc_).
         1. Set _ctorFunc_.[[PrivateMethods]] to _instancePrivateMethods_.
@@ -25853,9 +25885,9 @@
             1. Assert: _elementRecord_ is a ClassStaticBlockDefinition Record.
             1. Let _result_ be Completion(Call(_elementRecord_.[[BodyFunction]], _ctorFunc_)).
           1. If _result_ is an abrupt completion, then
-            1. Set the running execution context's PrivateEnvironment to _outerPrivateEnv_.
+            1. Set the running execution context's [[PrivateEnvironment]] to _outerPrivateEnv_.
             1. Return ? _result_.
-        1. Set the running execution context's PrivateEnvironment to _outerPrivateEnv_.
+        1. Set the running execution context's [[PrivateEnvironment]] to _outerPrivateEnv_.
         1. Return _ctorFunc_.
       </emu-alg>
     </emu-clause>
@@ -25869,7 +25901,7 @@
         1. Let _className_ be the StringValue of |BindingIdentifier|.
         1. Let _sourceText_ be the source text matched by |ClassDeclaration|.
         1. Let _value_ be ? ClassDefinitionEvaluation of |ClassTail| with arguments _className_, _className_, and _sourceText_.
-        1. Let _envRecord_ be the running execution context's LexicalEnvironment.
+        1. Let _envRecord_ be the running execution context's [[LexicalEnvironment]].
         1. Perform ? InitializeBoundName(_className_, _value_, _envRecord_).
         1. Return _value_.
       </emu-alg>
@@ -25907,7 +25939,7 @@
       <emu-grammar>ClassElementName : PrivateIdentifier</emu-grammar>
       <emu-alg>
         1. Let _privateIdentifier_ be the StringValue of |PrivateIdentifier|.
-        1. Let _privateEnvRecord_ be the running execution context's PrivateEnvironment.
+        1. Let _privateEnvRecord_ be the running execution context's [[PrivateEnvironment]].
         1. Let _names_ be _privateEnvRecord_.[[Names]].
         1. Assert: Exactly one element of _names_ is a Private Name whose [[Description]] is _privateIdentifier_.
         1. Let _privateName_ be the Private Name in _names_ whose [[Description]] is _privateIdentifier_.
@@ -26034,8 +26066,8 @@
       </emu-grammar>
       <emu-alg>
         1. If _name_ is not present, set _name_ to the empty String.
-        1. Let _envRecord_ be the LexicalEnvironment of the running execution context.
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _envRecord_ be the running execution context's [[LexicalEnvironment]].
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Let _sourceText_ be the source text matched by |AsyncFunctionExpression|.
         1. Let _closure_ be OrdinaryFunctionCreate(%AsyncFunction.prototype%, _sourceText_, |FormalParameters|, |AsyncFunctionBody|, ~non-lexical-this~, _envRecord_, _privateEnv_).
         1. Perform SetFunctionName(_closure_, _name_).
@@ -26047,10 +26079,10 @@
       <emu-alg>
         1. Assert: _name_ is not present.
         1. Set _name_ to the StringValue of |BindingIdentifier|.
-        1. Let _outerEnv_ be the LexicalEnvironment of the running execution context.
+        1. Let _outerEnv_ be the running execution context's [[LexicalEnvironment]].
         1. Let _funcEnv_ be NewDeclarativeEnvironment(_outerEnv_).
         1. Perform ! _funcEnv_.CreateImmutableBinding(_name_, *false*).
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Let _sourceText_ be the source text matched by |AsyncFunctionExpression|.
         1. Let _closure_ be OrdinaryFunctionCreate(%AsyncFunction.prototype%, _sourceText_, |FormalParameters|, |AsyncFunctionBody|, ~non-lexical-this~, _funcEnv_, _privateEnv_).
         1. Perform SetFunctionName(_closure_, _name_).
@@ -26212,8 +26244,8 @@
       </emu-grammar>
       <emu-alg>
         1. If _name_ is not present, set _name_ to the empty String.
-        1. Let _envRecord_ be the LexicalEnvironment of the running execution context.
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _envRecord_ be the running execution context's [[LexicalEnvironment]].
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Let _sourceText_ be the source text matched by |AsyncArrowFunction|.
         1. Let _params_ be |AsyncArrowBindingIdentifier|.
         1. Let _closure_ be OrdinaryFunctionCreate(%AsyncFunction.prototype%, _sourceText_, _params_, |AsyncConciseBody|, ~lexical-this~, _envRecord_, _privateEnv_).
@@ -26225,8 +26257,8 @@
       </emu-grammar>
       <emu-alg>
         1. If _name_ is not present, set _name_ to the empty String.
-        1. Let _envRecord_ be the LexicalEnvironment of the running execution context.
-        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _envRecord_ be the running execution context's [[LexicalEnvironment]].
+        1. Let _privateEnv_ be the running execution context's [[PrivateEnvironment]].
         1. Let _sourceText_ be the source text matched by |AsyncArrowFunction|.
         1. Let _head_ be the |AsyncArrowHead| that is covered by |CoverCallExpressionAndAsyncArrowHead|.
         1. Let _params_ be the |ArrowFormalParameters| of _head_.
@@ -26619,7 +26651,7 @@
       <dl class="header">
       </dl>
       <emu-alg>
-        1. Assert: The current execution context will not subsequently be used for the evaluation of any ECMAScript code or built-in functions. The invocation of Call subsequent to the invocation of this abstract operation will create and push a new execution context before performing any such evaluation.
+        1. Assert: The current execution context will not subsequently be used for the evaluation of any ECMAScript code or built-in functions. The invocation of Call subsequent to the invocation of this abstract operation will create and push a new ExecutionContext Record before performing any such evaluation.
         1. Discard all resources associated with the current execution context.
         1. Return ~unused~.
       </emu-alg>
@@ -26803,13 +26835,13 @@
 
       <emu-alg>
         1. Let _globalEnv_ be _scriptRecord_.[[Realm]].[[GlobalEnv]].
-        1. Let _scriptContext_ be a new ECMAScript code execution context.
-        1. Set the Function of _scriptContext_ to *null*.
-        1. Set the Realm of _scriptContext_ to _scriptRecord_.[[Realm]].
-        1. Set the ScriptOrModule of _scriptContext_ to _scriptRecord_.
-        1. Set the VariableEnvironment of _scriptContext_ to _globalEnv_.
-        1. Set the LexicalEnvironment of _scriptContext_ to _globalEnv_.
-        1. Set the PrivateEnvironment of _scriptContext_ to *null*.
+        1. Let _scriptContext_ be a new ECMAScript code ExecutionContext Record.
+        1. Set _scriptContext_.[[Function]] to *null*.
+        1. Set _scriptContext_.[[Realm]] to _scriptRecord_.[[Realm]].
+        1. Set _scriptContext_.[[ScriptOrModule]] to _scriptRecord_.
+        1. Set _scriptContext_.[[VariableEnvironment]] to _globalEnv_.
+        1. Set _scriptContext_.[[LexicalEnvironment]] to _globalEnv_.
+        1. Set _scriptContext_.[[PrivateEnvironment]] to *null*.
         1. Suspend the running execution context.
         1. Push _scriptContext_ onto the execution context stack; _scriptContext_ is now the running execution context.
         1. Let _scriptNode_ be _scriptRecord_.[[ECMAScriptCode]].
@@ -26888,8 +26920,8 @@
                       1. Perform ? CreateGlobalVarBinding(_envRecord_, _funcName_, *false*).
                       1. Append _funcName_ to _declaredFuncOrVariableNames_.
                     1. [id="step-globaldeclarationinstantiation-alt-funcdecl-eval"] When the |FunctionDeclaration| _funcDecl_ is evaluated, perform the following steps in place of the |FunctionDeclaration| Evaluation algorithm provided in <emu-xref href="#sec-function-definitions-runtime-semantics-evaluation"></emu-xref>:
-                      1. Let _globalEnv_ be the running execution context's VariableEnvironment.
-                      1. Let _blockEnv_ be the running execution context's LexicalEnvironment.
+                      1. Let _globalEnv_ be the running execution context's [[VariableEnvironment]].
+                      1. Let _blockEnv_ be the running execution context's [[LexicalEnvironment]].
                       1. Let _funcObj_ be ! _blockEnv_.GetBindingValue(_funcName_, *false*).
                       1. Perform ? <emu-meta effects="user-code">_globalEnv_.SetMutableBinding(_funcName_, _funcObj_, *false*)</emu-meta>.
                       1. Return ~unused~.
@@ -28604,10 +28636,10 @@
                 [[Context]]
               </td>
               <td>
-                an ECMAScript code execution context or ~empty~
+                an ECMAScript code ExecutionContext Record or ~empty~
               </td>
               <td>
-                The execution context associated with this module. It is ~empty~ until the module's environment has been initialized.
+                The ExecutionContext Record associated with this module. It is ~empty~ until the module's environment has been initialized.
               </td>
             </tr>
             <tr>
@@ -29256,14 +29288,14 @@
                     1. Perform ! _envRecord_.InitializeBinding(_importEntry_.[[LocalName]], _namespace_).
                   1. Else,
                     1. Perform CreateImportBinding(_envRecord_, _importEntry_.[[LocalName]], _resolution_.[[Module]], _resolution_.[[BindingName]]).
-              1. Let _moduleContext_ be a new ECMAScript code execution context.
-              1. Set the Function of _moduleContext_ to *null*.
+              1. Let _moduleContext_ be a new ECMAScript code ExecutionContext Record.
+              1. Set _moduleContext_.[[Function]] to *null*.
               1. Assert: _module_.[[Realm]] is not *undefined*.
-              1. Set the Realm of _moduleContext_ to _module_.[[Realm]].
-              1. Set the ScriptOrModule of _moduleContext_ to _module_.
-              1. Set the VariableEnvironment of _moduleContext_ to _module_.[[Environment]].
-              1. Set the LexicalEnvironment of _moduleContext_ to _module_.[[Environment]].
-              1. Set the PrivateEnvironment of _moduleContext_ to *null*.
+              1. Set _moduleContext_.[[Realm]] to _module_.[[Realm]].
+              1. Set _moduleContext_.[[ScriptOrModule]] to _module_.
+              1. Set _moduleContext_.[[VariableEnvironment]] to _module_.[[Environment]].
+              1. Set _moduleContext_.[[LexicalEnvironment]] to _module_.[[Environment]].
+              1. Set _moduleContext_.[[PrivateEnvironment]] to *null*.
               1. Set _module_.[[Context]] to _moduleContext_.
               1. Push _moduleContext_ onto the execution context stack; _moduleContext_ is now the running execution context.
               1. Let _code_ be _module_.[[ECMAScriptCode]].
@@ -29502,12 +29534,12 @@
             </dl>
 
             <emu-alg>
-              1. Let _moduleContext_ be a new ECMAScript code execution context.
-              1. Set the Function of _moduleContext_ to *null*.
-              1. Set the Realm of _moduleContext_ to _module_.[[Realm]].
-              1. Set the ScriptOrModule of _moduleContext_ to _module_.
-              1. Set the VariableEnvironment of _moduleContext_ to _module_.[[Environment]].
-              1. Set the LexicalEnvironment of _moduleContext_ to _module_.[[Environment]].
+              1. Let _moduleContext_ be a new ECMAScript code ExecutionContext Record.
+              1. Set _moduleContext_.[[Function]] to *null*.
+              1. Set _moduleContext_.[[Realm]] to _module_.[[Realm]].
+              1. Set _moduleContext_.[[ScriptOrModule]] to _module_.
+              1. Set _moduleContext_.[[VariableEnvironment]] to _module_.[[Environment]].
+              1. Set _moduleContext_.[[LexicalEnvironment]] to _module_.[[Environment]].
               1. Suspend the running execution context.
               1. Push _moduleContext_ onto the execution context stack; _moduleContext_ is now the running execution context.
               1. Let _steps_ be _module_.[[EvaluationSteps]].
@@ -29562,7 +29594,7 @@
 
           <pre><code class="html">&lt;button type="button" onclick="import('./foo.mjs')"&gt;Click me&lt;/button&gt;</code></pre>
 
-          <p>there will be no active script or module at the time the <emu-xref href="#sec-import-calls">`import()`</emu-xref> expression runs. More generally, this can happen in any situation where the host pushes execution contexts with *null* ScriptOrModule components onto the execution context stack.</p>
+          <p>there will be no active script or module at the time the <emu-xref href="#sec-import-calls">`import()`</emu-xref> expression runs. More generally, this can happen in any situation where the host pushes an ExecutionContext Record with a *null* [[ScriptOrModule]] field onto the execution context stack.</p>
         </emu-note>
 
         <p>An implementation of HostLoadImportedModule must conform to the following requirements:</p>
@@ -30284,7 +30316,7 @@
           1. Let _value_ be ? BindingClassDeclarationEvaluation of |ClassDeclaration|.
           1. Let _className_ be the sole element of the BoundNames of |ClassDeclaration|.
           1. If _className_ is *"\*default\*"*, then
-            1. Let _envRecord_ be the running execution context's LexicalEnvironment.
+            1. Let _envRecord_ be the running execution context's [[LexicalEnvironment]].
             1. Perform ? InitializeBoundName(*"\*default\*"*, _value_, _envRecord_).
           1. Return ~empty~.
         </emu-alg>
@@ -30295,7 +30327,7 @@
           1. Else,
             1. Let _rhs_ be ? Evaluation of |AssignmentExpression|.
             1. Let _value_ be ? GetValue(_rhs_).
-          1. Let _envRecord_ be the running execution context's LexicalEnvironment.
+          1. Let _envRecord_ be the running execution context's [[LexicalEnvironment]].
           1. Perform ? InitializeBoundName(*"\*default\*"*, _value_, _envRecord_).
           1. Return ~empty~.
         </emu-alg>
@@ -30482,22 +30514,22 @@
           1. Let _runningContext_ be the running execution context.
           1. NOTE: If _direct_ is *true*, _runningContext_ will be the execution context that performed the direct eval. If _direct_ is *false*, _runningContext_ will be the execution context for the invocation of the `eval` function.
           1. If _direct_ is *true*, then
-            1. Let _lexicalEnv_ be NewDeclarativeEnvironment(_runningContext_'s LexicalEnvironment).
-            1. Let _variableEnv_ be _runningContext_'s VariableEnvironment.
-            1. Let _privateEnv_ be _runningContext_'s PrivateEnvironment.
+            1. Let _lexicalEnv_ be NewDeclarativeEnvironment(_runningContext_.[[LexicalEnvironment]]).
+            1. Let _variableEnv_ be _runningContext_.[[VariableEnvironment]].
+            1. Let _privateEnv_ be _runningContext_.[[PrivateEnvironment]].
           1. Else,
             1. Let _lexicalEnv_ be NewDeclarativeEnvironment(_evalRealm_.[[GlobalEnv]]).
             1. Let _variableEnv_ be _evalRealm_.[[GlobalEnv]].
             1. Let _privateEnv_ be *null*.
           1. If _strictEval_ is *true*, set _variableEnv_ to _lexicalEnv_.
           1. If _runningContext_ is not already suspended, suspend _runningContext_.
-          1. Let _evalContext_ be a new ECMAScript code execution context.
-          1. Set _evalContext_'s Function to *null*.
-          1. Set _evalContext_'s Realm to _evalRealm_.
-          1. Set _evalContext_'s ScriptOrModule to _runningContext_'s ScriptOrModule.
-          1. Set _evalContext_'s VariableEnvironment to _variableEnv_.
-          1. Set _evalContext_'s LexicalEnvironment to _lexicalEnv_.
-          1. Set _evalContext_'s PrivateEnvironment to _privateEnv_.
+          1. Let _evalContext_ be a new ECMAScript code ExecutionContext Record.
+          1. Set _evalContext_.[[Function]] to *null*.
+          1. Set _evalContext_.[[Realm]] to _evalRealm_.
+          1. Set _evalContext_.[[ScriptOrModule]] to _runningContext_.[[ScriptOrModule]].
+          1. Set _evalContext_.[[VariableEnvironment]] to _variableEnv_.
+          1. Set _evalContext_.[[LexicalEnvironment]] to _lexicalEnv_.
+          1. Set _evalContext_.[[PrivateEnvironment]] to _privateEnv_.
           1. Push _evalContext_ onto the execution context stack; _evalContext_ is now the running execution context.
           1. Let _result_ be Completion(EvalDeclarationInstantiation(_body_, _variableEnv_, _lexicalEnv_, _privateEnv_, _strictEval_)).
           1. If _result_ is a normal completion, then
@@ -30509,7 +30541,7 @@
           1. Return ? _result_.
         </emu-alg>
         <emu-note>
-          <p>The eval code cannot instantiate variable or function bindings in the variable environment of the calling context that invoked the eval if either the code of the calling context or the eval code is strict mode code. Instead such bindings are instantiated in a new VariableEnvironment that is only accessible to the eval code. Bindings introduced by `let`, `const`, or `class` declarations are always instantiated in a new LexicalEnvironment.</p>
+          <p>The eval code cannot instantiate variable or function bindings in the variable environment of the calling context that invoked the eval if either the code of the calling context or the eval code is strict mode code. Instead such bindings are instantiated in a new [[VariableEnvironment]] that is only accessible to the eval code. Bindings introduced by `let`, `const`, or `class` declarations are always instantiated in a new [[LexicalEnvironment]].</p>
         </emu-note>
       </emu-clause>
 
@@ -30630,8 +30662,8 @@
                         1. Perform ! _variableEnv_.InitializeBinding(_funcName_, *undefined*).
                     1. Append _funcName_ to _declaredFuncOrVariableNames_.
                   1. [id="step-evaldeclarationinstantiation-alt-funcdecl-eval"] When the |FunctionDeclaration| _funcDecl_ is evaluated, perform the following steps in place of the |FunctionDeclaration| Evaluation algorithm provided in <emu-xref href="#sec-function-definitions-runtime-semantics-evaluation"></emu-xref>:
-                    1. Let _globalEnv_ be the running execution context's VariableEnvironment.
-                    1. Let _blockEnv_ be the running execution context's LexicalEnvironment.
+                    1. Let _globalEnv_ be the running execution context's [[VariableEnvironment]].
+                    1. Let _blockEnv_ be the running execution context's [[LexicalEnvironment]].
                     1. Let _funcObj_ be ! _blockEnv_.GetBindingValue(_funcName_, *false*).
                     1. Perform ? <emu-meta effects="user-code">_globalEnv_.SetMutableBinding(_funcName_, _funcObj_, *false*)</emu-meta>.
                     1. Return ~unused~.
@@ -51831,10 +51863,10 @@ THH:mm:ss.sss
               [[GeneratorContext]]
             </td>
             <td>
-              an execution context
+              an ExecutionContext Record
             </td>
             <td>
-              The execution context that is used when executing the code of this generator.
+              The ExecutionContext Record that is used when executing the code of this generator.
             </td>
           </tr>
           <tr>
@@ -51867,17 +51899,17 @@ THH:mm:ss.sss
         <emu-alg>
           1. Assert: _gen_.[[GeneratorState]] is ~suspended-start~.
           1. Let _genContext_ be the running execution context.
-          1. Set the Generator component of _genContext_ to _gen_.
+          1. Set _genContext_.[[Generator]] to _gen_.
           1. Let _closure_ be a new Abstract Closure with no parameters that captures _genBody_ and performs the following steps when called:
             1. Let _acGenContext_ be the running execution context.
-            1. Let _acGen_ be the Generator component of _acGenContext_.
+            1. Let _acGen_ be _acGenContext_.[[Generator]].
             1. If _genBody_ is a Parse Node, then
               1. Let _result_ be Completion(Evaluation of _genBody_).
             1. Else,
               1. Assert: _genBody_ is an Abstract Closure with no parameters.
               1. Let _result_ be Completion(_genBody_()).
             1. Assert: If we return here, the generator either threw an exception or performed either an implicit or explicit return.
-            1. Remove _acGenContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
+            1. Remove _acGenContext_ from the execution context stack and restore the ExecutionContext Record that is at the top of the execution context stack as the running execution context.
             1. Set _acGen_.[[GeneratorState]] to ~completed~.
             1. NOTE: Once a generator enters the ~completed~ state it never leaves it and its associated execution context is never resumed. Any execution state associated with _acGen_ can be discarded at this point.
             1. If _result_ is a throw completion, then
@@ -51891,7 +51923,7 @@ THH:mm:ss.sss
             1. Let _callerContext_ be the running execution context.
             1. Resume _callerContext_, passing _resumption_.
             1. Assert: This step is never reached.
-          1. Set the code evaluation state of _genContext_ such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
+          1. Set _genContext_.[[CodeEvaluationState]] such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
           1. Set _gen_.[[GeneratorContext]] to _genContext_.
           1. Return ~unused~.
         </emu-alg>
@@ -51970,8 +52002,8 @@ THH:mm:ss.sss
         </dl>
         <emu-alg>
           1. Let _genContext_ be the running execution context.
-          1. If _genContext_ does not have a Generator component, return ~non-generator~.
-          1. Let _gen_ be the Generator component of _genContext_.
+          1. If _genContext_ does not have a [[Generator]] field, return ~non-generator~.
+          1. Let _gen_ be _genContext_.[[Generator]].
           1. If _gen_ has an [[AsyncGeneratorState]] internal slot, return ~async~.
           1. Return ~sync~.
         </emu-alg>
@@ -51988,7 +52020,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _genContext_ be the running execution context.
           1. Assert: _genContext_ is the execution context of a generator.
-          1. Let _gen_ be the value of the Generator component of _genContext_.
+          1. Let _gen_ be _genContext_.[[Generator]].
           1. Assert: GetGeneratorKind() is ~sync~.
           1. Set _gen_.[[GeneratorState]] to ~suspended-yield~.
           1. Return ? RunCallerContext(_iteratorResult_).
@@ -52029,10 +52061,10 @@ THH:mm:ss.sss
           1. Set _gen_.[[GeneratorBrand]] to _genBrand_.
           1. Set _gen_.[[GeneratorState]] to ~suspended-start~.
           1. Let _callerContext_ be the running execution context.
-          1. Let _calleeContext_ be a new execution context.
-          1. Set the Function of _calleeContext_ to *null*.
-          1. Set the Realm of _calleeContext_ to the current Realm Record.
-          1. Set the ScriptOrModule of _calleeContext_ to _callerContext_'s ScriptOrModule.
+          1. Let _calleeContext_ be a new ExecutionContext Record.
+          1. Set _calleeContext_.[[Function]] to *null*.
+          1. Set _calleeContext_.[[Realm]] to the current Realm Record.
+          1. Set _calleeContext_.[[ScriptOrModule]] to _callerContext_.[[ScriptOrModule]].
           1. If _callerContext_ is not already suspended, suspend _callerContext_.
           1. Push _calleeContext_ onto the execution context stack; _calleeContext_ is now the running execution context.
           1. Perform GeneratorStart(_gen_, _closure_).
@@ -52159,8 +52191,8 @@ THH:mm:ss.sss
           </tr>
           <tr>
             <td>[[AsyncGeneratorContext]]</td>
-            <td>an execution context</td>
-            <td>The execution context that is used when executing the code of this async generator.</td>
+            <td>an ExecutionContext Record</td>
+            <td>The ExecutionContext Record that is used when executing the code of this async generator.</td>
           </tr>
           <tr>
             <td>[[AsyncGeneratorQueue]]</td>
@@ -52218,17 +52250,17 @@ THH:mm:ss.sss
         <emu-alg>
           1. Assert: _gen_.[[AsyncGeneratorState]] is ~suspended-start~.
           1. Let _genContext_ be the running execution context.
-          1. Set the Generator component of _genContext_ to _gen_.
+          1. Set _genContext_.[[Generator]] to _gen_.
           1. Let _closure_ be a new Abstract Closure with no parameters that captures _genBody_ and performs the following steps when called:
             1. Let _acGenContext_ be the running execution context.
-            1. Let _acGen_ be the Generator component of _acGenContext_.
+            1. Let _acGen_ be _acGenContext_.[[Generator]].
             1. If _genBody_ is a Parse Node, then
               1. Let _result_ be Completion(Evaluation of _genBody_).
             1. Else,
               1. Assert: _genBody_ is an Abstract Closure with no parameters.
               1. Let _result_ be Completion(_genBody_()).
             1. Assert: If we return here, the async generator either threw an exception or performed either an implicit or explicit return.
-            1. Remove _acGenContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
+            1. Remove _acGenContext_ from the execution context stack and restore the ExecutionContext Record that is at the top of the execution context stack as the running execution context.
             1. Set _acGen_.[[AsyncGeneratorState]] to ~draining-queue~.
             1. If _result_ is a normal completion, set _result_ to NormalCompletion(*undefined*).
             1. If _result_ is a return completion, set _result_ to NormalCompletion(_result_.[[Value]]).
@@ -52237,7 +52269,7 @@ THH:mm:ss.sss
             1. Let _callerContext_ be the running execution context.
             1. Resume _callerContext_, passing NormalCompletion(*undefined*).
             1. Assert: This step is never reached.
-          1. Set the code evaluation state of _genContext_ such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
+          1. Set _genContext_.[[CodeEvaluationState]] such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
           1. Set _gen_.[[AsyncGeneratorContext]] to _genContext_.
           1. Set _gen_.[[AsyncGeneratorQueue]] to a new empty List.
           1. Return ~unused~.
@@ -52301,10 +52333,10 @@ THH:mm:ss.sss
           1. Else,
             1. Assert: _completion_ is a normal completion.
             1. If _realm_ is present, then
-              1. Let _oldRealm_ be the running execution context's Realm.
-              1. Set the running execution context's Realm to _realm_.
+              1. Let _oldRealm_ be the running execution context's [[Realm]].
+              1. Set the running execution context's [[Realm]] to _realm_.
               1. Let _iteratorResult_ be CreateIteratorResultObject(_value_, _done_).
-              1. Set the running execution context's Realm to _oldRealm_.
+              1. Set the running execution context's [[Realm]] to _oldRealm_.
             1. Else,
               1. Let _iteratorResult_ be CreateIteratorResultObject(_value_, _done_).
             1. Perform ! <emu-meta effects="user-code">Call(_promiseCapability_.[[Resolve]], *undefined*, « _iteratorResult_ »)</emu-meta>.
@@ -52358,12 +52390,12 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _genContext_ be the running execution context.
           1. Assert: _genContext_ is the execution context of a generator.
-          1. Let _gen_ be the value of the Generator component of _genContext_.
+          1. Let _gen_ be _genContext_.[[Generator]].
           1. Assert: GetGeneratorKind() is ~async~.
           1. Let _completion_ be NormalCompletion(_arg_).
           1. Assert: The execution context stack has at least two elements.
           1. Let _previousContext_ be the second to top element of the execution context stack.
-          1. Let _previousRealm_ be _previousContext_'s Realm.
+          1. Let _previousRealm_ be _previousContext_.[[Realm]].
           1. Perform AsyncGeneratorCompleteStep(_gen_, _completion_, *false*, _previousRealm_).
           1. Let _queue_ be _gen_.[[AsyncGeneratorQueue]].
           1. If _queue_ is not empty, then
@@ -52567,7 +52599,7 @@ THH:mm:ss.sss
           AsyncBlockStart (
             _promiseCapability_: a PromiseCapability Record,
             _asyncBody_: a Parse Node or an Abstract Closure with no parameters,
-            _asyncContext_: an execution context,
+            _asyncContext_: an ExecutionContext Record,
           ): ~unused~
         </h1>
         <dl class="header">
@@ -52581,7 +52613,7 @@ THH:mm:ss.sss
               1. Assert: _asyncBody_ is an Abstract Closure with no parameters.
               1. Let _result_ be Completion(_asyncBody_()).
             1. Assert: If we return here, the async function either threw an exception or performed an implicit or explicit return; all awaiting is done.
-            1. Remove _acAsyncContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
+            1. Remove _acAsyncContext_ from the execution context stack and restore the ExecutionContext Record that is at the top of the execution context stack as the running execution context.
             1. If _result_ is a normal completion, then
               1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, « *undefined* »).
             1. Else if _result_ is a return completion, then
@@ -52592,7 +52624,7 @@ THH:mm:ss.sss
             1. Let _callerContext_ be the running execution context.
             1. [id="step-asyncblockstart-return-undefined"] Resume _callerContext_, passing NormalCompletion(~unused~).
             1. Assert: This step is never reached.
-          1. Set the code evaluation state of _asyncContext_ such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
+          1. Set _asyncContext_.[[CodeEvaluationState]] such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
           1. Let _result_ be ! RunSuspendedContext(_asyncContext_, NormalCompletion(~empty~)).
           1. Assert: _result_ is ~unused~.
           1. NOTE: The possible sources of _result_ values are Await or, if the async function doesn't await anything, step <emu-xref href="#step-asyncblockstart-return-undefined"></emu-xref> above.

--- a/spec.html
+++ b/spec.html
@@ -51923,7 +51923,7 @@ THH:mm:ss.sss
             1. Let _callerContext_ be the running execution context.
             1. Resume _callerContext_, passing _resumption_.
             1. Assert: This step is never reached.
-          1. Set _genContext_.[[CodeEvaluationState]] such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
+          1. Set _genContext_.[[CodeEvaluationState]] such that when evaluation is resumed for _genContext_, _closure_ will be called with no arguments.
           1. Set _gen_.[[GeneratorContext]] to _genContext_.
           1. Return ~unused~.
         </emu-alg>
@@ -52269,7 +52269,7 @@ THH:mm:ss.sss
             1. Let _callerContext_ be the running execution context.
             1. Resume _callerContext_, passing NormalCompletion(*undefined*).
             1. Assert: This step is never reached.
-          1. Set _genContext_.[[CodeEvaluationState]] such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
+          1. Set _genContext_.[[CodeEvaluationState]] such that when evaluation is resumed for _genContext_, _closure_ will be called with no arguments.
           1. Set _gen_.[[AsyncGeneratorContext]] to _genContext_.
           1. Set _gen_.[[AsyncGeneratorQueue]] to a new empty List.
           1. Return ~unused~.
@@ -52624,7 +52624,7 @@ THH:mm:ss.sss
             1. Let _callerContext_ be the running execution context.
             1. [id="step-asyncblockstart-return-undefined"] Resume _callerContext_, passing NormalCompletion(~unused~).
             1. Assert: This step is never reached.
-          1. Set _asyncContext_.[[CodeEvaluationState]] such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
+          1. Set _asyncContext_.[[CodeEvaluationState]] such that when evaluation is resumed for _asyncContext_, _closure_ will be called with no arguments.
           1. Let _result_ be ! RunSuspendedContext(_asyncContext_, NormalCompletion(~empty~)).
           1. Assert: _result_ is ~unused~.
           1. NOTE: The possible sources of _result_ values are Await or, if the async function doesn't await anything, step <emu-xref href="#step-asyncblockstart-return-undefined"></emu-xref> above.

--- a/spec.html
+++ b/spec.html
@@ -12223,7 +12223,7 @@
     <h1>Execution Contexts</h1>
     <p>An <dfn variants="execution contexts">execution context</dfn> is a specification device that is used to track the runtime evaluation of code by an ECMAScript implementation. At any point in time, there is at most one execution context per agent that is actually executing code. This is known as the agent's <dfn id="running-execution-context" variants="running execution contexts">running execution context</dfn>. All references to the running execution context in this specification denote the running execution context of the surrounding agent.</p>
     <p>The <dfn id="execution-context-stack" variants="execution context stacks">execution context stack</dfn> is used to track execution contexts. The running execution context is always the top element of this stack. A new execution context is created whenever control is transferred from the executable code associated with the currently running execution context to executable code that is not associated with that execution context. The newly created execution context is pushed onto the stack and becomes the running execution context.</p>
-    <p>Each execution context is represented as an ExecutionContext Record, with at least the fields listed in <emu-xref href="#table-state-components-for-all-execution-contexts"></emu-xref>.</p>
+    <p>Each execution context is represented as an <dfn variants="ExecutionContext Records">ExecutionContext Record</dfn>, with at least the fields listed in <emu-xref href="#table-state-components-for-all-execution-contexts"></emu-xref>.</p>
     <emu-table id="table-state-components-for-all-execution-contexts" caption="ExecutionContext Record Fields" oldids="table-22">
       <table>
         <thead>


### PR DESCRIPTION
Resolves the first comment in issue #1742

I believe this PR is complete in the sense that it would leave the spec in a consistent state. However, there are various further changes you might want, <strike>so it's currently a Draft PR</strike>.

- I introduced the term `ExecutionContext Record`, but left some occurrences of `execution context`. You might prefer to get rid of `execution context` entirely.

- I changed the caption text of the three `Fields` tables, but not their `id` attributes.

- The status quo creates the context and then separately sets each of its components. I kept that format, but you might prefer the use of a record "literal" to define it all in one step.
[Later: @bakkot prefers it as-is.]

- Where the status quo refers to `the running execution context's SomethingOrOther`, I introduced a step `Let _runningContext_ be the running execution context` and then referred to `_runningContext_.[[SomethingOrOther]]`. You might prefer to introduce a compact way to say "the running execution context". (About the only precedent for this is the use of `NewTarget` in algorithms.)
[Later: @syg suggests "the [[SomethingOrOther]] field of the running execution context"]
[Even later: settle on "the running execution context's [[SomethingOrOther]]"]

- When we define Additional Fields elsewhere in the spec (for Environment Records and Module Records), they're aligned with a (quasi) subtype hierarchy. This sort of works for `ExecutionContext Record` and `ECMAScript code ExecutionContext Record`, but not for `Generator ExecutionContext Record`: it's difficult to see the latter as a subtype. An `ExecutionContext Record` that represents the evaluation of a generator object is created as an `ECMAScript code ExecutionContext Record` (not a `Generator ExecutionContext Record`) and then later (after it's already been made the running execution context), it has a `[[Generator]]` field attached to it.

- The execution context stack could conceivably be modeled by giving each ExecutionContext Record something like a [[CallerContext]] field .

----

Downstream effects:
The HTML spec has some references to an execution context's "Realm component", which would be changed to its "[[Realm]] field" after this PR.
