### PR TITLE
Editorial: Use Number-literal notation for a few 'length' values

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -24710,7 +24710,7 @@
   <p>Each built-in function defined in this specification is created by calling the CreateBuiltinFunction abstract operation (<emu-xref href="#sec-createbuiltinfunction"></emu-xref>).</p>
   <p>Every built-in function object, including constructors, has a *"length"* property whose value is a non-negative integral Number. Unless otherwise specified, this value is equal to the number of required parameters shown in the subclause headings for the function description. Optional parameters and rest parameters are not included in the parameter count.</p>
   <emu-note>
-    <p>For example, the function object that is the initial value of the *"map"* property of the Array prototype object is described under the subclause heading &laquo;Array.prototype.map (callbackFn [ , thisArg])&raquo; which shows the two named arguments callbackFn and thisArg, the latter being optional; therefore the value of the *"length"* property of that function object is 1.</p>
+    <p>For example, the function object that is the initial value of the *"map"* property of the Array prototype object is described under the subclause heading &laquo;Array.prototype.map (callbackFn [ , thisArg])&raquo; which shows the two named arguments callbackFn and thisArg, the latter being optional; therefore the value of the *"length"* property of that function object is *1*<sub>𝔽</sub>.</p>
   </emu-note>
   <p>Unless otherwise specified, the *"length"* property of a built-in function object has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
   <p>Every built-in function object, including constructors, has a *"name"* property whose value is a String. Unless otherwise specified, this value is the name that is given to the function in this specification. Functions that are identified as anonymous functions use the empty String as the value of the *"name"* property. For functions that are specified as properties of objects, the name value is the property name string used to access the function. Functions that are specified as get or set accessor functions of built-in properties have *"get "* or *"set "* prepended to the property name string. The value of the *"name"* property is explicitly specified for each built-in functions whose property key is a Symbol value. The *"name"* property is set using SetFunctionName.</p>
@@ -26185,7 +26185,7 @@
         <li>does not have a [[Construct]] internal method; it cannot be used as a constructor with the `new` operator.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
         <li>does not have a *"prototype"* property.</li>
-        <li>has a *"length"* property whose value is 0.</li>
+        <li>has a *"length"* property whose value is *+0*<sub>𝔽</sub>.</li>
         <li>has a *"name"* property whose value is the empty String.</li>
       </ul>
       <emu-note>
@@ -28466,7 +28466,7 @@ THH:mm:ss.sss
         <li>returns a String representing the current time (UTC) when called as a function rather than as a constructor.</li>
         <li>is a function whose behaviour differs based upon the number and types of its arguments.</li>
         <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified Date behaviour must include a `super` call to the Date constructor to create and initialize the subclass instance with a [[DateValue]] internal slot.</li>
-        <li>has a *"length"* property whose value is 7.</li>
+        <li>has a *"length"* property whose value is *7*<sub>𝔽</sub>.</li>
       </ul>
 
       <emu-clause id="sec-date" oldids="sec-date-constructor-date,sec-date-value,sec-date-year-month-date-hours-minutes-seconds-ms">
@@ -29524,7 +29524,7 @@ THH:mm:ss.sss
         <li>is <dfn>%String.prototype%</dfn>.</li>
         <li>is a String exotic object and has the internal methods specified for such objects.</li>
         <li>has a [[StringData]] internal slot whose value is the empty String.</li>
-        <li>has a *"length"* property whose initial value is 0 and whose attributes are { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</li>
+        <li>has a *"length"* property whose initial value is *+0*<sub>𝔽</sub> and whose attributes are { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
       </ul>
       <p>Unless explicitly stated otherwise, the methods of the String prototype object defined below are not generic and the *this* value passed to them must be either a String value or an object that has a [[StringData]] internal slot that has been initialized to a String value.</p>
@@ -32695,7 +32695,7 @@ THH:mm:ss.sss
         <li>also creates and initializes a new Array object when called as a function rather than as a constructor. Thus the function call `Array(&hellip;)` is equivalent to the object creation expression `new Array(&hellip;)` with the same arguments.</li>
         <li>is a function whose behaviour differs based upon the number and types of its arguments.</li>
         <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the exotic Array behaviour must include a `super` call to the Array constructor to initialize subclass instances that are Array exotic objects. However, most of the `Array.prototype` methods are generic methods that are not dependent upon their *this* value being an Array exotic object.</li>
-        <li>has a *"length"* property whose value is 1.</li>
+        <li>has a *"length"* property whose value is *1*<sub>𝔽</sub>.</li>
       </ul>
 
       <emu-clause id="sec-array" oldids="sec-array-constructor-array,sec-array-len,sec-array-items">
@@ -32858,7 +32858,7 @@ THH:mm:ss.sss
       <ul>
         <li>is <dfn>%Array.prototype%</dfn>.</li>
         <li>is an Array exotic object and has the internal methods specified for such objects.</li>
-        <li>has a *"length"* property whose initial value is 0 and whose attributes are { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</li>
+        <li>has a *"length"* property whose initial value is *+0*<sub>𝔽</sub> and whose attributes are { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
       </ul>
       <emu-note>
@@ -35065,7 +35065,7 @@ THH:mm:ss.sss
         <li>is a function whose behaviour differs based upon the number and types of its arguments. The actual behaviour of a call of _TypedArray_ depends upon the number and kind of arguments that are passed to it.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
         <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified _TypedArray_ behaviour must include a `super` call to the _TypedArray_ constructor to create and initialize the subclass instance with the internal state necessary to support the %TypedArray%`.prototype` built-in methods.</li>
-        <li>has a *"length"* property whose value is 3.</li>
+        <li>has a *"length"* property whose value is *3*<sub>𝔽</sub>.</li>
       </ul>
 
       <emu-clause id="sec-typedarray" oldids="sec-typedarray-length,sec-typedarray-object">


### PR DESCRIPTION
The initial value of a 'length' property should be a Number, so use the appropriate notation, after PR #2007.


