### PR TITLE
Normative: do not apply Early Error for duplicate __proto__ properties when performing JSON.parse

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -42797,7 +42797,13 @@ THH:mm:ss.sss
 
     <emu-annex id="sec-__proto__-property-names-in-object-initializers">
       <h1>__proto__ Property Names in Object Initializers</h1>
-      <p>The following Early Error rule is added to those in <emu-xref href="#sec-object-initializer-static-semantics-early-errors"></emu-xref>. When |ObjectLiteral| appears in a context where |ObjectAssignmentPattern| is required the Early Error rule is <b>not</b> applied. In addition, it is not applied when initially parsing a |CoverParenthesizedExpressionAndArrowParameterList| or a |CoverCallExpressionAndAsyncArrowHead|.</p>
+      <p>The following Early Error rule is added to those in <emu-xref href="#sec-object-initializer-static-semantics-early-errors"></emu-xref>. This rule is <b>not</b> applied under any of the following circumstances:
+        <ul>
+          <li>when |ObjectLiteral| appears in a context where |ObjectAssignmentPattern| is required,</li>
+          <li>when initially parsing a |CoverParenthesizedExpressionAndArrowParameterList| or a |CoverCallExpressionAndAsyncArrowHead|, or</li>
+          <li>when parsing text for <emu-xref href="#sec-json.parse">JSON.parse</emu-xref>.</li>
+        </ul>
+      </p>
       <emu-grammar>
         ObjectLiteral : `{` PropertyDefinitionList `}`
 


### PR DESCRIPTION
Fixes https://github.com/tc39/ecma262/issues/2206. Quoting @michaelficarra there:

> As per today's editor call, we will mark this change as normative but make the change without asking for consensus (as a spec bugfix) since it matches with what we believe the intent of the committee to have been and with all known implementations.

I hope "when parsing text for JSON.parse" is sufficiently clear. I could make it more precise by labelling the step in JSON.parse which calls ParseText and then referring directly to that step, but that seemed like overkill.

This PR has two commits: the first makes the change, and the second rewords the prose list of conditions to be an HTML list, which I think reads better. I'm happy to back out the second if people dislike the style. If we keep it, the two commits should be combined before landing.