### PR TITLE
Editorial: reword definition of lookahead restrictions

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -745,8 +745,9 @@
           `9`
       </emu-grammar>
       <p>If the phrase &ldquo;[empty]&rdquo; appears as the right-hand side of a production, it indicates that the production's right-hand side contains no terminals or nonterminals.</p>
-      <p>If the phrase &ldquo;[lookahead &notin; _set_]&rdquo; appears in the right-hand side of a production, it indicates that the production may not be used if the immediately following input token sequence is a member of the given _set_. The _set_ can be written as a comma separated list of one or two element terminal sequences enclosed in curly brackets. For convenience, the set can also be written as a nonterminal, in which case it represents the set of all terminals to which that nonterminal could expand. If the _set_ consists of a single terminal the phrase &ldquo;[lookahead &ne; _terminal_]&rdquo; may be used.</p>
-      <p>For example, given the definitions:</p>
+      <p>If the phrase &ldquo;[lookahead = _seq_]&rdquo; appears in the right-hand side of a production, it indicates that the production may only be used if the token sequence _seq_ is a prefix of the immediately following input token sequence. Similarly, &ldquo;[lookahead &isin; _set_]&rdquo;, where _set_ is a finite nonempty set of token sequences, indicates that the production may only be used if some element of _set_ is a prefix of the immediately following token sequence. For convenience, the set can also be written as a nonterminal, in which case it represents the set of all token sequences to which that nonterminal could expand. It is considered an editorial error if the nonterminal could expand to infinitely many distinct token sequences.</p>
+      <p>These conditions may be negated. &ldquo;[lookahead &ne; _seq_]&rdquo; indicates that the containing production may only be used if _seq_ is <em>not</em> a prefix of the immediately following input token sequence, and &ldquo;[lookahead &notin; _set_]&rdquo; indicates that the production may only be used if <em>no</em> element of _set_ is a prefix of the immediately following token sequence.</p>
+      <p>As an example, given the definitions:</p>
       <emu-grammar type="example">
         DecimalDigit :: one of
           `0` `1` `2` `3` `4` `5` `6` `7` `8` `9`
@@ -762,7 +763,7 @@
           DecimalDigit [lookahead &lt;! DecimalDigit]
       </emu-grammar>
       <p>matches either the letter `n` followed by one or more decimal digits the first of which is even, or a decimal digit not followed by another decimal digit.</p>
-      <p>Similarly, if the phrase &ldquo;[lookahead &isin; _set_]&rdquo; appears in the right-hand side of a production, it indicates that the production may only be used if the immediately following input token sequence is a member of the given _set_. If the _set_ consists of a single terminal the phrase &ldquo;[lookahead = _terminal_]&rdquo; may be used.</p>
+      <p>Note that when these phrases are used in the syntactic grammar, it may not be possible to unambiguously identify the immediately following token sequence because determining later tokens requires knowing which lexical goal symbol to use at later positions. As such, when these are used in the syntactic grammar, it is considered an editorial error for a token sequence _seq_ to appear in a lookahead restriction (including as part of a set of sequences) if the choices of lexical goal symbols to use could change whether or not _seq_ would be a prefix of the resulting token sequence.</p>
       <p>If the phrase &ldquo;[no |LineTerminator| here]&rdquo; appears in the right-hand side of a production of the syntactic grammar, it indicates that the production is <em>a restricted production</em>: it may not be used if a |LineTerminator| occurs in the input stream at the indicated position. For example, the production:</p>
       <emu-grammar type="example">
         ThrowStatement :


### PR DESCRIPTION
There's a few differences here:
- It talks about the referenced token sequences being a _prefix_ of the following sequence, which I believe was always the intent (resolving the issue mentioned in [this comment](https://github.com/tc39/ecma262/pull/2227#issuecomment-727093111)).
- It describes how to handle the case where the following token sequence is ambiguous, namely, by only allowing lookahead restrictions for which the ambiguity cannot matter (resolving the issue mentioned in [this comment](https://github.com/tc39/ecma262/pull/2227#issuecomment-727095436)).
- It only ever talks about sequences of tokens, never individual tokens (and therefore subsumes https://github.com/tc39/ecma262/pull/1828). 
- It removes the restriction that sequences be of length 1 or 2. I think the point of that restriction was to emphasize that the grammar is LR(2), but I think emphasizing this here is of dubious value. And there are cases where we would want [longer restrictions](https://github.com/tc39/ecma262/pull/1727#discussion_r332641200).
- It introduces the phrases in the order `=`, `∈`, `≠`, `∉`, which I think is clearest.

@waldemarhorwat @gibson042 @jmdyck, since each of you have commented on this section in the past, I'd appreciate any feedback you have about this phrasing.