### PR TITLE
Markup: Move ul-within-p to outside the p

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -42799,13 +42799,12 @@ THH:mm:ss.sss
 
     <emu-annex id="sec-__proto__-property-names-in-object-initializers">
       <h1>__proto__ Property Names in Object Initializers</h1>
-      <p>The following Early Error rule is added to those in <emu-xref href="#sec-object-initializer-static-semantics-early-errors"></emu-xref>. This rule is <b>not</b> applied under any of the following circumstances:
-        <ul>
-          <li>when |ObjectLiteral| appears in a context where |ObjectAssignmentPattern| is required,</li>
-          <li>when initially parsing a |CoverParenthesizedExpressionAndArrowParameterList| or a |CoverCallExpressionAndAsyncArrowHead|, or</li>
-          <li>when parsing text for <emu-xref href="#sec-json.parse">JSON.parse</emu-xref>.</li>
-        </ul>
-      </p>
+      <p>The following Early Error rule is added to those in <emu-xref href="#sec-object-initializer-static-semantics-early-errors"></emu-xref>. This rule is <b>not</b> applied under any of the following circumstances:</p>
+      <ul>
+        <li>when |ObjectLiteral| appears in a context where |ObjectAssignmentPattern| is required,</li>
+        <li>when initially parsing a |CoverParenthesizedExpressionAndArrowParameterList| or a |CoverCallExpressionAndAsyncArrowHead|, or</li>
+        <li>when parsing text for <emu-xref href="#sec-json.parse">JSON.parse</emu-xref>.</li>
+      </ul>
       <emu-grammar>
         ObjectLiteral : `{` PropertyDefinitionList `}`
 


### PR DESCRIPTION
HTML doesn't allow a `<ul>` within a `<p>`.


