### PR TITLE
Normative: forbid for-of loops with variable named async

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -18306,7 +18306,7 @@
           `for` `(` [lookahead != `let` `[`] LeftHandSideExpression[?Yield, ?Await] `in` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
           `for` `(` `var` ForBinding[?Yield, ?Await] `in` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
           `for` `(` ForDeclaration[?Yield, ?Await] `in` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
-          `for` `(` [lookahead != `let`] LeftHandSideExpression[?Yield, ?Await] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
+          `for` `(` [lookahead &notin; {`let`, `async` `of`}] LeftHandSideExpression[?Yield, ?Await] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
           `for` `(` `var` ForBinding[?Yield, ?Await] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
           `for` `(` ForDeclaration[?Yield, ?Await] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
           [+Await] `for` `await` `(` [lookahead != `let`] LeftHandSideExpression[?Yield, ?Await] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]


### PR DESCRIPTION
Fixes https://github.com/tc39/ecma262/issues/2034, raised by @waldemarhorwat a year ago (sorry for the delay). See the [linked slides](https://docs.google.com/presentation/d/1POaK3AQxbdeDIq5M1RVjH1YIHe3fSxOCPPALTHIaLyo/edit) for context. This makes `for (async of [1,2,3]);` a syntax error, as it is in all major engines except V8.

We said [at the time](https://github.com/tc39/notes/blob/425ab0e16a32f8199b5521a1cf7439d10d4c8a83/meetings/2019-12/december-3.md#async-of-grammar-ambiguity) that we could resolve this with a single token of lookahead, presumably by just preventing for-of loops where the first token is `async`. Unfortunately, `let async = {x: 0}; for (async.x of [1,2,3]);` is a legal program with no ambiguities and we probably shouldn't forbid it. So I've used a two token lookahead here. We use two tokens of lookahead in some other contexts; I don't think there's any issue with extending that to this case, especially now that https://github.com/tc39/ecma262/pull/2254 has fixed up the definition.

~We should add a few tests asserting that `let async = {x: 0}; for (async.x of [1,2,3]);` and `for (async of => 0; false;);` are legal and `for (async of [1,2,3]);` is a syntax error.~ Edit: [done](https://github.com/tc39/test262/pull/2935).