### PR TITLE
Editorial: note that JSON is not a semantic subset of ECMAScript

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -37661,6 +37661,7 @@ THH:mm:ss.sss
       <p>The *"length"* property of the `parse` function is *2*<sub>𝔽</sub>.</p>
       <emu-note>
         <p>Valid JSON text is a subset of the ECMAScript |PrimaryExpression| syntax. Step <emu-xref href="#step-json-parse-validate"></emu-xref> verifies that _jsonString_ conforms to that subset, and step <emu-xref href="#step-json-parse-assert-type"></emu-xref> asserts that that parsing and evaluation returns a value of an appropriate type.</p>
+        <p>However, because <emu-xref href="#sec-__proto__-property-names-in-object-initializers"></emu-xref> applies when evaluating ECMAScript source text and does not apply during `JSON.parse`, the same source text can produce different results when evaluated as a |PrimaryExpression| rather than as JSON. Furthermore, the Early Error for duplicate *"__proto__"* properties in object literals, which likewise does not apply during `JSON.parse`, means that not all texts accepted by `JSON.parse` are valid as a |PrimaryExpression|, despite matching the grammar.</p>
       </emu-note>
 
       <emu-clause id="sec-internalizejsonproperty" aoid="InternalizeJSONProperty">


### PR DESCRIPTION
Fixes #1681.

Note that this races with https://github.com/tc39/ecma262/pull/2125. Whichever lands second will need to be updated to ensure the link introduced in this PR points to the right place (probably by adding a step label to the relevant section of `PropertyDefinitionEvaluation` introduced in #2125).

There's actually a second, more subtle difference, which is that `{ "__proto__": 0, "__proto__": 0 }` is valid JSON but, while it matches the `PrimaryExpression` grammar, it is not legal ECMAScript due to the early error for duplicate `__proto__` properties. ~I didn't think that worth mentioning, but I am happy to if people think it's warranted.~ Edit: that is noted as well.

cc @erights