### PR TITLE
Editorial: Fix author listing

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -181,7 +181,7 @@
   <p>ECMAScript usage has moved beyond simple scripting and it is now used for the full spectrum of programming tasks in many different environments and scales. As the usage of ECMAScript has expanded, so have the features and facilities it provides. ECMAScript is now a fully featured general-purpose programming language.</p>
   <p>Some of the facilities of ECMAScript are similar to those used in other programming languages; in particular C, Java&trade;, Self, and Scheme as described in:</p>
   <p>ISO/IEC 9899:1996, <i>Programming Languages &mdash; C</i>.</p>
-  <p>James Gosling, Bill Joy and Guy Steele. <i>The Java<sup>&trade;</sup> Language Specification</i>. Addison Wesley Publishing Co., 1996.</p>
+  <p>James Gosling, Bill Joy, and Guy Steele. <i>The Java<sup>&trade;</sup> Language Specification</i>. Addison Wesley Publishing Co., 1996.</p>
   <p>David Ungar, and Randall B. Smith. Self: The Power of Simplicity. <i>OOPSLA '87 Conference Proceedings</i>, pp. 227-241, Orlando, FL, October 1987.</p>
   <p><i>IEEE Standard for the Scheme Programming Language</i>. IEEE Std 1178-1990.</p>
 

--- a/spec.html
+++ b/spec.html
@@ -181,8 +181,8 @@
   <p>ECMAScript usage has moved beyond simple scripting and it is now used for the full spectrum of programming tasks in many different environments and scales. As the usage of ECMAScript has expanded, so have the features and facilities it provides. ECMAScript is now a fully featured general-purpose programming language.</p>
   <p>Some of the facilities of ECMAScript are similar to those used in other programming languages; in particular C, Java&trade;, Self, and Scheme as described in:</p>
   <p>ISO/IEC 9899:1996, <i>Programming Languages &mdash; C</i>.</p>
-  <p>Gosling, James, Bill Joy and Guy Steele. <i>The Java<sup>&trade;</sup> Language Specification</i>. Addison Wesley Publishing Co., 1996.</p>
-  <p>Ungar, David, and Smith, Randall B. Self: The Power of Simplicity. <i>OOPSLA '87 Conference Proceedings</i>, pp. 227-241, Orlando, FL, October 1987.</p>
+  <p>James Gosling, Bill Joy and Guy Steele. <i>The Java<sup>&trade;</sup> Language Specification</i>. Addison Wesley Publishing Co., 1996.</p>
+  <p>David Ungar, and Randall B. Smith. Self: The Power of Simplicity. <i>OOPSLA '87 Conference Proceedings</i>, pp. 227-241, Orlando, FL, October 1987.</p>
   <p><i>IEEE Standard for the Scheme Programming Language</i>. IEEE Std 1178-1990.</p>
 
   <emu-clause id="sec-web-scripting">


### PR DESCRIPTION
1. Changing the listing of authors to be in format `<firstname lastname>` consistently. Previously `<firstname lastname>` and `<lastname, firstname>` were both used. Choosing `<firstname lastname>` to prevent too many commas in a listing of multiple authors in a row which ultimately hinders readability.
2. Adding comma after the penultimate item in author listing (to be consistent with the subsequent line which was already doing it that way).