### PR TITLE
Meta: bump ecmarkup (and related tweaks)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,17 +11,17 @@
       "dev": true
     },
     "@babel/code-frame": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+      "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
       "requires": {
         "@babel/highlight": "^7.10.4"
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-      "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+      "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
     },
     "@babel/highlight": {
       "version": "7.10.4",
@@ -62,102 +62,102 @@
       }
     },
     "@esfx/async-canceltoken": {
-      "version": "1.0.0-pre.13",
-      "resolved": "https://registry.npmjs.org/@esfx/async-canceltoken/-/async-canceltoken-1.0.0-pre.13.tgz",
-      "integrity": "sha512-D8OF4aZWRuJDW9FAV8D8JB4umDvBpd6VF82Pybh/tFJ9FqIjZ80aURPwYDhQkK+9coF//Qx3zfsLO6ifSpjJJQ==",
+      "version": "1.0.0-pre.16",
+      "resolved": "https://registry.npmjs.org/@esfx/async-canceltoken/-/async-canceltoken-1.0.0-pre.16.tgz",
+      "integrity": "sha512-gGV068eL5+Rx5TPQDW8ZlLMvlKtwYL1ICR3NZpTTwA8Wo1+MyQOZN9rz/M85lJsV3kYVMrXYmDeNN6xH8rCF/Q==",
       "requires": {
-        "@esfx/cancelable": "^1.0.0-pre.13",
-        "@esfx/collections-linkedlist": "^1.0.0-pre.13",
-        "@esfx/disposable": "^1.0.0-pre.13",
-        "@esfx/internal-guards": "^1.0.0-pre.11",
+        "@esfx/cancelable": "^1.0.0-pre.16",
+        "@esfx/collections-linkedlist": "^1.0.0-pre.16",
+        "@esfx/disposable": "^1.0.0-pre.16",
+        "@esfx/internal-guards": "^1.0.0-pre.16",
         "@esfx/internal-tag": "^1.0.0-pre.6",
         "tslib": "^1.9.3"
       }
     },
     "@esfx/cancelable": {
-      "version": "1.0.0-pre.13",
-      "resolved": "https://registry.npmjs.org/@esfx/cancelable/-/cancelable-1.0.0-pre.13.tgz",
-      "integrity": "sha512-JpcXOrEPh/AMaZ8OGWrjYq+o65/emqxZFnW7NRRS6x8nrHbbZTUHEJnQmjahXkjvliPBgsFqueaLphXP52ACug==",
+      "version": "1.0.0-pre.16",
+      "resolved": "https://registry.npmjs.org/@esfx/cancelable/-/cancelable-1.0.0-pre.16.tgz",
+      "integrity": "sha512-xKwB92EEem1iMiT9t9eM5kNllXyqdZy4hb/ycWBURnScspxiE1x3O+hugX953Iq1zv9Iy4JgVWdTknH9SEO/+A==",
       "requires": {
-        "@esfx/disposable": "^1.0.0-pre.13",
-        "@esfx/internal-deprecate": "^1.0.0-pre.13",
-        "@esfx/internal-guards": "^1.0.0-pre.11",
+        "@esfx/disposable": "^1.0.0-pre.16",
+        "@esfx/internal-deprecate": "^1.0.0-pre.16",
+        "@esfx/internal-guards": "^1.0.0-pre.16",
         "@esfx/internal-tag": "^1.0.0-pre.6",
         "tslib": "^1.9.3"
       }
     },
     "@esfx/collection-core": {
-      "version": "1.0.0-pre.13",
-      "resolved": "https://registry.npmjs.org/@esfx/collection-core/-/collection-core-1.0.0-pre.13.tgz",
-      "integrity": "sha512-jMOy2238UjUeHC0sRVaNeJ2koK/YLZxITKTLbZfWUJpfp/4UVmDO/npv0cxIcob59KdWRf5MONjgz2WdzNpU+A==",
+      "version": "1.0.0-pre.16",
+      "resolved": "https://registry.npmjs.org/@esfx/collection-core/-/collection-core-1.0.0-pre.16.tgz",
+      "integrity": "sha512-lMV+7P3d85AOjgghRnGYMnI36GEjcMlJESH7cYs42PpbbhFAmRx42Czq57RuoV6IKlo4F2MawO2RqjzQy7OR+g==",
       "requires": {
-        "@esfx/internal-deprecate": "^1.0.0-pre.13",
-        "@esfx/internal-guards": "^1.0.0-pre.11",
+        "@esfx/internal-deprecate": "^1.0.0-pre.16",
+        "@esfx/internal-guards": "^1.0.0-pre.16",
         "tslib": "^1.9.3"
       }
     },
     "@esfx/collections-linkedlist": {
-      "version": "1.0.0-pre.13",
-      "resolved": "https://registry.npmjs.org/@esfx/collections-linkedlist/-/collections-linkedlist-1.0.0-pre.13.tgz",
-      "integrity": "sha512-rddmq8BWGxo0rnobqexp1XTF1iJqezxemPHgAvJBD8dLVowrZ/ffVkj5wjmbHtaTh2qwHhJ/kThyyT9/RzLKJg==",
+      "version": "1.0.0-pre.16",
+      "resolved": "https://registry.npmjs.org/@esfx/collections-linkedlist/-/collections-linkedlist-1.0.0-pre.16.tgz",
+      "integrity": "sha512-IHQJy0o8hOFf/o/0DknY1mgbg9n0iXPfOfmQmET3XMj30A28udB/GztI+bY7x04NcB9y9VuClMqnhu3O294+7A==",
       "requires": {
-        "@esfx/collection-core": "^1.0.0-pre.13",
-        "@esfx/equatable": "^1.0.0-pre.13",
-        "@esfx/internal-guards": "^1.0.0-pre.11",
+        "@esfx/collection-core": "^1.0.0-pre.16",
+        "@esfx/equatable": "^1.0.0-pre.16",
+        "@esfx/internal-guards": "^1.0.0-pre.16",
         "tslib": "^1.9.3"
       }
     },
     "@esfx/disposable": {
-      "version": "1.0.0-pre.13",
-      "resolved": "https://registry.npmjs.org/@esfx/disposable/-/disposable-1.0.0-pre.13.tgz",
-      "integrity": "sha512-rTypmtVgC8nx3gfxHIX96By2UNub0ewRthxUiWE1x/+NTSfzGOHVpVu0H8DF+VQJND04E6srcwwbO+Hpek16GA==",
+      "version": "1.0.0-pre.16",
+      "resolved": "https://registry.npmjs.org/@esfx/disposable/-/disposable-1.0.0-pre.16.tgz",
+      "integrity": "sha512-FYsDunVx1nyd0Fey9gG03AYmU33/+yt8xbyTnBq4mTN0u2n2kqldq/SnFYmbhreK36TdAsqmiLiCub+sARRquA==",
       "requires": {
-        "@esfx/internal-deprecate": "^1.0.0-pre.13",
-        "@esfx/internal-guards": "^1.0.0-pre.11",
+        "@esfx/internal-deprecate": "^1.0.0-pre.16",
+        "@esfx/internal-guards": "^1.0.0-pre.16",
         "@esfx/internal-tag": "^1.0.0-pre.6",
         "tslib": "^1.9.3"
       }
     },
     "@esfx/equatable": {
-      "version": "1.0.0-pre.13",
-      "resolved": "https://registry.npmjs.org/@esfx/equatable/-/equatable-1.0.0-pre.13.tgz",
-      "integrity": "sha512-2vYdGp5yCPB0HFLqetOqTVBuUfxos38La195fkeGJilNF/hZ1Zvwx2nrMuwyypKn5lyCZ9GgxJ5XlvY/rV8EwA==",
+      "version": "1.0.0-pre.16",
+      "resolved": "https://registry.npmjs.org/@esfx/equatable/-/equatable-1.0.0-pre.16.tgz",
+      "integrity": "sha512-HmHXim5IILl42CY0MXFAFwQEZN2EqZeVnXm2CDz3zKy6cJiuBGzxA128uQNRFdKLcwiglE/55Yl8zEFo9QYxmQ==",
       "requires": {
-        "@esfx/internal-deprecate": "^1.0.0-pre.13",
-        "@esfx/internal-hashcode": "^1.0.0-pre.9",
+        "@esfx/internal-deprecate": "^1.0.0-pre.16",
+        "@esfx/internal-hashcode": "^1.0.0-pre.16",
         "tslib": "^1.9.3"
       }
     },
     "@esfx/internal-deprecate": {
-      "version": "1.0.0-pre.13",
-      "resolved": "https://registry.npmjs.org/@esfx/internal-deprecate/-/internal-deprecate-1.0.0-pre.13.tgz",
-      "integrity": "sha512-uF4EhrILmUJdcDkSQNsr+33XEKaMj92/8804VIHswytdbwaQjQ85dbj1bSB9TFsXG2zkZtJo09NKNQ9p7NvTPQ==",
+      "version": "1.0.0-pre.16",
+      "resolved": "https://registry.npmjs.org/@esfx/internal-deprecate/-/internal-deprecate-1.0.0-pre.16.tgz",
+      "integrity": "sha512-PpxFI0LqkQrkrUppsJnAYjyrC5s+rEAcM7yZO04uazVZtbWGddgovHiJEbRBbrBpzpwA4KvAOrMl9vi2sdcs5A==",
       "requires": {
         "tslib": "^1.9.3"
       }
     },
     "@esfx/internal-guards": {
-      "version": "1.0.0-pre.11",
-      "resolved": "https://registry.npmjs.org/@esfx/internal-guards/-/internal-guards-1.0.0-pre.11.tgz",
-      "integrity": "sha512-DnRXkwwSrqIaml+sAm/zzpfDOCBnZkzflmGB833AqVYbgopO7xPBobngxqGBhYjutgTmVuXV3GKP0g08h4mQEw==",
+      "version": "1.0.0-pre.16",
+      "resolved": "https://registry.npmjs.org/@esfx/internal-guards/-/internal-guards-1.0.0-pre.16.tgz",
+      "integrity": "sha512-7859KZwi7PQDebsNG/cdM36ysEgv1YPtNZ1ixeZaSQG3YOE3NszPk8TcYESqCmfd3vQ3t4wEGpTNjQuHGuw4sw==",
       "requires": {
-        "@esfx/type-model": "^1.0.0-pre.11",
+        "@esfx/type-model": "^1.0.0-pre.16",
         "tslib": "^1.9.3"
       }
     },
     "@esfx/internal-hashcode": {
-      "version": "1.0.0-pre.9",
-      "resolved": "https://registry.npmjs.org/@esfx/internal-hashcode/-/internal-hashcode-1.0.0-pre.9.tgz",
-      "integrity": "sha512-TJ43s8iE6wnVHT3CyIaRIZRlOOFIlK7m0hk1fl2D0ZzrTLtw5GUEcMFqV2sIGkGXrEKjEqwkuK1/vPQl9rikvA==",
+      "version": "1.0.0-pre.16",
+      "resolved": "https://registry.npmjs.org/@esfx/internal-hashcode/-/internal-hashcode-1.0.0-pre.16.tgz",
+      "integrity": "sha512-pDap4fI2Topgq5+9GQvstyNa/rrD1BbK5v0naaGWHeOKsZq+YL2bLSJzTDmm5Yyvh7h6FUnjP7D7OWv72fMwcg==",
       "requires": {
-        "@esfx/internal-murmur3": "^1.0.0-pre.5",
+        "@esfx/internal-murmur3": "^1.0.0-pre.16",
         "tslib": "^1.9.3"
       }
     },
     "@esfx/internal-murmur3": {
-      "version": "1.0.0-pre.5",
-      "resolved": "https://registry.npmjs.org/@esfx/internal-murmur3/-/internal-murmur3-1.0.0-pre.5.tgz",
-      "integrity": "sha512-Jq+oO1sbxWeUvIoyS7tOF+jg1KLitOOD1/TPTmdYGu/ss53kM8GXaGw5H4x/g07tQfQdC3QyDlepxK/dvoQqoQ==",
+      "version": "1.0.0-pre.16",
+      "resolved": "https://registry.npmjs.org/@esfx/internal-murmur3/-/internal-murmur3-1.0.0-pre.16.tgz",
+      "integrity": "sha512-jjdoJMHGiiYNXpdxCRxEoZ7GYGkfZ7tKKIaSRK7C1THgTZbuKmtFQxrLRYFvvqJ/gRmDpVkqh+rg4eLL9t7jMw==",
       "requires": {
         "tslib": "^1.9.3"
       }
@@ -168,9 +168,9 @@
       "integrity": "sha512-nODidP9/RBLqX39HL12IhFLgaoBHrC5nrm6D/BwquCGNoPQI9EXNPau+IdmGqeUcaMoVOFLFOkYtnHU52RVngw=="
     },
     "@esfx/type-model": {
-      "version": "1.0.0-pre.11",
-      "resolved": "https://registry.npmjs.org/@esfx/type-model/-/type-model-1.0.0-pre.11.tgz",
-      "integrity": "sha512-ImM8fj0HFE2GRPRq+q1xnW3kNaIbZscpJfWjGyeo9KdMxKoI75bJebsA3XK6AH9zbEWba+521V+m6NDvDhcnSw==",
+      "version": "1.0.0-pre.16",
+      "resolved": "https://registry.npmjs.org/@esfx/type-model/-/type-model-1.0.0-pre.16.tgz",
+      "integrity": "sha512-TCYm7KoidPSbVS+Rt3xiFc5/GZrOxO70YsvDCqmF2YZP9pXSOlL5mKUkeCIJmIzg0kdmjpGNjATXF33jOfdadQ==",
       "requires": {
         "tslib": "^1.9.3"
       }
@@ -520,9 +520,9 @@
       }
     },
     "ecmarkup": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-4.2.3.tgz",
-      "integrity": "sha512-iaGkDBDjDoI/bVA06u+swlm79VhHrRVD65TQ++/l1062yX+gNDvjIrFQgQyKQveJPy4BD4keKMGMhSKjRe1epA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-5.0.0.tgz",
+      "integrity": "sha512-+D9wyLt3NX6bCpLVdcyYuS85oGn6Hqab8SJYmeYqsZ76pwX2FgqKziWBP+FEuiUKuLfMq4HANiKxSXvp25zI6Q==",
       "requires": {
         "bluebird": "^3.7.2",
         "chalk": "^1.1.3",
@@ -978,9 +978,9 @@
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
     },
     "import-fresh": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.2.tgz",
-      "integrity": "sha512-cTPNrlvJT6twpYy+YmKUKrTSjWFs3bjYjAhCwm+z4EOCubZxAuO+hHpRN64TqjEaYSHs7tJAE0w1CKMGmsG/lw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
       "requires": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -1133,9 +1133,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
-      "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "license": "SEE LICENSE IN https://tc39.es/ecma262/#sec-copyright-and-software-license",
   "homepage": "https://tc39.es/ecma262/",
   "dependencies": {
-    "ecmarkup": "^4.2.3"
+    "ecmarkup": "^5.0.0"
   },
   "devDependencies": {
     "@alrra/travis-scripts": "^2.1.0",

--- a/spec.html
+++ b/spec.html
@@ -154,7 +154,7 @@
   <p>A conforming implementation of ECMAScript must not implement any extension that is listed as a Forbidden Extension in subclause <emu-xref href="#sec-forbidden-extensions"></emu-xref>.</p>
   <p>A conforming implementation of ECMAScript must not redefine any facilities that are not implementation-defined, implementation-approximated, or host-defined.</p>
   <p>A conforming implementation of ECMAScript may choose to implement or not implement Normative Optional subclauses. If any Normative Optional behaviour is implemented, all of the behaviour in the containing Normative Optional clause must be implemented. A Normative Optional clause is denoted in this specification with the words "Normative Optional" in a coloured box, as shown below.</p>
-  <emu-clause id="sec-conformance.normative-optional" type="example" normative-optional>
+  <emu-clause id="sec-conformance.normative-optional" example normative-optional>
     <h1>Example Clause Heading</h1>
     <p>Example clause contents.</p>
   </emu-clause>
@@ -565,41 +565,41 @@
       <h1>Grammar Notation</h1>
       <p>Terminal symbols are shown in `fixed width` font, both in the productions of the grammars and throughout this specification whenever the text directly refers to such a terminal symbol. These are to appear in a script exactly as written. All terminal symbol code points specified in this way are to be understood as the appropriate Unicode code points from the Basic Latin range, as opposed to any similar-looking code points from other Unicode ranges. A code point in a terminal symbol cannot be expressed by a `\\` |UnicodeEscapeSequence|.</p>
       <p>Nonterminal symbols are shown in <i>italic</i> type. The definition of a nonterminal (also called a &ldquo;production&rdquo;) is introduced by the name of the nonterminal being defined followed by one or more colons. (The number of colons indicates to which grammar the production belongs.) One or more alternative right-hand sides for the nonterminal then follow on succeeding lines. For example, the syntactic definition:</p>
-      <emu-grammar type="example">
+      <emu-grammar type="definition" example>
         WhileStatement :
           `while` `(` Expression `)` Statement
       </emu-grammar>
       <p>states that the nonterminal |WhileStatement| represents the token `while`, followed by a left parenthesis token, followed by an |Expression|, followed by a right parenthesis token, followed by a |Statement|. The occurrences of |Expression| and |Statement| are themselves nonterminals. As another example, the syntactic definition:</p>
-      <emu-grammar type="example">
+      <emu-grammar type="definition" example>
         ArgumentList :
           AssignmentExpression
           ArgumentList `,` AssignmentExpression
       </emu-grammar>
       <p>states that an |ArgumentList| may represent either a single |AssignmentExpression| or an |ArgumentList|, followed by a comma, followed by an |AssignmentExpression|. This definition of |ArgumentList| is recursive, that is, it is defined in terms of itself. The result is that an |ArgumentList| may contain any positive number of arguments, separated by commas, where each argument expression is an |AssignmentExpression|. Such recursive definitions of nonterminals are common.</p>
       <p>The subscripted suffix &ldquo;<sub>opt</sub>&rdquo;, which may appear after a terminal or nonterminal, indicates an optional symbol. The alternative containing the optional symbol actually specifies two right-hand sides, one that omits the optional element and one that includes it. This means that:</p>
-      <emu-grammar type="example">
+      <emu-grammar type="definition" example>
         VariableDeclaration :
           BindingIdentifier Initializer?
       </emu-grammar>
       <p>is a convenient abbreviation for:</p>
-      <emu-grammar type="example">
+      <emu-grammar type="definition" example>
         VariableDeclaration :
           BindingIdentifier
           BindingIdentifier Initializer
       </emu-grammar>
       <p>and that:</p>
-      <emu-grammar type="example">
+      <emu-grammar type="definition" example>
         IterationStatement :
           `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement
       </emu-grammar>
       <p>is a convenient abbreviation for:</p>
-      <emu-grammar type="example">
+      <emu-grammar type="definition" example>
         IterationStatement :
           `for` `(` LexicalDeclaration `;` Expression? `)` Statement
           `for` `(` LexicalDeclaration Expression `;` Expression? `)` Statement
       </emu-grammar>
       <p>which in turn is an abbreviation for:</p>
-      <emu-grammar type="example">
+      <emu-grammar type="definition" example>
         IterationStatement :
           `for` `(` LexicalDeclaration `;` `)` Statement
           `for` `(` LexicalDeclaration `;` Expression `)` Statement
@@ -608,13 +608,13 @@
       </emu-grammar>
       <p>so, in this example, the nonterminal |IterationStatement| actually has four alternative right-hand sides.</p>
       <p>A production may be parameterized by a subscripted annotation of the form &ldquo;<sub>[parameters]</sub>&rdquo;, which may appear as a suffix to the nonterminal symbol defined by the production. &ldquo;<sub>parameters</sub>&rdquo; may be either a single name or a comma separated list of names. A parameterized production is shorthand for a set of productions defining all combinations of the parameter names, preceded by an underscore, appended to the parameterized nonterminal symbol. This means that:</p>
-      <emu-grammar type="example">
+      <emu-grammar type="definition" example>
         StatementList[Return] :
           ReturnStatement
           ExpressionStatement
       </emu-grammar>
       <p>is a convenient abbreviation for:</p>
-      <emu-grammar type="example">
+      <emu-grammar type="definition" example>
         StatementList :
           ReturnStatement
           ExpressionStatement
@@ -624,13 +624,13 @@
           ExpressionStatement
       </emu-grammar>
       <p>and that:</p>
-      <emu-grammar type="example">
+      <emu-grammar type="definition" example>
         StatementList[Return, In] :
           ReturnStatement
           ExpressionStatement
       </emu-grammar>
       <p>is an abbreviation for:</p>
-      <emu-grammar type="example">
+      <emu-grammar type="definition" example>
         StatementList :
           ReturnStatement
           ExpressionStatement
@@ -649,47 +649,47 @@
       </emu-grammar>
       <p>Multiple parameters produce a combinatory number of productions, not all of which are necessarily referenced in a complete grammar.</p>
       <p>References to nonterminals on the right-hand side of a production can also be parameterized. For example:</p>
-      <emu-grammar type="example">
+      <emu-grammar type="definition" example>
         StatementList :
           ReturnStatement
           ExpressionStatement[+In]
       </emu-grammar>
       <p>is equivalent to saying:</p>
-      <emu-grammar type="example">
+      <emu-grammar type="definition" example>
         StatementList :
           ReturnStatement
           ExpressionStatement_In
       </emu-grammar>
       <p>and:</p>
-      <emu-grammar type="example">
+      <emu-grammar type="definition" example>
         StatementList :
           ReturnStatement
           ExpressionStatement[~In]
       </emu-grammar>
       <p>is equivalent to:</p>
-      <emu-grammar type="example">
+      <emu-grammar type="definition" example>
         StatementList :
           ReturnStatement
           ExpressionStatement
       </emu-grammar>
       <p>A nonterminal reference may have both a parameter list and an &ldquo;<sub>opt</sub>&rdquo; suffix. For example:</p>
-      <emu-grammar type="example">
+      <emu-grammar type="definition" example>
         VariableDeclaration :
           BindingIdentifier Initializer[+In]?
       </emu-grammar>
       <p>is an abbreviation for:</p>
-      <emu-grammar type="example">
+      <emu-grammar type="definition" example>
         VariableDeclaration :
           BindingIdentifier
           BindingIdentifier Initializer_In
       </emu-grammar>
       <p>Prefixing a parameter name with &ldquo;<sub>?</sub>&rdquo; on a right-hand side nonterminal reference makes that parameter value dependent upon the occurrence of the parameter name on the reference to the current production's left-hand side symbol. For example:</p>
-      <emu-grammar type="example">
+      <emu-grammar type="definition" example>
         VariableDeclaration[In] :
           BindingIdentifier Initializer[?In]
       </emu-grammar>
       <p>is an abbreviation for:</p>
-      <emu-grammar type="example">
+      <emu-grammar type="definition" example>
         VariableDeclaration :
           BindingIdentifier Initializer
 
@@ -697,13 +697,13 @@
           BindingIdentifier Initializer_In
       </emu-grammar>
       <p>If a right-hand side alternative is prefixed with &ldquo;[+parameter]&rdquo; that alternative is only available if the named parameter was used in referencing the production's nonterminal symbol. If a right-hand side alternative is prefixed with &ldquo;[\~parameter]&rdquo; that alternative is only available if the named parameter was <em>not</em> used in referencing the production's nonterminal symbol. This means that:</p>
-      <emu-grammar type="example">
+      <emu-grammar type="definition" example>
         StatementList[Return] :
           [+Return] ReturnStatement
           ExpressionStatement
       </emu-grammar>
       <p>is an abbreviation for:</p>
-      <emu-grammar type="example">
+      <emu-grammar type="definition" example>
         StatementList :
           ExpressionStatement
 
@@ -712,13 +712,13 @@
           ExpressionStatement
       </emu-grammar>
       <p>and that:</p>
-      <emu-grammar type="example">
+      <emu-grammar type="definition" example>
         StatementList[Return] :
           [~Return] ReturnStatement
           ExpressionStatement
       </emu-grammar>
       <p>is an abbreviation for:</p>
-      <emu-grammar type="example">
+      <emu-grammar type="definition" example>
         StatementList :
           ReturnStatement
           ExpressionStatement
@@ -727,12 +727,12 @@
           ExpressionStatement
       </emu-grammar>
       <p>When the words &ldquo;<b>one of</b>&rdquo; follow the colon(s) in a grammar definition, they signify that each of the terminal symbols on the following line or lines is an alternative definition. For example, the lexical grammar for ECMAScript contains the production:</p>
-      <emu-grammar type="example">
+      <emu-grammar type="definition" example>
         NonZeroDigit :: one of
           `1` `2` `3` `4` `5` `6` `7` `8` `9`
       </emu-grammar>
       <p>which is merely a convenient abbreviation for:</p>
-      <emu-grammar type="example">
+      <emu-grammar type="definition" example>
         NonZeroDigit ::
           `1`
           `2`
@@ -748,7 +748,7 @@
       <p>If the phrase &ldquo;[lookahead = _seq_]&rdquo; appears in the right-hand side of a production, it indicates that the production may only be used if the token sequence _seq_ is a prefix of the immediately following input token sequence. Similarly, &ldquo;[lookahead &isin; _set_]&rdquo;, where _set_ is a finite nonempty set of token sequences, indicates that the production may only be used if some element of _set_ is a prefix of the immediately following token sequence. For convenience, the set can also be written as a nonterminal, in which case it represents the set of all token sequences to which that nonterminal could expand. It is considered an editorial error if the nonterminal could expand to infinitely many distinct token sequences.</p>
       <p>These conditions may be negated. &ldquo;[lookahead &ne; _seq_]&rdquo; indicates that the containing production may only be used if _seq_ is <em>not</em> a prefix of the immediately following input token sequence, and &ldquo;[lookahead &notin; _set_]&rdquo; indicates that the production may only be used if <em>no</em> element of _set_ is a prefix of the immediately following token sequence.</p>
       <p>As an example, given the definitions:</p>
-      <emu-grammar type="example">
+      <emu-grammar type="definition" example>
         DecimalDigit :: one of
           `0` `1` `2` `3` `4` `5` `6` `7` `8` `9`
 
@@ -757,7 +757,7 @@
           DecimalDigits DecimalDigit
       </emu-grammar>
       <p>the definition:</p>
-      <emu-grammar type="example">
+      <emu-grammar type="definition" example>
         LookaheadExample ::
           `n` [lookahead &lt;! {`1`, `3`, `5`, `7`, `9`}] DecimalDigits
           DecimalDigit [lookahead &lt;! DecimalDigit]
@@ -765,7 +765,7 @@
       <p>matches either the letter `n` followed by one or more decimal digits the first of which is even, or a decimal digit not followed by another decimal digit.</p>
       <p>Note that when these phrases are used in the syntactic grammar, it may not be possible to unambiguously identify the immediately following token sequence because determining later tokens requires knowing which lexical goal symbol to use at later positions. As such, when these are used in the syntactic grammar, it is considered an editorial error for a token sequence _seq_ to appear in a lookahead restriction (including as part of a set of sequences) if the choices of lexical goal symbols to use could change whether or not _seq_ would be a prefix of the resulting token sequence.</p>
       <p>If the phrase &ldquo;[no |LineTerminator| here]&rdquo; appears in the right-hand side of a production of the syntactic grammar, it indicates that the production is <em>a restricted production</em>: it may not be used if a |LineTerminator| occurs in the input stream at the indicated position. For example, the production:</p>
-      <emu-grammar type="example">
+      <emu-grammar type="definition" example>
         ThrowStatement :
           `throw` [no LineTerminator here] Expression `;`
       </emu-grammar>
@@ -773,13 +773,13 @@
       <p>Unless the presence of a |LineTerminator| is forbidden by a restricted production, any number of occurrences of |LineTerminator| may appear between any two consecutive tokens in the stream of input elements without affecting the syntactic acceptability of the script.</p>
       <p>When an alternative in a production of the lexical grammar or the numeric string grammar appears to be a multi-code point token, it represents the sequence of code points that would make up such a token.</p>
       <p>The right-hand side of a production may specify that certain expansions are not permitted by using the phrase &ldquo;<b>but not</b>&rdquo; and then indicating the expansions to be excluded. For example, the production:</p>
-      <emu-grammar type="example">
+      <emu-grammar type="definition" example>
         Identifier ::
           IdentifierName but not ReservedWord
       </emu-grammar>
       <p>means that the nonterminal |Identifier| may be replaced by any sequence of code points that could replace |IdentifierName| provided that the same sequence of code points could not replace |ReservedWord|.</p>
       <p>Finally, a few nonterminal symbols are described by a descriptive phrase in sans-serif type in cases where it would be impractical to list all the alternatives:</p>
-      <emu-grammar type="example">
+      <emu-grammar type="definition" example>
         SourceCharacter ::
           &gt; any Unicode code point
       </emu-grammar>
@@ -791,7 +791,7 @@
     <p>The specification often uses a numbered list to specify steps in an algorithm. These algorithms are used to precisely specify the required semantics of ECMAScript language constructs. The algorithms are not intended to imply the use of any specific implementation technique. In practice, there may be more efficient algorithms available to implement a given feature.</p>
     <p>Algorithms may be explicitly parameterized with an ordered, comma-separated sequence of alias names which may be used within the algorithm steps to reference the argument passed in that position. Optional parameters are denoted with surrounding brackets ([ , _name_ ]) and are no different from required parameters within algorithm steps. A rest parameter may appear at the end of a parameter list, denoted with leading ellipsis (, ..._name_). The rest parameter captures all of the arguments provided following the required and optional parameters into a List. If there are no such additional arguments, that List is empty.</p>
     <p>Algorithm steps may be subdivided into sequential substeps. Substeps are indented and may themselves be further divided into indented substeps. Outline numbering conventions are used to identify substeps with the first level of substeps labelled with lower case alphabetic characters and the second level of substeps labelled with lower case roman numerals. If more than three levels are required these rules repeat with the fourth level using numeric labels. For example:</p>
-    <emu-alg type="example">
+    <emu-alg example>
       1. Top-level step
         1. Substep.
         1. Substep.
@@ -816,20 +816,20 @@
       <p>A <dfn>syntax-directed operation</dfn> is a named operation whose definition consists of algorithms, each of which is associated with one or more productions from one of the ECMAScript grammars. A production that has multiple alternative definitions will typically have a distinct algorithm for each alternative. When an algorithm is associated with a grammar production, it may reference the terminal and nonterminal symbols of the production alternative as if they were parameters of the algorithm. When used in this manner, nonterminal symbols refer to the actual alternative definition that is matched when parsing the source text. The <dfn>source text matched by</dfn> a grammar production is the portion of the source text that starts at the beginning of the first terminal that participated in the match and ends at the end of the last terminal that participated in the match.</p>
       <p>When an algorithm is associated with a production alternative, the alternative is typically shown without any &ldquo;[ ]&rdquo; grammar annotations. Such annotations should only affect the syntactic recognition of the alternative and have no effect on the associated semantics for the alternative.</p>
       <p>Syntax-directed operations are invoked with a parse node and, optionally, other parameters by using the conventions on steps <emu-xref href="#step-sdo-invocation-example-1"></emu-xref>, <emu-xref href="#step-sdo-invocation-example-2"></emu-xref>, and <emu-xref href="#step-sdo-invocation-example-3"></emu-xref> in the following algorithm:</p>
-      <emu-alg>
+      <emu-alg example>
         1. [id="step-sdo-invocation-example-1"] Let _status_ be SyntaxDirectedOperation of |SomeNonTerminal|.
         1. Let _someParseNode_ be the parse of some source text.
         1. [id="step-sdo-invocation-example-2"] Perform SyntaxDirectedOperation of _someParseNode_.
         1. [id="step-sdo-invocation-example-3"] Perform SyntaxDirectedOperation of _someParseNode_ passing *"value"* as the argument.
       </emu-alg>
       <p>Unless explicitly specified otherwise, all chain productions have an implicit definition for every operation that might be applied to that production's left-hand side nonterminal. The implicit definition simply reapplies the same operation with the same parameters, if any, to the chain production's sole right-hand side nonterminal and then returns the result. For example, assume that some algorithm has a step of the form: &ldquo;Return the result of evaluating |Block|&rdquo; and that there is a production:</p>
-      <emu-grammar type="example">
+      <emu-grammar example>
         Block :
           `{` StatementList `}`
       </emu-grammar>
       <p>but the Evaluation operation does not associate an algorithm with that production. In that case, the Evaluation operation implicitly includes an association of the form:</p>
       <p><b>Runtime Semantics: Evaluation</b></p>
-      <emu-grammar type="example">Block : `{` StatementList `}`</emu-grammar>
+      <emu-grammar example>Block : `{` StatementList `}`</emu-grammar>
       <emu-alg>
         1. Return the result of evaluating |StatementList|.
       </emu-alg>
@@ -909,33 +909,33 @@
       <emu-clause id="sec-returnifabrupt-shorthands">
         <h1>ReturnIfAbrupt Shorthands</h1>
         <p>Invocations of abstract operations and syntax-directed operations that are prefixed by `?` indicate that ReturnIfAbrupt should be applied to the resulting Completion Record. For example, the step:</p>
-        <emu-alg>
+        <emu-alg example>
           1. ? OperationName().
         </emu-alg>
         <p>is equivalent to the following step:</p>
-        <emu-alg>
+        <emu-alg example>
           1. ReturnIfAbrupt(OperationName()).
         </emu-alg>
         <p>Similarly, for method application style, the step:</p>
-        <emu-alg>
+        <emu-alg example>
           1. ? _someValue_.OperationName().
         </emu-alg>
         <p>is equivalent to:</p>
-        <emu-alg>
+        <emu-alg example>
           1. ReturnIfAbrupt(_someValue_.OperationName()).
         </emu-alg>
         <p>Similarly, prefix `!` is used to indicate that the following invocation of an abstract or syntax-directed operation will never return an abrupt completion and that the resulting Completion Record's [[Value]] field should be used in place of the return value of the operation. For example, the step:</p>
-        <emu-alg>
+        <emu-alg example>
           1. Let _val_ be ! OperationName().
         </emu-alg>
         <p>is equivalent to the following steps:</p>
-        <emu-alg>
+        <emu-alg example>
           1. Let _val_ be OperationName().
           1. Assert: _val_ is never an abrupt completion.
           1. If _val_ is a Completion Record, set _val_ to _val_.[[Value]].
         </emu-alg>
         <p>Syntax-directed operations for runtime semantics make use of this shorthand by placing `!` or `?` before the invocation of the operation:</p>
-        <emu-alg>
+        <emu-alg example>
           1. Perform ! SyntaxDirectedOperation of |NonTerminal|.
         </emu-alg>
       </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -24996,7 +24996,7 @@
         <h1>URI Syntax and Semantics</h1>
         <p>A URI is composed of a sequence of components separated by component separators. The general form is:</p>
         <div class="rhs">
-          |Scheme| `:` |First| `/` |Second| `;` |Third| `?` |Fourth|
+          <em>Scheme</em> `:` <em>First</em> `/` <em>Second</em> `;` <em>Third</em> `?` <em>Fourth</em>
         </div>
         <p>where the italicized names represent components and &ldquo;`:`&rdquo;, &ldquo;`/`&rdquo;, &ldquo;`;`&rdquo; and &ldquo;`?`&rdquo; are reserved for use as separators. The `encodeURI` and `decodeURI` functions are intended to work with complete URIs; they assume that any reserved code units in the URI are intended to have special meaning and so are not encoded. The `encodeURIComponent` and `decodeURIComponent` functions are intended to work with the individual component parts of a URI; they assume that any reserved code units represent text and so must be encoded so that they are not interpreted as reserved code units when the component is part of a complete URI.</p>
         <p>The following lexical grammar specifies the form of encoded URIs.</p>

--- a/spec.html
+++ b/spec.html
@@ -2020,7 +2020,7 @@
           <p>The abstract operation BigInt::leftShift takes arguments _x_ (a BigInt) and _y_ (a BigInt). It performs the following steps when called:</p>
           <emu-alg>
             1. If _y_ &lt; *0*<sub>ℤ</sub>, then
-              1. Return the BigInt value that represents ℝ(_x_) &divide; 2<sup>-_y_</sup>, rounding down to the nearest integer, including for negative numbers.
+              1. Return the BigInt value that represents ℝ(_x_) / 2<sup>-_y_</sup>, rounding down to the nearest integer, including for negative numbers.
             1. Return the BigInt value that represents ℝ(_x_) &times; 2<sup>_y_</sup>.
           </emu-alg>
           <emu-note>Semantics here should be equivalent to a bitwise shift, treating the BigInt as an infinite length string of binary two's complement digits.</emu-note>
@@ -27235,7 +27235,7 @@
           1. If _x_ &ge; 10<sup>21</sup>, then
             1. Let _m_ be ! ToString(𝔽(_x_)).
           1. Else,
-            1. Let _n_ be an integer for which _n_ &divide; 10<sup>_f_</sup> - _x_ is as close to zero as possible. If there are two such _n_, pick the larger _n_.
+            1. Let _n_ be an integer for which _n_ / 10<sup>_f_</sup> - _x_ is as close to zero as possible. If there are two such _n_, pick the larger _n_.
             1. If _n_ = 0, let _m_ be the String *"0"*. Otherwise, let _m_ be the String value consisting of the digits of the decimal representation of _n_ (in order, with no leading zeroes).
             1. If _f_ &ne; 0, then
               1. Let _k_ be the length of _m_.

--- a/spec.html
+++ b/spec.html
@@ -43045,7 +43045,7 @@ THH:mm:ss.sss
       `implements`, `interface`, `let`, `package`, `private`, `protected`, `public`, `static`, and `yield` are reserved words within strict mode code. (<emu-xref href="#sec-keywords-and-reserved-words"></emu-xref>).
     </li>
     <li>
-      A conforming implementation, when processing strict mode code, must not extend, as described in <emu-xref href="#sec-additional-syntax-numeric-literals"></emu-xref>, the syntax of |NumericLiteral| to include |LegacyOctalIntegerLiteral|, nor extend the syntax of |DecimalIntegerLiteral| to include |NonOctalDecimalIntegerLiteral|.
+      A conforming implementation, when processing strict mode code, must not extend, as described in <emu-xref href="#sec-additional-syntax-numeric-literals"></emu-xref>, the syntax of |NumericLiteral| to include <emu-xref href="#prod-annexB-LegacyOctalIntegerLiteral"></emu-xref>, nor extend the syntax of |DecimalIntegerLiteral| to include <emu-xref href="#prod-annexB-NonOctalDecimalIntegerLiteral"></emu-xref>.
     </li>
     <li>
       A conforming implementation, when processing strict mode code, may not extend the syntax of |EscapeSequence| to include <emu-xref href="#prod-annexB-LegacyOctalEscapeSequence"></emu-xref> or <emu-xref href="#prod-annexB-NonOctalDecimalEscapeSequence"></emu-xref> as described in <emu-xref href="#sec-additional-syntax-string-literals"></emu-xref>.


### PR DESCRIPTION
See commits for details. These commits can be landed individually.

This also fixes #2183 by replacing the two usages of `÷` with `/`. I couldn't find any usages of `*` for multiplication, so I think we're good there.