### PR TITLE
Editorial: consolidate each SDO's definition

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -16624,125 +16624,6 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-destructuring-binding-patterns-static-semantics-containsexpression">
-        <h1>Static Semantics: ContainsExpression</h1>
-        <emu-see-also-para op="ContainsExpression"></emu-see-also-para>
-        <emu-grammar>
-          ObjectBindingPattern :
-            `{` `}`
-            `{` BindingRestProperty `}`
-        </emu-grammar>
-        <emu-alg>
-          1. Return *false*.
-        </emu-alg>
-        <emu-grammar>ObjectBindingPattern : `{` BindingPropertyList `,` BindingRestProperty `}`</emu-grammar>
-        <emu-alg>
-          1. Return ContainsExpression of |BindingPropertyList|.
-        </emu-alg>
-        <emu-grammar>ArrayBindingPattern : `[` Elision? `]`</emu-grammar>
-        <emu-alg>
-          1. Return *false*.
-        </emu-alg>
-        <emu-grammar>ArrayBindingPattern : `[` Elision? BindingRestElement `]`</emu-grammar>
-        <emu-alg>
-          1. Return ContainsExpression of |BindingRestElement|.
-        </emu-alg>
-        <emu-grammar>ArrayBindingPattern : `[` BindingElementList `,` Elision? `]`</emu-grammar>
-        <emu-alg>
-          1. Return ContainsExpression of |BindingElementList|.
-        </emu-alg>
-        <emu-grammar>ArrayBindingPattern : `[` BindingElementList `,` Elision? BindingRestElement `]`</emu-grammar>
-        <emu-alg>
-          1. Let _has_ be ContainsExpression of |BindingElementList|.
-          1. If _has_ is *true*, return *true*.
-          1. Return ContainsExpression of |BindingRestElement|.
-        </emu-alg>
-        <emu-grammar>BindingPropertyList : BindingPropertyList `,` BindingProperty</emu-grammar>
-        <emu-alg>
-          1. Let _has_ be ContainsExpression of |BindingPropertyList|.
-          1. If _has_ is *true*, return *true*.
-          1. Return ContainsExpression of |BindingProperty|.
-        </emu-alg>
-        <emu-grammar>BindingElementList : BindingElementList `,` BindingElisionElement</emu-grammar>
-        <emu-alg>
-          1. Let _has_ be ContainsExpression of |BindingElementList|.
-          1. If _has_ is *true*, return *true*.
-          1. Return ContainsExpression of |BindingElisionElement|.
-        </emu-alg>
-        <emu-grammar>BindingElisionElement : Elision? BindingElement</emu-grammar>
-        <emu-alg>
-          1. Return ContainsExpression of |BindingElement|.
-        </emu-alg>
-        <emu-grammar>BindingProperty : PropertyName `:` BindingElement</emu-grammar>
-        <emu-alg>
-          1. Let _has_ be IsComputedPropertyKey of |PropertyName|.
-          1. If _has_ is *true*, return *true*.
-          1. Return ContainsExpression of |BindingElement|.
-        </emu-alg>
-        <emu-grammar>BindingElement : BindingPattern Initializer</emu-grammar>
-        <emu-alg>
-          1. Return *true*.
-        </emu-alg>
-        <emu-grammar>SingleNameBinding : BindingIdentifier</emu-grammar>
-        <emu-alg>
-          1. Return *false*.
-        </emu-alg>
-        <emu-grammar>SingleNameBinding : BindingIdentifier Initializer</emu-grammar>
-        <emu-alg>
-          1. Return *true*.
-        </emu-alg>
-        <emu-grammar>BindingRestElement : `...` BindingIdentifier</emu-grammar>
-        <emu-alg>
-          1. Return *false*.
-        </emu-alg>
-        <emu-grammar>BindingRestElement : `...` BindingPattern</emu-grammar>
-        <emu-alg>
-          1. Return ContainsExpression of |BindingPattern|.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-destructuring-binding-patterns-static-semantics-hasinitializer">
-        <h1>Static Semantics: HasInitializer</h1>
-        <emu-see-also-para op="HasInitializer"></emu-see-also-para>
-        <emu-grammar>BindingElement : BindingPattern</emu-grammar>
-        <emu-alg>
-          1. Return *false*.
-        </emu-alg>
-        <emu-grammar>BindingElement : BindingPattern Initializer</emu-grammar>
-        <emu-alg>
-          1. Return *true*.
-        </emu-alg>
-        <emu-grammar>SingleNameBinding : BindingIdentifier</emu-grammar>
-        <emu-alg>
-          1. Return *false*.
-        </emu-alg>
-        <emu-grammar>SingleNameBinding : BindingIdentifier Initializer</emu-grammar>
-        <emu-alg>
-          1. Return *true*.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-destructuring-binding-patterns-static-semantics-issimpleparameterlist">
-        <h1>Static Semantics: IsSimpleParameterList</h1>
-        <emu-see-also-para op="IsSimpleParameterList"></emu-see-also-para>
-        <emu-grammar>BindingElement : BindingPattern</emu-grammar>
-        <emu-alg>
-          1. Return *false*.
-        </emu-alg>
-        <emu-grammar>BindingElement : BindingPattern Initializer</emu-grammar>
-        <emu-alg>
-          1. Return *false*.
-        </emu-alg>
-        <emu-grammar>SingleNameBinding : BindingIdentifier</emu-grammar>
-        <emu-alg>
-          1. Return *true*.
-        </emu-alg>
-        <emu-grammar>SingleNameBinding : BindingIdentifier Initializer</emu-grammar>
-        <emu-alg>
-          1. Return *false*.
-        </emu-alg>
-      </emu-clause>
-
       <emu-clause id="sec-destructuring-binding-patterns-runtime-semantics-bindinginitialization">
         <h1>Runtime Semantics: BindingInitialization</h1>
         <p>With parameters _value_ and _environment_.</p>
@@ -19328,6 +19209,249 @@
         <p>Multiple occurrences of the same |BindingIdentifier| in a |FormalParameterList| is only allowed for functions which have simple parameter lists and which are not defined in strict mode code.</p>
       </emu-note>
     </emu-clause>
+
+    <emu-clause id="sec-static-semantics-containsexpression" oldids="sec-destructuring-binding-patterns-static-semantics-containsexpression,sec-function-definitions-static-semantics-containsexpression,sec-arrow-function-definitions-static-semantics-containsexpression,sec-async-arrow-function-definitions-static-semantics-ContainsExpression" type="sdo" aoid="ContainsExpression">
+      <h1>Static Semantics: ContainsExpression</h1>
+      <emu-grammar>
+        ObjectBindingPattern :
+          `{` `}`
+          `{` BindingRestProperty `}`
+      </emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>ObjectBindingPattern : `{` BindingPropertyList `,` BindingRestProperty `}`</emu-grammar>
+      <emu-alg>
+        1. Return ContainsExpression of |BindingPropertyList|.
+      </emu-alg>
+      <emu-grammar>ArrayBindingPattern : `[` Elision? `]`</emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>ArrayBindingPattern : `[` Elision? BindingRestElement `]`</emu-grammar>
+      <emu-alg>
+        1. Return ContainsExpression of |BindingRestElement|.
+      </emu-alg>
+      <emu-grammar>ArrayBindingPattern : `[` BindingElementList `,` Elision? `]`</emu-grammar>
+      <emu-alg>
+        1. Return ContainsExpression of |BindingElementList|.
+      </emu-alg>
+      <emu-grammar>ArrayBindingPattern : `[` BindingElementList `,` Elision? BindingRestElement `]`</emu-grammar>
+      <emu-alg>
+        1. Let _has_ be ContainsExpression of |BindingElementList|.
+        1. If _has_ is *true*, return *true*.
+        1. Return ContainsExpression of |BindingRestElement|.
+      </emu-alg>
+      <emu-grammar>BindingPropertyList : BindingPropertyList `,` BindingProperty</emu-grammar>
+      <emu-alg>
+        1. Let _has_ be ContainsExpression of |BindingPropertyList|.
+        1. If _has_ is *true*, return *true*.
+        1. Return ContainsExpression of |BindingProperty|.
+      </emu-alg>
+      <emu-grammar>BindingElementList : BindingElementList `,` BindingElisionElement</emu-grammar>
+      <emu-alg>
+        1. Let _has_ be ContainsExpression of |BindingElementList|.
+        1. If _has_ is *true*, return *true*.
+        1. Return ContainsExpression of |BindingElisionElement|.
+      </emu-alg>
+      <emu-grammar>BindingElisionElement : Elision? BindingElement</emu-grammar>
+      <emu-alg>
+        1. Return ContainsExpression of |BindingElement|.
+      </emu-alg>
+      <emu-grammar>BindingProperty : PropertyName `:` BindingElement</emu-grammar>
+      <emu-alg>
+        1. Let _has_ be IsComputedPropertyKey of |PropertyName|.
+        1. If _has_ is *true*, return *true*.
+        1. Return ContainsExpression of |BindingElement|.
+      </emu-alg>
+      <emu-grammar>BindingElement : BindingPattern Initializer</emu-grammar>
+      <emu-alg>
+        1. Return *true*.
+      </emu-alg>
+      <emu-grammar>SingleNameBinding : BindingIdentifier</emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>SingleNameBinding : BindingIdentifier Initializer</emu-grammar>
+      <emu-alg>
+        1. Return *true*.
+      </emu-alg>
+      <emu-grammar>BindingRestElement : `...` BindingIdentifier</emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>BindingRestElement : `...` BindingPattern</emu-grammar>
+      <emu-alg>
+        1. Return ContainsExpression of |BindingPattern|.
+      </emu-alg>
+      <emu-grammar>FormalParameters : [empty]</emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>FormalParameters : FormalParameterList `,` FunctionRestParameter</emu-grammar>
+      <emu-alg>
+        1. If ContainsExpression of |FormalParameterList| is *true*, return *true*.
+        1. Return ContainsExpression of |FunctionRestParameter|.
+      </emu-alg>
+      <emu-grammar>FormalParameterList : FormalParameterList `,` FormalParameter</emu-grammar>
+      <emu-alg>
+        1. If ContainsExpression of |FormalParameterList| is *true*, return *true*.
+        1. Return ContainsExpression of |FormalParameter|.
+      </emu-alg>
+      <emu-grammar>ArrowParameters : BindingIdentifier</emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>ArrowParameters : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
+      <emu-alg>
+        1. Let _formals_ be CoveredFormalsList of |CoverParenthesizedExpressionAndArrowParameterList|.
+        1. Return ContainsExpression of _formals_.
+      </emu-alg>
+      <emu-grammar>
+        AsyncArrowBindingIdentifier : BindingIdentifier
+      </emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-static-semantics-issimpleparameterlist" oldids="sec-destructuring-binding-patterns-static-semantics-issimpleparameterlist,sec-function-definitions-static-semantics-issimpleparameterlist,sec-arrow-function-definitions-static-semantics-issimpleparameterlist,sec-async-arrow-function-definitions-static-semantics-IsSimpleParameterList" type="sdo" aoid="IsSimpleParameterList">
+      <h1>Static Semantics: IsSimpleParameterList</h1>
+      <emu-grammar>BindingElement : BindingPattern</emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>BindingElement : BindingPattern Initializer</emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>SingleNameBinding : BindingIdentifier</emu-grammar>
+      <emu-alg>
+        1. Return *true*.
+      </emu-alg>
+      <emu-grammar>SingleNameBinding : BindingIdentifier Initializer</emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>FormalParameters : [empty]</emu-grammar>
+      <emu-alg>
+        1. Return *true*.
+      </emu-alg>
+      <emu-grammar>FormalParameters : FunctionRestParameter</emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>FormalParameters : FormalParameterList `,` FunctionRestParameter</emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>FormalParameterList : FormalParameterList `,` FormalParameter</emu-grammar>
+      <emu-alg>
+        1. If IsSimpleParameterList of |FormalParameterList| is *false*, return *false*.
+        1. Return IsSimpleParameterList of |FormalParameter|.
+      </emu-alg>
+      <emu-grammar>FormalParameter : BindingElement</emu-grammar>
+      <emu-alg>
+        1. Return IsSimpleParameterList of |BindingElement|.
+      </emu-alg>
+      <emu-grammar>ArrowParameters : BindingIdentifier</emu-grammar>
+      <emu-alg>
+        1. Return *true*.
+      </emu-alg>
+      <emu-grammar>ArrowParameters : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
+      <emu-alg>
+        1. Let _formals_ be CoveredFormalsList of |CoverParenthesizedExpressionAndArrowParameterList|.
+        1. Return IsSimpleParameterList of _formals_.
+      </emu-alg>
+      <emu-grammar>
+        AsyncArrowBindingIdentifier[Yield] : BindingIdentifier[?Yield, +Await]
+      </emu-grammar>
+      <emu-alg>
+        1. Return *true*.
+      </emu-alg>
+      <emu-grammar>
+        CoverCallExpressionAndAsyncArrowHead : MemberExpression Arguments
+      </emu-grammar>
+      <emu-alg>
+        1. Let _head_ be CoveredAsyncArrowHead of |CoverCallExpressionAndAsyncArrowHead|.
+        1. Return IsSimpleParameterList of _head_.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-static-semantics-hasinitializer" oldids="sec-destructuring-binding-patterns-static-semantics-hasinitializer,sec-function-definitions-static-semantics-hasinitializer" type="sdo" aoid="HasInitializer">
+      <h1>Static Semantics: HasInitializer</h1>
+      <emu-grammar>BindingElement : BindingPattern</emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>BindingElement : BindingPattern Initializer</emu-grammar>
+      <emu-alg>
+        1. Return *true*.
+      </emu-alg>
+      <emu-grammar>SingleNameBinding : BindingIdentifier</emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>SingleNameBinding : BindingIdentifier Initializer</emu-grammar>
+      <emu-alg>
+        1. Return *true*.
+      </emu-alg>
+      <emu-grammar>FormalParameterList : FormalParameterList `,` FormalParameter</emu-grammar>
+      <emu-alg>
+        1. If HasInitializer of |FormalParameterList| is *true*, return *true*.
+        1. Return HasInitializer of |FormalParameter|.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-static-semantics-expectedargumentcount" oldids="sec-function-definitions-static-semantics-expectedargumentcount,sec-arrow-function-definitions-static-semantics-expectedargumentcount,sec-method-definitions-static-semantics-expectedargumentcount,sec-async-arrow-function-definitions-static-semantics-ExpectedArgumentCount" type="sdo" aoid="ExpectedArgumentCount">
+      <h1>Static Semantics: ExpectedArgumentCount</h1>
+      <emu-grammar>
+        FormalParameters :
+          [empty]
+          FunctionRestParameter
+      </emu-grammar>
+      <emu-alg>
+        1. Return 0.
+      </emu-alg>
+      <emu-grammar>FormalParameters : FormalParameterList `,` FunctionRestParameter</emu-grammar>
+      <emu-alg>
+        1. Return ExpectedArgumentCount of |FormalParameterList|.
+      </emu-alg>
+      <emu-note>
+        <p>The ExpectedArgumentCount of a |FormalParameterList| is the number of |FormalParameters| to the left of either the rest parameter or the first |FormalParameter| with an Initializer. A |FormalParameter| without an initializer is allowed after the first parameter with an initializer but such parameters are considered to be optional with *undefined* as their default value.</p>
+      </emu-note>
+      <emu-grammar>FormalParameterList : FormalParameter</emu-grammar>
+      <emu-alg>
+        1. If HasInitializer of |FormalParameter| is *true*, return 0.
+        1. Return 1.
+      </emu-alg>
+      <emu-grammar>FormalParameterList : FormalParameterList `,` FormalParameter</emu-grammar>
+      <emu-alg>
+        1. Let _count_ be ExpectedArgumentCount of |FormalParameterList|.
+        1. If HasInitializer of |FormalParameterList| is *true* or HasInitializer of |FormalParameter| is *true*, return _count_.
+        1. Return _count_ + 1.
+      </emu-alg>
+      <emu-grammar>ArrowParameters : BindingIdentifier</emu-grammar>
+      <emu-alg>
+        1. Return 1.
+      </emu-alg>
+      <emu-grammar>ArrowParameters : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
+      <emu-alg>
+        1. Let _formals_ be CoveredFormalsList of |CoverParenthesizedExpressionAndArrowParameterList|.
+        1. Return ExpectedArgumentCount of _formals_.
+      </emu-alg>
+      <emu-grammar>PropertySetParameterList : FormalParameter</emu-grammar>
+      <emu-alg>
+        1. If HasInitializer of |FormalParameter| is *true*, return 0.
+        1. Return 1.
+      </emu-alg>
+      <emu-grammar>
+        AsyncArrowBindingIdentifier : BindingIdentifier
+      </emu-grammar>
+      <emu-alg>
+        1. Return 1.
+      </emu-alg>
+    </emu-clause>
   </emu-clause>
 
   <emu-clause id="sec-function-definitions">
@@ -19467,25 +19591,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-function-definitions-static-semantics-containsexpression">
-      <h1>Static Semantics: ContainsExpression</h1>
-      <emu-see-also-para op="ContainsExpression"></emu-see-also-para>
-      <emu-grammar>FormalParameters : [empty]</emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-      <emu-grammar>FormalParameters : FormalParameterList `,` FunctionRestParameter</emu-grammar>
-      <emu-alg>
-        1. If ContainsExpression of |FormalParameterList| is *true*, return *true*.
-        1. Return ContainsExpression of |FunctionRestParameter|.
-      </emu-alg>
-      <emu-grammar>FormalParameterList : FormalParameterList `,` FormalParameter</emu-grammar>
-      <emu-alg>
-        1. If ContainsExpression of |FormalParameterList| is *true*, return *true*.
-        1. Return ContainsExpression of |FormalParameter|.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-function-definitions-static-semantics-containsundefinedbreaktarget">
       <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
       <p>With parameter _labelSet_.</p>
@@ -19512,47 +19617,6 @@
       <emu-grammar>FunctionBody : FunctionStatementList</emu-grammar>
       <emu-alg>
         1. If the Directive Prologue of |FunctionBody| contains a Use Strict Directive, return *true*; otherwise, return *false*.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-function-definitions-static-semantics-expectedargumentcount">
-      <h1>Static Semantics: ExpectedArgumentCount</h1>
-      <emu-see-also-para op="ExpectedArgumentCount"></emu-see-also-para>
-      <emu-grammar>
-        FormalParameters :
-          [empty]
-          FunctionRestParameter
-      </emu-grammar>
-      <emu-alg>
-        1. Return 0.
-      </emu-alg>
-      <emu-grammar>FormalParameters : FormalParameterList `,` FunctionRestParameter</emu-grammar>
-      <emu-alg>
-        1. Return ExpectedArgumentCount of |FormalParameterList|.
-      </emu-alg>
-      <emu-note>
-        <p>The ExpectedArgumentCount of a |FormalParameterList| is the number of |FormalParameters| to the left of either the rest parameter or the first |FormalParameter| with an Initializer. A |FormalParameter| without an initializer is allowed after the first parameter with an initializer but such parameters are considered to be optional with *undefined* as their default value.</p>
-      </emu-note>
-      <emu-grammar>FormalParameterList : FormalParameter</emu-grammar>
-      <emu-alg>
-        1. If HasInitializer of |FormalParameter| is *true*, return 0.
-        1. Return 1.
-      </emu-alg>
-      <emu-grammar>FormalParameterList : FormalParameterList `,` FormalParameter</emu-grammar>
-      <emu-alg>
-        1. Let _count_ be ExpectedArgumentCount of |FormalParameterList|.
-        1. If HasInitializer of |FormalParameterList| is *true* or HasInitializer of |FormalParameter| is *true*, return _count_.
-        1. Return _count_ + 1.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-function-definitions-static-semantics-hasinitializer">
-      <h1>Static Semantics: HasInitializer</h1>
-      <emu-see-also-para op="HasInitializer"></emu-see-also-para>
-      <emu-grammar>FormalParameterList : FormalParameterList `,` FormalParameter</emu-grammar>
-      <emu-alg>
-        1. If HasInitializer of |FormalParameterList| is *true*, return *true*.
-        1. Return HasInitializer of |FormalParameter|.
       </emu-alg>
     </emu-clause>
 
@@ -19599,32 +19663,6 @@
       <emu-grammar>FunctionExpression : `function` BindingIdentifier? `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Return *true*.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-function-definitions-static-semantics-issimpleparameterlist">
-      <h1>Static Semantics: IsSimpleParameterList</h1>
-      <emu-see-also-para op="IsSimpleParameterList"></emu-see-also-para>
-      <emu-grammar>FormalParameters : [empty]</emu-grammar>
-      <emu-alg>
-        1. Return *true*.
-      </emu-alg>
-      <emu-grammar>FormalParameters : FunctionRestParameter</emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-      <emu-grammar>FormalParameters : FormalParameterList `,` FunctionRestParameter</emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-      <emu-grammar>FormalParameterList : FormalParameterList `,` FormalParameter</emu-grammar>
-      <emu-alg>
-        1. If IsSimpleParameterList of |FormalParameterList| is *false*, return *false*.
-        1. Return IsSimpleParameterList of |FormalParameter|.
-      </emu-alg>
-      <emu-grammar>FormalParameter : BindingElement</emu-grammar>
-      <emu-alg>
-        1. Return IsSimpleParameterList of |BindingElement|.
       </emu-alg>
     </emu-clause>
 
@@ -19884,20 +19922,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-arrow-function-definitions-static-semantics-containsexpression">
-      <h1>Static Semantics: ContainsExpression</h1>
-      <emu-see-also-para op="ContainsExpression"></emu-see-also-para>
-      <emu-grammar>ArrowParameters : BindingIdentifier</emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-      <emu-grammar>ArrowParameters : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
-      <emu-alg>
-        1. Let _formals_ be CoveredFormalsList of |CoverParenthesizedExpressionAndArrowParameterList|.
-        1. Return ContainsExpression of _formals_.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-arrow-function-definitions-static-semantics-containsusestrict">
       <h1>Static Semantics: ContainsUseStrict</h1>
       <emu-see-also-para op="ContainsUseStrict"></emu-see-also-para>
@@ -19907,40 +19931,12 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-arrow-function-definitions-static-semantics-expectedargumentcount">
-      <h1>Static Semantics: ExpectedArgumentCount</h1>
-      <emu-see-also-para op="ExpectedArgumentCount"></emu-see-also-para>
-      <emu-grammar>ArrowParameters : BindingIdentifier</emu-grammar>
-      <emu-alg>
-        1. Return 1.
-      </emu-alg>
-      <emu-grammar>ArrowParameters : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
-      <emu-alg>
-        1. Let _formals_ be CoveredFormalsList of |CoverParenthesizedExpressionAndArrowParameterList|.
-        1. Return ExpectedArgumentCount of _formals_.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-arrow-function-definitions-static-semantics-hasname">
       <h1>Static Semantics: HasName</h1>
       <emu-see-also-para op="HasName"></emu-see-also-para>
       <emu-grammar>ArrowFunction : ArrowParameters `=&gt;` ConciseBody</emu-grammar>
       <emu-alg>
         1. Return *false*.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-arrow-function-definitions-static-semantics-issimpleparameterlist">
-      <h1>Static Semantics: IsSimpleParameterList</h1>
-      <emu-see-also-para op="IsSimpleParameterList"></emu-see-also-para>
-      <emu-grammar>ArrowParameters : BindingIdentifier</emu-grammar>
-      <emu-alg>
-        1. Return *true*.
-      </emu-alg>
-      <emu-grammar>ArrowParameters : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
-      <emu-alg>
-        1. Let _formals_ be CoveredFormalsList of |CoverParenthesizedExpressionAndArrowParameterList|.
-        1. Return IsSimpleParameterList of _formals_.
       </emu-alg>
     </emu-clause>
 
@@ -20125,16 +20121,6 @@
       </emu-grammar>
       <emu-alg>
         1. Return the result of ComputedPropertyContains for |PropertyName| with argument _symbol_.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-method-definitions-static-semantics-expectedargumentcount">
-      <h1>Static Semantics: ExpectedArgumentCount</h1>
-      <emu-see-also-para op="ExpectedArgumentCount"></emu-see-also-para>
-      <emu-grammar>PropertySetParameterList : FormalParameter</emu-grammar>
-      <emu-alg>
-        1. If HasInitializer of |FormalParameter| is *true*, return 0.
-        1. Return 1.
       </emu-alg>
     </emu-clause>
 
@@ -21627,32 +21613,12 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-async-arrow-function-definitions-static-semantics-ContainsExpression">
-      <h1>Static Semantics: ContainsExpression</h1>
-      <emu-grammar>
-        AsyncArrowBindingIdentifier : BindingIdentifier
-      </emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-async-arrow-function-definitions-static-semantics-containsusestrict">
       <h1>Static Semantics: ContainsUseStrict</h1>
       <emu-see-also-para op="ContainsUseStrict"></emu-see-also-para>
       <emu-grammar>AsyncConciseBody : ExpressionBody</emu-grammar>
       <emu-alg>
         1. Return *false*.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-async-arrow-function-definitions-static-semantics-ExpectedArgumentCount">
-      <h1>Static Semantics: ExpectedArgumentCount</h1>
-      <emu-grammar>
-        AsyncArrowBindingIdentifier : BindingIdentifier
-      </emu-grammar>
-      <emu-alg>
-        1. Return 1.
       </emu-alg>
     </emu-clause>
 
@@ -21665,23 +21631,6 @@
       </emu-grammar>
       <emu-alg>
         1. Return *false*.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-async-arrow-function-definitions-static-semantics-IsSimpleParameterList">
-      <h1>Static Semantics: IsSimpleParameterList</h1>
-      <emu-grammar>
-        AsyncArrowBindingIdentifier[Yield] : BindingIdentifier[?Yield, +Await]
-      </emu-grammar>
-      <emu-alg>
-        1. Return *true*.
-      </emu-alg>
-      <emu-grammar>
-        CoverCallExpressionAndAsyncArrowHead : MemberExpression Arguments
-      </emu-grammar>
-      <emu-alg>
-        1. Let _head_ be CoveredAsyncArrowHead of |CoverCallExpressionAndAsyncArrowHead|.
-        1. Return IsSimpleParameterList of _head_.
       </emu-alg>
     </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -13345,7 +13345,7 @@
         </ul>
       </emu-clause>
 
-      <emu-clause id="sec-numericvalue">
+      <emu-clause id="sec-numericvalue" type="sdo" aoid="NumericValue">
         <h1>Static Semantics: NumericValue</h1>
         <emu-grammar>NumericLiteral :: DecimalLiteral</emu-grammar>
         <emu-alg>
@@ -13463,7 +13463,7 @@
         <p>&lt;LF&gt; and &lt;CR&gt; cannot appear in a string literal, except as part of a |LineContinuation| to produce the empty code points sequence. The proper way to include either in the String value of a string literal is to use an escape sequence such as `\\n` or `\\u000A`.</p>
       </emu-note>
 
-      <emu-clause id="sec-static-semantics-sv" oldids="sec-string-literals-static-semantics-stringvalue">
+      <emu-clause id="sec-static-semantics-sv" oldids="sec-string-literals-static-semantics-stringvalue" type="sdo" aoid="SV">
         <h1>Static Semantics: SV</h1>
         <p>A string literal stands for a value of the String type. The String value (SV) of the literal is described in terms of String values contributed by the various parts of the string literal. As part of this process, some Unicode code points within the string literal are interpreted as having a mathematical value (MV), as described below or in <emu-xref href="#sec-literals-numeric-literals"></emu-xref>.</p>
         <ul>
@@ -13749,7 +13749,7 @@
         </ul>
       </emu-clause>
 
-      <emu-clause id="sec-static-semantics-bodytext">
+      <emu-clause id="sec-static-semantics-bodytext" type="sdo" aoid="BodyText">
         <h1>Static Semantics: BodyText</h1>
         <emu-grammar>RegularExpressionLiteral :: `/` RegularExpressionBody `/` RegularExpressionFlags</emu-grammar>
         <emu-alg>
@@ -13757,7 +13757,7 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-static-semantics-flagtext">
+      <emu-clause id="sec-static-semantics-flagtext" type="sdo" aoid="FlagText">
         <h1>Static Semantics: FlagText</h1>
         <emu-grammar>RegularExpressionLiteral :: `/` RegularExpressionBody `/` RegularExpressionFlags</emu-grammar>
         <emu-alg>
@@ -14369,7 +14369,7 @@
     <emu-clause id="sec-primary-expression-semantics">
       <h1>Semantics</h1>
 
-      <emu-clause id="sec-static-semantics-coveredparenthesizedexpression">
+      <emu-clause id="sec-static-semantics-coveredparenthesizedexpression" type="sdo" aoid="CoveredParenthesizedExpression">
         <h1>Static Semantics: CoveredParenthesizedExpression</h1>
         <emu-grammar>CoverParenthesizedExpressionAndArrowParameterList : `(` Expression `)`</emu-grammar>
         <emu-alg>
@@ -14482,7 +14482,7 @@
           `...` AssignmentExpression[+In, ?Yield, ?Await]
       </emu-grammar>
 
-      <emu-clause id="sec-runtime-semantics-arrayaccumulation" oldids="sec-static-semantics-elisionwidth">
+      <emu-clause id="sec-runtime-semantics-arrayaccumulation" oldids="sec-static-semantics-elisionwidth" type="sdo" aoid="ArrayAccumulation">
         <h1>Runtime Semantics: ArrayAccumulation</h1>
         <p>With parameters _array_ and _nextIndex_.</p>
         <emu-grammar>Elision : `,`</emu-grammar>
@@ -14681,7 +14681,7 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-static-semantics-iscomputedpropertykey">
+      <emu-clause id="sec-static-semantics-iscomputedpropertykey" type="sdo" aoid="IsComputedPropertyKey">
         <h1>Static Semantics: IsComputedPropertyKey</h1>
         <emu-grammar>PropertyName : LiteralPropertyName</emu-grammar>
         <emu-alg>
@@ -14693,7 +14693,7 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-static-semantics-propertynamelist">
+      <emu-clause id="sec-static-semantics-propertynamelist" type="sdo" aoid="PropertyNameList">
         <h1>Static Semantics: PropertyNameList</h1>
         <emu-grammar>PropertyDefinitionList : PropertyDefinition</emu-grammar>
         <emu-alg>
@@ -14934,7 +14934,7 @@
         </ul>
       </emu-clause>
 
-      <emu-clause id="sec-static-semantics-templatestrings">
+      <emu-clause id="sec-static-semantics-templatestrings" type="sdo" aoid="TemplateStrings">
         <h1>Static Semantics: TemplateStrings</h1>
         <p>With parameter _raw_.</p>
         <emu-grammar>TemplateLiteral : NoSubstitutionTemplate</emu-grammar>
@@ -15031,7 +15031,7 @@
         </emu-note>
       </emu-clause>
 
-      <emu-clause id="sec-runtime-semantics-substitutionevaluation">
+      <emu-clause id="sec-runtime-semantics-substitutionevaluation" type="sdo" aoid="SubstitutionEvaluation">
         <h1>Runtime Semantics: SubstitutionEvaluation</h1>
         <emu-grammar>TemplateSpans : TemplateTail</emu-grammar>
         <emu-alg>
@@ -15291,7 +15291,7 @@
         </ul>
       </emu-clause>
 
-      <emu-clause id="sec-left-hand-side-expressions-static-semantics-coveredcallexpression">
+      <emu-clause id="sec-left-hand-side-expressions-static-semantics-coveredcallexpression" type="sdo" aoid="CoveredCallExpression">
         <h1>Static Semantics: CoveredCallExpression</h1>
         <emu-grammar>
           CoverCallExpressionAndAsyncArrowHead : MemberExpression Arguments
@@ -15712,7 +15712,7 @@
           1. Return the result of performing ChainEvaluation of |OptionalChain| with arguments _baseValue_ and _baseReference_.
         </emu-alg>
       </emu-clause>
-      <emu-clause id="sec-optional-chaining-chain-evaluation">
+      <emu-clause id="sec-optional-chaining-chain-evaluation" type="sdo" aoid="ChainEvaluation">
         <h1>Runtime Semantics: ChainEvaluation</h1>
         <p>With parameters _baseValue_ and _baseReference_.</p>
         <emu-grammar>OptionalChain : `?.` Arguments</emu-grammar>
@@ -16978,7 +16978,7 @@
         </ul>
       </emu-clause>
 
-      <emu-clause id="sec-runtime-semantics-destructuringassignmentevaluation">
+      <emu-clause id="sec-runtime-semantics-destructuringassignmentevaluation" type="sdo" aoid="DestructuringAssignmentEvaluation">
         <h1>Runtime Semantics: DestructuringAssignmentEvaluation</h1>
         <p>With parameter _value_.</p>
         <emu-grammar>ObjectAssignmentPattern : `{` `}`</emu-grammar>
@@ -17059,7 +17059,7 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-runtime-semantics-propertydestructuringassignmentevaluation">
+      <emu-clause id="sec-runtime-semantics-propertydestructuringassignmentevaluation" type="sdo" aoid="PropertyDestructuringAssignmentEvaluation">
         <h1>Runtime Semantics: PropertyDestructuringAssignmentEvaluation</h1>
         <p>With parameter _value_.</p>
 
@@ -17097,7 +17097,7 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-runtime-semantics-restdestructuringassignmentevaluation">
+      <emu-clause id="sec-runtime-semantics-restdestructuringassignmentevaluation" type="sdo" aoid="RestDestructuringAssignmentEvaluation">
         <h1>Runtime Semantics: RestDestructuringAssignmentEvaluation</h1>
         <p>With parameters _value_ and _excludedNames_.</p>
 
@@ -17111,7 +17111,7 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-runtime-semantics-iteratordestructuringassignmentevaluation">
+      <emu-clause id="sec-runtime-semantics-iteratordestructuringassignmentevaluation" type="sdo" aoid="IteratorDestructuringAssignmentEvaluation">
         <h1>Runtime Semantics: IteratorDestructuringAssignmentEvaluation</h1>
         <p>With parameter _iteratorRecord_.</p>
         <emu-grammar>AssignmentElementList : AssignmentElisionElement</emu-grammar>
@@ -17206,7 +17206,7 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-runtime-semantics-keyeddestructuringassignmentevaluation">
+      <emu-clause id="sec-runtime-semantics-keyeddestructuringassignmentevaluation" type="sdo" aoid="KeyedDestructuringAssignmentEvaluation">
         <h1>Runtime Semantics: KeyedDestructuringAssignmentEvaluation</h1>
         <p>With parameters _value_ and _propertyName_.</p>
         <emu-grammar>AssignmentElement : DestructuringAssignmentTarget Initializer?</emu-grammar>
@@ -17617,7 +17617,7 @@
           `...` BindingPattern[?Yield, ?Await]
       </emu-grammar>
 
-      <emu-clause id="sec-destructuring-binding-patterns-runtime-semantics-propertybindinginitialization">
+      <emu-clause id="sec-destructuring-binding-patterns-runtime-semantics-propertybindinginitialization" type="sdo" aoid="PropertyBindingInitialization">
         <h1>Runtime Semantics: PropertyBindingInitialization</h1>
         <p>With parameters _value_ and _environment_.</p>
 
@@ -17647,7 +17647,7 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-destructuring-binding-patterns-runtime-semantics-restbindinginitialization">
+      <emu-clause id="sec-destructuring-binding-patterns-runtime-semantics-restbindinginitialization" type="sdo" aoid="RestBindingInitialization">
         <h1>Runtime Semantics: RestBindingInitialization</h1>
         <p>With parameters _value_, _environment_, and _excludedNames_.</p>
 
@@ -17661,7 +17661,7 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-runtime-semantics-keyedbindinginitialization">
+      <emu-clause id="sec-runtime-semantics-keyedbindinginitialization" type="sdo" aoid="KeyedBindingInitialization">
         <h1>Runtime Semantics: KeyedBindingInitialization</h1>
         <p>With parameters _value_, _environment_, and _propertyName_.</p>
         <emu-note>
@@ -18138,7 +18138,7 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-runtime-semantics-bindinginstantiation">
+      <emu-clause id="sec-runtime-semantics-bindinginstantiation" type="sdo" aoid="BindingInstantiation">
         <h1>Runtime Semantics: BindingInstantiation</h1>
         <p>With parameter _environment_.</p>
         <emu-grammar>ForDeclaration : LetOrConst ForBinding</emu-grammar>
@@ -18599,7 +18599,7 @@
       </ul>
     </emu-clause>
 
-    <emu-clause id="sec-runtime-semantics-caseblockevaluation">
+    <emu-clause id="sec-runtime-semantics-caseblockevaluation" type="sdo" aoid="CaseBlockEvaluation">
       <h1>Runtime Semantics: CaseBlockEvaluation</h1>
       <p>With parameter _input_.</p>
       <emu-grammar>CaseBlock : `{` `}`</emu-grammar>
@@ -18880,7 +18880,7 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-runtime-semantics-catchclauseevaluation">
+    <emu-clause id="sec-runtime-semantics-catchclauseevaluation" type="sdo" aoid="CatchClauseEvaluation">
       <h1>Runtime Semantics: CatchClauseEvaluation</h1>
       <p>With parameter _thrownValue_.</p>
       <emu-grammar>Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
@@ -19731,7 +19731,7 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-static-semantics-coveredformalslist">
+    <emu-clause id="sec-static-semantics-coveredformalslist" type="sdo" aoid="CoveredFormalsList">
       <h1>Static Semantics: CoveredFormalsList</h1>
       <emu-grammar>ArrowParameters : BindingIdentifier</emu-grammar>
       <emu-alg>
@@ -19885,7 +19885,7 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-static-semantics-specialmethod">
+    <emu-clause id="sec-static-semantics-specialmethod" type="sdo" aoid="SpecialMethod">
       <h1>Static Semantics: SpecialMethod</h1>
       <emu-grammar>MethodDefinition : PropertyName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
@@ -19904,7 +19904,7 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-runtime-semantics-definemethod">
+    <emu-clause id="sec-runtime-semantics-definemethod" type="sdo" aoid="DefineMethod">
       <h1>Runtime Semantics: DefineMethod</h1>
       <p>With parameter _object_ and optional parameter _functionPrototype_.</p>
       <emu-grammar>MethodDefinition : PropertyName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
@@ -20516,7 +20516,7 @@
       </ul>
     </emu-clause>
 
-    <emu-clause id="sec-static-semantics-classelementkind">
+    <emu-clause id="sec-static-semantics-classelementkind" type="sdo" aoid="ClassElementKind">
       <h1>Static Semantics: ClassElementKind</h1>
       <emu-grammar>ClassElement : MethodDefinition</emu-grammar>
       <emu-alg>
@@ -20533,7 +20533,7 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-static-semantics-constructormethod">
+    <emu-clause id="sec-static-semantics-constructormethod" type="sdo" aoid="ConstructorMethod">
       <h1>Static Semantics: ConstructorMethod</h1>
       <emu-grammar>ClassElementList : ClassElement</emu-grammar>
       <emu-alg>
@@ -20586,7 +20586,7 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-static-semantics-isstatic">
+    <emu-clause id="sec-static-semantics-isstatic" type="sdo" aoid="IsStatic">
       <h1>Static Semantics: IsStatic</h1>
       <emu-grammar>ClassElement : MethodDefinition</emu-grammar>
       <emu-alg>
@@ -20602,7 +20602,7 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-static-semantics-nonconstructormethoddefinitions">
+    <emu-clause id="sec-static-semantics-nonconstructormethoddefinitions" type="sdo" aoid="NonConstructorMethodDefinitions">
       <h1>Static Semantics: NonConstructorMethodDefinitions</h1>
       <emu-grammar>ClassElementList : ClassElement</emu-grammar>
       <emu-alg>
@@ -20619,7 +20619,7 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-static-semantics-prototypepropertynamelist">
+    <emu-clause id="sec-static-semantics-prototypepropertynamelist" type="sdo" aoid="PrototypePropertyNameList">
       <h1>Static Semantics: PrototypePropertyNameList</h1>
       <emu-grammar>ClassElementList : ClassElement</emu-grammar>
       <emu-alg>
@@ -20637,7 +20637,7 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-runtime-semantics-classdefinitionevaluation">
+    <emu-clause id="sec-runtime-semantics-classdefinitionevaluation" type="sdo" aoid="ClassDefinitionEvaluation">
       <h1>Runtime Semantics: ClassDefinitionEvaluation</h1>
       <p>With parameters _classBinding_ and _className_.</p>
       <emu-grammar>ClassTail : ClassHeritage? `{` ClassBody? `}`</emu-grammar>
@@ -20699,7 +20699,7 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-runtime-semantics-bindingclassdeclarationevaluation">
+    <emu-clause id="sec-runtime-semantics-bindingclassdeclarationevaluation" type="sdo" aoid="BindingClassDeclarationEvaluation">
       <h1>Runtime Semantics: BindingClassDeclarationEvaluation</h1>
       <emu-grammar>ClassDeclaration : `class` BindingIdentifier ClassTail</emu-grammar>
       <emu-alg>
@@ -21018,7 +21018,7 @@
       </ul>
     </emu-clause>
 
-    <emu-clause id="sec-async-arrow-function-definitions-static-semantics-CoveredAsyncArrowHead">
+    <emu-clause id="sec-async-arrow-function-definitions-static-semantics-CoveredAsyncArrowHead" type="sdo" aoid="CoveredAsyncArrowHead">
       <h1>Static Semantics: CoveredAsyncArrowHead</h1>
       <emu-grammar>
         CoverCallExpressionAndAsyncArrowHead : MemberExpression Arguments
@@ -21148,7 +21148,7 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-static-semantics-hascallintailposition">
+    <emu-clause id="sec-static-semantics-hascallintailposition" type="sdo" aoid="HasCallInTailPosition">
       <h1>Static Semantics: HasCallInTailPosition</h1>
       <p>With parameter _call_.</p>
       <emu-note>
@@ -21525,7 +21525,7 @@
       </ul>
     </emu-clause>
 
-    <emu-clause id="sec-static-semantics-isstrict">
+    <emu-clause id="sec-static-semantics-isstrict" type="sdo" aoid="IsStrict">
       <h1>Static Semantics: IsStrict</h1>
       <emu-grammar>Script : ScriptBody?</emu-grammar>
       <emu-alg>
@@ -23155,7 +23155,7 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-static-semantics-importentriesformodule">
+      <emu-clause id="sec-static-semantics-importentriesformodule" type="sdo" aoid="ImportEntriesForModule">
         <h1>Static Semantics: ImportEntriesForModule</h1>
         <p>With parameter _module_.</p>
         <emu-grammar>ImportClause : ImportedDefaultBinding `,` NameSpaceImport</emu-grammar>
@@ -23465,7 +23465,7 @@
         </emu-note>
       </emu-clause>
 
-      <emu-clause id="sec-static-semantics-exportentriesformodule">
+      <emu-clause id="sec-static-semantics-exportentriesformodule" type="sdo" aoid="ExportEntriesForModule">
         <h1>Static Semantics: ExportEntriesForModule</h1>
         <p>With parameter _module_.</p>
         <emu-grammar>ExportFromClause : `*`</emu-grammar>
@@ -23514,7 +23514,7 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-static-semantics-referencedbindings">
+      <emu-clause id="sec-static-semantics-referencedbindings" type="sdo" aoid="ReferencedBindings">
         <h1>Static Semantics: ReferencedBindings</h1>
         <emu-grammar>NamedExports : `{` `}`</emu-grammar>
         <emu-alg>
@@ -25085,7 +25085,7 @@
             <p>CreateDynamicFunction defines a *"prototype"* property on any function it creates whose _kind_ is not ~async~ to provide for the possibility that the function will be used as a constructor.</p>
           </emu-note>
 
-          <emu-table id="table-dynamic-function-sourcetext-prefixes" caption="Dynamic Function SourceText Prefixes">
+          <emu-table id="table-dynamic-function-sourcetext-prefixes" caption="Dynamic Function <emu-not-ref>SourceText</emu-not-ref> Prefixes">
             <table>
               <tbody>
                 <tr><th>Kind</th><th>Prefix</th></tr>
@@ -29696,7 +29696,7 @@ THH:mm:ss.sss
         </ul>
       </emu-clause>
 
-      <emu-clause id="sec-patterns-static-semantics-capturing-group-number">
+      <emu-clause id="sec-patterns-static-semantics-capturing-group-number" type="sdo" aoid="CapturingGroupNumber">
         <h1>Static Semantics: CapturingGroupNumber</h1>
         <emu-note>
           <p>This section is amended in <emu-xref href="#sec-patterns-static-semantics-early-errors-annexb"></emu-xref>.</p>
@@ -29713,7 +29713,7 @@ THH:mm:ss.sss
         <p>The definitions of &ldquo;the MV of |NonZeroDigit|&rdquo; and &ldquo;the MV of |DecimalDigits|&rdquo; are in <emu-xref href="#sec-literals-numeric-literals"></emu-xref>.</p>
       </emu-clause>
 
-      <emu-clause id="sec-patterns-static-semantics-is-character-class">
+      <emu-clause id="sec-patterns-static-semantics-is-character-class" type="sdo" aoid="IsCharacterClass">
         <h1>Static Semantics: IsCharacterClass</h1>
         <emu-note>
           <p>This section is amended in <emu-xref href="#sec-patterns-static-semantics-is-character-class-annexb"></emu-xref>.</p>
@@ -29738,7 +29738,7 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-patterns-static-semantics-character-value">
+      <emu-clause id="sec-patterns-static-semantics-character-value" type="sdo" aoid="CharacterValue">
         <h1>Static Semantics: CharacterValue</h1>
         <emu-note>
           <p>This section is amended in <emu-xref href="#sec-patterns-static-semantics-character-value-annexb"></emu-xref>.</p>
@@ -29929,7 +29929,7 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-static-semantics-sourcetext">
+      <emu-clause id="sec-static-semantics-sourcetext" type="sdo" aoid="SourceText">
         <h1>Static Semantics: SourceText</h1>
         <emu-grammar>
           UnicodePropertyNameCharacters :: UnicodePropertyNameCharacter UnicodePropertyNameCharacters?

--- a/spec.html
+++ b/spec.html
@@ -12511,20 +12511,7 @@
         <p>&lt;LF&gt; and &lt;CR&gt; cannot appear in a string literal, except as part of a |LineContinuation| to produce the empty code points sequence. The proper way to include either in the String value of a string literal is to use an escape sequence such as `\\n` or `\\u000A`.</p>
       </emu-note>
 
-      <emu-clause id="sec-string-literals-static-semantics-stringvalue">
-        <h1>Static Semantics: StringValue</h1>
-        <emu-see-also-para op="StringValue"></emu-see-also-para>
-        <emu-grammar>
-          StringLiteral ::
-            `"` DoubleStringCharacters? `"`
-            `'` SingleStringCharacters? `'`
-        </emu-grammar>
-        <emu-alg>
-          1. Return the SV of this |StringLiteral|.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-static-semantics-sv">
+      <emu-clause id="sec-static-semantics-sv" oldids="sec-string-literals-static-semantics-stringvalue">
         <h1>Static Semantics: SV</h1>
         <p>A string literal stands for a value of the String type. The String value (SV) of the literal is described in terms of String values contributed by the various parts of the string literal. As part of this process, some Unicode code points within the string literal are interpreted as having a mathematical value (MV), as described below or in <emu-xref href="#sec-literals-numeric-literals"></emu-xref>.</p>
         <ul>
@@ -13617,7 +13604,7 @@
         </emu-alg>
         <emu-grammar>Literal : StringLiteral</emu-grammar>
         <emu-alg>
-          1. Return the StringValue of |StringLiteral| as defined in <emu-xref href="#sec-string-literals-static-semantics-stringvalue"></emu-xref>.
+          1. Return the SV of |StringLiteral| as defined in <emu-xref href="#sec-static-semantics-sv"></emu-xref>.
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -23955,7 +23942,7 @@
         </emu-alg>
         <emu-grammar>ModuleSpecifier : StringLiteral</emu-grammar>
         <emu-alg>
-          1. Return a List whose sole element is the StringValue of |StringLiteral|.
+          1. Return a List whose sole element is the SV of |StringLiteral|.
         </emu-alg>
       </emu-clause>
     </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -12744,11 +12744,9 @@
           1. Return ? ToPropertyKey(_propName_).
         </emu-alg>
       </emu-clause>
-
-      <emu-clause id="sec-object-initializer-runtime-semantics-propertydefinitionevaluation">
+      <emu-clause id="sec-runtime-semantics-propertydefinitionevaluation" oldids="sec-object-initializer-runtime-semantics-propertydefinitionevaluation,sec-method-definitions-runtime-semantics-propertydefinitionevaluation,sec-generator-function-definitions-runtime-semantics-propertydefinitionevaluation,sec-asyncgenerator-definitions-propertydefinitionevaluation,sec-async-function-definitions-PropertyDefinitionEvaluation" type="sdo" aoid="PropertyDefinitionEvaluation">
         <h1>Runtime Semantics: PropertyDefinitionEvaluation</h1>
         <p>With parameters _object_ and _enumerable_.</p>
-        <emu-see-also-para op="PropertyDefinitionEvaluation"></emu-see-also-para>
         <emu-grammar>PropertyDefinitionList : PropertyDefinitionList `,` PropertyDefinition</emu-grammar>
         <emu-alg>
           1. Perform ? PropertyDefinitionEvaluation of |PropertyDefinitionList| with arguments _object_ and _enumerable_.
@@ -12786,6 +12784,82 @@
         <emu-note>
           <p>An alternative semantics for this production is given in <emu-xref href="#sec-__proto__-property-names-in-object-initializers"></emu-xref>.</p>
         </emu-note>
+        <emu-grammar>MethodDefinition : PropertyName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
+        <emu-alg>
+          1. Let _methodDef_ be ? DefineMethod of |MethodDefinition| with argument _object_.
+          1. Perform SetFunctionName(_methodDef_.[[Closure]], _methodDef_.[[Key]]).
+          1. Let _desc_ be the PropertyDescriptor { [[Value]]: _methodDef_.[[Closure]], [[Writable]]: *true*, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
+          1. Return ? DefinePropertyOrThrow(_object_, _methodDef_.[[Key]], _desc_).
+        </emu-alg>
+        <emu-grammar>MethodDefinition : `get` PropertyName `(` `)` `{` FunctionBody `}`</emu-grammar>
+        <emu-alg>
+          1. Let _propKey_ be the result of evaluating |PropertyName|.
+          1. ReturnIfAbrupt(_propKey_).
+          1. Let _scope_ be the running execution context's LexicalEnvironment.
+          1. Let _sourceText_ be the source text matched by |MethodDefinition|.
+          1. Let _formalParameterList_ be an instance of the production <emu-grammar>FormalParameters : [empty]</emu-grammar>.
+          1. Let _closure_ be OrdinaryFunctionCreate(%Function.prototype%, _sourceText_, _formalParameterList_, |FunctionBody|, ~non-lexical-this~, _scope_).
+          1. Perform MakeMethod(_closure_, _object_).
+          1. Perform SetFunctionName(_closure_, _propKey_, *"get"*).
+          1. Let _desc_ be the PropertyDescriptor { [[Get]]: _closure_, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
+          1. Return ? DefinePropertyOrThrow(_object_, _propKey_, _desc_).
+        </emu-alg>
+        <emu-grammar>MethodDefinition : `set` PropertyName `(` PropertySetParameterList `)` `{` FunctionBody `}`</emu-grammar>
+        <emu-alg>
+          1. Let _propKey_ be the result of evaluating |PropertyName|.
+          1. ReturnIfAbrupt(_propKey_).
+          1. Let _scope_ be the running execution context's LexicalEnvironment.
+          1. Let _sourceText_ be the source text matched by |MethodDefinition|.
+          1. Let _closure_ be OrdinaryFunctionCreate(%Function.prototype%, _sourceText_, |PropertySetParameterList|, |FunctionBody|, ~non-lexical-this~, _scope_).
+          1. Perform MakeMethod(_closure_, _object_).
+          1. Perform SetFunctionName(_closure_, _propKey_, *"set"*).
+          1. Let _desc_ be the PropertyDescriptor { [[Set]]: _closure_, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
+          1. Return ? DefinePropertyOrThrow(_object_, _propKey_, _desc_).
+        </emu-alg>
+        <emu-grammar>GeneratorMethod : `*` PropertyName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
+        <emu-alg>
+          1. Let _propKey_ be the result of evaluating |PropertyName|.
+          1. ReturnIfAbrupt(_propKey_).
+          1. Let _scope_ be the running execution context's LexicalEnvironment.
+          1. Let _sourceText_ be the source text matched by |GeneratorMethod|.
+          1. Let _closure_ be OrdinaryFunctionCreate(%GeneratorFunction.prototype%, _sourceText_, |UniqueFormalParameters|, |GeneratorBody|, ~non-lexical-this~, _scope_).
+          1. Perform MakeMethod(_closure_, _object_).
+          1. Perform SetFunctionName(_closure_, _propKey_).
+          1. Let _prototype_ be ! OrdinaryObjectCreate(%GeneratorFunction.prototype.prototype%).
+          1. Perform DefinePropertyOrThrow(_closure_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
+          1. Let _desc_ be the PropertyDescriptor { [[Value]]: _closure_, [[Writable]]: *true*, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
+          1. Return ? DefinePropertyOrThrow(_object_, _propKey_, _desc_).
+        </emu-alg>
+        <emu-grammar>
+          AsyncGeneratorMethod : `async` `*` PropertyName `(` UniqueFormalParameters `)` `{` AsyncGeneratorBody `}`
+        </emu-grammar>
+        <emu-alg>
+          1. Let _propKey_ be the result of evaluating |PropertyName|.
+          1. ReturnIfAbrupt(_propKey_).
+          1. Let _scope_ be the running execution context's LexicalEnvironment.
+          1. Let _sourceText_ be the source text matched by |AsyncGeneratorMethod|.
+          1. Let _closure_ be ! OrdinaryFunctionCreate(%AsyncGeneratorFunction.prototype%, _sourceText_, |UniqueFormalParameters|, |AsyncGeneratorBody|, ~non-lexical-this~, _scope_).
+          1. Perform ! MakeMethod(_closure_, _object_).
+          1. Perform ! SetFunctionName(_closure_, _propKey_).
+          1. Let _prototype_ be ! OrdinaryObjectCreate(%AsyncGeneratorFunction.prototype.prototype%).
+          1. Perform ! DefinePropertyOrThrow(_closure_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
+          1. Let _desc_ be PropertyDescriptor { [[Value]]: _closure_, [[Writable]]: *true*, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
+          1. Return ? DefinePropertyOrThrow(_object_, _propKey_, _desc_).
+        </emu-alg>
+        <emu-grammar>
+          AsyncMethod : `async` PropertyName `(` UniqueFormalParameters `)` `{` AsyncFunctionBody `}`
+        </emu-grammar>
+        <emu-alg>
+          1. Let _propKey_ be the result of evaluating |PropertyName|.
+          1. ReturnIfAbrupt(_propKey_).
+          1. Let _scope_ be the LexicalEnvironment of the running execution context.
+          1. Let _sourceText_ be the source text matched by |AsyncMethod|.
+          1. Let _closure_ be ! OrdinaryFunctionCreate(%AsyncFunction.prototype%, _sourceText_, |UniqueFormalParameters|, |AsyncFunctionBody|, ~non-lexical-this~, _scope_).
+          1. Perform ! MakeMethod(_closure_, _object_).
+          1. Perform ! SetFunctionName(_closure_, _propKey_).
+          1. Let _desc_ be the PropertyDescriptor { [[Value]]: _closure_, [[Writable]]: *true*, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
+          1. Return ? DefinePropertyOrThrow(_object_, _propKey_, _desc_).
+        </emu-alg>
       </emu-clause>
     </emu-clause>
 
@@ -20191,44 +20265,6 @@
         1. Return the Record { [[Key]]: _propKey_, [[Closure]]: _closure_ }.
       </emu-alg>
     </emu-clause>
-
-    <emu-clause id="sec-method-definitions-runtime-semantics-propertydefinitionevaluation">
-      <h1>Runtime Semantics: PropertyDefinitionEvaluation</h1>
-      <p>With parameters _object_ and _enumerable_.</p>
-      <emu-see-also-para op="PropertyDefinitionEvaluation"></emu-see-also-para>
-      <emu-grammar>MethodDefinition : PropertyName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
-      <emu-alg>
-        1. Let _methodDef_ be ? DefineMethod of |MethodDefinition| with argument _object_.
-        1. Perform SetFunctionName(_methodDef_.[[Closure]], _methodDef_.[[Key]]).
-        1. Let _desc_ be the PropertyDescriptor { [[Value]]: _methodDef_.[[Closure]], [[Writable]]: *true*, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
-        1. Return ? DefinePropertyOrThrow(_object_, _methodDef_.[[Key]], _desc_).
-      </emu-alg>
-      <emu-grammar>MethodDefinition : `get` PropertyName `(` `)` `{` FunctionBody `}`</emu-grammar>
-      <emu-alg>
-        1. Let _propKey_ be the result of evaluating |PropertyName|.
-        1. ReturnIfAbrupt(_propKey_).
-        1. Let _scope_ be the running execution context's LexicalEnvironment.
-        1. Let _sourceText_ be the source text matched by |MethodDefinition|.
-        1. Let _formalParameterList_ be an instance of the production <emu-grammar>FormalParameters : [empty]</emu-grammar>.
-        1. Let _closure_ be OrdinaryFunctionCreate(%Function.prototype%, _sourceText_, _formalParameterList_, |FunctionBody|, ~non-lexical-this~, _scope_).
-        1. Perform MakeMethod(_closure_, _object_).
-        1. Perform SetFunctionName(_closure_, _propKey_, *"get"*).
-        1. Let _desc_ be the PropertyDescriptor { [[Get]]: _closure_, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
-        1. Return ? DefinePropertyOrThrow(_object_, _propKey_, _desc_).
-      </emu-alg>
-      <emu-grammar>MethodDefinition : `set` PropertyName `(` PropertySetParameterList `)` `{` FunctionBody `}`</emu-grammar>
-      <emu-alg>
-        1. Let _propKey_ be the result of evaluating |PropertyName|.
-        1. ReturnIfAbrupt(_propKey_).
-        1. Let _scope_ be the running execution context's LexicalEnvironment.
-        1. Let _sourceText_ be the source text matched by |MethodDefinition|.
-        1. Let _closure_ be OrdinaryFunctionCreate(%Function.prototype%, _sourceText_, |PropertySetParameterList|, |FunctionBody|, ~non-lexical-this~, _scope_).
-        1. Perform MakeMethod(_closure_, _object_).
-        1. Perform SetFunctionName(_closure_, _propKey_, *"set"*).
-        1. Let _desc_ be the PropertyDescriptor { [[Set]]: _closure_, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
-        1. Return ? DefinePropertyOrThrow(_object_, _propKey_, _desc_).
-      </emu-alg>
-    </emu-clause>
   </emu-clause>
 
   <emu-clause id="sec-generator-function-definitions">
@@ -20457,26 +20493,6 @@
       <emu-note>
         <p>An anonymous |GeneratorDeclaration| can only occur as part of an `export default` declaration, and its function code is therefore always strict mode code.</p>
       </emu-note>
-    </emu-clause>
-
-    <emu-clause id="sec-generator-function-definitions-runtime-semantics-propertydefinitionevaluation">
-      <h1>Runtime Semantics: PropertyDefinitionEvaluation</h1>
-      <p>With parameters _object_ and _enumerable_.</p>
-      <emu-see-also-para op="PropertyDefinitionEvaluation"></emu-see-also-para>
-      <emu-grammar>GeneratorMethod : `*` PropertyName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
-      <emu-alg>
-        1. Let _propKey_ be the result of evaluating |PropertyName|.
-        1. ReturnIfAbrupt(_propKey_).
-        1. Let _scope_ be the running execution context's LexicalEnvironment.
-        1. Let _sourceText_ be the source text matched by |GeneratorMethod|.
-        1. Let _closure_ be OrdinaryFunctionCreate(%GeneratorFunction.prototype%, _sourceText_, |UniqueFormalParameters|, |GeneratorBody|, ~non-lexical-this~, _scope_).
-        1. Perform MakeMethod(_closure_, _object_).
-        1. Perform SetFunctionName(_closure_, _propKey_).
-        1. Let _prototype_ be ! OrdinaryObjectCreate(%GeneratorFunction.prototype.prototype%).
-        1. Perform DefinePropertyOrThrow(_closure_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
-        1. Let _desc_ be the PropertyDescriptor { [[Value]]: _closure_, [[Writable]]: *true*, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
-        1. Return ? DefinePropertyOrThrow(_object_, _propKey_, _desc_).
-      </emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-generator-function-definitions-runtime-semantics-namedevaluation">
@@ -20782,27 +20798,6 @@
       <emu-note>
         <p>An anonymous |AsyncGeneratorDeclaration| can only occur as part of an `export default` declaration.</p>
       </emu-note>
-    </emu-clause>
-
-    <emu-clause id="sec-asyncgenerator-definitions-propertydefinitionevaluation">
-      <h1>Runtime Semantics: PropertyDefinitionEvaluation</h1>
-      <p>With parameter _object_ and _enumerable_.</p>
-      <emu-grammar>
-        AsyncGeneratorMethod : `async` `*` PropertyName `(` UniqueFormalParameters `)` `{` AsyncGeneratorBody `}`
-      </emu-grammar>
-      <emu-alg>
-        1. Let _propKey_ be the result of evaluating |PropertyName|.
-        1. ReturnIfAbrupt(_propKey_).
-        1. Let _scope_ be the running execution context's LexicalEnvironment.
-        1. Let _sourceText_ be the source text matched by |AsyncGeneratorMethod|.
-        1. Let _closure_ be ! OrdinaryFunctionCreate(%AsyncGeneratorFunction.prototype%, _sourceText_, |UniqueFormalParameters|, |AsyncGeneratorBody|, ~non-lexical-this~, _scope_).
-        1. Perform ! MakeMethod(_closure_, _object_).
-        1. Perform ! SetFunctionName(_closure_, _propKey_).
-        1. Let _prototype_ be ! OrdinaryObjectCreate(%AsyncGeneratorFunction.prototype.prototype%).
-        1. Perform ! DefinePropertyOrThrow(_closure_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
-        1. Let _desc_ be PropertyDescriptor { [[Value]]: _closure_, [[Writable]]: *true*, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
-        1. Return ? DefinePropertyOrThrow(_object_, _propKey_, _desc_).
-      </emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-asyncgenerator-definitions-namedevaluation">
@@ -21445,25 +21440,6 @@
         1. Else,
           1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _declResult_.[[Value]] &raquo;).
         1. Return Completion { [[Type]]: ~return~, [[Value]]: _promiseCapability_.[[Promise]], [[Target]]: ~empty~ }.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-async-function-definitions-PropertyDefinitionEvaluation">
-      <h1>Runtime Semantics: PropertyDefinitionEvaluation</h1>
-      <p>With parameters _object_ and _enumerable_.</p>
-      <emu-grammar>
-        AsyncMethod : `async` PropertyName `(` UniqueFormalParameters `)` `{` AsyncFunctionBody `}`
-      </emu-grammar>
-      <emu-alg>
-        1. Let _propKey_ be the result of evaluating |PropertyName|.
-        1. ReturnIfAbrupt(_propKey_).
-        1. Let _scope_ be the LexicalEnvironment of the running execution context.
-        1. Let _sourceText_ be the source text matched by |AsyncMethod|.
-        1. Let _closure_ be ! OrdinaryFunctionCreate(%AsyncFunction.prototype%, _sourceText_, |UniqueFormalParameters|, |AsyncFunctionBody|, ~non-lexical-this~, _scope_).
-        1. Perform ! MakeMethod(_closure_, _object_).
-        1. Perform ! SetFunctionName(_closure_, _propKey_).
-        1. Let _desc_ be the PropertyDescriptor { [[Value]]: _closure_, [[Writable]]: *true*, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
-        1. Return ? DefinePropertyOrThrow(_object_, _propKey_, _desc_).
       </emu-alg>
     </emu-clause>
 
@@ -42635,7 +42611,7 @@ THH:mm:ss.sss
       <emu-note>
         <p>The List returned by PropertyNameList does not include string literal property names defined as using a |ComputedPropertyName|.</p>
       </emu-note>
-      <p>In <emu-xref href="#sec-object-initializer-runtime-semantics-propertydefinitionevaluation"></emu-xref> the PropertyDefinitionEvaluation algorithm for the production
+      <p>In <emu-xref href="#sec-runtime-semantics-propertydefinitionevaluation"></emu-xref> the PropertyDefinitionEvaluation algorithm for the production
         <br>
         <emu-grammar>PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar>
         <br>
@@ -43173,7 +43149,7 @@ THH:mm:ss.sss
   <p><emu-xref href="#sec-try-statement"></emu-xref>: In ECMAScript 2015, it is an early error for a |Catch| clause to contain a `var` declaration for the same |Identifier| that appears as the |Catch| clause parameter. In previous editions, such a variable declaration would be instantiated in the enclosing variable environment but the declaration's |Initializer| value would be assigned to the |Catch| parameter.</p>
   <p><emu-xref href="#sec-try-statement"></emu-xref>, <emu-xref href="#sec-evaldeclarationinstantiation"></emu-xref>: In ECMAScript 2015, a runtime *SyntaxError* is thrown if a |Catch| clause evaluates a non-strict direct `eval` whose eval code includes a `var` or `FunctionDeclaration` declaration that binds the same |Identifier| that appears as the |Catch| clause parameter.</p>
   <p><emu-xref href="#sec-try-statement-runtime-semantics-evaluation"></emu-xref>: In ECMAScript 2015, the completion value of a |TryStatement| is never the value ~empty~. If the |Block| part of a |TryStatement| evaluates to a normal completion whose value is ~empty~, the completion value of the |TryStatement| is *undefined*. If the |Block| part of a |TryStatement| evaluates to a throw completion and it has a |Catch| part that evaluates to a normal completion whose value is ~empty~, the completion value of the |TryStatement| is *undefined* if there is no |Finally| clause or if its |Finally| clause evaluates to an ~empty~ normal completion.</p>
-  <p><emu-xref href="#sec-method-definitions-runtime-semantics-propertydefinitionevaluation"></emu-xref> In ECMAScript 2015, the function objects that are created as the values of the [[Get]] or [[Set]] attribute of accessor properties in an |ObjectLiteral| are not constructor functions and they do not have a *"prototype"* own property. In the previous edition, they were constructors and had a *"prototype"* property.</p>
+  <p><emu-xref href="#sec-runtime-semantics-propertydefinitionevaluation"></emu-xref> In ECMAScript 2015, the function objects that are created as the values of the [[Get]] or [[Set]] attribute of accessor properties in an |ObjectLiteral| are not constructor functions and they do not have a *"prototype"* own property. In the previous edition, they were constructors and had a *"prototype"* property.</p>
   <p><emu-xref href="#sec-object.freeze"></emu-xref>: In ECMAScript 2015, if the argument to `Object.freeze` is not an object it is treated as if it was a non-extensible ordinary object with no own properties. In the previous edition, a non-object argument always causes a *TypeError* to be thrown.</p>
   <p><emu-xref href="#sec-object.getownpropertydescriptor"></emu-xref>: In ECMAScript 2015, if the argument to `Object.getOwnPropertyDescriptor` is not an object an attempt is made to coerce the argument using ToObject. If the coercion is successful the result is used in place of the original argument value. In the previous edition, a non-object argument always causes a *TypeError* to be thrown.</p>
   <p><emu-xref href="#sec-object.getownpropertynames"></emu-xref>: In ECMAScript 2015, if the argument to `Object.getOwnPropertyNames` is not an object an attempt is made to coerce the argument using ToObject. If the coercion is successful the result is used in place of the original argument value. In the previous edition, a non-object argument always causes a *TypeError* to be thrown.</p>

--- a/spec.html
+++ b/spec.html
@@ -21782,29 +21782,6 @@
         </emu-note>
       </emu-clause>
 
-      <emu-clause id="sec-module-semantics-static-semantics-exportentries">
-        <h1>Static Semantics: ExportEntries</h1>
-        <emu-see-also-para op="ExportEntries"></emu-see-also-para>
-        <emu-grammar>Module : [empty]</emu-grammar>
-        <emu-alg>
-          1. Return a new empty List.
-        </emu-alg>
-        <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
-        <emu-alg>
-          1. Let _entries_ be ExportEntries of |ModuleItemList|.
-          1. Append to _entries_ the elements of the ExportEntries of |ModuleItem|.
-          1. Return _entries_.
-        </emu-alg>
-        <emu-grammar>
-          ModuleItem :
-            ImportDeclaration
-            StatementListItem
-        </emu-grammar>
-        <emu-alg>
-          1. Return a new empty List.
-        </emu-alg>
-      </emu-clause>
-
       <emu-clause id="sec-module-semantics-static-semantics-importentries">
         <h1>Static Semantics: ImportEntries</h1>
         <emu-see-also-para op="ImportEntries"></emu-see-also-para>
@@ -23415,9 +23392,26 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-exports-static-semantics-exportentries">
+      <emu-clause id="sec-static-semantics-exportentries" oldids="sec-module-semantics-static-semantics-exportentries,sec-exports-static-semantics-exportentries" type="sdo" aoid="ExportEntries">
         <h1>Static Semantics: ExportEntries</h1>
-        <emu-see-also-para op="ExportEntries"></emu-see-also-para>
+        <emu-grammar>Module : [empty]</emu-grammar>
+        <emu-alg>
+          1. Return a new empty List.
+        </emu-alg>
+        <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
+        <emu-alg>
+          1. Let _entries_ be ExportEntries of |ModuleItemList|.
+          1. Append to _entries_ the elements of the ExportEntries of |ModuleItem|.
+          1. Return _entries_.
+        </emu-alg>
+        <emu-grammar>
+          ModuleItem :
+            ImportDeclaration
+            StatementListItem
+        </emu-grammar>
+        <emu-alg>
+          1. Return a new empty List.
+        </emu-alg>
         <emu-grammar>ExportDeclaration : `export` ExportFromClause FromClause `;`</emu-grammar>
         <emu-alg>
           1. Let _module_ be the sole element of ModuleRequests of |FromClause|.

--- a/spec.html
+++ b/spec.html
@@ -7746,12 +7746,6 @@
         1. Return AssignmentTargetType of _expr_.
       </emu-alg>
       <emu-grammar>
-        ParenthesizedExpression : `(` Expression `)`
-      </emu-grammar>
-      <emu-alg>
-        1. Return AssignmentTargetType of |Expression|.
-      </emu-alg>
-      <emu-grammar>
         PrimaryExpression :
           `this`
           Literal

--- a/spec.html
+++ b/spec.html
@@ -15911,33 +15911,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-statement-semantics-runtime-semantics-labelledevaluation">
-      <h1>Runtime Semantics: LabelledEvaluation</h1>
-      <p>With parameter _labelSet_.</p>
-      <emu-see-also-para op="LabelledEvaluation"></emu-see-also-para>
-      <emu-grammar>BreakableStatement : IterationStatement</emu-grammar>
-      <emu-alg>
-        1. Let _stmtResult_ be LabelledEvaluation of |IterationStatement| with argument _labelSet_.
-        1. If _stmtResult_.[[Type]] is ~break~, then
-          1. If _stmtResult_.[[Target]] is ~empty~, then
-            1. If _stmtResult_.[[Value]] is ~empty~, set _stmtResult_ to NormalCompletion(*undefined*).
-            1. Else, set _stmtResult_ to NormalCompletion(_stmtResult_.[[Value]]).
-        1. Return Completion(_stmtResult_).
-      </emu-alg>
-      <emu-grammar>BreakableStatement : SwitchStatement</emu-grammar>
-      <emu-alg>
-        1. Let _stmtResult_ be the result of evaluating |SwitchStatement|.
-        1. If _stmtResult_.[[Type]] is ~break~, then
-          1. If _stmtResult_.[[Target]] is ~empty~, then
-            1. If _stmtResult_.[[Value]] is ~empty~, set _stmtResult_ to NormalCompletion(*undefined*).
-            1. Else, set _stmtResult_ to NormalCompletion(_stmtResult_.[[Value]]).
-        1. Return Completion(_stmtResult_).
-      </emu-alg>
-      <emu-note>
-        <p>A |BreakableStatement| is one that can be exited via an unlabelled |BreakStatement|.</p>
-      </emu-note>
-    </emu-clause>
-
     <emu-clause id="sec-statement-semantics-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>
@@ -17312,23 +17285,6 @@
           1. Return the VarScopedDeclarations of |Statement|.
         </emu-alg>
       </emu-clause>
-
-      <emu-clause id="sec-do-while-statement-runtime-semantics-labelledevaluation">
-        <h1>Runtime Semantics: LabelledEvaluation</h1>
-        <p>With parameter _labelSet_.</p>
-        <emu-see-also-para op="LabelledEvaluation"></emu-see-also-para>
-        <emu-grammar>IterationStatement : `do` Statement `while` `(` Expression `)` `;`</emu-grammar>
-        <emu-alg>
-          1. Let _V_ be *undefined*.
-          1. Repeat,
-            1. Let _stmtResult_ be the result of evaluating |Statement|.
-            1. If LoopContinues(_stmtResult_, _labelSet_) is *false*, return Completion(UpdateEmpty(_stmtResult_, _V_)).
-            1. If _stmtResult_.[[Value]] is not ~empty~, set _V_ to _stmtResult_.[[Value]].
-            1. Let _exprRef_ be the result of evaluating |Expression|.
-            1. Let _exprValue_ be ? GetValue(_exprRef_).
-            1. If ! ToBoolean(_exprValue_) is *false*, return NormalCompletion(_V_).
-        </emu-alg>
-      </emu-clause>
     </emu-clause>
 
     <emu-clause id="sec-while-statement">
@@ -17379,23 +17335,6 @@
         <emu-grammar>IterationStatement : `while` `(` Expression `)` Statement</emu-grammar>
         <emu-alg>
           1. Return the VarScopedDeclarations of |Statement|.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-while-statement-runtime-semantics-labelledevaluation">
-        <h1>Runtime Semantics: LabelledEvaluation</h1>
-        <p>With parameter _labelSet_.</p>
-        <emu-see-also-para op="LabelledEvaluation"></emu-see-also-para>
-        <emu-grammar>IterationStatement : `while` `(` Expression `)` Statement</emu-grammar>
-        <emu-alg>
-          1. Let _V_ be *undefined*.
-          1. Repeat,
-            1. Let _exprRef_ be the result of evaluating |Expression|.
-            1. Let _exprValue_ be ? GetValue(_exprRef_).
-            1. If ! ToBoolean(_exprValue_) is *false*, return NormalCompletion(_V_).
-            1. Let _stmtResult_ be the result of evaluating |Statement|.
-            1. If LoopContinues(_stmtResult_, _labelSet_) is *false*, return Completion(UpdateEmpty(_stmtResult_, _V_)).
-            1. If _stmtResult_.[[Value]] is not ~empty~, set _V_ to _stmtResult_.[[Value]].
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -17493,46 +17432,6 @@
         <emu-grammar>IterationStatement : `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement</emu-grammar>
         <emu-alg>
           1. Return the VarScopedDeclarations of |Statement|.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-for-statement-runtime-semantics-labelledevaluation">
-        <h1>Runtime Semantics: LabelledEvaluation</h1>
-        <p>With parameter _labelSet_.</p>
-        <emu-see-also-para op="LabelledEvaluation"></emu-see-also-para>
-        <emu-grammar>IterationStatement : `for` `(` Expression? `;` Expression? `;` Expression? `)` Statement</emu-grammar>
-        <emu-alg>
-          1. If the first |Expression| is present, then
-            1. Let _exprRef_ be the result of evaluating the first |Expression|.
-            1. Perform ? GetValue(_exprRef_).
-          1. Return ? ForBodyEvaluation(the second |Expression|, the third |Expression|, |Statement|, &laquo; &raquo;, _labelSet_).
-        </emu-alg>
-        <emu-grammar>IterationStatement : `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement</emu-grammar>
-        <emu-alg>
-          1. Let _varDcl_ be the result of evaluating |VariableDeclarationList|.
-          1. ReturnIfAbrupt(_varDcl_).
-          1. Return ? ForBodyEvaluation(the first |Expression|, the second |Expression|, |Statement|, &laquo; &raquo;, _labelSet_).
-        </emu-alg>
-        <emu-grammar>IterationStatement : `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement</emu-grammar>
-        <emu-alg>
-          1. Let _oldEnv_ be the running execution context's LexicalEnvironment.
-          1. Let _loopEnv_ be NewDeclarativeEnvironment(_oldEnv_).
-          1. Let _isConst_ be IsConstantDeclaration of |LexicalDeclaration|.
-          1. Let _boundNames_ be the BoundNames of |LexicalDeclaration|.
-          1. For each element _dn_ of _boundNames_, do
-            1. If _isConst_ is *true*, then
-              1. Perform ! _loopEnv_.CreateImmutableBinding(_dn_, *true*).
-            1. Else,
-              1. Perform ! _loopEnv_.CreateMutableBinding(_dn_, *false*).
-          1. Set the running execution context's LexicalEnvironment to _loopEnv_.
-          1. Let _forDcl_ be the result of evaluating |LexicalDeclaration|.
-          1. If _forDcl_ is an abrupt completion, then
-            1. Set the running execution context's LexicalEnvironment to _oldEnv_.
-            1. Return Completion(_forDcl_).
-          1. If _isConst_ is *false*, let _perIterationLets_ be _boundNames_; otherwise let _perIterationLets_ be &laquo; &raquo;.
-          1. Let _bodyResult_ be ForBodyEvaluation(the first |Expression|, the second |Expression|, |Statement|, _perIterationLets_, _labelSet_).
-          1. Set the running execution context's LexicalEnvironment to _oldEnv_.
-          1. Return Completion(_bodyResult_).
         </emu-alg>
       </emu-clause>
 
@@ -17808,66 +17707,6 @@
             1. Else,
               1. Perform ! _environment_.CreateMutableBinding(_name_, *false*).
         </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation">
-        <h1>Runtime Semantics: LabelledEvaluation</h1>
-        <p>With parameter _labelSet_.</p>
-        <emu-see-also-para op="LabelledEvaluation"></emu-see-also-para>
-        <emu-grammar>IterationStatement : `for` `(` LeftHandSideExpression `in` Expression `)` Statement</emu-grammar>
-        <emu-alg>
-          1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(&laquo; &raquo;, |Expression|, ~enumerate~).
-          1. Return ? ForIn/OfBodyEvaluation(|LeftHandSideExpression|, |Statement|, _keyResult_, ~enumerate~, ~assignment~, _labelSet_).
-        </emu-alg>
-        <emu-grammar>IterationStatement : `for` `(` `var` ForBinding `in` Expression `)` Statement</emu-grammar>
-        <emu-alg>
-          1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(&laquo; &raquo;, |Expression|, ~enumerate~).
-          1. Return ? ForIn/OfBodyEvaluation(|ForBinding|, |Statement|, _keyResult_, ~enumerate~, ~varBinding~, _labelSet_).
-        </emu-alg>
-        <emu-grammar>IterationStatement : `for` `(` ForDeclaration `in` Expression `)` Statement</emu-grammar>
-        <emu-alg>
-          1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(BoundNames of |ForDeclaration|, |Expression|, ~enumerate~).
-          1. Return ? ForIn/OfBodyEvaluation(|ForDeclaration|, |Statement|, _keyResult_, ~enumerate~, ~lexicalBinding~, _labelSet_).
-        </emu-alg>
-        <emu-grammar>IterationStatement : `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement</emu-grammar>
-        <emu-alg>
-          1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(&laquo; &raquo;, |AssignmentExpression|, ~iterate~).
-          1. Return ? ForIn/OfBodyEvaluation(|LeftHandSideExpression|, |Statement|, _keyResult_, ~iterate~, ~assignment~, _labelSet_).
-        </emu-alg>
-        <emu-grammar>IterationStatement : `for` `(` `var` ForBinding `of` AssignmentExpression `)` Statement</emu-grammar>
-        <emu-alg>
-          1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(&laquo; &raquo;, |AssignmentExpression|, ~iterate~).
-          1. Return ? ForIn/OfBodyEvaluation(|ForBinding|, |Statement|, _keyResult_, ~iterate~, ~varBinding~, _labelSet_).
-        </emu-alg>
-        <emu-grammar>IterationStatement : `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement</emu-grammar>
-        <emu-alg>
-          1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(BoundNames of |ForDeclaration|, |AssignmentExpression|, ~iterate~).
-          1. Return ? ForIn/OfBodyEvaluation(|ForDeclaration|, |Statement|, _keyResult_, ~iterate~, ~lexicalBinding~, _labelSet_).
-        </emu-alg>
-        <emu-grammar>
-          IterationStatement : `for` `await` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
-        </emu-grammar>
-        <emu-alg>
-          1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(&laquo; &raquo;, |AssignmentExpression|, ~async-iterate~).
-          1. Return ? ForIn/OfBodyEvaluation(|LeftHandSideExpression|, |Statement|, _keyResult_, ~iterate~, ~assignment~, _labelSet_, ~async~).
-        </emu-alg>
-        <emu-grammar>
-          IterationStatement : `for` `await` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
-        </emu-grammar>
-        <emu-alg>
-          1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(&laquo; &raquo;, |AssignmentExpression|, ~async-iterate~).
-          1. Return ? ForIn/OfBodyEvaluation(|ForBinding|, |Statement|, _keyResult_, ~iterate~, ~varBinding~, _labelSet_, ~async~).
-        </emu-alg>
-        <emu-grammar>
-          IterationStatement : `for` `await` `(` ForDeclaration `of` AssignmentExpression `)` Statement
-        </emu-grammar>
-        <emu-alg>
-          1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(BoundNames of |ForDeclaration|, |AssignmentExpression|, ~async-iterate~).
-          1. Return ? ForIn/OfBodyEvaluation(|ForDeclaration|, |Statement|, _keyResult_, ~iterate~, ~lexicalBinding~, _labelSet_, ~async~).
-        </emu-alg>
-        <emu-note>
-          <p>This section is extended by Annex <emu-xref href="#sec-initializers-in-forin-statement-heads"></emu-xref>.</p>
-        </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-runtime-semantics-forinofheadevaluation" oldids="sec-runtime-semantics-forin-div-ofheadevaluation-tdznames-expr-iterationkind" aoid="ForIn/OfHeadEvaluation">
@@ -18970,10 +18809,149 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-labelled-statements-runtime-semantics-labelledevaluation">
+    <emu-clause id="sec-labelled-statements-runtime-semantics-evaluation">
+      <h1>Runtime Semantics: Evaluation</h1>
+      <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
+      <emu-alg>
+        1. Let _newLabelSet_ be a new empty List.
+        1. Return LabelledEvaluation of this |LabelledStatement| with argument _newLabelSet_.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-runtime-semantics-labelledevaluation" oldids="sec-statement-semantics-runtime-semantics-labelledevaluation,sec-do-while-statement-runtime-semantics-labelledevaluation,sec-while-statement-runtime-semantics-labelledevaluation,sec-for-statement-runtime-semantics-labelledevaluation,sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation,sec-labelled-statements-runtime-semantics-labelledevaluation" type="sdo" aoid="LabelledEvaluation">
       <h1>Runtime Semantics: LabelledEvaluation</h1>
       <p>With parameter _labelSet_.</p>
-      <emu-see-also-para op="LabelledEvaluation"></emu-see-also-para>
+      <emu-grammar>BreakableStatement : IterationStatement</emu-grammar>
+      <emu-alg>
+        1. Let _stmtResult_ be LabelledEvaluation of |IterationStatement| with argument _labelSet_.
+        1. If _stmtResult_.[[Type]] is ~break~, then
+          1. If _stmtResult_.[[Target]] is ~empty~, then
+            1. If _stmtResult_.[[Value]] is ~empty~, set _stmtResult_ to NormalCompletion(*undefined*).
+            1. Else, set _stmtResult_ to NormalCompletion(_stmtResult_.[[Value]]).
+        1. Return Completion(_stmtResult_).
+      </emu-alg>
+      <emu-grammar>BreakableStatement : SwitchStatement</emu-grammar>
+      <emu-alg>
+        1. Let _stmtResult_ be the result of evaluating |SwitchStatement|.
+        1. If _stmtResult_.[[Type]] is ~break~, then
+          1. If _stmtResult_.[[Target]] is ~empty~, then
+            1. If _stmtResult_.[[Value]] is ~empty~, set _stmtResult_ to NormalCompletion(*undefined*).
+            1. Else, set _stmtResult_ to NormalCompletion(_stmtResult_.[[Value]]).
+        1. Return Completion(_stmtResult_).
+      </emu-alg>
+      <emu-note>
+        <p>A |BreakableStatement| is one that can be exited via an unlabelled |BreakStatement|.</p>
+      </emu-note>
+      <emu-grammar>IterationStatement : `do` Statement `while` `(` Expression `)` `;`</emu-grammar>
+      <emu-alg>
+        1. Let _V_ be *undefined*.
+        1. Repeat,
+          1. Let _stmtResult_ be the result of evaluating |Statement|.
+          1. If LoopContinues(_stmtResult_, _labelSet_) is *false*, return Completion(UpdateEmpty(_stmtResult_, _V_)).
+          1. If _stmtResult_.[[Value]] is not ~empty~, set _V_ to _stmtResult_.[[Value]].
+          1. Let _exprRef_ be the result of evaluating |Expression|.
+          1. Let _exprValue_ be ? GetValue(_exprRef_).
+          1. If ! ToBoolean(_exprValue_) is *false*, return NormalCompletion(_V_).
+      </emu-alg>
+      <emu-grammar>IterationStatement : `while` `(` Expression `)` Statement</emu-grammar>
+      <emu-alg>
+        1. Let _V_ be *undefined*.
+        1. Repeat,
+          1. Let _exprRef_ be the result of evaluating |Expression|.
+          1. Let _exprValue_ be ? GetValue(_exprRef_).
+          1. If ! ToBoolean(_exprValue_) is *false*, return NormalCompletion(_V_).
+          1. Let _stmtResult_ be the result of evaluating |Statement|.
+          1. If LoopContinues(_stmtResult_, _labelSet_) is *false*, return Completion(UpdateEmpty(_stmtResult_, _V_)).
+          1. If _stmtResult_.[[Value]] is not ~empty~, set _V_ to _stmtResult_.[[Value]].
+      </emu-alg>
+      <emu-grammar>IterationStatement : `for` `(` Expression? `;` Expression? `;` Expression? `)` Statement</emu-grammar>
+      <emu-alg>
+        1. If the first |Expression| is present, then
+          1. Let _exprRef_ be the result of evaluating the first |Expression|.
+          1. Perform ? GetValue(_exprRef_).
+        1. Return ? ForBodyEvaluation(the second |Expression|, the third |Expression|, |Statement|, &laquo; &raquo;, _labelSet_).
+      </emu-alg>
+      <emu-grammar>IterationStatement : `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement</emu-grammar>
+      <emu-alg>
+        1. Let _varDcl_ be the result of evaluating |VariableDeclarationList|.
+        1. ReturnIfAbrupt(_varDcl_).
+        1. Return ? ForBodyEvaluation(the first |Expression|, the second |Expression|, |Statement|, &laquo; &raquo;, _labelSet_).
+      </emu-alg>
+      <emu-grammar>IterationStatement : `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement</emu-grammar>
+      <emu-alg>
+        1. Let _oldEnv_ be the running execution context's LexicalEnvironment.
+        1. Let _loopEnv_ be NewDeclarativeEnvironment(_oldEnv_).
+        1. Let _isConst_ be IsConstantDeclaration of |LexicalDeclaration|.
+        1. Let _boundNames_ be the BoundNames of |LexicalDeclaration|.
+        1. For each element _dn_ of _boundNames_, do
+          1. If _isConst_ is *true*, then
+            1. Perform ! _loopEnv_.CreateImmutableBinding(_dn_, *true*).
+          1. Else,
+            1. Perform ! _loopEnv_.CreateMutableBinding(_dn_, *false*).
+        1. Set the running execution context's LexicalEnvironment to _loopEnv_.
+        1. Let _forDcl_ be the result of evaluating |LexicalDeclaration|.
+        1. If _forDcl_ is an abrupt completion, then
+          1. Set the running execution context's LexicalEnvironment to _oldEnv_.
+          1. Return Completion(_forDcl_).
+        1. If _isConst_ is *false*, let _perIterationLets_ be _boundNames_; otherwise let _perIterationLets_ be &laquo; &raquo;.
+        1. Let _bodyResult_ be ForBodyEvaluation(the first |Expression|, the second |Expression|, |Statement|, _perIterationLets_, _labelSet_).
+        1. Set the running execution context's LexicalEnvironment to _oldEnv_.
+        1. Return Completion(_bodyResult_).
+      </emu-alg>
+      <emu-grammar>IterationStatement : `for` `(` LeftHandSideExpression `in` Expression `)` Statement</emu-grammar>
+      <emu-alg>
+        1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(&laquo; &raquo;, |Expression|, ~enumerate~).
+        1. Return ? ForIn/OfBodyEvaluation(|LeftHandSideExpression|, |Statement|, _keyResult_, ~enumerate~, ~assignment~, _labelSet_).
+      </emu-alg>
+      <emu-grammar>IterationStatement : `for` `(` `var` ForBinding `in` Expression `)` Statement</emu-grammar>
+      <emu-alg>
+        1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(&laquo; &raquo;, |Expression|, ~enumerate~).
+        1. Return ? ForIn/OfBodyEvaluation(|ForBinding|, |Statement|, _keyResult_, ~enumerate~, ~varBinding~, _labelSet_).
+      </emu-alg>
+      <emu-grammar>IterationStatement : `for` `(` ForDeclaration `in` Expression `)` Statement</emu-grammar>
+      <emu-alg>
+        1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(BoundNames of |ForDeclaration|, |Expression|, ~enumerate~).
+        1. Return ? ForIn/OfBodyEvaluation(|ForDeclaration|, |Statement|, _keyResult_, ~enumerate~, ~lexicalBinding~, _labelSet_).
+      </emu-alg>
+      <emu-grammar>IterationStatement : `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement</emu-grammar>
+      <emu-alg>
+        1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(&laquo; &raquo;, |AssignmentExpression|, ~iterate~).
+        1. Return ? ForIn/OfBodyEvaluation(|LeftHandSideExpression|, |Statement|, _keyResult_, ~iterate~, ~assignment~, _labelSet_).
+      </emu-alg>
+      <emu-grammar>IterationStatement : `for` `(` `var` ForBinding `of` AssignmentExpression `)` Statement</emu-grammar>
+      <emu-alg>
+        1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(&laquo; &raquo;, |AssignmentExpression|, ~iterate~).
+        1. Return ? ForIn/OfBodyEvaluation(|ForBinding|, |Statement|, _keyResult_, ~iterate~, ~varBinding~, _labelSet_).
+      </emu-alg>
+      <emu-grammar>IterationStatement : `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement</emu-grammar>
+      <emu-alg>
+        1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(BoundNames of |ForDeclaration|, |AssignmentExpression|, ~iterate~).
+        1. Return ? ForIn/OfBodyEvaluation(|ForDeclaration|, |Statement|, _keyResult_, ~iterate~, ~lexicalBinding~, _labelSet_).
+      </emu-alg>
+      <emu-grammar>
+        IterationStatement : `for` `await` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
+      </emu-grammar>
+      <emu-alg>
+        1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(&laquo; &raquo;, |AssignmentExpression|, ~async-iterate~).
+        1. Return ? ForIn/OfBodyEvaluation(|LeftHandSideExpression|, |Statement|, _keyResult_, ~iterate~, ~assignment~, _labelSet_, ~async~).
+      </emu-alg>
+      <emu-grammar>
+        IterationStatement : `for` `await` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
+      </emu-grammar>
+      <emu-alg>
+        1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(&laquo; &raquo;, |AssignmentExpression|, ~async-iterate~).
+        1. Return ? ForIn/OfBodyEvaluation(|ForBinding|, |Statement|, _keyResult_, ~iterate~, ~varBinding~, _labelSet_, ~async~).
+      </emu-alg>
+      <emu-grammar>
+        IterationStatement : `for` `await` `(` ForDeclaration `of` AssignmentExpression `)` Statement
+      </emu-grammar>
+      <emu-alg>
+        1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(BoundNames of |ForDeclaration|, |AssignmentExpression|, ~async-iterate~).
+        1. Return ? ForIn/OfBodyEvaluation(|ForDeclaration|, |Statement|, _keyResult_, ~iterate~, ~lexicalBinding~, _labelSet_, ~async~).
+      </emu-alg>
+      <emu-note>
+        <p>This section is extended by Annex <emu-xref href="#sec-initializers-in-forin-statement-heads"></emu-xref>.</p>
+      </emu-note>
       <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
       <emu-alg>
         1. Let _label_ be the StringValue of |LabelIdentifier|.
@@ -18993,15 +18971,6 @@
       <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
       <emu-alg>
         1. Return the result of evaluating |FunctionDeclaration|.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-labelled-statements-runtime-semantics-evaluation">
-      <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
-      <emu-alg>
-        1. Let _newLabelSet_ be a new empty List.
-        1. Return LabelledEvaluation of this |LabelledStatement| with argument _newLabelSet_.
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -42967,7 +42936,7 @@ THH:mm:ss.sss
         1. Append to _declarations_ the elements of the VarScopedDeclarations of |Statement|.
         1. Return _declarations_.
       </emu-alg>
-      <p>The runtime semantics of LabelledEvaluation in <emu-xref href="#sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation"></emu-xref> are augmented with the following:</p>
+      <p>The runtime semantics of LabelledEvaluation in <emu-xref href="#sec-runtime-semantics-labelledevaluation"></emu-xref> are augmented with the following:</p>
       <emu-grammar>IterationStatement : `for` `(` `var` BindingIdentifier Initializer `in` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Let _bindingId_ be StringValue of |BindingIdentifier|.

--- a/spec.html
+++ b/spec.html
@@ -19286,17 +19286,10 @@
     <p>Various ECMAScript language elements cause the creation of ECMAScript function objects (<emu-xref href="#sec-ecmascript-function-objects"></emu-xref>). Evaluation of such functions starts with the execution of their [[Call]] internal method (<emu-xref href="#sec-ecmascript-function-objects-call-thisargument-argumentslist"></emu-xref>).</p>
   </emu-note>
 
-  <emu-clause id="sec-function-definitions">
-    <h1>Function Definitions</h1>
+  <emu-clause id="sec-parameter-lists">
+    <h1>Parameter Lists</h1>
     <h2>Syntax</h2>
     <emu-grammar type="definition">
-      FunctionDeclaration[Yield, Await, Default] :
-        `function` BindingIdentifier[?Yield, ?Await] `(` FormalParameters[~Yield, ~Await] `)` `{` FunctionBody[~Yield, ~Await] `}`
-        [+Default] `function` `(` FormalParameters[~Yield, ~Await] `)` `{` FunctionBody[~Yield, ~Await] `}`
-
-      FunctionExpression :
-        `function` BindingIdentifier[~Yield, ~Await]? `(` FormalParameters[~Yield, ~Await] `)` `{` FunctionBody[~Yield, ~Await] `}`
-
       UniqueFormalParameters[Yield, Await] :
         FormalParameters[?Yield, ?Await]
 
@@ -19316,6 +19309,37 @@
 
       FormalParameter[Yield, Await] :
         BindingElement[?Yield, ?Await]
+    </emu-grammar>
+    <emu-clause id="sec-parameter-lists-static-semantics-early-errors">
+      <h1>Static Semantics: Early Errors</h1>
+      <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar>
+      <ul>
+        <li>
+          It is a Syntax Error if BoundNames of |FormalParameters| contains any duplicate elements.
+        </li>
+      </ul>
+      <emu-grammar>FormalParameters : FormalParameterList</emu-grammar>
+      <ul>
+        <li>
+          It is a Syntax Error if IsSimpleParameterList of |FormalParameterList| is *false* and BoundNames of |FormalParameterList| contains any duplicate elements.
+        </li>
+      </ul>
+      <emu-note>
+        <p>Multiple occurrences of the same |BindingIdentifier| in a |FormalParameterList| is only allowed for functions which have simple parameter lists and which are not defined in strict mode code.</p>
+      </emu-note>
+    </emu-clause>
+  </emu-clause>
+
+  <emu-clause id="sec-function-definitions">
+    <h1>Function Definitions</h1>
+    <h2>Syntax</h2>
+    <emu-grammar type="definition">
+      FunctionDeclaration[Yield, Await, Default] :
+        `function` BindingIdentifier[?Yield, ?Await] `(` FormalParameters[~Yield, ~Await] `)` `{` FunctionBody[~Yield, ~Await] `}`
+        [+Default] `function` `(` FormalParameters[~Yield, ~Await] `)` `{` FunctionBody[~Yield, ~Await] `}`
+
+      FunctionExpression :
+        `function` BindingIdentifier[~Yield, ~Await]? `(` FormalParameters[~Yield, ~Await] `)` `{` FunctionBody[~Yield, ~Await] `}`
 
       FunctionBody[Yield, Await] :
         FunctionStatementList[?Yield, ?Await]
@@ -19361,21 +19385,6 @@
       </ul>
       <emu-note>
         <p>The LexicallyDeclaredNames of a |FunctionBody| does not include identifiers bound using var or function declarations.</p>
-      </emu-note>
-      <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar>
-      <ul>
-        <li>
-          It is a Syntax Error if BoundNames of |FormalParameters| contains any duplicate elements.
-        </li>
-      </ul>
-      <emu-grammar>FormalParameters : FormalParameterList</emu-grammar>
-      <ul>
-        <li>
-          It is a Syntax Error if IsSimpleParameterList of |FormalParameterList| is *false* and BoundNames of |FormalParameterList| contains any duplicate elements.
-        </li>
-      </ul>
-      <emu-note>
-        <p>Multiple occurrences of the same |BindingIdentifier| in a |FormalParameterList| is only allowed for functions which have simple parameter lists and which are not defined in strict mode code.</p>
       </emu-note>
       <emu-grammar>FunctionBody : FunctionStatementList</emu-grammar>
       <ul>
@@ -41525,13 +41534,13 @@ THH:mm:ss.sss
 
   <emu-annex id="sec-functions-and-classes">
     <h1>Functions and Classes</h1>
-    <emu-prodref name="FunctionDeclaration"></emu-prodref>
-    <emu-prodref name="FunctionExpression"></emu-prodref>
     <emu-prodref name="UniqueFormalParameters"></emu-prodref>
     <emu-prodref name="FormalParameters"></emu-prodref>
     <emu-prodref name="FormalParameterList"></emu-prodref>
     <emu-prodref name="FunctionRestParameter"></emu-prodref>
     <emu-prodref name="FormalParameter"></emu-prodref>
+    <emu-prodref name="FunctionDeclaration"></emu-prodref>
+    <emu-prodref name="FunctionExpression"></emu-prodref>
     <emu-prodref name="FunctionBody"></emu-prodref>
     <emu-prodref name="FunctionStatementList"></emu-prodref>
     <emu-prodref name="ArrowFunction"></emu-prodref>

--- a/spec.html
+++ b/spec.html
@@ -944,16 +944,6 @@
       <h1>Static Semantics</h1>
       <p>Context-free grammars are not sufficiently powerful to express all the rules that define whether a stream of input elements form a valid ECMAScript |Script| or |Module| that may be evaluated. In some situations additional rules are needed that may be expressed using either ECMAScript algorithm conventions or prose requirements. Such rules are always associated with a production of a grammar and are called the <dfn>static semantics</dfn> of the production.</p>
       <p>Static Semantic Rules have names and typically are defined using an algorithm. Named Static Semantic Rules are associated with grammar productions and a production that has multiple alternative definitions will typically have for each alternative a distinct algorithm for each applicable named static semantic rule.</p>
-      <p>Unless otherwise specified every grammar production alternative in this specification implicitly has a definition for a static semantic rule named Contains which takes an argument named _symbol_ whose value is a terminal or nonterminal of the grammar that includes the associated production. The default definition of Contains is:</p>
-      <emu-alg>
-        1. For each child node _child_ of this Parse Node, do
-          1. If _child_ is an instance of _symbol_, return *true*.
-          1. If _child_ is an instance of a nonterminal, then
-            1. Let _contained_ be the result of _child_ Contains _symbol_.
-            1. If _contained_ is *true*, return *true*.
-        1. Return *false*.
-      </emu-alg>
-      <p>The above definition is explicitly over-ridden for specific productions.</p>
       <p>A special kind of static semantic rule is an <dfn id="early-error-rule">Early Error Rule</dfn>. Early error rules define early error conditions (see clause <emu-xref href="#sec-error-handling-and-language-extensions"></emu-xref>) that are associated with specific grammar productions. Evaluation of most early error rules are not explicitly invoked within the algorithms of this specification. A conforming implementation must, prior to the first evaluation of a |Script| or |Module|, validate all of the early error rules of the productions used to parse that |Script| or |Module|. If any of the early error rules are violated the |Script| or |Module| is invalid and cannot be evaluated.</p>
     </emu-clause>
     <emu-clause id="sec-mathematical-operations">
@@ -7430,6 +7420,131 @@
 
   <emu-clause id="sec-syntax-directed-operations-contains">
     <h1>Contains</h1>
+
+    <emu-clause id="sec-static-semantics-contains" oldids="sec-object-initializer-static-semantics-contains,sec-static-semantics-static-semantics-contains,sec-function-definitions-static-semantics-contains,sec-arrow-function-definitions-static-semantics-contains,sec-generator-function-definitions-static-semantics-contains,sec-async-generator-function-definitions-static-semantics-contains,sec-class-definitions-static-semantics-contains,sec-async-function-definitions-static-semantics-Contains,sec-async-arrow-function-definitions-static-semantics-Contains" type="sdo" aoid="Contains">
+      <h1>Static Semantics: Contains</h1>
+      <p>With parameter _symbol_.</p>
+      <p>Every grammar production alternative in this specification which is not listed below implicitly has the following default definition of Contains:</p>
+      <emu-alg>
+        1. For each child node _child_ of this Parse Node, do
+          1. If _child_ is an instance of _symbol_, return *true*.
+          1. If _child_ is an instance of a nonterminal, then
+            1. Let _contained_ be the result of _child_ Contains _symbol_.
+            1. If _contained_ is *true*, return *true*.
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>
+        FunctionDeclaration :
+          `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`
+          `function` `(` FormalParameters `)` `{` FunctionBody `}`
+
+        FunctionExpression :
+          `function` BindingIdentifier? `(` FormalParameters `)` `{` FunctionBody `}`
+
+        GeneratorDeclaration :
+          `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`
+          `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`
+
+        GeneratorExpression :
+          `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` GeneratorBody `}`
+
+        AsyncGeneratorDeclaration :
+          `async` `function` `*` BindingIdentifier `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+          `async` `function` `*` `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+
+        AsyncGeneratorExpression :
+          `async` `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+
+        AsyncFunctionDeclaration :
+          `async` `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
+          `async` `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
+
+        AsyncFunctionExpression :
+          `async` `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
+          `async` `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
+      </emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+      <emu-note>
+        <p>Static semantic rules that depend upon substructure generally do not look into function definitions.</p>
+      </emu-note>
+      <emu-grammar>ClassTail : ClassHeritage? `{` ClassBody `}`</emu-grammar>
+      <emu-alg>
+        1. If _symbol_ is |ClassBody|, return *true*.
+        1. If _symbol_ is |ClassHeritage|, then
+          1. If |ClassHeritage| is present, return *true*; otherwise return *false*.
+        1. Let _inHeritage_ be |ClassHeritage| Contains _symbol_.
+        1. If _inHeritage_ is *true*, return *true*.
+        1. Return the result of ComputedPropertyContains for |ClassBody| with argument _symbol_.
+      </emu-alg>
+      <emu-note>
+        <p>Static semantic rules that depend upon substructure generally do not look into class bodies except for |PropertyName|s.</p>
+      </emu-note>
+      <emu-grammar>ArrowFunction : ArrowParameters `=>` ConciseBody</emu-grammar>
+      <emu-alg>
+        1. If _symbol_ is not one of |NewTarget|, |SuperProperty|, |SuperCall|, `super` or `this`, return *false*.
+        1. If |ArrowParameters| Contains _symbol_ is *true*, return *true*.
+        1. Return |ConciseBody| Contains _symbol_.
+      </emu-alg>
+      <emu-grammar>ArrowParameters : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
+      <emu-alg>
+        1. Let _formals_ be CoveredFormalsList of |CoverParenthesizedExpressionAndArrowParameterList|.
+        1. Return _formals_ Contains _symbol_.
+      </emu-alg>
+      <emu-grammar>
+        AsyncArrowFunction : `async` AsyncArrowBindingIdentifier `=>` AsyncConciseBody
+      </emu-grammar>
+      <emu-alg>
+        1. If _symbol_ is not one of |NewTarget|, |SuperProperty|, |SuperCall|, `super`, or `this`, return *false*.
+        1. Return |AsyncConciseBody| Contains _symbol_.
+      </emu-alg>
+      <emu-grammar>
+        AsyncArrowFunction : CoverCallExpressionAndAsyncArrowHead `=>` AsyncConciseBody
+      </emu-grammar>
+      <emu-alg>
+        1. If _symbol_ is not one of |NewTarget|, |SuperProperty|, |SuperCall|, `super`, or `this`, return *false*.
+        1. Let _head_ be CoveredAsyncArrowHead of |CoverCallExpressionAndAsyncArrowHead|.
+        1. If _head_ Contains _symbol_ is *true*, return *true*.
+        1. Return |AsyncConciseBody| Contains _symbol_.
+      </emu-alg>
+      <emu-note>
+        <p>Contains is used to detect `new.target`, `this`, and `super` usage within an |ArrowFunction| or |AsyncArrowFunction|.</p>
+      </emu-note>
+      <emu-grammar>PropertyDefinition : MethodDefinition</emu-grammar>
+      <emu-alg>
+        1. If _symbol_ is |MethodDefinition|, return *true*.
+        1. Return the result of ComputedPropertyContains for |MethodDefinition| with argument _symbol_.
+      </emu-alg>
+      <emu-grammar>LiteralPropertyName : IdentifierName</emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>MemberExpression : MemberExpression `.` IdentifierName</emu-grammar>
+      <emu-alg>
+        1. If |MemberExpression| Contains _symbol_ is *true*, return *true*.
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>SuperProperty : `super` `.` IdentifierName</emu-grammar>
+      <emu-alg>
+        1. If _symbol_ is the |ReservedWord| `super`, return *true*.
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>CallExpression : CallExpression `.` IdentifierName</emu-grammar>
+      <emu-alg>
+        1. If |CallExpression| Contains _symbol_ is *true*, return *true*.
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>OptionalChain : `?.` IdentifierName</emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>OptionalChain : OptionalChain `.` IdentifierName</emu-grammar>
+      <emu-alg>
+        1. If |OptionalChain| Contains _symbol_ is *true*, return *true*.
+        1. Return *false*.
+      </emu-alg>
+    </emu-clause>
   </emu-clause>
 
   <emu-clause id="sec-syntax-directed-operations-miscellaneous">
@@ -14663,24 +14778,6 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-object-initializer-static-semantics-contains">
-        <h1>Static Semantics: Contains</h1>
-        <p>With parameter _symbol_.</p>
-        <emu-see-also-para op="Contains"></emu-see-also-para>
-        <emu-grammar>PropertyDefinition : MethodDefinition</emu-grammar>
-        <emu-alg>
-          1. If _symbol_ is |MethodDefinition|, return *true*.
-          1. Return the result of ComputedPropertyContains for |MethodDefinition| with argument _symbol_.
-        </emu-alg>
-        <emu-note>
-          <p>Static semantic rules that depend upon substructure generally do not look into function definitions.</p>
-        </emu-note>
-        <emu-grammar>LiteralPropertyName : IdentifierName</emu-grammar>
-        <emu-alg>
-          1. Return *false*.
-        </emu-alg>
-      </emu-clause>
-
       <emu-clause id="sec-static-semantics-iscomputedpropertykey" type="sdo" aoid="IsComputedPropertyKey">
         <h1>Static Semantics: IsComputedPropertyKey</h1>
         <emu-grammar>PropertyName : LiteralPropertyName</emu-grammar>
@@ -15298,36 +15395,6 @@
         </emu-grammar>
         <emu-alg>
           1. Return the |CallMemberExpression| that is covered by |CoverCallExpressionAndAsyncArrowHead|.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-static-semantics-static-semantics-contains">
-        <h1>Static Semantics: Contains</h1>
-        <p>With parameter _symbol_.</p>
-        <emu-see-also-para op="Contains"></emu-see-also-para>
-        <emu-grammar>MemberExpression : MemberExpression `.` IdentifierName</emu-grammar>
-        <emu-alg>
-          1. If |MemberExpression| Contains _symbol_ is *true*, return *true*.
-          1. Return *false*.
-        </emu-alg>
-        <emu-grammar>SuperProperty : `super` `.` IdentifierName</emu-grammar>
-        <emu-alg>
-          1. If _symbol_ is the |ReservedWord| `super`, return *true*.
-          1. Return *false*.
-        </emu-alg>
-        <emu-grammar>CallExpression : CallExpression `.` IdentifierName</emu-grammar>
-        <emu-alg>
-          1. If |CallExpression| Contains _symbol_ is *true*, return *true*.
-          1. Return *false*.
-        </emu-alg>
-        <emu-grammar>OptionalChain : `?.` IdentifierName</emu-grammar>
-        <emu-alg>
-          1. Return *false*.
-        </emu-alg>
-        <emu-grammar>OptionalChain : OptionalChain `.` IdentifierName</emu-grammar>
-        <emu-alg>
-          1. If |OptionalChain| Contains _symbol_ is *true*, return *true*.
-          1. Return *false*.
         </emu-alg>
       </emu-clause>
 
@@ -19330,25 +19397,6 @@
       </ul>
     </emu-clause>
 
-    <emu-clause id="sec-function-definitions-static-semantics-contains">
-      <h1>Static Semantics: Contains</h1>
-      <p>With parameter _symbol_.</p>
-      <emu-see-also-para op="Contains"></emu-see-also-para>
-      <emu-grammar>
-        FunctionDeclaration : `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`
-
-        FunctionDeclaration : `function` `(` FormalParameters `)` `{` FunctionBody `}`
-
-        FunctionExpression : `function` BindingIdentifier? `(` FormalParameters `)` `{` FunctionBody `}`
-      </emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-      <emu-note>
-        <p>Static semantic rules that depend upon substructure generally do not look into function definitions.</p>
-      </emu-note>
-    </emu-clause>
-
     <emu-clause id="sec-static-semantics-functionbodycontainsusestrict" oldids="sec-function-definitions-static-semantics-containsusestrict" type="sdo" aoid="FunctionBodyContainsUseStrict">
       <h1>Static Semantics: FunctionBodyContainsUseStrict</h1>
       <emu-grammar>FunctionBody : FunctionStatementList</emu-grammar>
@@ -19697,26 +19745,6 @@
           All early error rules for |ArrowFormalParameters| and its derived productions also apply to CoveredFormalsList of |CoverParenthesizedExpressionAndArrowParameterList|.
         </li>
       </ul>
-    </emu-clause>
-
-    <emu-clause id="sec-arrow-function-definitions-static-semantics-contains">
-      <h1>Static Semantics: Contains</h1>
-      <p>With parameter _symbol_.</p>
-      <emu-see-also-para op="Contains"></emu-see-also-para>
-      <emu-grammar>ArrowFunction : ArrowParameters `=>` ConciseBody</emu-grammar>
-      <emu-alg>
-        1. If _symbol_ is not one of |NewTarget|, |SuperProperty|, |SuperCall|, `super` or `this`, return *false*.
-        1. If |ArrowParameters| Contains _symbol_ is *true*, return *true*.
-        1. Return |ConciseBody| Contains _symbol_.
-      </emu-alg>
-      <emu-note>
-        <p>Static semantic rules that depend upon substructure generally do not look into function definitions. However, Contains is used to detect `new.target`, `this`, and `super` usage within an |ArrowFunction|.</p>
-      </emu-note>
-      <emu-grammar>ArrowParameters : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
-      <emu-alg>
-        1. Let _formals_ be CoveredFormalsList of |CoverParenthesizedExpressionAndArrowParameterList|.
-        1. Return _formals_ Contains _symbol_.
-      </emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-static-semantics-concisebodycontainsusestrict" oldids="sec-arrow-function-definitions-static-semantics-containsusestrict" type="sdo" aoid="ConciseBodyContainsUseStrict">
@@ -20102,25 +20130,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-generator-function-definitions-static-semantics-contains">
-      <h1>Static Semantics: Contains</h1>
-      <p>With parameter _symbol_.</p>
-      <emu-see-also-para op="Contains"></emu-see-also-para>
-      <emu-grammar>
-        GeneratorDeclaration : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`
-
-        GeneratorDeclaration : `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`
-
-        GeneratorExpression : `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` GeneratorBody `}`
-      </emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-      <emu-note>
-        <p>Static semantic rules that depend upon substructure generally do not look into function definitions.</p>
-      </emu-note>
-    </emu-clause>
-
     <emu-clause id="sec-runtime-semantics-evaluategeneratorbody" oldids="sec-generator-function-definitions-runtime-semantics-evaluatebody" type="sdo" aoid="EvaluateGeneratorBody">
       <h1>Runtime Semantics: EvaluateGeneratorBody</h1>
       <p>With parameters _functionObject_ and _argumentsList_ (a List).</p>
@@ -20330,25 +20339,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-async-generator-function-definitions-static-semantics-contains">
-      <h1>Static Semantics: Contains</h1>
-      <p>With parameter _symbol_.</p>
-      <emu-see-also-para op="Contains"></emu-see-also-para>
-      <emu-grammar>
-        AsyncGeneratorDeclaration : `async` `function` `*` BindingIdentifier `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
-
-        AsyncGeneratorDeclaration : `async` `function` `*` `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
-
-        AsyncGeneratorExpression : `async` `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
-      </emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-      <emu-note>
-        <p>Static semantic rules that depend upon substructure generally do not look into function definitions.</p>
-      </emu-note>
-    </emu-clause>
-
     <emu-clause id="sec-runtime-semantics-evaluateasyncgeneratorbody" oldids="sec-asyncgenerator-definitions-evaluatebody" type="sdo" aoid="EvaluateAsyncGeneratorBody">
       <h1>Runtime Semantics: EvaluateAsyncGeneratorBody</h1>
       <p>With parameters _functionObject_ and _argumentsList_ (a List).</p>
@@ -20549,24 +20539,6 @@
       </emu-alg>
       <emu-note>
         <p>Early Error rules ensure that there is only one method definition named *"constructor"* and that it is not an accessor property or generator definition.</p>
-      </emu-note>
-    </emu-clause>
-
-    <emu-clause id="sec-class-definitions-static-semantics-contains">
-      <h1>Static Semantics: Contains</h1>
-      <p>With parameter _symbol_.</p>
-      <emu-see-also-para op="Contains"></emu-see-also-para>
-      <emu-grammar>ClassTail : ClassHeritage? `{` ClassBody `}`</emu-grammar>
-      <emu-alg>
-        1. If _symbol_ is |ClassBody|, return *true*.
-        1. If _symbol_ is |ClassHeritage|, then
-          1. If |ClassHeritage| is present, return *true*; otherwise return *false*.
-        1. Let _inHeritage_ be |ClassHeritage| Contains _symbol_.
-        1. If _inHeritage_ is *true*, return *true*.
-        1. Return the result of ComputedPropertyContains for |ClassBody| with argument _symbol_.
-      </emu-alg>
-      <emu-note>
-        <p>Static semantic rules that depend upon substructure generally do not look into class bodies except for |PropertyName|s.</p>
       </emu-note>
     </emu-clause>
 
@@ -20842,26 +20814,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-async-function-definitions-static-semantics-Contains">
-      <h1>Static Semantics: Contains</h1>
-      <p>With parameter _symbol_.</p>
-      <emu-grammar>
-        AsyncFunctionDeclaration : `async` `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
-
-        AsyncFunctionDeclaration : `async` `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
-
-        AsyncFunctionExpression : `async` `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
-
-        AsyncFunctionExpression : `async` `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
-      </emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-      <emu-note>
-        <p>Static semantic rules that depend upon substructure generally do not look into function definitions.</p>
-      </emu-note>
-    </emu-clause>
-
     <emu-clause id="sec-runtime-semantics-instantiateasyncfunctionobject" oldids="sec-async-function-definitions-InstantiateFunctionObject" type="sdo" aoid="InstantiateAsyncFunctionObject">
       <h1>Runtime Semantics: InstantiateAsyncFunctionObject</h1>
       <p>With parameter _scope_.</p>
@@ -21026,30 +20978,6 @@
       <emu-alg>
         1. Return the |AsyncArrowHead| that is covered by |CoverCallExpressionAndAsyncArrowHead|.
       </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-async-arrow-function-definitions-static-semantics-Contains">
-      <h1>Static Semantics: Contains</h1>
-      <p>With parameter _symbol_.</p>
-      <emu-grammar>
-        AsyncArrowFunction : `async` AsyncArrowBindingIdentifier `=>` AsyncConciseBody
-      </emu-grammar>
-      <emu-alg>
-        1. If _symbol_ is not one of |NewTarget|, |SuperProperty|, |SuperCall|, `super`, or `this`, return *false*.
-        1. Return |AsyncConciseBody| Contains _symbol_.
-      </emu-alg>
-      <emu-grammar>
-        AsyncArrowFunction : CoverCallExpressionAndAsyncArrowHead `=>` AsyncConciseBody
-      </emu-grammar>
-      <emu-alg>
-        1. If _symbol_ is not one of |NewTarget|, |SuperProperty|, |SuperCall|, `super`, or `this`, return *false*.
-        1. Let _head_ be CoveredAsyncArrowHead of |CoverCallExpressionAndAsyncArrowHead|.
-        1. If _head_ Contains _symbol_ is *true*, return *true*.
-        1. Return |AsyncConciseBody| Contains _symbol_.
-      </emu-alg>
-      <emu-note>
-        <p>Static semantic rules that depend upon substructure generally do not look into function definitions. However, Contains is used to detect `new.target`, `this`, and `super` usage within an |AsyncArrowFunction|.</p>
-      </emu-note>
     </emu-clause>
 
     <emu-clause id="sec-static-semantics-asyncconcisebodycontainsusestrict" oldids="sec-async-arrow-function-definitions-static-semantics-containsusestrict" type="sdo" aoid="AsyncConciseBodyContainsUseStrict">

--- a/spec.html
+++ b/spec.html
@@ -9396,6 +9396,41 @@
         </emu-alg>
       </emu-clause>
 
+      <emu-clause id="sec-runtime-semantics-evaluatebody" type="sdo" aoid="EvaluateBody">
+        <h1>Runtime Semantics: EvaluateBody</h1>
+        <p>With parameters _functionObject_ and _argumentsList_ (a List).</p>
+        <emu-grammar>FunctionBody : FunctionStatementList</emu-grammar>
+        <emu-alg>
+          1. Return ? EvaluateFunctionBody of |FunctionBody| with arguments _functionObject_ and _argumentsList_.
+        </emu-alg>
+        <emu-grammar>ConciseBody : ExpressionBody</emu-grammar>
+        <emu-alg>
+          1. Return ? EvaluateConciseBody of |ConciseBody| with arguments _functionObject_ and _argumentsList_.
+        </emu-alg>
+        <emu-grammar>GeneratorBody : FunctionBody</emu-grammar>
+        <emu-alg>
+          1. Return ? EvaluateGeneratorBody of |GeneratorBody| with arguments _functionObject_ and _argumentsList_.
+        </emu-alg>
+        <emu-grammar>
+          AsyncGeneratorBody : FunctionBody
+        </emu-grammar>
+        <emu-alg>
+          1. Return ? EvaluateAsyncGeneratorBody of |AsyncGeneratorBody| with arguments _functionObject_ and _argumentsList_.
+        </emu-alg>
+        <emu-grammar>
+          AsyncFunctionBody : FunctionBody
+        </emu-grammar>
+        <emu-alg>
+          1. Return ? EvaluateAsyncFunctionBody of |AsyncFunctionBody| with arguments _functionObject_ and _argumentsList_.
+        </emu-alg>
+        <emu-grammar>
+          AsyncConciseBody : ExpressionBody
+        </emu-grammar>
+        <emu-alg>
+          1. Return ? EvaluateAsyncConciseBody of |AsyncConciseBody| with arguments _functionObject_ and _argumentsList_.
+        </emu-alg>
+      </emu-clause>
+
       <emu-clause id="sec-ordinarycallevaluatebody" aoid="OrdinaryCallEvaluateBody">
         <h1>OrdinaryCallEvaluateBody ( _F_, _argumentsList_ )</h1>
         <p>The abstract operation OrdinaryCallEvaluateBody takes arguments _F_ (a function object) and _argumentsList_ (a List). It performs the following steps when called:</p>
@@ -19852,10 +19887,9 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-function-definitions-runtime-semantics-evaluatebody">
-      <h1>Runtime Semantics: EvaluateBody</h1>
-      <p>With parameters _functionObject_ and List _argumentsList_.</p>
-      <emu-see-also-para op="EvaluateBody"></emu-see-also-para>
+    <emu-clause id="sec-runtime-semantics-evaluatefunctionbody" oldids="sec-function-definitions-runtime-semantics-evaluatebody" type="sdo" aoid="EvaluateFunctionBody">
+      <h1>Runtime Semantics: EvaluateFunctionBody</h1>
+      <p>With parameters _functionObject_ and _argumentsList_ (a List).</p>
       <emu-grammar>FunctionBody : FunctionStatementList</emu-grammar>
       <emu-alg>
         1. Perform ? FunctionDeclarationInstantiation(_functionObject_, _argumentsList_).
@@ -20116,10 +20150,9 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-arrow-function-definitions-runtime-semantics-evaluatebody">
-      <h1>Runtime Semantics: EvaluateBody</h1>
-      <p>With parameters _functionObject_ and List _argumentsList_.</p>
-      <emu-see-also-para op="EvaluateBody"></emu-see-also-para>
+    <emu-clause id="sec-runtime-semantics-evaluateconcisebody" oldids="sec-arrow-function-definitions-runtime-semantics-evaluatebody" type="sdo" aoid="EvaluateConciseBody">
+      <h1>Runtime Semantics: EvaluateConciseBody</h1>
+      <p>With parameters _functionObject_ and _argumentsList_ (a List).</p>
       <emu-grammar>ConciseBody : ExpressionBody</emu-grammar>
       <emu-alg>
         1. Perform ? FunctionDeclarationInstantiation(_functionObject_, _argumentsList_).
@@ -20525,10 +20558,9 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-generator-function-definitions-runtime-semantics-evaluatebody">
-      <h1>Runtime Semantics: EvaluateBody</h1>
-      <p>With parameters _functionObject_ and List _argumentsList_.</p>
-      <emu-see-also-para op="EvaluateBody"></emu-see-also-para>
+    <emu-clause id="sec-runtime-semantics-evaluategeneratorbody" oldids="sec-generator-function-definitions-runtime-semantics-evaluatebody" type="sdo" aoid="EvaluateGeneratorBody">
+      <h1>Runtime Semantics: EvaluateGeneratorBody</h1>
+      <p>With parameters _functionObject_ and _argumentsList_ (a List).</p>
       <emu-grammar>GeneratorBody : FunctionBody</emu-grammar>
       <emu-alg>
         1. Perform ? FunctionDeclarationInstantiation(_functionObject_, _argumentsList_).
@@ -20796,9 +20828,9 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-asyncgenerator-definitions-evaluatebody">
-      <h1>Runtime Semantics: EvaluateBody</h1>
-      <p>With parameters _functionObject_ and List _argumentsList_.</p>
+    <emu-clause id="sec-runtime-semantics-evaluateasyncgeneratorbody" oldids="sec-asyncgenerator-definitions-evaluatebody" type="sdo" aoid="EvaluateAsyncGeneratorBody">
+      <h1>Runtime Semantics: EvaluateAsyncGeneratorBody</h1>
+      <p>With parameters _functionObject_ and _argumentsList_ (a List).</p>
       <emu-grammar>
         AsyncGeneratorBody : FunctionBody
       </emu-grammar>
@@ -21414,9 +21446,9 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-async-function-definitions-EvaluateBody">
-      <h1>Runtime Semantics: EvaluateBody</h1>
-      <p>With parameters _functionObject_ and List _argumentsList_.</p>
+    <emu-clause id="sec-runtime-semantics-evaluateasyncfunctionbody" oldids="sec-async-function-definitions-EvaluateBody" type="sdo" aoid="EvaluateAsyncFunctionBody">
+      <h1>Runtime Semantics: EvaluateAsyncFunctionBody</h1>
+      <p>With parameters _functionObject_ and _argumentsList_ (a List).</p>
       <emu-grammar>
         AsyncFunctionBody : FunctionBody
       </emu-grammar>
@@ -21625,9 +21657,9 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-async-arrow-function-definitions-EvaluateBody">
-      <h1>Runtime Semantics: EvaluateBody</h1>
-      <p>With parameters _functionObject_ and List _argumentsList_.</p>
+    <emu-clause id="sec-runtime-semantics-evaluateasyncconcisebody" oldids="sec-async-arrow-function-definitions-EvaluateBody" type="sdo" aoid="EvaluateAsyncConciseBody">
+      <h1>Runtime Semantics: EvaluateAsyncConciseBody</h1>
+      <p>With parameters _functionObject_ and _argumentsList_ (a List).</p>
       <emu-grammar>
         AsyncConciseBody : ExpressionBody
       </emu-grammar>

--- a/spec.html
+++ b/spec.html
@@ -14017,7 +14017,7 @@
             `throw` [no LineTerminator here] Expression[+In, ?Yield, ?Await] `;`
 
           ArrowFunction[In, Yield, Await] :
-            ArrowParameters[?Yield, ?Await] [no LineTerminator here] `=&gt;` ConciseBody[?In]
+            ArrowParameters[?Yield, ?Await] [no LineTerminator here] `=>` ConciseBody[?In]
 
           YieldExpression[In, Await] :
             `yield`
@@ -14374,17 +14374,6 @@
         <emu-grammar>CoverParenthesizedExpressionAndArrowParameterList : `(` Expression `)`</emu-grammar>
         <emu-alg>
           1. Return the |ParenthesizedExpression| that is covered by |CoverParenthesizedExpressionAndArrowParameterList|.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-semantics-static-semantics-hasname">
-        <h1>Static Semantics: HasName</h1>
-        <emu-see-also-para op="HasName"></emu-see-also-para>
-        <emu-grammar>PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
-        <emu-alg>
-          1. Let _expr_ be CoveredParenthesizedExpression of |CoverParenthesizedExpressionAndArrowParameterList|.
-          1. If IsFunctionDefinition of _expr_ is *false*, return *false*.
-          1. Return HasName of _expr_.
         </emu-alg>
       </emu-clause>
 
@@ -19623,14 +19612,45 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-function-definitions-static-semantics-hasname">
+    <emu-clause id="sec-static-semantics-hasname" oldids="sec-semantics-static-semantics-hasname,sec-function-definitions-static-semantics-hasname,sec-arrow-function-definitions-static-semantics-hasname,sec-generator-function-definitions-static-semantics-hasname,sec-async-generator-function-definitions-static-semantics-hasname,sec-class-definitions-static-semantics-hasname,sec-async-function-definitions-static-semantics-HasName,sec-async-arrow-function-definitions-static-semantics-HasName" type="sdo" aoid="HasName">
       <h1>Static Semantics: HasName</h1>
-      <emu-see-also-para op="HasName"></emu-see-also-para>
-      <emu-grammar>FunctionExpression : `function` `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-grammar>PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
+      <emu-alg>
+        1. Let _expr_ be CoveredParenthesizedExpression of |CoverParenthesizedExpressionAndArrowParameterList|.
+        1. If IsFunctionDefinition of _expr_ is *false*, return *false*.
+        1. Return HasName of _expr_.
+      </emu-alg>
+      <emu-grammar>
+        FunctionExpression : `function` `(` FormalParameters `)` `{` FunctionBody `}`
+
+        GeneratorExpression : `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`
+
+        AsyncGeneratorExpression : `async` `function` `*` `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+
+        AsyncFunctionExpression : `async` `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
+
+        ArrowFunction : ArrowParameters `=>` ConciseBody
+
+        AsyncArrowFunction : `async` AsyncArrowBindingIdentifier `=>` AsyncConciseBody
+
+        AsyncArrowFunction : CoverCallExpressionAndAsyncArrowHead `=>` AsyncConciseBody
+
+        ClassExpression : `class` ClassTail
+      </emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
-      <emu-grammar>FunctionExpression : `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-grammar>
+        FunctionExpression : `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`
+
+        GeneratorExpression : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`
+
+        AsyncGeneratorExpression : `async` `function` `*` BindingIdentifier `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+
+        AsyncFunctionExpression : `async` `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
+
+        ClassExpression : `class` BindingIdentifier ClassTail
+      </emu-grammar>
       <emu-alg>
         1. Return *true*.
       </emu-alg>
@@ -19753,7 +19773,7 @@
     <h2>Syntax</h2>
     <emu-grammar type="definition">
       ArrowFunction[In, Yield, Await] :
-        ArrowParameters[?Yield, ?Await] [no LineTerminator here] `=&gt;` ConciseBody[?In]
+        ArrowParameters[?Yield, ?Await] [no LineTerminator here] `=>` ConciseBody[?In]
 
       ArrowParameters[Yield, Await] :
         BindingIdentifier[?Yield, ?Await]
@@ -19779,7 +19799,7 @@
 
     <emu-clause id="sec-arrow-function-definitions-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
-      <emu-grammar>ArrowFunction : ArrowParameters `=&gt;` ConciseBody</emu-grammar>
+      <emu-grammar>ArrowFunction : ArrowParameters `=>` ConciseBody</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if |ArrowParameters| Contains |YieldExpression| is *true*.
@@ -19809,7 +19829,7 @@
       <h1>Static Semantics: Contains</h1>
       <p>With parameter _symbol_.</p>
       <emu-see-also-para op="Contains"></emu-see-also-para>
-      <emu-grammar>ArrowFunction : ArrowParameters `=&gt;` ConciseBody</emu-grammar>
+      <emu-grammar>ArrowFunction : ArrowParameters `=>` ConciseBody</emu-grammar>
       <emu-alg>
         1. If _symbol_ is not one of |NewTarget|, |SuperProperty|, |SuperCall|, `super` or `this`, return *false*.
         1. If |ArrowParameters| Contains _symbol_ is *true*, return *true*.
@@ -19834,15 +19854,6 @@
       <emu-grammar>ConciseBody : `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Return FunctionBodyContainsUseStrict of |FunctionBody|.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-arrow-function-definitions-static-semantics-hasname">
-      <h1>Static Semantics: HasName</h1>
-      <emu-see-also-para op="HasName"></emu-see-also-para>
-      <emu-grammar>ArrowFunction : ArrowParameters `=&gt;` ConciseBody</emu-grammar>
-      <emu-alg>
-        1. Return *false*.
       </emu-alg>
     </emu-clause>
 
@@ -19880,7 +19891,7 @@
     <emu-clause id="sec-arrow-function-definitions-runtime-semantics-namedevaluation">
       <h1>Runtime Semantics: NamedEvaluation</h1>
       <p>With parameter _name_.</p>
-      <emu-grammar>ArrowFunction : ArrowParameters `=&gt;` ConciseBody</emu-grammar>
+      <emu-grammar>ArrowFunction : ArrowParameters `=>` ConciseBody</emu-grammar>
       <emu-alg>
         1. Let _scope_ be the LexicalEnvironment of the running execution context.
         1. Let _sourceText_ be the source text matched by |ArrowFunction|.
@@ -19896,7 +19907,7 @@
 
     <emu-clause id="sec-arrow-function-definitions-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar>ArrowFunction : ArrowParameters `=&gt;` ConciseBody</emu-grammar>
+      <emu-grammar>ArrowFunction : ArrowParameters `=>` ConciseBody</emu-grammar>
       <emu-alg>
         1. Return the result of performing NamedEvaluation for this |ArrowFunction| with argument *""*.
       </emu-alg>
@@ -20230,19 +20241,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-generator-function-definitions-static-semantics-hasname">
-      <h1>Static Semantics: HasName</h1>
-      <emu-see-also-para op="HasName"></emu-see-also-para>
-      <emu-grammar>GeneratorExpression : `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-      <emu-grammar>GeneratorExpression : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
-      <emu-alg>
-        1. Return *true*.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-generator-function-definitions-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
@@ -20490,19 +20488,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-async-generator-function-definitions-static-semantics-hasname">
-      <h1>Static Semantics: HasName</h1>
-      <emu-see-also-para op="HasName"></emu-see-also-para>
-      <emu-grammar>AsyncGeneratorExpression : `async` `function` `*` `(` FormalParameters `)` `{` AsyncGeneratorBody `}`</emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-      <emu-grammar>AsyncGeneratorExpression : `async` `function` `*` BindingIdentifier `(` FormalParameters `)` `{` AsyncGeneratorBody `}`</emu-grammar>
-      <emu-alg>
-        1. Return *true*.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-async-generator-function-definitions-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
@@ -20746,19 +20731,6 @@
       <emu-grammar>ClassElement : `;`</emu-grammar>
       <emu-alg>
         1. Return *false*.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-class-definitions-static-semantics-hasname">
-      <h1>Static Semantics: HasName</h1>
-      <emu-see-also-para op="HasName"></emu-see-also-para>
-      <emu-grammar>ClassExpression : `class` ClassTail</emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-      <emu-grammar>ClassExpression : `class` BindingIdentifier ClassTail</emu-grammar>
-      <emu-alg>
-        1. Return *true*.
       </emu-alg>
     </emu-clause>
 
@@ -21058,22 +21030,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-async-function-definitions-static-semantics-HasName">
-      <h1>Static Semantics: HasName</h1>
-      <emu-grammar>
-        AsyncFunctionExpression : `async` `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
-      </emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-      <emu-grammar>
-        AsyncFunctionExpression : `async` `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
-      </emu-grammar>
-      <emu-alg>
-        1. Return *true*.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-async-function-definitions-static-semantics-IsFunctionDefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-grammar>
@@ -21285,18 +21241,6 @@
       <emu-grammar>AsyncConciseBody : `{` AsyncFunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Return FunctionBodyContainsUseStrict of |AsyncFunctionBody|.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-async-arrow-function-definitions-static-semantics-HasName">
-      <h1>Static Semantics: HasName</h1>
-      <emu-grammar>
-        AsyncArrowFunction : `async` AsyncArrowBindingIdentifier `=>` AsyncConciseBody
-
-        AsyncArrowFunction : CoverCallExpressionAndAsyncArrowHead `=>` AsyncConciseBody
-      </emu-grammar>
-      <emu-alg>
-        1. Return *false*.
       </emu-alg>
     </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -14991,32 +14991,6 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-template-literals-runtime-semantics-argumentlistevaluation">
-        <h1>Runtime Semantics: ArgumentListEvaluation</h1>
-        <emu-see-also-para op="ArgumentListEvaluation"></emu-see-also-para>
-        <emu-grammar>TemplateLiteral : NoSubstitutionTemplate</emu-grammar>
-        <emu-alg>
-          1. Let _templateLiteral_ be this |TemplateLiteral|.
-          1. Let _siteObj_ be GetTemplateObject(_templateLiteral_).
-          1. Return a List whose sole element is _siteObj_.
-        </emu-alg>
-        <emu-grammar>TemplateLiteral : SubstitutionTemplate</emu-grammar>
-        <emu-alg>
-          1. Let _templateLiteral_ be this |TemplateLiteral|.
-          1. Let _siteObj_ be GetTemplateObject(_templateLiteral_).
-          1. Let _remaining_ be ? ArgumentListEvaluation of |SubstitutionTemplate|.
-          1. Return a List whose first element is _siteObj_ and whose subsequent elements are the elements of _remaining_.
-        </emu-alg>
-        <emu-grammar>SubstitutionTemplate : TemplateHead Expression TemplateSpans</emu-grammar>
-        <emu-alg>
-          1. Let _firstSubRef_ be the result of evaluating |Expression|.
-          1. Let _firstSub_ be ? GetValue(_firstSubRef_).
-          1. Let _restSub_ be ? SubstitutionEvaluation of |TemplateSpans|.
-          1. Assert: _restSub_ is a List.
-          1. Return a List whose first element is _firstSub_ and whose subsequent elements are the elements of _restSub_. _restSub_ may contain no elements.
-        </emu-alg>
-      </emu-clause>
-
       <emu-clause id="sec-gettemplateobject" aoid="GetTemplateObject">
         <h1>GetTemplateObject ( _templateLiteral_ )</h1>
         <p>The abstract operation GetTemplateObject takes argument _templateLiteral_ (a Parse Node). It performs the following steps when called:</p>
@@ -15661,9 +15635,8 @@
         <p>The evaluation of an argument list produces a List of values.</p>
       </emu-note>
 
-      <emu-clause id="sec-argument-lists-runtime-semantics-argumentlistevaluation">
+      <emu-clause id="sec-runtime-semantics-argumentlistevaluation" oldids="sec-template-literals-runtime-semantics-argumentlistevaluation,sec-argument-lists-runtime-semantics-argumentlistevaluation" type="sdo" aoid="ArgumentListEvaluation">
         <h1>Runtime Semantics: ArgumentListEvaluation</h1>
-        <emu-see-also-para op="ArgumentListEvaluation"></emu-see-also-para>
         <emu-grammar>Arguments : `(` `)`</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
@@ -15704,6 +15677,27 @@
             1. If _next_ is *false*, return _precedingArgs_.
             1. Let _nextArg_ be ? IteratorValue(_next_).
             1. Append _nextArg_ as the last element of _precedingArgs_.
+        </emu-alg>
+        <emu-grammar>TemplateLiteral : NoSubstitutionTemplate</emu-grammar>
+        <emu-alg>
+          1. Let _templateLiteral_ be this |TemplateLiteral|.
+          1. Let _siteObj_ be GetTemplateObject(_templateLiteral_).
+          1. Return a List whose sole element is _siteObj_.
+        </emu-alg>
+        <emu-grammar>TemplateLiteral : SubstitutionTemplate</emu-grammar>
+        <emu-alg>
+          1. Let _templateLiteral_ be this |TemplateLiteral|.
+          1. Let _siteObj_ be GetTemplateObject(_templateLiteral_).
+          1. Let _remaining_ be ? ArgumentListEvaluation of |SubstitutionTemplate|.
+          1. Return a List whose first element is _siteObj_ and whose subsequent elements are the elements of _remaining_.
+        </emu-alg>
+        <emu-grammar>SubstitutionTemplate : TemplateHead Expression TemplateSpans</emu-grammar>
+        <emu-alg>
+          1. Let _firstSubRef_ be the result of evaluating |Expression|.
+          1. Let _firstSub_ be ? GetValue(_firstSubRef_).
+          1. Let _restSub_ be ? SubstitutionEvaluation of |TemplateSpans|.
+          1. Assert: _restSub_ is a List.
+          1. Return a List whose first element is _firstSub_ and whose subsequent elements are the elements of _restSub_. _restSub_ may contain no elements.
         </emu-alg>
       </emu-clause>
     </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -21793,9 +21793,8 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-module-semantics-static-semantics-modulerequests">
+      <emu-clause id="sec-static-semantics-modulerequests" oldids="sec-module-semantics-static-semantics-modulerequests,sec-imports-static-semantics-modulerequests,sec-exports-static-semantics-modulerequests" type="sdo" aoid="ModuleRequests">
         <h1>Static Semantics: ModuleRequests</h1>
-        <emu-see-also-para op="ModuleRequests"></emu-see-also-para>
         <emu-grammar>Module : [empty]</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
@@ -21812,6 +21811,32 @@
           1. Return _moduleNames_.
         </emu-alg>
         <emu-grammar>ModuleItem : StatementListItem</emu-grammar>
+        <emu-alg>
+          1. Return a new empty List.
+        </emu-alg>
+        <emu-grammar>ImportDeclaration : `import` ImportClause FromClause `;`</emu-grammar>
+        <emu-alg>
+          1. Return ModuleRequests of |FromClause|.
+        </emu-alg>
+        <emu-grammar>ModuleSpecifier : StringLiteral</emu-grammar>
+        <emu-alg>
+          1. Return a List whose sole element is the SV of |StringLiteral|.
+        </emu-alg>
+        <emu-grammar>
+          ExportDeclaration : `export` ExportFromClause FromClause `;`
+        </emu-grammar>
+        <emu-alg>
+          1. Return the ModuleRequests of |FromClause|.
+        </emu-alg>
+        <emu-grammar>
+          ExportDeclaration :
+            `export` NamedExports `;`
+            `export` VariableStatement
+            `export` Declaration
+            `export` `default` HoistableDeclaration
+            `export` `default` ClassDeclaration
+            `export` `default` AssignmentExpression `;`
+        </emu-grammar>
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
@@ -23181,19 +23206,6 @@
           1. Return a List whose sole element is _entry_.
         </emu-alg>
       </emu-clause>
-
-      <emu-clause id="sec-imports-static-semantics-modulerequests">
-        <h1>Static Semantics: ModuleRequests</h1>
-        <emu-see-also-para op="ModuleRequests"></emu-see-also-para>
-        <emu-grammar>ImportDeclaration : `import` ImportClause FromClause `;`</emu-grammar>
-        <emu-alg>
-          1. Return ModuleRequests of |FromClause|.
-        </emu-alg>
-        <emu-grammar>ModuleSpecifier : StringLiteral</emu-grammar>
-        <emu-alg>
-          1. Return a List whose sole element is the SV of |StringLiteral|.
-        </emu-alg>
-      </emu-clause>
     </emu-clause>
 
     <emu-clause id="sec-exports">
@@ -23499,29 +23511,6 @@
             1. Let _localName_ be *null*.
             1. Let _importName_ be _sourceName_.
           1. Return a List whose sole element is the ExportEntry Record { [[ModuleRequest]]: _module_, [[ImportName]]: _importName_, [[LocalName]]: _localName_, [[ExportName]]: _exportName_ }.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-exports-static-semantics-modulerequests">
-        <h1>Static Semantics: ModuleRequests</h1>
-        <emu-see-also-para op="ModuleRequests"></emu-see-also-para>
-        <emu-grammar>
-          ExportDeclaration : `export` ExportFromClause FromClause `;`
-        </emu-grammar>
-        <emu-alg>
-          1. Return the ModuleRequests of |FromClause|.
-        </emu-alg>
-        <emu-grammar>
-          ExportDeclaration :
-            `export` NamedExports `;`
-            `export` VariableStatement
-            `export` Declaration
-            `export` `default` HoistableDeclaration
-            `export` `default` ClassDeclaration
-            `export` `default` AssignmentExpression `;`
-        </emu-grammar>
-        <emu-alg>
-          1. Return a new empty List.
         </emu-alg>
       </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -7472,6 +7472,75 @@
         1. Return ? InstantiateAsyncFunctionObject of |AsyncFunctionDeclaration| with argument _scope_.
       </emu-alg>
     </emu-clause>
+
+    <emu-clause id="sec-runtime-semantics-bindinginitialization" oldids="sec-identifiers-runtime-semantics-bindinginitialization,sec-destructuring-binding-patterns-runtime-semantics-bindinginitialization" type="sdo" aoid="BindingInitialization">
+      <h1>Runtime Semantics: BindingInitialization</h1>
+      <p>With parameters _value_ and _environment_.</p>
+      <emu-note>
+        <p>*undefined* is passed for _environment_ to indicate that a PutValue operation should be used to assign the initialization value. This is the case for `var` statements and formal parameter lists of some non-strict functions (See <emu-xref href="#sec-functiondeclarationinstantiation"></emu-xref>). In those cases a lexical binding is hoisted and preinitialized prior to evaluation of its initializer.</p>
+      </emu-note>
+      <emu-grammar>BindingIdentifier : Identifier</emu-grammar>
+      <emu-alg>
+        1. Let _name_ be StringValue of |Identifier|.
+        1. Return ? InitializeBoundName(_name_, _value_, _environment_).
+      </emu-alg>
+      <emu-grammar>BindingIdentifier : `yield`</emu-grammar>
+      <emu-alg>
+        1. Return ? InitializeBoundName(*"yield"*, _value_, _environment_).
+      </emu-alg>
+      <emu-grammar>BindingIdentifier : `await`</emu-grammar>
+      <emu-alg>
+        1. Return ? InitializeBoundName(*"await"*, _value_, _environment_).
+      </emu-alg>
+      <emu-grammar>BindingPattern : ObjectBindingPattern</emu-grammar>
+      <emu-alg>
+        1. Perform ? RequireObjectCoercible(_value_).
+        1. Return the result of performing BindingInitialization for |ObjectBindingPattern| using _value_ and _environment_ as arguments.
+      </emu-alg>
+      <emu-grammar>BindingPattern : ArrayBindingPattern</emu-grammar>
+      <emu-alg>
+        1. Let _iteratorRecord_ be ? GetIterator(_value_).
+        1. Let _result_ be IteratorBindingInitialization of |ArrayBindingPattern| with arguments _iteratorRecord_ and _environment_.
+        1. If _iteratorRecord_.[[Done]] is *false*, return ? IteratorClose(_iteratorRecord_, _result_).
+        1. Return _result_.
+      </emu-alg>
+      <emu-grammar>ObjectBindingPattern : `{` `}`</emu-grammar>
+      <emu-alg>
+        1. Return NormalCompletion(~empty~).
+      </emu-alg>
+      <emu-grammar>
+        ObjectBindingPattern :
+          `{` BindingPropertyList `}`
+          `{` BindingPropertyList `,` `}`
+      </emu-grammar>
+      <emu-alg>
+        1. Perform ? PropertyBindingInitialization for |BindingPropertyList| using _value_ and _environment_ as the arguments.
+        1. Return NormalCompletion(~empty~).
+      </emu-alg>
+      <emu-grammar>ObjectBindingPattern : `{` BindingRestProperty `}`</emu-grammar>
+      <emu-alg>
+        1. Let _excludedNames_ be a new empty List.
+        1. Return the result of performing RestBindingInitialization of |BindingRestProperty| with _value_, _environment_, and _excludedNames_ as the arguments.
+      </emu-alg>
+      <emu-grammar>ObjectBindingPattern : `{` BindingPropertyList `,` BindingRestProperty `}`</emu-grammar>
+      <emu-alg>
+        1. Let _excludedNames_ be ? PropertyBindingInitialization of |BindingPropertyList| with arguments _value_ and _environment_.
+        1. Return the result of performing RestBindingInitialization of |BindingRestProperty| with arguments _value_, _environment_, and _excludedNames_.
+      </emu-alg>
+      <emu-clause id="sec-initializeboundname" aoid="InitializeBoundName">
+        <h1>InitializeBoundName ( _name_, _value_, _environment_ )</h1>
+        <p>The abstract operation InitializeBoundName takes arguments _name_, _value_, and _environment_. It performs the following steps when called:</p>
+        <emu-alg>
+          1. Assert: Type(_name_) is String.
+          1. If _environment_ is not *undefined*, then
+            1. Perform _environment_.InitializeBinding(_name_, _value_).
+            1. Return NormalCompletion(*undefined*).
+          1. Else,
+            1. Let _lhs_ be ResolveBinding(_name_).
+            1. Return ? PutValue(_lhs_, _value_).
+        </emu-alg>
+      </emu-clause>
+    </emu-clause>
   </emu-clause>
 </emu-clause>
 
@@ -13869,42 +13938,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-identifiers-runtime-semantics-bindinginitialization">
-      <h1>Runtime Semantics: BindingInitialization</h1>
-      <p>With parameters _value_ and _environment_.</p>
-      <emu-see-also-para op="BindingInitialization"></emu-see-also-para>
-      <emu-note>
-        <p>*undefined* is passed for _environment_ to indicate that a PutValue operation should be used to assign the initialization value. This is the case for `var` statements and formal parameter lists of some non-strict functions (See <emu-xref href="#sec-functiondeclarationinstantiation"></emu-xref>). In those cases a lexical binding is hoisted and preinitialized prior to evaluation of its initializer.</p>
-      </emu-note>
-      <emu-grammar>BindingIdentifier : Identifier</emu-grammar>
-      <emu-alg>
-        1. Let _name_ be StringValue of |Identifier|.
-        1. Return ? InitializeBoundName(_name_, _value_, _environment_).
-      </emu-alg>
-      <emu-grammar>BindingIdentifier : `yield`</emu-grammar>
-      <emu-alg>
-        1. Return ? InitializeBoundName(*"yield"*, _value_, _environment_).
-      </emu-alg>
-      <emu-grammar>BindingIdentifier : `await`</emu-grammar>
-      <emu-alg>
-        1. Return ? InitializeBoundName(*"await"*, _value_, _environment_).
-      </emu-alg>
-
-      <emu-clause id="sec-initializeboundname" aoid="InitializeBoundName">
-        <h1>InitializeBoundName ( _name_, _value_, _environment_ )</h1>
-        <p>The abstract operation InitializeBoundName takes arguments _name_, _value_, and _environment_. It performs the following steps when called:</p>
-        <emu-alg>
-          1. Assert: Type(_name_) is String.
-          1. If _environment_ is not *undefined*, then
-            1. Perform _environment_.InitializeBinding(_name_, _value_).
-            1. Return NormalCompletion(*undefined*).
-          1. Else,
-            1. Let _lhs_ be ResolveBinding(_name_).
-            1. Return ? PutValue(_lhs_, _value_).
-        </emu-alg>
-      </emu-clause>
-    </emu-clause>
-
     <emu-clause id="sec-identifiers-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>IdentifierReference : Identifier</emu-grammar>
@@ -17802,52 +17835,6 @@
           `...` BindingIdentifier[?Yield, ?Await]
           `...` BindingPattern[?Yield, ?Await]
       </emu-grammar>
-
-      <emu-clause id="sec-destructuring-binding-patterns-runtime-semantics-bindinginitialization">
-        <h1>Runtime Semantics: BindingInitialization</h1>
-        <p>With parameters _value_ and _environment_.</p>
-        <emu-see-also-para op="BindingInitialization"></emu-see-also-para>
-        <emu-note>
-          <p>When *undefined* is passed for _environment_ it indicates that a PutValue operation should be used to assign the initialization value. This is the case for formal parameter lists of non-strict functions. In that case the formal parameter bindings are preinitialized in order to deal with the possibility of multiple parameters with the same name.</p>
-        </emu-note>
-        <emu-grammar>BindingPattern : ObjectBindingPattern</emu-grammar>
-        <emu-alg>
-          1. Perform ? RequireObjectCoercible(_value_).
-          1. Return the result of performing BindingInitialization for |ObjectBindingPattern| using _value_ and _environment_ as arguments.
-        </emu-alg>
-        <emu-grammar>BindingPattern : ArrayBindingPattern</emu-grammar>
-        <emu-alg>
-          1. Let _iteratorRecord_ be ? GetIterator(_value_).
-          1. Let _result_ be IteratorBindingInitialization of |ArrayBindingPattern| with arguments _iteratorRecord_ and _environment_.
-          1. If _iteratorRecord_.[[Done]] is *false*, return ? IteratorClose(_iteratorRecord_, _result_).
-          1. Return _result_.
-        </emu-alg>
-        <emu-grammar>ObjectBindingPattern : `{` `}`</emu-grammar>
-        <emu-alg>
-          1. Return NormalCompletion(~empty~).
-        </emu-alg>
-        <emu-grammar>
-          ObjectBindingPattern :
-            `{` BindingPropertyList `}`
-            `{` BindingPropertyList `,` `}`
-        </emu-grammar>
-        <emu-alg>
-          1. Perform ? PropertyBindingInitialization for |BindingPropertyList| using _value_ and _environment_ as the arguments.
-          1. Return NormalCompletion(~empty~).
-        </emu-alg>
-
-        <emu-grammar>ObjectBindingPattern : `{` BindingRestProperty `}`</emu-grammar>
-        <emu-alg>
-          1. Let _excludedNames_ be a new empty List.
-          1. Return the result of performing RestBindingInitialization of |BindingRestProperty| with _value_, _environment_, and _excludedNames_ as the arguments.
-        </emu-alg>
-
-        <emu-grammar>ObjectBindingPattern : `{` BindingPropertyList `,` BindingRestProperty `}`</emu-grammar>
-        <emu-alg>
-          1. Let _excludedNames_ be ? PropertyBindingInitialization of |BindingPropertyList| with arguments _value_ and _environment_.
-          1. Return the result of performing RestBindingInitialization of |BindingRestProperty| with arguments _value_, _environment_, and _excludedNames_.
-        </emu-alg>
-      </emu-clause>
 
       <emu-clause id="sec-destructuring-binding-patterns-runtime-semantics-propertybindinginitialization">
         <h1>Runtime Semantics: PropertyBindingInitialization</h1>

--- a/spec.html
+++ b/spec.html
@@ -7404,6 +7404,206 @@
 
   <emu-clause id="sec-syntax-directed-operations-function-name-inference">
     <h1>Function Name Inference</h1>
+    <emu-clause id="sec-static-semantics-hasname" oldids="sec-semantics-static-semantics-hasname,sec-function-definitions-static-semantics-hasname,sec-arrow-function-definitions-static-semantics-hasname,sec-generator-function-definitions-static-semantics-hasname,sec-async-generator-function-definitions-static-semantics-hasname,sec-class-definitions-static-semantics-hasname,sec-async-function-definitions-static-semantics-HasName,sec-async-arrow-function-definitions-static-semantics-HasName" type="sdo" aoid="HasName">
+      <h1>Static Semantics: HasName</h1>
+      <emu-grammar>PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
+      <emu-alg>
+        1. Let _expr_ be CoveredParenthesizedExpression of |CoverParenthesizedExpressionAndArrowParameterList|.
+        1. If IsFunctionDefinition of _expr_ is *false*, return *false*.
+        1. Return HasName of _expr_.
+      </emu-alg>
+      <emu-grammar>
+        FunctionExpression :
+          `function` `(` FormalParameters `)` `{` FunctionBody `}`
+
+        GeneratorExpression :
+          `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`
+
+        AsyncGeneratorExpression :
+          `async` `function` `*` `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+
+        AsyncFunctionExpression :
+          `async` `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
+
+        ArrowFunction :
+          ArrowParameters `=>` ConciseBody
+
+        AsyncArrowFunction :
+          `async` AsyncArrowBindingIdentifier `=>` AsyncConciseBody
+          CoverCallExpressionAndAsyncArrowHead `=>` AsyncConciseBody
+
+        ClassExpression : `class` ClassTail
+      </emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>
+        FunctionExpression :
+          `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`
+
+        GeneratorExpression :
+          `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`
+
+        AsyncGeneratorExpression :
+          `async` `function` `*` BindingIdentifier `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+
+        AsyncFunctionExpression :
+          `async` `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
+
+        ClassExpression : `class` BindingIdentifier ClassTail
+      </emu-grammar>
+      <emu-alg>
+        1. Return *true*.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-static-semantics-isfunctiondefinition" oldids="sec-semantics-static-semantics-isfunctiondefinition,sec-grouping-operator-static-semantics-isfunctiondefinition,sec-static-semantics-static-semantics-isfunctiondefinition,sec-update-expressions-static-semantics-isfunctiondefinition,sec-unary-operators-static-semantics-isfunctiondefinition,sec-exp-operator-static-semantics-isfunctiondefinition,sec-multiplicative-operators-static-semantics-isfunctiondefinition,sec-additive-operators-static-semantics-isfunctiondefinition,sec-bitwise-shift-operators-static-semantics-isfunctiondefinition,sec-relational-operators-static-semantics-isfunctiondefinition,sec-equality-operators-static-semantics-isfunctiondefinition,sec-binary-bitwise-operators-static-semantics-isfunctiondefinition,sec-binary-logical-operators-static-semantics-isfunctiondefinition,sec-conditional-operator-static-semantics-isfunctiondefinition,sec-assignment-operators-static-semantics-isfunctiondefinition,sec-comma-operator-static-semantics-isfunctiondefinition,sec-function-definitions-static-semantics-isfunctiondefinition,sec-generator-function-definitions-static-semantics-isfunctiondefinition,sec-async-generator-function-definitions-static-semantics-isfunctiondefinition,sec-class-definitions-static-semantics-isfunctiondefinition,sec-async-function-definitions-static-semantics-IsFunctionDefinition" type="sdo" aoid="IsFunctionDefinition">
+      <h1>Static Semantics: IsFunctionDefinition</h1>
+      <emu-grammar>PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
+      <emu-alg>
+        1. Let _expr_ be CoveredParenthesizedExpression of |CoverParenthesizedExpressionAndArrowParameterList|.
+        1. Return IsFunctionDefinition of _expr_.
+      </emu-alg>
+      <emu-grammar>
+        PrimaryExpression :
+          `this`
+          IdentifierReference
+          Literal
+          ArrayLiteral
+          ObjectLiteral
+          RegularExpressionLiteral
+          TemplateLiteral
+
+        MemberExpression :
+          MemberExpression `[` Expression `]`
+          MemberExpression `.` IdentifierName
+          MemberExpression TemplateLiteral
+          SuperProperty
+          MetaProperty
+          `new` MemberExpression Arguments
+
+        NewExpression :
+          `new` NewExpression
+
+        LeftHandSideExpression :
+          CallExpression
+          OptionalExpression
+
+        UpdateExpression :
+          LeftHandSideExpression `++`
+          LeftHandSideExpression `--`
+          `++` UnaryExpression
+          `--` UnaryExpression
+
+        UnaryExpression :
+          `delete` UnaryExpression
+          `void` UnaryExpression
+          `typeof` UnaryExpression
+          `+` UnaryExpression
+          `-` UnaryExpression
+          `~` UnaryExpression
+          `!` UnaryExpression
+          AwaitExpression
+
+        ExponentiationExpression :
+          UpdateExpression `**` ExponentiationExpression
+
+        MultiplicativeExpression :
+          MultiplicativeExpression MultiplicativeOperator ExponentiationExpression
+
+        AdditiveExpression :
+          AdditiveExpression `+` MultiplicativeExpression
+          AdditiveExpression `-` MultiplicativeExpression
+
+        ShiftExpression :
+          ShiftExpression `&lt;&lt;` AdditiveExpression
+          ShiftExpression `&gt;&gt;` AdditiveExpression
+          ShiftExpression `&gt;&gt;&gt;` AdditiveExpression
+
+        RelationalExpression :
+          RelationalExpression `&lt;` ShiftExpression
+          RelationalExpression `&gt;` ShiftExpression
+          RelationalExpression `&lt;=` ShiftExpression
+          RelationalExpression `&gt;=` ShiftExpression
+          RelationalExpression `instanceof` ShiftExpression
+          RelationalExpression `in` ShiftExpression
+
+        EqualityExpression :
+          EqualityExpression `==` RelationalExpression
+          EqualityExpression `!=` RelationalExpression
+          EqualityExpression `===` RelationalExpression
+          EqualityExpression `!==` RelationalExpression
+
+        BitwiseANDExpression :
+          BitwiseANDExpression `&amp;` EqualityExpression
+
+        BitwiseXORExpression :
+          BitwiseXORExpression `^` BitwiseANDExpression
+
+        BitwiseORExpression :
+          BitwiseORExpression `|` BitwiseXORExpression
+
+        LogicalANDExpression :
+          LogicalANDExpression `&amp;&amp;` BitwiseORExpression
+
+        LogicalORExpression :
+          LogicalORExpression `||` LogicalANDExpression
+
+        CoalesceExpression :
+          CoalesceExpressionHead `??` BitwiseORExpression
+
+        ConditionalExpression :
+          ShortCircuitExpression `?` AssignmentExpression `:` AssignmentExpression
+
+        AssignmentExpression :
+          YieldExpression
+          LeftHandSideExpression `=` AssignmentExpression
+          LeftHandSideExpression AssignmentOperator AssignmentExpression
+          LeftHandSideExpression `&amp;&amp;=` AssignmentExpression
+          LeftHandSideExpression `||=` AssignmentExpression
+          LeftHandSideExpression `??=` AssignmentExpression
+
+        Expression :
+          Expression `,` AssignmentExpression
+      </emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>
+        AssignmentExpression :
+          ArrowFunction
+          AsyncArrowFunction
+
+        FunctionExpression :
+          `function` BindingIdentifier? `(` FormalParameters `)` `{` FunctionBody `}`
+
+        GeneratorExpression :
+          `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` GeneratorBody `}`
+
+        AsyncGeneratorExpression :
+          `async` `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+
+        AsyncFunctionExpression :
+          `async` `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
+          `async` `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
+
+        ClassExpression : `class` BindingIdentifier? ClassTail
+      </emu-grammar>
+      <emu-alg>
+        1. Return *true*.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-isanonymousfunctiondefinition" aoid="IsAnonymousFunctionDefinition">
+      <h1>Static Semantics: IsAnonymousFunctionDefinition ( _expr_ )</h1>
+      <p>The abstract operation IsAnonymousFunctionDefinition takes argument _expr_ (a Parse Node for |AssignmentExpression| or a Parse Node for |Initializer|). It determines if its argument is a function definition that does not bind a name. It performs the following steps when called:</p>
+      <emu-alg>
+        1. If IsFunctionDefinition of _expr_ is *false*, return *false*.
+        1. Let _hasName_ be HasName of _expr_.
+        1. If _hasName_ is *true*, return *false*.
+        1. Return *true*.
+      </emu-alg>
+    </emu-clause>
 
     <emu-clause id="sec-static-semantics-isidentifierref" oldids="sec-semantics-static-semantics-isidentifierref,sec-static-semantics-static-semantics-isidentifierref" type="sdo" aoid="IsIdentifierRef">
       <h1>Static Semantics: IsIdentifierRef</h1>
@@ -19452,207 +19652,6 @@
       <emu-grammar>FunctionBody : FunctionStatementList</emu-grammar>
       <emu-alg>
         1. If the Directive Prologue of |FunctionBody| contains a Use Strict Directive, return *true*; otherwise, return *false*.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-static-semantics-hasname" oldids="sec-semantics-static-semantics-hasname,sec-function-definitions-static-semantics-hasname,sec-arrow-function-definitions-static-semantics-hasname,sec-generator-function-definitions-static-semantics-hasname,sec-async-generator-function-definitions-static-semantics-hasname,sec-class-definitions-static-semantics-hasname,sec-async-function-definitions-static-semantics-HasName,sec-async-arrow-function-definitions-static-semantics-HasName" type="sdo" aoid="HasName">
-      <h1>Static Semantics: HasName</h1>
-      <emu-grammar>PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
-      <emu-alg>
-        1. Let _expr_ be CoveredParenthesizedExpression of |CoverParenthesizedExpressionAndArrowParameterList|.
-        1. If IsFunctionDefinition of _expr_ is *false*, return *false*.
-        1. Return HasName of _expr_.
-      </emu-alg>
-      <emu-grammar>
-        FunctionExpression :
-          `function` `(` FormalParameters `)` `{` FunctionBody `}`
-
-        GeneratorExpression :
-          `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`
-
-        AsyncGeneratorExpression :
-          `async` `function` `*` `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
-
-        AsyncFunctionExpression :
-          `async` `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
-
-        ArrowFunction :
-          ArrowParameters `=>` ConciseBody
-
-        AsyncArrowFunction :
-          `async` AsyncArrowBindingIdentifier `=>` AsyncConciseBody
-          CoverCallExpressionAndAsyncArrowHead `=>` AsyncConciseBody
-
-        ClassExpression : `class` ClassTail
-      </emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-      <emu-grammar>
-        FunctionExpression :
-          `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`
-
-        GeneratorExpression :
-          `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`
-
-        AsyncGeneratorExpression :
-          `async` `function` `*` BindingIdentifier `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
-
-        AsyncFunctionExpression :
-          `async` `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
-
-        ClassExpression : `class` BindingIdentifier ClassTail
-      </emu-grammar>
-      <emu-alg>
-        1. Return *true*.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-static-semantics-isfunctiondefinition" oldids="sec-semantics-static-semantics-isfunctiondefinition,sec-grouping-operator-static-semantics-isfunctiondefinition,sec-static-semantics-static-semantics-isfunctiondefinition,sec-update-expressions-static-semantics-isfunctiondefinition,sec-unary-operators-static-semantics-isfunctiondefinition,sec-exp-operator-static-semantics-isfunctiondefinition,sec-multiplicative-operators-static-semantics-isfunctiondefinition,sec-additive-operators-static-semantics-isfunctiondefinition,sec-bitwise-shift-operators-static-semantics-isfunctiondefinition,sec-relational-operators-static-semantics-isfunctiondefinition,sec-equality-operators-static-semantics-isfunctiondefinition,sec-binary-bitwise-operators-static-semantics-isfunctiondefinition,sec-binary-logical-operators-static-semantics-isfunctiondefinition,sec-conditional-operator-static-semantics-isfunctiondefinition,sec-assignment-operators-static-semantics-isfunctiondefinition,sec-comma-operator-static-semantics-isfunctiondefinition,sec-function-definitions-static-semantics-isfunctiondefinition,sec-generator-function-definitions-static-semantics-isfunctiondefinition,sec-async-generator-function-definitions-static-semantics-isfunctiondefinition,sec-class-definitions-static-semantics-isfunctiondefinition,sec-async-function-definitions-static-semantics-IsFunctionDefinition" type="sdo" aoid="IsFunctionDefinition">
-      <h1>Static Semantics: IsFunctionDefinition</h1>
-      <emu-grammar>PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
-      <emu-alg>
-        1. Let _expr_ be CoveredParenthesizedExpression of |CoverParenthesizedExpressionAndArrowParameterList|.
-        1. Return IsFunctionDefinition of _expr_.
-      </emu-alg>
-      <emu-grammar>
-        PrimaryExpression :
-          `this`
-          IdentifierReference
-          Literal
-          ArrayLiteral
-          ObjectLiteral
-          RegularExpressionLiteral
-          TemplateLiteral
-
-        MemberExpression :
-          MemberExpression `[` Expression `]`
-          MemberExpression `.` IdentifierName
-          MemberExpression TemplateLiteral
-          SuperProperty
-          MetaProperty
-          `new` MemberExpression Arguments
-
-        NewExpression :
-          `new` NewExpression
-
-        LeftHandSideExpression :
-          CallExpression
-          OptionalExpression
-
-        UpdateExpression :
-          LeftHandSideExpression `++`
-          LeftHandSideExpression `--`
-          `++` UnaryExpression
-          `--` UnaryExpression
-
-        UnaryExpression :
-          `delete` UnaryExpression
-          `void` UnaryExpression
-          `typeof` UnaryExpression
-          `+` UnaryExpression
-          `-` UnaryExpression
-          `~` UnaryExpression
-          `!` UnaryExpression
-          AwaitExpression
-
-        ExponentiationExpression :
-          UpdateExpression `**` ExponentiationExpression
-
-        MultiplicativeExpression :
-          MultiplicativeExpression MultiplicativeOperator ExponentiationExpression
-
-        AdditiveExpression :
-          AdditiveExpression `+` MultiplicativeExpression
-          AdditiveExpression `-` MultiplicativeExpression
-
-        ShiftExpression :
-          ShiftExpression `&lt;&lt;` AdditiveExpression
-          ShiftExpression `&gt;&gt;` AdditiveExpression
-          ShiftExpression `&gt;&gt;&gt;` AdditiveExpression
-
-        RelationalExpression :
-          RelationalExpression `&lt;` ShiftExpression
-          RelationalExpression `&gt;` ShiftExpression
-          RelationalExpression `&lt;=` ShiftExpression
-          RelationalExpression `&gt;=` ShiftExpression
-          RelationalExpression `instanceof` ShiftExpression
-          RelationalExpression `in` ShiftExpression
-
-        EqualityExpression :
-          EqualityExpression `==` RelationalExpression
-          EqualityExpression `!=` RelationalExpression
-          EqualityExpression `===` RelationalExpression
-          EqualityExpression `!==` RelationalExpression
-
-        BitwiseANDExpression :
-          BitwiseANDExpression `&amp;` EqualityExpression
-
-        BitwiseXORExpression :
-          BitwiseXORExpression `^` BitwiseANDExpression
-
-        BitwiseORExpression :
-          BitwiseORExpression `|` BitwiseXORExpression
-
-        LogicalANDExpression :
-          LogicalANDExpression `&amp;&amp;` BitwiseORExpression
-
-        LogicalORExpression :
-          LogicalORExpression `||` LogicalANDExpression
-
-        CoalesceExpression :
-          CoalesceExpressionHead `??` BitwiseORExpression
-
-        ConditionalExpression :
-          ShortCircuitExpression `?` AssignmentExpression `:` AssignmentExpression
-
-        AssignmentExpression :
-          YieldExpression
-          LeftHandSideExpression `=` AssignmentExpression
-          LeftHandSideExpression AssignmentOperator AssignmentExpression
-          LeftHandSideExpression `&amp;&amp;=` AssignmentExpression
-          LeftHandSideExpression `||=` AssignmentExpression
-          LeftHandSideExpression `??=` AssignmentExpression
-
-        Expression :
-          Expression `,` AssignmentExpression
-      </emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-      <emu-grammar>
-        AssignmentExpression :
-          ArrowFunction
-          AsyncArrowFunction
-
-        FunctionExpression :
-          `function` BindingIdentifier? `(` FormalParameters `)` `{` FunctionBody `}`
-
-        GeneratorExpression :
-          `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` GeneratorBody `}`
-
-        AsyncGeneratorExpression :
-          `async` `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
-
-        AsyncFunctionExpression :
-          `async` `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
-          `async` `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
-
-        ClassExpression : `class` BindingIdentifier? ClassTail
-      </emu-grammar>
-      <emu-alg>
-        1. Return *true*.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-isanonymousfunctiondefinition" aoid="IsAnonymousFunctionDefinition">
-      <h1>Static Semantics: IsAnonymousFunctionDefinition ( _expr_ )</h1>
-      <p>The abstract operation IsAnonymousFunctionDefinition takes argument _expr_ (a Parse Node for |AssignmentExpression| or a Parse Node for |Initializer|). It determines if its argument is a function definition that does not bind a name. It performs the following steps when called:</p>
-      <emu-alg>
-        1. If IsFunctionDefinition of _expr_ is *false*, return *false*.
-        1. Let _hasName_ be HasName of _expr_.
-        1. If _hasName_ is *true*, return *false*.
-        1. Return *true*.
       </emu-alg>
     </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -19662,17 +19662,44 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-function-definitions-runtime-semantics-namedevaluation">
-      <h1>Runtime Semantics: NamedEvaluation</h1>
-      <p>With parameter _name_.</p>
+    <emu-clause id="sec-runtime-semantics-instantiateordinaryfunctionexpression" type="sdo" aoid="InstantiateOrdinaryFunctionExpression">
+      <h1>Runtime Semantics: InstantiateOrdinaryFunctionExpression</h1>
+      <p>With optional parameter _name_.</p>
       <emu-grammar>FunctionExpression : `function` `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
+        1. If _name_ is not present, set _name_ to *""*.
         1. Let _scope_ be the LexicalEnvironment of the running execution context.
         1. Let _sourceText_ be the source text matched by |FunctionExpression|.
         1. Let _closure_ be OrdinaryFunctionCreate(%Function.prototype%, _sourceText_, |FormalParameters|, |FunctionBody|, ~non-lexical-this~, _scope_).
         1. Perform SetFunctionName(_closure_, _name_).
         1. Perform MakeConstructor(_closure_).
         1. Return _closure_.
+      </emu-alg>
+      <emu-grammar>FunctionExpression : `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-alg>
+        1. Assert: _name_ is not present.
+        1. Set _name_ to StringValue of |BindingIdentifier|.
+        1. Let _scope_ be the running execution context's LexicalEnvironment.
+        1. Let _funcEnv_ be NewDeclarativeEnvironment(_scope_).
+        1. Perform _funcEnv_.CreateImmutableBinding(_name_, *false*).
+        1. Let _sourceText_ be the source text matched by |FunctionExpression|.
+        1. Let _closure_ be OrdinaryFunctionCreate(%Function.prototype%, _sourceText_, |FormalParameters|, |FunctionBody|, ~non-lexical-this~, _funcEnv_).
+        1. Perform SetFunctionName(_closure_, _name_).
+        1. Perform MakeConstructor(_closure_).
+        1. Perform _funcEnv_.InitializeBinding(_name_, _closure_).
+        1. Return _closure_.
+      </emu-alg>
+      <emu-note>
+        <p>The |BindingIdentifier| in a |FunctionExpression| can be referenced from inside the |FunctionExpression|'s |FunctionBody| to allow the function to call itself recursively. However, unlike in a |FunctionDeclaration|, the |BindingIdentifier| in a |FunctionExpression| cannot be referenced from and does not affect the scope enclosing the |FunctionExpression|.</p>
+      </emu-note>
+    </emu-clause>
+
+    <emu-clause id="sec-function-definitions-runtime-semantics-namedevaluation">
+      <h1>Runtime Semantics: NamedEvaluation</h1>
+      <p>With parameter _name_.</p>
+      <emu-grammar>FunctionExpression : `function` `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-alg>
+        1. Return InstantiateOrdinaryFunctionExpression of |FunctionExpression| with argument _name_.
       </emu-alg>
     </emu-clause>
 
@@ -19689,26 +19716,12 @@
       <emu-alg>
         1. Return NormalCompletion(~empty~).
       </emu-alg>
-      <emu-grammar>FunctionExpression : `function` `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-grammar>
+        FunctionExpression : `function` BindingIdentifier? `(` FormalParameters `)` `{` FunctionBody `}`
+      </emu-grammar>
       <emu-alg>
-        1. Return the result of performing NamedEvaluation for this |FunctionExpression| with argument *""*.
+        1. Return InstantiateOrdinaryFunctionExpression of |FunctionExpression|.
       </emu-alg>
-      <emu-grammar>FunctionExpression : `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
-      <emu-alg>
-        1. Let _scope_ be the running execution context's LexicalEnvironment.
-        1. Let _funcEnv_ be NewDeclarativeEnvironment(_scope_).
-        1. Let _name_ be StringValue of |BindingIdentifier|.
-        1. Perform _funcEnv_.CreateImmutableBinding(_name_, *false*).
-        1. Let _sourceText_ be the source text matched by |FunctionExpression|.
-        1. Let _closure_ be OrdinaryFunctionCreate(%Function.prototype%, _sourceText_, |FormalParameters|, |FunctionBody|, ~non-lexical-this~, _funcEnv_).
-        1. Perform SetFunctionName(_closure_, _name_).
-        1. Perform MakeConstructor(_closure_).
-        1. Perform _funcEnv_.InitializeBinding(_name_, _closure_).
-        1. Return _closure_.
-      </emu-alg>
-      <emu-note>
-        <p>The |BindingIdentifier| in a |FunctionExpression| can be referenced from inside the |FunctionExpression|'s |FunctionBody| to allow the function to call itself recursively. However, unlike in a |FunctionDeclaration|, the |BindingIdentifier| in a |FunctionExpression| cannot be referenced from and does not affect the scope enclosing the |FunctionExpression|.</p>
-      </emu-note>
       <emu-note>
         <p>A *"prototype"* property is automatically created for every function defined using a |FunctionDeclaration| or |FunctionExpression|, to allow for the possibility that the function will be used as a constructor.</p>
       </emu-note>
@@ -19819,11 +19832,12 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-arrow-function-definitions-runtime-semantics-namedevaluation">
-      <h1>Runtime Semantics: NamedEvaluation</h1>
-      <p>With parameter _name_.</p>
+    <emu-clause id="sec-runtime-semantics-instantiatearrowfunctionexpression" type="sdo" aoid="InstantiateArrowFunctionExpression">
+      <h1>Runtime Semantics: InstantiateArrowFunctionExpression</h1>
+      <p>With optional parameter _name_.</p>
       <emu-grammar>ArrowFunction : ArrowParameters `=>` ConciseBody</emu-grammar>
       <emu-alg>
+        1. If _name_ is not present, set _name_ to *""*.
         1. Let _scope_ be the LexicalEnvironment of the running execution context.
         1. Let _sourceText_ be the source text matched by |ArrowFunction|.
         1. Let _parameters_ be CoveredFormalsList of |ArrowParameters|.
@@ -19836,11 +19850,20 @@
       </emu-note>
     </emu-clause>
 
+    <emu-clause id="sec-arrow-function-definitions-runtime-semantics-namedevaluation">
+      <h1>Runtime Semantics: NamedEvaluation</h1>
+      <p>With parameter _name_.</p>
+      <emu-grammar>ArrowFunction : ArrowParameters `=>` ConciseBody</emu-grammar>
+      <emu-alg>
+        1. Return InstantiateArrowFunctionExpression of |ArrowFunction| with argument _name_.
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-arrow-function-definitions-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>ArrowFunction : ArrowParameters `=>` ConciseBody</emu-grammar>
       <emu-alg>
-        1. Return the result of performing NamedEvaluation for this |ArrowFunction| with argument *""*.
+        1. Return InstantiateArrowFunctionExpression of |ArrowFunction|.
       </emu-alg>
       <emu-grammar>ExpressionBody : AssignmentExpression</emu-grammar>
       <emu-alg>
@@ -20175,11 +20198,12 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-generator-function-definitions-runtime-semantics-namedevaluation">
-      <h1>Runtime Semantics: NamedEvaluation</h1>
-      <p>With parameter _name_.</p>
+    <emu-clause id="sec-runtime-semantics-instantiategeneratorfunctionexpression" type="sdo" aoid="InstantiateGeneratorFunctionExpression">
+      <h1>Runtime Semantics: InstantiateGeneratorFunctionExpression</h1>
+      <p>With optional parameter _name_.</p>
       <emu-grammar>GeneratorExpression : `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
+        1. If _name_ is not present, set _name_ to *""*.
         1. Let _scope_ be the LexicalEnvironment of the running execution context.
         1. Let _sourceText_ be the source text matched by |GeneratorExpression|.
         1. Let _closure_ be OrdinaryFunctionCreate(%GeneratorFunction.prototype%, _sourceText_, |FormalParameters|, |GeneratorBody|, ~non-lexical-this~, _scope_).
@@ -20188,19 +20212,12 @@
         1. Perform DefinePropertyOrThrow(_closure_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
         1. Return _closure_.
       </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-generator-function-definitions-runtime-semantics-evaluation">
-      <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar>GeneratorExpression : `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
-      <emu-alg>
-        1. Return the result of performing NamedEvaluation for this |GeneratorExpression| with argument *""*.
-      </emu-alg>
       <emu-grammar>GeneratorExpression : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
+        1. Assert: _name_ is not present.
+        1. Set _name_ to StringValue of |BindingIdentifier|.
         1. Let _scope_ be the running execution context's LexicalEnvironment.
         1. Let _funcEnv_ be NewDeclarativeEnvironment(_scope_).
-        1. Let _name_ be StringValue of |BindingIdentifier|.
         1. Perform _funcEnv_.CreateImmutableBinding(_name_, *false*).
         1. Let _sourceText_ be the source text matched by |GeneratorExpression|.
         1. Let _closure_ be OrdinaryFunctionCreate(%GeneratorFunction.prototype%, _sourceText_, |FormalParameters|, |GeneratorBody|, ~non-lexical-this~, _funcEnv_).
@@ -20213,6 +20230,25 @@
       <emu-note>
         <p>The |BindingIdentifier| in a |GeneratorExpression| can be referenced from inside the |GeneratorExpression|'s |FunctionBody| to allow the generator code to call itself recursively. However, unlike in a |GeneratorDeclaration|, the |BindingIdentifier| in a |GeneratorExpression| cannot be referenced from and does not affect the scope enclosing the |GeneratorExpression|.</p>
       </emu-note>
+    </emu-clause>
+
+    <emu-clause id="sec-generator-function-definitions-runtime-semantics-namedevaluation">
+      <h1>Runtime Semantics: NamedEvaluation</h1>
+      <p>With parameter _name_.</p>
+      <emu-grammar>GeneratorExpression : `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
+      <emu-alg>
+        1. Return InstantiateGeneratorFunctionExpression of |GeneratorExpression| with argument _name_.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-generator-function-definitions-runtime-semantics-evaluation">
+      <h1>Runtime Semantics: Evaluation</h1>
+      <emu-grammar>
+        GeneratorExpression : `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` GeneratorBody `}`
+      </emu-grammar>
+      <emu-alg>
+        1. Return InstantiateGeneratorFunctionExpression of |GeneratorExpression|.
+      </emu-alg>
       <emu-grammar>YieldExpression : `yield`</emu-grammar>
       <emu-alg>
         1. Return ? Yield(*undefined*).
@@ -20381,13 +20417,14 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-asyncgenerator-definitions-namedevaluation">
-      <h1>Runtime Semantics: NamedEvaluation</h1>
-      <p>With parameter _name_.</p>
+    <emu-clause id="sec-runtime-semantics-instantiateasyncgeneratorfunctionexpression" type="sdo" aoid="InstantiateAsyncGeneratorFunctionExpression">
+      <h1>Runtime Semantics: InstantiateAsyncGeneratorFunctionExpression</h1>
+      <p>With optional parameter _name_.</p>
       <emu-grammar>
         AsyncGeneratorExpression : `async` `function` `*` `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
       </emu-grammar>
       <emu-alg>
+        1. If _name_ is not present, set _name_ to *""*.
         1. Let _scope_ be the LexicalEnvironment of the running execution context.
         1. Let _sourceText_ be the source text matched by |AsyncGeneratorExpression|.
         1. Let _closure_ be ! OrdinaryFunctionCreate(%AsyncGeneratorFunction.prototype%, _sourceText_, |FormalParameters|, |AsyncGeneratorBody|, ~non-lexical-this~, _scope_).
@@ -20396,25 +20433,14 @@
         1. Perform ! DefinePropertyOrThrow(_closure_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
         1. Return _closure_.
       </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-asyncgenerator-definitions-evaluation">
-      <h1>Runtime Semantics: Evaluation</h1>
-
-      <emu-grammar>
-        AsyncGeneratorExpression : `async` `function` `*` `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
-      </emu-grammar>
-      <emu-alg>
-        1. Return the result of performing NamedEvaluation for this |AsyncGeneratorExpression| with argument *""*.
-      </emu-alg>
-
       <emu-grammar>
         AsyncGeneratorExpression : `async` `function` `*` BindingIdentifier `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
       </emu-grammar>
       <emu-alg>
+        1. Assert: _name_ is not present.
+        1. Set _name_ to StringValue of |BindingIdentifier|.
         1. Let _scope_ be the running execution context's LexicalEnvironment.
         1. Let _funcEnv_ be ! NewDeclarativeEnvironment(_scope_).
-        1. Let _name_ be StringValue of |BindingIdentifier|.
         1. Perform ! _funcEnv_.CreateImmutableBinding(_name_, *false*).
         1. Let _sourceText_ be the source text matched by |AsyncGeneratorExpression|.
         1. Let _closure_ be ! OrdinaryFunctionCreate(%AsyncGeneratorFunction.prototype%, _sourceText_, |FormalParameters|, |AsyncGeneratorBody|, ~non-lexical-this~, _funcEnv_).
@@ -20427,6 +20453,27 @@
       <emu-note>
         <p>The |BindingIdentifier| in an |AsyncGeneratorExpression| can be referenced from inside the |AsyncGeneratorExpression|'s |AsyncGeneratorBody| to allow the generator code to call itself recursively. However, unlike in an |AsyncGeneratorDeclaration|, the |BindingIdentifier| in an |AsyncGeneratorExpression| cannot be referenced from and does not affect the scope enclosing the |AsyncGeneratorExpression|.</p>
       </emu-note>
+    </emu-clause>
+
+    <emu-clause id="sec-asyncgenerator-definitions-namedevaluation">
+      <h1>Runtime Semantics: NamedEvaluation</h1>
+      <p>With parameter _name_.</p>
+      <emu-grammar>
+        AsyncGeneratorExpression : `async` `function` `*` `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+      </emu-grammar>
+      <emu-alg>
+        1. Return InstantiateAsyncGeneratorFunctionExpression of |AsyncGeneratorExpression| with argument _name_.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-asyncgenerator-definitions-evaluation">
+      <h1>Runtime Semantics: Evaluation</h1>
+      <emu-grammar>
+        AsyncGeneratorExpression : `async` `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+      </emu-grammar>
+      <emu-alg>
+        1. Return InstantiateAsyncGeneratorFunctionExpression of |AsyncGeneratorExpression|.
+      </emu-alg>
     </emu-clause>
   </emu-clause>
 
@@ -20807,6 +20854,40 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-runtime-semantics-instantiateasyncfunctionexpression" type="sdo" aoid="InstantiateAsyncFunctionExpression">
+      <h1>Runtime Semantics: InstantiateAsyncFunctionExpression</h1>
+      <p>With optional parameter _name_.</p>
+      <emu-grammar>
+        AsyncFunctionExpression : `async` `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
+      </emu-grammar>
+      <emu-alg>
+        1. If _name_ is not present, set _name_ to *""*.
+        1. Let _scope_ be the LexicalEnvironment of the running execution context.
+        1. Let _sourceText_ be the source text matched by |AsyncFunctionExpression|.
+        1. Let _closure_ be ! OrdinaryFunctionCreate(%AsyncFunction.prototype%, _sourceText_, |FormalParameters|, |AsyncFunctionBody|, ~non-lexical-this~, _scope_).
+        1. Perform SetFunctionName(_closure_, _name_).
+        1. Return _closure_.
+      </emu-alg>
+      <emu-grammar>
+        AsyncFunctionExpression : `async` `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
+      </emu-grammar>
+      <emu-alg>
+        1. Assert: _name_ is not present.
+        1. Set _name_ to StringValue of |BindingIdentifier|.
+        1. Let _scope_ be the LexicalEnvironment of the running execution context.
+        1. Let _funcEnv_ be ! NewDeclarativeEnvironment(_scope_).
+        1. Perform ! _funcEnv_.CreateImmutableBinding(_name_, *false*).
+        1. Let _sourceText_ be the source text matched by |AsyncFunctionExpression|.
+        1. Let _closure_ be ! OrdinaryFunctionCreate(%AsyncFunction.prototype%, _sourceText_, |FormalParameters|, |AsyncFunctionBody|, ~non-lexical-this~, _funcEnv_).
+        1. Perform ! SetFunctionName(_closure_, _name_).
+        1. Perform ! _funcEnv_.InitializeBinding(_name_, _closure_).
+        1. Return _closure_.
+      </emu-alg>
+      <emu-note>
+        <p>The |BindingIdentifier| in an |AsyncFunctionExpression| can be referenced from inside the |AsyncFunctionExpression|'s |AsyncFunctionBody| to allow the function to call itself recursively. However, unlike in a |FunctionDeclaration|, the |BindingIdentifier| in a |AsyncFunctionExpression| cannot be referenced from and does not affect the scope enclosing the |AsyncFunctionExpression|.</p>
+      </emu-note>
+    </emu-clause>
+
     <emu-clause id="sec-runtime-semantics-evaluateasyncfunctionbody" oldids="sec-async-function-definitions-EvaluateBody" type="sdo" aoid="EvaluateAsyncFunctionBody">
       <h1>Runtime Semantics: EvaluateAsyncFunctionBody</h1>
       <p>With parameters _functionObject_ and _argumentsList_ (a List).</p>
@@ -20831,11 +20912,7 @@
         AsyncFunctionExpression : `async` `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
       <emu-alg>
-        1. Let _scope_ be the LexicalEnvironment of the running execution context.
-        1. Let _sourceText_ be the source text matched by |AsyncFunctionExpression|.
-        1. Let _closure_ be ! OrdinaryFunctionCreate(%AsyncFunction.prototype%, _sourceText_, |FormalParameters|, |AsyncFunctionBody|, ~non-lexical-this~, _scope_).
-        1. Perform SetFunctionName(_closure_, _name_).
-        1. Return _closure_.
+        1. Return InstantiateAsyncFunctionExpression of |AsyncFunctionExpression| with argument _name_.
       </emu-alg>
     </emu-clause>
 
@@ -20847,36 +20924,20 @@
       <emu-alg>
         1. Return NormalCompletion(~empty~).
       </emu-alg>
-
       <emu-grammar>
         AsyncFunctionDeclaration : `async` `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
       <emu-alg>
         1. Return NormalCompletion(~empty~).
       </emu-alg>
-
       <emu-grammar>
-        AsyncFunctionExpression : `async` `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
+        AsyncFunctionExpression :
+          `async` `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
+          `async` `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
       <emu-alg>
-        1. Return the result of performing NamedEvaluation for this |AsyncFunctionExpression| with argument *""*.
+        1. Return InstantiateAsyncFunctionExpression of |AsyncFunctionExpression|.
       </emu-alg>
-
-      <emu-grammar>
-        AsyncFunctionExpression : `async` `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
-      </emu-grammar>
-      <emu-alg>
-        1. Let _scope_ be the LexicalEnvironment of the running execution context.
-        1. Let _funcEnv_ be ! NewDeclarativeEnvironment(_scope_).
-        1. Let _name_ be StringValue of |BindingIdentifier|.
-        1. Perform ! _funcEnv_.CreateImmutableBinding(_name_, *false*).
-        1. Let _sourceText_ be the source text matched by |AsyncFunctionExpression|.
-        1. Let _closure_ be ! OrdinaryFunctionCreate(%AsyncFunction.prototype%, _sourceText_, |FormalParameters|, |AsyncFunctionBody|, ~non-lexical-this~, _funcEnv_).
-        1. Perform ! SetFunctionName(_closure_, _name_).
-        1. Perform ! _funcEnv_.InitializeBinding(_name_, _closure_).
-        1. Return _closure_.
-      </emu-alg>
-
       <emu-grammar>
         AwaitExpression : `await` UnaryExpression
       </emu-grammar>
@@ -20978,13 +21039,14 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-async-arrow-function-definitions-runtime-semantics-namedevaluation">
-      <h1>Runtime Semantics: NamedEvaluation</h1>
-      <p>With parameter _name_.</p>
+    <emu-clause id="sec-runtime-semantics-instantiateasyncarrowfunctionexpression" type="sdo" aoid="InstantiateAsyncArrowFunctionExpression">
+      <h1>Runtime Semantics: InstantiateAsyncArrowFunctionExpression</h1>
+      <p>With optional parameter _name_.</p>
       <emu-grammar>
         AsyncArrowFunction : `async` AsyncArrowBindingIdentifier `=>` AsyncConciseBody
       </emu-grammar>
       <emu-alg>
+        1. If _name_ is not present, set _name_ to *""*.
         1. Let _scope_ be the LexicalEnvironment of the running execution context.
         1. Let _sourceText_ be the source text matched by |AsyncArrowFunction|.
         1. Let _parameters_ be |AsyncArrowBindingIdentifier|.
@@ -20996,6 +21058,7 @@
         AsyncArrowFunction : CoverCallExpressionAndAsyncArrowHead `=>` AsyncConciseBody
       </emu-grammar>
       <emu-alg>
+        1. If _name_ is not present, set _name_ to *""*.
         1. Let _scope_ be the LexicalEnvironment of the running execution context.
         1. Let _sourceText_ be the source text matched by |AsyncArrowFunction|.
         1. Let _head_ be CoveredAsyncArrowHead of |CoverCallExpressionAndAsyncArrowHead|.
@@ -21006,19 +21069,28 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-async-arrow-function-definitions-runtime-semantics-namedevaluation">
+      <h1>Runtime Semantics: NamedEvaluation</h1>
+      <p>With parameter _name_.</p>
+      <emu-grammar>
+        AsyncArrowFunction :
+          `async` AsyncArrowBindingIdentifier `=>` AsyncConciseBody
+          CoverCallExpressionAndAsyncArrowHead `=>` AsyncConciseBody
+      </emu-grammar>
+      <emu-alg>
+        1. Return InstantiateAsyncArrowFunctionExpression of |AsyncArrowFunction| with argument _name_.
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-async-arrow-function-definitions-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>
-        AsyncArrowFunction : `async` AsyncArrowBindingIdentifier `=>` AsyncConciseBody
+        AsyncArrowFunction :
+          `async` AsyncArrowBindingIdentifier `=>` AsyncConciseBody
+          CoverCallExpressionAndAsyncArrowHead `=>` AsyncConciseBody
       </emu-grammar>
       <emu-alg>
-        1. Return the result of performing NamedEvaluation for this |AsyncArrowFunction| with argument *""*.
-      </emu-alg>
-      <emu-grammar>
-        AsyncArrowFunction : CoverCallExpressionAndAsyncArrowHead `=>` AsyncConciseBody
-      </emu-grammar>
-      <emu-alg>
-        1. Return the result of performing NamedEvaluation for this |AsyncArrowFunction| with argument *""*.
+        1. Return InstantiateAsyncArrowFunctionExpression of |AsyncArrowFunction|.
       </emu-alg>
     </emu-clause>
   </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -19850,9 +19850,8 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-method-definitions-static-semantics-hasdirectsuper">
+    <emu-clause id="sec-static-semantics-hasdirectsuper" oldids="sec-method-definitions-static-semantics-hasdirectsuper,sec-generator-function-definitions-static-semantics-hasdirectsuper,sec-async-generator-function-definitions-static-semantics-hasdirectsuper,sec-async-function-definitions-static-semantics-HasDirectSuper" type="sdo" aoid="HasDirectSuper">
       <h1>Static Semantics: HasDirectSuper</h1>
-      <emu-see-also-para op="HasDirectSuper"></emu-see-also-para>
       <emu-grammar>MethodDefinition : PropertyName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. If |UniqueFormalParameters| Contains |SuperCall| is *true*, return *true*.
@@ -19866,6 +19865,23 @@
       <emu-alg>
         1. If |PropertySetParameterList| Contains |SuperCall| is *true*, return *true*.
         1. Return |FunctionBody| Contains |SuperCall|.
+      </emu-alg>
+      <emu-grammar>GeneratorMethod : `*` PropertyName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
+      <emu-alg>
+        1. If |UniqueFormalParameters| Contains |SuperCall| is *true*, return *true*.
+        1. Return |GeneratorBody| Contains |SuperCall|.
+      </emu-alg>
+      <emu-grammar>AsyncGeneratorMethod : `async` `*` PropertyName `(` UniqueFormalParameters `)` `{` AsyncGeneratorBody `}`</emu-grammar>
+      <emu-alg>
+        1. If |UniqueFormalParameters| Contains |SuperCall| is *true*, return *true*.
+        1. Return |AsyncGeneratorBody| Contains |SuperCall|.
+      </emu-alg>
+      <emu-grammar>
+        AsyncMethod : `async` PropertyName `(` UniqueFormalParameters `)` `{` AsyncFunctionBody `}`
+      </emu-grammar>
+      <emu-alg>
+        1. If |UniqueFormalParameters| Contains |SuperCall| is *true*, return *true*.
+        1. Return |AsyncFunctionBody| Contains |SuperCall|.
       </emu-alg>
     </emu-clause>
 
@@ -20105,16 +20121,6 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-generator-function-definitions-static-semantics-hasdirectsuper">
-      <h1>Static Semantics: HasDirectSuper</h1>
-      <emu-see-also-para op="HasDirectSuper"></emu-see-also-para>
-      <emu-grammar>GeneratorMethod : `*` PropertyName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
-      <emu-alg>
-        1. If |UniqueFormalParameters| Contains |SuperCall| is *true*, return *true*.
-        1. Return |GeneratorBody| Contains |SuperCall|.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-runtime-semantics-evaluategeneratorbody" oldids="sec-generator-function-definitions-runtime-semantics-evaluatebody" type="sdo" aoid="EvaluateGeneratorBody">
       <h1>Runtime Semantics: EvaluateGeneratorBody</h1>
       <p>With parameters _functionObject_ and _argumentsList_ (a List).</p>
@@ -20341,16 +20347,6 @@
       <emu-note>
         <p>Static semantic rules that depend upon substructure generally do not look into function definitions.</p>
       </emu-note>
-    </emu-clause>
-
-    <emu-clause id="sec-async-generator-function-definitions-static-semantics-hasdirectsuper">
-      <h1>Static Semantics: HasDirectSuper</h1>
-      <emu-see-also-para op="HasDirectSuper"></emu-see-also-para>
-      <emu-grammar>AsyncGeneratorMethod : `async` `*` PropertyName `(` UniqueFormalParameters `)` `{` AsyncGeneratorBody `}`</emu-grammar>
-      <emu-alg>
-        1. If |UniqueFormalParameters| Contains |SuperCall| is *true*, return *true*.
-        1. Return |AsyncGeneratorBody| Contains |SuperCall|.
-      </emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-runtime-semantics-evaluateasyncgeneratorbody" oldids="sec-asyncgenerator-definitions-evaluatebody" type="sdo" aoid="EvaluateAsyncGeneratorBody">
@@ -20864,17 +20860,6 @@
       <emu-note>
         <p>Static semantic rules that depend upon substructure generally do not look into function definitions.</p>
       </emu-note>
-    </emu-clause>
-
-    <emu-clause id="sec-async-function-definitions-static-semantics-HasDirectSuper">
-      <h1>Static Semantics: HasDirectSuper</h1>
-      <emu-grammar>
-        AsyncMethod : `async` PropertyName `(` UniqueFormalParameters `)` `{` AsyncFunctionBody `}`
-      </emu-grammar>
-      <emu-alg>
-        1. If |UniqueFormalParameters| Contains |SuperCall| is *true*, return *true*.
-        1. Return |AsyncFunctionBody| Contains |SuperCall|.
-      </emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-runtime-semantics-instantiateasyncfunctionobject" oldids="sec-async-function-definitions-InstantiateFunctionObject" type="sdo" aoid="InstantiateAsyncFunctionObject">

--- a/spec.html
+++ b/spec.html
@@ -7712,6 +7712,165 @@
         1. Return the result of performing BindingInitialization for |BindingIdentifier| using _v_ and _environment_ as the arguments.
       </emu-alg>
     </emu-clause>
+
+    <emu-clause id="sec-static-semantics-assignmenttargettype" oldids="sec-identifiers-static-semantics-assignmenttargettype,sec-identifiers-static-semantics-isvalidsimpleassignmenttarget,sec-semantics-static-semantics-assignmenttargettype,sec-semantics-static-semantics-isvalidsimpleassignmenttarget,sec-grouping-operator-static-semantics-assignmenttargettype,sec-grouping-operator-static-semantics-isvalidsimpleassignmenttarget,sec-static-semantics-static-semantics-assignmenttargettype,sec-static-semantics-static-semantics-isvalidsimpleassignmenttarget,sec-update-expressions-static-semantics-assignmenttargettype,sec-update-expressions-static-semantics-isvalidsimpleassignmenttarget,sec-unary-operators-static-semantics-assignmenttargettype,sec-unary-operators-static-semantics-isvalidsimpleassignmenttarget,sec-exp-operator-static-semantics-assignmenttargettype,sec-exp-operator-static-semantics-isvalidsimpleassignmenttarget,sec-multiplicative-operators-static-semantics-assignmenttargettype,sec-multiplicative-operators-static-semantics-isvalidsimpleassignmenttarget,sec-additive-operators-static-semantics-assignmenttargettype,sec-additive-operators-static-semantics-isvalidsimpleassignmenttarget,sec-bitwise-shift-operators-static-semantics-assignmenttargettype,sec-bitwise-shift-operators-static-semantics-isvalidsimpleassignmenttarget,sec-relational-operators-static-semantics-assignmenttargettype,sec-relational-operators-static-semantics-isvalidsimpleassignmenttarget,sec-equality-operators-static-semantics-assignmenttargettype,sec-equality-operators-static-semantics-isvalidsimpleassignmenttarget,sec-binary-bitwise-operators-static-semantics-assignmenttargettype,sec-binary-bitwise-operators-static-semantics-isvalidsimpleassignmenttarget,sec-binary-logical-operators-static-semantics-assignmenttargettype,sec-binary-logical-operators-static-semantics-isvalidsimpleassignmenttarget,sec-conditional-operator-static-semantics-assignmenttargettype,sec-conditional-operator-static-semantics-isvalidsimpleassignmenttarget,sec-assignment-operators-static-semantics-assignmenttargettype,sec-assignment-operators-static-semantics-isvalidsimpleassignmenttarget,sec-comma-operator-static-semantics-assignmenttargettype,sec-comma-operator-static-semantics-isvalidsimpleassignmenttarget" type="sdo" aoid="AssignmentTargetType">
+      <h1>Static Semantics: AssignmentTargetType</h1>
+      <emu-grammar>IdentifierReference : Identifier</emu-grammar>
+      <emu-alg>
+        1. If this |IdentifierReference| is contained in strict mode code and StringValue of |Identifier| is *"eval"* or *"arguments"*, return ~invalid~.
+        1. Return ~simple~.
+      </emu-alg>
+      <emu-grammar>
+        IdentifierReference :
+          `yield`
+          `await`
+
+        CallExpression :
+          CallExpression `[` Expression `]`
+          CallExpression `.` IdentifierName
+
+        MemberExpression :
+          MemberExpression `[` Expression `]`
+          MemberExpression `.` IdentifierName
+          SuperProperty
+      </emu-grammar>
+      <emu-alg>
+        1. Return ~simple~.
+      </emu-alg>
+      <emu-grammar>
+        PrimaryExpression :
+          CoverParenthesizedExpressionAndArrowParameterList
+      </emu-grammar>
+      <emu-alg>
+        1. Let _expr_ be CoveredParenthesizedExpression of |CoverParenthesizedExpressionAndArrowParameterList|.
+        1. Return AssignmentTargetType of _expr_.
+      </emu-alg>
+      <emu-grammar>
+        ParenthesizedExpression : `(` Expression `)`
+      </emu-grammar>
+      <emu-alg>
+        1. Return AssignmentTargetType of |Expression|.
+      </emu-alg>
+      <emu-grammar>
+        PrimaryExpression :
+          `this`
+          Literal
+          ArrayLiteral
+          ObjectLiteral
+          FunctionExpression
+          ClassExpression
+          GeneratorExpression
+          AsyncFunctionExpression
+          AsyncGeneratorExpression
+          RegularExpressionLiteral
+          TemplateLiteral
+
+        CallExpression :
+          CoverCallExpressionAndAsyncArrowHead
+          SuperCall
+          ImportCall
+          CallExpression Arguments
+          CallExpression TemplateLiteral
+
+        NewExpression :
+          `new` NewExpression
+
+        MemberExpression :
+          MemberExpression TemplateLiteral
+          `new` MemberExpression Arguments
+
+        NewTarget :
+          `new` `.` `target`
+
+        ImportMeta :
+          `import` `.` `meta`
+
+        LeftHandSideExpression :
+          OptionalExpression
+
+        UpdateExpression :
+          LeftHandSideExpression `++`
+          LeftHandSideExpression `--`
+          `++` UnaryExpression
+          `--` UnaryExpression
+
+        UnaryExpression :
+          `delete` UnaryExpression
+          `void` UnaryExpression
+          `typeof` UnaryExpression
+          `+` UnaryExpression
+          `-` UnaryExpression
+          `~` UnaryExpression
+          `!` UnaryExpression
+          AwaitExpression
+
+        ExponentiationExpression :
+          UpdateExpression `**` ExponentiationExpression
+
+        MultiplicativeExpression :
+          MultiplicativeExpression MultiplicativeOperator ExponentiationExpression
+
+        AdditiveExpression :
+          AdditiveExpression `+` MultiplicativeExpression
+          AdditiveExpression `-` MultiplicativeExpression
+
+        ShiftExpression :
+          ShiftExpression `&lt;&lt;` AdditiveExpression
+          ShiftExpression `&gt;&gt;` AdditiveExpression
+          ShiftExpression `&gt;&gt;&gt;` AdditiveExpression
+
+        RelationalExpression :
+          RelationalExpression `&lt;` ShiftExpression
+          RelationalExpression `&gt;` ShiftExpression
+          RelationalExpression `&lt;=` ShiftExpression
+          RelationalExpression `&gt;=` ShiftExpression
+          RelationalExpression `instanceof` ShiftExpression
+          RelationalExpression `in` ShiftExpression
+
+        EqualityExpression :
+          EqualityExpression `==` RelationalExpression
+          EqualityExpression `!=` RelationalExpression
+          EqualityExpression `===` RelationalExpression
+          EqualityExpression `!==` RelationalExpression
+
+        BitwiseANDExpression :
+          BitwiseANDExpression `&amp;` EqualityExpression
+
+        BitwiseXORExpression :
+          BitwiseXORExpression `^` BitwiseANDExpression
+
+        BitwiseORExpression :
+          BitwiseORExpression `|` BitwiseXORExpression
+
+        LogicalANDExpression :
+          LogicalANDExpression `&amp;&amp;` BitwiseORExpression
+
+        LogicalORExpression :
+          LogicalORExpression `||` LogicalANDExpression
+
+        CoalesceExpression :
+          CoalesceExpressionHead `??` BitwiseORExpression
+
+        ConditionalExpression :
+          ShortCircuitExpression `?` AssignmentExpression `:` AssignmentExpression
+
+        AssignmentExpression :
+          YieldExpression
+          ArrowFunction
+          AsyncArrowFunction
+          LeftHandSideExpression `=` AssignmentExpression
+          LeftHandSideExpression AssignmentOperator AssignmentExpression
+          LeftHandSideExpression `&amp;&amp;=` AssignmentExpression
+          LeftHandSideExpression `||=` AssignmentExpression
+          LeftHandSideExpression `??=` AssignmentExpression
+
+        Expression :
+          Expression `,` AssignmentExpression
+      </emu-grammar>
+      <emu-alg>
+        1. Return ~invalid~.
+      </emu-alg>
+    </emu-clause>
   </emu-clause>
 </emu-clause>
 
@@ -10499,7 +10658,7 @@
         <p><emu-xref href="#sec-block-level-function-declarations-web-legacy-compatibility-semantics"></emu-xref> provides an extension to the above algorithm that is necessary for backwards compatibility with web browser implementations of ECMAScript that predate ECMAScript 2015.</p>
       </emu-note>
       <emu-note>
-        <p>Parameter |Initializer|s may contain direct eval expressions. Any top level declarations of such evals are only visible to the eval code (<emu-xref href="#sec-types-of-source-code"></emu-xref>). The creation of the environment for such declarations is described in <emu-xref href="#sec-function-definitions-runtime-semantics-iteratorbindinginitialization"></emu-xref>.</p>
+        <p>Parameter |Initializer|s may contain direct eval expressions. Any top level declarations of such evals are only visible to the eval code (<emu-xref href="#sec-types-of-source-code"></emu-xref>). The creation of the environment for such declarations is described in <emu-xref href="#sec-runtime-semantics-iteratorbindinginitialization"></emu-xref>.</p>
       </emu-note>
     </emu-clause>
   </emu-clause>
@@ -12803,7 +12962,7 @@
         <p>Similarly, `implements`, `interface`, `package`, `private`, `protected`, and `public` are future reserved words in strict mode code.</p>
       </emu-note>
       <emu-note>
-        <p>The names `arguments` and `eval` are not keywords, but they are subject to some restrictions in strict mode code. See <emu-xref href="#sec-identifiers-static-semantics-early-errors"></emu-xref>, <emu-xref href="#sec-identifiers-static-semantics-assignmenttargettype"></emu-xref>, <emu-xref href="#sec-function-definitions-static-semantics-early-errors"></emu-xref>, <emu-xref href="#sec-generator-function-definitions-static-semantics-early-errors"></emu-xref>, <emu-xref href="#sec-async-generator-function-definitions-static-semantics-early-errors"></emu-xref>, and <emu-xref href="#sec-async-function-definitions-static-semantics-early-errors"></emu-xref>.</p>
+        <p>The names `arguments` and `eval` are not keywords, but they are subject to some restrictions in strict mode code. See <emu-xref href="#sec-identifiers-static-semantics-early-errors"></emu-xref>, <emu-xref href="#sec-static-semantics-assignmenttargettype"></emu-xref>, <emu-xref href="#sec-function-definitions-static-semantics-early-errors"></emu-xref>, <emu-xref href="#sec-generator-function-definitions-static-semantics-early-errors"></emu-xref>, <emu-xref href="#sec-async-generator-function-definitions-static-semantics-early-errors"></emu-xref>, and <emu-xref href="#sec-async-function-definitions-static-semantics-early-errors"></emu-xref>.</p>
       </emu-note>
     </emu-clause>
   </emu-clause>
@@ -14053,24 +14212,6 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause oldids="sec-identifiers-static-semantics-isvalidsimpleassignmenttarget" id="sec-identifiers-static-semantics-assignmenttargettype">
-      <h1>Static Semantics: AssignmentTargetType</h1>
-      <emu-see-also-para op="AssignmentTargetType"></emu-see-also-para>
-      <emu-grammar>IdentifierReference : Identifier</emu-grammar>
-      <emu-alg>
-        1. If this |IdentifierReference| is contained in strict mode code and StringValue of |Identifier| is *"eval"* or *"arguments"*, return ~invalid~.
-        1. Return ~simple~.
-      </emu-alg>
-      <emu-grammar>IdentifierReference : `yield`</emu-grammar>
-      <emu-alg>
-        1. Return ~simple~.
-      </emu-alg>
-      <emu-grammar>IdentifierReference : `await`</emu-grammar>
-      <emu-alg>
-        1. Return ~simple~.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-static-semantics-stringvalue" oldids="sec-identifiers-static-semantics-stringvalue,sec-identifier-names-static-semantics-stringvalue" type="sdo" aoid="StringValue">
       <h1>Static Semantics: StringValue</h1>
       <emu-grammar>
@@ -14240,33 +14381,6 @@
         </emu-grammar>
         <emu-alg>
           1. Return *false*.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause oldids="sec-semantics-static-semantics-isvalidsimpleassignmenttarget" id="sec-semantics-static-semantics-assignmenttargettype">
-        <h1>Static Semantics: AssignmentTargetType</h1>
-        <emu-see-also-para op="AssignmentTargetType"></emu-see-also-para>
-        <emu-grammar>
-          PrimaryExpression :
-            `this`
-            Literal
-            ArrayLiteral
-            ObjectLiteral
-            FunctionExpression
-            ClassExpression
-            GeneratorExpression
-            AsyncFunctionExpression
-            AsyncGeneratorExpression
-            RegularExpressionLiteral
-            TemplateLiteral
-        </emu-grammar>
-        <emu-alg>
-          1. Return ~invalid~.
-        </emu-alg>
-        <emu-grammar>PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
-        <emu-alg>
-          1. Let _expr_ be CoveredParenthesizedExpression of |CoverParenthesizedExpressionAndArrowParameterList|.
-          1. Return AssignmentTargetType of _expr_.
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -15065,15 +15179,6 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause oldids="sec-grouping-operator-static-semantics-isvalidsimpleassignmenttarget" id="sec-grouping-operator-static-semantics-assignmenttargettype">
-        <h1>Static Semantics: AssignmentTargetType</h1>
-        <emu-see-also-para op="AssignmentTargetType"></emu-see-also-para>
-        <emu-grammar>ParenthesizedExpression : `(` Expression `)`</emu-grammar>
-        <emu-alg>
-          1. Return AssignmentTargetType of |Expression|.
-        </emu-alg>
-      </emu-clause>
-
       <emu-clause id="sec-grouping-operator-runtime-semantics-namedevaluation">
         <h1>Runtime Semantics: NamedEvaluation</h1>
         <p>With parameter _name_.</p>
@@ -15349,51 +15454,6 @@
         </emu-grammar>
         <emu-alg>
           1. Return *false*.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause oldids="sec-static-semantics-static-semantics-isvalidsimpleassignmenttarget" id="sec-static-semantics-static-semantics-assignmenttargettype">
-        <h1>Static Semantics: AssignmentTargetType</h1>
-        <emu-see-also-para op="AssignmentTargetType"></emu-see-also-para>
-        <emu-grammar>
-          CallExpression :
-            CallExpression `[` Expression `]`
-            CallExpression `.` IdentifierName
-
-          MemberExpression :
-            MemberExpression `[` Expression `]`
-            MemberExpression `.` IdentifierName
-            SuperProperty
-        </emu-grammar>
-        <emu-alg>
-          1. Return ~simple~.
-        </emu-alg>
-        <emu-grammar>
-          CallExpression :
-            CoverCallExpressionAndAsyncArrowHead
-            SuperCall
-            ImportCall
-            CallExpression Arguments
-            CallExpression TemplateLiteral
-
-          NewExpression :
-            `new` NewExpression
-
-          MemberExpression :
-            MemberExpression TemplateLiteral
-            `new` MemberExpression Arguments
-
-          NewTarget :
-            `new` `.` `target`
-
-          ImportMeta :
-            `import` `.` `meta`
-
-          LeftHandSideExpression :
-            OptionalExpression
-        </emu-grammar>
-        <emu-alg>
-          1. Return ~invalid~.
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -15940,21 +16000,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause oldids="sec-update-expressions-static-semantics-isvalidsimpleassignmenttarget" id="sec-update-expressions-static-semantics-assignmenttargettype">
-      <h1>Static Semantics: AssignmentTargetType</h1>
-      <emu-see-also-para op="AssignmentTargetType"></emu-see-also-para>
-      <emu-grammar>
-        UpdateExpression :
-          LeftHandSideExpression `++`
-          LeftHandSideExpression `--`
-          `++` UnaryExpression
-          `--` UnaryExpression
-      </emu-grammar>
-      <emu-alg>
-        1. Return ~invalid~.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-postfix-increment-operator">
       <h1>Postfix Increment Operator</h1>
 
@@ -16052,25 +16097,6 @@
       </emu-grammar>
       <emu-alg>
         1. Return *false*.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause oldids="sec-unary-operators-static-semantics-isvalidsimpleassignmenttarget" id="sec-unary-operators-static-semantics-assignmenttargettype">
-      <h1>Static Semantics: AssignmentTargetType</h1>
-      <emu-see-also-para op="AssignmentTargetType"></emu-see-also-para>
-      <emu-grammar>
-        UnaryExpression :
-          `delete` UnaryExpression
-          `void` UnaryExpression
-          `typeof` UnaryExpression
-          `+` UnaryExpression
-          `-` UnaryExpression
-          `~` UnaryExpression
-          `!` UnaryExpression
-          AwaitExpression
-      </emu-grammar>
-      <emu-alg>
-        1. Return ~invalid~.
       </emu-alg>
     </emu-clause>
 
@@ -16336,18 +16362,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause oldids="sec-exp-operator-static-semantics-isvalidsimpleassignmenttarget" id="sec-exp-operator-static-semantics-assignmenttargettype">
-      <h1>Static Semantics: AssignmentTargetType</h1>
-      <emu-see-also-para op="AssignmentTargetType"></emu-see-also-para>
-      <emu-grammar>
-        ExponentiationExpression :
-          UpdateExpression `**` ExponentiationExpression
-      </emu-grammar>
-      <emu-alg>
-        1. Return ~invalid~.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-exp-operator-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>
@@ -16387,15 +16401,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause oldids="sec-multiplicative-operators-static-semantics-isvalidsimpleassignmenttarget" id="sec-multiplicative-operators-static-semantics-assignmenttargettype">
-      <h1>Static Semantics: AssignmentTargetType</h1>
-      <emu-see-also-para op="AssignmentTargetType"></emu-see-also-para>
-      <emu-grammar>MultiplicativeExpression : MultiplicativeExpression MultiplicativeOperator ExponentiationExpression</emu-grammar>
-      <emu-alg>
-        1. Return ~invalid~.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-multiplicative-operators-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>MultiplicativeExpression : MultiplicativeExpression MultiplicativeOperator ExponentiationExpression</emu-grammar>
@@ -16426,19 +16431,6 @@
       </emu-grammar>
       <emu-alg>
         1. Return *false*.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause oldids="sec-additive-operators-static-semantics-isvalidsimpleassignmenttarget" id="sec-additive-operators-static-semantics-assignmenttargettype">
-      <h1>Static Semantics: AssignmentTargetType</h1>
-      <emu-see-also-para op="AssignmentTargetType"></emu-see-also-para>
-      <emu-grammar>
-        AdditiveExpression :
-          AdditiveExpression `+` MultiplicativeExpression
-          AdditiveExpression `-` MultiplicativeExpression
-      </emu-grammar>
-      <emu-alg>
-        1. Return ~invalid~.
       </emu-alg>
     </emu-clause>
 
@@ -16495,20 +16487,6 @@
       </emu-grammar>
       <emu-alg>
         1. Return *false*.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause oldids="sec-bitwise-shift-operators-static-semantics-isvalidsimpleassignmenttarget" id="sec-bitwise-shift-operators-static-semantics-assignmenttargettype">
-      <h1>Static Semantics: AssignmentTargetType</h1>
-      <emu-see-also-para op="AssignmentTargetType"></emu-see-also-para>
-      <emu-grammar>
-        ShiftExpression :
-          ShiftExpression `&lt;&lt;` AdditiveExpression
-          ShiftExpression `&gt;&gt;` AdditiveExpression
-          ShiftExpression `&gt;&gt;&gt;` AdditiveExpression
-      </emu-grammar>
-      <emu-alg>
-        1. Return ~invalid~.
       </emu-alg>
     </emu-clause>
 
@@ -16592,23 +16570,6 @@
       </emu-grammar>
       <emu-alg>
         1. Return *false*.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause oldids="sec-relational-operators-static-semantics-isvalidsimpleassignmenttarget" id="sec-relational-operators-static-semantics-assignmenttargettype">
-      <h1>Static Semantics: AssignmentTargetType</h1>
-      <emu-see-also-para op="AssignmentTargetType"></emu-see-also-para>
-      <emu-grammar>
-        RelationalExpression :
-          RelationalExpression `&lt;` ShiftExpression
-          RelationalExpression `&gt;` ShiftExpression
-          RelationalExpression `&lt;=` ShiftExpression
-          RelationalExpression `&gt;=` ShiftExpression
-          RelationalExpression `instanceof` ShiftExpression
-          RelationalExpression `in` ShiftExpression
-      </emu-grammar>
-      <emu-alg>
-        1. Return ~invalid~.
       </emu-alg>
     </emu-clause>
 
@@ -16717,21 +16678,6 @@
       </emu-grammar>
       <emu-alg>
         1. Return *false*.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause oldids="sec-equality-operators-static-semantics-isvalidsimpleassignmenttarget" id="sec-equality-operators-static-semantics-assignmenttargettype">
-      <h1>Static Semantics: AssignmentTargetType</h1>
-      <emu-see-also-para op="AssignmentTargetType"></emu-see-also-para>
-      <emu-grammar>
-        EqualityExpression :
-          EqualityExpression `==` RelationalExpression
-          EqualityExpression `!=` RelationalExpression
-          EqualityExpression `===` RelationalExpression
-          EqualityExpression `!==` RelationalExpression
-      </emu-grammar>
-      <emu-alg>
-        1. Return ~invalid~.
       </emu-alg>
     </emu-clause>
 
@@ -16847,21 +16793,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause oldids="sec-binary-bitwise-operators-static-semantics-isvalidsimpleassignmenttarget" id="sec-binary-bitwise-operators-static-semantics-assignmenttargettype">
-      <h1>Static Semantics: AssignmentTargetType</h1>
-      <emu-see-also-para op="AssignmentTargetType"></emu-see-also-para>
-      <emu-grammar>
-        BitwiseANDExpression : BitwiseANDExpression `&amp;` EqualityExpression
-
-        BitwiseXORExpression : BitwiseXORExpression `^` BitwiseANDExpression
-
-        BitwiseORExpression : BitwiseORExpression `|` BitwiseXORExpression
-      </emu-grammar>
-      <emu-alg>
-        1. Return ~invalid~.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-binary-bitwise-operators-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>BitwiseANDExpression : BitwiseANDExpression `&amp;` EqualityExpression</emu-grammar>
@@ -16921,21 +16852,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause oldids="sec-binary-logical-operators-static-semantics-isvalidsimpleassignmenttarget" id="sec-binary-logical-operators-static-semantics-assignmenttargettype">
-      <h1>Static Semantics: AssignmentTargetType</h1>
-      <emu-see-also-para op="AssignmentTargetType"></emu-see-also-para>
-      <emu-grammar>
-        LogicalANDExpression : LogicalANDExpression `&amp;&amp;` BitwiseORExpression
-
-        LogicalORExpression : LogicalORExpression `||` LogicalANDExpression
-
-        CoalesceExpression : CoalesceExpressionHead `??` BitwiseORExpression
-      </emu-grammar>
-      <emu-alg>
-        1. Return ~invalid~.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-binary-logical-operators-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>LogicalANDExpression : LogicalANDExpression `&amp;&amp;` BitwiseORExpression</emu-grammar>
@@ -16986,15 +16902,6 @@
       <emu-grammar>ConditionalExpression : ShortCircuitExpression `?` AssignmentExpression `:` AssignmentExpression</emu-grammar>
       <emu-alg>
         1. Return *false*.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause oldids="sec-conditional-operator-static-semantics-isvalidsimpleassignmenttarget" id="sec-conditional-operator-static-semantics-assignmenttargettype">
-      <h1>Static Semantics: AssignmentTargetType</h1>
-      <emu-see-also-para op="AssignmentTargetType"></emu-see-also-para>
-      <emu-grammar>ConditionalExpression : ShortCircuitExpression `?` AssignmentExpression `:` AssignmentExpression</emu-grammar>
-      <emu-alg>
-        1. Return ~invalid~.
       </emu-alg>
     </emu-clause>
 
@@ -17087,25 +16994,6 @@
       </emu-grammar>
       <emu-alg>
         1. Return *false*.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause oldids="sec-assignment-operators-static-semantics-isvalidsimpleassignmenttarget" id="sec-assignment-operators-static-semantics-assignmenttargettype">
-      <h1>Static Semantics: AssignmentTargetType</h1>
-      <emu-see-also-para op="AssignmentTargetType"></emu-see-also-para>
-      <emu-grammar>
-        AssignmentExpression :
-          YieldExpression
-          ArrowFunction
-          AsyncArrowFunction
-          LeftHandSideExpression `=` AssignmentExpression
-          LeftHandSideExpression AssignmentOperator AssignmentExpression
-          LeftHandSideExpression `&amp;&amp;=` AssignmentExpression
-          LeftHandSideExpression `||=` AssignmentExpression
-          LeftHandSideExpression `??=` AssignmentExpression
-      </emu-grammar>
-      <emu-alg>
-        1. Return ~invalid~.
       </emu-alg>
     </emu-clause>
 
@@ -17618,15 +17506,6 @@
       <emu-grammar>Expression : Expression `,` AssignmentExpression</emu-grammar>
       <emu-alg>
         1. Return *false*.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause oldids="sec-comma-operator-static-semantics-isvalidsimpleassignmenttarget" id="sec-comma-operator-static-semantics-assignmenttargettype">
-      <h1>Static Semantics: AssignmentTargetType</h1>
-      <emu-see-also-para op="AssignmentTargetType"></emu-see-also-para>
-      <emu-grammar>Expression : Expression `,` AssignmentExpression</emu-grammar>
-      <emu-alg>
-        1. Return ~invalid~.
       </emu-alg>
     </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -5786,6 +5786,9 @@
 
     <emu-clause id="sec-static-semantics-boundnames" oldids="sec-identifiers-static-semantics-boundnames,sec-let-and-const-declarations-static-semantics-boundnames,sec-variable-statement-static-semantics-boundnames,sec-destructuring-binding-patterns-static-semantics-boundnames,sec-for-in-and-for-of-statements-static-semantics-boundnames,sec-function-definitions-static-semantics-boundnames,sec-arrow-function-definitions-static-semantics-boundnames,sec-generator-function-definitions-static-semantics-boundnames,sec-async-generator-function-definitions-static-semantics-boundnames,sec-class-definitions-static-semantics-boundnames,sec-async-function-definitions-static-semantics-BoundNames,sec-async-arrow-function-definitions-static-semantics-BoundNames,sec-imports-static-semantics-boundnames,sec-exports-static-semantics-boundnames" type="sdo" aoid="BoundNames">
       <h1>Static Semantics: BoundNames</h1>
+      <emu-note>
+        <p>*"\*default\*"* is used within this specification as a synthetic name for hoistable anonymous functions that are defined using export declarations.</p>
+      </emu-note>
       <emu-grammar>BindingIdentifier : Identifier</emu-grammar>
       <emu-alg>
         1. Return a List whose sole element is the StringValue of |Identifier|.
@@ -5898,9 +5901,6 @@
       <emu-alg>
         1. Return &laquo; *"\*default\*"* &raquo;.
       </emu-alg>
-      <emu-note>
-        <p>*"\*default\*"* is used within this specification as a synthetic name for hoistable anonymous functions that are defined using export declarations.</p>
-      </emu-note>
       <emu-grammar>FormalParameters : [empty]</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
@@ -5930,9 +5930,6 @@
       <emu-alg>
         1. Return &laquo; *"\*default\*"* &raquo;.
       </emu-alg>
-      <emu-note>
-        <p>*"\*default\*"* is used within this specification as a synthetic name for hoistable anonymous functions that are defined using export declarations.</p>
-      </emu-note>
       <emu-grammar>AsyncGeneratorDeclaration : `async` `function` `*` BindingIdentifier `(` FormalParameters `)` `{` AsyncGeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. Return the BoundNames of |BindingIdentifier|.
@@ -5941,9 +5938,6 @@
       <emu-alg>
         1. Return &laquo; *"\*default\*"* &raquo;.
       </emu-alg>
-      <emu-note>
-        <p>*"\*default\*"* is used within this specification as a synthetic name for hoistable anonymous functions that are defined using export declarations.</p>
-      </emu-note>
       <emu-grammar>ClassDeclaration : `class` BindingIdentifier ClassTail</emu-grammar>
       <emu-alg>
         1. Return the BoundNames of |BindingIdentifier|.
@@ -5964,7 +5958,6 @@
       <emu-alg>
         1. Return &laquo; *"\*default\*"* &raquo;.
       </emu-alg>
-      <emu-note>*"\*default\*"* is used within this specification as a synthetic name for hoistable anonymous functions that are defined using export declarations.</emu-note>
       <emu-grammar>
         CoverCallExpressionAndAsyncArrowHead : MemberExpression Arguments
       </emu-grammar>

--- a/spec.html
+++ b/spec.html
@@ -19489,7 +19489,7 @@
           If |BindingIdentifier| is present and the source code matching |BindingIdentifier| is strict mode code, it is a Syntax Error if the StringValue of |BindingIdentifier| is *"eval"* or *"arguments"*.
         </li>
         <li>
-          It is a Syntax Error if ContainsUseStrict of |FunctionBody| is *true* and IsSimpleParameterList of |FormalParameters| is *false*.
+          It is a Syntax Error if FunctionBodyContainsUseStrict of |FunctionBody| is *true* and IsSimpleParameterList of |FormalParameters| is *false*.
         </li>
         <li>
           It is a Syntax Error if any element of the BoundNames of |FormalParameters| also occurs in the LexicallyDeclaredNames of |FunctionBody|.
@@ -19611,9 +19611,8 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-function-definitions-static-semantics-containsusestrict">
-      <h1>Static Semantics: ContainsUseStrict</h1>
-      <emu-see-also-para op="ContainsUseStrict"></emu-see-also-para>
+    <emu-clause id="sec-static-semantics-functionbodycontainsusestrict" oldids="sec-function-definitions-static-semantics-containsusestrict" type="sdo" aoid="FunctionBodyContainsUseStrict">
+      <h1>Static Semantics: FunctionBodyContainsUseStrict</h1>
       <emu-grammar>FunctionBody : FunctionStatementList</emu-grammar>
       <emu-alg>
         1. If the Directive Prologue of |FunctionBody| contains a Use Strict Directive, return *true*; otherwise, return *false*.
@@ -19875,7 +19874,7 @@
           It is a Syntax Error if |ArrowParameters| Contains |AwaitExpression| is *true*.
         </li>
         <li>
-          It is a Syntax Error if ContainsUseStrict of |ConciseBody| is *true* and IsSimpleParameterList of |ArrowParameters| is *false*.
+          It is a Syntax Error if ConciseBodyContainsUseStrict of |ConciseBody| is *true* and IsSimpleParameterList of |ArrowParameters| is *false*.
         </li>
         <li>
           It is a Syntax Error if any element of the BoundNames of |ArrowParameters| also occurs in the LexicallyDeclaredNames of |ConciseBody|.
@@ -19922,12 +19921,15 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-arrow-function-definitions-static-semantics-containsusestrict">
-      <h1>Static Semantics: ContainsUseStrict</h1>
-      <emu-see-also-para op="ContainsUseStrict"></emu-see-also-para>
+    <emu-clause id="sec-static-semantics-concisebodycontainsusestrict" oldids="sec-arrow-function-definitions-static-semantics-containsusestrict" type="sdo" aoid="ConciseBodyContainsUseStrict">
+      <h1>Static Semantics: ConciseBodyContainsUseStrict</h1>
       <emu-grammar>ConciseBody : ExpressionBody</emu-grammar>
       <emu-alg>
         1. Return *false*.
+      </emu-alg>
+      <emu-grammar>ConciseBody : `{` FunctionBody `}`</emu-grammar>
+      <emu-alg>
+        1. Return FunctionBodyContainsUseStrict of |FunctionBody|.
       </emu-alg>
     </emu-clause>
 
@@ -20089,7 +20091,7 @@
       <emu-grammar>MethodDefinition : PropertyName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <ul>
         <li>
-          It is a Syntax Error if ContainsUseStrict of |FunctionBody| is *true* and IsSimpleParameterList of |UniqueFormalParameters| is *false*.
+          It is a Syntax Error if FunctionBodyContainsUseStrict of |FunctionBody| is *true* and IsSimpleParameterList of |UniqueFormalParameters| is *false*.
         </li>
         <li>
           It is a Syntax Error if any element of the BoundNames of |UniqueFormalParameters| also occurs in the LexicallyDeclaredNames of |FunctionBody|.
@@ -20101,7 +20103,7 @@
           It is a Syntax Error if BoundNames of |PropertySetParameterList| contains any duplicate elements.
         </li>
         <li>
-          It is a Syntax Error if ContainsUseStrict of |FunctionBody| is *true* and IsSimpleParameterList of |PropertySetParameterList| is *false*.
+          It is a Syntax Error if FunctionBodyContainsUseStrict of |FunctionBody| is *true* and IsSimpleParameterList of |PropertySetParameterList| is *false*.
         </li>
         <li>
           It is a Syntax Error if any element of the BoundNames of |PropertySetParameterList| also occurs in the LexicallyDeclaredNames of |FunctionBody|.
@@ -20320,7 +20322,7 @@
           It is a Syntax Error if |UniqueFormalParameters| Contains |YieldExpression| is *true*.
         </li>
         <li>
-          It is a Syntax Error if ContainsUseStrict of |GeneratorBody| is *true* and IsSimpleParameterList of |UniqueFormalParameters| is *false*.
+          It is a Syntax Error if FunctionBodyContainsUseStrict of |GeneratorBody| is *true* and IsSimpleParameterList of |UniqueFormalParameters| is *false*.
         </li>
         <li>
           It is a Syntax Error if any element of the BoundNames of |UniqueFormalParameters| also occurs in the LexicallyDeclaredNames of |GeneratorBody|.
@@ -20341,7 +20343,7 @@
           If |BindingIdentifier| is present and the source code matching |BindingIdentifier| is strict mode code, it is a Syntax Error if the StringValue of |BindingIdentifier| is *"eval"* or *"arguments"*.
         </li>
         <li>
-          It is a Syntax Error if ContainsUseStrict of |GeneratorBody| is *true* and IsSimpleParameterList of |FormalParameters| is *false*.
+          It is a Syntax Error if FunctionBodyContainsUseStrict of |GeneratorBody| is *true* and IsSimpleParameterList of |FormalParameters| is *false*.
         </li>
         <li>
           It is a Syntax Error if any element of the BoundNames of |FormalParameters| also occurs in the LexicallyDeclaredNames of |GeneratorBody|.
@@ -20640,7 +20642,7 @@
         <li>It is a Syntax Error if HasDirectSuper of |AsyncGeneratorMethod| is *true*.</li>
         <li>It is a Syntax Error if |UniqueFormalParameters| Contains |YieldExpression| is *true*.</li>
         <li>It is a Syntax Error if |UniqueFormalParameters| Contains |AwaitExpression| is *true*.</li>
-        <li>It is a Syntax Error if ContainsUseStrict of |AsyncGeneratorBody| is *true* and IsSimpleParameterList of |UniqueFormalParameters| is *false*.</li>
+        <li>It is a Syntax Error if FunctionBodyContainsUseStrict of |AsyncGeneratorBody| is *true* and IsSimpleParameterList of |UniqueFormalParameters| is *false*.</li>
         <li>It is a Syntax Error if any element of the BoundNames of |UniqueFormalParameters| also occurs in the LexicallyDeclaredNames of |AsyncGeneratorBody|.</li>
       </ul>
       <emu-grammar>
@@ -20653,7 +20655,7 @@
       <ul>
         <li>If the source code matching |FormalParameters| is strict mode code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.</li>
         <li>If |BindingIdentifier| is present and the source code matching |BindingIdentifier| is strict mode code, it is a Syntax Error if the StringValue of |BindingIdentifier| is *"eval"* or *"arguments"*.</li>
-        <li>It is a Syntax Error if ContainsUseStrict of |AsyncGeneratorBody| is *true* and IsSimpleParameterList of |FormalParameters| is *false*.</li>
+        <li>It is a Syntax Error if FunctionBodyContainsUseStrict of |AsyncGeneratorBody| is *true* and IsSimpleParameterList of |FormalParameters| is *false*.</li>
         <li>It is a Syntax Error if any element of the BoundNames of |FormalParameters| also occurs in the LexicallyDeclaredNames of |AsyncGeneratorBody|.</li>
         <li>It is a Syntax Error if |FormalParameters| Contains |YieldExpression| is *true*.</li>
         <li>It is a Syntax Error if |FormalParameters| Contains |AwaitExpression| is *true*.</li>
@@ -21276,7 +21278,7 @@
         AsyncMethod : `async` PropertyName `(` UniqueFormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
       <ul>
-        <li>It is a Syntax Error if ContainsUseStrict of |AsyncFunctionBody| is *true* and IsSimpleParameterList of |UniqueFormalParameters| is *false*.</li>
+        <li>It is a Syntax Error if FunctionBodyContainsUseStrict of |AsyncFunctionBody| is *true* and IsSimpleParameterList of |UniqueFormalParameters| is *false*.</li>
         <li>It is a Syntax Error if HasDirectSuper of |AsyncMethod| is *true*.</li>
         <li>It is a Syntax Error if |UniqueFormalParameters| Contains |AwaitExpression| is *true*.</li>
         <li>It is a Syntax Error if any element of the BoundNames of |UniqueFormalParameters| also occurs in the LexicallyDeclaredNames of |AsyncFunctionBody|.</li>
@@ -21291,7 +21293,7 @@
         AsyncFunctionExpression : `async` `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
       <ul>
-        <li>It is a Syntax Error if ContainsUseStrict of |AsyncFunctionBody| is *true* and IsSimpleParameterList of |FormalParameters| is *false*.</li>
+        <li>It is a Syntax Error if FunctionBodyContainsUseStrict of |AsyncFunctionBody| is *true* and IsSimpleParameterList of |FormalParameters| is *false*.</li>
         <li>It is a Syntax Error if |FormalParameters| Contains |AwaitExpression| is *true*.</li>
         <li>If the source code matching |FormalParameters| is strict mode code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.</li>
         <li>If |BindingIdentifier| is present and the source code matching |BindingIdentifier| is strict mode code, it is a Syntax Error if the StringValue of |BindingIdentifier| is *"eval"* or *"arguments"*.</li>
@@ -21563,7 +21565,7 @@
         <li>It is a Syntax Error if |CoverCallExpressionAndAsyncArrowHead| Contains |AwaitExpression| is *true*.</li>
         <li>It is a Syntax Error if |CoverCallExpressionAndAsyncArrowHead| is not covering an |AsyncArrowHead|.</li>
         <li>It is a Syntax Error if any element of the BoundNames of |CoverCallExpressionAndAsyncArrowHead| also occurs in the LexicallyDeclaredNames of |AsyncConciseBody|.</li>
-        <li>It is a Syntax Error if ContainsUseStrict of |AsyncConciseBody| is *true* and IsSimpleParameterList of |CoverCallExpressionAndAsyncArrowHead| is *false*.</li>
+        <li>It is a Syntax Error if AsyncConciseBodyContainsUseStrict of |AsyncConciseBody| is *true* and IsSimpleParameterList of |CoverCallExpressionAndAsyncArrowHead| is *false*.</li>
         <li>All Early Error rules for |AsyncArrowHead| and its derived productions apply to CoveredAsyncArrowHead of |CoverCallExpressionAndAsyncArrowHead|.</li>
       </ul>
     </emu-clause>
@@ -21613,12 +21615,15 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-async-arrow-function-definitions-static-semantics-containsusestrict">
-      <h1>Static Semantics: ContainsUseStrict</h1>
-      <emu-see-also-para op="ContainsUseStrict"></emu-see-also-para>
+    <emu-clause id="sec-static-semantics-asyncconcisebodycontainsusestrict" oldids="sec-async-arrow-function-definitions-static-semantics-containsusestrict" type="sdo" aoid="AsyncConciseBodyContainsUseStrict">
+      <h1>Static Semantics: AsyncConciseBodyContainsUseStrict</h1>
       <emu-grammar>AsyncConciseBody : ExpressionBody</emu-grammar>
       <emu-alg>
         1. Return *false*.
+      </emu-alg>
+      <emu-grammar>AsyncConciseBody : `{` AsyncFunctionBody `}`</emu-grammar>
+      <emu-alg>
+        1. Return FunctionBodyContainsUseStrict of |AsyncFunctionBody|.
       </emu-alg>
     </emu-clause>
 
@@ -26037,7 +26042,7 @@
               1. If _parameters_ is a List of errors, throw a *SyntaxError* exception.
               1. Let _body_ be ParseText(! StringToCodePoints(_bodyString_), _goal_).
               1. If _body_ is a List of errors, throw a *SyntaxError* exception.
-              1. Let _strict_ be ContainsUseStrict of _body_.
+              1. Let _strict_ be FunctionBodyContainsUseStrict of _body_.
               1. If _strict_ is *true*, apply the early error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> to _parameters_.
               1. If _strict_ is *true* and IsSimpleParameterList of _parameters_ is *false*, throw a *SyntaxError* exception.
               1. If any element of the BoundNames of _parameters_ also occurs in the LexicallyDeclaredNames of _body_, throw a *SyntaxError* exception.

--- a/spec.html
+++ b/spec.html
@@ -30652,7 +30652,7 @@ THH:mm:ss.sss
             It is a Syntax Error if _NcapturingParens_ &ge; 2<sup>32</sup> - 1.
           </li>
           <li>
-            It is a Syntax Error if |Pattern| contains multiple |GroupSpecifier|s whose enclosed |RegExpIdentifierName|s have the same StringValue.
+            It is a Syntax Error if |Pattern| contains multiple |GroupSpecifier|s whose enclosed |RegExpIdentifierName|s have the same CapturingGroupName.
           </li>
         </ul>
         <emu-grammar>QuantifierPrefix :: `{` DecimalDigits `,` DecimalDigits `}`</emu-grammar>
@@ -30664,7 +30664,7 @@ THH:mm:ss.sss
         <emu-grammar>AtomEscape :: `k` GroupName</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the enclosing |Pattern| does not contain a |GroupSpecifier| with an enclosed |RegExpIdentifierName| whose StringValue equals the StringValue of the |RegExpIdentifierName| of this production's |GroupName|.
+            It is a Syntax Error if the enclosing |Pattern| does not contain a |GroupSpecifier| with an enclosed |RegExpIdentifierName| whose CapturingGroupName equals the CapturingGroupName of the |RegExpIdentifierName| of this production's |GroupName|.
           </li>
         </ul>
         <emu-grammar>AtomEscape :: DecimalEscape</emu-grammar>
@@ -30977,9 +30977,8 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-regexp-identifier-names-static-semantics-stringvalue">
-        <h1>Static Semantics: StringValue</h1>
-        <emu-see-also-para op="StringValue"></emu-see-also-para>
+      <emu-clause id="sec-static-semantics-capturinggroupname" oldids="sec-regexp-identifier-names-static-semantics-stringvalue" type="sdo" aoid="CapturingGroupName">
+        <h1>Static Semantics: CapturingGroupName</h1>
         <emu-grammar>
           RegExpIdentifierName[U] ::
             RegExpIdentifierStart[?U]
@@ -31586,7 +31585,7 @@ THH:mm:ss.sss
         </emu-note>
         <p>The production <emu-grammar>AtomEscape :: `k` GroupName</emu-grammar> evaluates as follows:</p>
         <emu-alg>
-          1. Search the enclosing |Pattern| for an instance of a |GroupSpecifier| containing a |RegExpIdentifierName| which has a StringValue equal to the StringValue of the |RegExpIdentifierName| contained in |GroupName|.
+          1. Search the enclosing |Pattern| for an instance of a |GroupSpecifier| containing a |RegExpIdentifierName| which has a CapturingGroupName equal to the CapturingGroupName of the |RegExpIdentifierName| contained in |GroupName|.
           1. Assert: A unique such |GroupSpecifier| is found.
           1. Let _parenIndex_ be the number of left-capturing parentheses in the entire regular expression that occur to the left of the located |GroupSpecifier|. This is the total number of <emu-grammar>Atom :: `(` GroupSpecifier Disjunction `)`</emu-grammar> Parse Nodes prior to or enclosing the located |GroupSpecifier|, including its immediately enclosing |Atom|.
           1. Return ! BackreferenceMatcher(_parenIndex_, _direction_).
@@ -32094,7 +32093,7 @@ THH:mm:ss.sss
                 1. Let _capturedValue_ be the String value consisting of the code units of _captureI_.
               1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_i_)), _capturedValue_).
               1. If the _i_<sup>th</sup> capture of _R_ was defined with a |GroupName|, then
-                1. Let _s_ be the StringValue of the corresponding |RegExpIdentifierName|.
+                1. Let _s_ be the CapturingGroupName of the corresponding |RegExpIdentifierName|.
                 1. Perform ! CreateDataPropertyOrThrow(_groups_, _s_, _capturedValue_).
             1. Return _A_.
           </emu-alg>

--- a/spec.html
+++ b/spec.html
@@ -7445,6 +7445,60 @@
         1. Return *false*.
       </emu-alg>
     </emu-clause>
+
+    <emu-clause id="sec-runtime-semantics-namedevaluation" oldids="sec-grouping-operator-runtime-semantics-namedevaluation,sec-function-definitions-runtime-semantics-namedevaluation,sec-arrow-function-definitions-runtime-semantics-namedevaluation,sec-generator-function-definitions-runtime-semantics-namedevaluation,sec-asyncgenerator-definitions-namedevaluation,sec-class-definitions-runtime-semantics-namedevaluation,sec-async-function-definitions-runtime-semantics-namedevaluation,sec-async-arrow-function-definitions-runtime-semantics-namedevaluation" type="sdo" aoid="NamedEvaluation">
+      <h1>Runtime Semantics: NamedEvaluation</h1>
+      <p>With parameter _name_.</p>
+      <emu-grammar>PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
+      <emu-alg>
+        1. Let _expr_ be CoveredParenthesizedExpression of |CoverParenthesizedExpressionAndArrowParameterList|.
+        1. Return the result of performing NamedEvaluation for _expr_ with argument _name_.
+      </emu-alg>
+      <emu-grammar>ParenthesizedExpression : `(` Expression `)`</emu-grammar>
+      <emu-alg>
+        1. Assert: IsAnonymousFunctionDefinition(|Expression|) is *true*.
+        1. Return the result of performing NamedEvaluation for |Expression| with argument _name_.
+      </emu-alg>
+      <emu-grammar>FunctionExpression : `function` `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-alg>
+        1. Return InstantiateOrdinaryFunctionExpression of |FunctionExpression| with argument _name_.
+      </emu-alg>
+      <emu-grammar>GeneratorExpression : `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
+      <emu-alg>
+        1. Return InstantiateGeneratorFunctionExpression of |GeneratorExpression| with argument _name_.
+      </emu-alg>
+      <emu-grammar>
+        AsyncGeneratorExpression : `async` `function` `*` `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+      </emu-grammar>
+      <emu-alg>
+        1. Return InstantiateAsyncGeneratorFunctionExpression of |AsyncGeneratorExpression| with argument _name_.
+      </emu-alg>
+      <emu-grammar>
+        AsyncFunctionExpression : `async` `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
+      </emu-grammar>
+      <emu-alg>
+        1. Return InstantiateAsyncFunctionExpression of |AsyncFunctionExpression| with argument _name_.
+      </emu-alg>
+      <emu-grammar>ArrowFunction : ArrowParameters `=>` ConciseBody</emu-grammar>
+      <emu-alg>
+        1. Return InstantiateArrowFunctionExpression of |ArrowFunction| with argument _name_.
+      </emu-alg>
+      <emu-grammar>
+        AsyncArrowFunction :
+          `async` AsyncArrowBindingIdentifier `=>` AsyncConciseBody
+          CoverCallExpressionAndAsyncArrowHead `=>` AsyncConciseBody
+      </emu-grammar>
+      <emu-alg>
+        1. Return InstantiateAsyncArrowFunctionExpression of |AsyncArrowFunction| with argument _name_.
+      </emu-alg>
+      <emu-grammar>ClassExpression : `class` ClassTail</emu-grammar>
+      <emu-alg>
+        1. Let _value_ be the result of ClassDefinitionEvaluation of |ClassTail| with arguments *undefined* and _name_.
+        1. ReturnIfAbrupt(_value_).
+        1. Set _value_.[[SourceText]] to the source text matched by |ClassExpression|.
+        1. Return _value_.
+      </emu-alg>
+    </emu-clause>
   </emu-clause>
 
   <emu-clause id="sec-syntax-directed-operations-contains">
@@ -15261,21 +15315,6 @@
         </ul>
       </emu-clause>
 
-      <emu-clause id="sec-grouping-operator-runtime-semantics-namedevaluation">
-        <h1>Runtime Semantics: NamedEvaluation</h1>
-        <p>With parameter _name_.</p>
-        <emu-grammar>PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
-        <emu-alg>
-          1. Let _expr_ be CoveredParenthesizedExpression of |CoverParenthesizedExpressionAndArrowParameterList|.
-          1. Return the result of performing NamedEvaluation for _expr_ with argument _name_.
-        </emu-alg>
-        <emu-grammar>ParenthesizedExpression : `(` Expression `)`</emu-grammar>
-        <emu-alg>
-          1. Assert: IsAnonymousFunctionDefinition(|Expression|) is *true*.
-          1. Return the result of performing NamedEvaluation for |Expression| with argument _name_.
-        </emu-alg>
-      </emu-clause>
-
       <emu-clause id="sec-grouping-operator-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
@@ -19684,15 +19723,6 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-function-definitions-runtime-semantics-namedevaluation">
-      <h1>Runtime Semantics: NamedEvaluation</h1>
-      <p>With parameter _name_.</p>
-      <emu-grammar>FunctionExpression : `function` `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
-      <emu-alg>
-        1. Return InstantiateOrdinaryFunctionExpression of |FunctionExpression| with argument _name_.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-function-definitions-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>FunctionDeclaration : `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
@@ -19838,15 +19868,6 @@
       <emu-note>
         <p>An |ArrowFunction| does not define local bindings for `arguments`, `super`, `this`, or `new.target`. Any reference to `arguments`, `super`, `this`, or `new.target` within an |ArrowFunction| must resolve to a binding in a lexically enclosing environment. Typically this will be the Function Environment of an immediately enclosing function. Even though an |ArrowFunction| may contain references to `super`, the function object created in step <emu-xref href="#step-arrowfunction-evaluation-functioncreate"></emu-xref> is not made into a method by performing MakeMethod. An |ArrowFunction| that references `super` is always contained within a non-|ArrowFunction| and the necessary state to implement `super` is accessible via the _scope_ that is captured by the function object of the |ArrowFunction|.</p>
       </emu-note>
-    </emu-clause>
-
-    <emu-clause id="sec-arrow-function-definitions-runtime-semantics-namedevaluation">
-      <h1>Runtime Semantics: NamedEvaluation</h1>
-      <p>With parameter _name_.</p>
-      <emu-grammar>ArrowFunction : ArrowParameters `=>` ConciseBody</emu-grammar>
-      <emu-alg>
-        1. Return InstantiateArrowFunctionExpression of |ArrowFunction| with argument _name_.
-      </emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-arrow-function-definitions-runtime-semantics-evaluation">
@@ -20222,15 +20243,6 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-generator-function-definitions-runtime-semantics-namedevaluation">
-      <h1>Runtime Semantics: NamedEvaluation</h1>
-      <p>With parameter _name_.</p>
-      <emu-grammar>GeneratorExpression : `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
-      <emu-alg>
-        1. Return InstantiateGeneratorFunctionExpression of |GeneratorExpression| with argument _name_.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-generator-function-definitions-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>
@@ -20443,17 +20455,6 @@
       <emu-note>
         <p>The |BindingIdentifier| in an |AsyncGeneratorExpression| can be referenced from inside the |AsyncGeneratorExpression|'s |AsyncGeneratorBody| to allow the generator code to call itself recursively. However, unlike in an |AsyncGeneratorDeclaration|, the |BindingIdentifier| in an |AsyncGeneratorExpression| cannot be referenced from and does not affect the scope enclosing the |AsyncGeneratorExpression|.</p>
       </emu-note>
-    </emu-clause>
-
-    <emu-clause id="sec-asyncgenerator-definitions-namedevaluation">
-      <h1>Runtime Semantics: NamedEvaluation</h1>
-      <p>With parameter _name_.</p>
-      <emu-grammar>
-        AsyncGeneratorExpression : `async` `function` `*` `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
-      </emu-grammar>
-      <emu-alg>
-        1. Return InstantiateAsyncGeneratorFunctionExpression of |AsyncGeneratorExpression| with argument _name_.
-      </emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-asyncgenerator-definitions-evaluation">
@@ -20710,18 +20711,6 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-class-definitions-runtime-semantics-namedevaluation">
-      <h1>Runtime Semantics: NamedEvaluation</h1>
-      <p>With parameter _name_.</p>
-      <emu-grammar>ClassExpression : `class` ClassTail</emu-grammar>
-      <emu-alg>
-        1. Let _value_ be the result of ClassDefinitionEvaluation of |ClassTail| with arguments *undefined* and _name_.
-        1. ReturnIfAbrupt(_value_).
-        1. Set _value_.[[SourceText]] to the source text matched by |ClassExpression|.
-        1. Return _value_.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-class-definitions-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>ClassDeclaration : `class` BindingIdentifier ClassTail</emu-grammar>
@@ -20895,17 +20884,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-async-function-definitions-runtime-semantics-namedevaluation">
-      <h1>Runtime Semantics: NamedEvaluation</h1>
-      <p>With parameter _name_.</p>
-      <emu-grammar>
-        AsyncFunctionExpression : `async` `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
-      </emu-grammar>
-      <emu-alg>
-        1. Return InstantiateAsyncFunctionExpression of |AsyncFunctionExpression| with argument _name_.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-async-function-definitions-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>
@@ -21056,19 +21034,6 @@
         1. Let _closure_ be ! OrdinaryFunctionCreate(%AsyncFunction.prototype%, _sourceText_, _parameters_, |AsyncConciseBody|, ~lexical-this~, _scope_).
         1. Perform SetFunctionName(_closure_, _name_).
         1. Return _closure_.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-async-arrow-function-definitions-runtime-semantics-namedevaluation">
-      <h1>Runtime Semantics: NamedEvaluation</h1>
-      <p>With parameter _name_.</p>
-      <emu-grammar>
-        AsyncArrowFunction :
-          `async` AsyncArrowBindingIdentifier `=>` AsyncConciseBody
-          CoverCallExpressionAndAsyncArrowHead `=>` AsyncConciseBody
-      </emu-grammar>
-      <emu-alg>
-        1. Return InstantiateAsyncArrowFunctionExpression of |AsyncArrowFunction| with argument _name_.
       </emu-alg>
     </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -5783,6 +5783,1134 @@
 
   <emu-clause id="sec-syntax-directed-operations-scope-analysis">
     <h1>Scope Analysis</h1>
+
+    <emu-clause id="sec-static-semantics-boundnames" oldids="sec-identifiers-static-semantics-boundnames,sec-let-and-const-declarations-static-semantics-boundnames,sec-variable-statement-static-semantics-boundnames,sec-destructuring-binding-patterns-static-semantics-boundnames,sec-for-in-and-for-of-statements-static-semantics-boundnames,sec-function-definitions-static-semantics-boundnames,sec-arrow-function-definitions-static-semantics-boundnames,sec-generator-function-definitions-static-semantics-boundnames,sec-async-generator-function-definitions-static-semantics-boundnames,sec-class-definitions-static-semantics-boundnames,sec-async-function-definitions-static-semantics-BoundNames,sec-async-arrow-function-definitions-static-semantics-BoundNames,sec-imports-static-semantics-boundnames,sec-exports-static-semantics-boundnames" type="sdo" aoid="BoundNames">
+      <h1>Static Semantics: BoundNames</h1>
+      <emu-grammar>BindingIdentifier : Identifier</emu-grammar>
+      <emu-alg>
+        1. Return a List whose sole element is the StringValue of |Identifier|.
+      </emu-alg>
+      <emu-grammar>BindingIdentifier : `yield`</emu-grammar>
+      <emu-alg>
+        1. Return a List whose sole element is *"yield"*.
+      </emu-alg>
+      <emu-grammar>BindingIdentifier : `await`</emu-grammar>
+      <emu-alg>
+        1. Return a List whose sole element is *"await"*.
+      </emu-alg>
+      <emu-grammar>LexicalDeclaration : LetOrConst BindingList `;`</emu-grammar>
+      <emu-alg>
+        1. Return the BoundNames of |BindingList|.
+      </emu-alg>
+      <emu-grammar>BindingList : BindingList `,` LexicalBinding</emu-grammar>
+      <emu-alg>
+        1. Let _names_ be the BoundNames of |BindingList|.
+        1. Append to _names_ the elements of the BoundNames of |LexicalBinding|.
+        1. Return _names_.
+      </emu-alg>
+      <emu-grammar>LexicalBinding : BindingIdentifier Initializer?</emu-grammar>
+      <emu-alg>
+        1. Return the BoundNames of |BindingIdentifier|.
+      </emu-alg>
+      <emu-grammar>LexicalBinding : BindingPattern Initializer</emu-grammar>
+      <emu-alg>
+        1. Return the BoundNames of |BindingPattern|.
+      </emu-alg>
+      <emu-grammar>VariableDeclarationList : VariableDeclarationList `,` VariableDeclaration</emu-grammar>
+      <emu-alg>
+        1. Let _names_ be BoundNames of |VariableDeclarationList|.
+        1. Append to _names_ the elements of BoundNames of |VariableDeclaration|.
+        1. Return _names_.
+      </emu-alg>
+      <emu-grammar>VariableDeclaration : BindingIdentifier Initializer?</emu-grammar>
+      <emu-alg>
+        1. Return the BoundNames of |BindingIdentifier|.
+      </emu-alg>
+      <emu-grammar>VariableDeclaration : BindingPattern Initializer</emu-grammar>
+      <emu-alg>
+        1. Return the BoundNames of |BindingPattern|.
+      </emu-alg>
+      <emu-grammar>ObjectBindingPattern : `{` `}`</emu-grammar>
+      <emu-alg>
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>ObjectBindingPattern : `{` BindingPropertyList `,` BindingRestProperty `}`</emu-grammar>
+      <emu-alg>
+        1. Let _names_ be BoundNames of |BindingPropertyList|.
+        1. Append to _names_ the elements of BoundNames of |BindingRestProperty|.
+        1. Return _names_.
+      </emu-alg>
+      <emu-grammar>ArrayBindingPattern : `[` Elision? `]`</emu-grammar>
+      <emu-alg>
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>ArrayBindingPattern : `[` Elision? BindingRestElement `]`</emu-grammar>
+      <emu-alg>
+        1. Return the BoundNames of |BindingRestElement|.
+      </emu-alg>
+      <emu-grammar>ArrayBindingPattern : `[` BindingElementList `,` Elision? `]`</emu-grammar>
+      <emu-alg>
+        1. Return the BoundNames of |BindingElementList|.
+      </emu-alg>
+      <emu-grammar>ArrayBindingPattern : `[` BindingElementList `,` Elision? BindingRestElement `]`</emu-grammar>
+      <emu-alg>
+        1. Let _names_ be BoundNames of |BindingElementList|.
+        1. Append to _names_ the elements of BoundNames of |BindingRestElement|.
+        1. Return _names_.
+      </emu-alg>
+      <emu-grammar>BindingPropertyList : BindingPropertyList `,` BindingProperty</emu-grammar>
+      <emu-alg>
+        1. Let _names_ be BoundNames of |BindingPropertyList|.
+        1. Append to _names_ the elements of BoundNames of |BindingProperty|.
+        1. Return _names_.
+      </emu-alg>
+      <emu-grammar>BindingElementList : BindingElementList `,` BindingElisionElement</emu-grammar>
+      <emu-alg>
+        1. Let _names_ be BoundNames of |BindingElementList|.
+        1. Append to _names_ the elements of BoundNames of |BindingElisionElement|.
+        1. Return _names_.
+      </emu-alg>
+      <emu-grammar>BindingElisionElement : Elision? BindingElement</emu-grammar>
+      <emu-alg>
+        1. Return BoundNames of |BindingElement|.
+      </emu-alg>
+      <emu-grammar>BindingProperty : PropertyName `:` BindingElement</emu-grammar>
+      <emu-alg>
+        1. Return the BoundNames of |BindingElement|.
+      </emu-alg>
+      <emu-grammar>SingleNameBinding : BindingIdentifier Initializer?</emu-grammar>
+      <emu-alg>
+        1. Return the BoundNames of |BindingIdentifier|.
+      </emu-alg>
+      <emu-grammar>BindingElement : BindingPattern Initializer?</emu-grammar>
+      <emu-alg>
+        1. Return the BoundNames of |BindingPattern|.
+      </emu-alg>
+      <emu-grammar>ForDeclaration : LetOrConst ForBinding</emu-grammar>
+      <emu-alg>
+        1. Return the BoundNames of |ForBinding|.
+      </emu-alg>
+      <emu-grammar>FunctionDeclaration : `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-alg>
+        1. Return the BoundNames of |BindingIdentifier|.
+      </emu-alg>
+      <emu-grammar>FunctionDeclaration : `function` `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-alg>
+        1. Return &laquo; *"\*default\*"* &raquo;.
+      </emu-alg>
+      <emu-note>
+        <p>*"\*default\*"* is used within this specification as a synthetic name for hoistable anonymous functions that are defined using export declarations.</p>
+      </emu-note>
+      <emu-grammar>FormalParameters : [empty]</emu-grammar>
+      <emu-alg>
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>FormalParameters : FormalParameterList `,` FunctionRestParameter</emu-grammar>
+      <emu-alg>
+        1. Let _names_ be BoundNames of |FormalParameterList|.
+        1. Append to _names_ the BoundNames of |FunctionRestParameter|.
+        1. Return _names_.
+      </emu-alg>
+      <emu-grammar>FormalParameterList : FormalParameterList `,` FormalParameter</emu-grammar>
+      <emu-alg>
+        1. Let _names_ be BoundNames of |FormalParameterList|.
+        1. Append to _names_ the BoundNames of |FormalParameter|.
+        1. Return _names_.
+      </emu-alg>
+      <emu-grammar>ArrowParameters : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
+      <emu-alg>
+        1. Let _formals_ be CoveredFormalsList of |CoverParenthesizedExpressionAndArrowParameterList|.
+        1. Return the BoundNames of _formals_.
+      </emu-alg>
+      <emu-grammar>GeneratorDeclaration : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
+      <emu-alg>
+        1. Return the BoundNames of |BindingIdentifier|.
+      </emu-alg>
+      <emu-grammar>GeneratorDeclaration : `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
+      <emu-alg>
+        1. Return &laquo; *"\*default\*"* &raquo;.
+      </emu-alg>
+      <emu-note>
+        <p>*"\*default\*"* is used within this specification as a synthetic name for hoistable anonymous functions that are defined using export declarations.</p>
+      </emu-note>
+      <emu-grammar>AsyncGeneratorDeclaration : `async` `function` `*` BindingIdentifier `(` FormalParameters `)` `{` AsyncGeneratorBody `}`</emu-grammar>
+      <emu-alg>
+        1. Return the BoundNames of |BindingIdentifier|.
+      </emu-alg>
+      <emu-grammar>AsyncGeneratorDeclaration : `async` `function` `*` `(` FormalParameters `)` `{` AsyncGeneratorBody `}`</emu-grammar>
+      <emu-alg>
+        1. Return &laquo; *"\*default\*"* &raquo;.
+      </emu-alg>
+      <emu-note>
+        <p>*"\*default\*"* is used within this specification as a synthetic name for hoistable anonymous functions that are defined using export declarations.</p>
+      </emu-note>
+      <emu-grammar>ClassDeclaration : `class` BindingIdentifier ClassTail</emu-grammar>
+      <emu-alg>
+        1. Return the BoundNames of |BindingIdentifier|.
+      </emu-alg>
+      <emu-grammar>ClassDeclaration : `class` ClassTail</emu-grammar>
+      <emu-alg>
+        1. Return &laquo; *"\*default\*"* &raquo;.
+      </emu-alg>
+      <emu-grammar>
+        AsyncFunctionDeclaration : `async` `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
+      </emu-grammar>
+      <emu-alg>
+        1. Return the BoundNames of |BindingIdentifier|.
+      </emu-alg>
+      <emu-grammar>
+        AsyncFunctionDeclaration : `async` `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
+      </emu-grammar>
+      <emu-alg>
+        1. Return &laquo; *"\*default\*"* &raquo;.
+      </emu-alg>
+      <emu-note>*"\*default\*"* is used within this specification as a synthetic name for hoistable anonymous functions that are defined using export declarations.</emu-note>
+      <emu-grammar>
+        CoverCallExpressionAndAsyncArrowHead : MemberExpression Arguments
+      </emu-grammar>
+      <emu-alg>
+        1. Let _head_ be CoveredAsyncArrowHead of |CoverCallExpressionAndAsyncArrowHead|.
+        1. Return the BoundNames of _head_.
+      </emu-alg>
+      <emu-grammar>ImportDeclaration : `import` ImportClause FromClause `;`</emu-grammar>
+      <emu-alg>
+        1. Return the BoundNames of |ImportClause|.
+      </emu-alg>
+      <emu-grammar>ImportDeclaration : `import` ModuleSpecifier `;`</emu-grammar>
+      <emu-alg>
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>ImportClause : ImportedDefaultBinding `,` NameSpaceImport</emu-grammar>
+      <emu-alg>
+        1. Let _names_ be the BoundNames of |ImportedDefaultBinding|.
+        1. Append to _names_ the elements of the BoundNames of |NameSpaceImport|.
+        1. Return _names_.
+      </emu-alg>
+      <emu-grammar>ImportClause : ImportedDefaultBinding `,` NamedImports</emu-grammar>
+      <emu-alg>
+        1. Let _names_ be the BoundNames of |ImportedDefaultBinding|.
+        1. Append to _names_ the elements of the BoundNames of |NamedImports|.
+        1. Return _names_.
+      </emu-alg>
+      <emu-grammar>NamedImports : `{` `}`</emu-grammar>
+      <emu-alg>
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>ImportsList : ImportsList `,` ImportSpecifier</emu-grammar>
+      <emu-alg>
+        1. Let _names_ be the BoundNames of |ImportsList|.
+        1. Append to _names_ the elements of the BoundNames of |ImportSpecifier|.
+        1. Return _names_.
+      </emu-alg>
+      <emu-grammar>ImportSpecifier : IdentifierName `as` ImportedBinding</emu-grammar>
+      <emu-alg>
+        1. Return the BoundNames of |ImportedBinding|.
+      </emu-alg>
+      <emu-grammar>
+        ExportDeclaration :
+          `export` ExportFromClause FromClause `;`
+          `export` NamedExports `;`
+      </emu-grammar>
+      <emu-alg>
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>ExportDeclaration : `export` VariableStatement</emu-grammar>
+      <emu-alg>
+        1. Return the BoundNames of |VariableStatement|.
+      </emu-alg>
+      <emu-grammar>ExportDeclaration : `export` Declaration</emu-grammar>
+      <emu-alg>
+        1. Return the BoundNames of |Declaration|.
+      </emu-alg>
+      <emu-grammar>ExportDeclaration : `export` `default` HoistableDeclaration</emu-grammar>
+      <emu-alg>
+        1. Let _declarationNames_ be the BoundNames of |HoistableDeclaration|.
+        1. If _declarationNames_ does not include the element *"\*default\*"*, append *"\*default\*"* to _declarationNames_.
+        1. Return _declarationNames_.
+      </emu-alg>
+      <emu-grammar>ExportDeclaration : `export` `default` ClassDeclaration</emu-grammar>
+      <emu-alg>
+        1. Let _declarationNames_ be the BoundNames of |ClassDeclaration|.
+        1. If _declarationNames_ does not include the element *"\*default\*"*, append *"\*default\*"* to _declarationNames_.
+        1. Return _declarationNames_.
+      </emu-alg>
+      <emu-grammar>ExportDeclaration : `export` `default` AssignmentExpression `;`</emu-grammar>
+      <emu-alg>
+        1. Return &laquo; *"\*default\*"* &raquo;.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-static-semantics-declarationpart" type="sdo" aoid="DeclarationPart">
+      <h1>Static Semantics: DeclarationPart</h1>
+      <emu-grammar>HoistableDeclaration : FunctionDeclaration</emu-grammar>
+      <emu-alg>
+        1. Return |FunctionDeclaration|.
+      </emu-alg>
+      <emu-grammar>HoistableDeclaration : GeneratorDeclaration</emu-grammar>
+      <emu-alg>
+        1. Return |GeneratorDeclaration|.
+      </emu-alg>
+      <emu-grammar>HoistableDeclaration : AsyncFunctionDeclaration</emu-grammar>
+      <emu-alg>
+        1. Return |AsyncFunctionDeclaration|.
+      </emu-alg>
+      <emu-grammar>HoistableDeclaration : AsyncGeneratorDeclaration</emu-grammar>
+      <emu-alg>
+        1. Return |AsyncGeneratorDeclaration|.
+      </emu-alg>
+      <emu-grammar>Declaration : ClassDeclaration</emu-grammar>
+      <emu-alg>
+        1. Return |ClassDeclaration|.
+      </emu-alg>
+      <emu-grammar>Declaration : LexicalDeclaration</emu-grammar>
+      <emu-alg>
+        1. Return |LexicalDeclaration|.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-static-semantics-isconstantdeclaration" oldids="sec-let-and-const-declarations-static-semantics-isconstantdeclaration,sec-function-definitions-static-semantics-isconstantdeclaration,sec-generator-function-definitions-static-semantics-isconstantdeclaration,sec-async-generator-function-definitions-static-semantics-isconstantdeclaration,sec-class-definitions-static-semantics-isconstantdeclaration,sec-async-function-definitions-static-semantics-IsConstantDeclaration,sec-exports-static-semantics-isconstantdeclaration" type="sdo" aoid="IsConstantDeclaration">
+      <h1>Static Semantics: IsConstantDeclaration</h1>
+      <emu-grammar>LexicalDeclaration : LetOrConst BindingList `;`</emu-grammar>
+      <emu-alg>
+        1. Return IsConstantDeclaration of |LetOrConst|.
+      </emu-alg>
+      <emu-grammar>LetOrConst : `let`</emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>LetOrConst : `const`</emu-grammar>
+      <emu-alg>
+        1. Return *true*.
+      </emu-alg>
+      <emu-grammar>
+        FunctionDeclaration : `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`
+
+        FunctionDeclaration : `function` `(` FormalParameters `)` `{` FunctionBody `}`
+      </emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>
+        GeneratorDeclaration : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`
+
+        GeneratorDeclaration : `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`
+      </emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>
+        AsyncGeneratorDeclaration : `async` `function` `*` BindingIdentifier `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+
+        AsyncGeneratorDeclaration : `async` `function` `*` `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+      </emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>
+        ClassDeclaration : `class` BindingIdentifier ClassTail
+
+        ClassDeclaration : `class` ClassTail
+      </emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>
+        AsyncFunctionDeclaration : `async` `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
+
+        AsyncFunctionDeclaration : `async` `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
+      </emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>
+        ExportDeclaration :
+          `export` ExportFromClause FromClause `;`
+          `export` NamedExports `;`
+          `export` `default` AssignmentExpression `;`
+      </emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+      <emu-note>
+        <p>It is not necessary to treat `export default` |AssignmentExpression| as a constant declaration because there is no syntax that permits assignment to the internal bound name used to reference a module's default object.</p>
+      </emu-note>
+    </emu-clause>
+
+    <emu-clause id="sec-static-semantics-lexicallydeclarednames" oldids="sec-block-static-semantics-lexicallydeclarednames,sec-switch-statement-static-semantics-lexicallydeclarednames,sec-labelled-statements-static-semantics-lexicallydeclarednames,sec-function-definitions-static-semantics-lexicallydeclarednames,sec-arrow-function-definitions-static-semantics-lexicallydeclarednames,sec-async-arrow-function-definitions-static-semantics-LexicallyDeclaredNames,sec-scripts-static-semantics-lexicallydeclarednames,sec-module-semantics-static-semantics-lexicallydeclarednames" type="sdo" aoid="LexicallyDeclaredNames">
+      <h1>Static Semantics: LexicallyDeclaredNames</h1>
+      <emu-grammar>Block : `{` `}`</emu-grammar>
+      <emu-alg>
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
+      <emu-alg>
+        1. Let _names_ be LexicallyDeclaredNames of |StatementList|.
+        1. Append to _names_ the elements of the LexicallyDeclaredNames of |StatementListItem|.
+        1. Return _names_.
+      </emu-alg>
+      <emu-grammar>StatementListItem : Statement</emu-grammar>
+      <emu-alg>
+        1. If |Statement| is <emu-grammar>Statement : LabelledStatement</emu-grammar> , return LexicallyDeclaredNames of |LabelledStatement|.
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>StatementListItem : Declaration</emu-grammar>
+      <emu-alg>
+        1. Return the BoundNames of |Declaration|.
+      </emu-alg>
+      <emu-grammar>CaseBlock : `{` `}`</emu-grammar>
+      <emu-alg>
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
+      <emu-alg>
+        1. If the first |CaseClauses| is present, let _names_ be the LexicallyDeclaredNames of the first |CaseClauses|.
+        1. Else, let _names_ be a new empty List.
+        1. Append to _names_ the elements of the LexicallyDeclaredNames of |DefaultClause|.
+        1. If the second |CaseClauses| is not present, return _names_.
+        1. Return the result of appending to _names_ the elements of the LexicallyDeclaredNames of the second |CaseClauses|.
+      </emu-alg>
+      <emu-grammar>CaseClauses : CaseClauses CaseClause</emu-grammar>
+      <emu-alg>
+        1. Let _names_ be LexicallyDeclaredNames of |CaseClauses|.
+        1. Append to _names_ the elements of the LexicallyDeclaredNames of |CaseClause|.
+        1. Return _names_.
+      </emu-alg>
+      <emu-grammar>CaseClause : `case` Expression `:` StatementList?</emu-grammar>
+      <emu-alg>
+        1. If the |StatementList| is present, return the LexicallyDeclaredNames of |StatementList|.
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>DefaultClause : `default` `:` StatementList?</emu-grammar>
+      <emu-alg>
+        1. If the |StatementList| is present, return the LexicallyDeclaredNames of |StatementList|.
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
+      <emu-alg>
+        1. Return the LexicallyDeclaredNames of |LabelledItem|.
+      </emu-alg>
+      <emu-grammar>LabelledItem : Statement</emu-grammar>
+      <emu-alg>
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
+      <emu-alg>
+        1. Return BoundNames of |FunctionDeclaration|.
+      </emu-alg>
+      <emu-grammar>FunctionStatementList : [empty]</emu-grammar>
+      <emu-alg>
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>FunctionStatementList : StatementList</emu-grammar>
+      <emu-alg>
+        1. Return TopLevelLexicallyDeclaredNames of |StatementList|.
+      </emu-alg>
+      <emu-grammar>ConciseBody : ExpressionBody</emu-grammar>
+      <emu-alg>
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>
+        AsyncConciseBody : ExpressionBody
+      </emu-grammar>
+      <emu-alg>
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>ScriptBody : StatementList</emu-grammar>
+      <emu-alg>
+        1. Return TopLevelLexicallyDeclaredNames of |StatementList|.
+      </emu-alg>
+      <emu-note>
+        <p>At the top level of a |Script|, function declarations are treated like var declarations rather than like lexical declarations.</p>
+      </emu-note>
+      <emu-note>
+        <p>The LexicallyDeclaredNames of a |Module| includes the names of all of its imported bindings.</p>
+      </emu-note>
+      <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
+      <emu-alg>
+        1. Let _names_ be LexicallyDeclaredNames of |ModuleItemList|.
+        1. Append to _names_ the elements of the LexicallyDeclaredNames of |ModuleItem|.
+        1. Return _names_.
+      </emu-alg>
+      <emu-grammar>ModuleItem : ImportDeclaration</emu-grammar>
+      <emu-alg>
+        1. Return the BoundNames of |ImportDeclaration|.
+      </emu-alg>
+      <emu-grammar>ModuleItem : ExportDeclaration</emu-grammar>
+      <emu-alg>
+        1. If |ExportDeclaration| is `export` |VariableStatement|, return a new empty List.
+        1. Return the BoundNames of |ExportDeclaration|.
+      </emu-alg>
+      <emu-grammar>ModuleItem : StatementListItem</emu-grammar>
+      <emu-alg>
+        1. Return LexicallyDeclaredNames of |StatementListItem|.
+      </emu-alg>
+      <emu-note>
+        <p>At the top level of a |Module|, function declarations are treated like lexical declarations rather than like var declarations.</p>
+      </emu-note>
+    </emu-clause>
+
+    <emu-clause id="sec-static-semantics-lexicallyscopeddeclarations" oldids="sec-block-static-semantics-lexicallyscopeddeclarations,sec-switch-statement-static-semantics-lexicallyscopeddeclarations,sec-labelled-statements-static-semantics-lexicallyscopeddeclarations,sec-function-definitions-static-semantics-lexicallyscopeddeclarations,sec-arrow-function-definitions-static-semantics-lexicallyscopeddeclarations,sec-async-arrow-function-definitions-static-semantics-LexicallyScopedDeclarations,sec-scripts-static-semantics-lexicallyscopeddeclarations,sec-module-semantics-static-semantics-lexicallyscopeddeclarations,sec-exports-static-semantics-lexicallyscopeddeclarations" type="sdo" aoid="LexicallyScopedDeclarations">
+      <h1>Static Semantics: LexicallyScopedDeclarations</h1>
+      <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
+      <emu-alg>
+        1. Let _declarations_ be LexicallyScopedDeclarations of |StatementList|.
+        1. Append to _declarations_ the elements of the LexicallyScopedDeclarations of |StatementListItem|.
+        1. Return _declarations_.
+      </emu-alg>
+      <emu-grammar>StatementListItem : Statement</emu-grammar>
+      <emu-alg>
+        1. If |Statement| is <emu-grammar>Statement : LabelledStatement</emu-grammar> , return LexicallyScopedDeclarations of |LabelledStatement|.
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>StatementListItem : Declaration</emu-grammar>
+      <emu-alg>
+        1. Return a List whose sole element is DeclarationPart of |Declaration|.
+      </emu-alg>
+      <emu-grammar>CaseBlock : `{` `}`</emu-grammar>
+      <emu-alg>
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
+      <emu-alg>
+        1. If the first |CaseClauses| is present, let _declarations_ be the LexicallyScopedDeclarations of the first |CaseClauses|.
+        1. Else, let _declarations_ be a new empty List.
+        1. Append to _declarations_ the elements of the LexicallyScopedDeclarations of |DefaultClause|.
+        1. If the second |CaseClauses| is not present, return _declarations_.
+        1. Return the result of appending to _declarations_ the elements of the LexicallyScopedDeclarations of the second |CaseClauses|.
+      </emu-alg>
+      <emu-grammar>CaseClauses : CaseClauses CaseClause</emu-grammar>
+      <emu-alg>
+        1. Let _declarations_ be LexicallyScopedDeclarations of |CaseClauses|.
+        1. Append to _declarations_ the elements of the LexicallyScopedDeclarations of |CaseClause|.
+        1. Return _declarations_.
+      </emu-alg>
+      <emu-grammar>CaseClause : `case` Expression `:` StatementList?</emu-grammar>
+      <emu-alg>
+        1. If the |StatementList| is present, return the LexicallyScopedDeclarations of |StatementList|.
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>DefaultClause : `default` `:` StatementList?</emu-grammar>
+      <emu-alg>
+        1. If the |StatementList| is present, return the LexicallyScopedDeclarations of |StatementList|.
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
+      <emu-alg>
+        1. Return the LexicallyScopedDeclarations of |LabelledItem|.
+      </emu-alg>
+      <emu-grammar>LabelledItem : Statement</emu-grammar>
+      <emu-alg>
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
+      <emu-alg>
+        1. Return a List whose sole element is |FunctionDeclaration|.
+      </emu-alg>
+      <emu-grammar>FunctionStatementList : [empty]</emu-grammar>
+      <emu-alg>
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>FunctionStatementList : StatementList</emu-grammar>
+      <emu-alg>
+        1. Return the TopLevelLexicallyScopedDeclarations of |StatementList|.
+      </emu-alg>
+      <emu-grammar>ConciseBody : ExpressionBody</emu-grammar>
+      <emu-alg>
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>
+        AsyncConciseBody : ExpressionBody
+      </emu-grammar>
+      <emu-alg>
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>ScriptBody : StatementList</emu-grammar>
+      <emu-alg>
+        1. Return TopLevelLexicallyScopedDeclarations of |StatementList|.
+      </emu-alg>
+      <emu-grammar>Module : [empty]</emu-grammar>
+      <emu-alg>
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
+      <emu-alg>
+        1. Let _declarations_ be LexicallyScopedDeclarations of |ModuleItemList|.
+        1. Append to _declarations_ the elements of the LexicallyScopedDeclarations of |ModuleItem|.
+        1. Return _declarations_.
+      </emu-alg>
+      <emu-grammar>ModuleItem : ImportDeclaration</emu-grammar>
+      <emu-alg>
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>
+        ExportDeclaration :
+          `export` ExportFromClause FromClause `;`
+          `export` NamedExports `;`
+          `export` VariableStatement
+      </emu-grammar>
+      <emu-alg>
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>ExportDeclaration : `export` Declaration</emu-grammar>
+      <emu-alg>
+        1. Return a List whose sole element is DeclarationPart of |Declaration|.
+      </emu-alg>
+      <emu-grammar>ExportDeclaration : `export` `default` HoistableDeclaration</emu-grammar>
+      <emu-alg>
+        1. Return a List whose sole element is DeclarationPart of |HoistableDeclaration|.
+      </emu-alg>
+      <emu-grammar>ExportDeclaration : `export` `default` ClassDeclaration</emu-grammar>
+      <emu-alg>
+        1. Return a List whose sole element is |ClassDeclaration|.
+      </emu-alg>
+      <emu-grammar>ExportDeclaration : `export` `default` AssignmentExpression `;`</emu-grammar>
+      <emu-alg>
+        1. Return a List whose sole element is this |ExportDeclaration|.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-static-semantics-vardeclarednames" oldids="sec-statement-semantics-static-semantics-vardeclarednames,sec-block-static-semantics-vardeclarednames,sec-variable-statement-static-semantics-vardeclarednames,sec-if-statement-static-semantics-vardeclarednames,sec-do-while-statement-static-semantics-vardeclarednames,sec-while-statement-static-semantics-vardeclarednames,sec-for-statement-static-semantics-vardeclarednames,sec-for-in-and-for-of-statements-static-semantics-vardeclarednames,sec-with-statement-static-semantics-vardeclarednames,sec-switch-statement-static-semantics-vardeclarednames,sec-labelled-statements-static-semantics-vardeclarednames,sec-try-statement-static-semantics-vardeclarednames,sec-function-definitions-static-semantics-vardeclarednames,sec-arrow-function-definitions-static-semantics-vardeclarednames,sec-async-arrow-function-definitions-static-semantics-VarDeclaredNames,sec-scripts-static-semantics-vardeclarednames,sec-module-semantics-static-semantics-vardeclarednames" type="sdo" aoid="VarDeclaredNames">
+      <h1>Static Semantics: VarDeclaredNames</h1>
+      <emu-grammar>
+        Statement :
+          EmptyStatement
+          ExpressionStatement
+          ContinueStatement
+          BreakStatement
+          ReturnStatement
+          ThrowStatement
+          DebuggerStatement
+      </emu-grammar>
+      <emu-alg>
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>Block : `{` `}`</emu-grammar>
+      <emu-alg>
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
+      <emu-alg>
+        1. Let _names_ be VarDeclaredNames of |StatementList|.
+        1. Append to _names_ the elements of the VarDeclaredNames of |StatementListItem|.
+        1. Return _names_.
+      </emu-alg>
+      <emu-grammar>StatementListItem : Declaration</emu-grammar>
+      <emu-alg>
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>VariableStatement : `var` VariableDeclarationList `;`</emu-grammar>
+      <emu-alg>
+        1. Return BoundNames of |VariableDeclarationList|.
+      </emu-alg>
+      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
+      <emu-alg>
+        1. Let _names_ be VarDeclaredNames of the first |Statement|.
+        1. Append to _names_ the elements of the VarDeclaredNames of the second |Statement|.
+        1. Return _names_.
+      </emu-alg>
+      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement</emu-grammar>
+      <emu-alg>
+        1. Return the VarDeclaredNames of |Statement|.
+      </emu-alg>
+      <emu-grammar>IterationStatement : `do` Statement `while` `(` Expression `)` `;`</emu-grammar>
+      <emu-alg>
+        1. Return the VarDeclaredNames of |Statement|.
+      </emu-alg>
+      <emu-grammar>IterationStatement : `while` `(` Expression `)` Statement</emu-grammar>
+      <emu-alg>
+        1. Return the VarDeclaredNames of |Statement|.
+      </emu-alg>
+      <emu-grammar>IterationStatement : `for` `(` Expression? `;` Expression? `;` Expression? `)` Statement</emu-grammar>
+      <emu-alg>
+        1. Return the VarDeclaredNames of |Statement|.
+      </emu-alg>
+      <emu-grammar>IterationStatement : `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement</emu-grammar>
+      <emu-alg>
+        1. Let _names_ be BoundNames of |VariableDeclarationList|.
+        1. Append to _names_ the elements of the VarDeclaredNames of |Statement|.
+        1. Return _names_.
+      </emu-alg>
+      <emu-grammar>IterationStatement : `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement</emu-grammar>
+      <emu-alg>
+        1. Return the VarDeclaredNames of |Statement|.
+      </emu-alg>
+      <emu-grammar>
+        IterationStatement :
+          `for` `(` LeftHandSideExpression `in` Expression `)` Statement
+          `for` `(` ForDeclaration `in` Expression `)` Statement
+          `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
+          `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement
+          `for` `await` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
+          `for` `await` `(` ForDeclaration `of` AssignmentExpression `)` Statement
+      </emu-grammar>
+      <emu-alg>
+        1. Return the VarDeclaredNames of |Statement|.
+      </emu-alg>
+      <emu-grammar>
+        IterationStatement :
+          `for` `(` `var` ForBinding `in` Expression `)` Statement
+          `for` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
+          `for` `await` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
+      </emu-grammar>
+      <emu-alg>
+        1. Let _names_ be the BoundNames of |ForBinding|.
+        1. Append to _names_ the elements of the VarDeclaredNames of |Statement|.
+        1. Return _names_.
+      </emu-alg>
+      <emu-note>
+        <p>This section is extended by Annex <emu-xref href="#sec-initializers-in-forin-statement-heads"></emu-xref>.</p>
+      </emu-note>
+      <emu-grammar>WithStatement : `with` `(` Expression `)` Statement</emu-grammar>
+      <emu-alg>
+        1. Return the VarDeclaredNames of |Statement|.
+      </emu-alg>
+      <emu-grammar>SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
+      <emu-alg>
+        1. Return the VarDeclaredNames of |CaseBlock|.
+      </emu-alg>
+      <emu-grammar>CaseBlock : `{` `}`</emu-grammar>
+      <emu-alg>
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
+      <emu-alg>
+        1. If the first |CaseClauses| is present, let _names_ be the VarDeclaredNames of the first |CaseClauses|.
+        1. Else, let _names_ be a new empty List.
+        1. Append to _names_ the elements of the VarDeclaredNames of |DefaultClause|.
+        1. If the second |CaseClauses| is not present, return _names_.
+        1. Return the result of appending to _names_ the elements of the VarDeclaredNames of the second |CaseClauses|.
+      </emu-alg>
+      <emu-grammar>CaseClauses : CaseClauses CaseClause</emu-grammar>
+      <emu-alg>
+        1. Let _names_ be VarDeclaredNames of |CaseClauses|.
+        1. Append to _names_ the elements of the VarDeclaredNames of |CaseClause|.
+        1. Return _names_.
+      </emu-alg>
+      <emu-grammar>CaseClause : `case` Expression `:` StatementList?</emu-grammar>
+      <emu-alg>
+        1. If the |StatementList| is present, return the VarDeclaredNames of |StatementList|.
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>DefaultClause : `default` `:` StatementList?</emu-grammar>
+      <emu-alg>
+        1. If the |StatementList| is present, return the VarDeclaredNames of |StatementList|.
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
+      <emu-alg>
+        1. Return the VarDeclaredNames of |LabelledItem|.
+      </emu-alg>
+      <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
+      <emu-alg>
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>TryStatement : `try` Block Catch</emu-grammar>
+      <emu-alg>
+        1. Let _names_ be VarDeclaredNames of |Block|.
+        1. Append to _names_ the elements of the VarDeclaredNames of |Catch|.
+        1. Return _names_.
+      </emu-alg>
+      <emu-grammar>TryStatement : `try` Block Finally</emu-grammar>
+      <emu-alg>
+        1. Let _names_ be VarDeclaredNames of |Block|.
+        1. Append to _names_ the elements of the VarDeclaredNames of |Finally|.
+        1. Return _names_.
+      </emu-alg>
+      <emu-grammar>TryStatement : `try` Block Catch Finally</emu-grammar>
+      <emu-alg>
+        1. Let _names_ be VarDeclaredNames of |Block|.
+        1. Append to _names_ the elements of the VarDeclaredNames of |Catch|.
+        1. Append to _names_ the elements of the VarDeclaredNames of |Finally|.
+        1. Return _names_.
+      </emu-alg>
+      <emu-grammar>Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
+      <emu-alg>
+        1. Return the VarDeclaredNames of |Block|.
+      </emu-alg>
+      <emu-grammar>FunctionStatementList : [empty]</emu-grammar>
+      <emu-alg>
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>FunctionStatementList : StatementList</emu-grammar>
+      <emu-alg>
+        1. Return TopLevelVarDeclaredNames of |StatementList|.
+      </emu-alg>
+      <emu-grammar>ConciseBody : ExpressionBody</emu-grammar>
+      <emu-alg>
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>
+        AsyncConciseBody : ExpressionBody
+      </emu-grammar>
+      <emu-alg>
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>ScriptBody : StatementList</emu-grammar>
+      <emu-alg>
+        1. Return TopLevelVarDeclaredNames of |StatementList|.
+      </emu-alg>
+      <emu-grammar>Module : [empty]</emu-grammar>
+      <emu-alg>
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
+      <emu-alg>
+        1. Let _names_ be VarDeclaredNames of |ModuleItemList|.
+        1. Append to _names_ the elements of the VarDeclaredNames of |ModuleItem|.
+        1. Return _names_.
+      </emu-alg>
+      <emu-grammar>ModuleItem : ImportDeclaration</emu-grammar>
+      <emu-alg>
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>ModuleItem : ExportDeclaration</emu-grammar>
+      <emu-alg>
+        1. If |ExportDeclaration| is `export` |VariableStatement|, return BoundNames of |ExportDeclaration|.
+        1. Return a new empty List.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-static-semantics-varscopeddeclarations" oldids="sec-statement-semantics-static-semantics-varscopeddeclarations,sec-block-static-semantics-varscopeddeclarations,sec-variable-statement-static-semantics-varscopeddeclarations,sec-if-statement-static-semantics-varscopeddeclarations,sec-do-while-statement-static-semantics-varscopeddeclarations,sec-while-statement-static-semantics-varscopeddeclarations,sec-for-statement-static-semantics-varscopeddeclarations,sec-for-in-and-for-of-statements-static-semantics-varscopeddeclarations,sec-with-statement-static-semantics-varscopeddeclarations,sec-switch-statement-static-semantics-varscopeddeclarations,sec-labelled-statements-static-semantics-varscopeddeclarations,sec-try-statement-static-semantics-varscopeddeclarations,sec-function-definitions-static-semantics-varscopeddeclarations,sec-arrow-function-definitions-static-semantics-varscopeddeclarations,sec-async-arrow-function-definitions-static-semantics-VarScopedDeclarations,sec-scripts-static-semantics-varscopeddeclarations,sec-module-semantics-static-semantics-varscopeddeclarations" type="sdo" aoid="VarScopedDeclarations">
+      <h1>Static Semantics: VarScopedDeclarations</h1>
+      <emu-grammar>
+        Statement :
+          EmptyStatement
+          ExpressionStatement
+          ContinueStatement
+          BreakStatement
+          ReturnStatement
+          ThrowStatement
+          DebuggerStatement
+      </emu-grammar>
+      <emu-alg>
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>Block : `{` `}`</emu-grammar>
+      <emu-alg>
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
+      <emu-alg>
+        1. Let _declarations_ be VarScopedDeclarations of |StatementList|.
+        1. Append to _declarations_ the elements of the VarScopedDeclarations of |StatementListItem|.
+        1. Return _declarations_.
+      </emu-alg>
+      <emu-grammar>StatementListItem : Declaration</emu-grammar>
+      <emu-alg>
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>VariableDeclarationList : VariableDeclaration</emu-grammar>
+      <emu-alg>
+        1. Return a List whose sole element is |VariableDeclaration|.
+      </emu-alg>
+      <emu-grammar>VariableDeclarationList : VariableDeclarationList `,` VariableDeclaration</emu-grammar>
+      <emu-alg>
+        1. Let _declarations_ be VarScopedDeclarations of |VariableDeclarationList|.
+        1. Append |VariableDeclaration| to _declarations_.
+        1. Return _declarations_.
+      </emu-alg>
+      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
+      <emu-alg>
+        1. Let _declarations_ be VarScopedDeclarations of the first |Statement|.
+        1. Append to _declarations_ the elements of the VarScopedDeclarations of the second |Statement|.
+        1. Return _declarations_.
+      </emu-alg>
+      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement</emu-grammar>
+      <emu-alg>
+        1. Return the VarScopedDeclarations of |Statement|.
+      </emu-alg>
+      <emu-grammar>IterationStatement : `do` Statement `while` `(` Expression `)` `;`</emu-grammar>
+      <emu-alg>
+        1. Return the VarScopedDeclarations of |Statement|.
+      </emu-alg>
+      <emu-grammar>IterationStatement : `while` `(` Expression `)` Statement</emu-grammar>
+      <emu-alg>
+        1. Return the VarScopedDeclarations of |Statement|.
+      </emu-alg>
+      <emu-grammar>IterationStatement : `for` `(` Expression? `;` Expression? `;` Expression? `)` Statement</emu-grammar>
+      <emu-alg>
+        1. Return the VarScopedDeclarations of |Statement|.
+      </emu-alg>
+      <emu-grammar>IterationStatement : `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement</emu-grammar>
+      <emu-alg>
+        1. Let _declarations_ be VarScopedDeclarations of |VariableDeclarationList|.
+        1. Append to _declarations_ the elements of the VarScopedDeclarations of |Statement|.
+        1. Return _declarations_.
+      </emu-alg>
+      <emu-grammar>IterationStatement : `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement</emu-grammar>
+      <emu-alg>
+        1. Return the VarScopedDeclarations of |Statement|.
+      </emu-alg>
+      <emu-grammar>
+        IterationStatement :
+          `for` `(` LeftHandSideExpression `in` Expression `)` Statement
+          `for` `(` ForDeclaration `in` Expression `)` Statement
+          `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
+          `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement
+          `for` `await` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
+          `for` `await` `(` ForDeclaration `of` AssignmentExpression `)` Statement
+      </emu-grammar>
+      <emu-alg>
+        1. Return the VarScopedDeclarations of |Statement|.
+      </emu-alg>
+      <emu-grammar>
+        IterationStatement :
+          `for` `(` `var` ForBinding `in` Expression `)` Statement
+          `for` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
+          `for` `await` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
+      </emu-grammar>
+      <emu-alg>
+        1. Let _declarations_ be a List whose sole element is |ForBinding|.
+        1. Append to _declarations_ the elements of the VarScopedDeclarations of |Statement|.
+        1. Return _declarations_.
+      </emu-alg>
+      <emu-note>
+        <p>This section is extended by Annex <emu-xref href="#sec-initializers-in-forin-statement-heads"></emu-xref>.</p>
+      </emu-note>
+      <emu-grammar>WithStatement : `with` `(` Expression `)` Statement</emu-grammar>
+      <emu-alg>
+        1. Return the VarScopedDeclarations of |Statement|.
+      </emu-alg>
+      <emu-grammar>SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
+      <emu-alg>
+        1. Return the VarScopedDeclarations of |CaseBlock|.
+      </emu-alg>
+      <emu-grammar>CaseBlock : `{` `}`</emu-grammar>
+      <emu-alg>
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
+      <emu-alg>
+        1. If the first |CaseClauses| is present, let _declarations_ be the VarScopedDeclarations of the first |CaseClauses|.
+        1. Else, let _declarations_ be a new empty List.
+        1. Append to _declarations_ the elements of the VarScopedDeclarations of |DefaultClause|.
+        1. If the second |CaseClauses| is not present, return _declarations_.
+        1. Return the result of appending to _declarations_ the elements of the VarScopedDeclarations of the second |CaseClauses|.
+      </emu-alg>
+      <emu-grammar>CaseClauses : CaseClauses CaseClause</emu-grammar>
+      <emu-alg>
+        1. Let _declarations_ be VarScopedDeclarations of |CaseClauses|.
+        1. Append to _declarations_ the elements of the VarScopedDeclarations of |CaseClause|.
+        1. Return _declarations_.
+      </emu-alg>
+      <emu-grammar>CaseClause : `case` Expression `:` StatementList?</emu-grammar>
+      <emu-alg>
+        1. If the |StatementList| is present, return the VarScopedDeclarations of |StatementList|.
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>DefaultClause : `default` `:` StatementList?</emu-grammar>
+      <emu-alg>
+        1. If the |StatementList| is present, return the VarScopedDeclarations of |StatementList|.
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
+      <emu-alg>
+        1. Return the VarScopedDeclarations of |LabelledItem|.
+      </emu-alg>
+      <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
+      <emu-alg>
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>TryStatement : `try` Block Catch</emu-grammar>
+      <emu-alg>
+        1. Let _declarations_ be VarScopedDeclarations of |Block|.
+        1. Append to _declarations_ the elements of the VarScopedDeclarations of |Catch|.
+        1. Return _declarations_.
+      </emu-alg>
+      <emu-grammar>TryStatement : `try` Block Finally</emu-grammar>
+      <emu-alg>
+        1. Let _declarations_ be VarScopedDeclarations of |Block|.
+        1. Append to _declarations_ the elements of the VarScopedDeclarations of |Finally|.
+        1. Return _declarations_.
+      </emu-alg>
+      <emu-grammar>TryStatement : `try` Block Catch Finally</emu-grammar>
+      <emu-alg>
+        1. Let _declarations_ be VarScopedDeclarations of |Block|.
+        1. Append to _declarations_ the elements of the VarScopedDeclarations of |Catch|.
+        1. Append to _declarations_ the elements of the VarScopedDeclarations of |Finally|.
+        1. Return _declarations_.
+      </emu-alg>
+      <emu-grammar>Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
+      <emu-alg>
+        1. Return the VarScopedDeclarations of |Block|.
+      </emu-alg>
+      <emu-grammar>FunctionStatementList : [empty]</emu-grammar>
+      <emu-alg>
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>FunctionStatementList : StatementList</emu-grammar>
+      <emu-alg>
+        1. Return the TopLevelVarScopedDeclarations of |StatementList|.
+      </emu-alg>
+      <emu-grammar>ConciseBody : ExpressionBody</emu-grammar>
+      <emu-alg>
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>
+        AsyncConciseBody : ExpressionBody
+      </emu-grammar>
+      <emu-alg>
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>ScriptBody : StatementList</emu-grammar>
+      <emu-alg>
+        1. Return TopLevelVarScopedDeclarations of |StatementList|.
+      </emu-alg>
+      <emu-grammar>Module : [empty]</emu-grammar>
+      <emu-alg>
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
+      <emu-alg>
+        1. Let _declarations_ be VarScopedDeclarations of |ModuleItemList|.
+        1. Append to _declarations_ the elements of the VarScopedDeclarations of |ModuleItem|.
+        1. Return _declarations_.
+      </emu-alg>
+      <emu-grammar>ModuleItem : ImportDeclaration</emu-grammar>
+      <emu-alg>
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>ModuleItem : ExportDeclaration</emu-grammar>
+      <emu-alg>
+        1. If |ExportDeclaration| is `export` |VariableStatement|, return VarScopedDeclarations of |VariableStatement|.
+        1. Return a new empty List.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-static-semantics-toplevellexicallydeclarednames" oldids="sec-block-static-semantics-toplevellexicallydeclarednames,sec-labelled-statements-static-semantics-toplevellexicallydeclarednames" type="sdo" aoid="TopLevelLexicallyDeclaredNames">
+      <h1>Static Semantics: TopLevelLexicallyDeclaredNames</h1>
+      <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
+      <emu-alg>
+        1. Let _names_ be TopLevelLexicallyDeclaredNames of |StatementList|.
+        1. Append to _names_ the elements of the TopLevelLexicallyDeclaredNames of |StatementListItem|.
+        1. Return _names_.
+      </emu-alg>
+      <emu-grammar>StatementListItem : Statement</emu-grammar>
+      <emu-alg>
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>StatementListItem : Declaration</emu-grammar>
+      <emu-alg>
+        1. If |Declaration| is <emu-grammar>Declaration : HoistableDeclaration</emu-grammar> , then
+          1. Return &laquo; &raquo;.
+        1. Return the BoundNames of |Declaration|.
+      </emu-alg>
+      <emu-note>
+        <p>At the top level of a function, or script, function declarations are treated like var declarations rather than like lexical declarations.</p>
+      </emu-note>
+      <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
+      <emu-alg>
+        1. Return a new empty List.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-static-semantics-toplevellexicallyscopeddeclarations" oldids="sec-block-static-semantics-toplevellexicallyscopeddeclarations,sec-labelled-statements-static-semantics-toplevellexicallyscopeddeclarations" type="sdo" aoid="TopLevelLexicallyScopedDeclarations">
+      <h1>Static Semantics: TopLevelLexicallyScopedDeclarations</h1>
+      <emu-grammar>Block : `{` `}`</emu-grammar>
+      <emu-alg>
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
+      <emu-alg>
+        1. Let _declarations_ be TopLevelLexicallyScopedDeclarations of |StatementList|.
+        1. Append to _declarations_ the elements of the TopLevelLexicallyScopedDeclarations of |StatementListItem|.
+        1. Return _declarations_.
+      </emu-alg>
+      <emu-grammar>StatementListItem : Statement</emu-grammar>
+      <emu-alg>
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>StatementListItem : Declaration</emu-grammar>
+      <emu-alg>
+        1. If |Declaration| is <emu-grammar>Declaration : HoistableDeclaration</emu-grammar> , then
+          1. Return &laquo; &raquo;.
+        1. Return a List whose sole element is |Declaration|.
+      </emu-alg>
+      <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
+      <emu-alg>
+        1. Return a new empty List.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-static-semantics-toplevelvardeclarednames" oldids="sec-block-static-semantics-toplevelvardeclarednames,sec-labelled-statements-static-semantics-toplevelvardeclarednames" type="sdo" aoid="TopLevelVarDeclaredNames">
+      <h1>Static Semantics: TopLevelVarDeclaredNames</h1>
+      <emu-grammar>Block : `{` `}`</emu-grammar>
+      <emu-alg>
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
+      <emu-alg>
+        1. Let _names_ be TopLevelVarDeclaredNames of |StatementList|.
+        1. Append to _names_ the elements of the TopLevelVarDeclaredNames of |StatementListItem|.
+        1. Return _names_.
+      </emu-alg>
+      <emu-grammar>StatementListItem : Declaration</emu-grammar>
+      <emu-alg>
+        1. If |Declaration| is <emu-grammar>Declaration : HoistableDeclaration</emu-grammar> , then
+          1. Return the BoundNames of |HoistableDeclaration|.
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>StatementListItem : Statement</emu-grammar>
+      <emu-alg>
+        1. If |Statement| is <emu-grammar>Statement : LabelledStatement</emu-grammar> , return TopLevelVarDeclaredNames of |Statement|.
+        1. Return VarDeclaredNames of |Statement|.
+      </emu-alg>
+      <emu-note>
+        <p>At the top level of a function or script, inner function declarations are treated like var declarations.</p>
+      </emu-note>
+      <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
+      <emu-alg>
+        1. Return the TopLevelVarDeclaredNames of |LabelledItem|.
+      </emu-alg>
+      <emu-grammar>LabelledItem : Statement</emu-grammar>
+      <emu-alg>
+        1. If |Statement| is <emu-grammar>Statement : LabelledStatement</emu-grammar> , return TopLevelVarDeclaredNames of |Statement|.
+        1. Return VarDeclaredNames of |Statement|.
+      </emu-alg>
+      <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
+      <emu-alg>
+        1. Return BoundNames of |FunctionDeclaration|.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-static-semantics-toplevelvarscopeddeclarations" oldids="sec-block-static-semantics-toplevelvarscopeddeclarations,sec-labelled-statements-static-semantics-toplevelvarscopeddeclarations" type="sdo" aoid="TopLevelVarScopedDeclarations">
+      <h1>Static Semantics: TopLevelVarScopedDeclarations</h1>
+      <emu-grammar>Block : `{` `}`</emu-grammar>
+      <emu-alg>
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
+      <emu-alg>
+        1. Let _declarations_ be TopLevelVarScopedDeclarations of |StatementList|.
+        1. Append to _declarations_ the elements of the TopLevelVarScopedDeclarations of |StatementListItem|.
+        1. Return _declarations_.
+      </emu-alg>
+      <emu-grammar>StatementListItem : Statement</emu-grammar>
+      <emu-alg>
+        1. If |Statement| is <emu-grammar>Statement : LabelledStatement</emu-grammar> , return TopLevelVarScopedDeclarations of |Statement|.
+        1. Return VarScopedDeclarations of |Statement|.
+      </emu-alg>
+      <emu-grammar>StatementListItem : Declaration</emu-grammar>
+      <emu-alg>
+        1. If |Declaration| is <emu-grammar>Declaration : HoistableDeclaration</emu-grammar> , then
+          1. Let _declaration_ be DeclarationPart of |HoistableDeclaration|.
+          1. Return &laquo; _declaration_ &raquo;.
+        1. Return a new empty List.
+      </emu-alg>
+      <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
+      <emu-alg>
+        1. Return the TopLevelVarScopedDeclarations of |LabelledItem|.
+      </emu-alg>
+      <emu-grammar>LabelledItem : Statement</emu-grammar>
+      <emu-alg>
+        1. If |Statement| is <emu-grammar>Statement : LabelledStatement</emu-grammar> , return TopLevelVarScopedDeclarations of |Statement|.
+        1. Return VarScopedDeclarations of |Statement|.
+      </emu-alg>
+      <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
+      <emu-alg>
+        1. Return a List whose sole element is |FunctionDeclaration|.
+      </emu-alg>
+    </emu-clause>
   </emu-clause>
 
   <emu-clause id="sec-syntax-directed-operations-labels">
@@ -6329,7 +7457,7 @@
 
       <emu-clause id="sec-global-environment-records" oldids="global-environment">
         <h1>Global Environment Records</h1>
-        <p>A <dfn>global Environment Record</dfn> is used to represent the outer most scope that is shared by all of the ECMAScript |Script| elements that are processed in a common realm. A global Environment Record provides the bindings for built-in globals (clause <emu-xref href="#sec-global-object"></emu-xref>), properties of the global object, and for all top-level declarations (<emu-xref href="#sec-block-static-semantics-toplevellexicallyscopeddeclarations"></emu-xref>, <emu-xref href="#sec-block-static-semantics-toplevelvarscopeddeclarations"></emu-xref>) that occur within a |Script|.</p>
+        <p>A <dfn>global Environment Record</dfn> is used to represent the outer most scope that is shared by all of the ECMAScript |Script| elements that are processed in a common realm. A global Environment Record provides the bindings for built-in globals (clause <emu-xref href="#sec-global-object"></emu-xref>), properties of the global object, and for all top-level declarations (<emu-xref href="#sec-static-semantics-toplevellexicallyscopeddeclarations"></emu-xref>, <emu-xref href="#sec-static-semantics-toplevelvarscopeddeclarations"></emu-xref>) that occur within a |Script|.</p>
         <p>A global Environment Record is logically a single record but it is specified as a composite encapsulating an object Environment Record and a declarative Environment Record. The object Environment Record has as its base object the global object of the associated Realm Record. This global object is the value returned by the global Environment Record's GetThisBinding concrete method. The object Environment Record component of a global Environment Record contains the bindings for all built-in globals (clause <emu-xref href="#sec-global-object"></emu-xref>) and all bindings introduced by a |FunctionDeclaration|, |GeneratorDeclaration|, |AsyncFunctionDeclaration|, |AsyncGeneratorDeclaration|, or |VariableStatement| contained in global code. The bindings for all other ECMAScript declarations in global code are contained in the declarative Environment Record component of the global Environment Record.</p>
         <p>Properties may be created directly on a global object. Hence, the object Environment Record component of a global Environment Record may contain both bindings created explicitly by |FunctionDeclaration|, |GeneratorDeclaration|, |AsyncFunctionDeclaration|, |AsyncGeneratorDeclaration|, or |VariableDeclaration| declarations and bindings created implicitly as properties of the global object. In order to identify which bindings were explicitly created using declarations, a global Environment Record maintains a list of the names bound using its CreateGlobalVarBinding and CreateGlobalFunctionBinding concrete methods.</p>
         <p>Global Environment Records have the additional fields listed in <emu-xref href="#table-additional-fields-of-global-environment-records"></emu-xref> and the additional methods listed in <emu-xref href="#table-additional-methods-of-global-environment-records"></emu-xref>.</p>
@@ -12134,23 +13262,6 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-identifiers-static-semantics-boundnames">
-      <h1>Static Semantics: BoundNames</h1>
-      <emu-see-also-para op="BoundNames"></emu-see-also-para>
-      <emu-grammar>BindingIdentifier : Identifier</emu-grammar>
-      <emu-alg>
-        1. Return a List whose sole element is the StringValue of |Identifier|.
-      </emu-alg>
-      <emu-grammar>BindingIdentifier : `yield`</emu-grammar>
-      <emu-alg>
-        1. Return a List whose sole element is *"yield"*.
-      </emu-alg>
-      <emu-grammar>BindingIdentifier : `await`</emu-grammar>
-      <emu-alg>
-        1. Return a List whose sole element is *"await"*.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause oldids="sec-identifiers-static-semantics-isvalidsimpleassignmenttarget" id="sec-identifiers-static-semantics-assignmenttargettype">
       <h1>Static Semantics: AssignmentTargetType</h1>
       <emu-see-also-para op="AssignmentTargetType"></emu-see-also-para>
@@ -15873,70 +16984,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-static-semantics-declarationpart">
-      <h1>Static Semantics: DeclarationPart</h1>
-      <emu-grammar>HoistableDeclaration : FunctionDeclaration</emu-grammar>
-      <emu-alg>
-        1. Return |FunctionDeclaration|.
-      </emu-alg>
-      <emu-grammar>HoistableDeclaration : GeneratorDeclaration</emu-grammar>
-      <emu-alg>
-        1. Return |GeneratorDeclaration|.
-      </emu-alg>
-      <emu-grammar>HoistableDeclaration : AsyncFunctionDeclaration</emu-grammar>
-      <emu-alg>
-        1. Return |AsyncFunctionDeclaration|.
-      </emu-alg>
-      <emu-grammar>HoistableDeclaration : AsyncGeneratorDeclaration</emu-grammar>
-      <emu-alg>
-        1. Return |AsyncGeneratorDeclaration|.
-      </emu-alg>
-      <emu-grammar>Declaration : ClassDeclaration</emu-grammar>
-      <emu-alg>
-        1. Return |ClassDeclaration|.
-      </emu-alg>
-      <emu-grammar>Declaration : LexicalDeclaration</emu-grammar>
-      <emu-alg>
-        1. Return |LexicalDeclaration|.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-statement-semantics-static-semantics-vardeclarednames">
-      <h1>Static Semantics: VarDeclaredNames</h1>
-      <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
-      <emu-grammar>
-        Statement :
-          EmptyStatement
-          ExpressionStatement
-          ContinueStatement
-          BreakStatement
-          ReturnStatement
-          ThrowStatement
-          DebuggerStatement
-      </emu-grammar>
-      <emu-alg>
-        1. Return a new empty List.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-statement-semantics-static-semantics-varscopeddeclarations">
-      <h1>Static Semantics: VarScopedDeclarations</h1>
-      <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
-      <emu-grammar>
-        Statement :
-          EmptyStatement
-          ExpressionStatement
-          ContinueStatement
-          BreakStatement
-          ReturnStatement
-          ThrowStatement
-          DebuggerStatement
-      </emu-grammar>
-      <emu-alg>
-        1. Return a new empty List.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-statement-semantics-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>
@@ -16058,193 +17105,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-block-static-semantics-lexicallydeclarednames">
-      <h1>Static Semantics: LexicallyDeclaredNames</h1>
-      <emu-see-also-para op="LexicallyDeclaredNames"></emu-see-also-para>
-      <emu-grammar>Block : `{` `}`</emu-grammar>
-      <emu-alg>
-        1. Return a new empty List.
-      </emu-alg>
-      <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
-      <emu-alg>
-        1. Let _names_ be LexicallyDeclaredNames of |StatementList|.
-        1. Append to _names_ the elements of the LexicallyDeclaredNames of |StatementListItem|.
-        1. Return _names_.
-      </emu-alg>
-      <emu-grammar>StatementListItem : Statement</emu-grammar>
-      <emu-alg>
-        1. If |Statement| is <emu-grammar>Statement : LabelledStatement</emu-grammar> , return LexicallyDeclaredNames of |LabelledStatement|.
-        1. Return a new empty List.
-      </emu-alg>
-      <emu-grammar>StatementListItem : Declaration</emu-grammar>
-      <emu-alg>
-        1. Return the BoundNames of |Declaration|.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-block-static-semantics-lexicallyscopeddeclarations">
-      <h1>Static Semantics: LexicallyScopedDeclarations</h1>
-      <emu-see-also-para op="LexicallyScopedDeclarations"></emu-see-also-para>
-      <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
-      <emu-alg>
-        1. Let _declarations_ be LexicallyScopedDeclarations of |StatementList|.
-        1. Append to _declarations_ the elements of the LexicallyScopedDeclarations of |StatementListItem|.
-        1. Return _declarations_.
-      </emu-alg>
-      <emu-grammar>StatementListItem : Statement</emu-grammar>
-      <emu-alg>
-        1. If |Statement| is <emu-grammar>Statement : LabelledStatement</emu-grammar> , return LexicallyScopedDeclarations of |LabelledStatement|.
-        1. Return a new empty List.
-      </emu-alg>
-      <emu-grammar>StatementListItem : Declaration</emu-grammar>
-      <emu-alg>
-        1. Return a List whose sole element is DeclarationPart of |Declaration|.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-block-static-semantics-toplevellexicallydeclarednames">
-      <h1>Static Semantics: TopLevelLexicallyDeclaredNames</h1>
-      <emu-see-also-para op="TopLevelLexicallyDeclaredNames"></emu-see-also-para>
-      <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
-      <emu-alg>
-        1. Let _names_ be TopLevelLexicallyDeclaredNames of |StatementList|.
-        1. Append to _names_ the elements of the TopLevelLexicallyDeclaredNames of |StatementListItem|.
-        1. Return _names_.
-      </emu-alg>
-      <emu-grammar>StatementListItem : Statement</emu-grammar>
-      <emu-alg>
-        1. Return a new empty List.
-      </emu-alg>
-      <emu-grammar>StatementListItem : Declaration</emu-grammar>
-      <emu-alg>
-        1. If |Declaration| is <emu-grammar>Declaration : HoistableDeclaration</emu-grammar> , then
-          1. Return &laquo; &raquo;.
-        1. Return the BoundNames of |Declaration|.
-      </emu-alg>
-      <emu-note>
-        <p>At the top level of a function, or script, function declarations are treated like var declarations rather than like lexical declarations.</p>
-      </emu-note>
-    </emu-clause>
-
-    <emu-clause id="sec-block-static-semantics-toplevellexicallyscopeddeclarations">
-      <h1>Static Semantics: TopLevelLexicallyScopedDeclarations</h1>
-      <emu-see-also-para op="TopLevelLexicallyScopedDeclarations"></emu-see-also-para>
-      <emu-grammar>Block : `{` `}`</emu-grammar>
-      <emu-alg>
-        1. Return a new empty List.
-      </emu-alg>
-      <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
-      <emu-alg>
-        1. Let _declarations_ be TopLevelLexicallyScopedDeclarations of |StatementList|.
-        1. Append to _declarations_ the elements of the TopLevelLexicallyScopedDeclarations of |StatementListItem|.
-        1. Return _declarations_.
-      </emu-alg>
-      <emu-grammar>StatementListItem : Statement</emu-grammar>
-      <emu-alg>
-        1. Return a new empty List.
-      </emu-alg>
-      <emu-grammar>StatementListItem : Declaration</emu-grammar>
-      <emu-alg>
-        1. If |Declaration| is <emu-grammar>Declaration : HoistableDeclaration</emu-grammar> , then
-          1. Return &laquo; &raquo;.
-        1. Return a List whose sole element is |Declaration|.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-block-static-semantics-toplevelvardeclarednames">
-      <h1>Static Semantics: TopLevelVarDeclaredNames</h1>
-      <emu-see-also-para op="TopLevelVarDeclaredNames"></emu-see-also-para>
-      <emu-grammar>Block : `{` `}`</emu-grammar>
-      <emu-alg>
-        1. Return a new empty List.
-      </emu-alg>
-      <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
-      <emu-alg>
-        1. Let _names_ be TopLevelVarDeclaredNames of |StatementList|.
-        1. Append to _names_ the elements of the TopLevelVarDeclaredNames of |StatementListItem|.
-        1. Return _names_.
-      </emu-alg>
-      <emu-grammar>StatementListItem : Declaration</emu-grammar>
-      <emu-alg>
-        1. If |Declaration| is <emu-grammar>Declaration : HoistableDeclaration</emu-grammar> , then
-          1. Return the BoundNames of |HoistableDeclaration|.
-        1. Return a new empty List.
-      </emu-alg>
-      <emu-grammar>StatementListItem : Statement</emu-grammar>
-      <emu-alg>
-        1. If |Statement| is <emu-grammar>Statement : LabelledStatement</emu-grammar> , return TopLevelVarDeclaredNames of |Statement|.
-        1. Return VarDeclaredNames of |Statement|.
-      </emu-alg>
-      <emu-note>
-        <p>At the top level of a function or script, inner function declarations are treated like var declarations.</p>
-      </emu-note>
-    </emu-clause>
-
-    <emu-clause id="sec-block-static-semantics-toplevelvarscopeddeclarations">
-      <h1>Static Semantics: TopLevelVarScopedDeclarations</h1>
-      <emu-see-also-para op="TopLevelVarScopedDeclarations"></emu-see-also-para>
-      <emu-grammar>Block : `{` `}`</emu-grammar>
-      <emu-alg>
-        1. Return a new empty List.
-      </emu-alg>
-      <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
-      <emu-alg>
-        1. Let _declarations_ be TopLevelVarScopedDeclarations of |StatementList|.
-        1. Append to _declarations_ the elements of the TopLevelVarScopedDeclarations of |StatementListItem|.
-        1. Return _declarations_.
-      </emu-alg>
-      <emu-grammar>StatementListItem : Statement</emu-grammar>
-      <emu-alg>
-        1. If |Statement| is <emu-grammar>Statement : LabelledStatement</emu-grammar> , return TopLevelVarScopedDeclarations of |Statement|.
-        1. Return VarScopedDeclarations of |Statement|.
-      </emu-alg>
-      <emu-grammar>StatementListItem : Declaration</emu-grammar>
-      <emu-alg>
-        1. If |Declaration| is <emu-grammar>Declaration : HoistableDeclaration</emu-grammar> , then
-          1. Let _declaration_ be DeclarationPart of |HoistableDeclaration|.
-          1. Return &laquo; _declaration_ &raquo;.
-        1. Return a new empty List.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-block-static-semantics-vardeclarednames">
-      <h1>Static Semantics: VarDeclaredNames</h1>
-      <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
-      <emu-grammar>Block : `{` `}`</emu-grammar>
-      <emu-alg>
-        1. Return a new empty List.
-      </emu-alg>
-      <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
-      <emu-alg>
-        1. Let _names_ be VarDeclaredNames of |StatementList|.
-        1. Append to _names_ the elements of the VarDeclaredNames of |StatementListItem|.
-        1. Return _names_.
-      </emu-alg>
-      <emu-grammar>StatementListItem : Declaration</emu-grammar>
-      <emu-alg>
-        1. Return a new empty List.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-block-static-semantics-varscopeddeclarations">
-      <h1>Static Semantics: VarScopedDeclarations</h1>
-      <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
-      <emu-grammar>Block : `{` `}`</emu-grammar>
-      <emu-alg>
-        1. Return a new empty List.
-      </emu-alg>
-      <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
-      <emu-alg>
-        1. Let _declarations_ be VarScopedDeclarations of |StatementList|.
-        1. Append to _declarations_ the elements of the VarScopedDeclarations of |StatementListItem|.
-        1. Return _declarations_.
-      </emu-alg>
-      <emu-grammar>StatementListItem : Declaration</emu-grammar>
-      <emu-alg>
-        1. Return a new empty List.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-block-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>Block : `{` `}`</emu-grammar>
@@ -16354,46 +17214,6 @@
         </ul>
       </emu-clause>
 
-      <emu-clause id="sec-let-and-const-declarations-static-semantics-boundnames">
-        <h1>Static Semantics: BoundNames</h1>
-        <emu-see-also-para op="BoundNames"></emu-see-also-para>
-        <emu-grammar>LexicalDeclaration : LetOrConst BindingList `;`</emu-grammar>
-        <emu-alg>
-          1. Return the BoundNames of |BindingList|.
-        </emu-alg>
-        <emu-grammar>BindingList : BindingList `,` LexicalBinding</emu-grammar>
-        <emu-alg>
-          1. Let _names_ be the BoundNames of |BindingList|.
-          1. Append to _names_ the elements of the BoundNames of |LexicalBinding|.
-          1. Return _names_.
-        </emu-alg>
-        <emu-grammar>LexicalBinding : BindingIdentifier Initializer?</emu-grammar>
-        <emu-alg>
-          1. Return the BoundNames of |BindingIdentifier|.
-        </emu-alg>
-        <emu-grammar>LexicalBinding : BindingPattern Initializer</emu-grammar>
-        <emu-alg>
-          1. Return the BoundNames of |BindingPattern|.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-let-and-const-declarations-static-semantics-isconstantdeclaration">
-        <h1>Static Semantics: IsConstantDeclaration</h1>
-        <emu-see-also-para op="IsConstantDeclaration"></emu-see-also-para>
-        <emu-grammar>LexicalDeclaration : LetOrConst BindingList `;`</emu-grammar>
-        <emu-alg>
-          1. Return IsConstantDeclaration of |LetOrConst|.
-        </emu-alg>
-        <emu-grammar>LetOrConst : `let`</emu-grammar>
-        <emu-alg>
-          1. Return *false*.
-        </emu-alg>
-        <emu-grammar>LetOrConst : `const`</emu-grammar>
-        <emu-alg>
-          1. Return *true*.
-        </emu-alg>
-      </emu-clause>
-
       <emu-clause id="sec-let-and-const-declarations-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>LexicalDeclaration : LetOrConst BindingList `;`</emu-grammar>
@@ -16455,49 +17275,6 @@
           BindingIdentifier[?Yield, ?Await] Initializer[?In, ?Yield, ?Await]?
           BindingPattern[?Yield, ?Await] Initializer[?In, ?Yield, ?Await]
       </emu-grammar>
-
-      <emu-clause id="sec-variable-statement-static-semantics-boundnames">
-        <h1>Static Semantics: BoundNames</h1>
-        <emu-see-also-para op="BoundNames"></emu-see-also-para>
-        <emu-grammar>VariableDeclarationList : VariableDeclarationList `,` VariableDeclaration</emu-grammar>
-        <emu-alg>
-          1. Let _names_ be BoundNames of |VariableDeclarationList|.
-          1. Append to _names_ the elements of BoundNames of |VariableDeclaration|.
-          1. Return _names_.
-        </emu-alg>
-        <emu-grammar>VariableDeclaration : BindingIdentifier Initializer?</emu-grammar>
-        <emu-alg>
-          1. Return the BoundNames of |BindingIdentifier|.
-        </emu-alg>
-        <emu-grammar>VariableDeclaration : BindingPattern Initializer</emu-grammar>
-        <emu-alg>
-          1. Return the BoundNames of |BindingPattern|.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-variable-statement-static-semantics-vardeclarednames">
-        <h1>Static Semantics: VarDeclaredNames</h1>
-        <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
-        <emu-grammar>VariableStatement : `var` VariableDeclarationList `;`</emu-grammar>
-        <emu-alg>
-          1. Return BoundNames of |VariableDeclarationList|.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-variable-statement-static-semantics-varscopeddeclarations">
-        <h1>Static Semantics: VarScopedDeclarations</h1>
-        <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
-        <emu-grammar>VariableDeclarationList : VariableDeclaration</emu-grammar>
-        <emu-alg>
-          1. Return a List whose sole element is |VariableDeclaration|.
-        </emu-alg>
-        <emu-grammar>VariableDeclarationList : VariableDeclarationList `,` VariableDeclaration</emu-grammar>
-        <emu-alg>
-          1. Let _declarations_ be VarScopedDeclarations of |VariableDeclarationList|.
-          1. Append |VariableDeclaration| to _declarations_.
-          1. Return _declarations_.
-        </emu-alg>
-      </emu-clause>
 
       <emu-clause id="sec-variable-statement-runtime-semantics-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
@@ -16588,67 +17365,6 @@
           `...` BindingIdentifier[?Yield, ?Await]
           `...` BindingPattern[?Yield, ?Await]
       </emu-grammar>
-
-      <emu-clause id="sec-destructuring-binding-patterns-static-semantics-boundnames">
-        <h1>Static Semantics: BoundNames</h1>
-        <emu-see-also-para op="BoundNames"></emu-see-also-para>
-        <emu-grammar>ObjectBindingPattern : `{` `}`</emu-grammar>
-        <emu-alg>
-          1. Return a new empty List.
-        </emu-alg>
-        <emu-grammar>ObjectBindingPattern : `{` BindingPropertyList `,` BindingRestProperty `}`</emu-grammar>
-        <emu-alg>
-          1. Let _names_ be BoundNames of |BindingPropertyList|.
-          1. Append to _names_ the elements of BoundNames of |BindingRestProperty|.
-          1. Return _names_.
-        </emu-alg>
-        <emu-grammar>ArrayBindingPattern : `[` Elision? `]`</emu-grammar>
-        <emu-alg>
-          1. Return a new empty List.
-        </emu-alg>
-        <emu-grammar>ArrayBindingPattern : `[` Elision? BindingRestElement `]`</emu-grammar>
-        <emu-alg>
-          1. Return the BoundNames of |BindingRestElement|.
-        </emu-alg>
-        <emu-grammar>ArrayBindingPattern : `[` BindingElementList `,` Elision? `]`</emu-grammar>
-        <emu-alg>
-          1. Return the BoundNames of |BindingElementList|.
-        </emu-alg>
-        <emu-grammar>ArrayBindingPattern : `[` BindingElementList `,` Elision? BindingRestElement `]`</emu-grammar>
-        <emu-alg>
-          1. Let _names_ be BoundNames of |BindingElementList|.
-          1. Append to _names_ the elements of BoundNames of |BindingRestElement|.
-          1. Return _names_.
-        </emu-alg>
-        <emu-grammar>BindingPropertyList : BindingPropertyList `,` BindingProperty</emu-grammar>
-        <emu-alg>
-          1. Let _names_ be BoundNames of |BindingPropertyList|.
-          1. Append to _names_ the elements of BoundNames of |BindingProperty|.
-          1. Return _names_.
-        </emu-alg>
-        <emu-grammar>BindingElementList : BindingElementList `,` BindingElisionElement</emu-grammar>
-        <emu-alg>
-          1. Let _names_ be BoundNames of |BindingElementList|.
-          1. Append to _names_ the elements of BoundNames of |BindingElisionElement|.
-          1. Return _names_.
-        </emu-alg>
-        <emu-grammar>BindingElisionElement : Elision? BindingElement</emu-grammar>
-        <emu-alg>
-          1. Return BoundNames of |BindingElement|.
-        </emu-alg>
-        <emu-grammar>BindingProperty : PropertyName `:` BindingElement</emu-grammar>
-        <emu-alg>
-          1. Return the BoundNames of |BindingElement|.
-        </emu-alg>
-        <emu-grammar>SingleNameBinding : BindingIdentifier Initializer?</emu-grammar>
-        <emu-alg>
-          1. Return the BoundNames of |BindingIdentifier|.
-        </emu-alg>
-        <emu-grammar>BindingElement : BindingPattern Initializer?</emu-grammar>
-        <emu-alg>
-          1. Return the BoundNames of |BindingPattern|.
-        </emu-alg>
-      </emu-clause>
 
       <emu-clause id="sec-destructuring-binding-patterns-runtime-semantics-bindinginitialization">
         <h1>Runtime Semantics: BindingInitialization</h1>
@@ -17008,36 +17724,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-if-statement-static-semantics-vardeclarednames">
-      <h1>Static Semantics: VarDeclaredNames</h1>
-      <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
-      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
-      <emu-alg>
-        1. Let _names_ be VarDeclaredNames of the first |Statement|.
-        1. Append to _names_ the elements of the VarDeclaredNames of the second |Statement|.
-        1. Return _names_.
-      </emu-alg>
-      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement</emu-grammar>
-      <emu-alg>
-        1. Return the VarDeclaredNames of |Statement|.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-if-statement-static-semantics-varscopeddeclarations">
-      <h1>Static Semantics: VarScopedDeclarations</h1>
-      <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
-      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
-      <emu-alg>
-        1. Let _declarations_ be VarScopedDeclarations of the first |Statement|.
-        1. Append to _declarations_ the elements of the VarScopedDeclarations of the second |Statement|.
-        1. Return _declarations_.
-      </emu-alg>
-      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement</emu-grammar>
-      <emu-alg>
-        1. Return the VarScopedDeclarations of |Statement|.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-if-statement-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
@@ -17289,24 +17975,6 @@
           1. Return ContainsUndefinedContinueTarget of |Statement| with arguments _iterationSet_ and &laquo; &raquo;.
         </emu-alg>
       </emu-clause>
-
-      <emu-clause id="sec-do-while-statement-static-semantics-vardeclarednames">
-        <h1>Static Semantics: VarDeclaredNames</h1>
-        <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
-        <emu-grammar>IterationStatement : `do` Statement `while` `(` Expression `)` `;`</emu-grammar>
-        <emu-alg>
-          1. Return the VarDeclaredNames of |Statement|.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-do-while-statement-static-semantics-varscopeddeclarations">
-        <h1>Static Semantics: VarScopedDeclarations</h1>
-        <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
-        <emu-grammar>IterationStatement : `do` Statement `while` `(` Expression `)` `;`</emu-grammar>
-        <emu-alg>
-          1. Return the VarScopedDeclarations of |Statement|.
-        </emu-alg>
-      </emu-clause>
     </emu-clause>
 
     <emu-clause id="sec-while-statement">
@@ -17339,24 +18007,6 @@
         <emu-grammar>IterationStatement : `while` `(` Expression `)` Statement</emu-grammar>
         <emu-alg>
           1. Return ContainsUndefinedContinueTarget of |Statement| with arguments _iterationSet_ and &laquo; &raquo;.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-while-statement-static-semantics-vardeclarednames">
-        <h1>Static Semantics: VarDeclaredNames</h1>
-        <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
-        <emu-grammar>IterationStatement : `while` `(` Expression `)` Statement</emu-grammar>
-        <emu-alg>
-          1. Return the VarDeclaredNames of |Statement|.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-while-statement-static-semantics-varscopeddeclarations">
-        <h1>Static Semantics: VarScopedDeclarations</h1>
-        <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
-        <emu-grammar>IterationStatement : `while` `(` Expression `)` Statement</emu-grammar>
-        <emu-alg>
-          1. Return the VarScopedDeclarations of |Statement|.
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -17416,44 +18066,6 @@
         </emu-grammar>
         <emu-alg>
           1. Return ContainsUndefinedContinueTarget of |Statement| with arguments _iterationSet_ and &laquo; &raquo;.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-for-statement-static-semantics-vardeclarednames">
-        <h1>Static Semantics: VarDeclaredNames</h1>
-        <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
-        <emu-grammar>IterationStatement : `for` `(` Expression? `;` Expression? `;` Expression? `)` Statement</emu-grammar>
-        <emu-alg>
-          1. Return the VarDeclaredNames of |Statement|.
-        </emu-alg>
-        <emu-grammar>IterationStatement : `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement</emu-grammar>
-        <emu-alg>
-          1. Let _names_ be BoundNames of |VariableDeclarationList|.
-          1. Append to _names_ the elements of the VarDeclaredNames of |Statement|.
-          1. Return _names_.
-        </emu-alg>
-        <emu-grammar>IterationStatement : `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement</emu-grammar>
-        <emu-alg>
-          1. Return the VarDeclaredNames of |Statement|.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-for-statement-static-semantics-varscopeddeclarations">
-        <h1>Static Semantics: VarScopedDeclarations</h1>
-        <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
-        <emu-grammar>IterationStatement : `for` `(` Expression? `;` Expression? `;` Expression? `)` Statement</emu-grammar>
-        <emu-alg>
-          1. Return the VarScopedDeclarations of |Statement|.
-        </emu-alg>
-        <emu-grammar>IterationStatement : `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement</emu-grammar>
-        <emu-alg>
-          1. Let _declarations_ be VarScopedDeclarations of |VariableDeclarationList|.
-          1. Append to _declarations_ the elements of the VarScopedDeclarations of |Statement|.
-          1. Return _declarations_.
-        </emu-alg>
-        <emu-grammar>IterationStatement : `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement</emu-grammar>
-        <emu-alg>
-          1. Return the VarScopedDeclarations of |Statement|.
         </emu-alg>
       </emu-clause>
 
@@ -17542,15 +18154,6 @@
         </ul>
       </emu-clause>
 
-      <emu-clause id="sec-for-in-and-for-of-statements-static-semantics-boundnames">
-        <h1>Static Semantics: BoundNames</h1>
-        <emu-see-also-para op="BoundNames"></emu-see-also-para>
-        <emu-grammar>ForDeclaration : LetOrConst ForBinding</emu-grammar>
-        <emu-alg>
-          1. Return the BoundNames of |ForBinding|.
-        </emu-alg>
-      </emu-clause>
-
       <emu-clause id="sec-for-in-and-for-of-statements-static-semantics-containsduplicatelabels">
         <h1>Static Semantics: ContainsDuplicateLabels</h1>
         <p>With parameter _labelSet_.</p>
@@ -17637,68 +18240,6 @@
         <emu-grammar>ForBinding : BindingPattern</emu-grammar>
         <emu-alg>
           1. Return *true*.
-        </emu-alg>
-        <emu-note>
-          <p>This section is extended by Annex <emu-xref href="#sec-initializers-in-forin-statement-heads"></emu-xref>.</p>
-        </emu-note>
-      </emu-clause>
-
-      <emu-clause id="sec-for-in-and-for-of-statements-static-semantics-vardeclarednames">
-        <h1>Static Semantics: VarDeclaredNames</h1>
-        <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
-        <emu-grammar>
-          IterationStatement :
-            `for` `(` LeftHandSideExpression `in` Expression `)` Statement
-            `for` `(` ForDeclaration `in` Expression `)` Statement
-            `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
-            `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement
-            `for` `await` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
-            `for` `await` `(` ForDeclaration `of` AssignmentExpression `)` Statement
-        </emu-grammar>
-        <emu-alg>
-          1. Return the VarDeclaredNames of |Statement|.
-        </emu-alg>
-        <emu-grammar>
-          IterationStatement :
-            `for` `(` `var` ForBinding `in` Expression `)` Statement
-            `for` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
-            `for` `await` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
-        </emu-grammar>
-        <emu-alg>
-          1. Let _names_ be the BoundNames of |ForBinding|.
-          1. Append to _names_ the elements of the VarDeclaredNames of |Statement|.
-          1. Return _names_.
-        </emu-alg>
-        <emu-note>
-          <p>This section is extended by Annex <emu-xref href="#sec-initializers-in-forin-statement-heads"></emu-xref>.</p>
-        </emu-note>
-      </emu-clause>
-
-      <emu-clause id="sec-for-in-and-for-of-statements-static-semantics-varscopeddeclarations">
-        <h1>Static Semantics: VarScopedDeclarations</h1>
-        <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
-        <emu-grammar>
-          IterationStatement :
-            `for` `(` LeftHandSideExpression `in` Expression `)` Statement
-            `for` `(` ForDeclaration `in` Expression `)` Statement
-            `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
-            `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement
-            `for` `await` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
-            `for` `await` `(` ForDeclaration `of` AssignmentExpression `)` Statement
-        </emu-grammar>
-        <emu-alg>
-          1. Return the VarScopedDeclarations of |Statement|.
-        </emu-alg>
-        <emu-grammar>
-          IterationStatement :
-            `for` `(` `var` ForBinding `in` Expression `)` Statement
-            `for` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
-            `for` `await` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
-        </emu-grammar>
-        <emu-alg>
-          1. Let _declarations_ be a List whose sole element is |ForBinding|.
-          1. Append to _declarations_ the elements of the VarScopedDeclarations of |Statement|.
-          1. Return _declarations_.
         </emu-alg>
         <emu-note>
           <p>This section is extended by Annex <emu-xref href="#sec-initializers-in-forin-statement-heads"></emu-xref>.</p>
@@ -18183,24 +18724,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-with-statement-static-semantics-vardeclarednames">
-      <h1>Static Semantics: VarDeclaredNames</h1>
-      <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
-      <emu-grammar>WithStatement : `with` `(` Expression `)` Statement</emu-grammar>
-      <emu-alg>
-        1. Return the VarDeclaredNames of |Statement|.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-with-statement-static-semantics-varscopeddeclarations">
-      <h1>Static Semantics: VarScopedDeclarations</h1>
-      <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
-      <emu-grammar>WithStatement : `with` `(` Expression `)` Statement</emu-grammar>
-      <emu-alg>
-        1. Return the VarScopedDeclarations of |Statement|.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-with-statement-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>WithStatement : `with` `(` Expression `)` Statement</emu-grammar>
@@ -18373,146 +18896,6 @@
       <emu-alg>
         1. If the |StatementList| is present, return ContainsUndefinedContinueTarget of |StatementList| with arguments _iterationSet_ and &laquo; &raquo;.
         1. Return *false*.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-switch-statement-static-semantics-lexicallydeclarednames">
-      <h1>Static Semantics: LexicallyDeclaredNames</h1>
-      <emu-see-also-para op="LexicallyDeclaredNames"></emu-see-also-para>
-      <emu-grammar>CaseBlock : `{` `}`</emu-grammar>
-      <emu-alg>
-        1. Return a new empty List.
-      </emu-alg>
-      <emu-grammar>CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
-      <emu-alg>
-        1. If the first |CaseClauses| is present, let _names_ be the LexicallyDeclaredNames of the first |CaseClauses|.
-        1. Else, let _names_ be a new empty List.
-        1. Append to _names_ the elements of the LexicallyDeclaredNames of |DefaultClause|.
-        1. If the second |CaseClauses| is not present, return _names_.
-        1. Return the result of appending to _names_ the elements of the LexicallyDeclaredNames of the second |CaseClauses|.
-      </emu-alg>
-      <emu-grammar>CaseClauses : CaseClauses CaseClause</emu-grammar>
-      <emu-alg>
-        1. Let _names_ be LexicallyDeclaredNames of |CaseClauses|.
-        1. Append to _names_ the elements of the LexicallyDeclaredNames of |CaseClause|.
-        1. Return _names_.
-      </emu-alg>
-      <emu-grammar>CaseClause : `case` Expression `:` StatementList?</emu-grammar>
-      <emu-alg>
-        1. If the |StatementList| is present, return the LexicallyDeclaredNames of |StatementList|.
-        1. Return a new empty List.
-      </emu-alg>
-      <emu-grammar>DefaultClause : `default` `:` StatementList?</emu-grammar>
-      <emu-alg>
-        1. If the |StatementList| is present, return the LexicallyDeclaredNames of |StatementList|.
-        1. Return a new empty List.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-switch-statement-static-semantics-lexicallyscopeddeclarations">
-      <h1>Static Semantics: LexicallyScopedDeclarations</h1>
-      <emu-see-also-para op="LexicallyScopedDeclarations"></emu-see-also-para>
-      <emu-grammar>CaseBlock : `{` `}`</emu-grammar>
-      <emu-alg>
-        1. Return a new empty List.
-      </emu-alg>
-      <emu-grammar>CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
-      <emu-alg>
-        1. If the first |CaseClauses| is present, let _declarations_ be the LexicallyScopedDeclarations of the first |CaseClauses|.
-        1. Else, let _declarations_ be a new empty List.
-        1. Append to _declarations_ the elements of the LexicallyScopedDeclarations of |DefaultClause|.
-        1. If the second |CaseClauses| is not present, return _declarations_.
-        1. Return the result of appending to _declarations_ the elements of the LexicallyScopedDeclarations of the second |CaseClauses|.
-      </emu-alg>
-      <emu-grammar>CaseClauses : CaseClauses CaseClause</emu-grammar>
-      <emu-alg>
-        1. Let _declarations_ be LexicallyScopedDeclarations of |CaseClauses|.
-        1. Append to _declarations_ the elements of the LexicallyScopedDeclarations of |CaseClause|.
-        1. Return _declarations_.
-      </emu-alg>
-      <emu-grammar>CaseClause : `case` Expression `:` StatementList?</emu-grammar>
-      <emu-alg>
-        1. If the |StatementList| is present, return the LexicallyScopedDeclarations of |StatementList|.
-        1. Return a new empty List.
-      </emu-alg>
-      <emu-grammar>DefaultClause : `default` `:` StatementList?</emu-grammar>
-      <emu-alg>
-        1. If the |StatementList| is present, return the LexicallyScopedDeclarations of |StatementList|.
-        1. Return a new empty List.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-switch-statement-static-semantics-vardeclarednames">
-      <h1>Static Semantics: VarDeclaredNames</h1>
-      <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
-      <emu-grammar>SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
-      <emu-alg>
-        1. Return the VarDeclaredNames of |CaseBlock|.
-      </emu-alg>
-      <emu-grammar>CaseBlock : `{` `}`</emu-grammar>
-      <emu-alg>
-        1. Return a new empty List.
-      </emu-alg>
-      <emu-grammar>CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
-      <emu-alg>
-        1. If the first |CaseClauses| is present, let _names_ be the VarDeclaredNames of the first |CaseClauses|.
-        1. Else, let _names_ be a new empty List.
-        1. Append to _names_ the elements of the VarDeclaredNames of |DefaultClause|.
-        1. If the second |CaseClauses| is not present, return _names_.
-        1. Return the result of appending to _names_ the elements of the VarDeclaredNames of the second |CaseClauses|.
-      </emu-alg>
-      <emu-grammar>CaseClauses : CaseClauses CaseClause</emu-grammar>
-      <emu-alg>
-        1. Let _names_ be VarDeclaredNames of |CaseClauses|.
-        1. Append to _names_ the elements of the VarDeclaredNames of |CaseClause|.
-        1. Return _names_.
-      </emu-alg>
-      <emu-grammar>CaseClause : `case` Expression `:` StatementList?</emu-grammar>
-      <emu-alg>
-        1. If the |StatementList| is present, return the VarDeclaredNames of |StatementList|.
-        1. Return a new empty List.
-      </emu-alg>
-      <emu-grammar>DefaultClause : `default` `:` StatementList?</emu-grammar>
-      <emu-alg>
-        1. If the |StatementList| is present, return the VarDeclaredNames of |StatementList|.
-        1. Return a new empty List.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-switch-statement-static-semantics-varscopeddeclarations">
-      <h1>Static Semantics: VarScopedDeclarations</h1>
-      <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
-      <emu-grammar>SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
-      <emu-alg>
-        1. Return the VarScopedDeclarations of |CaseBlock|.
-      </emu-alg>
-      <emu-grammar>CaseBlock : `{` `}`</emu-grammar>
-      <emu-alg>
-        1. Return a new empty List.
-      </emu-alg>
-      <emu-grammar>CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
-      <emu-alg>
-        1. If the first |CaseClauses| is present, let _declarations_ be the VarScopedDeclarations of the first |CaseClauses|.
-        1. Else, let _declarations_ be a new empty List.
-        1. Append to _declarations_ the elements of the VarScopedDeclarations of |DefaultClause|.
-        1. If the second |CaseClauses| is not present, return _declarations_.
-        1. Return the result of appending to _declarations_ the elements of the VarScopedDeclarations of the second |CaseClauses|.
-      </emu-alg>
-      <emu-grammar>CaseClauses : CaseClauses CaseClause</emu-grammar>
-      <emu-alg>
-        1. Let _declarations_ be VarScopedDeclarations of |CaseClauses|.
-        1. Append to _declarations_ the elements of the VarScopedDeclarations of |CaseClause|.
-        1. Return _declarations_.
-      </emu-alg>
-      <emu-grammar>CaseClause : `case` Expression `:` StatementList?</emu-grammar>
-      <emu-alg>
-        1. If the |StatementList| is present, return the VarScopedDeclarations of |StatementList|.
-        1. Return a new empty List.
-      </emu-alg>
-      <emu-grammar>DefaultClause : `default` `:` StatementList?</emu-grammar>
-      <emu-alg>
-        1. If the |StatementList| is present, return the VarScopedDeclarations of |StatementList|.
-        1. Return a new empty List.
       </emu-alg>
     </emu-clause>
 
@@ -18714,120 +19097,6 @@
         1. If _item_ is <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar> , return *true*.
         1. Let _subStmt_ be the |Statement| of _item_.
         1. Return IsLabelledFunction(_subStmt_).
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-labelled-statements-static-semantics-lexicallydeclarednames">
-      <h1>Static Semantics: LexicallyDeclaredNames</h1>
-      <emu-see-also-para op="LexicallyDeclaredNames"></emu-see-also-para>
-      <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
-      <emu-alg>
-        1. Return the LexicallyDeclaredNames of |LabelledItem|.
-      </emu-alg>
-      <emu-grammar>LabelledItem : Statement</emu-grammar>
-      <emu-alg>
-        1. Return a new empty List.
-      </emu-alg>
-      <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
-      <emu-alg>
-        1. Return BoundNames of |FunctionDeclaration|.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-labelled-statements-static-semantics-lexicallyscopeddeclarations">
-      <h1>Static Semantics: LexicallyScopedDeclarations</h1>
-      <emu-see-also-para op="LexicallyScopedDeclarations"></emu-see-also-para>
-      <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
-      <emu-alg>
-        1. Return the LexicallyScopedDeclarations of |LabelledItem|.
-      </emu-alg>
-      <emu-grammar>LabelledItem : Statement</emu-grammar>
-      <emu-alg>
-        1. Return a new empty List.
-      </emu-alg>
-      <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
-      <emu-alg>
-        1. Return a List whose sole element is |FunctionDeclaration|.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-labelled-statements-static-semantics-toplevellexicallydeclarednames">
-      <h1>Static Semantics: TopLevelLexicallyDeclaredNames</h1>
-      <emu-see-also-para op="TopLevelLexicallyDeclaredNames"></emu-see-also-para>
-      <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
-      <emu-alg>
-        1. Return a new empty List.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-labelled-statements-static-semantics-toplevellexicallyscopeddeclarations">
-      <h1>Static Semantics: TopLevelLexicallyScopedDeclarations</h1>
-      <emu-see-also-para op="TopLevelLexicallyScopedDeclarations"></emu-see-also-para>
-      <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
-      <emu-alg>
-        1. Return a new empty List.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-labelled-statements-static-semantics-toplevelvardeclarednames">
-      <h1>Static Semantics: TopLevelVarDeclaredNames</h1>
-      <emu-see-also-para op="TopLevelVarDeclaredNames"></emu-see-also-para>
-      <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
-      <emu-alg>
-        1. Return the TopLevelVarDeclaredNames of |LabelledItem|.
-      </emu-alg>
-      <emu-grammar>LabelledItem : Statement</emu-grammar>
-      <emu-alg>
-        1. If |Statement| is <emu-grammar>Statement : LabelledStatement</emu-grammar> , return TopLevelVarDeclaredNames of |Statement|.
-        1. Return VarDeclaredNames of |Statement|.
-      </emu-alg>
-      <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
-      <emu-alg>
-        1. Return BoundNames of |FunctionDeclaration|.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-labelled-statements-static-semantics-toplevelvarscopeddeclarations">
-      <h1>Static Semantics: TopLevelVarScopedDeclarations</h1>
-      <emu-see-also-para op="TopLevelVarScopedDeclarations"></emu-see-also-para>
-      <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
-      <emu-alg>
-        1. Return the TopLevelVarScopedDeclarations of |LabelledItem|.
-      </emu-alg>
-      <emu-grammar>LabelledItem : Statement</emu-grammar>
-      <emu-alg>
-        1. If |Statement| is <emu-grammar>Statement : LabelledStatement</emu-grammar> , return TopLevelVarScopedDeclarations of |Statement|.
-        1. Return VarScopedDeclarations of |Statement|.
-      </emu-alg>
-      <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
-      <emu-alg>
-        1. Return a List whose sole element is |FunctionDeclaration|.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-labelled-statements-static-semantics-vardeclarednames">
-      <h1>Static Semantics: VarDeclaredNames</h1>
-      <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
-      <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
-      <emu-alg>
-        1. Return the VarDeclaredNames of |LabelledItem|.
-      </emu-alg>
-      <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
-      <emu-alg>
-        1. Return a new empty List.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-labelled-statements-static-semantics-varscopeddeclarations">
-      <h1>Static Semantics: VarScopedDeclarations</h1>
-      <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
-      <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
-      <emu-alg>
-        1. Return the VarScopedDeclarations of |LabelledItem|.
-      </emu-alg>
-      <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
-      <emu-alg>
-        1. Return a new empty List.
       </emu-alg>
     </emu-clause>
 
@@ -19047,62 +19316,6 @@
       <emu-grammar>Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
       <emu-alg>
         1. Return ContainsUndefinedContinueTarget of |Block| with arguments _iterationSet_ and &laquo; &raquo;.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-try-statement-static-semantics-vardeclarednames">
-      <h1>Static Semantics: VarDeclaredNames</h1>
-      <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
-      <emu-grammar>TryStatement : `try` Block Catch</emu-grammar>
-      <emu-alg>
-        1. Let _names_ be VarDeclaredNames of |Block|.
-        1. Append to _names_ the elements of the VarDeclaredNames of |Catch|.
-        1. Return _names_.
-      </emu-alg>
-      <emu-grammar>TryStatement : `try` Block Finally</emu-grammar>
-      <emu-alg>
-        1. Let _names_ be VarDeclaredNames of |Block|.
-        1. Append to _names_ the elements of the VarDeclaredNames of |Finally|.
-        1. Return _names_.
-      </emu-alg>
-      <emu-grammar>TryStatement : `try` Block Catch Finally</emu-grammar>
-      <emu-alg>
-        1. Let _names_ be VarDeclaredNames of |Block|.
-        1. Append to _names_ the elements of the VarDeclaredNames of |Catch|.
-        1. Append to _names_ the elements of the VarDeclaredNames of |Finally|.
-        1. Return _names_.
-      </emu-alg>
-      <emu-grammar>Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
-      <emu-alg>
-        1. Return the VarDeclaredNames of |Block|.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-try-statement-static-semantics-varscopeddeclarations">
-      <h1>Static Semantics: VarScopedDeclarations</h1>
-      <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
-      <emu-grammar>TryStatement : `try` Block Catch</emu-grammar>
-      <emu-alg>
-        1. Let _declarations_ be VarScopedDeclarations of |Block|.
-        1. Append to _declarations_ the elements of the VarScopedDeclarations of |Catch|.
-        1. Return _declarations_.
-      </emu-alg>
-      <emu-grammar>TryStatement : `try` Block Finally</emu-grammar>
-      <emu-alg>
-        1. Let _declarations_ be VarScopedDeclarations of |Block|.
-        1. Append to _declarations_ the elements of the VarScopedDeclarations of |Finally|.
-        1. Return _declarations_.
-      </emu-alg>
-      <emu-grammar>TryStatement : `try` Block Catch Finally</emu-grammar>
-      <emu-alg>
-        1. Let _declarations_ be VarScopedDeclarations of |Block|.
-        1. Append to _declarations_ the elements of the VarScopedDeclarations of |Catch|.
-        1. Append to _declarations_ the elements of the VarScopedDeclarations of |Finally|.
-        1. Return _declarations_.
-      </emu-alg>
-      <emu-grammar>Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
-      <emu-alg>
-        1. Return the VarScopedDeclarations of |Block|.
       </emu-alg>
     </emu-clause>
 
@@ -19556,38 +19769,6 @@
       </ul>
     </emu-clause>
 
-    <emu-clause id="sec-function-definitions-static-semantics-boundnames">
-      <h1>Static Semantics: BoundNames</h1>
-      <emu-see-also-para op="BoundNames"></emu-see-also-para>
-      <emu-grammar>FunctionDeclaration : `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
-      <emu-alg>
-        1. Return the BoundNames of |BindingIdentifier|.
-      </emu-alg>
-      <emu-grammar>FunctionDeclaration : `function` `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
-      <emu-alg>
-        1. Return &laquo; *"\*default\*"* &raquo;.
-      </emu-alg>
-      <emu-note>
-        <p>*"\*default\*"* is used within this specification as a synthetic name for hoistable anonymous functions that are defined using export declarations.</p>
-      </emu-note>
-      <emu-grammar>FormalParameters : [empty]</emu-grammar>
-      <emu-alg>
-        1. Return a new empty List.
-      </emu-alg>
-      <emu-grammar>FormalParameters : FormalParameterList `,` FunctionRestParameter</emu-grammar>
-      <emu-alg>
-        1. Let _names_ be BoundNames of |FormalParameterList|.
-        1. Append to _names_ the BoundNames of |FunctionRestParameter|.
-        1. Return _names_.
-      </emu-alg>
-      <emu-grammar>FormalParameterList : FormalParameterList `,` FormalParameter</emu-grammar>
-      <emu-alg>
-        1. Let _names_ be BoundNames of |FormalParameterList|.
-        1. Append to _names_ the BoundNames of |FormalParameter|.
-        1. Return _names_.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-function-definitions-static-semantics-contains">
       <h1>Static Semantics: Contains</h1>
       <p>With parameter _symbol_.</p>
@@ -19669,77 +19850,12 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-function-definitions-static-semantics-isconstantdeclaration">
-      <h1>Static Semantics: IsConstantDeclaration</h1>
-      <emu-see-also-para op="IsConstantDeclaration"></emu-see-also-para>
-      <emu-grammar>
-        FunctionDeclaration : `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`
-
-        FunctionDeclaration : `function` `(` FormalParameters `)` `{` FunctionBody `}`
-      </emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-function-definitions-static-semantics-isfunctiondefinition">
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
       <emu-grammar>FunctionExpression : `function` BindingIdentifier? `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Return *true*.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-function-definitions-static-semantics-lexicallydeclarednames">
-      <h1>Static Semantics: LexicallyDeclaredNames</h1>
-      <emu-see-also-para op="LexicallyDeclaredNames"></emu-see-also-para>
-      <emu-grammar>FunctionStatementList : [empty]</emu-grammar>
-      <emu-alg>
-        1. Return a new empty List.
-      </emu-alg>
-      <emu-grammar>FunctionStatementList : StatementList</emu-grammar>
-      <emu-alg>
-        1. Return TopLevelLexicallyDeclaredNames of |StatementList|.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-function-definitions-static-semantics-lexicallyscopeddeclarations">
-      <h1>Static Semantics: LexicallyScopedDeclarations</h1>
-      <emu-see-also-para op="LexicallyScopedDeclarations"></emu-see-also-para>
-      <emu-grammar>FunctionStatementList : [empty]</emu-grammar>
-      <emu-alg>
-        1. Return a new empty List.
-      </emu-alg>
-      <emu-grammar>FunctionStatementList : StatementList</emu-grammar>
-      <emu-alg>
-        1. Return the TopLevelLexicallyScopedDeclarations of |StatementList|.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-function-definitions-static-semantics-vardeclarednames">
-      <h1>Static Semantics: VarDeclaredNames</h1>
-      <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
-      <emu-grammar>FunctionStatementList : [empty]</emu-grammar>
-      <emu-alg>
-        1. Return a new empty List.
-      </emu-alg>
-      <emu-grammar>FunctionStatementList : StatementList</emu-grammar>
-      <emu-alg>
-        1. Return TopLevelVarDeclaredNames of |StatementList|.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-function-definitions-static-semantics-varscopeddeclarations">
-      <h1>Static Semantics: VarScopedDeclarations</h1>
-      <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
-      <emu-grammar>FunctionStatementList : [empty]</emu-grammar>
-      <emu-alg>
-        1. Return a new empty List.
-      </emu-alg>
-      <emu-grammar>FunctionStatementList : StatementList</emu-grammar>
-      <emu-alg>
-        1. Return the TopLevelVarScopedDeclarations of |StatementList|.
       </emu-alg>
     </emu-clause>
 
@@ -19917,16 +20033,6 @@
       </ul>
     </emu-clause>
 
-    <emu-clause id="sec-arrow-function-definitions-static-semantics-boundnames">
-      <h1>Static Semantics: BoundNames</h1>
-      <emu-see-also-para op="BoundNames"></emu-see-also-para>
-      <emu-grammar>ArrowParameters : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
-      <emu-alg>
-        1. Let _formals_ be CoveredFormalsList of |CoverParenthesizedExpressionAndArrowParameterList|.
-        1. Return the BoundNames of _formals_.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-arrow-function-definitions-static-semantics-contains">
       <h1>Static Semantics: Contains</h1>
       <p>With parameter _symbol_.</p>
@@ -19986,42 +20092,6 @@
       </emu-grammar>
       <emu-alg>
         1. Return the |ArrowFormalParameters| that is covered by |CoverParenthesizedExpressionAndArrowParameterList|.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-arrow-function-definitions-static-semantics-lexicallydeclarednames">
-      <h1>Static Semantics: LexicallyDeclaredNames</h1>
-      <emu-see-also-para op="LexicallyDeclaredNames"></emu-see-also-para>
-      <emu-grammar>ConciseBody : ExpressionBody</emu-grammar>
-      <emu-alg>
-        1. Return a new empty List.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-arrow-function-definitions-static-semantics-lexicallyscopeddeclarations">
-      <h1>Static Semantics: LexicallyScopedDeclarations</h1>
-      <emu-see-also-para op="LexicallyScopedDeclarations"></emu-see-also-para>
-      <emu-grammar>ConciseBody : ExpressionBody</emu-grammar>
-      <emu-alg>
-        1. Return a new empty List.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-arrow-function-definitions-static-semantics-vardeclarednames">
-      <h1>Static Semantics: VarDeclaredNames</h1>
-      <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
-      <emu-grammar>ConciseBody : ExpressionBody</emu-grammar>
-      <emu-alg>
-        1. Return a new empty List.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-arrow-function-definitions-static-semantics-varscopeddeclarations">
-      <h1>Static Semantics: VarScopedDeclarations</h1>
-      <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
-      <emu-grammar>ConciseBody : ExpressionBody</emu-grammar>
-      <emu-alg>
-        1. Return a new empty List.
       </emu-alg>
     </emu-clause>
 
@@ -20392,22 +20462,6 @@
       </ul>
     </emu-clause>
 
-    <emu-clause id="sec-generator-function-definitions-static-semantics-boundnames">
-      <h1>Static Semantics: BoundNames</h1>
-      <emu-see-also-para op="BoundNames"></emu-see-also-para>
-      <emu-grammar>GeneratorDeclaration : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
-      <emu-alg>
-        1. Return the BoundNames of |BindingIdentifier|.
-      </emu-alg>
-      <emu-grammar>GeneratorDeclaration : `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
-      <emu-alg>
-        1. Return &laquo; *"\*default\*"* &raquo;.
-      </emu-alg>
-      <emu-note>
-        <p>*"\*default\*"* is used within this specification as a synthetic name for hoistable anonymous functions that are defined using export declarations.</p>
-      </emu-note>
-    </emu-clause>
-
     <emu-clause id="sec-generator-function-definitions-static-semantics-computedpropertycontains">
       <h1>Static Semantics: ComputedPropertyContains</h1>
       <p>With parameter _symbol_.</p>
@@ -20457,19 +20511,6 @@
       <emu-grammar>GeneratorExpression : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. Return *true*.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-generator-function-definitions-static-semantics-isconstantdeclaration">
-      <h1>Static Semantics: IsConstantDeclaration</h1>
-      <emu-see-also-para op="IsConstantDeclaration"></emu-see-also-para>
-      <emu-grammar>
-        GeneratorDeclaration : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`
-
-        GeneratorDeclaration : `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`
-      </emu-grammar>
-      <emu-alg>
-        1. Return *false*.
       </emu-alg>
     </emu-clause>
 
@@ -20692,22 +20733,6 @@
       </ul>
     </emu-clause>
 
-    <emu-clause id="sec-async-generator-function-definitions-static-semantics-boundnames">
-      <h1>Static Semantics: BoundNames</h1>
-      <emu-see-also-para op="BoundNames"></emu-see-also-para>
-      <emu-grammar>AsyncGeneratorDeclaration : `async` `function` `*` BindingIdentifier `(` FormalParameters `)` `{` AsyncGeneratorBody `}`</emu-grammar>
-      <emu-alg>
-        1. Return the BoundNames of |BindingIdentifier|.
-      </emu-alg>
-      <emu-grammar>AsyncGeneratorDeclaration : `async` `function` `*` `(` FormalParameters `)` `{` AsyncGeneratorBody `}`</emu-grammar>
-      <emu-alg>
-        1. Return &laquo; *"\*default\*"* &raquo;.
-      </emu-alg>
-      <emu-note>
-        <p>*"\*default\*"* is used within this specification as a synthetic name for hoistable anonymous functions that are defined using export declarations.</p>
-      </emu-note>
-    </emu-clause>
-
     <emu-clause id="sec-async-generator-function-definitions-static-semantics-computedpropertycontains">
       <h1>Static Semantics: ComputedPropertyContains</h1>
       <p>With parameter _symbol_.</p>
@@ -20757,19 +20782,6 @@
       <emu-grammar>AsyncGeneratorExpression : `async` `function` `*` BindingIdentifier `(` FormalParameters `)` `{` AsyncGeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. Return *true*.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-async-generator-function-definitions-static-semantics-isconstantdeclaration">
-      <h1>Static Semantics: IsConstantDeclaration</h1>
-      <emu-see-also-para op="IsConstantDeclaration"></emu-see-also-para>
-      <emu-grammar>
-        AsyncGeneratorDeclaration : `async` `function` `*` BindingIdentifier `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
-
-        AsyncGeneratorDeclaration : `async` `function` `*` `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
-      </emu-grammar>
-      <emu-alg>
-        1. Return *false*.
       </emu-alg>
     </emu-clause>
 
@@ -20959,19 +20971,6 @@
       </ul>
     </emu-clause>
 
-    <emu-clause id="sec-class-definitions-static-semantics-boundnames">
-      <h1>Static Semantics: BoundNames</h1>
-      <emu-see-also-para op="BoundNames"></emu-see-also-para>
-      <emu-grammar>ClassDeclaration : `class` BindingIdentifier ClassTail</emu-grammar>
-      <emu-alg>
-        1. Return the BoundNames of |BindingIdentifier|.
-      </emu-alg>
-      <emu-grammar>ClassDeclaration : `class` ClassTail</emu-grammar>
-      <emu-alg>
-        1. Return &laquo; *"\*default\*"* &raquo;.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-static-semantics-classelementkind">
       <h1>Static Semantics: ClassElementKind</h1>
       <emu-grammar>ClassElement : MethodDefinition</emu-grammar>
@@ -21052,19 +21051,6 @@
       <emu-grammar>ClassExpression : `class` BindingIdentifier ClassTail</emu-grammar>
       <emu-alg>
         1. Return *true*.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-class-definitions-static-semantics-isconstantdeclaration">
-      <h1>Static Semantics: IsConstantDeclaration</h1>
-      <emu-see-also-para op="IsConstantDeclaration"></emu-see-also-para>
-      <emu-grammar>
-        ClassDeclaration : `class` BindingIdentifier ClassTail
-
-        ClassDeclaration : `class` ClassTail
-      </emu-grammar>
-      <emu-alg>
-        1. Return *false*.
       </emu-alg>
     </emu-clause>
 
@@ -21331,23 +21317,6 @@
       </ul>
     </emu-clause>
 
-    <emu-clause id="sec-async-function-definitions-static-semantics-BoundNames">
-      <h1>Static Semantics: BoundNames</h1>
-      <emu-grammar>
-        AsyncFunctionDeclaration : `async` `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
-      </emu-grammar>
-      <emu-alg>
-        1. Return the BoundNames of |BindingIdentifier|.
-      </emu-alg>
-      <emu-grammar>
-        AsyncFunctionDeclaration : `async` `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
-      </emu-grammar>
-      <emu-alg>
-        1. Return &laquo; *"\*default\*"* &raquo;.
-      </emu-alg>
-      <emu-note>*"\*default\*"* is used within this specification as a synthetic name for hoistable anonymous functions that are defined using export declarations.</emu-note>
-    </emu-clause>
-
     <emu-clause id="sec-async-function-definitions-static-semantics-ComputedPropertyContains">
       <h1>Static Semantics: ComputedPropertyContains</h1>
       <p>With parameter _symbol_.</p>
@@ -21403,18 +21372,6 @@
       </emu-grammar>
       <emu-alg>
         1. Return *true*.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-async-function-definitions-static-semantics-IsConstantDeclaration">
-      <h1>Static Semantics: IsConstantDeclaration</h1>
-      <emu-grammar>
-        AsyncFunctionDeclaration : `async` `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
-
-        AsyncFunctionDeclaration : `async` `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
-      </emu-grammar>
-      <emu-alg>
-        1. Return *false*.
       </emu-alg>
     </emu-clause>
 
@@ -21606,17 +21563,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-async-arrow-function-definitions-static-semantics-BoundNames">
-      <h1>Static Semantics: BoundNames</h1>
-      <emu-grammar>
-        CoverCallExpressionAndAsyncArrowHead : MemberExpression Arguments
-      </emu-grammar>
-      <emu-alg>
-        1. Let _head_ be CoveredAsyncArrowHead of |CoverCallExpressionAndAsyncArrowHead|.
-        1. Return the BoundNames of _head_.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-async-arrow-function-definitions-static-semantics-Contains">
       <h1>Static Semantics: Contains</h1>
       <p>With parameter _symbol_.</p>
@@ -21662,46 +21608,6 @@
       </emu-grammar>
       <emu-alg>
         1. Return *false*.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-async-arrow-function-definitions-static-semantics-LexicallyDeclaredNames">
-      <h1>Static Semantics: LexicallyDeclaredNames</h1>
-      <emu-grammar>
-        AsyncConciseBody : ExpressionBody
-      </emu-grammar>
-      <emu-alg>
-        1. Return a new empty List.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-async-arrow-function-definitions-static-semantics-LexicallyScopedDeclarations">
-      <h1>Static Semantics: LexicallyScopedDeclarations</h1>
-      <emu-grammar>
-        AsyncConciseBody : ExpressionBody
-      </emu-grammar>
-      <emu-alg>
-        1. Return a new empty List.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-async-arrow-function-definitions-static-semantics-VarDeclaredNames">
-      <h1>Static Semantics: VarDeclaredNames</h1>
-      <emu-grammar>
-        AsyncConciseBody : ExpressionBody
-      </emu-grammar>
-      <emu-alg>
-        1. Return a new empty List.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-async-arrow-function-definitions-static-semantics-VarScopedDeclarations">
-      <h1>Static Semantics: VarScopedDeclarations</h1>
-      <emu-grammar>
-        AsyncConciseBody : ExpressionBody
-      </emu-grammar>
-      <emu-alg>
-        1. Return a new empty List.
       </emu-alg>
     </emu-clause>
 
@@ -22195,45 +22101,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-scripts-static-semantics-lexicallydeclarednames">
-      <h1>Static Semantics: LexicallyDeclaredNames</h1>
-      <emu-see-also-para op="LexicallyDeclaredNames"></emu-see-also-para>
-      <emu-grammar>ScriptBody : StatementList</emu-grammar>
-      <emu-alg>
-        1. Return TopLevelLexicallyDeclaredNames of |StatementList|.
-      </emu-alg>
-      <emu-note>
-        <p>At the top level of a |Script|, function declarations are treated like var declarations rather than like lexical declarations.</p>
-      </emu-note>
-    </emu-clause>
-
-    <emu-clause id="sec-scripts-static-semantics-lexicallyscopeddeclarations">
-      <h1>Static Semantics: LexicallyScopedDeclarations</h1>
-      <emu-see-also-para op="LexicallyScopedDeclarations"></emu-see-also-para>
-      <emu-grammar>ScriptBody : StatementList</emu-grammar>
-      <emu-alg>
-        1. Return TopLevelLexicallyScopedDeclarations of |StatementList|.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-scripts-static-semantics-vardeclarednames">
-      <h1>Static Semantics: VarDeclaredNames</h1>
-      <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
-      <emu-grammar>ScriptBody : StatementList</emu-grammar>
-      <emu-alg>
-        1. Return TopLevelVarDeclaredNames of |StatementList|.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-scripts-static-semantics-varscopeddeclarations">
-      <h1>Static Semantics: VarScopedDeclarations</h1>
-      <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
-      <emu-grammar>ScriptBody : StatementList</emu-grammar>
-      <emu-alg>
-        1. Return TopLevelVarScopedDeclarations of |StatementList|.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-script-semantics-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>Script : [empty]</emu-grammar>
@@ -22668,103 +22535,6 @@
         </emu-alg>
         <emu-grammar>ModuleItem : StatementListItem</emu-grammar>
         <emu-alg>
-          1. Return a new empty List.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-module-semantics-static-semantics-lexicallydeclarednames">
-        <h1>Static Semantics: LexicallyDeclaredNames</h1>
-        <emu-see-also-para op="LexicallyDeclaredNames"></emu-see-also-para>
-        <emu-note>
-          <p>The LexicallyDeclaredNames of a |Module| includes the names of all of its imported bindings.</p>
-        </emu-note>
-        <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
-        <emu-alg>
-          1. Let _names_ be LexicallyDeclaredNames of |ModuleItemList|.
-          1. Append to _names_ the elements of the LexicallyDeclaredNames of |ModuleItem|.
-          1. Return _names_.
-        </emu-alg>
-        <emu-grammar>ModuleItem : ImportDeclaration</emu-grammar>
-        <emu-alg>
-          1. Return the BoundNames of |ImportDeclaration|.
-        </emu-alg>
-        <emu-grammar>ModuleItem : ExportDeclaration</emu-grammar>
-        <emu-alg>
-          1. If |ExportDeclaration| is `export` |VariableStatement|, return a new empty List.
-          1. Return the BoundNames of |ExportDeclaration|.
-        </emu-alg>
-        <emu-grammar>ModuleItem : StatementListItem</emu-grammar>
-        <emu-alg>
-          1. Return LexicallyDeclaredNames of |StatementListItem|.
-        </emu-alg>
-        <emu-note>
-          <p>At the top level of a |Module|, function declarations are treated like lexical declarations rather than like var declarations.</p>
-        </emu-note>
-      </emu-clause>
-
-      <emu-clause id="sec-module-semantics-static-semantics-lexicallyscopeddeclarations">
-        <h1>Static Semantics: LexicallyScopedDeclarations</h1>
-        <emu-see-also-para op="LexicallyScopedDeclarations"></emu-see-also-para>
-        <emu-grammar>Module : [empty]</emu-grammar>
-        <emu-alg>
-          1. Return a new empty List.
-        </emu-alg>
-        <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
-        <emu-alg>
-          1. Let _declarations_ be LexicallyScopedDeclarations of |ModuleItemList|.
-          1. Append to _declarations_ the elements of the LexicallyScopedDeclarations of |ModuleItem|.
-          1. Return _declarations_.
-        </emu-alg>
-        <emu-grammar>ModuleItem : ImportDeclaration</emu-grammar>
-        <emu-alg>
-          1. Return a new empty List.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-module-semantics-static-semantics-vardeclarednames">
-        <h1>Static Semantics: VarDeclaredNames</h1>
-        <emu-see-also-para op="VarDeclaredNames"></emu-see-also-para>
-        <emu-grammar>Module : [empty]</emu-grammar>
-        <emu-alg>
-          1. Return a new empty List.
-        </emu-alg>
-        <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
-        <emu-alg>
-          1. Let _names_ be VarDeclaredNames of |ModuleItemList|.
-          1. Append to _names_ the elements of the VarDeclaredNames of |ModuleItem|.
-          1. Return _names_.
-        </emu-alg>
-        <emu-grammar>ModuleItem : ImportDeclaration</emu-grammar>
-        <emu-alg>
-          1. Return a new empty List.
-        </emu-alg>
-        <emu-grammar>ModuleItem : ExportDeclaration</emu-grammar>
-        <emu-alg>
-          1. If |ExportDeclaration| is `export` |VariableStatement|, return BoundNames of |ExportDeclaration|.
-          1. Return a new empty List.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-module-semantics-static-semantics-varscopeddeclarations">
-        <h1>Static Semantics: VarScopedDeclarations</h1>
-        <emu-see-also-para op="VarScopedDeclarations"></emu-see-also-para>
-        <emu-grammar>Module : [empty]</emu-grammar>
-        <emu-alg>
-          1. Return a new empty List.
-        </emu-alg>
-        <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
-        <emu-alg>
-          1. Let _declarations_ be VarScopedDeclarations of |ModuleItemList|.
-          1. Append to _declarations_ the elements of the VarScopedDeclarations of |ModuleItem|.
-          1. Return _declarations_.
-        </emu-alg>
-        <emu-grammar>ModuleItem : ImportDeclaration</emu-grammar>
-        <emu-alg>
-          1. Return a new empty List.
-        </emu-alg>
-        <emu-grammar>ModuleItem : ExportDeclaration</emu-grammar>
-        <emu-alg>
-          1. If |ExportDeclaration| is `export` |VariableStatement|, return VarScopedDeclarations of |VariableStatement|.
           1. Return a new empty List.
         </emu-alg>
       </emu-clause>
@@ -24051,45 +23821,6 @@
         </ul>
       </emu-clause>
 
-      <emu-clause id="sec-imports-static-semantics-boundnames">
-        <h1>Static Semantics: BoundNames</h1>
-        <emu-see-also-para op="BoundNames"></emu-see-also-para>
-        <emu-grammar>ImportDeclaration : `import` ImportClause FromClause `;`</emu-grammar>
-        <emu-alg>
-          1. Return the BoundNames of |ImportClause|.
-        </emu-alg>
-        <emu-grammar>ImportDeclaration : `import` ModuleSpecifier `;`</emu-grammar>
-        <emu-alg>
-          1. Return a new empty List.
-        </emu-alg>
-        <emu-grammar>ImportClause : ImportedDefaultBinding `,` NameSpaceImport</emu-grammar>
-        <emu-alg>
-          1. Let _names_ be the BoundNames of |ImportedDefaultBinding|.
-          1. Append to _names_ the elements of the BoundNames of |NameSpaceImport|.
-          1. Return _names_.
-        </emu-alg>
-        <emu-grammar>ImportClause : ImportedDefaultBinding `,` NamedImports</emu-grammar>
-        <emu-alg>
-          1. Let _names_ be the BoundNames of |ImportedDefaultBinding|.
-          1. Append to _names_ the elements of the BoundNames of |NamedImports|.
-          1. Return _names_.
-        </emu-alg>
-        <emu-grammar>NamedImports : `{` `}`</emu-grammar>
-        <emu-alg>
-          1. Return a new empty List.
-        </emu-alg>
-        <emu-grammar>ImportsList : ImportsList `,` ImportSpecifier</emu-grammar>
-        <emu-alg>
-          1. Let _names_ be the BoundNames of |ImportsList|.
-          1. Append to _names_ the elements of the BoundNames of |ImportSpecifier|.
-          1. Return _names_.
-        </emu-alg>
-        <emu-grammar>ImportSpecifier : IdentifierName `as` ImportedBinding</emu-grammar>
-        <emu-alg>
-          1. Return the BoundNames of |ImportedBinding|.
-        </emu-alg>
-      </emu-clause>
-
       <emu-clause id="sec-imports-static-semantics-importentries">
         <h1>Static Semantics: ImportEntries</h1>
         <emu-see-also-para op="ImportEntries"></emu-see-also-para>
@@ -24213,43 +23944,6 @@
         <emu-note>
           <p>The above rule means that each ReferencedBindings of |NamedExports| is treated as an |IdentifierReference|.</p>
         </emu-note>
-      </emu-clause>
-
-      <emu-clause id="sec-exports-static-semantics-boundnames">
-        <h1>Static Semantics: BoundNames</h1>
-        <emu-see-also-para op="BoundNames"></emu-see-also-para>
-        <emu-grammar>
-          ExportDeclaration :
-            `export` ExportFromClause FromClause `;`
-            `export` NamedExports `;`
-        </emu-grammar>
-        <emu-alg>
-          1. Return a new empty List.
-        </emu-alg>
-        <emu-grammar>ExportDeclaration : `export` VariableStatement</emu-grammar>
-        <emu-alg>
-          1. Return the BoundNames of |VariableStatement|.
-        </emu-alg>
-        <emu-grammar>ExportDeclaration : `export` Declaration</emu-grammar>
-        <emu-alg>
-          1. Return the BoundNames of |Declaration|.
-        </emu-alg>
-        <emu-grammar>ExportDeclaration : `export` `default` HoistableDeclaration</emu-grammar>
-        <emu-alg>
-          1. Let _declarationNames_ be the BoundNames of |HoistableDeclaration|.
-          1. If _declarationNames_ does not include the element *"\*default\*"*, append *"\*default\*"* to _declarationNames_.
-          1. Return _declarationNames_.
-        </emu-alg>
-        <emu-grammar>ExportDeclaration : `export` `default` ClassDeclaration</emu-grammar>
-        <emu-alg>
-          1. Let _declarationNames_ be the BoundNames of |ClassDeclaration|.
-          1. If _declarationNames_ does not include the element *"\*default\*"*, append *"\*default\*"* to _declarationNames_.
-          1. Return _declarationNames_.
-        </emu-alg>
-        <emu-grammar>ExportDeclaration : `export` `default` AssignmentExpression `;`</emu-grammar>
-        <emu-alg>
-          1. Return &laquo; *"\*default\*"* &raquo;.
-        </emu-alg>
       </emu-clause>
 
       <emu-clause id="sec-exports-static-semantics-exportedbindings">
@@ -24457,53 +24151,6 @@
             1. Let _localName_ be *null*.
             1. Let _importName_ be _sourceName_.
           1. Return a List whose sole element is the ExportEntry Record { [[ModuleRequest]]: _module_, [[ImportName]]: _importName_, [[LocalName]]: _localName_, [[ExportName]]: _exportName_ }.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-exports-static-semantics-isconstantdeclaration">
-        <h1>Static Semantics: IsConstantDeclaration</h1>
-        <emu-see-also-para op="IsConstantDeclaration"></emu-see-also-para>
-        <emu-grammar>
-          ExportDeclaration :
-            `export` ExportFromClause FromClause `;`
-            `export` NamedExports `;`
-            `export` `default` AssignmentExpression `;`
-        </emu-grammar>
-        <emu-alg>
-          1. Return *false*.
-        </emu-alg>
-        <emu-note>
-          <p>It is not necessary to treat `export default` |AssignmentExpression| as a constant declaration because there is no syntax that permits assignment to the internal bound name used to reference a module's default object.</p>
-        </emu-note>
-      </emu-clause>
-
-      <emu-clause id="sec-exports-static-semantics-lexicallyscopeddeclarations">
-        <h1>Static Semantics: LexicallyScopedDeclarations</h1>
-        <emu-see-also-para op="LexicallyScopedDeclarations"></emu-see-also-para>
-        <emu-grammar>
-          ExportDeclaration :
-            `export` ExportFromClause FromClause `;`
-            `export` NamedExports `;`
-            `export` VariableStatement
-        </emu-grammar>
-        <emu-alg>
-          1. Return a new empty List.
-        </emu-alg>
-        <emu-grammar>ExportDeclaration : `export` Declaration</emu-grammar>
-        <emu-alg>
-          1. Return a List whose sole element is DeclarationPart of |Declaration|.
-        </emu-alg>
-        <emu-grammar>ExportDeclaration : `export` `default` HoistableDeclaration</emu-grammar>
-        <emu-alg>
-          1. Return a List whose sole element is DeclarationPart of |HoistableDeclaration|.
-        </emu-alg>
-        <emu-grammar>ExportDeclaration : `export` `default` ClassDeclaration</emu-grammar>
-        <emu-alg>
-          1. Return a List whose sole element is |ClassDeclaration|.
-        </emu-alg>
-        <emu-grammar>ExportDeclaration : `export` `default` AssignmentExpression `;`</emu-grammar>
-        <emu-alg>
-          1. Return a List whose sole element is this |ExportDeclaration|.
         </emu-alg>
       </emu-clause>
 
@@ -42927,14 +42574,14 @@ THH:mm:ss.sss
       <emu-alg>
         1. Return *false*.
       </emu-alg>
-      <p>The static semantics of VarDeclaredNames in <emu-xref href="#sec-for-in-and-for-of-statements-static-semantics-vardeclarednames"></emu-xref> are augmented with the following:</p>
+      <p>The static semantics of VarDeclaredNames in <emu-xref href="#sec-static-semantics-vardeclarednames"></emu-xref> are augmented with the following:</p>
       <emu-grammar>IterationStatement : `for` `(` `var` BindingIdentifier Initializer `in` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Let _names_ be the BoundNames of |BindingIdentifier|.
         1. Append to _names_ the elements of the VarDeclaredNames of |Statement|.
         1. Return _names_.
       </emu-alg>
-      <p>The static semantics of VarScopedDeclarations in <emu-xref href="#sec-for-in-and-for-of-statements-static-semantics-varscopeddeclarations"></emu-xref> are augmented with the following:</p>
+      <p>The static semantics of VarScopedDeclarations in <emu-xref href="#sec-static-semantics-varscopeddeclarations"></emu-xref> are augmented with the following:</p>
       <emu-grammar>IterationStatement : `for` `(` `var` BindingIdentifier Initializer `in` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Let _declarations_ be a List whose sole element is |BindingIdentifier|.

--- a/spec.html
+++ b/spec.html
@@ -17233,6 +17233,121 @@
           <p>Within the |Statement| part of an |IterationStatement| a |ContinueStatement| may be used to begin a new iteration.</p>
         </emu-note>
       </emu-clause>
+
+      <emu-clause id="sec-runtime-semantics-loopevaluation" oldids="sec-do-while-statement-runtime-semantics-labelledevaluation,sec-while-statement-runtime-semantics-labelledevaluation,sec-for-statement-runtime-semantics-labelledevaluation,sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation" type="sdo" aoid="LoopEvaluation">
+        <h1>Runtime Semantics: LoopEvaluation</h1>
+        <p>With parameter _labelSet_.</p>
+        <emu-grammar>IterationStatement : `do` Statement `while` `(` Expression `)` `;`</emu-grammar>
+        <emu-alg>
+          1. Let _V_ be *undefined*.
+          1. Repeat,
+            1. Let _stmtResult_ be the result of evaluating |Statement|.
+            1. If LoopContinues(_stmtResult_, _labelSet_) is *false*, return Completion(UpdateEmpty(_stmtResult_, _V_)).
+            1. If _stmtResult_.[[Value]] is not ~empty~, set _V_ to _stmtResult_.[[Value]].
+            1. Let _exprRef_ be the result of evaluating |Expression|.
+            1. Let _exprValue_ be ? GetValue(_exprRef_).
+            1. If ! ToBoolean(_exprValue_) is *false*, return NormalCompletion(_V_).
+        </emu-alg>
+        <emu-grammar>IterationStatement : `while` `(` Expression `)` Statement</emu-grammar>
+        <emu-alg>
+          1. Let _V_ be *undefined*.
+          1. Repeat,
+            1. Let _exprRef_ be the result of evaluating |Expression|.
+            1. Let _exprValue_ be ? GetValue(_exprRef_).
+            1. If ! ToBoolean(_exprValue_) is *false*, return NormalCompletion(_V_).
+            1. Let _stmtResult_ be the result of evaluating |Statement|.
+            1. If LoopContinues(_stmtResult_, _labelSet_) is *false*, return Completion(UpdateEmpty(_stmtResult_, _V_)).
+            1. If _stmtResult_.[[Value]] is not ~empty~, set _V_ to _stmtResult_.[[Value]].
+        </emu-alg>
+        <emu-grammar>IterationStatement : `for` `(` Expression? `;` Expression? `;` Expression? `)` Statement</emu-grammar>
+        <emu-alg>
+          1. If the first |Expression| is present, then
+            1. Let _exprRef_ be the result of evaluating the first |Expression|.
+            1. Perform ? GetValue(_exprRef_).
+          1. Return ? ForBodyEvaluation(the second |Expression|, the third |Expression|, |Statement|, &laquo; &raquo;, _labelSet_).
+        </emu-alg>
+        <emu-grammar>IterationStatement : `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement</emu-grammar>
+        <emu-alg>
+          1. Let _varDcl_ be the result of evaluating |VariableDeclarationList|.
+          1. ReturnIfAbrupt(_varDcl_).
+          1. Return ? ForBodyEvaluation(the first |Expression|, the second |Expression|, |Statement|, &laquo; &raquo;, _labelSet_).
+        </emu-alg>
+        <emu-grammar>IterationStatement : `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement</emu-grammar>
+        <emu-alg>
+          1. Let _oldEnv_ be the running execution context's LexicalEnvironment.
+          1. Let _loopEnv_ be NewDeclarativeEnvironment(_oldEnv_).
+          1. Let _isConst_ be IsConstantDeclaration of |LexicalDeclaration|.
+          1. Let _boundNames_ be the BoundNames of |LexicalDeclaration|.
+          1. For each element _dn_ of _boundNames_, do
+            1. If _isConst_ is *true*, then
+              1. Perform ! _loopEnv_.CreateImmutableBinding(_dn_, *true*).
+            1. Else,
+              1. Perform ! _loopEnv_.CreateMutableBinding(_dn_, *false*).
+          1. Set the running execution context's LexicalEnvironment to _loopEnv_.
+          1. Let _forDcl_ be the result of evaluating |LexicalDeclaration|.
+          1. If _forDcl_ is an abrupt completion, then
+            1. Set the running execution context's LexicalEnvironment to _oldEnv_.
+            1. Return Completion(_forDcl_).
+          1. If _isConst_ is *false*, let _perIterationLets_ be _boundNames_; otherwise let _perIterationLets_ be &laquo; &raquo;.
+          1. Let _bodyResult_ be ForBodyEvaluation(the first |Expression|, the second |Expression|, |Statement|, _perIterationLets_, _labelSet_).
+          1. Set the running execution context's LexicalEnvironment to _oldEnv_.
+          1. Return Completion(_bodyResult_).
+        </emu-alg>
+        <emu-grammar>IterationStatement : `for` `(` LeftHandSideExpression `in` Expression `)` Statement</emu-grammar>
+        <emu-alg>
+          1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(&laquo; &raquo;, |Expression|, ~enumerate~).
+          1. Return ? ForIn/OfBodyEvaluation(|LeftHandSideExpression|, |Statement|, _keyResult_, ~enumerate~, ~assignment~, _labelSet_).
+        </emu-alg>
+        <emu-grammar>IterationStatement : `for` `(` `var` ForBinding `in` Expression `)` Statement</emu-grammar>
+        <emu-alg>
+          1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(&laquo; &raquo;, |Expression|, ~enumerate~).
+          1. Return ? ForIn/OfBodyEvaluation(|ForBinding|, |Statement|, _keyResult_, ~enumerate~, ~varBinding~, _labelSet_).
+        </emu-alg>
+        <emu-grammar>IterationStatement : `for` `(` ForDeclaration `in` Expression `)` Statement</emu-grammar>
+        <emu-alg>
+          1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(BoundNames of |ForDeclaration|, |Expression|, ~enumerate~).
+          1. Return ? ForIn/OfBodyEvaluation(|ForDeclaration|, |Statement|, _keyResult_, ~enumerate~, ~lexicalBinding~, _labelSet_).
+        </emu-alg>
+        <emu-grammar>IterationStatement : `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement</emu-grammar>
+        <emu-alg>
+          1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(&laquo; &raquo;, |AssignmentExpression|, ~iterate~).
+          1. Return ? ForIn/OfBodyEvaluation(|LeftHandSideExpression|, |Statement|, _keyResult_, ~iterate~, ~assignment~, _labelSet_).
+        </emu-alg>
+        <emu-grammar>IterationStatement : `for` `(` `var` ForBinding `of` AssignmentExpression `)` Statement</emu-grammar>
+        <emu-alg>
+          1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(&laquo; &raquo;, |AssignmentExpression|, ~iterate~).
+          1. Return ? ForIn/OfBodyEvaluation(|ForBinding|, |Statement|, _keyResult_, ~iterate~, ~varBinding~, _labelSet_).
+        </emu-alg>
+        <emu-grammar>IterationStatement : `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement</emu-grammar>
+        <emu-alg>
+          1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(BoundNames of |ForDeclaration|, |AssignmentExpression|, ~iterate~).
+          1. Return ? ForIn/OfBodyEvaluation(|ForDeclaration|, |Statement|, _keyResult_, ~iterate~, ~lexicalBinding~, _labelSet_).
+        </emu-alg>
+        <emu-grammar>
+          IterationStatement : `for` `await` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
+        </emu-grammar>
+        <emu-alg>
+          1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(&laquo; &raquo;, |AssignmentExpression|, ~async-iterate~).
+          1. Return ? ForIn/OfBodyEvaluation(|LeftHandSideExpression|, |Statement|, _keyResult_, ~iterate~, ~assignment~, _labelSet_, ~async~).
+        </emu-alg>
+        <emu-grammar>
+          IterationStatement : `for` `await` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
+        </emu-grammar>
+        <emu-alg>
+          1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(&laquo; &raquo;, |AssignmentExpression|, ~async-iterate~).
+          1. Return ? ForIn/OfBodyEvaluation(|ForBinding|, |Statement|, _keyResult_, ~iterate~, ~varBinding~, _labelSet_, ~async~).
+        </emu-alg>
+        <emu-grammar>
+          IterationStatement : `for` `await` `(` ForDeclaration `of` AssignmentExpression `)` Statement
+        </emu-grammar>
+        <emu-alg>
+          1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(BoundNames of |ForDeclaration|, |AssignmentExpression|, ~async-iterate~).
+          1. Return ? ForIn/OfBodyEvaluation(|ForDeclaration|, |Statement|, _keyResult_, ~iterate~, ~lexicalBinding~, _labelSet_, ~async~).
+        </emu-alg>
+        <emu-note>
+          <p>This section is extended by Annex <emu-xref href="#sec-initializers-in-forin-statement-heads"></emu-xref>.</p>
+        </emu-note>
+      </emu-clause>
     </emu-clause>
 
     <emu-clause id="sec-do-while-statement">
@@ -18818,12 +18933,12 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-runtime-semantics-labelledevaluation" oldids="sec-statement-semantics-runtime-semantics-labelledevaluation,sec-do-while-statement-runtime-semantics-labelledevaluation,sec-while-statement-runtime-semantics-labelledevaluation,sec-for-statement-runtime-semantics-labelledevaluation,sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation,sec-labelled-statements-runtime-semantics-labelledevaluation" type="sdo" aoid="LabelledEvaluation">
+    <emu-clause id="sec-runtime-semantics-labelledevaluation" oldids="sec-statement-semantics-runtime-semantics-labelledevaluation,sec-labelled-statements-runtime-semantics-labelledevaluation" type="sdo" aoid="LabelledEvaluation">
       <h1>Runtime Semantics: LabelledEvaluation</h1>
       <p>With parameter _labelSet_.</p>
       <emu-grammar>BreakableStatement : IterationStatement</emu-grammar>
       <emu-alg>
-        1. Let _stmtResult_ be LabelledEvaluation of |IterationStatement| with argument _labelSet_.
+        1. Let _stmtResult_ be LoopEvaluation of |IterationStatement| with argument _labelSet_.
         1. If _stmtResult_.[[Type]] is ~break~, then
           1. If _stmtResult_.[[Target]] is ~empty~, then
             1. If _stmtResult_.[[Value]] is ~empty~, set _stmtResult_ to NormalCompletion(*undefined*).
@@ -18841,116 +18956,6 @@
       </emu-alg>
       <emu-note>
         <p>A |BreakableStatement| is one that can be exited via an unlabelled |BreakStatement|.</p>
-      </emu-note>
-      <emu-grammar>IterationStatement : `do` Statement `while` `(` Expression `)` `;`</emu-grammar>
-      <emu-alg>
-        1. Let _V_ be *undefined*.
-        1. Repeat,
-          1. Let _stmtResult_ be the result of evaluating |Statement|.
-          1. If LoopContinues(_stmtResult_, _labelSet_) is *false*, return Completion(UpdateEmpty(_stmtResult_, _V_)).
-          1. If _stmtResult_.[[Value]] is not ~empty~, set _V_ to _stmtResult_.[[Value]].
-          1. Let _exprRef_ be the result of evaluating |Expression|.
-          1. Let _exprValue_ be ? GetValue(_exprRef_).
-          1. If ! ToBoolean(_exprValue_) is *false*, return NormalCompletion(_V_).
-      </emu-alg>
-      <emu-grammar>IterationStatement : `while` `(` Expression `)` Statement</emu-grammar>
-      <emu-alg>
-        1. Let _V_ be *undefined*.
-        1. Repeat,
-          1. Let _exprRef_ be the result of evaluating |Expression|.
-          1. Let _exprValue_ be ? GetValue(_exprRef_).
-          1. If ! ToBoolean(_exprValue_) is *false*, return NormalCompletion(_V_).
-          1. Let _stmtResult_ be the result of evaluating |Statement|.
-          1. If LoopContinues(_stmtResult_, _labelSet_) is *false*, return Completion(UpdateEmpty(_stmtResult_, _V_)).
-          1. If _stmtResult_.[[Value]] is not ~empty~, set _V_ to _stmtResult_.[[Value]].
-      </emu-alg>
-      <emu-grammar>IterationStatement : `for` `(` Expression? `;` Expression? `;` Expression? `)` Statement</emu-grammar>
-      <emu-alg>
-        1. If the first |Expression| is present, then
-          1. Let _exprRef_ be the result of evaluating the first |Expression|.
-          1. Perform ? GetValue(_exprRef_).
-        1. Return ? ForBodyEvaluation(the second |Expression|, the third |Expression|, |Statement|, &laquo; &raquo;, _labelSet_).
-      </emu-alg>
-      <emu-grammar>IterationStatement : `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement</emu-grammar>
-      <emu-alg>
-        1. Let _varDcl_ be the result of evaluating |VariableDeclarationList|.
-        1. ReturnIfAbrupt(_varDcl_).
-        1. Return ? ForBodyEvaluation(the first |Expression|, the second |Expression|, |Statement|, &laquo; &raquo;, _labelSet_).
-      </emu-alg>
-      <emu-grammar>IterationStatement : `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement</emu-grammar>
-      <emu-alg>
-        1. Let _oldEnv_ be the running execution context's LexicalEnvironment.
-        1. Let _loopEnv_ be NewDeclarativeEnvironment(_oldEnv_).
-        1. Let _isConst_ be IsConstantDeclaration of |LexicalDeclaration|.
-        1. Let _boundNames_ be the BoundNames of |LexicalDeclaration|.
-        1. For each element _dn_ of _boundNames_, do
-          1. If _isConst_ is *true*, then
-            1. Perform ! _loopEnv_.CreateImmutableBinding(_dn_, *true*).
-          1. Else,
-            1. Perform ! _loopEnv_.CreateMutableBinding(_dn_, *false*).
-        1. Set the running execution context's LexicalEnvironment to _loopEnv_.
-        1. Let _forDcl_ be the result of evaluating |LexicalDeclaration|.
-        1. If _forDcl_ is an abrupt completion, then
-          1. Set the running execution context's LexicalEnvironment to _oldEnv_.
-          1. Return Completion(_forDcl_).
-        1. If _isConst_ is *false*, let _perIterationLets_ be _boundNames_; otherwise let _perIterationLets_ be &laquo; &raquo;.
-        1. Let _bodyResult_ be ForBodyEvaluation(the first |Expression|, the second |Expression|, |Statement|, _perIterationLets_, _labelSet_).
-        1. Set the running execution context's LexicalEnvironment to _oldEnv_.
-        1. Return Completion(_bodyResult_).
-      </emu-alg>
-      <emu-grammar>IterationStatement : `for` `(` LeftHandSideExpression `in` Expression `)` Statement</emu-grammar>
-      <emu-alg>
-        1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(&laquo; &raquo;, |Expression|, ~enumerate~).
-        1. Return ? ForIn/OfBodyEvaluation(|LeftHandSideExpression|, |Statement|, _keyResult_, ~enumerate~, ~assignment~, _labelSet_).
-      </emu-alg>
-      <emu-grammar>IterationStatement : `for` `(` `var` ForBinding `in` Expression `)` Statement</emu-grammar>
-      <emu-alg>
-        1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(&laquo; &raquo;, |Expression|, ~enumerate~).
-        1. Return ? ForIn/OfBodyEvaluation(|ForBinding|, |Statement|, _keyResult_, ~enumerate~, ~varBinding~, _labelSet_).
-      </emu-alg>
-      <emu-grammar>IterationStatement : `for` `(` ForDeclaration `in` Expression `)` Statement</emu-grammar>
-      <emu-alg>
-        1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(BoundNames of |ForDeclaration|, |Expression|, ~enumerate~).
-        1. Return ? ForIn/OfBodyEvaluation(|ForDeclaration|, |Statement|, _keyResult_, ~enumerate~, ~lexicalBinding~, _labelSet_).
-      </emu-alg>
-      <emu-grammar>IterationStatement : `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement</emu-grammar>
-      <emu-alg>
-        1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(&laquo; &raquo;, |AssignmentExpression|, ~iterate~).
-        1. Return ? ForIn/OfBodyEvaluation(|LeftHandSideExpression|, |Statement|, _keyResult_, ~iterate~, ~assignment~, _labelSet_).
-      </emu-alg>
-      <emu-grammar>IterationStatement : `for` `(` `var` ForBinding `of` AssignmentExpression `)` Statement</emu-grammar>
-      <emu-alg>
-        1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(&laquo; &raquo;, |AssignmentExpression|, ~iterate~).
-        1. Return ? ForIn/OfBodyEvaluation(|ForBinding|, |Statement|, _keyResult_, ~iterate~, ~varBinding~, _labelSet_).
-      </emu-alg>
-      <emu-grammar>IterationStatement : `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement</emu-grammar>
-      <emu-alg>
-        1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(BoundNames of |ForDeclaration|, |AssignmentExpression|, ~iterate~).
-        1. Return ? ForIn/OfBodyEvaluation(|ForDeclaration|, |Statement|, _keyResult_, ~iterate~, ~lexicalBinding~, _labelSet_).
-      </emu-alg>
-      <emu-grammar>
-        IterationStatement : `for` `await` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
-      </emu-grammar>
-      <emu-alg>
-        1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(&laquo; &raquo;, |AssignmentExpression|, ~async-iterate~).
-        1. Return ? ForIn/OfBodyEvaluation(|LeftHandSideExpression|, |Statement|, _keyResult_, ~iterate~, ~assignment~, _labelSet_, ~async~).
-      </emu-alg>
-      <emu-grammar>
-        IterationStatement : `for` `await` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
-      </emu-grammar>
-      <emu-alg>
-        1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(&laquo; &raquo;, |AssignmentExpression|, ~async-iterate~).
-        1. Return ? ForIn/OfBodyEvaluation(|ForBinding|, |Statement|, _keyResult_, ~iterate~, ~varBinding~, _labelSet_, ~async~).
-      </emu-alg>
-      <emu-grammar>
-        IterationStatement : `for` `await` `(` ForDeclaration `of` AssignmentExpression `)` Statement
-      </emu-grammar>
-      <emu-alg>
-        1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(BoundNames of |ForDeclaration|, |AssignmentExpression|, ~async-iterate~).
-        1. Return ? ForIn/OfBodyEvaluation(|ForDeclaration|, |Statement|, _keyResult_, ~iterate~, ~lexicalBinding~, _labelSet_, ~async~).
-      </emu-alg>
-      <emu-note>
-        <p>This section is extended by Annex <emu-xref href="#sec-initializers-in-forin-statement-heads"></emu-xref>.</p>
       </emu-note>
       <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
       <emu-alg>
@@ -42936,7 +42941,7 @@ THH:mm:ss.sss
         1. Append to _declarations_ the elements of the VarScopedDeclarations of |Statement|.
         1. Return _declarations_.
       </emu-alg>
-      <p>The runtime semantics of LabelledEvaluation in <emu-xref href="#sec-runtime-semantics-labelledevaluation"></emu-xref> are augmented with the following:</p>
+      <p>The runtime semantics of LoopEvaluation in <emu-xref href="#sec-runtime-semantics-loopevaluation"></emu-xref> are augmented with the following:</p>
       <emu-grammar>IterationStatement : `for` `(` `var` BindingIdentifier Initializer `in` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Let _bindingId_ be StringValue of |BindingIdentifier|.

--- a/spec.html
+++ b/spec.html
@@ -7404,6 +7404,47 @@
 
   <emu-clause id="sec-syntax-directed-operations-function-name-inference">
     <h1>Function Name Inference</h1>
+
+    <emu-clause id="sec-static-semantics-isidentifierref" oldids="sec-semantics-static-semantics-isidentifierref,sec-static-semantics-static-semantics-isidentifierref" type="sdo" aoid="IsIdentifierRef">
+      <h1>Static Semantics: IsIdentifierRef</h1>
+      <emu-grammar>PrimaryExpression : IdentifierReference</emu-grammar>
+      <emu-alg>
+        1. Return *true*.
+      </emu-alg>
+      <emu-grammar>
+        PrimaryExpression :
+          `this`
+          Literal
+          ArrayLiteral
+          ObjectLiteral
+          FunctionExpression
+          ClassExpression
+          GeneratorExpression
+          AsyncFunctionExpression
+          AsyncGeneratorExpression
+          RegularExpressionLiteral
+          TemplateLiteral
+          CoverParenthesizedExpressionAndArrowParameterList
+
+        MemberExpression :
+          MemberExpression `[` Expression `]`
+          MemberExpression `.` IdentifierName
+          MemberExpression TemplateLiteral
+          SuperProperty
+          MetaProperty
+          `new` MemberExpression Arguments
+
+        NewExpression :
+          `new` NewExpression
+
+        LeftHandSideExpression :
+          CallExpression
+          OptionalExpression
+      </emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+    </emu-clause>
   </emu-clause>
 
   <emu-clause id="sec-syntax-directed-operations-contains">
@@ -14525,33 +14566,6 @@
           1. Return the |ParenthesizedExpression| that is covered by |CoverParenthesizedExpressionAndArrowParameterList|.
         </emu-alg>
       </emu-clause>
-
-      <emu-clause id="sec-semantics-static-semantics-isidentifierref">
-        <h1>Static Semantics: IsIdentifierRef</h1>
-        <emu-see-also-para op="IsIdentifierRef"></emu-see-also-para>
-        <emu-grammar>PrimaryExpression : IdentifierReference</emu-grammar>
-        <emu-alg>
-          1. Return *true*.
-        </emu-alg>
-        <emu-grammar>
-          PrimaryExpression :
-            `this`
-            Literal
-            ArrayLiteral
-            ObjectLiteral
-            FunctionExpression
-            ClassExpression
-            GeneratorExpression
-            AsyncFunctionExpression
-            AsyncGeneratorExpression
-            RegularExpressionLiteral
-            TemplateLiteral
-            CoverParenthesizedExpressionAndArrowParameterList
-        </emu-grammar>
-        <emu-alg>
-          1. Return *false*.
-        </emu-alg>
-      </emu-clause>
     </emu-clause>
 
     <emu-clause id="sec-this-keyword">
@@ -15415,30 +15429,6 @@
         </emu-grammar>
         <emu-alg>
           1. Return the |CallMemberExpression| that is covered by |CoverCallExpressionAndAsyncArrowHead|.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-static-semantics-static-semantics-isidentifierref">
-        <h1>Static Semantics: IsIdentifierRef</h1>
-        <emu-see-also-para op="IsIdentifierRef"></emu-see-also-para>
-        <emu-grammar>
-          MemberExpression :
-            MemberExpression `[` Expression `]`
-            MemberExpression `.` IdentifierName
-            MemberExpression TemplateLiteral
-            SuperProperty
-            MetaProperty
-            `new` MemberExpression Arguments
-
-          NewExpression :
-            `new` NewExpression
-
-          LeftHandSideExpression :
-            CallExpression
-            OptionalExpression
-        </emu-grammar>
-        <emu-alg>
-          1. Return *false*.
         </emu-alg>
       </emu-clause>
     </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -21782,29 +21782,6 @@
         </emu-note>
       </emu-clause>
 
-      <emu-clause id="sec-module-semantics-static-semantics-importentries">
-        <h1>Static Semantics: ImportEntries</h1>
-        <emu-see-also-para op="ImportEntries"></emu-see-also-para>
-        <emu-grammar>Module : [empty]</emu-grammar>
-        <emu-alg>
-          1. Return a new empty List.
-        </emu-alg>
-        <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
-        <emu-alg>
-          1. Let _entries_ be ImportEntries of |ModuleItemList|.
-          1. Append to _entries_ the elements of the ImportEntries of |ModuleItem|.
-          1. Return _entries_.
-        </emu-alg>
-        <emu-grammar>
-          ModuleItem :
-            ExportDeclaration
-            StatementListItem
-        </emu-grammar>
-        <emu-alg>
-          1. Return a new empty List.
-        </emu-alg>
-      </emu-clause>
-
       <emu-clause id="sec-importedlocalnames" aoid="ImportedLocalNames">
         <h1>Static Semantics: ImportedLocalNames ( _importEntries_ )</h1>
         <p>The abstract operation ImportedLocalNames takes argument _importEntries_ (a List of ImportEntry Records (see <emu-xref href="#table-importentry-record-fields"></emu-xref>)). It creates a List of all of the local name bindings defined by _importEntries_. It performs the following steps when called:</p>
@@ -23122,9 +23099,26 @@
         </ul>
       </emu-clause>
 
-      <emu-clause id="sec-imports-static-semantics-importentries">
+      <emu-clause id="sec-static-semantics-importentries" oldids="sec-module-semantics-static-semantics-importentries,sec-imports-static-semantics-importentries" type="sdo" aoid="ImportEntries">
         <h1>Static Semantics: ImportEntries</h1>
-        <emu-see-also-para op="ImportEntries"></emu-see-also-para>
+        <emu-grammar>Module : [empty]</emu-grammar>
+        <emu-alg>
+          1. Return a new empty List.
+        </emu-alg>
+        <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
+        <emu-alg>
+          1. Let _entries_ be ImportEntries of |ModuleItemList|.
+          1. Append to _entries_ the elements of the ImportEntries of |ModuleItem|.
+          1. Return _entries_.
+        </emu-alg>
+        <emu-grammar>
+          ModuleItem :
+            ExportDeclaration
+            StatementListItem
+        </emu-grammar>
+        <emu-alg>
+          1. Return a new empty List.
+        </emu-alg>
         <emu-grammar>ImportDeclaration : `import` ImportClause FromClause `;`</emu-grammar>
         <emu-alg>
           1. Let _module_ be the sole element of ModuleRequests of |FromClause|.

--- a/spec.html
+++ b/spec.html
@@ -6908,6 +6908,520 @@
 
   <emu-clause id="sec-syntax-directed-operations-labels">
     <h1>Labels</h1>
+
+    <emu-clause id="sec-static-semantics-containsduplicatelabels" oldids="sec-statement-semantics-static-semantics-containsduplicatelabels,sec-block-static-semantics-containsduplicatelabels,sec-if-statement-static-semantics-containsduplicatelabels,sec-do-while-statement-static-semantics-containsduplicatelabels,sec-while-statement-static-semantics-containsduplicatelabels,sec-for-statement-static-semantics-containsduplicatelabels,sec-for-in-and-for-of-statements-static-semantics-containsduplicatelabels,sec-with-statement-static-semantics-containsduplicatelabels,sec-switch-statement-static-semantics-containsduplicatelabels,sec-labelled-statements-static-semantics-containsduplicatelabels,sec-try-statement-static-semantics-containsduplicatelabels,sec-function-definitions-static-semantics-containsduplicatelabels,sec-module-semantics-static-semantics-containsduplicatelabels" type="sdo" aoid="ContainsDuplicateLabels">
+      <h1>Static Semantics: ContainsDuplicateLabels</h1>
+      <p>With parameter _labelSet_.</p>
+      <emu-grammar>
+        Statement :
+          VariableStatement
+          EmptyStatement
+          ExpressionStatement
+          ContinueStatement
+          BreakStatement
+          ReturnStatement
+          ThrowStatement
+          DebuggerStatement
+
+        Block : `{` `}`
+
+        StatementListItem : Declaration
+      </emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
+      <emu-alg>
+        1. Let _hasDuplicates_ be ContainsDuplicateLabels of |StatementList| with argument _labelSet_.
+        1. If _hasDuplicates_ is *true*, return *true*.
+        1. Return ContainsDuplicateLabels of |StatementListItem| with argument _labelSet_.
+      </emu-alg>
+      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
+      <emu-alg>
+        1. Let _hasDuplicate_ be ContainsDuplicateLabels of the first |Statement| with argument _labelSet_.
+        1. If _hasDuplicate_ is *true*, return *true*.
+        1. Return ContainsDuplicateLabels of the second |Statement| with argument _labelSet_.
+      </emu-alg>
+      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement</emu-grammar>
+      <emu-alg>
+        1. Return ContainsDuplicateLabels of |Statement| with argument _labelSet_.
+      </emu-alg>
+      <emu-grammar>IterationStatement : `do` Statement `while` `(` Expression `)` `;`</emu-grammar>
+      <emu-alg>
+        1. Return ContainsDuplicateLabels of |Statement| with argument _labelSet_.
+      </emu-alg>
+      <emu-grammar>IterationStatement : `while` `(` Expression `)` Statement</emu-grammar>
+      <emu-alg>
+        1. Return ContainsDuplicateLabels of |Statement| with argument _labelSet_.
+      </emu-alg>
+      <emu-grammar>
+        IterationStatement :
+          `for` `(` Expression? `;` Expression? `;` Expression? `)` Statement
+          `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement
+          `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement
+      </emu-grammar>
+      <emu-alg>
+        1. Return ContainsDuplicateLabels of |Statement| with argument _labelSet_.
+      </emu-alg>
+      <emu-grammar>
+        IterationStatement :
+          `for` `(` LeftHandSideExpression `in` Expression `)` Statement
+          `for` `(` `var` ForBinding `in` Expression `)` Statement
+          `for` `(` ForDeclaration `in` Expression `)` Statement
+          `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
+          `for` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
+          `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement
+          `for` `await` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
+          `for` `await` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
+          `for` `await` `(` ForDeclaration `of` AssignmentExpression `)` Statement
+      </emu-grammar>
+      <emu-alg>
+        1. Return ContainsDuplicateLabels of |Statement| with argument _labelSet_.
+      </emu-alg>
+      <emu-note>
+        <p>This section is extended by Annex <emu-xref href="#sec-initializers-in-forin-statement-heads"></emu-xref>.</p>
+      </emu-note>
+      <emu-grammar>WithStatement : `with` `(` Expression `)` Statement</emu-grammar>
+      <emu-alg>
+        1. Return ContainsDuplicateLabels of |Statement| with argument _labelSet_.
+      </emu-alg>
+      <emu-grammar>SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
+      <emu-alg>
+        1. Return ContainsDuplicateLabels of |CaseBlock| with argument _labelSet_.
+      </emu-alg>
+      <emu-grammar>CaseBlock : `{` `}`</emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
+      <emu-alg>
+        1. If the first |CaseClauses| is present, then
+          1. Let _hasDuplicates_ be ContainsDuplicateLabels of the first |CaseClauses| with argument _labelSet_.
+          1. If _hasDuplicates_ is *true*, return *true*.
+        1. Let _hasDuplicates_ be ContainsDuplicateLabels of |DefaultClause| with argument _labelSet_.
+        1. If _hasDuplicates_ is *true*, return *true*.
+        1. If the second |CaseClauses| is not present, return *false*.
+        1. Return ContainsDuplicateLabels of the second |CaseClauses| with argument _labelSet_.
+      </emu-alg>
+      <emu-grammar>CaseClauses : CaseClauses CaseClause</emu-grammar>
+      <emu-alg>
+        1. Let _hasDuplicates_ be ContainsDuplicateLabels of |CaseClauses| with argument _labelSet_.
+        1. If _hasDuplicates_ is *true*, return *true*.
+        1. Return ContainsDuplicateLabels of |CaseClause| with argument _labelSet_.
+      </emu-alg>
+      <emu-grammar>CaseClause : `case` Expression `:` StatementList?</emu-grammar>
+      <emu-alg>
+        1. If the |StatementList| is present, return ContainsDuplicateLabels of |StatementList| with argument _labelSet_.
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>DefaultClause : `default` `:` StatementList?</emu-grammar>
+      <emu-alg>
+        1. If the |StatementList| is present, return ContainsDuplicateLabels of |StatementList| with argument _labelSet_.
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
+      <emu-alg>
+        1. Let _label_ be the StringValue of |LabelIdentifier|.
+        1. If _label_ is an element of _labelSet_, return *true*.
+        1. Let _newLabelSet_ be a copy of _labelSet_ with _label_ appended.
+        1. Return ContainsDuplicateLabels of |LabelledItem| with argument _newLabelSet_.
+      </emu-alg>
+      <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>TryStatement : `try` Block Catch</emu-grammar>
+      <emu-alg>
+        1. Let _hasDuplicates_ be ContainsDuplicateLabels of |Block| with argument _labelSet_.
+        1. If _hasDuplicates_ is *true*, return *true*.
+        1. Return ContainsDuplicateLabels of |Catch| with argument _labelSet_.
+      </emu-alg>
+      <emu-grammar>TryStatement : `try` Block Finally</emu-grammar>
+      <emu-alg>
+        1. Let _hasDuplicates_ be ContainsDuplicateLabels of |Block| with argument _labelSet_.
+        1. If _hasDuplicates_ is *true*, return *true*.
+        1. Return ContainsDuplicateLabels of |Finally| with argument _labelSet_.
+      </emu-alg>
+      <emu-grammar>TryStatement : `try` Block Catch Finally</emu-grammar>
+      <emu-alg>
+        1. Let _hasDuplicates_ be ContainsDuplicateLabels of |Block| with argument _labelSet_.
+        1. If _hasDuplicates_ is *true*, return *true*.
+        1. Let _hasDuplicates_ be ContainsDuplicateLabels of |Catch| with argument _labelSet_.
+        1. If _hasDuplicates_ is *true*, return *true*.
+        1. Return ContainsDuplicateLabels of |Finally| with argument _labelSet_.
+      </emu-alg>
+      <emu-grammar>Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
+      <emu-alg>
+        1. Return ContainsDuplicateLabels of |Block| with argument _labelSet_.
+      </emu-alg>
+      <emu-grammar>FunctionStatementList : [empty]</emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
+      <emu-alg>
+        1. Let _hasDuplicates_ be ContainsDuplicateLabels of |ModuleItemList| with argument _labelSet_.
+        1. If _hasDuplicates_ is *true*, return *true*.
+        1. Return ContainsDuplicateLabels of |ModuleItem| with argument _labelSet_.
+      </emu-alg>
+      <emu-grammar>
+        ModuleItem :
+          ImportDeclaration
+          ExportDeclaration
+      </emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-static-semantics-containsundefinedbreaktarget" oldids="sec-statement-semantics-static-semantics-containsundefinedbreaktarget,sec-block-static-semantics-containsundefinedbreaktarget,sec-if-statement-static-semantics-containsundefinedbreaktarget,sec-do-while-statement-static-semantics-containsundefinedbreaktarget,sec-while-statement-static-semantics-containsundefinedbreaktarget,sec-for-statement-static-semantics-containsundefinedbreaktarget,sec-for-in-and-for-of-statements-static-semantics-containsundefinedbreaktarget,sec-break-statement-static-semantics-containsundefinedbreaktarget,sec-with-statement-static-semantics-containsundefinedbreaktarget,sec-switch-statement-static-semantics-containsundefinedbreaktarget,sec-labelled-statements-static-semantics-containsundefinedbreaktarget,sec-try-statement-static-semantics-containsundefinedbreaktarget,sec-function-definitions-static-semantics-containsundefinedbreaktarget,sec-module-semantics-static-semantics-containsundefinedbreaktarget" type="sdo" aoid="ContainsUndefinedBreakTarget">
+      <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
+      <p>With parameter _labelSet_.</p>
+      <emu-grammar>
+        Statement :
+          VariableStatement
+          EmptyStatement
+          ExpressionStatement
+          ContinueStatement
+          ReturnStatement
+          ThrowStatement
+          DebuggerStatement
+
+        Block : `{` `}`
+
+        StatementListItem : Declaration
+      </emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
+      <emu-alg>
+        1. Let _hasUndefinedLabels_ be ContainsUndefinedBreakTarget of |StatementList| with argument _labelSet_.
+        1. If _hasUndefinedLabels_ is *true*, return *true*.
+        1. Return ContainsUndefinedBreakTarget of |StatementListItem| with argument _labelSet_.
+      </emu-alg>
+      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
+      <emu-alg>
+        1. Let _hasUndefinedLabels_ be ContainsUndefinedBreakTarget of the first |Statement| with argument _labelSet_.
+        1. If _hasUndefinedLabels_ is *true*, return *true*.
+        1. Return ContainsUndefinedBreakTarget of the second |Statement| with argument _labelSet_.
+      </emu-alg>
+      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement</emu-grammar>
+      <emu-alg>
+        1. Return ContainsUndefinedBreakTarget of |Statement| with argument _labelSet_.
+      </emu-alg>
+      <emu-grammar>IterationStatement : `do` Statement `while` `(` Expression `)` `;`</emu-grammar>
+      <emu-alg>
+        1. Return ContainsUndefinedBreakTarget of |Statement| with argument _labelSet_.
+      </emu-alg>
+      <emu-grammar>IterationStatement : `while` `(` Expression `)` Statement</emu-grammar>
+      <emu-alg>
+        1. Return ContainsUndefinedBreakTarget of |Statement| with argument _labelSet_.
+      </emu-alg>
+      <emu-grammar>
+        IterationStatement :
+          `for` `(` Expression? `;` Expression? `;` Expression? `)` Statement
+          `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement
+          `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement
+      </emu-grammar>
+      <emu-alg>
+        1. Return ContainsUndefinedBreakTarget of |Statement| with argument _labelSet_.
+      </emu-alg>
+      <emu-grammar>
+        IterationStatement :
+          `for` `(` LeftHandSideExpression `in` Expression `)` Statement
+          `for` `(` `var` ForBinding `in` Expression `)` Statement
+          `for` `(` ForDeclaration `in` Expression `)` Statement
+          `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
+          `for` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
+          `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement
+          `for` `await` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
+          `for` `await` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
+          `for` `await` `(` ForDeclaration `of` AssignmentExpression `)` Statement
+      </emu-grammar>
+      <emu-alg>
+        1. Return ContainsUndefinedBreakTarget of |Statement| with argument _labelSet_.
+      </emu-alg>
+      <emu-note>
+        <p>This section is extended by Annex <emu-xref href="#sec-initializers-in-forin-statement-heads"></emu-xref>.</p>
+      </emu-note>
+      <emu-grammar>BreakStatement : `break` `;`</emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>BreakStatement : `break` LabelIdentifier `;`</emu-grammar>
+      <emu-alg>
+        1. If the StringValue of |LabelIdentifier| is not an element of _labelSet_, return *true*.
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>WithStatement : `with` `(` Expression `)` Statement</emu-grammar>
+      <emu-alg>
+        1. Return ContainsUndefinedBreakTarget of |Statement| with argument _labelSet_.
+      </emu-alg>
+      <emu-grammar>SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
+      <emu-alg>
+        1. Return ContainsUndefinedBreakTarget of |CaseBlock| with argument _labelSet_.
+      </emu-alg>
+      <emu-grammar>CaseBlock : `{` `}`</emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
+      <emu-alg>
+        1. If the first |CaseClauses| is present, then
+          1. Let _hasUndefinedLabels_ be ContainsUndefinedBreakTarget of the first |CaseClauses| with argument _labelSet_.
+          1. If _hasUndefinedLabels_ is *true*, return *true*.
+        1. Let _hasUndefinedLabels_ be ContainsUndefinedBreakTarget of |DefaultClause| with argument _labelSet_.
+        1. If _hasUndefinedLabels_ is *true*, return *true*.
+        1. If the second |CaseClauses| is not present, return *false*.
+        1. Return ContainsUndefinedBreakTarget of the second |CaseClauses| with argument _labelSet_.
+      </emu-alg>
+      <emu-grammar>CaseClauses : CaseClauses CaseClause</emu-grammar>
+      <emu-alg>
+        1. Let _hasUndefinedLabels_ be ContainsUndefinedBreakTarget of |CaseClauses| with argument _labelSet_.
+        1. If _hasUndefinedLabels_ is *true*, return *true*.
+        1. Return ContainsUndefinedBreakTarget of |CaseClause| with argument _labelSet_.
+      </emu-alg>
+      <emu-grammar>CaseClause : `case` Expression `:` StatementList?</emu-grammar>
+      <emu-alg>
+        1. If the |StatementList| is present, return ContainsUndefinedBreakTarget of |StatementList| with argument _labelSet_.
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>DefaultClause : `default` `:` StatementList?</emu-grammar>
+      <emu-alg>
+        1. If the |StatementList| is present, return ContainsUndefinedBreakTarget of |StatementList| with argument _labelSet_.
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
+      <emu-alg>
+        1. Let _label_ be the StringValue of |LabelIdentifier|.
+        1. Let _newLabelSet_ be a copy of _labelSet_ with _label_ appended.
+        1. Return ContainsUndefinedBreakTarget of |LabelledItem| with argument _newLabelSet_.
+      </emu-alg>
+      <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>TryStatement : `try` Block Catch</emu-grammar>
+      <emu-alg>
+        1. Let _hasUndefinedLabels_ be ContainsUndefinedBreakTarget of |Block| with argument _labelSet_.
+        1. If _hasUndefinedLabels_ is *true*, return *true*.
+        1. Return ContainsUndefinedBreakTarget of |Catch| with argument _labelSet_.
+      </emu-alg>
+      <emu-grammar>TryStatement : `try` Block Finally</emu-grammar>
+      <emu-alg>
+        1. Let _hasUndefinedLabels_ be ContainsUndefinedBreakTarget of |Block| with argument _labelSet_.
+        1. If _hasUndefinedLabels_ is *true*, return *true*.
+        1. Return ContainsUndefinedBreakTarget of |Finally| with argument _labelSet_.
+      </emu-alg>
+      <emu-grammar>TryStatement : `try` Block Catch Finally</emu-grammar>
+      <emu-alg>
+        1. Let _hasUndefinedLabels_ be ContainsUndefinedBreakTarget of |Block| with argument _labelSet_.
+        1. If _hasUndefinedLabels_ is *true*, return *true*.
+        1. Let _hasUndefinedLabels_ be ContainsUndefinedBreakTarget of |Catch| with argument _labelSet_.
+        1. If _hasUndefinedLabels_ is *true*, return *true*.
+        1. Return ContainsUndefinedBreakTarget of |Finally| with argument _labelSet_.
+      </emu-alg>
+      <emu-grammar>Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
+      <emu-alg>
+        1. Return ContainsUndefinedBreakTarget of |Block| with argument _labelSet_.
+      </emu-alg>
+      <emu-grammar>FunctionStatementList : [empty]</emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
+      <emu-alg>
+        1. Let _hasUndefinedLabels_ be ContainsUndefinedBreakTarget of |ModuleItemList| with argument _labelSet_.
+        1. If _hasUndefinedLabels_ is *true*, return *true*.
+        1. Return ContainsUndefinedBreakTarget of |ModuleItem| with argument _labelSet_.
+      </emu-alg>
+      <emu-grammar>
+        ModuleItem :
+          ImportDeclaration
+          ExportDeclaration
+      </emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-static-semantics-containsundefinedcontinuetarget" oldids="sec-statement-semantics-static-semantics-containsundefinedcontinuetarget,sec-block-static-semantics-containsundefinedcontinuetarget,sec-if-statement-static-semantics-containsundefinedcontinuetarget,sec-do-while-statement-static-semantics-containsundefinedcontinuetarget,sec-while-statement-static-semantics-containsundefinedcontinuetarget,sec-for-statement-static-semantics-containsundefinedcontinuetarget,sec-for-in-and-for-of-statements-static-semantics-containsundefinedcontinuetarget,sec-continue-statement-static-semantics-containsundefinedcontinuetarget,sec-with-statement-static-semantics-containsundefinedcontinuetarget,sec-switch-statement-static-semantics-containsundefinedcontinuetarget,sec-labelled-statements-static-semantics-containsundefinedcontinuetarget,sec-try-statement-static-semantics-containsundefinedcontinuetarget,sec-function-definitions-static-semantics-containsundefinedcontinuetarget,sec-module-semantics-static-semantics-containsundefinedcontinuetarget" type="sdo" aoid="ContainsUndefinedContinueTarget">
+      <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
+      <p>With parameters _iterationSet_ and _labelSet_.</p>
+      <emu-grammar>
+        Statement :
+          VariableStatement
+          EmptyStatement
+          ExpressionStatement
+          BreakStatement
+          ReturnStatement
+          ThrowStatement
+          DebuggerStatement
+
+        Block : `{` `}`
+
+        StatementListItem : Declaration
+      </emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>BreakableStatement : IterationStatement</emu-grammar>
+      <emu-alg>
+        1. Let _newIterationSet_ be a copy of _iterationSet_ with all the elements of _labelSet_ appended.
+        1. Return ContainsUndefinedContinueTarget of |IterationStatement| with arguments _newIterationSet_ and &laquo; &raquo;.
+      </emu-alg>
+      <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
+      <emu-alg>
+        1. Let _hasUndefinedLabels_ be ContainsUndefinedContinueTarget of |StatementList| with arguments _iterationSet_ and &laquo; &raquo;.
+        1. If _hasUndefinedLabels_ is *true*, return *true*.
+        1. Return ContainsUndefinedContinueTarget of |StatementListItem| with arguments _iterationSet_ and &laquo; &raquo;.
+      </emu-alg>
+      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
+      <emu-alg>
+        1. Let _hasUndefinedLabels_ be ContainsUndefinedContinueTarget of the first |Statement| with arguments _iterationSet_ and &laquo; &raquo;.
+        1. If _hasUndefinedLabels_ is *true*, return *true*.
+        1. Return ContainsUndefinedContinueTarget of the second |Statement| with arguments _iterationSet_ and &laquo; &raquo;.
+      </emu-alg>
+      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement</emu-grammar>
+      <emu-alg>
+        1. Return ContainsUndefinedContinueTarget of |Statement| with arguments _iterationSet_ and &laquo; &raquo;.
+      </emu-alg>
+      <emu-grammar>IterationStatement : `do` Statement `while` `(` Expression `)` `;`</emu-grammar>
+      <emu-alg>
+        1. Return ContainsUndefinedContinueTarget of |Statement| with arguments _iterationSet_ and &laquo; &raquo;.
+      </emu-alg>
+      <emu-grammar>IterationStatement : `while` `(` Expression `)` Statement</emu-grammar>
+      <emu-alg>
+        1. Return ContainsUndefinedContinueTarget of |Statement| with arguments _iterationSet_ and &laquo; &raquo;.
+      </emu-alg>
+      <emu-grammar>
+        IterationStatement :
+          `for` `(` Expression? `;` Expression? `;` Expression? `)` Statement
+          `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement
+          `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement
+      </emu-grammar>
+      <emu-alg>
+        1. Return ContainsUndefinedContinueTarget of |Statement| with arguments _iterationSet_ and &laquo; &raquo;.
+      </emu-alg>
+      <emu-grammar>
+        IterationStatement :
+          `for` `(` LeftHandSideExpression `in` Expression `)` Statement
+          `for` `(` `var` ForBinding `in` Expression `)` Statement
+          `for` `(` ForDeclaration `in` Expression `)` Statement
+          `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
+          `for` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
+          `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement
+          `for` `await` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
+          `for` `await` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
+          `for` `await` `(` ForDeclaration `of` AssignmentExpression `)` Statement
+      </emu-grammar>
+      <emu-alg>
+        1. Return ContainsUndefinedContinueTarget of |Statement| with arguments _iterationSet_ and &laquo; &raquo;.
+      </emu-alg>
+      <emu-note>
+        <p>This section is extended by Annex <emu-xref href="#sec-initializers-in-forin-statement-heads"></emu-xref>.</p>
+      </emu-note>
+      <emu-grammar>ContinueStatement : `continue` `;`</emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>ContinueStatement : `continue` LabelIdentifier `;`</emu-grammar>
+      <emu-alg>
+        1. If the StringValue of |LabelIdentifier| is not an element of _iterationSet_, return *true*.
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>WithStatement : `with` `(` Expression `)` Statement</emu-grammar>
+      <emu-alg>
+        1. Return ContainsUndefinedContinueTarget of |Statement| with arguments _iterationSet_ and &laquo; &raquo;.
+      </emu-alg>
+      <emu-grammar>SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
+      <emu-alg>
+        1. Return ContainsUndefinedContinueTarget of |CaseBlock| with arguments _iterationSet_ and &laquo; &raquo;.
+      </emu-alg>
+      <emu-grammar>CaseBlock : `{` `}`</emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
+      <emu-alg>
+        1. If the first |CaseClauses| is present, then
+          1. Let _hasUndefinedLabels_ be ContainsUndefinedContinueTarget of the first |CaseClauses| with arguments _iterationSet_ and &laquo; &raquo;.
+          1. If _hasUndefinedLabels_ is *true*, return *true*.
+        1. Let _hasUndefinedLabels_ be ContainsUndefinedContinueTarget of |DefaultClause| with arguments _iterationSet_ and &laquo; &raquo;.
+        1. If _hasUndefinedLabels_ is *true*, return *true*.
+        1. If the second |CaseClauses| is not present, return *false*.
+        1. Return ContainsUndefinedContinueTarget of the second |CaseClauses| with arguments _iterationSet_ and &laquo; &raquo;.
+      </emu-alg>
+      <emu-grammar>CaseClauses : CaseClauses CaseClause</emu-grammar>
+      <emu-alg>
+        1. Let _hasUndefinedLabels_ be ContainsUndefinedContinueTarget of |CaseClauses| with arguments _iterationSet_ and &laquo; &raquo;.
+        1. If _hasUndefinedLabels_ is *true*, return *true*.
+        1. Return ContainsUndefinedContinueTarget of |CaseClause| with arguments _iterationSet_ and &laquo; &raquo;.
+      </emu-alg>
+      <emu-grammar>CaseClause : `case` Expression `:` StatementList?</emu-grammar>
+      <emu-alg>
+        1. If the |StatementList| is present, return ContainsUndefinedContinueTarget of |StatementList| with arguments _iterationSet_ and &laquo; &raquo;.
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>DefaultClause : `default` `:` StatementList?</emu-grammar>
+      <emu-alg>
+        1. If the |StatementList| is present, return ContainsUndefinedContinueTarget of |StatementList| with arguments _iterationSet_ and &laquo; &raquo;.
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
+      <emu-alg>
+        1. Let _label_ be the StringValue of |LabelIdentifier|.
+        1. Let _newLabelSet_ be a copy of _labelSet_ with _label_ appended.
+        1. Return ContainsUndefinedContinueTarget of |LabelledItem| with arguments _iterationSet_ and _newLabelSet_.
+      </emu-alg>
+      <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>TryStatement : `try` Block Catch</emu-grammar>
+      <emu-alg>
+        1. Let _hasUndefinedLabels_ be ContainsUndefinedContinueTarget of |Block| with arguments _iterationSet_ and &laquo; &raquo;.
+        1. If _hasUndefinedLabels_ is *true*, return *true*.
+        1. Return ContainsUndefinedContinueTarget of |Catch| with arguments _iterationSet_ and &laquo; &raquo;.
+      </emu-alg>
+      <emu-grammar>TryStatement : `try` Block Finally</emu-grammar>
+      <emu-alg>
+        1. Let _hasUndefinedLabels_ be ContainsUndefinedContinueTarget of |Block| with arguments _iterationSet_ and &laquo; &raquo;.
+        1. If _hasUndefinedLabels_ is *true*, return *true*.
+        1. Return ContainsUndefinedContinueTarget of |Finally| with arguments _iterationSet_ and &laquo; &raquo;.
+      </emu-alg>
+      <emu-grammar>TryStatement : `try` Block Catch Finally</emu-grammar>
+      <emu-alg>
+        1. Let _hasUndefinedLabels_ be ContainsUndefinedContinueTarget of |Block| with arguments _iterationSet_ and &laquo; &raquo;.
+        1. If _hasUndefinedLabels_ is *true*, return *true*.
+        1. Let _hasUndefinedLabels_ be ContainsUndefinedContinueTarget of |Catch| with arguments _iterationSet_ and &laquo; &raquo;.
+        1. If _hasUndefinedLabels_ is *true*, return *true*.
+        1. Return ContainsUndefinedContinueTarget of |Finally| with arguments _iterationSet_ and &laquo; &raquo;.
+      </emu-alg>
+      <emu-grammar>Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
+      <emu-alg>
+        1. Return ContainsUndefinedContinueTarget of |Block| with arguments _iterationSet_ and &laquo; &raquo;.
+      </emu-alg>
+      <emu-grammar>FunctionStatementList : [empty]</emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
+      <emu-alg>
+        1. Let _hasUndefinedLabels_ be ContainsUndefinedContinueTarget of |ModuleItemList| with arguments _iterationSet_ and &laquo; &raquo;.
+        1. If _hasUndefinedLabels_ is *true*, return *true*.
+        1. Return ContainsUndefinedContinueTarget of |ModuleItem| with arguments _iterationSet_ and &laquo; &raquo;.
+      </emu-alg>
+      <emu-grammar>
+        ModuleItem :
+          ImportDeclaration
+          ExportDeclaration
+      </emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+    </emu-clause>
   </emu-clause>
 
   <emu-clause id="sec-syntax-directed-operations-function-name-inference">
@@ -16967,69 +17481,6 @@
   <emu-clause id="sec-statement-semantics">
     <h1>Statement Semantics</h1>
 
-    <emu-clause id="sec-statement-semantics-static-semantics-containsduplicatelabels">
-      <h1>Static Semantics: ContainsDuplicateLabels</h1>
-      <p>With parameter _labelSet_.</p>
-      <emu-see-also-para op="ContainsDuplicateLabels"></emu-see-also-para>
-      <emu-grammar>
-        Statement :
-          VariableStatement
-          EmptyStatement
-          ExpressionStatement
-          ContinueStatement
-          BreakStatement
-          ReturnStatement
-          ThrowStatement
-          DebuggerStatement
-      </emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-statement-semantics-static-semantics-containsundefinedbreaktarget">
-      <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
-      <p>With parameter _labelSet_.</p>
-      <emu-see-also-para op="ContainsUndefinedBreakTarget"></emu-see-also-para>
-      <emu-grammar>
-        Statement :
-          VariableStatement
-          EmptyStatement
-          ExpressionStatement
-          ContinueStatement
-          ReturnStatement
-          ThrowStatement
-          DebuggerStatement
-      </emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-statement-semantics-static-semantics-containsundefinedcontinuetarget">
-      <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
-      <p>With parameters _iterationSet_ and _labelSet_.</p>
-      <emu-see-also-para op="ContainsUndefinedContinueTarget"></emu-see-also-para>
-      <emu-grammar>
-        Statement :
-          VariableStatement
-          EmptyStatement
-          ExpressionStatement
-          BreakStatement
-          ReturnStatement
-          ThrowStatement
-          DebuggerStatement
-      </emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-      <emu-grammar>BreakableStatement : IterationStatement</emu-grammar>
-      <emu-alg>
-        1. Let _newIterationSet_ be a copy of _iterationSet_ with all the elements of _labelSet_ appended.
-        1. Return ContainsUndefinedContinueTarget of |IterationStatement| with arguments _newIterationSet_ and &laquo; &raquo;.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-statement-semantics-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>
@@ -17089,66 +17540,6 @@
           It is a Syntax Error if any element of the LexicallyDeclaredNames of |StatementList| also occurs in the VarDeclaredNames of |StatementList|.
         </li>
       </ul>
-    </emu-clause>
-
-    <emu-clause id="sec-block-static-semantics-containsduplicatelabels">
-      <h1>Static Semantics: ContainsDuplicateLabels</h1>
-      <p>With parameter _labelSet_.</p>
-      <emu-see-also-para op="ContainsDuplicateLabels"></emu-see-also-para>
-      <emu-grammar>Block : `{` `}`</emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-      <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
-      <emu-alg>
-        1. Let _hasDuplicates_ be ContainsDuplicateLabels of |StatementList| with argument _labelSet_.
-        1. If _hasDuplicates_ is *true*, return *true*.
-        1. Return ContainsDuplicateLabels of |StatementListItem| with argument _labelSet_.
-      </emu-alg>
-      <emu-grammar>StatementListItem : Declaration</emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-block-static-semantics-containsundefinedbreaktarget">
-      <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
-      <p>With parameter _labelSet_.</p>
-      <emu-see-also-para op="ContainsUndefinedBreakTarget"></emu-see-also-para>
-      <emu-grammar>Block : `{` `}`</emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-      <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
-      <emu-alg>
-        1. Let _hasUndefinedLabels_ be ContainsUndefinedBreakTarget of |StatementList| with argument _labelSet_.
-        1. If _hasUndefinedLabels_ is *true*, return *true*.
-        1. Return ContainsUndefinedBreakTarget of |StatementListItem| with argument _labelSet_.
-      </emu-alg>
-      <emu-grammar>StatementListItem : Declaration</emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-block-static-semantics-containsundefinedcontinuetarget">
-      <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
-      <p>With parameters _iterationSet_ and _labelSet_.</p>
-      <emu-see-also-para op="ContainsUndefinedContinueTarget"></emu-see-also-para>
-      <emu-grammar>Block : `{` `}`</emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-      <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
-      <emu-alg>
-        1. Let _hasUndefinedLabels_ be ContainsUndefinedContinueTarget of |StatementList| with arguments _iterationSet_ and &laquo; &raquo;.
-        1. If _hasUndefinedLabels_ is *true*, return *true*.
-        1. Return ContainsUndefinedContinueTarget of |StatementListItem| with arguments _iterationSet_ and &laquo; &raquo;.
-      </emu-alg>
-      <emu-grammar>StatementListItem : Declaration</emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-block-runtime-semantics-evaluation">
@@ -17722,54 +18113,6 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-if-statement-static-semantics-containsduplicatelabels">
-      <h1>Static Semantics: ContainsDuplicateLabels</h1>
-      <p>With parameter _labelSet_.</p>
-      <emu-see-also-para op="ContainsDuplicateLabels"></emu-see-also-para>
-      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
-      <emu-alg>
-        1. Let _hasDuplicate_ be ContainsDuplicateLabels of the first |Statement| with argument _labelSet_.
-        1. If _hasDuplicate_ is *true*, return *true*.
-        1. Return ContainsDuplicateLabels of the second |Statement| with argument _labelSet_.
-      </emu-alg>
-      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement</emu-grammar>
-      <emu-alg>
-        1. Return ContainsDuplicateLabels of |Statement| with argument _labelSet_.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-if-statement-static-semantics-containsundefinedbreaktarget">
-      <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
-      <p>With parameter _labelSet_.</p>
-      <emu-see-also-para op="ContainsUndefinedBreakTarget"></emu-see-also-para>
-      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
-      <emu-alg>
-        1. Let _hasUndefinedLabels_ be ContainsUndefinedBreakTarget of the first |Statement| with argument _labelSet_.
-        1. If _hasUndefinedLabels_ is *true*, return *true*.
-        1. Return ContainsUndefinedBreakTarget of the second |Statement| with argument _labelSet_.
-      </emu-alg>
-      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement</emu-grammar>
-      <emu-alg>
-        1. Return ContainsUndefinedBreakTarget of |Statement| with argument _labelSet_.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-if-statement-static-semantics-containsundefinedcontinuetarget">
-      <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
-      <p>With parameters _iterationSet_ and _labelSet_.</p>
-      <emu-see-also-para op="ContainsUndefinedContinueTarget"></emu-see-also-para>
-      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
-      <emu-alg>
-        1. Let _hasUndefinedLabels_ be ContainsUndefinedContinueTarget of the first |Statement| with arguments _iterationSet_ and &laquo; &raquo;.
-        1. If _hasUndefinedLabels_ is *true*, return *true*.
-        1. Return ContainsUndefinedContinueTarget of the second |Statement| with arguments _iterationSet_ and &laquo; &raquo;.
-      </emu-alg>
-      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement</emu-grammar>
-      <emu-alg>
-        1. Return ContainsUndefinedContinueTarget of |Statement| with arguments _iterationSet_ and &laquo; &raquo;.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-if-statement-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
@@ -17991,70 +18334,10 @@
 
     <emu-clause id="sec-do-while-statement">
       <h1>The `do`-`while` Statement</h1>
-
-      <emu-clause id="sec-do-while-statement-static-semantics-containsduplicatelabels">
-        <h1>Static Semantics: ContainsDuplicateLabels</h1>
-        <p>With parameter _labelSet_.</p>
-        <emu-see-also-para op="ContainsDuplicateLabels"></emu-see-also-para>
-        <emu-grammar>IterationStatement : `do` Statement `while` `(` Expression `)` `;`</emu-grammar>
-        <emu-alg>
-          1. Return ContainsDuplicateLabels of |Statement| with argument _labelSet_.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-do-while-statement-static-semantics-containsundefinedbreaktarget">
-        <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
-        <p>With parameter _labelSet_.</p>
-        <emu-see-also-para op="ContainsUndefinedBreakTarget"></emu-see-also-para>
-        <emu-grammar>IterationStatement : `do` Statement `while` `(` Expression `)` `;`</emu-grammar>
-        <emu-alg>
-          1. Return ContainsUndefinedBreakTarget of |Statement| with argument _labelSet_.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-do-while-statement-static-semantics-containsundefinedcontinuetarget">
-        <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
-        <p>With parameters _iterationSet_ and _labelSet_.</p>
-        <emu-see-also-para op="ContainsUndefinedContinueTarget"></emu-see-also-para>
-        <emu-grammar>IterationStatement : `do` Statement `while` `(` Expression `)` `;`</emu-grammar>
-        <emu-alg>
-          1. Return ContainsUndefinedContinueTarget of |Statement| with arguments _iterationSet_ and &laquo; &raquo;.
-        </emu-alg>
-      </emu-clause>
     </emu-clause>
 
     <emu-clause id="sec-while-statement">
       <h1>The `while` Statement</h1>
-
-      <emu-clause id="sec-while-statement-static-semantics-containsduplicatelabels">
-        <h1>Static Semantics: ContainsDuplicateLabels</h1>
-        <p>With parameter _labelSet_.</p>
-        <emu-see-also-para op="ContainsDuplicateLabels"></emu-see-also-para>
-        <emu-grammar>IterationStatement : `while` `(` Expression `)` Statement</emu-grammar>
-        <emu-alg>
-          1. Return ContainsDuplicateLabels of |Statement| with argument _labelSet_.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-while-statement-static-semantics-containsundefinedbreaktarget">
-        <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
-        <p>With parameter _labelSet_.</p>
-        <emu-see-also-para op="ContainsUndefinedBreakTarget"></emu-see-also-para>
-        <emu-grammar>IterationStatement : `while` `(` Expression `)` Statement</emu-grammar>
-        <emu-alg>
-          1. Return ContainsUndefinedBreakTarget of |Statement| with argument _labelSet_.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-while-statement-static-semantics-containsundefinedcontinuetarget">
-        <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
-        <p>With parameters _iterationSet_ and _labelSet_.</p>
-        <emu-see-also-para op="ContainsUndefinedContinueTarget"></emu-see-also-para>
-        <emu-grammar>IterationStatement : `while` `(` Expression `)` Statement</emu-grammar>
-        <emu-alg>
-          1. Return ContainsUndefinedContinueTarget of |Statement| with arguments _iterationSet_ and &laquo; &raquo;.
-        </emu-alg>
-      </emu-clause>
     </emu-clause>
 
     <emu-clause id="sec-for-statement">
@@ -18068,51 +18351,6 @@
             It is a Syntax Error if any element of the BoundNames of |LexicalDeclaration| also occurs in the VarDeclaredNames of |Statement|.
           </li>
         </ul>
-      </emu-clause>
-
-      <emu-clause id="sec-for-statement-static-semantics-containsduplicatelabels">
-        <h1>Static Semantics: ContainsDuplicateLabels</h1>
-        <p>With parameter _labelSet_.</p>
-        <emu-see-also-para op="ContainsDuplicateLabels"></emu-see-also-para>
-        <emu-grammar>
-          IterationStatement :
-            `for` `(` Expression? `;` Expression? `;` Expression? `)` Statement
-            `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement
-            `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement
-        </emu-grammar>
-        <emu-alg>
-          1. Return ContainsDuplicateLabels of |Statement| with argument _labelSet_.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-for-statement-static-semantics-containsundefinedbreaktarget">
-        <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
-        <p>With parameter _labelSet_.</p>
-        <emu-see-also-para op="ContainsUndefinedBreakTarget"></emu-see-also-para>
-        <emu-grammar>
-          IterationStatement :
-            `for` `(` Expression? `;` Expression? `;` Expression? `)` Statement
-            `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement
-            `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement
-        </emu-grammar>
-        <emu-alg>
-          1. Return ContainsUndefinedBreakTarget of |Statement| with argument _labelSet_.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-for-statement-static-semantics-containsundefinedcontinuetarget">
-        <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
-        <p>With parameters _iterationSet_ and _labelSet_.</p>
-        <emu-see-also-para op="ContainsUndefinedContinueTarget"></emu-see-also-para>
-        <emu-grammar>
-          IterationStatement :
-            `for` `(` Expression? `;` Expression? `;` Expression? `)` Statement
-            `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement
-            `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement
-        </emu-grammar>
-        <emu-alg>
-          1. Return ContainsUndefinedContinueTarget of |Statement| with arguments _iterationSet_ and &laquo; &raquo;.
-        </emu-alg>
       </emu-clause>
 
       <emu-clause id="sec-forbodyevaluation" aoid="ForBodyEvaluation">
@@ -18198,78 +18436,6 @@
             It is a Syntax Error if the BoundNames of |ForDeclaration| contains any duplicate entries.
           </li>
         </ul>
-      </emu-clause>
-
-      <emu-clause id="sec-for-in-and-for-of-statements-static-semantics-containsduplicatelabels">
-        <h1>Static Semantics: ContainsDuplicateLabels</h1>
-        <p>With parameter _labelSet_.</p>
-        <emu-see-also-para op="ContainsDuplicateLabels"></emu-see-also-para>
-        <emu-grammar>
-          IterationStatement :
-            `for` `(` LeftHandSideExpression `in` Expression `)` Statement
-            `for` `(` `var` ForBinding `in` Expression `)` Statement
-            `for` `(` ForDeclaration `in` Expression `)` Statement
-            `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
-            `for` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
-            `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement
-            `for` `await` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
-            `for` `await` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
-            `for` `await` `(` ForDeclaration `of` AssignmentExpression `)` Statement
-        </emu-grammar>
-        <emu-alg>
-          1. Return ContainsDuplicateLabels of |Statement| with argument _labelSet_.
-        </emu-alg>
-        <emu-note>
-          <p>This section is extended by Annex <emu-xref href="#sec-initializers-in-forin-statement-heads"></emu-xref>.</p>
-        </emu-note>
-      </emu-clause>
-
-      <emu-clause id="sec-for-in-and-for-of-statements-static-semantics-containsundefinedbreaktarget">
-        <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
-        <p>With parameter _labelSet_.</p>
-        <emu-see-also-para op="ContainsUndefinedBreakTarget"></emu-see-also-para>
-        <emu-grammar>
-          IterationStatement :
-            `for` `(` LeftHandSideExpression `in` Expression `)` Statement
-            `for` `(` `var` ForBinding `in` Expression `)` Statement
-            `for` `(` ForDeclaration `in` Expression `)` Statement
-            `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
-            `for` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
-            `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement
-            `for` `await` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
-            `for` `await` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
-            `for` `await` `(` ForDeclaration `of` AssignmentExpression `)` Statement
-        </emu-grammar>
-        <emu-alg>
-          1. Return ContainsUndefinedBreakTarget of |Statement| with argument _labelSet_.
-        </emu-alg>
-        <emu-note>
-          <p>This section is extended by Annex <emu-xref href="#sec-initializers-in-forin-statement-heads"></emu-xref>.</p>
-        </emu-note>
-      </emu-clause>
-
-      <emu-clause id="sec-for-in-and-for-of-statements-static-semantics-containsundefinedcontinuetarget">
-        <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
-        <p>With parameters _iterationSet_ and _labelSet_.</p>
-        <emu-see-also-para op="ContainsUndefinedContinueTarget"></emu-see-also-para>
-        <emu-grammar>
-          IterationStatement :
-            `for` `(` LeftHandSideExpression `in` Expression `)` Statement
-            `for` `(` `var` ForBinding `in` Expression `)` Statement
-            `for` `(` ForDeclaration `in` Expression `)` Statement
-            `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
-            `for` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
-            `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement
-            `for` `await` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
-            `for` `await` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
-            `for` `await` `(` ForDeclaration `of` AssignmentExpression `)` Statement
-        </emu-grammar>
-        <emu-alg>
-          1. Return ContainsUndefinedContinueTarget of |Statement| with arguments _iterationSet_ and &laquo; &raquo;.
-        </emu-alg>
-        <emu-note>
-          <p>This section is extended by Annex <emu-xref href="#sec-initializers-in-forin-statement-heads"></emu-xref>.</p>
-        </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-for-in-and-for-of-statements-static-semantics-isdestructuring">
@@ -18608,21 +18774,6 @@
       </ul>
     </emu-clause>
 
-    <emu-clause id="sec-continue-statement-static-semantics-containsundefinedcontinuetarget">
-      <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
-      <p>With parameters _iterationSet_ and _labelSet_.</p>
-      <emu-see-also-para op="ContainsUndefinedContinueTarget"></emu-see-also-para>
-      <emu-grammar>ContinueStatement : `continue` `;`</emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-      <emu-grammar>ContinueStatement : `continue` LabelIdentifier `;`</emu-grammar>
-      <emu-alg>
-        1. If the StringValue of |LabelIdentifier| is not an element of _iterationSet_, return *true*.
-        1. Return *false*.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-continue-statement-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>ContinueStatement : `continue` `;`</emu-grammar>
@@ -18654,21 +18805,6 @@
           It is a Syntax Error if this |BreakStatement| is not nested, directly or indirectly (but not crossing function boundaries), within an |IterationStatement| or a |SwitchStatement|.
         </li>
       </ul>
-    </emu-clause>
-
-    <emu-clause id="sec-break-statement-static-semantics-containsundefinedbreaktarget">
-      <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
-      <p>With parameter _labelSet_.</p>
-      <emu-see-also-para op="ContainsUndefinedBreakTarget"></emu-see-also-para>
-      <emu-grammar>BreakStatement : `break` `;`</emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-      <emu-grammar>BreakStatement : `break` LabelIdentifier `;`</emu-grammar>
-      <emu-alg>
-        1. If the StringValue of |LabelIdentifier| is not an element of _labelSet_, return *true*.
-        1. Return *false*.
-      </emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-break-statement-runtime-semantics-evaluation">
@@ -18740,36 +18876,6 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-with-statement-static-semantics-containsduplicatelabels">
-      <h1>Static Semantics: ContainsDuplicateLabels</h1>
-      <p>With parameter _labelSet_.</p>
-      <emu-see-also-para op="ContainsDuplicateLabels"></emu-see-also-para>
-      <emu-grammar>WithStatement : `with` `(` Expression `)` Statement</emu-grammar>
-      <emu-alg>
-        1. Return ContainsDuplicateLabels of |Statement| with argument _labelSet_.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-with-statement-static-semantics-containsundefinedbreaktarget">
-      <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
-      <p>With parameter _labelSet_.</p>
-      <emu-see-also-para op="ContainsUndefinedBreakTarget"></emu-see-also-para>
-      <emu-grammar>WithStatement : `with` `(` Expression `)` Statement</emu-grammar>
-      <emu-alg>
-        1. Return ContainsUndefinedBreakTarget of |Statement| with argument _labelSet_.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-with-statement-static-semantics-containsundefinedcontinuetarget">
-      <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
-      <p>With parameters _iterationSet_ and _labelSet_.</p>
-      <emu-see-also-para op="ContainsUndefinedContinueTarget"></emu-see-also-para>
-      <emu-grammar>WithStatement : `with` `(` Expression `)` Statement</emu-grammar>
-      <emu-alg>
-        1. Return ContainsUndefinedContinueTarget of |Statement| with arguments _iterationSet_ and &laquo; &raquo;.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-with-statement-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>WithStatement : `with` `(` Expression `)` Statement</emu-grammar>
@@ -18823,126 +18929,6 @@
           It is a Syntax Error if any element of the LexicallyDeclaredNames of |CaseBlock| also occurs in the VarDeclaredNames of |CaseBlock|.
         </li>
       </ul>
-    </emu-clause>
-
-    <emu-clause id="sec-switch-statement-static-semantics-containsduplicatelabels">
-      <h1>Static Semantics: ContainsDuplicateLabels</h1>
-      <p>With parameter _labelSet_.</p>
-      <emu-see-also-para op="ContainsDuplicateLabels"></emu-see-also-para>
-      <emu-grammar>SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
-      <emu-alg>
-        1. Return ContainsDuplicateLabels of |CaseBlock| with argument _labelSet_.
-      </emu-alg>
-      <emu-grammar>CaseBlock : `{` `}`</emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-      <emu-grammar>CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
-      <emu-alg>
-        1. If the first |CaseClauses| is present, then
-          1. Let _hasDuplicates_ be ContainsDuplicateLabels of the first |CaseClauses| with argument _labelSet_.
-          1. If _hasDuplicates_ is *true*, return *true*.
-        1. Let _hasDuplicates_ be ContainsDuplicateLabels of |DefaultClause| with argument _labelSet_.
-        1. If _hasDuplicates_ is *true*, return *true*.
-        1. If the second |CaseClauses| is not present, return *false*.
-        1. Return ContainsDuplicateLabels of the second |CaseClauses| with argument _labelSet_.
-      </emu-alg>
-      <emu-grammar>CaseClauses : CaseClauses CaseClause</emu-grammar>
-      <emu-alg>
-        1. Let _hasDuplicates_ be ContainsDuplicateLabels of |CaseClauses| with argument _labelSet_.
-        1. If _hasDuplicates_ is *true*, return *true*.
-        1. Return ContainsDuplicateLabels of |CaseClause| with argument _labelSet_.
-      </emu-alg>
-      <emu-grammar>CaseClause : `case` Expression `:` StatementList?</emu-grammar>
-      <emu-alg>
-        1. If the |StatementList| is present, return ContainsDuplicateLabels of |StatementList| with argument _labelSet_.
-        1. Return *false*.
-      </emu-alg>
-      <emu-grammar>DefaultClause : `default` `:` StatementList?</emu-grammar>
-      <emu-alg>
-        1. If the |StatementList| is present, return ContainsDuplicateLabels of |StatementList| with argument _labelSet_.
-        1. Return *false*.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-switch-statement-static-semantics-containsundefinedbreaktarget">
-      <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
-      <p>With parameter _labelSet_.</p>
-      <emu-see-also-para op="ContainsUndefinedBreakTarget"></emu-see-also-para>
-      <emu-grammar>SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
-      <emu-alg>
-        1. Return ContainsUndefinedBreakTarget of |CaseBlock| with argument _labelSet_.
-      </emu-alg>
-      <emu-grammar>CaseBlock : `{` `}`</emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-      <emu-grammar>CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
-      <emu-alg>
-        1. If the first |CaseClauses| is present, then
-          1. Let _hasUndefinedLabels_ be ContainsUndefinedBreakTarget of the first |CaseClauses| with argument _labelSet_.
-          1. If _hasUndefinedLabels_ is *true*, return *true*.
-        1. Let _hasUndefinedLabels_ be ContainsUndefinedBreakTarget of |DefaultClause| with argument _labelSet_.
-        1. If _hasUndefinedLabels_ is *true*, return *true*.
-        1. If the second |CaseClauses| is not present, return *false*.
-        1. Return ContainsUndefinedBreakTarget of the second |CaseClauses| with argument _labelSet_.
-      </emu-alg>
-      <emu-grammar>CaseClauses : CaseClauses CaseClause</emu-grammar>
-      <emu-alg>
-        1. Let _hasUndefinedLabels_ be ContainsUndefinedBreakTarget of |CaseClauses| with argument _labelSet_.
-        1. If _hasUndefinedLabels_ is *true*, return *true*.
-        1. Return ContainsUndefinedBreakTarget of |CaseClause| with argument _labelSet_.
-      </emu-alg>
-      <emu-grammar>CaseClause : `case` Expression `:` StatementList?</emu-grammar>
-      <emu-alg>
-        1. If the |StatementList| is present, return ContainsUndefinedBreakTarget of |StatementList| with argument _labelSet_.
-        1. Return *false*.
-      </emu-alg>
-      <emu-grammar>DefaultClause : `default` `:` StatementList?</emu-grammar>
-      <emu-alg>
-        1. If the |StatementList| is present, return ContainsUndefinedBreakTarget of |StatementList| with argument _labelSet_.
-        1. Return *false*.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-switch-statement-static-semantics-containsundefinedcontinuetarget">
-      <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
-      <p>With parameters _iterationSet_ and _labelSet_.</p>
-      <emu-see-also-para op="ContainsUndefinedContinueTarget"></emu-see-also-para>
-      <emu-grammar>SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
-      <emu-alg>
-        1. Return ContainsUndefinedContinueTarget of |CaseBlock| with arguments _iterationSet_ and &laquo; &raquo;.
-      </emu-alg>
-      <emu-grammar>CaseBlock : `{` `}`</emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-      <emu-grammar>CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
-      <emu-alg>
-        1. If the first |CaseClauses| is present, then
-          1. Let _hasUndefinedLabels_ be ContainsUndefinedContinueTarget of the first |CaseClauses| with arguments _iterationSet_ and &laquo; &raquo;.
-          1. If _hasUndefinedLabels_ is *true*, return *true*.
-        1. Let _hasUndefinedLabels_ be ContainsUndefinedContinueTarget of |DefaultClause| with arguments _iterationSet_ and &laquo; &raquo;.
-        1. If _hasUndefinedLabels_ is *true*, return *true*.
-        1. If the second |CaseClauses| is not present, return *false*.
-        1. Return ContainsUndefinedContinueTarget of the second |CaseClauses| with arguments _iterationSet_ and &laquo; &raquo;.
-      </emu-alg>
-      <emu-grammar>CaseClauses : CaseClauses CaseClause</emu-grammar>
-      <emu-alg>
-        1. Let _hasUndefinedLabels_ be ContainsUndefinedContinueTarget of |CaseClauses| with arguments _iterationSet_ and &laquo; &raquo;.
-        1. If _hasUndefinedLabels_ is *true*, return *true*.
-        1. Return ContainsUndefinedContinueTarget of |CaseClause| with arguments _iterationSet_ and &laquo; &raquo;.
-      </emu-alg>
-      <emu-grammar>CaseClause : `case` Expression `:` StatementList?</emu-grammar>
-      <emu-alg>
-        1. If the |StatementList| is present, return ContainsUndefinedContinueTarget of |StatementList| with arguments _iterationSet_ and &laquo; &raquo;.
-        1. Return *false*.
-      </emu-alg>
-      <emu-grammar>DefaultClause : `default` `:` StatementList?</emu-grammar>
-      <emu-alg>
-        1. If the |StatementList| is present, return ContainsUndefinedContinueTarget of |StatementList| with arguments _iterationSet_ and &laquo; &raquo;.
-        1. Return *false*.
-      </emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-runtime-semantics-caseblockevaluation">
@@ -19085,55 +19071,6 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-labelled-statements-static-semantics-containsduplicatelabels">
-      <h1>Static Semantics: ContainsDuplicateLabels</h1>
-      <p>With parameter _labelSet_.</p>
-      <emu-see-also-para op="ContainsDuplicateLabels"></emu-see-also-para>
-      <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
-      <emu-alg>
-        1. Let _label_ be the StringValue of |LabelIdentifier|.
-        1. If _label_ is an element of _labelSet_, return *true*.
-        1. Let _newLabelSet_ be a copy of _labelSet_ with _label_ appended.
-        1. Return ContainsDuplicateLabels of |LabelledItem| with argument _newLabelSet_.
-      </emu-alg>
-      <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-labelled-statements-static-semantics-containsundefinedbreaktarget">
-      <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
-      <p>With parameter _labelSet_.</p>
-      <emu-see-also-para op="ContainsUndefinedBreakTarget"></emu-see-also-para>
-      <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
-      <emu-alg>
-        1. Let _label_ be the StringValue of |LabelIdentifier|.
-        1. Let _newLabelSet_ be a copy of _labelSet_ with _label_ appended.
-        1. Return ContainsUndefinedBreakTarget of |LabelledItem| with argument _newLabelSet_.
-      </emu-alg>
-      <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-labelled-statements-static-semantics-containsundefinedcontinuetarget">
-      <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
-      <p>With parameters _iterationSet_ and _labelSet_.</p>
-      <emu-see-also-para op="ContainsUndefinedContinueTarget"></emu-see-also-para>
-      <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
-      <emu-alg>
-        1. Let _label_ be the StringValue of |LabelIdentifier|.
-        1. Let _newLabelSet_ be a copy of _labelSet_ with _label_ appended.
-        1. Return ContainsUndefinedContinueTarget of |LabelledItem| with arguments _iterationSet_ and _newLabelSet_.
-      </emu-alg>
-      <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-islabelledfunction" aoid="IsLabelledFunction">
       <h1>Static Semantics: IsLabelledFunction ( _stmt_ )</h1>
       <p>The abstract operation IsLabelledFunction takes argument _stmt_. It performs the following steps when called:</p>
@@ -19273,96 +19210,6 @@
       <emu-note>
         <p>An alternative static semantics for this production is given in <emu-xref href="#sec-variablestatements-in-catch-blocks"></emu-xref>.</p>
       </emu-note>
-    </emu-clause>
-
-    <emu-clause id="sec-try-statement-static-semantics-containsduplicatelabels">
-      <h1>Static Semantics: ContainsDuplicateLabels</h1>
-      <p>With parameter _labelSet_.</p>
-      <emu-see-also-para op="ContainsDuplicateLabels"></emu-see-also-para>
-      <emu-grammar>TryStatement : `try` Block Catch</emu-grammar>
-      <emu-alg>
-        1. Let _hasDuplicates_ be ContainsDuplicateLabels of |Block| with argument _labelSet_.
-        1. If _hasDuplicates_ is *true*, return *true*.
-        1. Return ContainsDuplicateLabels of |Catch| with argument _labelSet_.
-      </emu-alg>
-      <emu-grammar>TryStatement : `try` Block Finally</emu-grammar>
-      <emu-alg>
-        1. Let _hasDuplicates_ be ContainsDuplicateLabels of |Block| with argument _labelSet_.
-        1. If _hasDuplicates_ is *true*, return *true*.
-        1. Return ContainsDuplicateLabels of |Finally| with argument _labelSet_.
-      </emu-alg>
-      <emu-grammar>TryStatement : `try` Block Catch Finally</emu-grammar>
-      <emu-alg>
-        1. Let _hasDuplicates_ be ContainsDuplicateLabels of |Block| with argument _labelSet_.
-        1. If _hasDuplicates_ is *true*, return *true*.
-        1. Let _hasDuplicates_ be ContainsDuplicateLabels of |Catch| with argument _labelSet_.
-        1. If _hasDuplicates_ is *true*, return *true*.
-        1. Return ContainsDuplicateLabels of |Finally| with argument _labelSet_.
-      </emu-alg>
-      <emu-grammar>Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
-      <emu-alg>
-        1. Return ContainsDuplicateLabels of |Block| with argument _labelSet_.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-try-statement-static-semantics-containsundefinedbreaktarget">
-      <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
-      <p>With parameter _labelSet_.</p>
-      <emu-see-also-para op="ContainsUndefinedBreakTarget"></emu-see-also-para>
-      <emu-grammar>TryStatement : `try` Block Catch</emu-grammar>
-      <emu-alg>
-        1. Let _hasUndefinedLabels_ be ContainsUndefinedBreakTarget of |Block| with argument _labelSet_.
-        1. If _hasUndefinedLabels_ is *true*, return *true*.
-        1. Return ContainsUndefinedBreakTarget of |Catch| with argument _labelSet_.
-      </emu-alg>
-      <emu-grammar>TryStatement : `try` Block Finally</emu-grammar>
-      <emu-alg>
-        1. Let _hasUndefinedLabels_ be ContainsUndefinedBreakTarget of |Block| with argument _labelSet_.
-        1. If _hasUndefinedLabels_ is *true*, return *true*.
-        1. Return ContainsUndefinedBreakTarget of |Finally| with argument _labelSet_.
-      </emu-alg>
-      <emu-grammar>TryStatement : `try` Block Catch Finally</emu-grammar>
-      <emu-alg>
-        1. Let _hasUndefinedLabels_ be ContainsUndefinedBreakTarget of |Block| with argument _labelSet_.
-        1. If _hasUndefinedLabels_ is *true*, return *true*.
-        1. Let _hasUndefinedLabels_ be ContainsUndefinedBreakTarget of |Catch| with argument _labelSet_.
-        1. If _hasUndefinedLabels_ is *true*, return *true*.
-        1. Return ContainsUndefinedBreakTarget of |Finally| with argument _labelSet_.
-      </emu-alg>
-      <emu-grammar>Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
-      <emu-alg>
-        1. Return ContainsUndefinedBreakTarget of |Block| with argument _labelSet_.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-try-statement-static-semantics-containsundefinedcontinuetarget">
-      <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
-      <p>With parameters _iterationSet_ and _labelSet_.</p>
-      <emu-see-also-para op="ContainsUndefinedContinueTarget"></emu-see-also-para>
-      <emu-grammar>TryStatement : `try` Block Catch</emu-grammar>
-      <emu-alg>
-        1. Let _hasUndefinedLabels_ be ContainsUndefinedContinueTarget of |Block| with arguments _iterationSet_ and &laquo; &raquo;.
-        1. If _hasUndefinedLabels_ is *true*, return *true*.
-        1. Return ContainsUndefinedContinueTarget of |Catch| with arguments _iterationSet_ and &laquo; &raquo;.
-      </emu-alg>
-      <emu-grammar>TryStatement : `try` Block Finally</emu-grammar>
-      <emu-alg>
-        1. Let _hasUndefinedLabels_ be ContainsUndefinedContinueTarget of |Block| with arguments _iterationSet_ and &laquo; &raquo;.
-        1. If _hasUndefinedLabels_ is *true*, return *true*.
-        1. Return ContainsUndefinedContinueTarget of |Finally| with arguments _iterationSet_ and &laquo; &raquo;.
-      </emu-alg>
-      <emu-grammar>TryStatement : `try` Block Catch Finally</emu-grammar>
-      <emu-alg>
-        1. Let _hasUndefinedLabels_ be ContainsUndefinedContinueTarget of |Block| with arguments _iterationSet_ and &laquo; &raquo;.
-        1. If _hasUndefinedLabels_ is *true*, return *true*.
-        1. Let _hasUndefinedLabels_ be ContainsUndefinedContinueTarget of |Catch| with arguments _iterationSet_ and &laquo; &raquo;.
-        1. If _hasUndefinedLabels_ is *true*, return *true*.
-        1. Return ContainsUndefinedContinueTarget of |Finally| with arguments _iterationSet_ and &laquo; &raquo;.
-      </emu-alg>
-      <emu-grammar>Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
-      <emu-alg>
-        1. Return ContainsUndefinedContinueTarget of |Block| with arguments _iterationSet_ and &laquo; &raquo;.
-      </emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-runtime-semantics-catchclauseevaluation">
@@ -19832,36 +19679,6 @@
       <emu-note>
         <p>Static semantic rules that depend upon substructure generally do not look into function definitions.</p>
       </emu-note>
-    </emu-clause>
-
-    <emu-clause id="sec-function-definitions-static-semantics-containsduplicatelabels">
-      <h1>Static Semantics: ContainsDuplicateLabels</h1>
-      <p>With parameter _labelSet_.</p>
-      <emu-see-also-para op="ContainsDuplicateLabels"></emu-see-also-para>
-      <emu-grammar>FunctionStatementList : [empty]</emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-function-definitions-static-semantics-containsundefinedbreaktarget">
-      <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
-      <p>With parameter _labelSet_.</p>
-      <emu-see-also-para op="ContainsUndefinedBreakTarget"></emu-see-also-para>
-      <emu-grammar>FunctionStatementList : [empty]</emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-function-definitions-static-semantics-containsundefinedcontinuetarget">
-      <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
-      <p>With parameters _iterationSet_ and _labelSet_.</p>
-      <emu-see-also-para op="ContainsUndefinedContinueTarget"></emu-see-also-para>
-      <emu-grammar>FunctionStatementList : [empty]</emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-static-semantics-functionbodycontainsusestrict" oldids="sec-function-definitions-static-semantics-containsusestrict" type="sdo" aoid="FunctionBodyContainsUseStrict">
@@ -22388,66 +22205,6 @@
         <emu-note>
           <p>The duplicate ExportedNames rule implies that multiple `export default` |ExportDeclaration| items within a |ModuleBody| is a Syntax Error. Additional error conditions relating to conflicting or duplicate declarations are checked during module linking prior to evaluation of a |Module|. If any such errors are detected the |Module| is not evaluated.</p>
         </emu-note>
-      </emu-clause>
-
-      <emu-clause id="sec-module-semantics-static-semantics-containsduplicatelabels">
-        <h1>Static Semantics: ContainsDuplicateLabels</h1>
-        <p>With parameter _labelSet_.</p>
-        <emu-see-also-para op="ContainsDuplicateLabels"></emu-see-also-para>
-        <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
-        <emu-alg>
-          1. Let _hasDuplicates_ be ContainsDuplicateLabels of |ModuleItemList| with argument _labelSet_.
-          1. If _hasDuplicates_ is *true*, return *true*.
-          1. Return ContainsDuplicateLabels of |ModuleItem| with argument _labelSet_.
-        </emu-alg>
-        <emu-grammar>
-          ModuleItem :
-            ImportDeclaration
-            ExportDeclaration
-        </emu-grammar>
-        <emu-alg>
-          1. Return *false*.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-module-semantics-static-semantics-containsundefinedbreaktarget">
-        <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
-        <p>With parameter _labelSet_.</p>
-        <emu-see-also-para op="ContainsUndefinedBreakTarget"></emu-see-also-para>
-        <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
-        <emu-alg>
-          1. Let _hasUndefinedLabels_ be ContainsUndefinedBreakTarget of |ModuleItemList| with argument _labelSet_.
-          1. If _hasUndefinedLabels_ is *true*, return *true*.
-          1. Return ContainsUndefinedBreakTarget of |ModuleItem| with argument _labelSet_.
-        </emu-alg>
-        <emu-grammar>
-          ModuleItem :
-            ImportDeclaration
-            ExportDeclaration
-        </emu-grammar>
-        <emu-alg>
-          1. Return *false*.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-module-semantics-static-semantics-containsundefinedcontinuetarget">
-        <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
-        <p>With parameters _iterationSet_ and _labelSet_.</p>
-        <emu-see-also-para op="ContainsUndefinedContinueTarget"></emu-see-also-para>
-        <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
-        <emu-alg>
-          1. Let _hasUndefinedLabels_ be ContainsUndefinedContinueTarget of |ModuleItemList| with arguments _iterationSet_ and &laquo; &raquo;.
-          1. If _hasUndefinedLabels_ is *true*, return *true*.
-          1. Return ContainsUndefinedContinueTarget of |ModuleItem| with arguments _iterationSet_ and &laquo; &raquo;.
-        </emu-alg>
-        <emu-grammar>
-          ModuleItem :
-            ImportDeclaration
-            ExportDeclaration
-        </emu-grammar>
-        <emu-alg>
-          1. Return *false*.
-        </emu-alg>
       </emu-clause>
 
       <emu-clause id="sec-module-semantics-static-semantics-exportedbindings">
@@ -42589,17 +42346,17 @@ THH:mm:ss.sss
           `for` `(` `var` BindingIdentifier[?Yield, ?Await] Initializer[~In, ?Yield, ?Await] `in` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
       </emu-grammar>
       <p>This production only applies when parsing non-strict code.</p>
-      <p>The static semantics of ContainsDuplicateLabels in <emu-xref href="#sec-for-in-and-for-of-statements-static-semantics-containsduplicatelabels"></emu-xref> are augmented with the following:</p>
+      <p>The static semantics of ContainsDuplicateLabels in <emu-xref href="#sec-static-semantics-containsduplicatelabels"></emu-xref> are augmented with the following:</p>
       <emu-grammar>IterationStatement : `for` `(` `var` BindingIdentifier Initializer `in` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Return ContainsDuplicateLabels of |Statement| with argument _labelSet_.
       </emu-alg>
-      <p>The static semantics of ContainsUndefinedBreakTarget in <emu-xref href="#sec-for-in-and-for-of-statements-static-semantics-containsundefinedbreaktarget"></emu-xref> are augmented with the following:</p>
+      <p>The static semantics of ContainsUndefinedBreakTarget in <emu-xref href="#sec-static-semantics-containsundefinedbreaktarget"></emu-xref> are augmented with the following:</p>
       <emu-grammar>IterationStatement : `for` `(` `var` BindingIdentifier Initializer `in` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Return ContainsUndefinedBreakTarget of |Statement| with argument _labelSet_.
       </emu-alg>
-      <p>The static semantics of ContainsUndefinedContinueTarget in <emu-xref href="#sec-for-in-and-for-of-statements-static-semantics-containsundefinedcontinuetarget"></emu-xref> are augmented with the following:</p>
+      <p>The static semantics of ContainsUndefinedContinueTarget in <emu-xref href="#sec-static-semantics-containsundefinedcontinuetarget"></emu-xref> are augmented with the following:</p>
       <emu-grammar>IterationStatement : `for` `(` `var` BindingIdentifier Initializer `in` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Return ContainsUndefinedContinueTarget of |Statement| with arguments _iterationSet_ and &laquo; &raquo;.

--- a/spec.html
+++ b/spec.html
@@ -11997,21 +11997,6 @@
           </li>
         </ul>
       </emu-clause>
-
-      <emu-clause id="sec-identifier-names-static-semantics-stringvalue">
-        <h1>Static Semantics: StringValue</h1>
-        <emu-see-also-para op="StringValue"></emu-see-also-para>
-        <emu-grammar>
-          IdentifierName ::
-            IdentifierStart
-            IdentifierName IdentifierPart
-        </emu-grammar>
-        <emu-alg>
-          1. Let _idText_ be the source text matched by |IdentifierName|.
-          1. Let _idTextUnescaped_ be the result of replacing any occurrences of `\\` |UnicodeEscapeSequence| in _idText_ with the code point represented by the |UnicodeEscapeSequence|.
-          1. Return ! CodePointsToString(_idTextUnescaped_).
-        </emu-alg>
-      </emu-clause>
     </emu-clause>
 
     <emu-clause id="sec-keywords-and-reserved-words" oldids="sec-reserved-words,sec-keywords,sec-future-reserved-words">
@@ -13332,9 +13317,18 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-identifiers-static-semantics-stringvalue">
+    <emu-clause id="sec-static-semantics-stringvalue" oldids="sec-identifiers-static-semantics-stringvalue,sec-identifier-names-static-semantics-stringvalue" type="sdo" aoid="StringValue">
       <h1>Static Semantics: StringValue</h1>
-      <emu-see-also-para op="StringValue"></emu-see-also-para>
+      <emu-grammar>
+        IdentifierName ::
+          IdentifierStart
+          IdentifierName IdentifierPart
+      </emu-grammar>
+      <emu-alg>
+        1. Let _idText_ be the source text matched by |IdentifierName|.
+        1. Let _idTextUnescaped_ be the result of replacing any occurrences of `\\` |UnicodeEscapeSequence| in _idText_ with the code point represented by the |UnicodeEscapeSequence|.
+        1. Return ! CodePointsToString(_idTextUnescaped_).
+      </emu-alg>
       <emu-grammar>
         IdentifierReference : `yield`
 

--- a/spec.html
+++ b/spec.html
@@ -21782,28 +21782,6 @@
         </emu-note>
       </emu-clause>
 
-      <emu-clause id="sec-module-semantics-static-semantics-exportedbindings">
-        <h1>Static Semantics: ExportedBindings</h1>
-        <emu-see-also-para op="ExportedBindings"></emu-see-also-para>
-        <emu-note>
-          <p>ExportedBindings are the locally bound names that are explicitly associated with a |Module|'s ExportedNames.</p>
-        </emu-note>
-        <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
-        <emu-alg>
-          1. Let _names_ be ExportedBindings of |ModuleItemList|.
-          1. Append to _names_ the elements of the ExportedBindings of |ModuleItem|.
-          1. Return _names_.
-        </emu-alg>
-        <emu-grammar>
-          ModuleItem :
-            ImportDeclaration
-            StatementListItem
-        </emu-grammar>
-        <emu-alg>
-          1. Return a new empty List.
-        </emu-alg>
-      </emu-clause>
-
       <emu-clause id="sec-module-semantics-static-semantics-exportednames">
         <h1>Static Semantics: ExportedNames</h1>
         <emu-see-also-para op="ExportedNames"></emu-see-also-para>
@@ -23318,9 +23296,25 @@
         </emu-note>
       </emu-clause>
 
-      <emu-clause id="sec-exports-static-semantics-exportedbindings">
+      <emu-clause id="sec-static-semantics-exportedbindings" oldids="sec-module-semantics-static-semantics-exportedbindings,sec-exports-static-semantics-exportedbindings" type="sdo" aoid="ExportedBindings">
         <h1>Static Semantics: ExportedBindings</h1>
-        <emu-see-also-para op="ExportedBindings"></emu-see-also-para>
+        <emu-note>
+          <p>ExportedBindings are the locally bound names that are explicitly associated with a |Module|'s ExportedNames.</p>
+        </emu-note>
+        <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
+        <emu-alg>
+          1. Let _names_ be ExportedBindings of |ModuleItemList|.
+          1. Append to _names_ the elements of the ExportedBindings of |ModuleItem|.
+          1. Return _names_.
+        </emu-alg>
+        <emu-grammar>
+          ModuleItem :
+            ImportDeclaration
+            StatementListItem
+        </emu-grammar>
+        <emu-alg>
+          1. Return a new empty List.
+        </emu-alg>
         <emu-grammar>
           ExportDeclaration :
             `export` ExportFromClause FromClause `;`

--- a/spec.html
+++ b/spec.html
@@ -7865,6 +7865,66 @@
         1. Return ~invalid~.
       </emu-alg>
     </emu-clause>
+
+    <emu-clause id="sec-static-semantics-propname" oldids="sec-object-initializer-static-semantics-propname,sec-method-definitions-static-semantics-propname,sec-generator-function-definitions-static-semantics-propname,sec-async-generator-function-definitions-static-semantics-propname,sec-class-definitions-static-semantics-propname,sec-async-function-definitions-static-semantics-PropName" type="sdo" aoid="PropName">
+      <h1>Static Semantics: PropName</h1>
+      <emu-grammar>PropertyDefinition : IdentifierReference</emu-grammar>
+      <emu-alg>
+        1. Return StringValue of |IdentifierReference|.
+      </emu-alg>
+      <emu-grammar>PropertyDefinition : `...` AssignmentExpression</emu-grammar>
+      <emu-alg>
+        1. Return ~empty~.
+      </emu-alg>
+      <emu-grammar>PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar>
+      <emu-alg>
+        1. Return PropName of |PropertyName|.
+      </emu-alg>
+      <emu-grammar>LiteralPropertyName : IdentifierName</emu-grammar>
+      <emu-alg>
+        1. Return StringValue of |IdentifierName|.
+      </emu-alg>
+      <emu-grammar>LiteralPropertyName : StringLiteral</emu-grammar>
+      <emu-alg>
+        1. Return the SV of |StringLiteral|.
+      </emu-alg>
+      <emu-grammar>LiteralPropertyName : NumericLiteral</emu-grammar>
+      <emu-alg>
+        1. Let _nbr_ be the NumericValue of |NumericLiteral|.
+        1. Return ! ToString(_nbr_).
+      </emu-alg>
+      <emu-grammar>ComputedPropertyName : `[` AssignmentExpression `]`</emu-grammar>
+      <emu-alg>
+        1. Return ~empty~.
+      </emu-alg>
+      <emu-grammar>
+        MethodDefinition :
+          PropertyName `(` UniqueFormalParameters `)` `{` FunctionBody `}`
+          `get` PropertyName `(` `)` `{` FunctionBody `}`
+          `set` PropertyName `(` PropertySetParameterList `)` `{` FunctionBody `}`
+      </emu-grammar>
+      <emu-alg>
+        1. Return PropName of |PropertyName|.
+      </emu-alg>
+      <emu-grammar>GeneratorMethod : `*` PropertyName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
+      <emu-alg>
+        1. Return PropName of |PropertyName|.
+      </emu-alg>
+      <emu-grammar>AsyncGeneratorMethod : `async` `*` PropertyName `(` UniqueFormalParameters `)` `{` AsyncGeneratorBody `}`</emu-grammar>
+      <emu-alg>
+        1. Return PropName of |PropertyName|.
+      </emu-alg>
+      <emu-grammar>ClassElement : `;`</emu-grammar>
+      <emu-alg>
+        1. Return ~empty~.
+      </emu-alg>
+      <emu-grammar>
+        AsyncMethod : `async` PropertyName `(` UniqueFormalParameters `)` `{` AsyncFunctionBody `}`
+      </emu-grammar>
+      <emu-alg>
+        1. Return PropName of |PropertyName|.
+      </emu-alg>
+    </emu-clause>
   </emu-clause>
 </emu-clause>
 
@@ -14667,40 +14727,6 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-object-initializer-static-semantics-propname">
-        <h1>Static Semantics: PropName</h1>
-        <emu-see-also-para op="PropName"></emu-see-also-para>
-        <emu-grammar>PropertyDefinition : IdentifierReference</emu-grammar>
-        <emu-alg>
-          1. Return StringValue of |IdentifierReference|.
-        </emu-alg>
-        <emu-grammar>PropertyDefinition : `...` AssignmentExpression</emu-grammar>
-        <emu-alg>
-          1. Return ~empty~.
-        </emu-alg>
-        <emu-grammar>PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar>
-        <emu-alg>
-          1. Return PropName of |PropertyName|.
-        </emu-alg>
-        <emu-grammar>LiteralPropertyName : IdentifierName</emu-grammar>
-        <emu-alg>
-          1. Return StringValue of |IdentifierName|.
-        </emu-alg>
-        <emu-grammar>LiteralPropertyName : StringLiteral</emu-grammar>
-        <emu-alg>
-          1. Return the SV of |StringLiteral|.
-        </emu-alg>
-        <emu-grammar>LiteralPropertyName : NumericLiteral</emu-grammar>
-        <emu-alg>
-          1. Let _nbr_ be the NumericValue of |NumericLiteral|.
-          1. Return ! ToString(_nbr_).
-        </emu-alg>
-        <emu-grammar>ComputedPropertyName : `[` AssignmentExpression `]`</emu-grammar>
-        <emu-alg>
-          1. Return ~empty~.
-        </emu-alg>
-      </emu-clause>
-
       <emu-clause id="sec-static-semantics-propertynamelist">
         <h1>Static Semantics: PropertyNameList</h1>
         <emu-grammar>PropertyDefinitionList : PropertyDefinition</emu-grammar>
@@ -19958,20 +19984,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-method-definitions-static-semantics-propname">
-      <h1>Static Semantics: PropName</h1>
-      <emu-see-also-para op="PropName"></emu-see-also-para>
-      <emu-grammar>
-        MethodDefinition :
-          PropertyName `(` UniqueFormalParameters `)` `{` FunctionBody `}`
-          `get` PropertyName `(` `)` `{` FunctionBody `}`
-          `set` PropertyName `(` PropertySetParameterList `)` `{` FunctionBody `}`
-      </emu-grammar>
-      <emu-alg>
-        1. Return PropName of |PropertyName|.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-static-semantics-specialmethod">
       <h1>Static Semantics: SpecialMethod</h1>
       <emu-grammar>MethodDefinition : PropertyName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
@@ -20240,15 +20252,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-generator-function-definitions-static-semantics-propname">
-      <h1>Static Semantics: PropName</h1>
-      <emu-see-also-para op="PropName"></emu-see-also-para>
-      <emu-grammar>GeneratorMethod : `*` PropertyName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
-      <emu-alg>
-        1. Return PropName of |PropertyName|.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-runtime-semantics-evaluategeneratorbody" oldids="sec-generator-function-definitions-runtime-semantics-evaluatebody" type="sdo" aoid="EvaluateGeneratorBody">
       <h1>Runtime Semantics: EvaluateGeneratorBody</h1>
       <p>With parameters _functionObject_ and _argumentsList_ (a List).</p>
@@ -20506,15 +20509,6 @@
       <emu-grammar>AsyncGeneratorExpression : `async` `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` AsyncGeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. Return *true*.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-async-generator-function-definitions-static-semantics-propname">
-      <h1>Static Semantics: PropName</h1>
-      <emu-see-also-para op="PropName"></emu-see-also-para>
-      <emu-grammar>AsyncGeneratorMethod : `async` `*` PropertyName `(` UniqueFormalParameters `)` `{` AsyncGeneratorBody `}`</emu-grammar>
-      <emu-alg>
-        1. Return PropName of |PropertyName|.
       </emu-alg>
     </emu-clause>
 
@@ -20828,15 +20822,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-class-definitions-static-semantics-propname">
-      <h1>Static Semantics: PropName</h1>
-      <emu-see-also-para op="PropName"></emu-see-also-para>
-      <emu-grammar>ClassElement : `;`</emu-grammar>
-      <emu-alg>
-        1. Return ~empty~.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-runtime-semantics-classdefinitionevaluation">
       <h1>Runtime Semantics: ClassDefinitionEvaluation</h1>
       <p>With parameters _classBinding_ and _className_.</p>
@@ -21098,16 +21083,6 @@
       </emu-grammar>
       <emu-alg>
         1. Return *true*.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-async-function-definitions-static-semantics-PropName">
-      <h1>Static Semantics: PropName</h1>
-      <emu-grammar>
-        AsyncMethod : `async` PropertyName `(` UniqueFormalParameters `)` `{` AsyncFunctionBody `}`
-      </emu-grammar>
-      <emu-alg>
-        1. Return PropName of |PropertyName|.
       </emu-alg>
     </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -18138,8 +18138,8 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-runtime-semantics-bindinginstantiation" type="sdo" aoid="BindingInstantiation">
-        <h1>Runtime Semantics: BindingInstantiation</h1>
+      <emu-clause id="sec-runtime-semantics-fordeclarationbindinginstantiation" oldids="sec-runtime-semantics-bindinginstantiation" type="sdo" aoid="ForDeclarationBindingInstantiation">
+        <h1>Runtime Semantics: ForDeclarationBindingInstantiation</h1>
         <p>With parameter _environment_.</p>
         <emu-grammar>ForDeclaration : LetOrConst ForBinding</emu-grammar>
         <emu-alg>
@@ -18206,7 +18206,7 @@
               1. Assert: _lhsKind_ is ~lexicalBinding~.
               1. Assert: _lhs_ is a |ForDeclaration|.
               1. Let _iterationEnv_ be NewDeclarativeEnvironment(_oldEnv_).
-              1. Perform BindingInstantiation for _lhs_ passing _iterationEnv_ as the argument.
+              1. Perform ForDeclarationBindingInstantiation for _lhs_ passing _iterationEnv_ as the argument.
               1. Set the running execution context's LexicalEnvironment to _iterationEnv_.
               1. If _destructuring_ is *false*, then
                 1. Assert: _lhs_ binds a single name.

--- a/spec.html
+++ b/spec.html
@@ -17761,10 +17761,9 @@
         </emu-note>
       </emu-clause>
 
-      <emu-clause id="sec-for-in-and-for-of-statements-runtime-semantics-bindinginitialization">
-        <h1>Runtime Semantics: BindingInitialization</h1>
+      <emu-clause id="sec-runtime-semantics-fordeclarationbindinginitialization" oldids="sec-for-in-and-for-of-statements-runtime-semantics-bindinginitialization" type="sdo" aoid="ForDeclarationBindingInitialization">
+        <h1>Runtime Semantics: ForDeclarationBindingInitialization</h1>
         <p>With parameters _value_ and _environment_.</p>
-        <emu-see-also-para op="BindingInitialization"></emu-see-also-para>
         <emu-note>
           <p>*undefined* is passed for _environment_ to indicate that a PutValue operation should be used to assign the initialization value. This is the case for `var` statements and the formal parameter lists of some non-strict functions (see <emu-xref href="#sec-functiondeclarationinstantiation"></emu-xref>). In those cases a lexical binding is hoisted and preinitialized prior to evaluation of its initializer.</p>
         </emu-note>
@@ -17924,7 +17923,7 @@
               1. Else,
                 1. Assert: _lhsKind_ is ~lexicalBinding~.
                 1. Assert: _lhs_ is a |ForDeclaration|.
-                1. Let _status_ be BindingInitialization of _lhs_ with arguments _nextValue_ and _iterationEnv_.
+                1. Let _status_ be ForDeclarationBindingInitialization of _lhs_ with arguments _nextValue_ and _iterationEnv_.
             1. If _status_ is an abrupt completion, then
               1. Set the running execution context's LexicalEnvironment to _oldEnv_.
               1. If _iteratorKind_ is ~async~, return ? AsyncIteratorClose(_iteratorRecord_, _status_).

--- a/spec.html
+++ b/spec.html
@@ -21782,32 +21782,6 @@
         </emu-note>
       </emu-clause>
 
-      <emu-clause id="sec-module-semantics-static-semantics-exportednames">
-        <h1>Static Semantics: ExportedNames</h1>
-        <emu-see-also-para op="ExportedNames"></emu-see-also-para>
-        <emu-note>
-          <p>ExportedNames are the externally visible names that a |Module| explicitly maps to one of its local name bindings.</p>
-        </emu-note>
-        <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
-        <emu-alg>
-          1. Let _names_ be ExportedNames of |ModuleItemList|.
-          1. Append to _names_ the elements of the ExportedNames of |ModuleItem|.
-          1. Return _names_.
-        </emu-alg>
-        <emu-grammar>ModuleItem : ExportDeclaration</emu-grammar>
-        <emu-alg>
-          1. Return the ExportedNames of |ExportDeclaration|.
-        </emu-alg>
-        <emu-grammar>
-          ModuleItem :
-            ImportDeclaration
-            StatementListItem
-        </emu-grammar>
-        <emu-alg>
-          1. Return a new empty List.
-        </emu-alg>
-      </emu-clause>
-
       <emu-clause id="sec-module-semantics-static-semantics-exportentries">
         <h1>Static Semantics: ExportEntries</h1>
         <emu-see-also-para op="ExportEntries"></emu-see-also-para>
@@ -23364,9 +23338,29 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-exports-static-semantics-exportednames">
+      <emu-clause id="sec-static-semantics-exportednames" oldids="sec-module-semantics-static-semantics-exportednames,sec-exports-static-semantics-exportednames" type="sdo" aoid="ExportedNames">
         <h1>Static Semantics: ExportedNames</h1>
-        <emu-see-also-para op="ExportedNames"></emu-see-also-para>
+        <emu-note>
+          <p>ExportedNames are the externally visible names that a |Module| explicitly maps to one of its local name bindings.</p>
+        </emu-note>
+        <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
+        <emu-alg>
+          1. Let _names_ be ExportedNames of |ModuleItemList|.
+          1. Append to _names_ the elements of the ExportedNames of |ModuleItem|.
+          1. Return _names_.
+        </emu-alg>
+        <emu-grammar>ModuleItem : ExportDeclaration</emu-grammar>
+        <emu-alg>
+          1. Return the ExportedNames of |ExportDeclaration|.
+        </emu-alg>
+        <emu-grammar>
+          ModuleItem :
+            ImportDeclaration
+            StatementListItem
+        </emu-grammar>
+        <emu-alg>
+          1. Return a new empty List.
+        </emu-alg>
         <emu-grammar>ExportDeclaration : `export` ExportFromClause FromClause `;`</emu-grammar>
         <emu-alg>
           1. Return the ExportedNames of |ExportFromClause|.

--- a/spec.html
+++ b/spec.html
@@ -7545,6 +7545,52 @@
         1. Return *false*.
       </emu-alg>
     </emu-clause>
+
+    <emu-clause id="sec-static-semantics-computedpropertycontains" oldids="sec-object-initializer-static-semantics-computedpropertycontains,sec-method-definitions-static-semantics-computedpropertycontains,sec-generator-function-definitions-static-semantics-computedpropertycontains,sec-async-generator-function-definitions-static-semantics-computedpropertycontains,sec-class-definitions-static-semantics-computedpropertycontains,sec-async-function-definitions-static-semantics-ComputedPropertyContains" type="sdo" aoid="ComputedPropertyContains">
+      <h1>Static Semantics: ComputedPropertyContains</h1>
+      <p>With parameter _symbol_.</p>
+      <emu-grammar>PropertyName : LiteralPropertyName</emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>PropertyName : ComputedPropertyName</emu-grammar>
+      <emu-alg>
+        1. Return the result of |ComputedPropertyName| Contains _symbol_.
+      </emu-alg>
+      <emu-grammar>
+        MethodDefinition :
+          PropertyName `(` UniqueFormalParameters `)` `{` FunctionBody `}`
+          `get` PropertyName `(` `)` `{` FunctionBody `}`
+          `set` PropertyName `(` PropertySetParameterList `)` `{` FunctionBody `}`
+      </emu-grammar>
+      <emu-alg>
+        1. Return the result of ComputedPropertyContains for |PropertyName| with argument _symbol_.
+      </emu-alg>
+      <emu-grammar>GeneratorMethod : `*` PropertyName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
+      <emu-alg>
+        1. Return the result of ComputedPropertyContains for |PropertyName| with argument _symbol_.
+      </emu-alg>
+      <emu-grammar>AsyncGeneratorMethod : `async` `*` PropertyName `(` UniqueFormalParameters `)` `{` AsyncGeneratorBody `}`</emu-grammar>
+      <emu-alg>
+        1. Return the result of ComputedPropertyContains for |PropertyName| with argument _symbol_.
+      </emu-alg>
+      <emu-grammar>ClassElementList : ClassElementList ClassElement</emu-grammar>
+      <emu-alg>
+        1. Let _inList_ be ComputedPropertyContains of |ClassElementList| with argument _symbol_.
+        1. If _inList_ is *true*, return *true*.
+        1. Return the result of ComputedPropertyContains for |ClassElement| with argument _symbol_.
+      </emu-alg>
+      <emu-grammar>ClassElement : `;`</emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>
+        AsyncMethod : `async` PropertyName `(` UniqueFormalParameters `)` `{` AsyncFunctionBody `}`
+      </emu-grammar>
+      <emu-alg>
+        1. Return the result of ComputedPropertyContains for |PropertyName| with argument _symbol_.
+      </emu-alg>
+    </emu-clause>
   </emu-clause>
 
   <emu-clause id="sec-syntax-directed-operations-miscellaneous">
@@ -14764,20 +14810,6 @@
         </emu-note>
       </emu-clause>
 
-      <emu-clause id="sec-object-initializer-static-semantics-computedpropertycontains">
-        <h1>Static Semantics: ComputedPropertyContains</h1>
-        <p>With parameter _symbol_.</p>
-        <emu-see-also-para op="ComputedPropertyContains"></emu-see-also-para>
-        <emu-grammar>PropertyName : LiteralPropertyName</emu-grammar>
-        <emu-alg>
-          1. Return *false*.
-        </emu-alg>
-        <emu-grammar>PropertyName : ComputedPropertyName</emu-grammar>
-        <emu-alg>
-          1. Return the result of |ComputedPropertyName| Contains _symbol_.
-        </emu-alg>
-      </emu-clause>
-
       <emu-clause id="sec-static-semantics-iscomputedpropertykey" type="sdo" aoid="IsComputedPropertyKey">
         <h1>Static Semantics: IsComputedPropertyKey</h1>
         <emu-grammar>PropertyName : LiteralPropertyName</emu-grammar>
@@ -19863,21 +19895,6 @@
       </ul>
     </emu-clause>
 
-    <emu-clause id="sec-method-definitions-static-semantics-computedpropertycontains">
-      <h1>Static Semantics: ComputedPropertyContains</h1>
-      <p>With parameter _symbol_.</p>
-      <emu-see-also-para op="ComputedPropertyContains"></emu-see-also-para>
-      <emu-grammar>
-        MethodDefinition :
-          PropertyName `(` UniqueFormalParameters `)` `{` FunctionBody `}`
-          `get` PropertyName `(` `)` `{` FunctionBody `}`
-          `set` PropertyName `(` PropertySetParameterList `)` `{` FunctionBody `}`
-      </emu-grammar>
-      <emu-alg>
-        1. Return the result of ComputedPropertyContains for |PropertyName| with argument _symbol_.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-static-semantics-hasdirectsuper" oldids="sec-method-definitions-static-semantics-hasdirectsuper,sec-generator-function-definitions-static-semantics-hasdirectsuper,sec-async-generator-function-definitions-static-semantics-hasdirectsuper,sec-async-function-definitions-static-semantics-HasDirectSuper" type="sdo" aoid="HasDirectSuper">
       <h1>Static Semantics: HasDirectSuper</h1>
       <emu-grammar>MethodDefinition : PropertyName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
@@ -20120,16 +20137,6 @@
       </ul>
     </emu-clause>
 
-    <emu-clause id="sec-generator-function-definitions-static-semantics-computedpropertycontains">
-      <h1>Static Semantics: ComputedPropertyContains</h1>
-      <p>With parameter _symbol_.</p>
-      <emu-see-also-para op="ComputedPropertyContains"></emu-see-also-para>
-      <emu-grammar>GeneratorMethod : `*` PropertyName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
-      <emu-alg>
-        1. Return the result of ComputedPropertyContains for |PropertyName| with argument _symbol_.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-runtime-semantics-evaluategeneratorbody" oldids="sec-generator-function-definitions-runtime-semantics-evaluatebody" type="sdo" aoid="EvaluateGeneratorBody">
       <h1>Runtime Semantics: EvaluateGeneratorBody</h1>
       <p>With parameters _functionObject_ and _argumentsList_ (a List).</p>
@@ -20327,16 +20334,6 @@
         <li>It is a Syntax Error if |FormalParameters| Contains |SuperCall| is *true*.</li>
         <li>It is a Syntax Error if |AsyncGeneratorBody| Contains |SuperCall| is *true*.</li>
       </ul>
-    </emu-clause>
-
-    <emu-clause id="sec-async-generator-function-definitions-static-semantics-computedpropertycontains">
-      <h1>Static Semantics: ComputedPropertyContains</h1>
-      <p>With parameter _symbol_.</p>
-      <emu-see-also-para op="ComputedPropertyContains"></emu-see-also-para>
-      <emu-grammar>AsyncGeneratorMethod : `async` `*` PropertyName `(` UniqueFormalParameters `)` `{` AsyncGeneratorBody `}`</emu-grammar>
-      <emu-alg>
-        1. Return the result of ComputedPropertyContains for |PropertyName| with argument _symbol_.
-      </emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-runtime-semantics-evaluateasyncgeneratorbody" oldids="sec-asyncgenerator-definitions-evaluatebody" type="sdo" aoid="EvaluateAsyncGeneratorBody">
@@ -20540,22 +20537,6 @@
       <emu-note>
         <p>Early Error rules ensure that there is only one method definition named *"constructor"* and that it is not an accessor property or generator definition.</p>
       </emu-note>
-    </emu-clause>
-
-    <emu-clause id="sec-class-definitions-static-semantics-computedpropertycontains">
-      <h1>Static Semantics: ComputedPropertyContains</h1>
-      <p>With parameter _symbol_.</p>
-      <emu-see-also-para op="ComputedPropertyContains"></emu-see-also-para>
-      <emu-grammar>ClassElementList : ClassElementList ClassElement</emu-grammar>
-      <emu-alg>
-        1. Let _inList_ be ComputedPropertyContains of |ClassElementList| with argument _symbol_.
-        1. If _inList_ is *true*, return *true*.
-        1. Return the result of ComputedPropertyContains for |ClassElement| with argument _symbol_.
-      </emu-alg>
-      <emu-grammar>ClassElement : `;`</emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-static-semantics-isstatic" type="sdo" aoid="IsStatic">
@@ -20801,17 +20782,6 @@
         <li>It is a Syntax Error if |FormalParameters| Contains |SuperCall| is *true*.</li>
         <li>It is a Syntax Error if |AsyncFunctionBody| Contains |SuperCall| is *true*.</li>
       </ul>
-    </emu-clause>
-
-    <emu-clause id="sec-async-function-definitions-static-semantics-ComputedPropertyContains">
-      <h1>Static Semantics: ComputedPropertyContains</h1>
-      <p>With parameter _symbol_.</p>
-      <emu-grammar>
-        AsyncMethod : `async` PropertyName `(` UniqueFormalParameters `)` `{` AsyncFunctionBody `}`
-      </emu-grammar>
-      <emu-alg>
-        1. Return the result of ComputedPropertyContains for |PropertyName| with argument _symbol_.
-      </emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-runtime-semantics-instantiateasyncfunctionobject" oldids="sec-async-function-definitions-InstantiateFunctionObject" type="sdo" aoid="InstantiateAsyncFunctionObject">

--- a/spec.html
+++ b/spec.html
@@ -7541,6 +7541,177 @@
         </emu-alg>
       </emu-clause>
     </emu-clause>
+
+    <emu-clause id="sec-runtime-semantics-iteratorbindinginitialization" oldids="sec-destructuring-binding-patterns-runtime-semantics-iteratorbindinginitialization,sec-function-definitions-runtime-semantics-iteratorbindinginitialization,sec-arrow-function-definitions-runtime-semantics-iteratorbindinginitialization,sec-async-arrow-function-definitions-IteratorBindingInitialization" type="sdo" aoid="IteratorBindingInitialization">
+      <h1>Runtime Semantics: IteratorBindingInitialization</h1>
+      <p>With parameters _iteratorRecord_ and _environment_.</p>
+      <emu-note>
+        <p>When *undefined* is passed for _environment_ it indicates that a PutValue operation should be used to assign the initialization value. This is the case for formal parameter lists of non-strict functions. In that case the formal parameter bindings are preinitialized in order to deal with the possibility of multiple parameters with the same name.</p>
+      </emu-note>
+      <emu-grammar>ArrayBindingPattern : `[` `]`</emu-grammar>
+      <emu-alg>
+        1. Return NormalCompletion(~empty~).
+      </emu-alg>
+      <emu-grammar>ArrayBindingPattern : `[` Elision `]`</emu-grammar>
+      <emu-alg>
+        1. Return the result of performing IteratorDestructuringAssignmentEvaluation of |Elision| with _iteratorRecord_ as the argument.
+      </emu-alg>
+      <emu-grammar>ArrayBindingPattern : `[` Elision? BindingRestElement `]`</emu-grammar>
+      <emu-alg>
+        1. If |Elision| is present, then
+          1. Perform ? IteratorDestructuringAssignmentEvaluation of |Elision| with _iteratorRecord_ as the argument.
+        1. Return the result of performing IteratorBindingInitialization for |BindingRestElement| with _iteratorRecord_ and _environment_ as arguments.
+      </emu-alg>
+      <emu-grammar>ArrayBindingPattern : `[` BindingElementList `,` Elision `]`</emu-grammar>
+      <emu-alg>
+        1. Perform ? IteratorBindingInitialization for |BindingElementList| with _iteratorRecord_ and _environment_ as arguments.
+        1. Return the result of performing IteratorDestructuringAssignmentEvaluation of |Elision| with _iteratorRecord_ as the argument.
+      </emu-alg>
+      <emu-grammar>ArrayBindingPattern : `[` BindingElementList `,` Elision? BindingRestElement `]`</emu-grammar>
+      <emu-alg>
+        1. Perform ? IteratorBindingInitialization for |BindingElementList| with _iteratorRecord_ and _environment_ as arguments.
+        1. If |Elision| is present, then
+          1. Perform ? IteratorDestructuringAssignmentEvaluation of |Elision| with _iteratorRecord_ as the argument.
+        1. Return the result of performing IteratorBindingInitialization for |BindingRestElement| with _iteratorRecord_ and _environment_ as arguments.
+      </emu-alg>
+      <emu-grammar>BindingElementList : BindingElementList `,` BindingElisionElement</emu-grammar>
+      <emu-alg>
+        1. Perform ? IteratorBindingInitialization for |BindingElementList| with _iteratorRecord_ and _environment_ as arguments.
+        1. Return the result of performing IteratorBindingInitialization for |BindingElisionElement| using _iteratorRecord_ and _environment_ as arguments.
+      </emu-alg>
+      <emu-grammar>BindingElisionElement : Elision BindingElement</emu-grammar>
+      <emu-alg>
+        1. Perform ? IteratorDestructuringAssignmentEvaluation of |Elision| with _iteratorRecord_ as the argument.
+        1. Return the result of performing IteratorBindingInitialization of |BindingElement| with _iteratorRecord_ and _environment_ as the arguments.
+      </emu-alg>
+      <emu-grammar>SingleNameBinding : BindingIdentifier Initializer?</emu-grammar>
+      <emu-alg>
+        1. Let _bindingId_ be StringValue of |BindingIdentifier|.
+        1. Let _lhs_ be ? ResolveBinding(_bindingId_, _environment_).
+        1. If _iteratorRecord_.[[Done]] is *false*, then
+          1. Let _next_ be IteratorStep(_iteratorRecord_).
+          1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
+          1. ReturnIfAbrupt(_next_).
+          1. If _next_ is *false*, set _iteratorRecord_.[[Done]] to *true*.
+          1. Else,
+            1. Let _v_ be IteratorValue(_next_).
+            1. If _v_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
+            1. ReturnIfAbrupt(_v_).
+        1. If _iteratorRecord_.[[Done]] is *true*, let _v_ be *undefined*.
+        1. If |Initializer| is present and _v_ is *undefined*, then
+          1. If IsAnonymousFunctionDefinition(|Initializer|) is *true*, then
+            1. Set _v_ to the result of performing NamedEvaluation for |Initializer| with argument _bindingId_.
+          1. Else,
+            1. Let _defaultValue_ be the result of evaluating |Initializer|.
+            1. Set _v_ to ? GetValue(_defaultValue_).
+        1. If _environment_ is *undefined*, return ? PutValue(_lhs_, _v_).
+        1. Return InitializeReferencedBinding(_lhs_, _v_).
+      </emu-alg>
+      <emu-grammar>BindingElement : BindingPattern Initializer?</emu-grammar>
+      <emu-alg>
+        1. If _iteratorRecord_.[[Done]] is *false*, then
+          1. Let _next_ be IteratorStep(_iteratorRecord_).
+          1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
+          1. ReturnIfAbrupt(_next_).
+          1. If _next_ is *false*, set _iteratorRecord_.[[Done]] to *true*.
+          1. Else,
+            1. Let _v_ be IteratorValue(_next_).
+            1. If _v_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
+            1. ReturnIfAbrupt(_v_).
+        1. If _iteratorRecord_.[[Done]] is *true*, let _v_ be *undefined*.
+        1. If |Initializer| is present and _v_ is *undefined*, then
+          1. Let _defaultValue_ be the result of evaluating |Initializer|.
+          1. Set _v_ to ? GetValue(_defaultValue_).
+        1. Return the result of performing BindingInitialization of |BindingPattern| with _v_ and _environment_ as the arguments.
+      </emu-alg>
+      <emu-grammar>BindingRestElement : `...` BindingIdentifier</emu-grammar>
+      <emu-alg>
+        1. Let _lhs_ be ? ResolveBinding(StringValue of |BindingIdentifier|, _environment_).
+        1. Let _A_ be ! ArrayCreate(0).
+        1. Let _n_ be 0.
+        1. Repeat,
+          1. If _iteratorRecord_.[[Done]] is *false*, then
+            1. Let _next_ be IteratorStep(_iteratorRecord_).
+            1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
+            1. ReturnIfAbrupt(_next_).
+            1. If _next_ is *false*, set _iteratorRecord_.[[Done]] to *true*.
+          1. If _iteratorRecord_.[[Done]] is *true*, then
+            1. If _environment_ is *undefined*, return ? PutValue(_lhs_, _A_).
+            1. Return InitializeReferencedBinding(_lhs_, _A_).
+          1. Let _nextValue_ be IteratorValue(_next_).
+          1. If _nextValue_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
+          1. ReturnIfAbrupt(_nextValue_).
+          1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_n_)), _nextValue_).
+          1. Set _n_ to _n_ + 1.
+      </emu-alg>
+      <emu-grammar>BindingRestElement : `...` BindingPattern</emu-grammar>
+      <emu-alg>
+        1. Let _A_ be ! ArrayCreate(0).
+        1. Let _n_ be 0.
+        1. Repeat,
+          1. If _iteratorRecord_.[[Done]] is *false*, then
+            1. Let _next_ be IteratorStep(_iteratorRecord_).
+            1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
+            1. ReturnIfAbrupt(_next_).
+            1. If _next_ is *false*, set _iteratorRecord_.[[Done]] to *true*.
+          1. If _iteratorRecord_.[[Done]] is *true*, then
+            1. Return the result of performing BindingInitialization of |BindingPattern| with _A_ and _environment_ as the arguments.
+          1. Let _nextValue_ be IteratorValue(_next_).
+          1. If _nextValue_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
+          1. ReturnIfAbrupt(_nextValue_).
+          1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_n_)), _nextValue_).
+          1. Set _n_ to _n_ + 1.
+      </emu-alg>
+      <emu-grammar>FormalParameters : [empty]</emu-grammar>
+      <emu-alg>
+        1. Return NormalCompletion(~empty~).
+      </emu-alg>
+      <emu-grammar>FormalParameters : FormalParameterList `,` FunctionRestParameter</emu-grammar>
+      <emu-alg>
+        1. Perform ? IteratorBindingInitialization for |FormalParameterList| using _iteratorRecord_ and _environment_ as the arguments.
+        1. Return the result of performing IteratorBindingInitialization for |FunctionRestParameter| using _iteratorRecord_ and _environment_ as the arguments.
+      </emu-alg>
+      <emu-grammar>FormalParameterList : FormalParameterList `,` FormalParameter</emu-grammar>
+      <emu-alg>
+        1. Perform ? IteratorBindingInitialization for |FormalParameterList| using _iteratorRecord_ and _environment_ as the arguments.
+        1. Return the result of performing IteratorBindingInitialization for |FormalParameter| using _iteratorRecord_ and _environment_ as the arguments.
+      </emu-alg>
+      <emu-grammar>ArrowParameters : BindingIdentifier</emu-grammar>
+      <emu-alg>
+        1. Assert: _iteratorRecord_.[[Done]] is *false*.
+        1. Let _next_ be IteratorStep(_iteratorRecord_).
+        1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
+        1. ReturnIfAbrupt(_next_).
+        1. If _next_ is *false*, set _iteratorRecord_.[[Done]] to *true*.
+        1. Else,
+          1. Let _v_ be IteratorValue(_next_).
+          1. If _v_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
+          1. ReturnIfAbrupt(_v_).
+        1. If _iteratorRecord_.[[Done]] is *true*, let _v_ be *undefined*.
+        1. Return the result of performing BindingInitialization for |BindingIdentifier| using _v_ and _environment_ as the arguments.
+      </emu-alg>
+      <emu-grammar>ArrowParameters : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
+      <emu-alg>
+        1. Let _formals_ be CoveredFormalsList of |CoverParenthesizedExpressionAndArrowParameterList|.
+        1. Return IteratorBindingInitialization of _formals_ with arguments _iteratorRecord_ and _environment_.
+      </emu-alg>
+      <emu-grammar>
+        AsyncArrowBindingIdentifier : BindingIdentifier
+      </emu-grammar>
+      <emu-alg>
+        1. Assert: _iteratorRecord_.[[Done]] is *false*.
+        1. Let _next_ be IteratorStep(_iteratorRecord_).
+        1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
+        1. ReturnIfAbrupt(_next_).
+        1. If _next_ is *false*, set _iteratorRecord_.[[Done]] to *true*.
+        1. Else,
+          1. Let _v_ be IteratorValue(_next_).
+          1. If _v_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
+          1. ReturnIfAbrupt(_v_).
+        1. If _iteratorRecord_.[[Done]] is *true*, let _v_ be *undefined*.
+        1. Return the result of performing BindingInitialization for |BindingIdentifier| using _v_ and _environment_ as the arguments.
+      </emu-alg>
+    </emu-clause>
   </emu-clause>
 </emu-clause>
 
@@ -17880,129 +18051,6 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-destructuring-binding-patterns-runtime-semantics-iteratorbindinginitialization">
-        <h1>Runtime Semantics: IteratorBindingInitialization</h1>
-        <p>With parameters _iteratorRecord_ and _environment_.</p>
-        <emu-see-also-para op="IteratorBindingInitialization"></emu-see-also-para>
-        <emu-note>
-          <p>When *undefined* is passed for _environment_ it indicates that a PutValue operation should be used to assign the initialization value. This is the case for formal parameter lists of non-strict functions. In that case the formal parameter bindings are preinitialized in order to deal with the possibility of multiple parameters with the same name.</p>
-        </emu-note>
-        <emu-grammar>ArrayBindingPattern : `[` `]`</emu-grammar>
-        <emu-alg>
-          1. Return NormalCompletion(~empty~).
-        </emu-alg>
-        <emu-grammar>ArrayBindingPattern : `[` Elision `]`</emu-grammar>
-        <emu-alg>
-          1. Return the result of performing IteratorDestructuringAssignmentEvaluation of |Elision| with _iteratorRecord_ as the argument.
-        </emu-alg>
-        <emu-grammar>ArrayBindingPattern : `[` Elision? BindingRestElement `]`</emu-grammar>
-        <emu-alg>
-          1. If |Elision| is present, then
-            1. Perform ? IteratorDestructuringAssignmentEvaluation of |Elision| with _iteratorRecord_ as the argument.
-          1. Return the result of performing IteratorBindingInitialization for |BindingRestElement| with _iteratorRecord_ and _environment_ as arguments.
-        </emu-alg>
-        <emu-grammar>ArrayBindingPattern : `[` BindingElementList `,` Elision `]`</emu-grammar>
-        <emu-alg>
-          1. Perform ? IteratorBindingInitialization for |BindingElementList| with _iteratorRecord_ and _environment_ as arguments.
-          1. Return the result of performing IteratorDestructuringAssignmentEvaluation of |Elision| with _iteratorRecord_ as the argument.
-        </emu-alg>
-        <emu-grammar>ArrayBindingPattern : `[` BindingElementList `,` Elision? BindingRestElement `]`</emu-grammar>
-        <emu-alg>
-          1. Perform ? IteratorBindingInitialization for |BindingElementList| with _iteratorRecord_ and _environment_ as arguments.
-          1. If |Elision| is present, then
-            1. Perform ? IteratorDestructuringAssignmentEvaluation of |Elision| with _iteratorRecord_ as the argument.
-          1. Return the result of performing IteratorBindingInitialization for |BindingRestElement| with _iteratorRecord_ and _environment_ as arguments.
-        </emu-alg>
-        <emu-grammar>BindingElementList : BindingElementList `,` BindingElisionElement</emu-grammar>
-        <emu-alg>
-          1. Perform ? IteratorBindingInitialization for |BindingElementList| with _iteratorRecord_ and _environment_ as arguments.
-          1. Return the result of performing IteratorBindingInitialization for |BindingElisionElement| using _iteratorRecord_ and _environment_ as arguments.
-        </emu-alg>
-        <emu-grammar>BindingElisionElement : Elision BindingElement</emu-grammar>
-        <emu-alg>
-          1. Perform ? IteratorDestructuringAssignmentEvaluation of |Elision| with _iteratorRecord_ as the argument.
-          1. Return the result of performing IteratorBindingInitialization of |BindingElement| with _iteratorRecord_ and _environment_ as the arguments.
-        </emu-alg>
-        <emu-grammar>SingleNameBinding : BindingIdentifier Initializer?</emu-grammar>
-        <emu-alg>
-          1. Let _bindingId_ be StringValue of |BindingIdentifier|.
-          1. Let _lhs_ be ? ResolveBinding(_bindingId_, _environment_).
-          1. If _iteratorRecord_.[[Done]] is *false*, then
-            1. Let _next_ be IteratorStep(_iteratorRecord_).
-            1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
-            1. ReturnIfAbrupt(_next_).
-            1. If _next_ is *false*, set _iteratorRecord_.[[Done]] to *true*.
-            1. Else,
-              1. Let _v_ be IteratorValue(_next_).
-              1. If _v_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
-              1. ReturnIfAbrupt(_v_).
-          1. If _iteratorRecord_.[[Done]] is *true*, let _v_ be *undefined*.
-          1. If |Initializer| is present and _v_ is *undefined*, then
-            1. If IsAnonymousFunctionDefinition(|Initializer|) is *true*, then
-              1. Set _v_ to the result of performing NamedEvaluation for |Initializer| with argument _bindingId_.
-            1. Else,
-              1. Let _defaultValue_ be the result of evaluating |Initializer|.
-              1. Set _v_ to ? GetValue(_defaultValue_).
-          1. If _environment_ is *undefined*, return ? PutValue(_lhs_, _v_).
-          1. Return InitializeReferencedBinding(_lhs_, _v_).
-        </emu-alg>
-        <emu-grammar>BindingElement : BindingPattern Initializer?</emu-grammar>
-        <emu-alg>
-          1. If _iteratorRecord_.[[Done]] is *false*, then
-            1. Let _next_ be IteratorStep(_iteratorRecord_).
-            1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
-            1. ReturnIfAbrupt(_next_).
-            1. If _next_ is *false*, set _iteratorRecord_.[[Done]] to *true*.
-            1. Else,
-              1. Let _v_ be IteratorValue(_next_).
-              1. If _v_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
-              1. ReturnIfAbrupt(_v_).
-          1. If _iteratorRecord_.[[Done]] is *true*, let _v_ be *undefined*.
-          1. If |Initializer| is present and _v_ is *undefined*, then
-            1. Let _defaultValue_ be the result of evaluating |Initializer|.
-            1. Set _v_ to ? GetValue(_defaultValue_).
-          1. Return the result of performing BindingInitialization of |BindingPattern| with _v_ and _environment_ as the arguments.
-        </emu-alg>
-        <emu-grammar>BindingRestElement : `...` BindingIdentifier</emu-grammar>
-        <emu-alg>
-          1. Let _lhs_ be ? ResolveBinding(StringValue of |BindingIdentifier|, _environment_).
-          1. Let _A_ be ! ArrayCreate(0).
-          1. Let _n_ be 0.
-          1. Repeat,
-            1. If _iteratorRecord_.[[Done]] is *false*, then
-              1. Let _next_ be IteratorStep(_iteratorRecord_).
-              1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
-              1. ReturnIfAbrupt(_next_).
-              1. If _next_ is *false*, set _iteratorRecord_.[[Done]] to *true*.
-            1. If _iteratorRecord_.[[Done]] is *true*, then
-              1. If _environment_ is *undefined*, return ? PutValue(_lhs_, _A_).
-              1. Return InitializeReferencedBinding(_lhs_, _A_).
-            1. Let _nextValue_ be IteratorValue(_next_).
-            1. If _nextValue_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
-            1. ReturnIfAbrupt(_nextValue_).
-            1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_n_)), _nextValue_).
-            1. Set _n_ to _n_ + 1.
-        </emu-alg>
-        <emu-grammar>BindingRestElement : `...` BindingPattern</emu-grammar>
-        <emu-alg>
-          1. Let _A_ be ! ArrayCreate(0).
-          1. Let _n_ be 0.
-          1. Repeat,
-            1. If _iteratorRecord_.[[Done]] is *false*, then
-              1. Let _next_ be IteratorStep(_iteratorRecord_).
-              1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
-              1. ReturnIfAbrupt(_next_).
-              1. If _next_ is *false*, set _iteratorRecord_.[[Done]] to *true*.
-            1. If _iteratorRecord_.[[Done]] is *true*, then
-              1. Return the result of performing BindingInitialization of |BindingPattern| with _A_ and _environment_ as the arguments.
-            1. Let _nextValue_ be IteratorValue(_next_).
-            1. If _nextValue_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
-            1. ReturnIfAbrupt(_nextValue_).
-            1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_n_)), _nextValue_).
-            1. Set _n_ to _n_ + 1.
-        </emu-alg>
-      </emu-clause>
-
       <emu-clause id="sec-runtime-semantics-keyedbindinginitialization">
         <h1>Runtime Semantics: KeyedBindingInitialization</h1>
         <p>With parameters _value_, _environment_, and _propertyName_.</p>
@@ -19719,29 +19767,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-function-definitions-runtime-semantics-iteratorbindinginitialization">
-      <h1>Runtime Semantics: IteratorBindingInitialization</h1>
-      <p>With parameters _iteratorRecord_ and _environment_.</p>
-      <emu-note>
-        <p>When *undefined* is passed for _environment_ it indicates that a PutValue operation should be used to assign the initialization value. This is the case for formal parameter lists of non-strict functions. In that case the formal parameter bindings are preinitialized in order to deal with the possibility of multiple parameters with the same name.</p>
-      </emu-note>
-      <emu-see-also-para op="IteratorBindingInitialization"></emu-see-also-para>
-      <emu-grammar>FormalParameters : [empty]</emu-grammar>
-      <emu-alg>
-        1. Return NormalCompletion(~empty~).
-      </emu-alg>
-      <emu-grammar>FormalParameters : FormalParameterList `,` FunctionRestParameter</emu-grammar>
-      <emu-alg>
-        1. Perform ? IteratorBindingInitialization for |FormalParameterList| using _iteratorRecord_ and _environment_ as the arguments.
-        1. Return the result of performing IteratorBindingInitialization for |FunctionRestParameter| using _iteratorRecord_ and _environment_ as the arguments.
-      </emu-alg>
-      <emu-grammar>FormalParameterList : FormalParameterList `,` FormalParameter</emu-grammar>
-      <emu-alg>
-        1. Perform ? IteratorBindingInitialization for |FormalParameterList| using _iteratorRecord_ and _environment_ as the arguments.
-        1. Return the result of performing IteratorBindingInitialization for |FormalParameter| using _iteratorRecord_ and _environment_ as the arguments.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-runtime-semantics-instantiateordinaryfunctionobject" oldids="sec-function-definitions-runtime-semantics-instantiatefunctionobject" type="sdo" aoid="InstantiateOrdinaryFunctionObject">
       <h1>Runtime Semantics: InstantiateOrdinaryFunctionObject</h1>
       <p>With parameter _scope_.</p>
@@ -19940,34 +19965,6 @@
       </emu-grammar>
       <emu-alg>
         1. Return the |ArrowFormalParameters| that is covered by |CoverParenthesizedExpressionAndArrowParameterList|.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-arrow-function-definitions-runtime-semantics-iteratorbindinginitialization">
-      <h1>Runtime Semantics: IteratorBindingInitialization</h1>
-      <p>With parameters _iteratorRecord_ and _environment_.</p>
-      <emu-see-also-para op="IteratorBindingInitialization"></emu-see-also-para>
-      <emu-note>
-        <p>When *undefined* is passed for _environment_ it indicates that a PutValue operation should be used to assign the initialization value. This is the case for formal parameter lists of non-strict functions. In that case the formal parameter bindings are preinitialized in order to deal with the possibility of multiple parameters with the same name.</p>
-      </emu-note>
-      <emu-grammar>ArrowParameters : BindingIdentifier</emu-grammar>
-      <emu-alg>
-        1. Assert: _iteratorRecord_.[[Done]] is *false*.
-        1. Let _next_ be IteratorStep(_iteratorRecord_).
-        1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
-        1. ReturnIfAbrupt(_next_).
-        1. If _next_ is *false*, set _iteratorRecord_.[[Done]] to *true*.
-        1. Else,
-          1. Let _v_ be IteratorValue(_next_).
-          1. If _v_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
-          1. ReturnIfAbrupt(_v_).
-        1. If _iteratorRecord_.[[Done]] is *true*, let _v_ be *undefined*.
-        1. Return the result of performing BindingInitialization for |BindingIdentifier| using _v_ and _environment_ as the arguments.
-      </emu-alg>
-      <emu-grammar>ArrowParameters : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
-      <emu-alg>
-        1. Let _formals_ be CoveredFormalsList of |CoverParenthesizedExpressionAndArrowParameterList|.
-        1. Return IteratorBindingInitialization of _formals_ with arguments _iteratorRecord_ and _environment_.
       </emu-alg>
     </emu-clause>
 
@@ -21452,27 +21449,6 @@
       </emu-grammar>
       <emu-alg>
         1. Return *false*.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-async-arrow-function-definitions-IteratorBindingInitialization">
-      <h1>Runtime Semantics: IteratorBindingInitialization</h1>
-      <p>With parameters _iteratorRecord_ and _environment_.</p>
-      <emu-grammar>
-        AsyncArrowBindingIdentifier : BindingIdentifier
-      </emu-grammar>
-      <emu-alg>
-        1. Assert: _iteratorRecord_.[[Done]] is *false*.
-        1. Let _next_ be IteratorStep(_iteratorRecord_).
-        1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
-        1. ReturnIfAbrupt(_next_).
-        1. If _next_ is *false*, set _iteratorRecord_.[[Done]] to *true*.
-        1. Else,
-          1. Let _v_ be IteratorValue(_next_).
-          1. If _v_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
-          1. ReturnIfAbrupt(_v_).
-        1. If _iteratorRecord_.[[Done]] is *true*, let _v_ be *undefined*.
-        1. Return the result of performing BindingInitialization for |BindingIdentifier| using _v_ and _environment_ as the arguments.
       </emu-alg>
     </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -19131,6 +19131,9 @@
       <emu-alg>
         1. Return the result of evaluating |Statement|.
       </emu-alg>
+      <emu-note>
+        <p>The only two productions of |Statement| which have special semantics for LabelledEvaluation are |BreakableStatement| and |LabelledStatement|.</p>
+      </emu-note>
     </emu-clause>
   </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -14377,29 +14377,6 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-semantics-static-semantics-isfunctiondefinition">
-        <h1>Static Semantics: IsFunctionDefinition</h1>
-        <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-        <emu-grammar>
-          PrimaryExpression :
-            `this`
-            IdentifierReference
-            Literal
-            ArrayLiteral
-            ObjectLiteral
-            RegularExpressionLiteral
-            TemplateLiteral
-        </emu-grammar>
-        <emu-alg>
-          1. Return *false*.
-        </emu-alg>
-        <emu-grammar>PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
-        <emu-alg>
-          1. Let _expr_ be CoveredParenthesizedExpression of |CoverParenthesizedExpressionAndArrowParameterList|.
-          1. Return IsFunctionDefinition of _expr_.
-        </emu-alg>
-      </emu-clause>
-
       <emu-clause id="sec-semantics-static-semantics-isidentifierref">
         <h1>Static Semantics: IsIdentifierRef</h1>
         <emu-see-also-para op="IsIdentifierRef"></emu-see-also-para>
@@ -15179,15 +15156,6 @@
         </ul>
       </emu-clause>
 
-      <emu-clause id="sec-grouping-operator-static-semantics-isfunctiondefinition">
-        <h1>Static Semantics: IsFunctionDefinition</h1>
-        <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-        <emu-grammar>ParenthesizedExpression : `(` Expression `)`</emu-grammar>
-        <emu-alg>
-          1. Return IsFunctionDefinition of |Expression|.
-        </emu-alg>
-      </emu-clause>
-
       <emu-clause id="sec-grouping-operator-runtime-semantics-namedevaluation">
         <h1>Runtime Semantics: NamedEvaluation</h1>
         <p>With parameter _name_.</p>
@@ -15385,30 +15353,6 @@
         <emu-grammar>OptionalChain : OptionalChain `.` IdentifierName</emu-grammar>
         <emu-alg>
           1. If |OptionalChain| Contains _symbol_ is *true*, return *true*.
-          1. Return *false*.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-static-semantics-static-semantics-isfunctiondefinition">
-        <h1>Static Semantics: IsFunctionDefinition</h1>
-        <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-        <emu-grammar>
-          MemberExpression :
-            MemberExpression `[` Expression `]`
-            MemberExpression `.` IdentifierName
-            MemberExpression TemplateLiteral
-            SuperProperty
-            MetaProperty
-            `new` MemberExpression Arguments
-
-          NewExpression :
-            `new` NewExpression
-
-          LeftHandSideExpression :
-            CallExpression
-            OptionalExpression
-        </emu-grammar>
-        <emu-alg>
           1. Return *false*.
         </emu-alg>
       </emu-clause>
@@ -15994,21 +15938,6 @@
       </ul>
     </emu-clause>
 
-    <emu-clause id="sec-update-expressions-static-semantics-isfunctiondefinition">
-      <h1>Static Semantics: IsFunctionDefinition</h1>
-      <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-      <emu-grammar>
-        UpdateExpression :
-          LeftHandSideExpression `++`
-          LeftHandSideExpression `--`
-          `++` UnaryExpression
-          `--` UnaryExpression
-      </emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-postfix-increment-operator">
       <h1>Postfix Increment Operator</h1>
 
@@ -16089,25 +16018,6 @@
         `!` UnaryExpression[?Yield, ?Await]
         [+Await] AwaitExpression[?Yield]
     </emu-grammar>
-
-    <emu-clause id="sec-unary-operators-static-semantics-isfunctiondefinition">
-      <h1>Static Semantics: IsFunctionDefinition</h1>
-      <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-      <emu-grammar>
-        UnaryExpression :
-          `delete` UnaryExpression
-          `void` UnaryExpression
-          `typeof` UnaryExpression
-          `+` UnaryExpression
-          `-` UnaryExpression
-          `~` UnaryExpression
-          `!` UnaryExpression
-          AwaitExpression
-      </emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-    </emu-clause>
 
     <emu-clause id="sec-delete-operator">
       <h1>The `delete` Operator</h1>
@@ -16359,18 +16269,6 @@
         UpdateExpression[?Yield, ?Await] `**` ExponentiationExpression[?Yield, ?Await]
     </emu-grammar>
 
-    <emu-clause id="sec-exp-operator-static-semantics-isfunctiondefinition">
-      <h1>Static Semantics: IsFunctionDefinition</h1>
-      <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-      <emu-grammar>
-        ExponentiationExpression :
-          UpdateExpression `**` ExponentiationExpression
-      </emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-exp-operator-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>
@@ -16401,15 +16299,6 @@
       </ul>
     </emu-note>
 
-    <emu-clause id="sec-multiplicative-operators-static-semantics-isfunctiondefinition">
-      <h1>Static Semantics: IsFunctionDefinition</h1>
-      <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-      <emu-grammar>MultiplicativeExpression : MultiplicativeExpression MultiplicativeOperator ExponentiationExpression</emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-multiplicative-operators-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>MultiplicativeExpression : MultiplicativeExpression MultiplicativeOperator ExponentiationExpression</emu-grammar>
@@ -16429,19 +16318,6 @@
         AdditiveExpression[?Yield, ?Await] `+` MultiplicativeExpression[?Yield, ?Await]
         AdditiveExpression[?Yield, ?Await] `-` MultiplicativeExpression[?Yield, ?Await]
     </emu-grammar>
-
-    <emu-clause id="sec-additive-operators-static-semantics-isfunctiondefinition">
-      <h1>Static Semantics: IsFunctionDefinition</h1>
-      <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-      <emu-grammar>
-        AdditiveExpression :
-          AdditiveExpression `+` MultiplicativeExpression
-          AdditiveExpression `-` MultiplicativeExpression
-      </emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-    </emu-clause>
 
     <emu-clause id="sec-addition-operator-plus">
       <h1>The Addition Operator ( `+` )</h1>
@@ -16484,20 +16360,6 @@
         ShiftExpression[?Yield, ?Await] `&gt;&gt;` AdditiveExpression[?Yield, ?Await]
         ShiftExpression[?Yield, ?Await] `&gt;&gt;&gt;` AdditiveExpression[?Yield, ?Await]
     </emu-grammar>
-
-    <emu-clause id="sec-bitwise-shift-operators-static-semantics-isfunctiondefinition">
-      <h1>Static Semantics: IsFunctionDefinition</h1>
-      <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-      <emu-grammar>
-        ShiftExpression :
-          ShiftExpression `&lt;&lt;` AdditiveExpression
-          ShiftExpression `&gt;&gt;` AdditiveExpression
-          ShiftExpression `&gt;&gt;&gt;` AdditiveExpression
-      </emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-    </emu-clause>
 
     <emu-clause id="sec-left-shift-operator">
       <h1>The Left Shift Operator ( `&lt;&lt;` )</h1>
@@ -16564,23 +16426,6 @@
     <emu-note>
       <p>The <sub>[In]</sub> grammar parameter is needed to avoid confusing the `in` operator in a relational expression with the `in` operator in a `for` statement.</p>
     </emu-note>
-
-    <emu-clause id="sec-relational-operators-static-semantics-isfunctiondefinition">
-      <h1>Static Semantics: IsFunctionDefinition</h1>
-      <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-      <emu-grammar>
-        RelationalExpression :
-          RelationalExpression `&lt;` ShiftExpression
-          RelationalExpression `&gt;` ShiftExpression
-          RelationalExpression `&lt;=` ShiftExpression
-          RelationalExpression `&gt;=` ShiftExpression
-          RelationalExpression `instanceof` ShiftExpression
-          RelationalExpression `in` ShiftExpression
-      </emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-    </emu-clause>
 
     <emu-clause id="sec-relational-operators-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
@@ -16674,21 +16519,6 @@
         EqualityExpression[?In, ?Yield, ?Await] `===` RelationalExpression[?In, ?Yield, ?Await]
         EqualityExpression[?In, ?Yield, ?Await] `!==` RelationalExpression[?In, ?Yield, ?Await]
     </emu-grammar>
-
-    <emu-clause id="sec-equality-operators-static-semantics-isfunctiondefinition">
-      <h1>Static Semantics: IsFunctionDefinition</h1>
-      <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-      <emu-grammar>
-        EqualityExpression :
-          EqualityExpression `==` RelationalExpression
-          EqualityExpression `!=` RelationalExpression
-          EqualityExpression `===` RelationalExpression
-          EqualityExpression `!==` RelationalExpression
-      </emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-    </emu-clause>
 
     <emu-clause id="sec-equality-operators-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
@@ -16787,21 +16617,6 @@
         BitwiseORExpression[?In, ?Yield, ?Await] `|` BitwiseXORExpression[?In, ?Yield, ?Await]
     </emu-grammar>
 
-    <emu-clause id="sec-binary-bitwise-operators-static-semantics-isfunctiondefinition">
-      <h1>Static Semantics: IsFunctionDefinition</h1>
-      <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-      <emu-grammar>
-        BitwiseANDExpression : BitwiseANDExpression `&amp;` EqualityExpression
-
-        BitwiseXORExpression : BitwiseXORExpression `^` BitwiseANDExpression
-
-        BitwiseORExpression : BitwiseORExpression `|` BitwiseXORExpression
-      </emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-binary-bitwise-operators-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>BitwiseANDExpression : BitwiseANDExpression `&amp;` EqualityExpression</emu-grammar>
@@ -16846,21 +16661,6 @@
       <p>The value produced by a `&amp;&amp;` or `||` operator is not necessarily of type Boolean. The value produced will always be the value of one of the two operand expressions.</p>
     </emu-note>
 
-    <emu-clause id="sec-binary-logical-operators-static-semantics-isfunctiondefinition">
-      <h1>Static Semantics: IsFunctionDefinition</h1>
-      <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-      <emu-grammar>
-        LogicalANDExpression : LogicalANDExpression `&amp;&amp;` BitwiseORExpression
-
-        LogicalORExpression : LogicalORExpression `||` LogicalANDExpression
-
-        CoalesceExpression : CoalesceExpressionHead `??` BitwiseORExpression
-      </emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-binary-logical-operators-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>LogicalANDExpression : LogicalANDExpression `&amp;&amp;` BitwiseORExpression</emu-grammar>
@@ -16904,15 +16704,6 @@
     <emu-note>
       <p>The grammar for a |ConditionalExpression| in ECMAScript is slightly different from that in C and Java, which each allow the second subexpression to be an |Expression| but restrict the third expression to be a |ConditionalExpression|. The motivation for this difference in ECMAScript is to allow an assignment expression to be governed by either arm of a conditional and to eliminate the confusing and fairly useless case of a comma expression as the centre expression.</p>
     </emu-note>
-
-    <emu-clause id="sec-conditional-operator-static-semantics-isfunctiondefinition">
-      <h1>Static Semantics: IsFunctionDefinition</h1>
-      <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-      <emu-grammar>ConditionalExpression : ShortCircuitExpression `?` AssignmentExpression `:` AssignmentExpression</emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-    </emu-clause>
 
     <emu-clause id="sec-conditional-operator-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
@@ -16979,31 +16770,6 @@
           It is a Syntax Error if AssignmentTargetType of |LeftHandSideExpression| is not ~simple~.
         </li>
       </ul>
-    </emu-clause>
-
-    <emu-clause id="sec-assignment-operators-static-semantics-isfunctiondefinition">
-      <h1>Static Semantics: IsFunctionDefinition</h1>
-      <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-      <emu-grammar>
-        AssignmentExpression :
-          ArrowFunction
-          AsyncArrowFunction
-      </emu-grammar>
-      <emu-alg>
-        1. Return *true*.
-      </emu-alg>
-      <emu-grammar>
-        AssignmentExpression :
-          YieldExpression
-          LeftHandSideExpression `=` AssignmentExpression
-          LeftHandSideExpression AssignmentOperator AssignmentExpression
-          LeftHandSideExpression `&amp;&amp;=` AssignmentExpression
-          LeftHandSideExpression `||=` AssignmentExpression
-          LeftHandSideExpression `??=` AssignmentExpression
-      </emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-assignment-operators-runtime-semantics-evaluation">
@@ -17508,15 +17274,6 @@
         AssignmentExpression[?In, ?Yield, ?Await]
         Expression[?In, ?Yield, ?Await] `,` AssignmentExpression[?In, ?Yield, ?Await]
     </emu-grammar>
-
-    <emu-clause id="sec-comma-operator-static-semantics-isfunctiondefinition">
-      <h1>Static Semantics: IsFunctionDefinition</h1>
-      <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-      <emu-grammar>Expression : Expression `,` AssignmentExpression</emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-    </emu-clause>
 
     <emu-clause id="sec-comma-operator-runtime-semantics-evaluation">
       <h1>Runtime Semantics: Evaluation</h1>
@@ -19656,6 +19413,148 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-static-semantics-isfunctiondefinition" oldids="sec-semantics-static-semantics-isfunctiondefinition,sec-grouping-operator-static-semantics-isfunctiondefinition,sec-static-semantics-static-semantics-isfunctiondefinition,sec-update-expressions-static-semantics-isfunctiondefinition,sec-unary-operators-static-semantics-isfunctiondefinition,sec-exp-operator-static-semantics-isfunctiondefinition,sec-multiplicative-operators-static-semantics-isfunctiondefinition,sec-additive-operators-static-semantics-isfunctiondefinition,sec-bitwise-shift-operators-static-semantics-isfunctiondefinition,sec-relational-operators-static-semantics-isfunctiondefinition,sec-equality-operators-static-semantics-isfunctiondefinition,sec-binary-bitwise-operators-static-semantics-isfunctiondefinition,sec-binary-logical-operators-static-semantics-isfunctiondefinition,sec-conditional-operator-static-semantics-isfunctiondefinition,sec-assignment-operators-static-semantics-isfunctiondefinition,sec-comma-operator-static-semantics-isfunctiondefinition,sec-function-definitions-static-semantics-isfunctiondefinition,sec-generator-function-definitions-static-semantics-isfunctiondefinition,sec-async-generator-function-definitions-static-semantics-isfunctiondefinition,sec-class-definitions-static-semantics-isfunctiondefinition,sec-async-function-definitions-static-semantics-IsFunctionDefinition" type="sdo" aoid="IsFunctionDefinition">
+      <h1>Static Semantics: IsFunctionDefinition</h1>
+      <emu-grammar>PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
+      <emu-alg>
+        1. Let _expr_ be CoveredParenthesizedExpression of |CoverParenthesizedExpressionAndArrowParameterList|.
+        1. Return IsFunctionDefinition of _expr_.
+      </emu-alg>
+      <emu-grammar>ParenthesizedExpression : `(` Expression `)`</emu-grammar>
+      <emu-alg>
+        1. Return IsFunctionDefinition of |Expression|.
+      </emu-alg>
+      <emu-grammar>
+        PrimaryExpression :
+          `this`
+          IdentifierReference
+          Literal
+          ArrayLiteral
+          ObjectLiteral
+          RegularExpressionLiteral
+          TemplateLiteral
+
+        MemberExpression :
+          MemberExpression `[` Expression `]`
+          MemberExpression `.` IdentifierName
+          MemberExpression TemplateLiteral
+          SuperProperty
+          MetaProperty
+          `new` MemberExpression Arguments
+
+        NewExpression :
+          `new` NewExpression
+
+        LeftHandSideExpression :
+          CallExpression
+          OptionalExpression
+
+        UpdateExpression :
+          LeftHandSideExpression `++`
+          LeftHandSideExpression `--`
+          `++` UnaryExpression
+          `--` UnaryExpression
+
+        UnaryExpression :
+          `delete` UnaryExpression
+          `void` UnaryExpression
+          `typeof` UnaryExpression
+          `+` UnaryExpression
+          `-` UnaryExpression
+          `~` UnaryExpression
+          `!` UnaryExpression
+          AwaitExpression
+
+        ExponentiationExpression :
+          UpdateExpression `**` ExponentiationExpression
+
+        MultiplicativeExpression :
+          MultiplicativeExpression MultiplicativeOperator ExponentiationExpression
+
+        AdditiveExpression :
+          AdditiveExpression `+` MultiplicativeExpression
+          AdditiveExpression `-` MultiplicativeExpression
+
+        ShiftExpression :
+          ShiftExpression `&lt;&lt;` AdditiveExpression
+          ShiftExpression `&gt;&gt;` AdditiveExpression
+          ShiftExpression `&gt;&gt;&gt;` AdditiveExpression
+
+        RelationalExpression :
+          RelationalExpression `&lt;` ShiftExpression
+          RelationalExpression `&gt;` ShiftExpression
+          RelationalExpression `&lt;=` ShiftExpression
+          RelationalExpression `&gt;=` ShiftExpression
+          RelationalExpression `instanceof` ShiftExpression
+          RelationalExpression `in` ShiftExpression
+
+        EqualityExpression :
+          EqualityExpression `==` RelationalExpression
+          EqualityExpression `!=` RelationalExpression
+          EqualityExpression `===` RelationalExpression
+          EqualityExpression `!==` RelationalExpression
+
+        BitwiseANDExpression :
+          BitwiseANDExpression `&amp;` EqualityExpression
+
+        BitwiseXORExpression :
+          BitwiseXORExpression `^` BitwiseANDExpression
+
+        BitwiseORExpression :
+          BitwiseORExpression `|` BitwiseXORExpression
+
+        LogicalANDExpression :
+          LogicalANDExpression `&amp;&amp;` BitwiseORExpression
+
+        LogicalORExpression :
+          LogicalORExpression `||` LogicalANDExpression
+
+        CoalesceExpression :
+          CoalesceExpressionHead `??` BitwiseORExpression
+
+        ConditionalExpression :
+          ShortCircuitExpression `?` AssignmentExpression `:` AssignmentExpression
+
+        AssignmentExpression :
+          YieldExpression
+          LeftHandSideExpression `=` AssignmentExpression
+          LeftHandSideExpression AssignmentOperator AssignmentExpression
+          LeftHandSideExpression `&amp;&amp;=` AssignmentExpression
+          LeftHandSideExpression `||=` AssignmentExpression
+          LeftHandSideExpression `??=` AssignmentExpression
+
+        Expression :
+          Expression `,` AssignmentExpression
+      </emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>
+        AssignmentExpression :
+          ArrowFunction
+          AsyncArrowFunction
+
+        FunctionExpression :
+          `function` BindingIdentifier? `(` FormalParameters `)` `{` FunctionBody `}`
+
+        GeneratorExpression :
+          `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` GeneratorBody `}`
+
+        AsyncGeneratorExpression :
+          `async` `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+
+        AsyncFunctionExpression :
+          `async` `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
+          `async` `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
+
+        ClassExpression :
+          `class` BindingIdentifier? ClassTail
+      </emu-grammar>
+      <emu-alg>
+        1. Return *true*.
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-isanonymousfunctiondefinition" aoid="IsAnonymousFunctionDefinition">
       <h1>Static Semantics: IsAnonymousFunctionDefinition ( _expr_ )</h1>
       <p>The abstract operation IsAnonymousFunctionDefinition takes argument _expr_ (a Parse Node for |AssignmentExpression| or a Parse Node for |Initializer|). It determines if its argument is a function definition that does not bind a name. It performs the following steps when called:</p>
@@ -19663,15 +19562,6 @@
         1. If IsFunctionDefinition of _expr_ is *false*, return *false*.
         1. Let _hasName_ be HasName of _expr_.
         1. If _hasName_ is *true*, return *false*.
-        1. Return *true*.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-function-definitions-static-semantics-isfunctiondefinition">
-      <h1>Static Semantics: IsFunctionDefinition</h1>
-      <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-      <emu-grammar>FunctionExpression : `function` BindingIdentifier? `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
-      <emu-alg>
         1. Return *true*.
       </emu-alg>
     </emu-clause>
@@ -20241,15 +20131,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-generator-function-definitions-static-semantics-isfunctiondefinition">
-      <h1>Static Semantics: IsFunctionDefinition</h1>
-      <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-      <emu-grammar>GeneratorExpression : `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
-      <emu-alg>
-        1. Return *true*.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-runtime-semantics-evaluategeneratorbody" oldids="sec-generator-function-definitions-runtime-semantics-evaluatebody" type="sdo" aoid="EvaluateGeneratorBody">
       <h1>Runtime Semantics: EvaluateGeneratorBody</h1>
       <p>With parameters _functionObject_ and _argumentsList_ (a List).</p>
@@ -20488,15 +20369,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-async-generator-function-definitions-static-semantics-isfunctiondefinition">
-      <h1>Static Semantics: IsFunctionDefinition</h1>
-      <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-      <emu-grammar>AsyncGeneratorExpression : `async` `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` AsyncGeneratorBody `}`</emu-grammar>
-      <emu-alg>
-        1. Return *true*.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-runtime-semantics-evaluateasyncgeneratorbody" oldids="sec-asyncgenerator-definitions-evaluatebody" type="sdo" aoid="EvaluateAsyncGeneratorBody">
       <h1>Runtime Semantics: EvaluateAsyncGeneratorBody</h1>
       <p>With parameters _functionObject_ and _argumentsList_ (a List).</p>
@@ -20731,15 +20603,6 @@
       <emu-grammar>ClassElement : `;`</emu-grammar>
       <emu-alg>
         1. Return *false*.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-class-definitions-static-semantics-isfunctiondefinition">
-      <h1>Static Semantics: IsFunctionDefinition</h1>
-      <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
-      <emu-grammar>ClassExpression : `class` BindingIdentifier? ClassTail</emu-grammar>
-      <emu-alg>
-        1. Return *true*.
       </emu-alg>
     </emu-clause>
 
@@ -21027,18 +20890,6 @@
       <emu-alg>
         1. If |UniqueFormalParameters| Contains |SuperCall| is *true*, return *true*.
         1. Return |AsyncFunctionBody| Contains |SuperCall|.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-async-function-definitions-static-semantics-IsFunctionDefinition">
-      <h1>Static Semantics: IsFunctionDefinition</h1>
-      <emu-grammar>
-        AsyncFunctionExpression : `async` `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
-
-        AsyncFunctionExpression : `async` `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
-      </emu-grammar>
-      <emu-alg>
-        1. Return *true*.
       </emu-alg>
     </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -6921,6 +6921,43 @@
   <emu-clause id="sec-syntax-directed-operations-miscellaneous">
     <h1>Miscellaneous</h1>
     <p>These operations are used in multiple places throughout the specification.</p>
+
+    <emu-clause id="sec-runtime-semantics-instantiatefunctionobject" type="sdo" aoid="InstantiateFunctionObject">
+      <h1>Runtime Semantics: InstantiateFunctionObject</h1>
+      <p>With parameter _scope_.</p>
+      <emu-grammar>
+        FunctionDeclaration :
+          `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`
+          `function` `(` FormalParameters `)` `{` FunctionBody `}`
+      </emu-grammar>
+      <emu-alg>
+        1. Return ? InstantiateOrdinaryFunctionObject of |FunctionDeclaration| with argument _scope_.
+      </emu-alg>
+      <emu-grammar>
+        GeneratorDeclaration :
+          `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`
+          `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`
+      </emu-grammar>
+      <emu-alg>
+        1. Return ? InstantiateGeneratorFunctionObject of |GeneratorDeclaration| with argument _scope_.
+      </emu-alg>
+      <emu-grammar>
+        AsyncGeneratorDeclaration :
+          `async` `function` `*` BindingIdentifier `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+          `async` `function` `*` `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+      </emu-grammar>
+      <emu-alg>
+        1. Return ? InstantiateAsyncGeneratorFunctionObject of |AsyncGeneratorDeclaration| with argument _scope_.
+      </emu-alg>
+      <emu-grammar>
+        AsyncFunctionDeclaration :
+          `async` `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
+          `async` `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
+      </emu-grammar>
+      <emu-alg>
+        1. Return ? InstantiateAsyncFunctionObject of |AsyncFunctionDeclaration| with argument _scope_.
+      </emu-alg>
+    </emu-clause>
   </emu-clause>
 </emu-clause>
 
@@ -19920,10 +19957,9 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-function-definitions-runtime-semantics-instantiatefunctionobject">
-      <h1>Runtime Semantics: InstantiateFunctionObject</h1>
+    <emu-clause id="sec-runtime-semantics-instantiateordinaryfunctionobject" oldids="sec-function-definitions-runtime-semantics-instantiatefunctionobject" type="sdo" aoid="InstantiateOrdinaryFunctionObject">
+      <h1>Runtime Semantics: InstantiateOrdinaryFunctionObject</h1>
       <p>With parameter _scope_.</p>
-      <emu-see-also-para op="InstantiateFunctionObject"></emu-see-also-para>
       <emu-grammar>FunctionDeclaration : `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Let _name_ be StringValue of |BindingIdentifier|.
@@ -20571,10 +20607,9 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-generator-function-definitions-runtime-semantics-instantiatefunctionobject">
-      <h1>Runtime Semantics: InstantiateFunctionObject</h1>
+    <emu-clause id="sec-runtime-semantics-instantiategeneratorfunctionobject" oldids="sec-generator-function-definitions-runtime-semantics-instantiatefunctionobject" type="sdo" aoid="InstantiateGeneratorFunctionObject">
+      <h1>Runtime Semantics: InstantiateGeneratorFunctionObject</h1>
       <p>With parameter _scope_.</p>
-      <emu-see-also-para op="InstantiateFunctionObject"></emu-see-also-para>
       <emu-grammar>GeneratorDeclaration : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. Let _name_ be StringValue of |BindingIdentifier|.
@@ -20843,8 +20878,8 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-asyncgenerator-definitions-instantiatefunctionobject">
-      <h1>Runtime Semantics: InstantiateFunctionObject</h1>
+    <emu-clause id="sec-runtime-semantics-instantiateasyncgeneratorfunctionobject" oldids="sec-asyncgenerator-definitions-instantiatefunctionobject" type="sdo" aoid="InstantiateAsyncGeneratorFunctionObject">
+      <h1>Runtime Semantics: InstantiateAsyncGeneratorFunctionObject</h1>
       <p>With parameter _scope_.</p>
       <emu-grammar>
         AsyncGeneratorDeclaration : `async` `function` `*` BindingIdentifier `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
@@ -20858,7 +20893,6 @@
         1. Perform ! DefinePropertyOrThrow(_F_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
         1. Return _F_.
       </emu-alg>
-
       <emu-grammar>
         AsyncGeneratorDeclaration : `async` `function` `*` `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
       </emu-grammar>
@@ -21422,8 +21456,8 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-async-function-definitions-InstantiateFunctionObject">
-      <h1>Runtime Semantics: InstantiateFunctionObject</h1>
+    <emu-clause id="sec-runtime-semantics-instantiateasyncfunctionobject" oldids="sec-async-function-definitions-InstantiateFunctionObject" type="sdo" aoid="InstantiateAsyncFunctionObject">
+      <h1>Runtime Semantics: InstantiateAsyncFunctionObject</h1>
       <p>With parameter _scope_.</p>
       <emu-grammar>
         AsyncFunctionDeclaration : `async` `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`

--- a/spec.html
+++ b/spec.html
@@ -12744,7 +12744,7 @@
           1. Return ? ToPropertyKey(_propName_).
         </emu-alg>
       </emu-clause>
-      <emu-clause id="sec-runtime-semantics-propertydefinitionevaluation" oldids="sec-object-initializer-runtime-semantics-propertydefinitionevaluation,sec-method-definitions-runtime-semantics-propertydefinitionevaluation,sec-generator-function-definitions-runtime-semantics-propertydefinitionevaluation,sec-asyncgenerator-definitions-propertydefinitionevaluation,sec-async-function-definitions-PropertyDefinitionEvaluation" type="sdo" aoid="PropertyDefinitionEvaluation">
+      <emu-clause id="sec-runtime-semantics-propertydefinitionevaluation" oldids="sec-object-initializer-runtime-semantics-propertydefinitionevaluation" type="sdo" aoid="PropertyDefinitionEvaluation">
         <h1>Runtime Semantics: PropertyDefinitionEvaluation</h1>
         <p>With parameters _object_ and _enumerable_.</p>
         <emu-grammar>PropertyDefinitionList : PropertyDefinitionList `,` PropertyDefinition</emu-grammar>
@@ -12784,81 +12784,30 @@
         <emu-note>
           <p>An alternative semantics for this production is given in <emu-xref href="#sec-__proto__-property-names-in-object-initializers"></emu-xref>.</p>
         </emu-note>
-        <emu-grammar>MethodDefinition : PropertyName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
+        <emu-grammar>
+          MethodDefinition :
+            PropertyName `(` UniqueFormalParameters `)` `{` FunctionBody `}`
+            `get` PropertyName `(` `)` `{` FunctionBody `}`
+            `set` PropertyName `(` PropertySetParameterList `)` `{` FunctionBody `}`
+        </emu-grammar>
         <emu-alg>
-          1. Let _methodDef_ be ? DefineMethod of |MethodDefinition| with argument _object_.
-          1. Perform SetFunctionName(_methodDef_.[[Closure]], _methodDef_.[[Key]]).
-          1. Let _desc_ be the PropertyDescriptor { [[Value]]: _methodDef_.[[Closure]], [[Writable]]: *true*, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
-          1. Return ? DefinePropertyOrThrow(_object_, _methodDef_.[[Key]], _desc_).
-        </emu-alg>
-        <emu-grammar>MethodDefinition : `get` PropertyName `(` `)` `{` FunctionBody `}`</emu-grammar>
-        <emu-alg>
-          1. Let _propKey_ be the result of evaluating |PropertyName|.
-          1. ReturnIfAbrupt(_propKey_).
-          1. Let _scope_ be the running execution context's LexicalEnvironment.
-          1. Let _sourceText_ be the source text matched by |MethodDefinition|.
-          1. Let _formalParameterList_ be an instance of the production <emu-grammar>FormalParameters : [empty]</emu-grammar>.
-          1. Let _closure_ be OrdinaryFunctionCreate(%Function.prototype%, _sourceText_, _formalParameterList_, |FunctionBody|, ~non-lexical-this~, _scope_).
-          1. Perform MakeMethod(_closure_, _object_).
-          1. Perform SetFunctionName(_closure_, _propKey_, *"get"*).
-          1. Let _desc_ be the PropertyDescriptor { [[Get]]: _closure_, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
-          1. Return ? DefinePropertyOrThrow(_object_, _propKey_, _desc_).
-        </emu-alg>
-        <emu-grammar>MethodDefinition : `set` PropertyName `(` PropertySetParameterList `)` `{` FunctionBody `}`</emu-grammar>
-        <emu-alg>
-          1. Let _propKey_ be the result of evaluating |PropertyName|.
-          1. ReturnIfAbrupt(_propKey_).
-          1. Let _scope_ be the running execution context's LexicalEnvironment.
-          1. Let _sourceText_ be the source text matched by |MethodDefinition|.
-          1. Let _closure_ be OrdinaryFunctionCreate(%Function.prototype%, _sourceText_, |PropertySetParameterList|, |FunctionBody|, ~non-lexical-this~, _scope_).
-          1. Perform MakeMethod(_closure_, _object_).
-          1. Perform SetFunctionName(_closure_, _propKey_, *"set"*).
-          1. Let _desc_ be the PropertyDescriptor { [[Set]]: _closure_, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
-          1. Return ? DefinePropertyOrThrow(_object_, _propKey_, _desc_).
+          1. Return ? MethodDefinitionEvaluation of |MethodDefinition| with arguments _object_ and _enumerable_.
         </emu-alg>
         <emu-grammar>GeneratorMethod : `*` PropertyName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
         <emu-alg>
-          1. Let _propKey_ be the result of evaluating |PropertyName|.
-          1. ReturnIfAbrupt(_propKey_).
-          1. Let _scope_ be the running execution context's LexicalEnvironment.
-          1. Let _sourceText_ be the source text matched by |GeneratorMethod|.
-          1. Let _closure_ be OrdinaryFunctionCreate(%GeneratorFunction.prototype%, _sourceText_, |UniqueFormalParameters|, |GeneratorBody|, ~non-lexical-this~, _scope_).
-          1. Perform MakeMethod(_closure_, _object_).
-          1. Perform SetFunctionName(_closure_, _propKey_).
-          1. Let _prototype_ be ! OrdinaryObjectCreate(%GeneratorFunction.prototype.prototype%).
-          1. Perform DefinePropertyOrThrow(_closure_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
-          1. Let _desc_ be the PropertyDescriptor { [[Value]]: _closure_, [[Writable]]: *true*, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
-          1. Return ? DefinePropertyOrThrow(_object_, _propKey_, _desc_).
+          1. Return ? MethodDefinitionEvaluation of |GeneratorMethod| with arguments _object_ and _enumerable_.
         </emu-alg>
         <emu-grammar>
           AsyncGeneratorMethod : `async` `*` PropertyName `(` UniqueFormalParameters `)` `{` AsyncGeneratorBody `}`
         </emu-grammar>
         <emu-alg>
-          1. Let _propKey_ be the result of evaluating |PropertyName|.
-          1. ReturnIfAbrupt(_propKey_).
-          1. Let _scope_ be the running execution context's LexicalEnvironment.
-          1. Let _sourceText_ be the source text matched by |AsyncGeneratorMethod|.
-          1. Let _closure_ be ! OrdinaryFunctionCreate(%AsyncGeneratorFunction.prototype%, _sourceText_, |UniqueFormalParameters|, |AsyncGeneratorBody|, ~non-lexical-this~, _scope_).
-          1. Perform ! MakeMethod(_closure_, _object_).
-          1. Perform ! SetFunctionName(_closure_, _propKey_).
-          1. Let _prototype_ be ! OrdinaryObjectCreate(%AsyncGeneratorFunction.prototype.prototype%).
-          1. Perform ! DefinePropertyOrThrow(_closure_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
-          1. Let _desc_ be PropertyDescriptor { [[Value]]: _closure_, [[Writable]]: *true*, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
-          1. Return ? DefinePropertyOrThrow(_object_, _propKey_, _desc_).
+          1. Return ? MethodDefinitionEvaluation of |AsyncGeneratorMethod| with arguments _object_ and _enumerable_.
         </emu-alg>
         <emu-grammar>
           AsyncMethod : `async` PropertyName `(` UniqueFormalParameters `)` `{` AsyncFunctionBody `}`
         </emu-grammar>
         <emu-alg>
-          1. Let _propKey_ be the result of evaluating |PropertyName|.
-          1. ReturnIfAbrupt(_propKey_).
-          1. Let _scope_ be the LexicalEnvironment of the running execution context.
-          1. Let _sourceText_ be the source text matched by |AsyncMethod|.
-          1. Let _closure_ be ! OrdinaryFunctionCreate(%AsyncFunction.prototype%, _sourceText_, |UniqueFormalParameters|, |AsyncFunctionBody|, ~non-lexical-this~, _scope_).
-          1. Perform ! MakeMethod(_closure_, _object_).
-          1. Perform ! SetFunctionName(_closure_, _propKey_).
-          1. Let _desc_ be the PropertyDescriptor { [[Value]]: _closure_, [[Writable]]: *true*, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
-          1. Return ? DefinePropertyOrThrow(_object_, _propKey_, _desc_).
+          1. Return ? MethodDefinitionEvaluation of |AsyncMethod| with arguments _object_ and _enumerable_.
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -20263,6 +20212,87 @@
         1. Let _closure_ be OrdinaryFunctionCreate(_prototype_, _sourceText_, |UniqueFormalParameters|, |FunctionBody|, ~non-lexical-this~, _scope_).
         1. Perform MakeMethod(_closure_, _object_).
         1. Return the Record { [[Key]]: _propKey_, [[Closure]]: _closure_ }.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-runtime-semantics-methoddefinitionevaluation" oldids="sec-method-definitions-runtime-semantics-propertydefinitionevaluation,sec-generator-function-definitions-runtime-semantics-propertydefinitionevaluation,sec-asyncgenerator-definitions-propertydefinitionevaluation,sec-async-function-definitions-PropertyDefinitionEvaluation" type="sdo" aoid="MethodDefinitionEvaluation">
+      <h1>Runtime Semantics: MethodDefinitionEvaluation</h1>
+      <p>With parameters _object_ and _enumerable_.</p>
+      <emu-grammar>MethodDefinition : PropertyName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-alg>
+        1. Let _methodDef_ be ? DefineMethod of |MethodDefinition| with argument _object_.
+        1. Perform SetFunctionName(_methodDef_.[[Closure]], _methodDef_.[[Key]]).
+        1. Let _desc_ be the PropertyDescriptor { [[Value]]: _methodDef_.[[Closure]], [[Writable]]: *true*, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
+        1. Return ? DefinePropertyOrThrow(_object_, _methodDef_.[[Key]], _desc_).
+      </emu-alg>
+      <emu-grammar>MethodDefinition : `get` PropertyName `(` `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-alg>
+        1. Let _propKey_ be the result of evaluating |PropertyName|.
+        1. ReturnIfAbrupt(_propKey_).
+        1. Let _scope_ be the running execution context's LexicalEnvironment.
+        1. Let _sourceText_ be the source text matched by |MethodDefinition|.
+        1. Let _formalParameterList_ be an instance of the production <emu-grammar>FormalParameters : [empty]</emu-grammar>.
+        1. Let _closure_ be OrdinaryFunctionCreate(%Function.prototype%, _sourceText_, _formalParameterList_, |FunctionBody|, ~non-lexical-this~, _scope_).
+        1. Perform MakeMethod(_closure_, _object_).
+        1. Perform SetFunctionName(_closure_, _propKey_, *"get"*).
+        1. Let _desc_ be the PropertyDescriptor { [[Get]]: _closure_, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
+        1. Return ? DefinePropertyOrThrow(_object_, _propKey_, _desc_).
+      </emu-alg>
+      <emu-grammar>MethodDefinition : `set` PropertyName `(` PropertySetParameterList `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-alg>
+        1. Let _propKey_ be the result of evaluating |PropertyName|.
+        1. ReturnIfAbrupt(_propKey_).
+        1. Let _scope_ be the running execution context's LexicalEnvironment.
+        1. Let _sourceText_ be the source text matched by |MethodDefinition|.
+        1. Let _closure_ be OrdinaryFunctionCreate(%Function.prototype%, _sourceText_, |PropertySetParameterList|, |FunctionBody|, ~non-lexical-this~, _scope_).
+        1. Perform MakeMethod(_closure_, _object_).
+        1. Perform SetFunctionName(_closure_, _propKey_, *"set"*).
+        1. Let _desc_ be the PropertyDescriptor { [[Set]]: _closure_, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
+        1. Return ? DefinePropertyOrThrow(_object_, _propKey_, _desc_).
+      </emu-alg>
+      <emu-grammar>GeneratorMethod : `*` PropertyName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
+      <emu-alg>
+        1. Let _propKey_ be the result of evaluating |PropertyName|.
+        1. ReturnIfAbrupt(_propKey_).
+        1. Let _scope_ be the running execution context's LexicalEnvironment.
+        1. Let _sourceText_ be the source text matched by |GeneratorMethod|.
+        1. Let _closure_ be OrdinaryFunctionCreate(%GeneratorFunction.prototype%, _sourceText_, |UniqueFormalParameters|, |GeneratorBody|, ~non-lexical-this~, _scope_).
+        1. Perform MakeMethod(_closure_, _object_).
+        1. Perform SetFunctionName(_closure_, _propKey_).
+        1. Let _prototype_ be ! OrdinaryObjectCreate(%GeneratorFunction.prototype.prototype%).
+        1. Perform DefinePropertyOrThrow(_closure_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
+        1. Let _desc_ be the PropertyDescriptor { [[Value]]: _closure_, [[Writable]]: *true*, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
+        1. Return ? DefinePropertyOrThrow(_object_, _propKey_, _desc_).
+      </emu-alg>
+      <emu-grammar>
+        AsyncGeneratorMethod : `async` `*` PropertyName `(` UniqueFormalParameters `)` `{` AsyncGeneratorBody `}`
+      </emu-grammar>
+      <emu-alg>
+        1. Let _propKey_ be the result of evaluating |PropertyName|.
+        1. ReturnIfAbrupt(_propKey_).
+        1. Let _scope_ be the running execution context's LexicalEnvironment.
+        1. Let _sourceText_ be the source text matched by |AsyncGeneratorMethod|.
+        1. Let _closure_ be ! OrdinaryFunctionCreate(%AsyncGeneratorFunction.prototype%, _sourceText_, |UniqueFormalParameters|, |AsyncGeneratorBody|, ~non-lexical-this~, _scope_).
+        1. Perform ! MakeMethod(_closure_, _object_).
+        1. Perform ! SetFunctionName(_closure_, _propKey_).
+        1. Let _prototype_ be ! OrdinaryObjectCreate(%AsyncGeneratorFunction.prototype.prototype%).
+        1. Perform ! DefinePropertyOrThrow(_closure_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
+        1. Let _desc_ be PropertyDescriptor { [[Value]]: _closure_, [[Writable]]: *true*, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
+        1. Return ? DefinePropertyOrThrow(_object_, _propKey_, _desc_).
+      </emu-alg>
+      <emu-grammar>
+        AsyncMethod : `async` PropertyName `(` UniqueFormalParameters `)` `{` AsyncFunctionBody `}`
+      </emu-grammar>
+      <emu-alg>
+        1. Let _propKey_ be the result of evaluating |PropertyName|.
+        1. ReturnIfAbrupt(_propKey_).
+        1. Let _scope_ be the LexicalEnvironment of the running execution context.
+        1. Let _sourceText_ be the source text matched by |AsyncMethod|.
+        1. Let _closure_ be ! OrdinaryFunctionCreate(%AsyncFunction.prototype%, _sourceText_, |UniqueFormalParameters|, |AsyncFunctionBody|, ~non-lexical-this~, _scope_).
+        1. Perform ! MakeMethod(_closure_, _object_).
+        1. Perform ! SetFunctionName(_closure_, _propKey_).
+        1. Let _desc_ be the PropertyDescriptor { [[Value]]: _closure_, [[Writable]]: *true*, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
+        1. Return ? DefinePropertyOrThrow(_object_, _propKey_, _desc_).
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -43149,7 +43179,7 @@ THH:mm:ss.sss
   <p><emu-xref href="#sec-try-statement"></emu-xref>: In ECMAScript 2015, it is an early error for a |Catch| clause to contain a `var` declaration for the same |Identifier| that appears as the |Catch| clause parameter. In previous editions, such a variable declaration would be instantiated in the enclosing variable environment but the declaration's |Initializer| value would be assigned to the |Catch| parameter.</p>
   <p><emu-xref href="#sec-try-statement"></emu-xref>, <emu-xref href="#sec-evaldeclarationinstantiation"></emu-xref>: In ECMAScript 2015, a runtime *SyntaxError* is thrown if a |Catch| clause evaluates a non-strict direct `eval` whose eval code includes a `var` or `FunctionDeclaration` declaration that binds the same |Identifier| that appears as the |Catch| clause parameter.</p>
   <p><emu-xref href="#sec-try-statement-runtime-semantics-evaluation"></emu-xref>: In ECMAScript 2015, the completion value of a |TryStatement| is never the value ~empty~. If the |Block| part of a |TryStatement| evaluates to a normal completion whose value is ~empty~, the completion value of the |TryStatement| is *undefined*. If the |Block| part of a |TryStatement| evaluates to a throw completion and it has a |Catch| part that evaluates to a normal completion whose value is ~empty~, the completion value of the |TryStatement| is *undefined* if there is no |Finally| clause or if its |Finally| clause evaluates to an ~empty~ normal completion.</p>
-  <p><emu-xref href="#sec-runtime-semantics-propertydefinitionevaluation"></emu-xref> In ECMAScript 2015, the function objects that are created as the values of the [[Get]] or [[Set]] attribute of accessor properties in an |ObjectLiteral| are not constructor functions and they do not have a *"prototype"* own property. In the previous edition, they were constructors and had a *"prototype"* property.</p>
+  <p><emu-xref href="#sec-runtime-semantics-methoddefinitionevaluation"></emu-xref> In ECMAScript 2015, the function objects that are created as the values of the [[Get]] or [[Set]] attribute of accessor properties in an |ObjectLiteral| are not constructor functions and they do not have a *"prototype"* own property. In the previous edition, they were constructors and had a *"prototype"* property.</p>
   <p><emu-xref href="#sec-object.freeze"></emu-xref>: In ECMAScript 2015, if the argument to `Object.freeze` is not an object it is treated as if it was a non-extensible ordinary object with no own properties. In the previous edition, a non-object argument always causes a *TypeError* to be thrown.</p>
   <p><emu-xref href="#sec-object.getownpropertydescriptor"></emu-xref>: In ECMAScript 2015, if the argument to `Object.getOwnPropertyDescriptor` is not an object an attempt is made to coerce the argument using ToObject. If the coercion is successful the result is used in place of the original argument value. In the previous edition, a non-object argument always causes a *TypeError* to be thrown.</p>
   <p><emu-xref href="#sec-object.getownpropertynames"></emu-xref>: In ECMAScript 2015, if the argument to `Object.getOwnPropertyNames` is not an object an attempt is made to coerce the argument using ToObject. If the coercion is successful the result is used in place of the original argument value. In the previous edition, a non-object argument always causes a *TypeError* to be thrown.</p>

--- a/spec.html
+++ b/spec.html
@@ -15331,35 +15331,6 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-static-semantics-static-semantics-isdestructuring">
-        <h1>Static Semantics: IsDestructuring</h1>
-        <emu-see-also-para op="IsDestructuring"></emu-see-also-para>
-        <emu-grammar>MemberExpression : PrimaryExpression</emu-grammar>
-        <emu-alg>
-          1. If |PrimaryExpression| is either an |ObjectLiteral| or an |ArrayLiteral|, return *true*.
-          1. Return *false*.
-        </emu-alg>
-        <emu-grammar>
-          MemberExpression :
-            MemberExpression `[` Expression `]`
-            MemberExpression `.` IdentifierName
-            MemberExpression TemplateLiteral
-            SuperProperty
-            MetaProperty
-            `new` MemberExpression Arguments
-
-          NewExpression :
-            `new` NewExpression
-
-          LeftHandSideExpression :
-            CallExpression
-            OptionalExpression
-        </emu-grammar>
-        <emu-alg>
-          1. Return *false*.
-        </emu-alg>
-      </emu-clause>
-
       <emu-clause id="sec-static-semantics-static-semantics-isidentifierref">
         <h1>Static Semantics: IsIdentifierRef</h1>
         <emu-see-also-para op="IsIdentifierRef"></emu-see-also-para>
@@ -18112,9 +18083,32 @@
         </ul>
       </emu-clause>
 
-      <emu-clause id="sec-for-in-and-for-of-statements-static-semantics-isdestructuring">
+      <emu-clause id="sec-static-semantics-isdestructuring" oldids="sec-static-semantics-static-semantics-isdestructuring,sec-for-in-and-for-of-statements-static-semantics-isdestructuring" type="sdo" aoid="IsDestructuring">
         <h1>Static Semantics: IsDestructuring</h1>
-        <emu-see-also-para op="IsDestructuring"></emu-see-also-para>
+        <emu-grammar>MemberExpression : PrimaryExpression</emu-grammar>
+        <emu-alg>
+          1. If |PrimaryExpression| is either an |ObjectLiteral| or an |ArrayLiteral|, return *true*.
+          1. Return *false*.
+        </emu-alg>
+        <emu-grammar>
+          MemberExpression :
+            MemberExpression `[` Expression `]`
+            MemberExpression `.` IdentifierName
+            MemberExpression TemplateLiteral
+            SuperProperty
+            MetaProperty
+            `new` MemberExpression Arguments
+
+          NewExpression :
+            `new` NewExpression
+
+          LeftHandSideExpression :
+            CallExpression
+            OptionalExpression
+        </emu-grammar>
+        <emu-alg>
+          1. Return *false*.
+        </emu-alg>
         <emu-grammar>ForDeclaration : LetOrConst ForBinding</emu-grammar>
         <emu-alg>
           1. Return IsDestructuring of |ForBinding|.
@@ -41957,7 +41951,7 @@ THH:mm:ss.sss
       <emu-alg>
         1. Return ContainsUndefinedContinueTarget of |Statement| with arguments _iterationSet_ and &laquo; &raquo;.
       </emu-alg>
-      <p>The static semantics of IsDestructuring in <emu-xref href="#sec-for-in-and-for-of-statements-static-semantics-isdestructuring"></emu-xref> are augmented with the following:</p>
+      <p>The static semantics of IsDestructuring in <emu-xref href="#sec-static-semantics-isdestructuring"></emu-xref> are augmented with the following:</p>
       <emu-grammar>
         BindingIdentifier :
           Identifier

--- a/spec.html
+++ b/spec.html
@@ -5777,6 +5777,32 @@
   </emu-clause>
 </emu-clause>
 
+<emu-clause id="sec-syntax-directed-operations">
+  <h1>Syntax-Directed Operations</h1>
+  <p>In addition to those defined in this section, specialized syntax-directed operations are defined throughout this specification.</p>
+
+  <emu-clause id="sec-syntax-directed-operations-scope-analysis">
+    <h1>Scope Analysis</h1>
+  </emu-clause>
+
+  <emu-clause id="sec-syntax-directed-operations-labels">
+    <h1>Labels</h1>
+  </emu-clause>
+
+  <emu-clause id="sec-syntax-directed-operations-function-name-inference">
+    <h1>Function Name Inference</h1>
+  </emu-clause>
+
+  <emu-clause id="sec-syntax-directed-operations-contains">
+    <h1>Contains</h1>
+  </emu-clause>
+
+  <emu-clause id="sec-syntax-directed-operations-miscellaneous">
+    <h1>Miscellaneous</h1>
+    <p>These operations are used in multiple places throughout the specification.</p>
+  </emu-clause>
+</emu-clause>
+
 <emu-clause id="sec-executable-code-and-execution-contexts">
   <h1>Executable Code and Execution Contexts</h1>
 

--- a/spec.html
+++ b/spec.html
@@ -19420,10 +19420,6 @@
         1. Let _expr_ be CoveredParenthesizedExpression of |CoverParenthesizedExpressionAndArrowParameterList|.
         1. Return IsFunctionDefinition of _expr_.
       </emu-alg>
-      <emu-grammar>ParenthesizedExpression : `(` Expression `)`</emu-grammar>
-      <emu-alg>
-        1. Return IsFunctionDefinition of |Expression|.
-      </emu-alg>
       <emu-grammar>
         PrimaryExpression :
           `this`

--- a/spec.html
+++ b/spec.html
@@ -6066,41 +6066,29 @@
         1. Return *true*.
       </emu-alg>
       <emu-grammar>
-        FunctionDeclaration : `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`
+        FunctionDeclaration :
+          `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`
+          `function` `(` FormalParameters `)` `{` FunctionBody `}`
 
-        FunctionDeclaration : `function` `(` FormalParameters `)` `{` FunctionBody `}`
+        GeneratorDeclaration :
+          `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`
+          `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`
+
+        AsyncGeneratorDeclaration :
+          `async` `function` `*` BindingIdentifier `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+          `async` `function` `*` `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+
+        AsyncFunctionDeclaration :
+          `async` `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
+          `async` `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
       <emu-grammar>
-        GeneratorDeclaration : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`
-
-        GeneratorDeclaration : `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`
-      </emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-      <emu-grammar>
-        AsyncGeneratorDeclaration : `async` `function` `*` BindingIdentifier `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
-
-        AsyncGeneratorDeclaration : `async` `function` `*` `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
-      </emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-      <emu-grammar>
-        ClassDeclaration : `class` BindingIdentifier ClassTail
-
-        ClassDeclaration : `class` ClassTail
-      </emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-      <emu-grammar>
-        AsyncFunctionDeclaration : `async` `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
-
-        AsyncFunctionDeclaration : `async` `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
+        ClassDeclaration :
+          `class` BindingIdentifier ClassTail
+          `class` ClassTail
       </emu-grammar>
       <emu-alg>
         1. Return *false*.
@@ -18530,9 +18518,9 @@
     <emu-clause id="sec-continue-statement-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
       <emu-grammar>
-        ContinueStatement : `continue` `;`
-
-        ContinueStatement : `continue` LabelIdentifier `;`
+        ContinueStatement :
+          `continue` `;`
+          `continue` LabelIdentifier `;`
       </emu-grammar>
       <ul>
         <li>
@@ -19374,11 +19362,12 @@
     <emu-clause id="sec-function-definitions-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
       <emu-grammar>
-        FunctionDeclaration : `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`
+        FunctionDeclaration :
+          `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`
+          `function` `(` FormalParameters `)` `{` FunctionBody `}`
 
-        FunctionDeclaration : `function` `(` FormalParameters `)` `{` FunctionBody `}`
-
-        FunctionExpression : `function` BindingIdentifier? `(` FormalParameters `)` `{` FunctionBody `}`
+        FunctionExpression :
+          `function` BindingIdentifier? `(` FormalParameters `)` `{` FunctionBody `}`
       </emu-grammar>
       <ul>
         <li>
@@ -19446,19 +19435,24 @@
         1. Return HasName of _expr_.
       </emu-alg>
       <emu-grammar>
-        FunctionExpression : `function` `(` FormalParameters `)` `{` FunctionBody `}`
+        FunctionExpression :
+          `function` `(` FormalParameters `)` `{` FunctionBody `}`
 
-        GeneratorExpression : `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`
+        GeneratorExpression :
+          `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`
 
-        AsyncGeneratorExpression : `async` `function` `*` `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+        AsyncGeneratorExpression :
+          `async` `function` `*` `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
 
-        AsyncFunctionExpression : `async` `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
+        AsyncFunctionExpression :
+          `async` `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
 
-        ArrowFunction : ArrowParameters `=>` ConciseBody
+        ArrowFunction :
+          ArrowParameters `=>` ConciseBody
 
-        AsyncArrowFunction : `async` AsyncArrowBindingIdentifier `=>` AsyncConciseBody
-
-        AsyncArrowFunction : CoverCallExpressionAndAsyncArrowHead `=>` AsyncConciseBody
+        AsyncArrowFunction :
+          `async` AsyncArrowBindingIdentifier `=>` AsyncConciseBody
+          CoverCallExpressionAndAsyncArrowHead `=>` AsyncConciseBody
 
         ClassExpression : `class` ClassTail
       </emu-grammar>
@@ -19466,13 +19460,17 @@
         1. Return *false*.
       </emu-alg>
       <emu-grammar>
-        FunctionExpression : `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`
+        FunctionExpression :
+          `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`
 
-        GeneratorExpression : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`
+        GeneratorExpression :
+          `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`
 
-        AsyncGeneratorExpression : `async` `function` `*` BindingIdentifier `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+        AsyncGeneratorExpression :
+          `async` `function` `*` BindingIdentifier `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
 
-        AsyncFunctionExpression : `async` `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
+        AsyncFunctionExpression :
+          `async` `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
 
         ClassExpression : `class` BindingIdentifier ClassTail
       </emu-grammar>
@@ -19611,8 +19609,7 @@
           `async` `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
           `async` `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
 
-        ClassExpression :
-          `class` BindingIdentifier? ClassTail
+        ClassExpression : `class` BindingIdentifier? ClassTail
       </emu-grammar>
       <emu-alg>
         1. Return *true*.
@@ -20100,11 +20097,12 @@
         </li>
       </ul>
       <emu-grammar>
-        GeneratorDeclaration : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`
+        GeneratorDeclaration :
+          `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`
+          `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`
 
-        GeneratorDeclaration : `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`
-
-        GeneratorExpression : `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` GeneratorBody `}`
+        GeneratorExpression :
+          `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` GeneratorBody `}`
       </emu-grammar>
       <ul>
         <li>
@@ -20316,11 +20314,12 @@
         <li>It is a Syntax Error if any element of the BoundNames of |UniqueFormalParameters| also occurs in the LexicallyDeclaredNames of |AsyncGeneratorBody|.</li>
       </ul>
       <emu-grammar>
-        AsyncGeneratorDeclaration : `async` `function` `*` BindingIdentifier `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+        AsyncGeneratorDeclaration :
+          `async` `function` `*` BindingIdentifier `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+          `async` `function` `*` `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
 
-        AsyncGeneratorDeclaration : `async` `function` `*` `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
-
-        AsyncGeneratorExpression : `async` `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+        AsyncGeneratorExpression :
+          `async` `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
       </emu-grammar>
       <ul>
         <li>If the source code matching |FormalParameters| is strict mode code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.</li>
@@ -20763,13 +20762,13 @@
         <li>It is a Syntax Error if any element of the BoundNames of |UniqueFormalParameters| also occurs in the LexicallyDeclaredNames of |AsyncFunctionBody|.</li>
       </ul>
       <emu-grammar>
-        AsyncFunctionDeclaration : `async` `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
+        AsyncFunctionDeclaration :
+          `async` `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
+          `async` `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
 
-        AsyncFunctionDeclaration : `async` `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
-
-        AsyncFunctionExpression : `async` `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
-
-        AsyncFunctionExpression : `async` `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
+        AsyncFunctionExpression :
+          `async` `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
+          `async` `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
       <ul>
         <li>It is a Syntax Error if FunctionBodyContainsUseStrict of |AsyncFunctionBody| is *true* and IsSimpleParameterList of |FormalParameters| is *false*.</li>
@@ -23190,11 +23189,10 @@
           1. Return the BoundNames of |Declaration|.
         </emu-alg>
         <emu-grammar>
-          ExportDeclaration : `export` `default` HoistableDeclaration
-
-          ExportDeclaration : `export` `default` ClassDeclaration
-
-          ExportDeclaration : `export` `default` AssignmentExpression `;`
+          ExportDeclaration :
+            `export` `default` HoistableDeclaration
+            `export` `default` ClassDeclaration
+            `export` `default` AssignmentExpression `;`
         </emu-grammar>
         <emu-alg>
           1. Return the BoundNames of this |ExportDeclaration|.
@@ -23267,11 +23265,10 @@
           1. Return the BoundNames of |Declaration|.
         </emu-alg>
         <emu-grammar>
-          ExportDeclaration : `export` `default` HoistableDeclaration
-
-          ExportDeclaration : `export` `default` ClassDeclaration
-
-          ExportDeclaration : `export` `default` AssignmentExpression `;`
+          ExportDeclaration :
+            `export` `default` HoistableDeclaration
+            `export` `default` ClassDeclaration
+            `export` `default` AssignmentExpression `;`
         </emu-grammar>
         <emu-alg>
           1. Return &laquo; *"default"* &raquo;.
@@ -41485,9 +41482,9 @@ THH:mm:ss.sss
         <li>when parsing text for <emu-xref href="#sec-json.parse">JSON.parse</emu-xref>.</li>
       </ul>
       <emu-grammar>
-        ObjectLiteral : `{` PropertyDefinitionList `}`
-
-        ObjectLiteral : `{` PropertyDefinitionList `,` `}`
+        ObjectLiteral :
+          `{` PropertyDefinitionList `}`
+          `{` PropertyDefinitionList `,` `}`
       </emu-grammar>
       <ul>
         <li>

--- a/spec.html
+++ b/spec.html
@@ -18966,16 +18966,27 @@
           1. Set _stmtResult_ to NormalCompletion(_stmtResult_.[[Value]]).
         1. Return Completion(_stmtResult_).
       </emu-alg>
-      <emu-grammar>LabelledItem : Statement</emu-grammar>
-      <emu-alg>
-        1. If |Statement| is either a |LabelledStatement| or a |BreakableStatement|, then
-          1. Return LabelledEvaluation of |Statement| with argument _labelSet_.
-        1. Else,
-          1. Return the result of evaluating |Statement|.
-      </emu-alg>
       <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
       <emu-alg>
         1. Return the result of evaluating |FunctionDeclaration|.
+      </emu-alg>
+      <emu-grammar>
+        Statement :
+          BlockStatement
+          VariableStatement
+          EmptyStatement
+          ExpressionStatement
+          IfStatement
+          ContinueStatement
+          BreakStatement
+          ReturnStatement
+          WithStatement
+          ThrowStatement
+          TryStatement
+          DebuggerStatement
+      </emu-grammar>
+      <emu-alg>
+        1. Return the result of evaluating |Statement|.
       </emu-alg>
     </emu-clause>
   </emu-clause>


### PR DESCRIPTION
Fixes #1950. Fixes #2251.

This ensures every SDO is defined in a single place (modulo tweaks in Annex B, and excepting Early Errors and Evaluation). That way usages of SDOs can be automatically linked to their definition site, as is done for other abstract operations. This makes the spec _much_ easier to navigate, I think.

That was generally just a matter of moving things around and some minor tweaking or renaming. Most SDOs had a natural place to live: `ExportEntries` can go in the `Exports` section, say. We introduced a new top-level "Syntax-Directed Operations" clause to hold some more broadly applicable operations.

However, in a few cases @michaelficarra and I judged that the result would have separated sections which logically ought to be grouped, which we resolved by introducing new SDOs. For example, `InstantiateFunctionObject` has the semantics for setting up all four kinds of function declaration, and we wanted each those semantics to be together with their respective declaration kind. So we introduced `InstantiateOrdinaryFunctionObject`, `InstantiateGeneratorFunctionObject`, `InstantiateAsyncGeneratorFunctionObject`, and `InstantiateAsyncFunctionObject`, and made the original `InstantiateFunctionObject` dispatch the appropriate one.

~This is marked as a draft because there's still a few cases to do (specifically `IsIdentifierRef`, `NamedEvaluation`, and `StringValue`), as well as some necessary cleanup (for example, the [while statement](https://tc39.es/ecma262/#sec-while-statement) clause is now entirely empty).~ Edit: ready to go! Needs https://github.com/tc39/ecmarkup/pull/285 upstreamed, though.

This does not yet allow you to trivially answer the question "what SDOs are defined over this production?", which will come as part of https://github.com/tc39/ecmarkup/pull/276.

Commits should be individually reviewable.