### PR TITLE
Editorial: Delete "the Number value for" in Number::leftShift

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1762,7 +1762,7 @@
             1. Let _lnum_ be ! ToInt32(_x_).
             1. Let _rnum_ be ! ToUint32(_y_).
             1. Let _shiftCount_ be ℝ(_rnum_) modulo 32.
-            1. Return the Number value for the result of left shifting _lnum_ by _shiftCount_ bits. The mathematical value of the result is exactly representable as a 32-bit two's complement bit string.
+            1. Return the result of left shifting _lnum_ by _shiftCount_ bits. The mathematical value of the result is exactly representable as a 32-bit two's complement bit string.
           </emu-alg>
         </emu-clause>
 


### PR DESCRIPTION
For consistency with `Number::signedRightShift` and `Number::unsignedRightShift`, the result of a left or right shift is a Number, so it doesn't make sense to get "the Number value for" that result.