### PR TITLE
Editorial: Express some 'bitwise' Number methods more explicitly

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -2238,10 +2238,8 @@
           <dl class="header">
           </dl>
           <emu-alg>
-            1. Let _lNum_ be ! ToInt32(_x_).
-            1. Let _rNum_ be ! ToInt32(_y_).
-            1. Let _lBits_ be the 32-bit two's complement bit string representing ℝ(_lNum_).
-            1. Let _rBits_ be the 32-bit two's complement bit string representing ℝ(_rNum_).
+            1. Let _lBits_ be NumberToInt32Bits(_x_).
+            1. Let _rBits_ be NumberToInt32Bits(_y_).
             1. If _op_ is `&amp;`, then
               1. Let _result_ be the result of applying the bitwise AND operation to _lBits_ and _rBits_.
             1. Else if _op_ is `^`, then
@@ -2249,7 +2247,35 @@
             1. Else,
               1. Assert: _op_ is `|`.
               1. Let _result_ be the result of applying the bitwise inclusive OR operation to _lBits_ and _rBits_.
-            1. Return the Number value for the integer represented by the 32-bit two's complement bit string _result_.
+            1. Return Int32BitsToNumber(_result_).
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-numbertoint32bits" type="abstract operation">
+          <h1>
+            NumberToInt32Bits (
+              _number_: a Number,
+            ): a 32-bit bit string
+          </h1>
+          <dl class="header">
+          </dl>
+          <emu-alg>
+            1. Let _n_ be ! ToInt32(_number_).
+            1. Return the 32-bit two's complement bit string representing ℝ(_n_).
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-int32bitstonumber" type="abstract operation">
+          <h1>
+            Int32BitsToNumber (
+              _bits_: a 32-bit bit string,
+            ): an integral Number
+          </h1>
+          <dl class="header">
+          </dl>
+          <emu-alg>
+            1. Let _i_ be the result of interpreting _bits_ as a 32-bit two's complement signed integer.
+            1. Return 𝔽(_i_).
           </emu-alg>
         </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -1903,8 +1903,9 @@
           <dl class="header">
           </dl>
           <emu-alg>
-            1. Let _oldValue_ be ! ToInt32(_x_).
-            1. Return the bitwise complement of _oldValue_. The mathematical value of the result is exactly representable as a 32-bit two's complement bit string.
+            1. Let _xBits_ be NumberToInt32Bits(_x_).
+            1. Let _cBits_ be the bitwise complement of _xBits_.
+            1. Return Int32BitsToNumber(_cBits_).
           </emu-alg>
         </emu-clause>
 
@@ -2107,10 +2108,11 @@
           <dl class="header">
           </dl>
           <emu-alg>
-            1. Let _lNum_ be ! ToInt32(_x_).
+            1. Let _lBits_ be NumberToInt32Bits(_x_).
             1. Let _rNum_ be ! ToUint32(_y_).
             1. Let _shiftCount_ be ℝ(_rNum_) modulo 32.
-            1. Return the result of left shifting _lNum_ by _shiftCount_ bits. The mathematical value of the result is exactly representable as a 32-bit two's complement bit string.
+            1. Let _shifted_ be the result of left shifting _lBits_ by _shiftCount_ bits.
+            1. Return Int32BitsToNumber(_shifted_).
           </emu-alg>
         </emu-clause>
 
@@ -2124,10 +2126,11 @@
           <dl class="header">
           </dl>
           <emu-alg>
-            1. Let _lNum_ be ! ToInt32(_x_).
+            1. Let _lBits_ be NumberToInt32Bits(_x_).
             1. Let _rNum_ be ! ToUint32(_y_).
             1. Let _shiftCount_ be ℝ(_rNum_) modulo 32.
-            1. Return the result of performing a sign-extending right shift of _lNum_ by _shiftCount_ bits. The most significant bit is propagated. The mathematical value of the result is exactly representable as a 32-bit two's complement bit string.
+            1. Let _shifted_ be the result of performing a sign-extending right shift of _lBits_ by _shiftCount_ bits. The most significant bit is propagated.
+            1. Return Int32BitsToNumber(_shifted_).
           </emu-alg>
         </emu-clause>
 
@@ -2141,10 +2144,11 @@
           <dl class="header">
           </dl>
           <emu-alg>
-            1. Let _lNum_ be ! ToUint32(_x_).
+            1. Let _lBits_ be NumberToUint32Bits(_x_).
             1. Let _rNum_ be ! ToUint32(_y_).
             1. Let _shiftCount_ be ℝ(_rNum_) modulo 32.
-            1. Return the result of performing a zero-filling right shift of _lNum_ by _shiftCount_ bits. Vacated bits are filled with zero. The mathematical value of the result is exactly representable as a 32-bit unsigned bit string.
+            1. Let _shifted_ be the result of performing a zero-filling right shift of _lBits_ by _shiftCount_ bits. Vacated bits are filled with zero.
+            1. Return Uint32BitsToNumber(_shifted_).
           </emu-alg>
         </emu-clause>
 
@@ -2275,6 +2279,34 @@
           </dl>
           <emu-alg>
             1. Let _i_ be the result of interpreting _bits_ as a 32-bit two's complement signed integer.
+            1. Return 𝔽(_i_).
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-numbertouint32bits" type="abstract operation">
+          <h1>
+            NumberToUint32Bits (
+              _number_: a Number,
+            ): a 32-bit bit string
+          </h1>
+          <dl class="header">
+          </dl>
+          <emu-alg>
+            1. Let _n_ be ! ToUint32(_number_).
+            1. Return the 32-bit unsigned bit string representing ℝ(_n_).
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-uint32bitstonumber" type="abstract operation">
+          <h1>
+            Uint32BitsToNumber (
+              _bits_: a 32-bit bit string,
+            ): an integral Number
+          </h1>
+          <dl class="header">
+          </dl>
+          <emu-alg>
+            1. Let _i_ be the result of interpreting _bits_ as a 32-bit unsigned integer.
             1. Return 𝔽(_i_).
           </emu-alg>
         </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -2369,10 +2369,8 @@
           <dl class="header">
           </dl>
           <emu-alg>
-            1. Let _leftNumber_ be ! ToInt32(_x_).
-            1. Let _rightNumber_ be ! ToInt32(_y_).
-            1. Let _leftBits_ be the 32-bit two's complement bit string representing ℝ(_leftNumber_).
-            1. Let _rightBits_ be the 32-bit two's complement bit string representing ℝ(_rightNumber_).
+            1. Let _leftBits_ be NumberToInt32Bits(_x_).
+            1. Let _rightBits_ be NumberToInt32Bits(_y_).
             1. If _op_ is `&amp;`, then
               1. Let _result_ be the result of applying the bitwise AND operation to _leftBits_ and _rightBits_.
             1. Else if _op_ is `^`, then
@@ -2380,7 +2378,35 @@
             1. Else,
               1. Assert: _op_ is `|`.
               1. Let _result_ be the result of applying the bitwise inclusive OR operation to _leftBits_ and _rightBits_.
-            1. Return the Number value for the integer represented by the 32-bit two's complement bit string _result_.
+            1. Return Int32BitsToNumber(_result_).
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-numbertoint32bits" type="abstract operation">
+          <h1>
+            NumberToInt32Bits (
+              _number_: a Number,
+            ): a 32-bit bit string
+          </h1>
+          <dl class="header">
+          </dl>
+          <emu-alg>
+            1. Let _n_ be ! ToInt32(_number_).
+            1. Return the 32-bit two's complement bit string representing ℝ(_n_).
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-int32bitstonumber" type="abstract operation">
+          <h1>
+            Int32BitsToNumber (
+              _bits_: a 32-bit bit string,
+            ): an integral Number
+          </h1>
+          <dl class="header">
+          </dl>
+          <emu-alg>
+            1. Let _i_ be the result of interpreting _bits_ as a 32-bit two's complement signed integer.
+            1. Return 𝔽(_i_).
           </emu-alg>
         </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -2025,8 +2025,9 @@
           <dl class="header">
           </dl>
           <emu-alg>
-            1. Let _oldValue_ be ! ToInt32(_number_).
-            1. Return the bitwise complement of _oldValue_. The mathematical value of the result is exactly representable as a 32-bit two's complement bit string.
+            1. Let _bits_ be NumberToInt32Bits(_number_).
+            1. Let _complementBits_ be the bitwise complement of _bits_.
+            1. Return Int32BitsToNumber(_complementBits_).
           </emu-alg>
         </emu-clause>
 
@@ -2237,10 +2238,11 @@
           <dl class="header">
           </dl>
           <emu-alg>
-            1. Let _leftNumber_ be ! ToInt32(_x_).
+            1. Let _leftBits_ be NumberToInt32Bits(_x_).
             1. Let _rightNumber_ be ! ToUint32(_y_).
             1. Let _shiftCount_ be ℝ(_rightNumber_) modulo 32.
-            1. Return the result of left shifting _leftNumber_ by _shiftCount_ bits. The mathematical value of the result is exactly representable as a 32-bit two's complement bit string.
+            1. Let _shifted_ be the result of left shifting _leftBits_ by _shiftCount_ bits.
+            1. Return Int32BitsToNumber(_shifted_).
           </emu-alg>
         </emu-clause>
 
@@ -2254,10 +2256,11 @@
           <dl class="header">
           </dl>
           <emu-alg>
-            1. Let _leftNumber_ be ! ToInt32(_x_).
+            1. Let _leftBits_ be NumberToInt32Bits(_x_).
             1. Let _rightNumber_ be ! ToUint32(_y_).
             1. Let _shiftCount_ be ℝ(_rightNumber_) modulo 32.
-            1. Return the result of performing a sign-extending right shift of _leftNumber_ by _shiftCount_ bits. The most significant bit is propagated. The mathematical value of the result is exactly representable as a 32-bit two's complement bit string.
+            1. Let _shifted_ be the result of performing a sign-extending right shift of _leftBits_ by _shiftCount_ bits. The most significant bit is propagated.
+            1. Return Int32BitsToNumber(_shifted_).
           </emu-alg>
         </emu-clause>
 
@@ -2271,10 +2274,11 @@
           <dl class="header">
           </dl>
           <emu-alg>
-            1. Let _leftNumber_ be ! ToUint32(_x_).
+            1. Let _leftBits_ be NumberToUint32Bits(_x_).
             1. Let _rightNumber_ be ! ToUint32(_y_).
             1. Let _shiftCount_ be ℝ(_rightNumber_) modulo 32.
-            1. Return the result of performing a zero-filling right shift of _leftNumber_ by _shiftCount_ bits. Vacated bits are filled with zero. The mathematical value of the result is exactly representable as a 32-bit unsigned bit string.
+            1. Let _shifted_ be the result of performing a zero-filling right shift of _leftBits_ by _shiftCount_ bits. Vacated bits are filled with zero.
+            1. Return Uint32BitsToNumber(_shifted_).
           </emu-alg>
         </emu-clause>
 
@@ -2406,6 +2410,34 @@
           </dl>
           <emu-alg>
             1. Let _i_ be the result of interpreting _bits_ as a 32-bit two's complement signed integer.
+            1. Return 𝔽(_i_).
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-numbertouint32bits" type="abstract operation">
+          <h1>
+            NumberToUint32Bits (
+              _number_: a Number,
+            ): a 32-bit bit string
+          </h1>
+          <dl class="header">
+          </dl>
+          <emu-alg>
+            1. Let _n_ be ! ToUint32(_number_).
+            1. Return the 32-bit unsigned bit string representing ℝ(_n_).
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-uint32bitstonumber" type="abstract operation">
+          <h1>
+            Uint32BitsToNumber (
+              _bits_: a 32-bit bit string,
+            ): an integral Number
+          </h1>
+          <dl class="header">
+          </dl>
+          <emu-alg>
+            1. Let _i_ be the result of interpreting _bits_ as a 32-bit unsigned integer.
             1. Return 𝔽(_i_).
           </emu-alg>
         </emu-clause>


### PR DESCRIPTION
When expressing 'bitwise' operations on Number values, `NumberBitwiseOp` explicitly expresses the conversion from Number to mathematical integer to bit string, and then from bit string to mathematical integer to Number.

This PR expresses
- Number::bitwiseNOT
- Number::leftShift
- Number::signedRightShift
- Number::unsignedRightShift

to the same level of explicitness.

To do so, it introduces abstract operations:
- NumberToInt32Bits and Int32BitsToNumber
- NumberToUint32Bits and Uint32BitsToNumber

