### PR TITLE
Editorial: Merge the RHSs of AsyncFunctionExpression

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -7587,8 +7587,7 @@
           `async` `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
 
         AsyncFunctionExpression :
-          `async` `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
-          `async` `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
+          `async` `function` BindingIdentifier? `(` FormalParameters `)` `{` AsyncFunctionBody `}`
 
         ClassExpression : `class` BindingIdentifier? ClassTail
       </emu-grammar>
@@ -7746,8 +7745,7 @@
           `async` `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
 
         AsyncFunctionExpression :
-          `async` `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
-          `async` `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
+          `async` `function` BindingIdentifier? `(` FormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
       <emu-alg>
         1. Return *false*.
@@ -20839,8 +20837,7 @@
         [+Default] `async` [no LineTerminator here] `function` `(` FormalParameters[~Yield, +Await] `)` `{` AsyncFunctionBody `}`
 
       AsyncFunctionExpression :
-        `async` [no LineTerminator here] `function` `(` FormalParameters[~Yield, +Await] `)` `{` AsyncFunctionBody `}`
-        `async` [no LineTerminator here] `function` BindingIdentifier[~Yield, +Await] `(` FormalParameters[~Yield, +Await] `)` `{` AsyncFunctionBody `}`
+        `async` [no LineTerminator here] `function` BindingIdentifier[~Yield, +Await]? `(` FormalParameters[~Yield, +Await] `)` `{` AsyncFunctionBody `}`
 
       AsyncMethod[Yield, Await] :
         `async` [no LineTerminator here] PropertyName[?Yield, ?Await] `(` UniqueFormalParameters[~Yield, +Await] `)` `{` AsyncFunctionBody `}`
@@ -20886,8 +20883,7 @@
           `async` `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
 
         AsyncFunctionExpression :
-          `async` `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
-          `async` `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
+          `async` `function` BindingIdentifier? `(` FormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
       <ul>
         <li>It is a Syntax Error if FunctionBodyContainsUseStrict of |AsyncFunctionBody| is *true* and IsSimpleParameterList of |FormalParameters| is *false*.</li>
@@ -20993,8 +20989,7 @@
       </emu-alg>
       <emu-grammar>
         AsyncFunctionExpression :
-          `async` `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
-          `async` `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
+          `async` `function` BindingIdentifier? `(` FormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
       <emu-alg>
         1. Return InstantiateAsyncFunctionExpression of |AsyncFunctionExpression|.


### PR DESCRIPTION
The nonterminals:
- FunctionExpression
- ClassExpression
- GeneratorExpression
- AsyncGeneratorExpression

are all defined with a single RHS involving an optional BindingIdentifier.

But AsyncFunctionExpression is defined with two RHSs, one with a BindingIdentifier and one without. (It's been that way since it was introduced in PR #692.) I can't see any reason for it to be not like the others.