### PR TITLE
Editorial: split up IterationStatement

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -589,24 +589,24 @@
       </emu-grammar>
       <p>and that:</p>
       <emu-grammar type="definition" example>
-        IterationStatement :
+        ForStatement :
           `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement
       </emu-grammar>
       <p>is a convenient abbreviation for:</p>
       <emu-grammar type="definition" example>
-        IterationStatement :
+        ForStatement :
           `for` `(` LexicalDeclaration `;` Expression? `)` Statement
           `for` `(` LexicalDeclaration Expression `;` Expression? `)` Statement
       </emu-grammar>
       <p>which in turn is an abbreviation for:</p>
       <emu-grammar type="definition" example>
-        IterationStatement :
+        ForStatement :
           `for` `(` LexicalDeclaration `;` `)` Statement
           `for` `(` LexicalDeclaration `;` Expression `)` Statement
           `for` `(` LexicalDeclaration Expression `;` `)` Statement
           `for` `(` LexicalDeclaration Expression `;` Expression `)` Statement
       </emu-grammar>
-      <p>so, in this example, the nonterminal |IterationStatement| actually has four alternative right-hand sides.</p>
+      <p>so, in this example, the nonterminal |ForStatement| actually has four alternative right-hand sides.</p>
       <p>A production may be parameterized by a subscripted annotation of the form &ldquo;<sub>[parameters]</sub>&rdquo;, which may appear as a suffix to the nonterminal symbol defined by the production. &ldquo;<sub>parameters</sub>&rdquo; may be either a single name or a comma separated list of names. A parameterized production is shorthand for a set of productions defining all combinations of the parameter names, preceded by an underscore, appended to the parameterized nonterminal symbol. This means that:</p>
       <emu-grammar type="definition" example>
         StatementList[Return] :
@@ -6386,30 +6386,30 @@
       <emu-alg>
         1. Return the VarDeclaredNames of |Statement|.
       </emu-alg>
-      <emu-grammar>IterationStatement : `do` Statement `while` `(` Expression `)` `;`</emu-grammar>
+      <emu-grammar>DoWhileStatement : `do` Statement `while` `(` Expression `)` `;`</emu-grammar>
       <emu-alg>
         1. Return the VarDeclaredNames of |Statement|.
       </emu-alg>
-      <emu-grammar>IterationStatement : `while` `(` Expression `)` Statement</emu-grammar>
+      <emu-grammar>WhileStatement : `while` `(` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Return the VarDeclaredNames of |Statement|.
       </emu-alg>
-      <emu-grammar>IterationStatement : `for` `(` Expression? `;` Expression? `;` Expression? `)` Statement</emu-grammar>
+      <emu-grammar>ForStatement : `for` `(` Expression? `;` Expression? `;` Expression? `)` Statement</emu-grammar>
       <emu-alg>
         1. Return the VarDeclaredNames of |Statement|.
       </emu-alg>
-      <emu-grammar>IterationStatement : `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement</emu-grammar>
+      <emu-grammar>ForStatement : `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement</emu-grammar>
       <emu-alg>
         1. Let _names_ be BoundNames of |VariableDeclarationList|.
         1. Append to _names_ the elements of the VarDeclaredNames of |Statement|.
         1. Return _names_.
       </emu-alg>
-      <emu-grammar>IterationStatement : `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement</emu-grammar>
+      <emu-grammar>ForStatement : `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement</emu-grammar>
       <emu-alg>
         1. Return the VarDeclaredNames of |Statement|.
       </emu-alg>
       <emu-grammar>
-        IterationStatement :
+        ForInOfStatement :
           `for` `(` LeftHandSideExpression `in` Expression `)` Statement
           `for` `(` ForDeclaration `in` Expression `)` Statement
           `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
@@ -6421,7 +6421,7 @@
         1. Return the VarDeclaredNames of |Statement|.
       </emu-alg>
       <emu-grammar>
-        IterationStatement :
+        ForInOfStatement :
           `for` `(` `var` ForBinding `in` Expression `)` Statement
           `for` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
           `for` `await` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
@@ -6593,30 +6593,30 @@
       <emu-alg>
         1. Return the VarScopedDeclarations of |Statement|.
       </emu-alg>
-      <emu-grammar>IterationStatement : `do` Statement `while` `(` Expression `)` `;`</emu-grammar>
+      <emu-grammar>DoWhileStatement : `do` Statement `while` `(` Expression `)` `;`</emu-grammar>
       <emu-alg>
         1. Return the VarScopedDeclarations of |Statement|.
       </emu-alg>
-      <emu-grammar>IterationStatement : `while` `(` Expression `)` Statement</emu-grammar>
+      <emu-grammar>WhileStatement : `while` `(` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Return the VarScopedDeclarations of |Statement|.
       </emu-alg>
-      <emu-grammar>IterationStatement : `for` `(` Expression? `;` Expression? `;` Expression? `)` Statement</emu-grammar>
+      <emu-grammar>ForStatement : `for` `(` Expression? `;` Expression? `;` Expression? `)` Statement</emu-grammar>
       <emu-alg>
         1. Return the VarScopedDeclarations of |Statement|.
       </emu-alg>
-      <emu-grammar>IterationStatement : `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement</emu-grammar>
+      <emu-grammar>ForStatement : `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement</emu-grammar>
       <emu-alg>
         1. Let _declarations_ be VarScopedDeclarations of |VariableDeclarationList|.
         1. Append to _declarations_ the elements of the VarScopedDeclarations of |Statement|.
         1. Return _declarations_.
       </emu-alg>
-      <emu-grammar>IterationStatement : `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement</emu-grammar>
+      <emu-grammar>ForStatement : `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement</emu-grammar>
       <emu-alg>
         1. Return the VarScopedDeclarations of |Statement|.
       </emu-alg>
       <emu-grammar>
-        IterationStatement :
+        ForInOfStatement :
           `for` `(` LeftHandSideExpression `in` Expression `)` Statement
           `for` `(` ForDeclaration `in` Expression `)` Statement
           `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
@@ -6628,7 +6628,7 @@
         1. Return the VarScopedDeclarations of |Statement|.
       </emu-alg>
       <emu-grammar>
-        IterationStatement :
+        ForInOfStatement :
           `for` `(` `var` ForBinding `in` Expression `)` Statement
           `for` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
           `for` `await` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
@@ -6927,16 +6927,16 @@
       <emu-alg>
         1. Return ContainsDuplicateLabels of |Statement| with argument _labelSet_.
       </emu-alg>
-      <emu-grammar>IterationStatement : `do` Statement `while` `(` Expression `)` `;`</emu-grammar>
+      <emu-grammar>DoWhileStatement : `do` Statement `while` `(` Expression `)` `;`</emu-grammar>
       <emu-alg>
         1. Return ContainsDuplicateLabels of |Statement| with argument _labelSet_.
       </emu-alg>
-      <emu-grammar>IterationStatement : `while` `(` Expression `)` Statement</emu-grammar>
+      <emu-grammar>WhileStatement : `while` `(` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Return ContainsDuplicateLabels of |Statement| with argument _labelSet_.
       </emu-alg>
       <emu-grammar>
-        IterationStatement :
+        ForStatement :
           `for` `(` Expression? `;` Expression? `;` Expression? `)` Statement
           `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement
           `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement
@@ -6945,7 +6945,7 @@
         1. Return ContainsDuplicateLabels of |Statement| with argument _labelSet_.
       </emu-alg>
       <emu-grammar>
-        IterationStatement :
+        ForInOfStatement :
           `for` `(` LeftHandSideExpression `in` Expression `)` Statement
           `for` `(` `var` ForBinding `in` Expression `)` Statement
           `for` `(` ForDeclaration `in` Expression `)` Statement
@@ -7091,16 +7091,16 @@
       <emu-alg>
         1. Return ContainsUndefinedBreakTarget of |Statement| with argument _labelSet_.
       </emu-alg>
-      <emu-grammar>IterationStatement : `do` Statement `while` `(` Expression `)` `;`</emu-grammar>
+      <emu-grammar>DoWhileStatement : `do` Statement `while` `(` Expression `)` `;`</emu-grammar>
       <emu-alg>
         1. Return ContainsUndefinedBreakTarget of |Statement| with argument _labelSet_.
       </emu-alg>
-      <emu-grammar>IterationStatement : `while` `(` Expression `)` Statement</emu-grammar>
+      <emu-grammar>WhileStatement : `while` `(` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Return ContainsUndefinedBreakTarget of |Statement| with argument _labelSet_.
       </emu-alg>
       <emu-grammar>
-        IterationStatement :
+        ForStatement :
           `for` `(` Expression? `;` Expression? `;` Expression? `)` Statement
           `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement
           `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement
@@ -7109,7 +7109,7 @@
         1. Return ContainsUndefinedBreakTarget of |Statement| with argument _labelSet_.
       </emu-alg>
       <emu-grammar>
-        IterationStatement :
+        ForInOfStatement :
           `for` `(` LeftHandSideExpression `in` Expression `)` Statement
           `for` `(` `var` ForBinding `in` Expression `)` Statement
           `for` `(` ForDeclaration `in` Expression `)` Statement
@@ -7268,16 +7268,16 @@
       <emu-alg>
         1. Return ContainsUndefinedContinueTarget of |Statement| with arguments _iterationSet_ and &laquo; &raquo;.
       </emu-alg>
-      <emu-grammar>IterationStatement : `do` Statement `while` `(` Expression `)` `;`</emu-grammar>
+      <emu-grammar>DoWhileStatement : `do` Statement `while` `(` Expression `)` `;`</emu-grammar>
       <emu-alg>
         1. Return ContainsUndefinedContinueTarget of |Statement| with arguments _iterationSet_ and &laquo; &raquo;.
       </emu-alg>
-      <emu-grammar>IterationStatement : `while` `(` Expression `)` Statement</emu-grammar>
+      <emu-grammar>WhileStatement : `while` `(` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Return ContainsUndefinedContinueTarget of |Statement| with arguments _iterationSet_ and &laquo; &raquo;.
       </emu-alg>
       <emu-grammar>
-        IterationStatement :
+        ForStatement :
           `for` `(` Expression? `;` Expression? `;` Expression? `)` Statement
           `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement
           `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement
@@ -7286,7 +7286,7 @@
         1. Return ContainsUndefinedContinueTarget of |Statement| with arguments _iterationSet_ and &laquo; &raquo;.
       </emu-alg>
       <emu-grammar>
-        IterationStatement :
+        ForInOfStatement :
           `for` `(` LeftHandSideExpression `in` Expression `)` Statement
           `for` `(` `var` ForBinding `in` Expression `)` Statement
           `for` `(` ForDeclaration `in` Expression `)` Statement
@@ -18108,63 +18108,14 @@
     <h2>Syntax</h2>
     <emu-grammar type="definition">
       IterationStatement[Yield, Await, Return] :
-        `do` Statement[?Yield, ?Await, ?Return] `while` `(` Expression[+In, ?Yield, ?Await] `)` `;`
-        `while` `(` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
-        `for` `(` [lookahead != `let` `[`] Expression[~In, ?Yield, ?Await]? `;` Expression[+In, ?Yield, ?Await]? `;` Expression[+In, ?Yield, ?Await]? `)` Statement[?Yield, ?Await, ?Return]
-        `for` `(` `var` VariableDeclarationList[~In, ?Yield, ?Await] `;` Expression[+In, ?Yield, ?Await]? `;` Expression[+In, ?Yield, ?Await]? `)` Statement[?Yield, ?Await, ?Return]
-        `for` `(` LexicalDeclaration[~In, ?Yield, ?Await] Expression[+In, ?Yield, ?Await]? `;` Expression[+In, ?Yield, ?Await]? `)` Statement[?Yield, ?Await, ?Return]
-        `for` `(` [lookahead != `let` `[`] LeftHandSideExpression[?Yield, ?Await] `in` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
-        `for` `(` `var` ForBinding[?Yield, ?Await] `in` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
-        `for` `(` ForDeclaration[?Yield, ?Await] `in` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
-        `for` `(` [lookahead != `let`] LeftHandSideExpression[?Yield, ?Await] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
-        `for` `(` `var` ForBinding[?Yield, ?Await] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
-        `for` `(` ForDeclaration[?Yield, ?Await] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
-        [+Await] `for` `await` `(` [lookahead != `let`] LeftHandSideExpression[?Yield, ?Await] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
-        [+Await] `for` `await` `(` `var` ForBinding[?Yield, ?Await] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
-        [+Await] `for` `await` `(` ForDeclaration[?Yield, ?Await] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
-
-      ForDeclaration[Yield, Await] :
-        LetOrConst ForBinding[?Yield, ?Await]
-
-      ForBinding[Yield, Await] :
-        BindingIdentifier[?Yield, ?Await]
-        BindingPattern[?Yield, ?Await]
+        DoWhileStatement[?Yield, ?Await, ?Return]
+        WhileStatement[?Yield, ?Await, ?Return]
+        ForStatement[?Yield, ?Await, ?Return]
+        ForInOfStatement[?Yield, ?Await, ?Return]
     </emu-grammar>
-    <emu-note>
-      <p>This section is extended by Annex <emu-xref href="#sec-initializers-in-forin-statement-heads"></emu-xref>.</p>
-    </emu-note>
 
     <emu-clause id="sec-iteration-statements-semantics">
       <h1>Semantics</h1>
-
-      <emu-clause id="sec-semantics-static-semantics-early-errors">
-        <h1>Static Semantics: Early Errors</h1>
-        <emu-grammar>
-          IterationStatement :
-            `do` Statement `while` `(` Expression `)` `;`
-            `while` `(` Expression `)` Statement
-            `for` `(` Expression? `;` Expression? `;` Expression? `)` Statement
-            `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement
-            `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement
-            `for` `(` LeftHandSideExpression `in` Expression `)` Statement
-            `for` `(` `var` ForBinding `in` Expression `)` Statement
-            `for` `(` ForDeclaration `in` Expression `)` Statement
-            `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
-            `for` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
-            `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement
-            `for` `await` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
-            `for` `await` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
-            `for` `await` `(` ForDeclaration `of` AssignmentExpression `)` Statement
-        </emu-grammar>
-        <ul>
-          <li>
-            It is a Syntax Error if IsLabelledFunction(|Statement|) is *true*.
-          </li>
-        </ul>
-        <emu-note>
-          <p>It is only necessary to apply this rule if the extension specified in <emu-xref href="#sec-labelled-function-declarations"></emu-xref> is implemented.</p>
-        </emu-note>
-      </emu-clause>
 
       <emu-clause id="sec-loopcontinues" aoid="LoopContinues">
         <h1>LoopContinues ( _completion_, _labelSet_ )</h1>
@@ -18181,10 +18132,53 @@
         </emu-note>
       </emu-clause>
 
-      <emu-clause id="sec-runtime-semantics-loopevaluation" oldids="sec-do-while-statement-runtime-semantics-labelledevaluation,sec-while-statement-runtime-semantics-labelledevaluation,sec-for-statement-runtime-semantics-labelledevaluation,sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation" type="sdo" aoid="LoopEvaluation">
+      <emu-clause id="sec-runtime-semantics-loopevaluation" type="sdo" aoid="LoopEvaluation">
         <h1>Runtime Semantics: LoopEvaluation</h1>
         <p>With parameter _labelSet_.</p>
-        <emu-grammar>IterationStatement : `do` Statement `while` `(` Expression `)` `;`</emu-grammar>
+        <emu-grammar>IterationStatement : DoWhileStatement</emu-grammar>
+        <emu-alg>
+          1. Return ? DoWhileLoopEvaluation of |DoWhileStatement| with argument _labelSet_.
+        </emu-alg>
+        <emu-grammar>IterationStatement : WhileStatement</emu-grammar>
+        <emu-alg>
+          1. Return ? WhileLoopEvaluation of |WhileStatement| with argument _labelSet_.
+        </emu-alg>
+        <emu-grammar>IterationStatement : ForStatement</emu-grammar>
+        <emu-alg>
+          1. Return ? ForLoopEvaluation of |ForStatement| with argument _labelSet_.
+        </emu-alg>
+        <emu-grammar>IterationStatement : ForInOfStatement</emu-grammar>
+        <emu-alg>
+          1. Return ? ForInOfLoopEvaluation of |ForInOfStatement| with argument _labelSet_.
+        </emu-alg>
+      </emu-clause>
+    </emu-clause>
+
+    <emu-clause id="sec-do-while-statement">
+      <h1>The `do`-`while` Statement</h1>
+      <h2>Syntax</h2>
+      <emu-grammar type="definition">
+        DoWhileStatement[Yield, Await, Return] :
+          `do` Statement[?Yield, ?Await, ?Return] `while` `(` Expression[+In, ?Yield, ?Await] `)` `;`
+      </emu-grammar>
+
+      <emu-clause id="sec-do-while-statement-static-semantics-early-errors">
+        <h1>Static Semantics: Early Errors</h1>
+        <emu-grammar>DoWhileStatement : `do` Statement `while` `(` Expression `)` `;`</emu-grammar>
+        <ul>
+          <li>
+            It is a Syntax Error if IsLabelledFunction(|Statement|) is *true*.
+          </li>
+        </ul>
+        <emu-note>
+          <p>It is only necessary to apply this rule if the extension specified in <emu-xref href="#sec-labelled-function-declarations"></emu-xref> is implemented.</p>
+        </emu-note>
+      </emu-clause>
+
+      <emu-clause id="sec-runtime-semantics-dowhileloopevaluation" oldids="sec-do-while-statement-runtime-semantics-labelledevaluation" type="sdo" aoid="DoWhileLoopEvaluation">
+        <h1>Runtime Semantics: DoWhileLoopEvaluation</h1>
+        <p>With parameter _labelSet_.</p>
+        <emu-grammar>DoWhileStatement : `do` Statement `while` `(` Expression `)` `;`</emu-grammar>
         <emu-alg>
           1. Let _V_ be *undefined*.
           1. Repeat,
@@ -18195,7 +18189,34 @@
             1. Let _exprValue_ be ? GetValue(_exprRef_).
             1. If ! ToBoolean(_exprValue_) is *false*, return NormalCompletion(_V_).
         </emu-alg>
-        <emu-grammar>IterationStatement : `while` `(` Expression `)` Statement</emu-grammar>
+      </emu-clause>
+    </emu-clause>
+
+    <emu-clause id="sec-while-statement">
+      <h1>The `while` Statement</h1>
+      <h2>Syntax</h2>
+      <emu-grammar type="definition">
+        WhileStatement[Yield, Await, Return] :
+          `while` `(` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
+      </emu-grammar>
+
+      <emu-clause id="sec-while-statement-static-semantics-early-errors">
+        <h1>Static Semantics: Early Errors</h1>
+        <emu-grammar>WhileStatement : `while` `(` Expression `)` Statement</emu-grammar>
+        <ul>
+          <li>
+            It is a Syntax Error if IsLabelledFunction(|Statement|) is *true*.
+          </li>
+        </ul>
+        <emu-note>
+          <p>It is only necessary to apply this rule if the extension specified in <emu-xref href="#sec-labelled-function-declarations"></emu-xref> is implemented.</p>
+        </emu-note>
+      </emu-clause>
+
+      <emu-clause id="sec-runtime-semantics-whileloopevaluation" oldids="sec-while-statement-runtime-semantics-labelledevaluation" type="sdo" aoid="WhileLoopEvaluation">
+        <h1>Runtime Semantics: WhileLoopEvaluation</h1>
+        <p>With parameter _labelSet_.</p>
+        <emu-grammar>WhileStatement : `while` `(` Expression `)` Statement</emu-grammar>
         <emu-alg>
           1. Let _V_ be *undefined*.
           1. Repeat,
@@ -18206,20 +18227,60 @@
             1. If LoopContinues(_stmtResult_, _labelSet_) is *false*, return Completion(UpdateEmpty(_stmtResult_, _V_)).
             1. If _stmtResult_.[[Value]] is not ~empty~, set _V_ to _stmtResult_.[[Value]].
         </emu-alg>
-        <emu-grammar>IterationStatement : `for` `(` Expression? `;` Expression? `;` Expression? `)` Statement</emu-grammar>
+      </emu-clause>
+    </emu-clause>
+
+    <emu-clause id="sec-for-statement">
+      <h1>The `for` Statement</h1>
+      <h2>Syntax</h2>
+      <emu-grammar type="definition">
+        ForStatement[Yield, Await, Return] :
+          `for` `(` [lookahead != `let` `[`] Expression[~In, ?Yield, ?Await]? `;` Expression[+In, ?Yield, ?Await]? `;` Expression[+In, ?Yield, ?Await]? `)` Statement[?Yield, ?Await, ?Return]
+          `for` `(` `var` VariableDeclarationList[~In, ?Yield, ?Await] `;` Expression[+In, ?Yield, ?Await]? `;` Expression[+In, ?Yield, ?Await]? `)` Statement[?Yield, ?Await, ?Return]
+          `for` `(` LexicalDeclaration[~In, ?Yield, ?Await] Expression[+In, ?Yield, ?Await]? `;` Expression[+In, ?Yield, ?Await]? `)` Statement[?Yield, ?Await, ?Return]
+      </emu-grammar>
+
+      <emu-clause id="sec-for-statement-static-semantics-early-errors">
+        <h1>Static Semantics: Early Errors</h1>
+        <emu-grammar>
+          ForStatement :
+            `for` `(` Expression? `;` Expression? `;` Expression? `)` Statement
+            `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement
+            `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement
+        </emu-grammar>
+        <ul>
+          <li>
+            It is a Syntax Error if IsLabelledFunction(|Statement|) is *true*.
+          </li>
+        </ul>
+        <emu-note>
+          <p>It is only necessary to apply this rule if the extension specified in <emu-xref href="#sec-labelled-function-declarations"></emu-xref> is implemented.</p>
+        </emu-note>
+        <emu-grammar>ForStatement : `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement</emu-grammar>
+        <ul>
+          <li>
+            It is a Syntax Error if any element of the BoundNames of |LexicalDeclaration| also occurs in the VarDeclaredNames of |Statement|.
+          </li>
+        </ul>
+      </emu-clause>
+
+      <emu-clause id="sec-runtime-semantics-forloopevaluation" oldids="sec-for-statement-runtime-semantics-labelledevaluation" type="sdo" aoid="ForLoopEvaluation">
+        <h1>Runtime Semantics: ForLoopEvaluation</h1>
+        <p>With parameter _labelSet_.</p>
+        <emu-grammar>ForStatement : `for` `(` Expression? `;` Expression? `;` Expression? `)` Statement</emu-grammar>
         <emu-alg>
           1. If the first |Expression| is present, then
             1. Let _exprRef_ be the result of evaluating the first |Expression|.
             1. Perform ? GetValue(_exprRef_).
           1. Return ? ForBodyEvaluation(the second |Expression|, the third |Expression|, |Statement|, &laquo; &raquo;, _labelSet_).
         </emu-alg>
-        <emu-grammar>IterationStatement : `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement</emu-grammar>
+        <emu-grammar>ForStatement : `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement</emu-grammar>
         <emu-alg>
           1. Let _varDcl_ be the result of evaluating |VariableDeclarationList|.
           1. ReturnIfAbrupt(_varDcl_).
           1. Return ? ForBodyEvaluation(the first |Expression|, the second |Expression|, |Statement|, &laquo; &raquo;, _labelSet_).
         </emu-alg>
-        <emu-grammar>IterationStatement : `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement</emu-grammar>
+        <emu-grammar>ForStatement : `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement</emu-grammar>
         <emu-alg>
           1. Let _oldEnv_ be the running execution context's LexicalEnvironment.
           1. Let _loopEnv_ be NewDeclarativeEnvironment(_oldEnv_).
@@ -18240,82 +18301,6 @@
           1. Set the running execution context's LexicalEnvironment to _oldEnv_.
           1. Return Completion(_bodyResult_).
         </emu-alg>
-        <emu-grammar>IterationStatement : `for` `(` LeftHandSideExpression `in` Expression `)` Statement</emu-grammar>
-        <emu-alg>
-          1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(&laquo; &raquo;, |Expression|, ~enumerate~).
-          1. Return ? ForIn/OfBodyEvaluation(|LeftHandSideExpression|, |Statement|, _keyResult_, ~enumerate~, ~assignment~, _labelSet_).
-        </emu-alg>
-        <emu-grammar>IterationStatement : `for` `(` `var` ForBinding `in` Expression `)` Statement</emu-grammar>
-        <emu-alg>
-          1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(&laquo; &raquo;, |Expression|, ~enumerate~).
-          1. Return ? ForIn/OfBodyEvaluation(|ForBinding|, |Statement|, _keyResult_, ~enumerate~, ~varBinding~, _labelSet_).
-        </emu-alg>
-        <emu-grammar>IterationStatement : `for` `(` ForDeclaration `in` Expression `)` Statement</emu-grammar>
-        <emu-alg>
-          1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(BoundNames of |ForDeclaration|, |Expression|, ~enumerate~).
-          1. Return ? ForIn/OfBodyEvaluation(|ForDeclaration|, |Statement|, _keyResult_, ~enumerate~, ~lexicalBinding~, _labelSet_).
-        </emu-alg>
-        <emu-grammar>IterationStatement : `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement</emu-grammar>
-        <emu-alg>
-          1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(&laquo; &raquo;, |AssignmentExpression|, ~iterate~).
-          1. Return ? ForIn/OfBodyEvaluation(|LeftHandSideExpression|, |Statement|, _keyResult_, ~iterate~, ~assignment~, _labelSet_).
-        </emu-alg>
-        <emu-grammar>IterationStatement : `for` `(` `var` ForBinding `of` AssignmentExpression `)` Statement</emu-grammar>
-        <emu-alg>
-          1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(&laquo; &raquo;, |AssignmentExpression|, ~iterate~).
-          1. Return ? ForIn/OfBodyEvaluation(|ForBinding|, |Statement|, _keyResult_, ~iterate~, ~varBinding~, _labelSet_).
-        </emu-alg>
-        <emu-grammar>IterationStatement : `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement</emu-grammar>
-        <emu-alg>
-          1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(BoundNames of |ForDeclaration|, |AssignmentExpression|, ~iterate~).
-          1. Return ? ForIn/OfBodyEvaluation(|ForDeclaration|, |Statement|, _keyResult_, ~iterate~, ~lexicalBinding~, _labelSet_).
-        </emu-alg>
-        <emu-grammar>
-          IterationStatement : `for` `await` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
-        </emu-grammar>
-        <emu-alg>
-          1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(&laquo; &raquo;, |AssignmentExpression|, ~async-iterate~).
-          1. Return ? ForIn/OfBodyEvaluation(|LeftHandSideExpression|, |Statement|, _keyResult_, ~iterate~, ~assignment~, _labelSet_, ~async~).
-        </emu-alg>
-        <emu-grammar>
-          IterationStatement : `for` `await` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
-        </emu-grammar>
-        <emu-alg>
-          1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(&laquo; &raquo;, |AssignmentExpression|, ~async-iterate~).
-          1. Return ? ForIn/OfBodyEvaluation(|ForBinding|, |Statement|, _keyResult_, ~iterate~, ~varBinding~, _labelSet_, ~async~).
-        </emu-alg>
-        <emu-grammar>
-          IterationStatement : `for` `await` `(` ForDeclaration `of` AssignmentExpression `)` Statement
-        </emu-grammar>
-        <emu-alg>
-          1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(BoundNames of |ForDeclaration|, |AssignmentExpression|, ~async-iterate~).
-          1. Return ? ForIn/OfBodyEvaluation(|ForDeclaration|, |Statement|, _keyResult_, ~iterate~, ~lexicalBinding~, _labelSet_, ~async~).
-        </emu-alg>
-        <emu-note>
-          <p>This section is extended by Annex <emu-xref href="#sec-initializers-in-forin-statement-heads"></emu-xref>.</p>
-        </emu-note>
-      </emu-clause>
-    </emu-clause>
-
-    <emu-clause id="sec-do-while-statement">
-      <h1>The `do`-`while` Statement</h1>
-    </emu-clause>
-
-    <emu-clause id="sec-while-statement">
-      <h1>The `while` Statement</h1>
-    </emu-clause>
-
-    <emu-clause id="sec-for-statement">
-      <h1>The `for` Statement</h1>
-
-      <emu-clause id="sec-for-statement-static-semantics-early-errors">
-        <h1>Static Semantics: Early Errors</h1>
-        <emu-grammar>IterationStatement : `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement</emu-grammar>
-        <ul>
-          <li>
-            It is a Syntax Error if any element of the BoundNames of |LexicalDeclaration| also occurs in the VarDeclaredNames of |Statement|.
-          </li>
-        </ul>
       </emu-clause>
 
       <emu-clause id="sec-forbodyevaluation" aoid="ForBodyEvaluation">
@@ -18360,11 +18345,54 @@
 
     <emu-clause id="sec-for-in-and-for-of-statements">
       <h1>The `for`-`in`, `for`-`of`, and `for`-`await`-`of` Statements</h1>
+      <h2>Syntax</h2>
+      <emu-grammar type="definition">
+        ForInOfStatement[Yield, Await, Return] :
+          `for` `(` [lookahead != `let` `[`] LeftHandSideExpression[?Yield, ?Await] `in` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
+          `for` `(` `var` ForBinding[?Yield, ?Await] `in` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
+          `for` `(` ForDeclaration[?Yield, ?Await] `in` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
+          `for` `(` [lookahead != `let`] LeftHandSideExpression[?Yield, ?Await] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
+          `for` `(` `var` ForBinding[?Yield, ?Await] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
+          `for` `(` ForDeclaration[?Yield, ?Await] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
+          [+Await] `for` `await` `(` [lookahead != `let`] LeftHandSideExpression[?Yield, ?Await] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
+          [+Await] `for` `await` `(` `var` ForBinding[?Yield, ?Await] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
+          [+Await] `for` `await` `(` ForDeclaration[?Yield, ?Await] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
+
+        ForDeclaration[Yield, Await] :
+          LetOrConst ForBinding[?Yield, ?Await]
+
+        ForBinding[Yield, Await] :
+          BindingIdentifier[?Yield, ?Await]
+          BindingPattern[?Yield, ?Await]
+      </emu-grammar>
+      <emu-note>
+        <p>This section is extended by Annex <emu-xref href="#sec-initializers-in-forin-statement-heads"></emu-xref>.</p>
+      </emu-note>
 
       <emu-clause id="sec-for-in-and-for-of-statements-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>
         <emu-grammar>
-          IterationStatement :
+          ForInOfStatement :
+            `for` `(` LeftHandSideExpression `in` Expression `)` Statement
+            `for` `(` `var` ForBinding `in` Expression `)` Statement
+            `for` `(` ForDeclaration `in` Expression `)` Statement
+            `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
+            `for` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
+            `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement
+            `for` `await` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
+            `for` `await` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
+            `for` `await` `(` ForDeclaration `of` AssignmentExpression `)` Statement
+        </emu-grammar>
+        <ul>
+          <li>
+            It is a Syntax Error if IsLabelledFunction(|Statement|) is *true*.
+          </li>
+        </ul>
+        <emu-note>
+          <p>It is only necessary to apply this rule if the extension specified in <emu-xref href="#sec-labelled-function-declarations"></emu-xref> is implemented.</p>
+        </emu-note>
+        <emu-grammar>
+          ForInOfStatement :
             `for` `(` LeftHandSideExpression `in` Expression `)` Statement
             `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
             `for` `await` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
@@ -18385,7 +18413,7 @@
           </li>
         </ul>
         <emu-grammar>
-          IterationStatement :
+          ForInOfStatement :
             `for` `(` ForDeclaration `in` Expression `)` Statement
             `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement
             `for` `await` `(` ForDeclaration `of` AssignmentExpression `)` Statement
@@ -18470,6 +18498,65 @@
             1. Else,
               1. Perform ! _environment_.CreateMutableBinding(_name_, *false*).
         </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-runtime-semantics-forinofloopevaluation" oldids="sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation" type="sdo" aoid="ForInOfLoopEvaluation">
+        <h1>Runtime Semantics: ForInOfLoopEvaluation</h1>
+        <p>With parameter _labelSet_.</p>
+        <emu-grammar>ForInOfStatement : `for` `(` LeftHandSideExpression `in` Expression `)` Statement</emu-grammar>
+        <emu-alg>
+          1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(&laquo; &raquo;, |Expression|, ~enumerate~).
+          1. Return ? ForIn/OfBodyEvaluation(|LeftHandSideExpression|, |Statement|, _keyResult_, ~enumerate~, ~assignment~, _labelSet_).
+        </emu-alg>
+        <emu-grammar>ForInOfStatement : `for` `(` `var` ForBinding `in` Expression `)` Statement</emu-grammar>
+        <emu-alg>
+          1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(&laquo; &raquo;, |Expression|, ~enumerate~).
+          1. Return ? ForIn/OfBodyEvaluation(|ForBinding|, |Statement|, _keyResult_, ~enumerate~, ~varBinding~, _labelSet_).
+        </emu-alg>
+        <emu-grammar>ForInOfStatement : `for` `(` ForDeclaration `in` Expression `)` Statement</emu-grammar>
+        <emu-alg>
+          1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(BoundNames of |ForDeclaration|, |Expression|, ~enumerate~).
+          1. Return ? ForIn/OfBodyEvaluation(|ForDeclaration|, |Statement|, _keyResult_, ~enumerate~, ~lexicalBinding~, _labelSet_).
+        </emu-alg>
+        <emu-grammar>ForInOfStatement : `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement</emu-grammar>
+        <emu-alg>
+          1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(&laquo; &raquo;, |AssignmentExpression|, ~iterate~).
+          1. Return ? ForIn/OfBodyEvaluation(|LeftHandSideExpression|, |Statement|, _keyResult_, ~iterate~, ~assignment~, _labelSet_).
+        </emu-alg>
+        <emu-grammar>ForInOfStatement : `for` `(` `var` ForBinding `of` AssignmentExpression `)` Statement</emu-grammar>
+        <emu-alg>
+          1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(&laquo; &raquo;, |AssignmentExpression|, ~iterate~).
+          1. Return ? ForIn/OfBodyEvaluation(|ForBinding|, |Statement|, _keyResult_, ~iterate~, ~varBinding~, _labelSet_).
+        </emu-alg>
+        <emu-grammar>ForInOfStatement : `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement</emu-grammar>
+        <emu-alg>
+          1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(BoundNames of |ForDeclaration|, |AssignmentExpression|, ~iterate~).
+          1. Return ? ForIn/OfBodyEvaluation(|ForDeclaration|, |Statement|, _keyResult_, ~iterate~, ~lexicalBinding~, _labelSet_).
+        </emu-alg>
+        <emu-grammar>
+          ForInOfStatement : `for` `await` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
+        </emu-grammar>
+        <emu-alg>
+          1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(&laquo; &raquo;, |AssignmentExpression|, ~async-iterate~).
+          1. Return ? ForIn/OfBodyEvaluation(|LeftHandSideExpression|, |Statement|, _keyResult_, ~iterate~, ~assignment~, _labelSet_, ~async~).
+        </emu-alg>
+        <emu-grammar>
+          ForInOfStatement : `for` `await` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
+        </emu-grammar>
+        <emu-alg>
+          1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(&laquo; &raquo;, |AssignmentExpression|, ~async-iterate~).
+          1. Return ? ForIn/OfBodyEvaluation(|ForBinding|, |Statement|, _keyResult_, ~iterate~, ~varBinding~, _labelSet_, ~async~).
+        </emu-alg>
+        <emu-grammar>
+          ForInOfStatement : `for` `await` `(` ForDeclaration `of` AssignmentExpression `)` Statement
+        </emu-grammar>
+        <emu-alg>
+          1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(BoundNames of |ForDeclaration|, |AssignmentExpression|, ~async-iterate~).
+          1. Return ? ForIn/OfBodyEvaluation(|ForDeclaration|, |Statement|, _keyResult_, ~iterate~, ~lexicalBinding~, _labelSet_, ~async~).
+        </emu-alg>
+        <emu-note>
+          <p>This section is extended by Annex <emu-xref href="#sec-initializers-in-forin-statement-heads"></emu-xref>.</p>
+        </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-runtime-semantics-forinofheadevaluation" oldids="sec-runtime-semantics-forin-div-ofheadevaluation-tdznames-expr-iterationkind" aoid="ForIn/OfHeadEvaluation">
@@ -21113,7 +21200,7 @@
 
           LabelledItem : FunctionDeclaration
 
-          IterationStatement :
+          ForInOfStatement :
             `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
             `for` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
             `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement
@@ -21132,12 +21219,16 @@
         <emu-grammar>
           IfStatement : `if` `(` Expression `)` Statement
 
-          IterationStatement :
-            `do` Statement `while` `(` Expression `)` `;`
-            `while` `(` Expression `)` Statement
+          DoWhileStatement : `do` Statement `while` `(` Expression `)` `;`
+
+          WhileStatement : `while` `(` Expression `)` Statement
+
+          ForStatement :
             `for` `(` Expression? `;` Expression? `;` Expression? `)` Statement
             `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement
             `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement
+
+          ForInOfStatement :
             `for` `(` LeftHandSideExpression `in` Expression `)` Statement
             `for` `(` `var` ForBinding `in` Expression `)` Statement
             `for` `(` ForDeclaration `in` Expression `)` Statement
@@ -40403,6 +40494,10 @@ THH:mm:ss.sss
     <emu-prodref name="ExpressionStatement"></emu-prodref>
     <emu-prodref name="IfStatement"></emu-prodref>
     <emu-prodref name="IterationStatement"></emu-prodref>
+    <emu-prodref name="DoWhileStatement"></emu-prodref>
+    <emu-prodref name="WhileStatement"></emu-prodref>
+    <emu-prodref name="ForStatement"></emu-prodref>
+    <emu-prodref name="ForInOfStatement"></emu-prodref>
     <emu-prodref name="ForDeclaration"></emu-prodref>
     <emu-prodref name="ForBinding"></emu-prodref>
     <emu-prodref name="ContinueStatement"></emu-prodref>
@@ -41808,24 +41903,24 @@ THH:mm:ss.sss
 
     <emu-annex id="sec-initializers-in-forin-statement-heads">
       <h1>Initializers in ForIn Statement Heads</h1>
-      <p>The following augments the |IterationStatement| production in <emu-xref href="#sec-iteration-statements"></emu-xref>:</p>
+      <p>The following augments the |ForInOfStatement| production in <emu-xref href="#sec-for-in-and-for-of-statements"></emu-xref>:</p>
       <emu-grammar type="definition">
-        IterationStatement[Yield, Await, Return] :
+        ForInOfStatement[Yield, Await, Return] :
           `for` `(` `var` BindingIdentifier[?Yield, ?Await] Initializer[~In, ?Yield, ?Await] `in` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
       </emu-grammar>
       <p>This production only applies when parsing non-strict code.</p>
       <p>The static semantics of ContainsDuplicateLabels in <emu-xref href="#sec-static-semantics-containsduplicatelabels"></emu-xref> are augmented with the following:</p>
-      <emu-grammar>IterationStatement : `for` `(` `var` BindingIdentifier Initializer `in` Expression `)` Statement</emu-grammar>
+      <emu-grammar>ForInOfStatement : `for` `(` `var` BindingIdentifier Initializer `in` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Return ContainsDuplicateLabels of |Statement| with argument _labelSet_.
       </emu-alg>
       <p>The static semantics of ContainsUndefinedBreakTarget in <emu-xref href="#sec-static-semantics-containsundefinedbreaktarget"></emu-xref> are augmented with the following:</p>
-      <emu-grammar>IterationStatement : `for` `(` `var` BindingIdentifier Initializer `in` Expression `)` Statement</emu-grammar>
+      <emu-grammar>ForInOfStatement : `for` `(` `var` BindingIdentifier Initializer `in` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Return ContainsUndefinedBreakTarget of |Statement| with argument _labelSet_.
       </emu-alg>
       <p>The static semantics of ContainsUndefinedContinueTarget in <emu-xref href="#sec-static-semantics-containsundefinedcontinuetarget"></emu-xref> are augmented with the following:</p>
-      <emu-grammar>IterationStatement : `for` `(` `var` BindingIdentifier Initializer `in` Expression `)` Statement</emu-grammar>
+      <emu-grammar>ForInOfStatement : `for` `(` `var` BindingIdentifier Initializer `in` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Return ContainsUndefinedContinueTarget of |Statement| with arguments _iterationSet_ and &laquo; &raquo;.
       </emu-alg>
@@ -41840,21 +41935,21 @@ THH:mm:ss.sss
         1. Return *false*.
       </emu-alg>
       <p>The static semantics of VarDeclaredNames in <emu-xref href="#sec-static-semantics-vardeclarednames"></emu-xref> are augmented with the following:</p>
-      <emu-grammar>IterationStatement : `for` `(` `var` BindingIdentifier Initializer `in` Expression `)` Statement</emu-grammar>
+      <emu-grammar>ForInOfStatement : `for` `(` `var` BindingIdentifier Initializer `in` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Let _names_ be the BoundNames of |BindingIdentifier|.
         1. Append to _names_ the elements of the VarDeclaredNames of |Statement|.
         1. Return _names_.
       </emu-alg>
       <p>The static semantics of VarScopedDeclarations in <emu-xref href="#sec-static-semantics-varscopeddeclarations"></emu-xref> are augmented with the following:</p>
-      <emu-grammar>IterationStatement : `for` `(` `var` BindingIdentifier Initializer `in` Expression `)` Statement</emu-grammar>
+      <emu-grammar>ForInOfStatement : `for` `(` `var` BindingIdentifier Initializer `in` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Let _declarations_ be a List whose sole element is |BindingIdentifier|.
         1. Append to _declarations_ the elements of the VarScopedDeclarations of |Statement|.
         1. Return _declarations_.
       </emu-alg>
-      <p>The runtime semantics of LoopEvaluation in <emu-xref href="#sec-runtime-semantics-loopevaluation"></emu-xref> are augmented with the following:</p>
-      <emu-grammar>IterationStatement : `for` `(` `var` BindingIdentifier Initializer `in` Expression `)` Statement</emu-grammar>
+      <p>The runtime semantics of ForInOfLoopEvaluation in <emu-xref href="#sec-runtime-semantics-forinofloopevaluation"></emu-xref> are augmented with the following:</p>
+      <emu-grammar>ForInOfStatement : `for` `(` `var` BindingIdentifier Initializer `in` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Let _bindingId_ be StringValue of |BindingIdentifier|.
         1. Let _lhs_ be ? ResolveBinding(_bindingId_).


### PR DESCRIPTION
The `IterationStatement` nonterminal has gotten pretty unwieldy, with 14 right-hand sides. The only comparably large nonterminals are `PrimaryExpression` and `Statement`, and the right-hand sides in those cases are trivial, having one or two symbols each (compared to as many as 10 for `IterationStatement`, plus constraints, parameters, and lookahead restrictions). This PR splits it up so that `IterationStatement` produces `DoWhileStatement`, `WhileStatement`, `ForStatement`, and `ForInOfStatement`, which are defined in the relevant sections.

Commits can be squashed before merging.