### PR TITLE
Editorial: improve “About this Specification” section

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -106,7 +106,7 @@
   </ul>
   <p>Refer to the <emu-xref href="#sec-colophon">colophon</emu-xref> for more information on how this document is created.</p>
   <h1>About this Specification</h1>
-  <p>This document at <a href=".">https://tc39.es/ecma262/</a> is the most accurate and up-to-date ECMAScript specification. It contains the content of the most recent yearly snapshot plus any <a href="https://github.com/tc39/proposals/blob/master/finished-proposals.md">finished proposals</a> (those that have reached Stage&nbsp;4 in the <a href="https://tc39.es/process-document/">proposal process</a> and thus are implemented in several implementations and will be in the next practical revision) since that snapshot was taken.</p>
+  <p>The document at <a href="https://tc39.es/ecma262/">https://tc39.es/ecma262/</a> is the most accurate and up-to-date ECMAScript specification. It contains the content of the most recent yearly snapshot plus any <a href="https://github.com/tc39/proposals/blob/master/finished-proposals.md">finished proposals</a> (those that have reached Stage&nbsp;4 in the <a href="https://tc39.es/process-document/">proposal process</a> and thus are implemented in several implementations and will be in the next practical revision) since that snapshot was taken.</p>
 </div>
 <emu-intro id="sec-intro">
   <h1>Introduction</h1>


### PR DESCRIPTION
Published snapshots such as https://262.ecma-international.org/11.0/ include the exact same text. This patch tweaks the text so that the sentence still makes sense even when it’s being read from a snapshot copy. It also hardcodes the link’s target URL so that the link text and destination are always in sync and point to the expected location.

Context: https://github.com/tc39/Reflector/issues/349#issuecomment-763624846