### PR TITLE
Meta: bump ecmarkup to 6.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -520,16 +520,16 @@
       }
     },
     "ecmarkup": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-5.0.0.tgz",
-      "integrity": "sha512-+D9wyLt3NX6bCpLVdcyYuS85oGn6Hqab8SJYmeYqsZ76pwX2FgqKziWBP+FEuiUKuLfMq4HANiKxSXvp25zI6Q==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-6.0.0.tgz",
+      "integrity": "sha512-R/a7B36x8RqtszzImMHsSsPoTfaE1CUUUAFcOOxvPtkRrsf7PIsanMYnnjp2se3Gp9KM+qxIodV2o0Fef7g8qQ==",
       "requires": {
         "bluebird": "^3.7.2",
         "chalk": "^1.1.3",
         "ecmarkdown": "^6.0.0",
         "eslint": "^6.8.0",
         "grammarkdown": "^3.1.1",
-        "highlight.js": "^9.17.1",
+        "highlight.js": "^10.5.0",
         "html-escape": "^1.0.2",
         "js-yaml": "^3.13.1",
         "jsdom": "11.10.0",
@@ -937,9 +937,9 @@
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "highlight.js": {
-      "version": "9.18.5",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.5.tgz",
-      "integrity": "sha512-a5bFyofd/BHCX52/8i8uJkjr9DYwXIPnM/plwI6W7ezItLGqzt7X2G2nXuYSfsIJdkwwj/g9DG1LkcGJI/dDoA=="
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.5.0.tgz",
+      "integrity": "sha512-xTmvd9HiIHR6L53TMC7TKolEj65zG1XU+Onr8oi86mYa+nLcIbxTTWkpW7CsEwv/vK7u1zb8alZIMLDqqN6KTw=="
     },
     "html-encoding-sniffer": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "license": "SEE LICENSE IN https://tc39.es/ecma262/#sec-copyright-and-software-license",
   "homepage": "https://tc39.es/ecma262/",
   "dependencies": {
-    "ecmarkup": "^5.0.0"
+    "ecmarkup": "^6.0.0"
   },
   "devDependencies": {
     "@alrra/travis-scripts": "^2.1.0",

--- a/spec.html
+++ b/spec.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <link rel="icon" href="img/favicon.ico">
 <link href="ecmarkup.css" rel="stylesheet">
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.5.0/styles/solarized-light.min.css">
 <script src="ecmarkup.js"></script>
 <style>
   /* custom styles */


### PR DESCRIPTION
The main feature is [support for listing the SDOs associated with a production](https://github.com/tc39/ecmarkup/pull/276) - when you hover a production's definition, you should get a tooltip which will let you pop up a pane containing the SDOs defined over that production.

The breaking change is the [bump of highlight.js](https://github.com/tc39/ecmarkup/pull/284), hence the changed stylesheet.