### PR TITLE
Editorial: Remove unnecessary statement following heading for `find`.

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -31932,7 +31932,6 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-array.prototype.find">
         <h1>Array.prototype.find ( _predicate_ [ , _thisArg_ ] )</h1>
-        <p>The `find` method is called with one or two arguments, _predicate_ and _thisArg_.</p>
         <emu-note>
           <p>_predicate_ should be a function that accepts three arguments and returns a value that is coercible to a Boolean value. `find` calls _predicate_ once for each element of the array, in ascending order, until it finds one where _predicate_ returns *true*. If such an element is found, `find` immediately returns that element value. Otherwise, `find` returns *undefined*.</p>
           <p>If a _thisArg_ parameter is provided, it will be used as the *this* value for each invocation of _predicate_. If it is not provided, *undefined* is used instead.</p>

--- a/spec.html
+++ b/spec.html
@@ -31939,7 +31939,7 @@ THH:mm:ss.sss
           <p>`find` does not directly mutate the object on which it is called but the object may be mutated by the calls to _predicate_.</p>
           <p>The range of elements processed by `find` is set before the first call to _predicate_. Elements that are appended to the array after the call to `find` begins will not be visited by _predicate_. If existing elements of the array are changed, their value as passed to _predicate_ will be the value at the time that `find` visits them; elements that are deleted after the call to `find` begins and before being visited are not visited.</p>
         </emu-note>
-        <p>When the `find` method is called, the following steps are taken:</p>
+        <p>When the `find` method is called with one or two arguments, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).


### PR DESCRIPTION
I found this while reading over the proposed spec text for `findLast`. It seems like no other function/method contains text like this.