### PR TITLE
Editorial: swap phrasing to indefinite article for Boolean-coercibles.

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -31840,7 +31840,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-array.prototype.every">
         <h1>Array.prototype.every ( _callbackfn_ [ , _thisArg_ ] )</h1>
         <emu-note>
-          <p>_callbackfn_ should be a function that accepts three arguments and returns a value that is coercible to the Boolean value *true* or *false*. `every` calls _callbackfn_ once for each element present in the array, in ascending order, until it finds one where _callbackfn_ returns *false*. If such an element is found, `every` immediately returns *false*. Otherwise, if _callbackfn_ returned *true* for all elements, `every` will return *true*. _callbackfn_ is called only for elements of the array which actually exist; it is not called for missing elements of the array.</p>
+          <p>_callbackfn_ should be a function that accepts three arguments and returns a value that is coercible to a Boolean value. `every` calls _callbackfn_ once for each element present in the array, in ascending order, until it finds one where _callbackfn_ returns *false*. If such an element is found, `every` immediately returns *false*. Otherwise, if _callbackfn_ returned *true* for all elements, `every` will return *true*. _callbackfn_ is called only for elements of the array which actually exist; it is not called for missing elements of the array.</p>
           <p>If a _thisArg_ parameter is provided, it will be used as the *this* value for each invocation of _callbackfn_. If it is not provided, *undefined* is used instead.</p>
           <p>_callbackfn_ is called with three arguments: the value of the element, the index of the element, and the object being traversed.</p>
           <p>`every` does not directly mutate the object on which it is called but the object may be mutated by the calls to _callbackfn_.</p>
@@ -31899,7 +31899,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-array.prototype.filter">
         <h1>Array.prototype.filter ( _callbackfn_ [ , _thisArg_ ] )</h1>
         <emu-note>
-          <p>_callbackfn_ should be a function that accepts three arguments and returns a value that is coercible to the Boolean value *true* or *false*. `filter` calls _callbackfn_ once for each element in the array, in ascending order, and constructs a new array of all the values for which _callbackfn_ returns *true*. _callbackfn_ is called only for elements of the array which actually exist; it is not called for missing elements of the array.</p>
+          <p>_callbackfn_ should be a function that accepts three arguments and returns a value that is coercible to a Boolean value. `filter` calls _callbackfn_ once for each element in the array, in ascending order, and constructs a new array of all the values for which _callbackfn_ returns *true*. _callbackfn_ is called only for elements of the array which actually exist; it is not called for missing elements of the array.</p>
           <p>If a _thisArg_ parameter is provided, it will be used as the *this* value for each invocation of _callbackfn_. If it is not provided, *undefined* is used instead.</p>
           <p>_callbackfn_ is called with three arguments: the value of the element, the index of the element, and the object being traversed.</p>
           <p>`filter` does not directly mutate the object on which it is called but the object may be mutated by the calls to _callbackfn_.</p>
@@ -31962,7 +31962,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-array.prototype.findindex">
         <h1>Array.prototype.findIndex ( _predicate_ [ , _thisArg_ ] )</h1>
         <emu-note>
-          <p>_predicate_ should be a function that accepts three arguments and returns a value that is coercible to the Boolean value *true* or *false*. `findIndex` calls _predicate_ once for each element of the array, in ascending order, until it finds one where _predicate_ returns *true*. If such an element is found, `findIndex` immediately returns the index of that element value. Otherwise, `findIndex` returns -1.</p>
+          <p>_predicate_ should be a function that accepts three arguments and returns a value that is coercible to a Boolean value. `findIndex` calls _predicate_ once for each element of the array, in ascending order, until it finds one where _predicate_ returns *true*. If such an element is found, `findIndex` immediately returns the index of that element value. Otherwise, `findIndex` returns -1.</p>
           <p>If a _thisArg_ parameter is provided, it will be used as the *this* value for each invocation of _predicate_. If it is not provided, *undefined* is used instead.</p>
           <p>_predicate_ is called with three arguments: the value of the element, the index of the element, and the object being traversed.</p>
           <p>`findIndex` does not directly mutate the object on which it is called but the object may be mutated by the calls to _predicate_.</p>
@@ -32496,7 +32496,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-array.prototype.some">
         <h1>Array.prototype.some ( _callbackfn_ [ , _thisArg_ ] )</h1>
         <emu-note>
-          <p>_callbackfn_ should be a function that accepts three arguments and returns a value that is coercible to the Boolean value *true* or *false*. `some` calls _callbackfn_ once for each element present in the array, in ascending order, until it finds one where _callbackfn_ returns *true*. If such an element is found, `some` immediately returns *true*. Otherwise, `some` returns *false*. _callbackfn_ is called only for elements of the array which actually exist; it is not called for missing elements of the array.</p>
+          <p>_callbackfn_ should be a function that accepts three arguments and returns a value that is coercible to a Boolean value. `some` calls _callbackfn_ once for each element present in the array, in ascending order, until it finds one where _callbackfn_ returns *true*. If such an element is found, `some` immediately returns *true*. Otherwise, `some` returns *false*. _callbackfn_ is called only for elements of the array which actually exist; it is not called for missing elements of the array.</p>
           <p>If a _thisArg_ parameter is provided, it will be used as the *this* value for each invocation of _callbackfn_. If it is not provided, *undefined* is used instead.</p>
           <p>_callbackfn_ is called with three arguments: the value of the element, the index of the element, and the object being traversed.</p>
           <p>`some` does not directly mutate the object on which it is called but the object may be mutated by the calls to _callbackfn_.</p>


### PR DESCRIPTION
In the definition for `Array.prototype.find`, we have

> ```md
> _predicate_ should be a function that accepts three arguments and returns a value that is coercible to a Boolean value.
> ```

In several other places like `Array.prototype.findIndex`, we have

> ```md
> _predicate_ should be a function that accepts three arguments and returns a value that is coercible to the Boolean value *true* or *false*.
> ```

While `find` is the odd-one-out, I think it uses cleaner language, and this PR makes other locations more consistent.

Alternatively, I can amend the definition of `find`.