### PR TITLE
Editorial: remove unnecessary assertion

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -29111,7 +29111,6 @@ THH:mm:ss.sss
           <h1>SplitMatch ( _S_, _q_, _R_ )</h1>
           <p>The abstract operation SplitMatch takes arguments _S_ (a String), _q_ (a non-negative integer), and _R_ (a String). It returns either ~not-matched~ or the end index of a match. It performs the following steps when called:</p>
           <emu-alg>
-            1. Assert: Type(_R_) is String.
             1. Let _r_ be the number of code units in _R_.
             1. Let _s_ be the number of code units in _S_.
             1. If _q_ + _r_ &gt; _s_, return ~not-matched~.


### PR DESCRIPTION
Both S and R are Strings, and both are asserted in the prose, so either both or neither should be asserted in the steps. I chose neither.