### PR TITLE
Editorial: add <dfn> for "TypedArray element type"

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -32870,7 +32870,7 @@ THH:mm:ss.sss
 
   <emu-clause id="sec-typedarray-objects">
     <h1>TypedArray Objects</h1>
-    <p>_TypedArray_ objects present an array-like view of an underlying binary data buffer (<emu-xref href="#sec-arraybuffer-objects"></emu-xref>). Each element of a _TypedArray_ instance has the same underlying binary scalar data type. There is a distinct _TypedArray_ constructor, listed in <emu-xref href="#table-the-typedarray-constructors"></emu-xref>, for each of the supported element types. Each constructor in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> has a corresponding distinct prototype object.</p>
+    <p>_TypedArray_ objects present an array-like view of an underlying binary data buffer (<emu-xref href="#sec-arraybuffer-objects"></emu-xref>). A <dfn>TypedArray element type</dfn> is the underlying binary scalar data type that all elements of a _TypedArray_ instance have. There is a distinct _TypedArray_ constructor, listed in <emu-xref href="#table-the-typedarray-constructors"></emu-xref>, for each of the supported element types. Each constructor in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> has a corresponding distinct prototype object.</p>
     <emu-table id="table-the-typedarray-constructors" caption="The TypedArray Constructors" oldids="table-49">
       <table>
         <tbody>


### PR DESCRIPTION
This is solving the problem that the term "TypedArray element type" appears 8 times in the spec as an implied assertion on AO arguments and similar, but is not auto-linked or explicitly defined anywhere.

This first attempt is making the table column name a `<dfn>`, but this might look a little weird since it italicizes the column name.

The other alternative is to change the prose from `supported element types` to `supported <dfn>TypedArray element type<dfn>s` or something similar, but i'm not sure of the cleanest way to do that. 