### PR TITLE
fix: Remove percent sign from IDs

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -3361,7 +3361,7 @@
               <td>
               </td>
               <td>
-                The super class of all typed Array constructors (<emu-xref href="#sec-%typedarray%-intrinsic-object"></emu-xref>)
+                The super class of all typed Array constructors (<emu-xref href="#sec-typedarray-intrinsic-object"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -10913,7 +10913,7 @@
         1. Return ! DefinePropertyOrThrow(_F_, *"arguments"*, PropertyDescriptor { [[Get]]: _thrower_, [[Set]]: _thrower_, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
       </emu-alg>
 
-      <emu-clause id="sec-%throwtypeerror%">
+      <emu-clause id="sec-throwtypeerror">
         <h1>%ThrowTypeError% ( )</h1>
         <p>The <dfn>%ThrowTypeError%</dfn> intrinsic is an anonymous built-in function object that is defined once for each realm. When %ThrowTypeError% is called it performs the following steps:</p>
         <emu-alg>
@@ -18645,7 +18645,7 @@
         </ul>
 
         <emu-note>
-          <p>ECMAScript implementations are not required to implement the algorithm in <emu-xref href="#sec-%foriniteratorprototype%.next"></emu-xref> directly. They may choose any implementation whose behaviour will not deviate from that algorithm unless one of the constraints in the previous paragraph is violated.</p>
+          <p>ECMAScript implementations are not required to implement the algorithm in <emu-xref href="#sec-foriniteratorprototype.next"></emu-xref> directly. They may choose any implementation whose behaviour will not deviate from that algorithm unless one of the constraints in the previous paragraph is violated.</p>
           <p>The following is an informative definition of an ECMAScript generator function that conforms to these rules:</p>
           <pre><code class="javascript">
             function* EnumerateObjectProperties(obj) {
@@ -18689,7 +18689,7 @@
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-%foriniteratorprototype%-object">
+        <emu-clause id="sec-foriniteratorprototype-object">
           <h1>The %ForInIteratorPrototype% Object</h1>
           <p>The <dfn>%ForInIteratorPrototype%</dfn> object:</p>
           <ul>
@@ -18700,7 +18700,7 @@
             <li>has the following properties:</li>
           </ul>
 
-          <emu-clause id="sec-%foriniteratorprototype%.next">
+          <emu-clause id="sec-foriniteratorprototype.next">
             <h1>%ForInIteratorPrototype%.next ( )</h1>
             <emu-alg>
               1. Let _O_ be the *this* value.
@@ -29337,7 +29337,7 @@ THH:mm:ss.sss
       <h1>String Iterator Objects</h1>
       <p>A String Iterator is an object, that represents a specific iteration over some specific String instance object. There is not a named constructor for String Iterator objects. Instead, String iterator objects are created by calling certain methods of String instance objects.</p>
 
-      <emu-clause id="sec-%stringiteratorprototype%-object">
+      <emu-clause id="sec-stringiteratorprototype-object">
         <h1>The %StringIteratorPrototype% Object</h1>
         <p>The <dfn>%StringIteratorPrototype%</dfn> object:</p>
         <ul>
@@ -29347,14 +29347,14 @@ THH:mm:ss.sss
           <li>has the following properties:</li>
         </ul>
 
-        <emu-clause id="sec-%stringiteratorprototype%.next">
+        <emu-clause id="sec-stringiteratorprototype.next">
           <h1>%StringIteratorPrototype%.next ( )</h1>
           <emu-alg>
             1. Return ? GeneratorResume(*this* value, ~empty~, *"%StringIteratorPrototype%"*).
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-%stringiteratorprototype%-@@tostringtag">
+        <emu-clause id="sec-stringiteratorprototype-@@tostringtag">
           <h1>%StringIteratorPrototype% [ @@toStringTag ]</h1>
           <p>The initial value of the @@toStringTag property is the String value *"String Iterator"*.</p>
           <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
@@ -31471,7 +31471,7 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-%regexpstringiteratorprototype%-object">
+      <emu-clause id="sec-regexpstringiteratorprototype-object">
         <h1>The %RegExpStringIteratorPrototype% Object</h1>
         <p>The <dfn>%RegExpStringIteratorPrototype%</dfn> object:</p>
         <ul>
@@ -31481,14 +31481,14 @@ THH:mm:ss.sss
           <li>has the following properties:</li>
         </ul>
 
-        <emu-clause id="sec-%regexpstringiteratorprototype%.next">
+        <emu-clause id="sec-regexpstringiteratorprototype.next">
           <h1>%RegExpStringIteratorPrototype%.next ( )</h1>
           <emu-alg>
             1. Return ? GeneratorResume(*this* value, ~empty~, *"%RegExpStringIteratorPrototype%"*).
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-%regexpstringiteratorprototype%-@@tostringtag">
+        <emu-clause id="sec-regexpstringiteratorprototype-@@tostringtag">
           <h1>%RegExpStringIteratorPrototype% [ @@toStringTag ]</h1>
           <p>The initial value of the @@toStringTag property is the String value *"RegExp String Iterator"*.</p>
           <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
@@ -32867,7 +32867,7 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-%arrayiteratorprototype%-object">
+      <emu-clause id="sec-arrayiteratorprototype-object">
         <h1>The %ArrayIteratorPrototype% Object</h1>
         <p>The <dfn>%ArrayIteratorPrototype%</dfn> object:</p>
         <ul>
@@ -32877,14 +32877,14 @@ THH:mm:ss.sss
           <li>has the following properties:</li>
         </ul>
 
-        <emu-clause id="sec-%arrayiteratorprototype%.next">
+        <emu-clause id="sec-arrayiteratorprototype.next">
           <h1>%ArrayIteratorPrototype%.next ( )</h1>
           <emu-alg>
             1. Return ? GeneratorResume(*this* value, ~empty~, *"%ArrayIteratorPrototype%"*).
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-%arrayiteratorprototype%-@@tostringtag">
+        <emu-clause id="sec-arrayiteratorprototype-@@tostringtag">
           <h1>%ArrayIteratorPrototype% [ @@toStringTag ]</h1>
           <p>The initial value of the @@toStringTag property is the String value *"Array Iterator"*.</p>
           <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
@@ -33128,7 +33128,7 @@ THH:mm:ss.sss
     </emu-table>
     <p>In the definitions below, references to _TypedArray_ should be replaced with the appropriate constructor name from the above table.</p>
 
-    <emu-clause id="sec-%typedarray%-intrinsic-object">
+    <emu-clause id="sec-typedarray-intrinsic-object">
       <h1>The %TypedArray% Intrinsic Object</h1>
       <p>The <dfn>%TypedArray%</dfn> intrinsic object:</p>
       <ul>
@@ -33139,7 +33139,7 @@ THH:mm:ss.sss
         <li>will throw an error when invoked, because it is an abstract class constructor. The _TypedArray_ constructors do not perform a `super` call to it.</li>
       </ul>
 
-      <emu-clause id="sec-%typedarray%">
+      <emu-clause id="sec-typedarray">
         <h1>%TypedArray% ( )</h1>
         <p>The %TypedArray% constructor performs the following steps:</p>
         <emu-alg>
@@ -33158,7 +33158,7 @@ THH:mm:ss.sss
         <li>has the following properties:</li>
       </ul>
 
-      <emu-clause id="sec-%typedarray%.from">
+      <emu-clause id="sec-typedarray.from">
         <h1>%TypedArray%.from ( _source_ [ , _mapfn_ [ , _thisArg_ ] ] )</h1>
         <p>When the `from` method is called with argument _source_, and optional arguments _mapfn_ and _thisArg_, the following steps are taken:</p>
         <emu-alg>
@@ -33201,7 +33201,7 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-%typedarray%.of">
+      <emu-clause id="sec-typedarray.of">
         <h1>%TypedArray%.of ( ..._items_ )</h1>
         <p>When the `of` method is called with any number of arguments, the following steps are taken:</p>
         <emu-alg>
@@ -33219,7 +33219,7 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-%typedarray%.prototype">
+      <emu-clause id="sec-typedarray.prototype">
         <h1>%TypedArray%.prototype</h1>
         <p>The initial value of %TypedArray%`.prototype` is the %TypedArray% prototype object.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
@@ -33288,12 +33288,12 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-%typedarray%.prototype.constructor">
+      <emu-clause id="sec-typedarray.prototype.constructor">
         <h1>%TypedArray%.prototype.constructor</h1>
         <p>The initial value of %TypedArray%`.prototype.constructor` is the %TypedArray% intrinsic object.</p>
       </emu-clause>
 
-      <emu-clause id="sec-%typedarray%.prototype.copywithin">
+      <emu-clause id="sec-typedarray.prototype.copywithin">
         <h1>%TypedArray%.prototype.copyWithin ( _target_, _start_ [ , _end_ ] )</h1>
         <p>The interpretation and use of the arguments of %TypedArray%`.prototype.copyWithin` are the same as for `Array.prototype.copyWithin` as defined in <emu-xref href="#sec-array.prototype.copywithin"></emu-xref>.</p>
         <p>The following steps are taken:</p>
@@ -33340,7 +33340,7 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-%typedarray%.prototype.entries">
+      <emu-clause id="sec-typedarray.prototype.entries">
         <h1>%TypedArray%.prototype.entries ( )</h1>
         <p>The following steps are taken:</p>
         <emu-alg>
@@ -33350,13 +33350,13 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-%typedarray%.prototype.every">
+      <emu-clause id="sec-typedarray.prototype.every">
         <h1>%TypedArray%.prototype.every ( _callbackfn_ [ , _thisArg_ ] )</h1>
         <p>%TypedArray%`.prototype.every` is a distinct function that implements the same algorithm as `Array.prototype.every` as defined in <emu-xref href="#sec-array.prototype.every"></emu-xref> except that the *this* value's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of *"length"*. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer-indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _callbackfn_ may cause the *this* value to become detached.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
-      <emu-clause id="sec-%typedarray%.prototype.fill">
+      <emu-clause id="sec-typedarray.prototype.fill">
         <h1>%TypedArray%.prototype.fill ( _value_ [ , _start_ [ , _end_ ] ] )</h1>
         <p>The interpretation and use of the arguments of %TypedArray%`.prototype.fill` are the same as for `Array.prototype.fill` as defined in <emu-xref href="#sec-array.prototype.fill"></emu-xref>.</p>
         <p>The following steps are taken:</p>
@@ -33383,7 +33383,7 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-%typedarray%.prototype.filter">
+      <emu-clause id="sec-typedarray.prototype.filter">
         <h1>%TypedArray%.prototype.filter ( _callbackfn_ [ , _thisArg_ ] )</h1>
         <p>The interpretation and use of the arguments of %TypedArray%`.prototype.filter` are the same as for `Array.prototype.filter` as defined in <emu-xref href="#sec-array.prototype.filter"></emu-xref>.</p>
         <p>When the `filter` method is called with one or two arguments, the following steps are taken:</p>
@@ -33413,43 +33413,43 @@ THH:mm:ss.sss
         <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
       </emu-clause>
 
-      <emu-clause id="sec-%typedarray%.prototype.find">
+      <emu-clause id="sec-typedarray.prototype.find">
         <h1>%TypedArray%.prototype.find ( _predicate_ [ , _thisArg_ ] )</h1>
         <p>%TypedArray%`.prototype.find` is a distinct function that implements the same algorithm as `Array.prototype.find` as defined in <emu-xref href="#sec-array.prototype.find"></emu-xref> except that the *this* value's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of *"length"*. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _predicate_ may cause the *this* value to become detached.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
-      <emu-clause id="sec-%typedarray%.prototype.findindex">
+      <emu-clause id="sec-typedarray.prototype.findindex">
         <h1>%TypedArray%.prototype.findIndex ( _predicate_ [ , _thisArg_ ] )</h1>
         <p>%TypedArray%`.prototype.findIndex` is a distinct function that implements the same algorithm as `Array.prototype.findIndex` as defined in <emu-xref href="#sec-array.prototype.findindex"></emu-xref> except that the *this* value's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of *"length"*. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _predicate_ may cause the *this* value to become detached.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
-      <emu-clause id="sec-%typedarray%.prototype.foreach">
+      <emu-clause id="sec-typedarray.prototype.foreach">
         <h1>%TypedArray%.prototype.forEach ( _callbackfn_ [ , _thisArg_ ] )</h1>
         <p>%TypedArray%`.prototype.forEach` is a distinct function that implements the same algorithm as `Array.prototype.forEach` as defined in <emu-xref href="#sec-array.prototype.foreach"></emu-xref> except that the *this* value's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of *"length"*. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _callbackfn_ may cause the *this* value to become detached.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
-      <emu-clause id="sec-%typedarray%.prototype.includes">
+      <emu-clause id="sec-typedarray.prototype.includes">
         <h1>%TypedArray%.prototype.includes ( _searchElement_ [ , _fromIndex_ ] )</h1>
         <p>%TypedArray%`.prototype.includes` is a distinct function that implements the same algorithm as `Array.prototype.includes` as defined in <emu-xref href="#sec-array.prototype.includes"></emu-xref> except that the *this* value's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of *"length"*. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
-      <emu-clause id="sec-%typedarray%.prototype.indexof">
+      <emu-clause id="sec-typedarray.prototype.indexof">
         <h1>%TypedArray%.prototype.indexOf ( _searchElement_ [ , _fromIndex_ ] )</h1>
         <p>%TypedArray%`.prototype.indexOf` is a distinct function that implements the same algorithm as `Array.prototype.indexOf` as defined in <emu-xref href="#sec-array.prototype.indexof"></emu-xref> except that the *this* value's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of *"length"*. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
-      <emu-clause id="sec-%typedarray%.prototype.join">
+      <emu-clause id="sec-typedarray.prototype.join">
         <h1>%TypedArray%.prototype.join ( _separator_ )</h1>
         <p>%TypedArray%`.prototype.join` is a distinct function that implements the same algorithm as `Array.prototype.join` as defined in <emu-xref href="#sec-array.prototype.join"></emu-xref> except that the *this* value's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of *"length"*. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
-      <emu-clause id="sec-%typedarray%.prototype.keys">
+      <emu-clause id="sec-typedarray.prototype.keys">
         <h1>%TypedArray%.prototype.keys ( )</h1>
         <p>The following steps are taken:</p>
         <emu-alg>
@@ -33459,7 +33459,7 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-%typedarray%.prototype.lastindexof">
+      <emu-clause id="sec-typedarray.prototype.lastindexof">
         <h1>%TypedArray%.prototype.lastIndexOf ( _searchElement_ [ , _fromIndex_ ] )</h1>
         <p>%TypedArray%`.prototype.lastIndexOf` is a distinct function that implements the same algorithm as `Array.prototype.lastIndexOf` as defined in <emu-xref href="#sec-array.prototype.lastindexof"></emu-xref> except that the *this* value's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of *"length"*. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
@@ -33480,7 +33480,7 @@ THH:mm:ss.sss
         <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
       </emu-clause>
 
-      <emu-clause id="sec-%typedarray%.prototype.map">
+      <emu-clause id="sec-typedarray.prototype.map">
         <h1>%TypedArray%.prototype.map ( _callbackfn_ [ , _thisArg_ ] )</h1>
         <p>The interpretation and use of the arguments of %TypedArray%`.prototype.map` are the same as for `Array.prototype.map` as defined in <emu-xref href="#sec-array.prototype.map"></emu-xref>.</p>
         <p>When the `map` method is called with one or two arguments, the following steps are taken:</p>
@@ -33502,25 +33502,25 @@ THH:mm:ss.sss
         <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
       </emu-clause>
 
-      <emu-clause id="sec-%typedarray%.prototype.reduce">
+      <emu-clause id="sec-typedarray.prototype.reduce">
         <h1>%TypedArray%.prototype.reduce ( _callbackfn_ [ , _initialValue_ ] )</h1>
         <p>%TypedArray%`.prototype.reduce` is a distinct function that implements the same algorithm as `Array.prototype.reduce` as defined in <emu-xref href="#sec-array.prototype.reduce"></emu-xref> except that the *this* value's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of *"length"*. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _callbackfn_ may cause the *this* value to become detached.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
-      <emu-clause id="sec-%typedarray%.prototype.reduceright">
+      <emu-clause id="sec-typedarray.prototype.reduceright">
         <h1>%TypedArray%.prototype.reduceRight ( _callbackfn_ [ , _initialValue_ ] )</h1>
         <p>%TypedArray%`.prototype.reduceRight` is a distinct function that implements the same algorithm as `Array.prototype.reduceRight` as defined in <emu-xref href="#sec-array.prototype.reduceright"></emu-xref> except that the *this* value's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of *"length"*. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _callbackfn_ may cause the *this* value to become detached.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
-      <emu-clause id="sec-%typedarray%.prototype.reverse">
+      <emu-clause id="sec-typedarray.prototype.reverse">
         <h1>%TypedArray%.prototype.reverse ( )</h1>
         <p>%TypedArray%`.prototype.reverse` is a distinct function that implements the same algorithm as `Array.prototype.reverse` as defined in <emu-xref href="#sec-array.prototype.reverse"></emu-xref> except that the *this* value's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of *"length"*. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
-      <emu-clause id="sec-%typedarray%.prototype.set" oldids="sec-%typedarray%.prototype.set-overloaded-offset">
+      <emu-clause id="sec-typedarray.prototype.set" oldids="sec-typedarray.prototype.set-overloaded-offset">
         <h1>%TypedArray%.prototype.set ( _source_ [ , _offset_ ] )</h1>
         <p>%TypedArray%`.prototype.set` is a function whose behaviour differs based upon the type of its first argument.</p>
         <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
@@ -33538,7 +33538,7 @@ THH:mm:ss.sss
           1. Return *undefined*.
         </emu-alg>
 
-        <emu-clause id="sec-settypedarrayfromtypedarray" aoid="SetTypedArrayFromTypedArray" oldids="sec-%typedarray%.prototype.set-typedarray-offset">
+        <emu-clause id="sec-settypedarrayfromtypedarray" aoid="SetTypedArrayFromTypedArray" oldids="sec-typedarray.prototype.set-typedarray-offset">
           <h1>SetTypedArrayFromTypedArray ( _target_, _targetOffset_, _source_ )</h1>
           <p>The abstract operation SetTypedArrayFromTypedArray takes arguments _target_ (a TypedArray object), _targetOffset_ (a non-negative integer or +&infin;), and _source_ (a TypedArray object). It sets multiple values in _target_, starting at index _targetOffset_, reading the values from _source_. It performs the following steps when called:</p>
           <emu-alg>
@@ -33587,7 +33587,7 @@ THH:mm:ss.sss
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-settypedarrayfromarraylike" aoid="SetTypedArrayFromArrayLike" oldids="sec-%typedarray%.prototype.set-array-offset">
+        <emu-clause id="sec-settypedarrayfromarraylike" aoid="SetTypedArrayFromArrayLike" oldids="sec-typedarray.prototype.set-array-offset">
           <h1>SetTypedArrayFromArrayLike ( _target_, _targetOffset_, _source_ )</h1>
           <p>The abstract operation SetTypedArrayFromArrayLike takes arguments _target_ (a TypedArray object), _targetOffset_ (a non-negative integer or +&infin;), and _source_ (an ECMAScript value other than a TypedArray object). It sets multiple values in _target_, starting at index _targetOffset_, reading the values from _source_. It performs the following steps when called:</p>
           <emu-alg>
@@ -33619,7 +33619,7 @@ THH:mm:ss.sss
         </emu-clause>
       </emu-clause>
 
-      <emu-clause id="sec-%typedarray%.prototype.slice">
+      <emu-clause id="sec-typedarray.prototype.slice">
         <h1>%TypedArray%.prototype.slice ( _start_, _end_ )</h1>
         <p>The interpretation and use of the arguments of %TypedArray%`.prototype.slice` are the same as for `Array.prototype.slice` as defined in <emu-xref href="#sec-array.prototype.slice"></emu-xref>. The following steps are taken:</p>
         <emu-alg>
@@ -33669,13 +33669,13 @@ THH:mm:ss.sss
         <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
       </emu-clause>
 
-      <emu-clause id="sec-%typedarray%.prototype.some">
+      <emu-clause id="sec-typedarray.prototype.some">
         <h1>%TypedArray%.prototype.some ( _callbackfn_ [ , _thisArg_ ] )</h1>
         <p>%TypedArray%`.prototype.some` is a distinct function that implements the same algorithm as `Array.prototype.some` as defined in <emu-xref href="#sec-array.prototype.some"></emu-xref> except that the *this* value's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of *"length"*. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm and must take into account the possibility that calls to _callbackfn_ may cause the *this* value to become detached.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
 
-      <emu-clause id="sec-%typedarray%.prototype.sort">
+      <emu-clause id="sec-typedarray.prototype.sort">
         <h1>%TypedArray%.prototype.sort ( _comparefn_ )</h1>
         <p>%TypedArray%`.prototype.sort` is a distinct function that, except as described below, implements the same requirements as those of `Array.prototype.sort` as defined in <emu-xref href="#sec-array.prototype.sort"></emu-xref>. The implementation of the %TypedArray%`.prototype.sort` specification may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. The only internal methods of the *this* value that the algorithm may call are [[Get]] and [[Set]].</p>
         <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
@@ -33710,7 +33710,7 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <emu-clause id="sec-%typedarray%.prototype.subarray">
+      <emu-clause id="sec-typedarray.prototype.subarray">
         <h1>%TypedArray%.prototype.subarray ( _begin_, _end_ )</h1>
         <p>Returns a new _TypedArray_ object whose element type is the same as this _TypedArray_ and whose ArrayBuffer is the same as the ArrayBuffer of this _TypedArray_, referencing the elements at _begin_, inclusive, up to _end_, exclusive. If either _begin_ or _end_ is negative, it refers to an index from the end of the array, as opposed to from the beginning.</p>
         <emu-alg>
@@ -33738,7 +33738,7 @@ THH:mm:ss.sss
         <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
       </emu-clause>
 
-      <emu-clause id="sec-%typedarray%.prototype.tolocalestring">
+      <emu-clause id="sec-typedarray.prototype.tolocalestring">
         <h1>%TypedArray%.prototype.toLocaleString ( [ _reserved1_ [ , _reserved2_ ] ] )</h1>
         <p>%TypedArray%`.prototype.toLocaleString` is a distinct function that implements the same algorithm as `Array.prototype.toLocaleString` as defined in <emu-xref href="#sec-array.prototype.tolocalestring"></emu-xref> except that the *this* value's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of *"length"*. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
         <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
@@ -33747,12 +33747,12 @@ THH:mm:ss.sss
         </emu-note>
       </emu-clause>
 
-      <emu-clause id="sec-%typedarray%.prototype.tostring">
+      <emu-clause id="sec-typedarray.prototype.tostring">
         <h1>%TypedArray%.prototype.toString ( )</h1>
         <p>The initial value of the %TypedArray%`.prototype.toString` data property is the same built-in function object as the `Array.prototype.toString` method defined in <emu-xref href="#sec-array.prototype.tostring"></emu-xref>.</p>
       </emu-clause>
 
-      <emu-clause id="sec-%typedarray%.prototype.values">
+      <emu-clause id="sec-typedarray.prototype.values">
         <h1>%TypedArray%.prototype.values ( )</h1>
         <p>The following steps are taken:</p>
         <emu-alg>
@@ -33762,7 +33762,7 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-%typedarray%.prototype-@@iterator">
+      <emu-clause id="sec-typedarray.prototype-@@iterator">
         <h1>%TypedArray%.prototype [ @@iterator ] ( )</h1>
         <p>The initial value of the @@iterator property is the same function object as the initial value of the %TypedArray%`.prototype.values` property.</p>
       </emu-clause>
@@ -34360,7 +34360,7 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-%mapiteratorprototype%-object">
+      <emu-clause id="sec-mapiteratorprototype-object">
         <h1>The %MapIteratorPrototype% Object</h1>
         <p>The <dfn>%MapIteratorPrototype%</dfn> object:</p>
         <ul>
@@ -34370,14 +34370,14 @@ THH:mm:ss.sss
           <li>has the following properties:</li>
         </ul>
 
-        <emu-clause id="sec-%mapiteratorprototype%.next">
+        <emu-clause id="sec-mapiteratorprototype.next">
           <h1>%MapIteratorPrototype%.next ( )</h1>
           <emu-alg>
             1. Return ? GeneratorResume(*this* value, ~empty~, *"%MapIteratorPrototype%"*).
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-%mapiteratorprototype%-@@tostringtag">
+        <emu-clause id="sec-mapiteratorprototype-@@tostringtag">
           <h1>%MapIteratorPrototype% [ @@toStringTag ]</h1>
           <p>The initial value of the @@toStringTag property is the String value *"Map Iterator"*.</p>
           <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
@@ -34641,7 +34641,7 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-%setiteratorprototype%-object">
+      <emu-clause id="sec-setiteratorprototype-object">
         <h1>The %SetIteratorPrototype% Object</h1>
         <p>The <dfn>%SetIteratorPrototype%</dfn> object:</p>
         <ul>
@@ -34651,14 +34651,14 @@ THH:mm:ss.sss
           <li>has the following properties:</li>
         </ul>
 
-        <emu-clause id="sec-%setiteratorprototype%.next">
+        <emu-clause id="sec-setiteratorprototype.next">
           <h1>%SetIteratorPrototype%.next ( )</h1>
           <emu-alg>
             1. Return ? GeneratorResume(*this* value, ~empty~, *"%SetIteratorPrototype%"*).
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-%setiteratorprototype%-@@tostringtag">
+        <emu-clause id="sec-setiteratorprototype-@@tostringtag">
           <h1>%SetIteratorPrototype% [ @@toStringTag ]</h1>
           <p>The initial value of the @@toStringTag property is the String value *"Set Iterator"*.</p>
           <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
@@ -37204,7 +37204,7 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <emu-clause id="sec-%iteratorprototype%-object">
+    <emu-clause id="sec-iteratorprototype-object">
       <h1>The %IteratorPrototype% Object</h1>
       <p>The <dfn>%IteratorPrototype%</dfn> object:</p>
       <ul>
@@ -37217,7 +37217,7 @@ THH:mm:ss.sss
         <pre><code class="javascript">Object.getPrototypeOf(Object.getPrototypeOf([][Symbol.iterator]()))</code></pre>
       </emu-note>
 
-      <emu-clause id="sec-%iteratorprototype%-@@iterator">
+      <emu-clause id="sec-iteratorprototype-@@iterator">
         <h1>%IteratorPrototype% [ @@iterator ] ( )</h1>
         <p>The following steps are taken:</p>
         <emu-alg>
@@ -37264,7 +37264,7 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-%asyncfromsynciteratorprototype%-object">
+      <emu-clause id="sec-asyncfromsynciteratorprototype-object">
         <h1>The %AsyncFromSyncIteratorPrototype% Object</h1>
         <p>The <dfn>%AsyncFromSyncIteratorPrototype%</dfn> object:</p>
         <ul>
@@ -37274,7 +37274,7 @@ THH:mm:ss.sss
           <li>has the following properties:</li>
         </ul>
 
-        <emu-clause id="sec-%asyncfromsynciteratorprototype%.next">
+        <emu-clause id="sec-asyncfromsynciteratorprototype.next">
           <h1>%AsyncFromSyncIteratorPrototype%.next ( [ _value_ ] )</h1>
           <emu-alg>
             1. Let _O_ be the *this* value.
@@ -37290,7 +37290,7 @@ THH:mm:ss.sss
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-%asyncfromsynciteratorprototype%.return">
+        <emu-clause id="sec-asyncfromsynciteratorprototype.return">
           <h1>%AsyncFromSyncIteratorPrototype%.return ( [ _value_ ] )</h1>
 
           <emu-alg>
@@ -37316,9 +37316,9 @@ THH:mm:ss.sss
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-%asyncfromsynciteratorprototype%.throw">
+        <emu-clause id="sec-asyncfromsynciteratorprototype.throw">
           <h1>%AsyncFromSyncIteratorPrototype%.throw ( [ _value_ ] )</h1>
-          <emu-note>In this specification, _value_ is always provided, but is left optional for consistency with <emu-xref title href="#sec-%asyncfromsynciteratorprototype%.return"></emu-xref>.</emu-note>
+          <emu-note>In this specification, _value_ is always provided, but is left optional for consistency with <emu-xref title href="#sec-asyncfromsynciteratorprototype.return"></emu-xref>.</emu-note>
 
           <emu-alg>
             1. Let _O_ be the *this* value.


### PR DESCRIPTION
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->

Related to https://github.com/heycam/webidl/pull/955
