### PR TITLE
Meta: bump ecmarkup to 6.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,11 +11,11 @@
       "dev": true
     },
     "@babel/code-frame": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
-      "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+      "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
       "requires": {
-        "@babel/highlight": "^7.10.4"
+        "@babel/highlight": "^7.12.13"
       }
     },
     "@babel/helper-validator-identifier": {
@@ -24,11 +24,11 @@
       "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
     },
     "@babel/highlight": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-      "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.12.13.tgz",
+      "integrity": "sha512-kocDQvIbgMKlWxXe9fof3TQ+gkIPOUSEYhJjqUjvKMez3krV7vbzYCDq39Oj11UAVK7JqPVGQPlgE85dPNlQww==",
       "requires": {
-        "@babel/helper-validator-identifier": "^7.10.4",
+        "@babel/helper-validator-identifier": "^7.12.11",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -62,105 +62,99 @@
       }
     },
     "@esfx/async-canceltoken": {
-      "version": "1.0.0-pre.16",
-      "resolved": "https://registry.npmjs.org/@esfx/async-canceltoken/-/async-canceltoken-1.0.0-pre.16.tgz",
-      "integrity": "sha512-gGV068eL5+Rx5TPQDW8ZlLMvlKtwYL1ICR3NZpTTwA8Wo1+MyQOZN9rz/M85lJsV3kYVMrXYmDeNN6xH8rCF/Q==",
+      "version": "1.0.0-pre.17",
+      "resolved": "https://registry.npmjs.org/@esfx/async-canceltoken/-/async-canceltoken-1.0.0-pre.17.tgz",
+      "integrity": "sha512-e2zSnqahQzcAJ+tfBnbyuuuiZQx7HoT+5xgpL9M+w+HkLAIpMEHMv6paGRWrjldOpHeHLAm3/MOR5br+m331Lw==",
       "requires": {
-        "@esfx/cancelable": "^1.0.0-pre.16",
-        "@esfx/collections-linkedlist": "^1.0.0-pre.16",
-        "@esfx/disposable": "^1.0.0-pre.16",
-        "@esfx/internal-guards": "^1.0.0-pre.16",
+        "@esfx/cancelable": "^1.0.0-pre.17",
+        "@esfx/collections-linkedlist": "^1.0.0-pre.17",
+        "@esfx/disposable": "^1.0.0-pre.17",
+        "@esfx/internal-guards": "^1.0.0-pre.17",
         "@esfx/internal-tag": "^1.0.0-pre.6",
-        "tslib": "^1.9.3"
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+        }
       }
     },
     "@esfx/cancelable": {
-      "version": "1.0.0-pre.16",
-      "resolved": "https://registry.npmjs.org/@esfx/cancelable/-/cancelable-1.0.0-pre.16.tgz",
-      "integrity": "sha512-xKwB92EEem1iMiT9t9eM5kNllXyqdZy4hb/ycWBURnScspxiE1x3O+hugX953Iq1zv9Iy4JgVWdTknH9SEO/+A==",
+      "version": "1.0.0-pre.17",
+      "resolved": "https://registry.npmjs.org/@esfx/cancelable/-/cancelable-1.0.0-pre.17.tgz",
+      "integrity": "sha512-0r2OwLfoSzDWmtANCO0HKhqJAyJS4tEavRkUeYzckReIK/IIF6n/2UPLaCXaleCx/LE7PdczS0VI2//qpFIZSg==",
       "requires": {
-        "@esfx/disposable": "^1.0.0-pre.16",
-        "@esfx/internal-deprecate": "^1.0.0-pre.16",
-        "@esfx/internal-guards": "^1.0.0-pre.16",
-        "@esfx/internal-tag": "^1.0.0-pre.6",
-        "tslib": "^1.9.3"
+        "@esfx/disposable": "^1.0.0-pre.17",
+        "@esfx/internal-deprecate": "^1.0.0-pre.17",
+        "@esfx/internal-guards": "^1.0.0-pre.17",
+        "@esfx/internal-tag": "^1.0.0-pre.6"
       }
     },
     "@esfx/collection-core": {
-      "version": "1.0.0-pre.16",
-      "resolved": "https://registry.npmjs.org/@esfx/collection-core/-/collection-core-1.0.0-pre.16.tgz",
-      "integrity": "sha512-lMV+7P3d85AOjgghRnGYMnI36GEjcMlJESH7cYs42PpbbhFAmRx42Czq57RuoV6IKlo4F2MawO2RqjzQy7OR+g==",
+      "version": "1.0.0-pre.17",
+      "resolved": "https://registry.npmjs.org/@esfx/collection-core/-/collection-core-1.0.0-pre.17.tgz",
+      "integrity": "sha512-dzaw35wkW/tzbLtbxRGU5laNxAejGNVY83Snj7gJie3lQ4HefJ0CPYzeLWN2JvMc6G4ut5kmfGfyXvVIyKQKxw==",
       "requires": {
-        "@esfx/internal-deprecate": "^1.0.0-pre.16",
-        "@esfx/internal-guards": "^1.0.0-pre.16",
-        "tslib": "^1.9.3"
+        "@esfx/internal-deprecate": "^1.0.0-pre.17",
+        "@esfx/internal-guards": "^1.0.0-pre.17"
       }
     },
     "@esfx/collections-linkedlist": {
-      "version": "1.0.0-pre.16",
-      "resolved": "https://registry.npmjs.org/@esfx/collections-linkedlist/-/collections-linkedlist-1.0.0-pre.16.tgz",
-      "integrity": "sha512-IHQJy0o8hOFf/o/0DknY1mgbg9n0iXPfOfmQmET3XMj30A28udB/GztI+bY7x04NcB9y9VuClMqnhu3O294+7A==",
+      "version": "1.0.0-pre.17",
+      "resolved": "https://registry.npmjs.org/@esfx/collections-linkedlist/-/collections-linkedlist-1.0.0-pre.17.tgz",
+      "integrity": "sha512-fRvvzEpPqo5ICWScHrga1OJnT6JzEYErA4//x8JnC9vcvVUHgqcXzIzACf2YoEJ8VkSC8KxA4fyONEffpqJwDw==",
       "requires": {
-        "@esfx/collection-core": "^1.0.0-pre.16",
-        "@esfx/equatable": "^1.0.0-pre.16",
-        "@esfx/internal-guards": "^1.0.0-pre.16",
-        "tslib": "^1.9.3"
+        "@esfx/collection-core": "^1.0.0-pre.17",
+        "@esfx/equatable": "^1.0.0-pre.17",
+        "@esfx/internal-guards": "^1.0.0-pre.17"
       }
     },
     "@esfx/disposable": {
-      "version": "1.0.0-pre.16",
-      "resolved": "https://registry.npmjs.org/@esfx/disposable/-/disposable-1.0.0-pre.16.tgz",
-      "integrity": "sha512-FYsDunVx1nyd0Fey9gG03AYmU33/+yt8xbyTnBq4mTN0u2n2kqldq/SnFYmbhreK36TdAsqmiLiCub+sARRquA==",
+      "version": "1.0.0-pre.17",
+      "resolved": "https://registry.npmjs.org/@esfx/disposable/-/disposable-1.0.0-pre.17.tgz",
+      "integrity": "sha512-enOvrXG0E2bIFyfq6Rr18qxWkZOtltjPj/Ne7zkZJEfls05uDt3BCpZE5RxRdnVu3YDFAcGMYUIpOfrYJ7iUXw==",
       "requires": {
-        "@esfx/internal-deprecate": "^1.0.0-pre.16",
-        "@esfx/internal-guards": "^1.0.0-pre.16",
-        "@esfx/internal-tag": "^1.0.0-pre.6",
-        "tslib": "^1.9.3"
+        "@esfx/internal-deprecate": "^1.0.0-pre.17",
+        "@esfx/internal-guards": "^1.0.0-pre.17",
+        "@esfx/internal-tag": "^1.0.0-pre.6"
       }
     },
     "@esfx/equatable": {
-      "version": "1.0.0-pre.16",
-      "resolved": "https://registry.npmjs.org/@esfx/equatable/-/equatable-1.0.0-pre.16.tgz",
-      "integrity": "sha512-HmHXim5IILl42CY0MXFAFwQEZN2EqZeVnXm2CDz3zKy6cJiuBGzxA128uQNRFdKLcwiglE/55Yl8zEFo9QYxmQ==",
+      "version": "1.0.0-pre.17",
+      "resolved": "https://registry.npmjs.org/@esfx/equatable/-/equatable-1.0.0-pre.17.tgz",
+      "integrity": "sha512-VzHDMmVj2JsE75yBDL2H6h0BcxSQLdYCYD7KomXxa2BuJvhbOabPOTyapy7+ECzyHrffnNVzFbGs+At3xdGbEw==",
       "requires": {
-        "@esfx/internal-deprecate": "^1.0.0-pre.16",
-        "@esfx/internal-hashcode": "^1.0.0-pre.16",
-        "tslib": "^1.9.3"
+        "@esfx/internal-deprecate": "^1.0.0-pre.17",
+        "@esfx/internal-hashcode": "^1.0.0-pre.17"
       }
     },
     "@esfx/internal-deprecate": {
-      "version": "1.0.0-pre.16",
-      "resolved": "https://registry.npmjs.org/@esfx/internal-deprecate/-/internal-deprecate-1.0.0-pre.16.tgz",
-      "integrity": "sha512-PpxFI0LqkQrkrUppsJnAYjyrC5s+rEAcM7yZO04uazVZtbWGddgovHiJEbRBbrBpzpwA4KvAOrMl9vi2sdcs5A==",
-      "requires": {
-        "tslib": "^1.9.3"
-      }
+      "version": "1.0.0-pre.17",
+      "resolved": "https://registry.npmjs.org/@esfx/internal-deprecate/-/internal-deprecate-1.0.0-pre.17.tgz",
+      "integrity": "sha512-91dsKj+a5HQuzxnuFuQGOVQK9uLNRvpAeUapFyIDSBC2ARjHvUBcTDlRaQvP7f0qhiHivWn/I6mA3IgUgDptnA=="
     },
     "@esfx/internal-guards": {
-      "version": "1.0.0-pre.16",
-      "resolved": "https://registry.npmjs.org/@esfx/internal-guards/-/internal-guards-1.0.0-pre.16.tgz",
-      "integrity": "sha512-7859KZwi7PQDebsNG/cdM36ysEgv1YPtNZ1ixeZaSQG3YOE3NszPk8TcYESqCmfd3vQ3t4wEGpTNjQuHGuw4sw==",
+      "version": "1.0.0-pre.17",
+      "resolved": "https://registry.npmjs.org/@esfx/internal-guards/-/internal-guards-1.0.0-pre.17.tgz",
+      "integrity": "sha512-QzDEALC/eVhee+7Rk/9IKLJ7afzD08CqqYcOdE/6K9BOR18rBMxadDZ+0dCkVyLYhz2iNynAh8a3IAEBFfx3Sw==",
       "requires": {
-        "@esfx/type-model": "^1.0.0-pre.16",
-        "tslib": "^1.9.3"
+        "@esfx/type-model": "^1.0.0-pre.17"
       }
     },
     "@esfx/internal-hashcode": {
-      "version": "1.0.0-pre.16",
-      "resolved": "https://registry.npmjs.org/@esfx/internal-hashcode/-/internal-hashcode-1.0.0-pre.16.tgz",
-      "integrity": "sha512-pDap4fI2Topgq5+9GQvstyNa/rrD1BbK5v0naaGWHeOKsZq+YL2bLSJzTDmm5Yyvh7h6FUnjP7D7OWv72fMwcg==",
+      "version": "1.0.0-pre.17",
+      "resolved": "https://registry.npmjs.org/@esfx/internal-hashcode/-/internal-hashcode-1.0.0-pre.17.tgz",
+      "integrity": "sha512-plMkjPEKlVjjfaHjh9J5VKDDpKLNhJOwuB94coWYLx/PkxgPpbYW7lUiWi6TwunxxjcF0dQa4EIk24HejvNmmw==",
       "requires": {
-        "@esfx/internal-murmur3": "^1.0.0-pre.16",
-        "tslib": "^1.9.3"
+        "@esfx/internal-murmur3": "^1.0.0-pre.17"
       }
     },
     "@esfx/internal-murmur3": {
-      "version": "1.0.0-pre.16",
-      "resolved": "https://registry.npmjs.org/@esfx/internal-murmur3/-/internal-murmur3-1.0.0-pre.16.tgz",
-      "integrity": "sha512-jjdoJMHGiiYNXpdxCRxEoZ7GYGkfZ7tKKIaSRK7C1THgTZbuKmtFQxrLRYFvvqJ/gRmDpVkqh+rg4eLL9t7jMw==",
-      "requires": {
-        "tslib": "^1.9.3"
-      }
+      "version": "1.0.0-pre.17",
+      "resolved": "https://registry.npmjs.org/@esfx/internal-murmur3/-/internal-murmur3-1.0.0-pre.17.tgz",
+      "integrity": "sha512-AHTmhvM663suNCaj3Xak0OrXFifb2QNdMJh4/VRP5cnfja7jwRaYka/3VtG5DR4JXgzc1cZ+E87ZFF/SkojcWw=="
     },
     "@esfx/internal-tag": {
       "version": "1.0.0-pre.6",
@@ -168,12 +162,9 @@
       "integrity": "sha512-nODidP9/RBLqX39HL12IhFLgaoBHrC5nrm6D/BwquCGNoPQI9EXNPau+IdmGqeUcaMoVOFLFOkYtnHU52RVngw=="
     },
     "@esfx/type-model": {
-      "version": "1.0.0-pre.16",
-      "resolved": "https://registry.npmjs.org/@esfx/type-model/-/type-model-1.0.0-pre.16.tgz",
-      "integrity": "sha512-TCYm7KoidPSbVS+Rt3xiFc5/GZrOxO70YsvDCqmF2YZP9pXSOlL5mKUkeCIJmIzg0kdmjpGNjATXF33jOfdadQ==",
-      "requires": {
-        "tslib": "^1.9.3"
-      }
+      "version": "1.0.0-pre.17",
+      "resolved": "https://registry.npmjs.org/@esfx/type-model/-/type-model-1.0.0-pre.17.tgz",
+      "integrity": "sha512-jJfiYUD1ntLme6uxDol7McJZ2wfZkLHw0nEuHwyGNn99oL29U0aO+xNGhDQs9Lr5ytF1NbXojFiAxVmgRfBPzA=="
     },
     "abab": {
       "version": "1.0.4",
@@ -520,9 +511,9 @@
       }
     },
     "ecmarkup": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-6.0.0.tgz",
-      "integrity": "sha512-R/a7B36x8RqtszzImMHsSsPoTfaE1CUUUAFcOOxvPtkRrsf7PIsanMYnnjp2se3Gp9KM+qxIodV2o0Fef7g8qQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-6.0.1.tgz",
+      "integrity": "sha512-hHZdaGhr0pVlV5wPKrKFJi658YZUmbTHuHIXHOoyIFVhF4Iwq48qo/D8rbPyWyM/vQIX4v92p9s7srmPD3NU6A==",
       "requires": {
         "bluebird": "^3.7.2",
         "chalk": "^1.1.3",
@@ -728,9 +719,9 @@
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "esquery": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
-      "integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
+      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
       "requires": {
         "estraverse": "^5.1.0"
       },
@@ -937,9 +928,9 @@
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "highlight.js": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.5.0.tgz",
-      "integrity": "sha512-xTmvd9HiIHR6L53TMC7TKolEj65zG1XU+Onr8oi86mYa+nLcIbxTTWkpW7CsEwv/vK7u1zb8alZIMLDqqN6KTw=="
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.6.0.tgz",
+      "integrity": "sha512-8mlRcn5vk/r4+QcqerapwBYTe+iPL5ih6xrNylxrnBdHQiijDETfXX7VIxC3UiCRiINBJfANBAsPzAvRQj8RpQ=="
     },
     "html-encoding-sniffer": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "license": "SEE LICENSE IN https://tc39.es/ecma262/#sec-copyright-and-software-license",
   "homepage": "https://tc39.es/ecma262/",
   "dependencies": {
-    "ecmarkup": "^6.0.0"
+    "ecmarkup": "^6.0.1"
   },
   "devDependencies": {
     "@alrra/travis-scripts": "^2.1.0",

--- a/spec.html
+++ b/spec.html
@@ -40902,7 +40902,7 @@ THH:mm:ss.sss
 
         AtomEscape[U, N] ::
           [+U] DecimalEscape
-          [~U] DecimalEscape [> but only if the CapturingGroupNumber of |DecimalEscape| is &lt;= _NcapturingParens_]
+          [~U] DecimalEscape [> but only if the CapturingGroupNumber of |DecimalEscape| is &le; _NcapturingParens_]
           CharacterClassEscape[?U]
           CharacterEscape[?U, ?N]
           [+N] `k` GroupName[?U]


### PR DESCRIPTION
Fixes https://github.com/tc39/ecma262/issues/570. Also has a drive-by fix to spell <= as ≤.