### PR TITLE
Editorial: Give TypedArraySortCompare its own sub-clause

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -39015,27 +39015,39 @@ THH:mm:ss.sss
           1. Let _buffer_ be _obj_.[[ViewedArrayBuffer]].
           1. Let _len_ be _obj_.[[ArrayLength]].
         </emu-alg>
-        <p>The following version of SortCompare is used by %TypedArray%`.prototype.sort`. It performs a numeric comparison rather than the string comparison used in <emu-xref href="#sec-array.prototype.sort"></emu-xref>.</p>
-        <p>The abstract operation TypedArraySortCompare takes arguments _x_ and _y_. It also has access to the _comparefn_ and _buffer_ values of the current invocation of the `sort` method. It performs the following steps when called:</p>
-        <emu-alg>
-          1. Assert: Both Type(_x_) and Type(_y_) are Number or both are BigInt.
-          1. If _comparefn_ is not *undefined*, then
-            1. Let _v_ be ? ToNumber(? Call(_comparefn_, *undefined*, &laquo; _x_, _y_ &raquo;)).
-            1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
-            1. If _v_ is *NaN*, return *+0*<sub>𝔽</sub>.
-            1. Return _v_.
-          1. If _x_ and _y_ are both *NaN*, return *+0*<sub>𝔽</sub>.
-          1. If _x_ is *NaN*, return *1*<sub>𝔽</sub>.
-          1. If _y_ is *NaN*, return *-1*<sub>𝔽</sub>.
-          1. If _x_ &lt; _y_, return *-1*<sub>𝔽</sub>.
-          1. If _x_ &gt; _y_, return *1*<sub>𝔽</sub>.
-          1. If _x_ is *-0*<sub>𝔽</sub> and _y_ is *+0*<sub>𝔽</sub>, return *-1*<sub>𝔽</sub>.
-          1. If _x_ is *+0*<sub>𝔽</sub> and _y_ is *-0*<sub>𝔽</sub>, return *1*<sub>𝔽</sub>.
-          1. Return *+0*<sub>𝔽</sub>.
-        </emu-alg>
-        <emu-note>
-          <p>Because *NaN* always compares greater than any other value, *NaN* property values always sort to the end of the result when _comparefn_ is not provided.</p>
-        </emu-note>
+        <p>%TypedArray%`.prototype.sort` calls TypedArraySortCompare rather than SortCompare.</p>
+
+        <emu-clause id="sec-typedarraysortcompare" type="abstract operation">
+          <h1>
+            TypedArraySortCompare (
+              _x_: unknown,
+              _y_: unknown,
+            )
+          </h1>
+          <dl class="header">
+            <dt>description</dt>
+            <dd>It also has access to the _comparefn_ and _buffer_ values of the current invocation of the %TypedArray%`.prototype.sort` method. It performs a numeric comparison rather than the string comparison used in <emu-xref href="#sec-array.prototype.sort"></emu-xref>.</dd>
+          </dl>
+          <emu-alg>
+            1. Assert: Both Type(_x_) and Type(_y_) are Number or both are BigInt.
+            1. If _comparefn_ is not *undefined*, then
+              1. Let _v_ be ? ToNumber(? Call(_comparefn_, *undefined*, &laquo; _x_, _y_ &raquo;)).
+              1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
+              1. If _v_ is *NaN*, return *+0*<sub>𝔽</sub>.
+              1. Return _v_.
+            1. If _x_ and _y_ are both *NaN*, return *+0*<sub>𝔽</sub>.
+            1. If _x_ is *NaN*, return *1*<sub>𝔽</sub>.
+            1. If _y_ is *NaN*, return *-1*<sub>𝔽</sub>.
+            1. If _x_ &lt; _y_, return *-1*<sub>𝔽</sub>.
+            1. If _x_ &gt; _y_, return *1*<sub>𝔽</sub>.
+            1. If _x_ is *-0*<sub>𝔽</sub> and _y_ is *+0*<sub>𝔽</sub>, return *-1*<sub>𝔽</sub>.
+            1. If _x_ is *+0*<sub>𝔽</sub> and _y_ is *-0*<sub>𝔽</sub>, return *1*<sub>𝔽</sub>.
+            1. Return *+0*<sub>𝔽</sub>.
+          </emu-alg>
+          <emu-note>
+            <p>Because *NaN* always compares greater than any other value, *NaN* property values always sort to the end of the result when _comparefn_ is not provided.</p>
+          </emu-note>
+        </emu-clause>
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.subarray">


### PR DESCRIPTION
(Salvaged from PR #1612.)

(GitHub's diff is not very helpful: most of the apparent diff arises from a change of indentation.)