### PR TITLE
Editorial: Modernize overview paragraph comparing ES to other PLs

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -179,11 +179,7 @@
   <p>ECMAScript was originally designed to be used as a scripting language, but has become widely used as a general-purpose programming language. A <em>scripting language</em> is a programming language that is used to manipulate, customize, and automate the facilities of an existing system. In such systems, useful functionality is already available through a user interface, and the scripting language is a mechanism for exposing that functionality to program control. In this way, the existing system is said to provide a host environment of objects and facilities, which completes the capabilities of the scripting language. A scripting language is intended for use by both professional and non-professional programmers.</p>
   <p>ECMAScript was originally designed to be a <em>Web scripting language</em>, providing a mechanism to enliven Web pages in browsers and to perform server computation as part of a Web-based client-server architecture. ECMAScript is now used to provide core scripting capabilities for a variety of host environments. Therefore the core language is specified in this document apart from any particular host environment.</p>
   <p>ECMAScript usage has moved beyond simple scripting and it is now used for the full spectrum of programming tasks in many different environments and scales. As the usage of ECMAScript has expanded, so have the features and facilities it provides. ECMAScript is now a fully featured general-purpose programming language.</p>
-  <p>Some of the facilities of ECMAScript are similar to those used in other programming languages; in particular C, Java&trade;, Self, and Scheme as described in:</p>
-  <p>ISO/IEC 9899:1996, <i>Programming Languages &mdash; C</i>.</p>
-  <p>Gosling, James, Bill Joy and Guy Steele. <i>The Java<sup>&trade;</sup> Language Specification</i>. Addison Wesley Publishing Co., 1996.</p>
-  <p>Ungar, David, and Smith, Randall B. Self: The Power of Simplicity. <i>OOPSLA '87 Conference Proceedings</i>, pp. 227-241, Orlando, FL, October 1987.</p>
-  <p><i>IEEE Standard for the Scheme Programming Language</i>. IEEE Std 1178-1990.</p>
+  <p>Some of the original facilities of ECMAScript are similar to those used in other programming languages, such as C, Java&trade;, Scheme, and Self. Additionally, some the facilities that have been added since the original design are similar to those used in programming languages such as C&#9839; and Python.</p>
 
   <emu-clause id="sec-web-scripting">
     <h1>Web Scripting</h1>


### PR DESCRIPTION
Closes #2266

References to other languages' specifications and papers are also
removed, as the editor group does not wish to keep an up-to-date
non-normative bibliography to other specifications (some of which are
withdrawn, like Scheme's). Additionally, web searching technology has
advanced sufficiently that finding information on the other PLs should
be easy.