### PR TITLE
Meta: bump ecmarkup to 6.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -511,9 +511,9 @@
       }
     },
     "ecmarkup": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-6.0.1.tgz",
-      "integrity": "sha512-hHZdaGhr0pVlV5wPKrKFJi658YZUmbTHuHIXHOoyIFVhF4Iwq48qo/D8rbPyWyM/vQIX4v92p9s7srmPD3NU6A==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-6.1.0.tgz",
+      "integrity": "sha512-J7hAvyH68mxpBQn+PJ8ymL/rs4phW2MGg8ecty2aYAlSAF5uZp7rBo6nM5xT8X0q8zF4yrQLSRJYMyF+7t2ZLQ==",
       "requires": {
         "bluebird": "^3.7.2",
         "chalk": "^1.1.3",
@@ -887,9 +887,9 @@
       }
     },
     "grammarkdown": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/grammarkdown/-/grammarkdown-3.1.1.tgz",
-      "integrity": "sha512-z7v8HVTc0LtWiGz+1w2lK3QBkha2DsczMrtxprBi7o31wxqgryE5BqKfVvMmUjJPMo+dY0572Z1vBG0r9wlmOQ==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/grammarkdown/-/grammarkdown-3.1.2.tgz",
+      "integrity": "sha512-2WHeSg1sYjeeWMqnt0jEa4FyhofhE8T02a9PhBXvA1+6hLdZ39E753X05LYIdTff+1GYW6UMy+2nLfeQYQZ9Hw==",
       "requires": {
         "@esfx/async-canceltoken": "^1.0.0-pre.13",
         "@esfx/cancelable": "^1.0.0-pre.13"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "license": "SEE LICENSE IN https://tc39.es/ecma262/#sec-copyright-and-software-license",
   "homepage": "https://tc39.es/ecma262/",
   "dependencies": {
-    "ecmarkup": "^6.0.1"
+    "ecmarkup": "^6.1.0"
   },
   "devDependencies": {
     "@alrra/travis-scripts": "^2.1.0",

--- a/spec.html
+++ b/spec.html
@@ -57,17 +57,6 @@
   emu-table td {
     background: #fff;
   }
-  [normative-optional] {
-    border-left: 5px solid #ff6600;
-    padding: .5em;
-    display: block;
-    background: #ffeedd;
-  }
-  [normative-optional]:before {
-    display: block;
-    color: #884400;
-    content: "NORMATIVE OPTIONAL";
-  }
 </style>
 </head>
 <body>

--- a/spec.html
+++ b/spec.html
@@ -142,7 +142,7 @@
   <p>A conforming implementation of ECMAScript may support program and regular expression syntax not described in this specification. In particular, a conforming implementation of ECMAScript may support program syntax that makes use of any &ldquo;future reserved words&rdquo; noted in subclause <emu-xref href="#sec-keywords-and-reserved-words"></emu-xref> of this specification.</p>
   <p>A conforming implementation of ECMAScript must not implement any extension that is listed as a Forbidden Extension in subclause <emu-xref href="#sec-forbidden-extensions"></emu-xref>.</p>
   <p>A conforming implementation of ECMAScript must not redefine any facilities that are not implementation-defined, implementation-approximated, or host-defined.</p>
-  <p>A conforming implementation of ECMAScript may choose to implement or not implement Normative Optional subclauses. If any Normative Optional behaviour is implemented, all of the behaviour in the containing Normative Optional clause must be implemented. A Normative Optional clause is denoted in this specification with the words "Normative Optional" in a coloured box, as shown below.</p>
+  <p>A conforming implementation of ECMAScript may choose to implement or not implement <dfn>Normative Optional</dfn> subclauses. If any Normative Optional behaviour is implemented, all of the behaviour in the containing Normative Optional clause must be implemented. A Normative Optional clause is denoted in this specification with the words "Normative Optional" in a coloured box, as shown below.</p>
   <emu-clause id="sec-conformance.normative-optional" example normative-optional>
     <h1>Example Clause Heading</h1>
     <p>Example clause contents.</p>


### PR DESCRIPTION
Notable changes:
- https://github.com/tc39/ecmarkup/pull/292, which also entailed dropping the inline CSS here (as [promised](https://github.com/tc39/ecma262/pull/2215#pullrequestreview-545222381))
- https://github.com/tc39/ecmarkup/pull/291, which fixes an overflow observable in e.g. in [RegExp.prototype [ @@split ]](https://tc39.es/ecma262/#sec-regexp.prototype-@@split)
- https://github.com/tc39/ecmarkup/pull/290, which makes it so that if you copy-paste an algorithm step (by triple-clicking to select the whole line) it will include the step number

I've also added a `dfn` to "Normative Optional", so that you can click on the label in the heading of such clauses to be taken to its definition.