### PR TITLE
Normative: Use HostJobCallbacks for FinalizationRegistry callbacks

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -10171,7 +10171,7 @@
       1. While _finalizationRegistry_.[[Cells]] contains a Record _cell_ such that _cell_.[[WeakRefTarget]] is ~empty~, an implementation may perform the following steps:
         1. Choose any such _cell_.
         1. Remove _cell_ from _finalizationRegistry_.[[Cells]].
-        1. Perform ? Call(_callback_, *undefined*, &laquo; _cell_.[[HeldValue]] &raquo;).
+        1. Perform ? HostCallJobCallback(_callback_, *undefined*, &laquo; _cell_.[[HeldValue]] &raquo;).
       1. Return NormalCompletion(*undefined*).
     </emu-alg>
   </emu-clause>
@@ -37054,7 +37054,7 @@ THH:mm:ss.sss
           1. Let _finalizationRegistry_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%FinalizationRegistry.prototype%"*, &laquo; [[Realm]], [[CleanupCallback]], [[Cells]] &raquo;).
           1. Let _fn_ be the active function object.
           1. Set _finalizationRegistry_.[[Realm]] to _fn_.[[Realm]].
-          1. Set _finalizationRegistry_.[[CleanupCallback]] to _cleanupCallback_.
+          1. Set _finalizationRegistry_.[[CleanupCallback]] to HostMakeJobCallback(_cleanupCallback_).
           1. Set _finalizationRegistry_.[[Cells]] to a new empty List.
           1. Return _finalizationRegistry_.
         </emu-alg>


### PR DESCRIPTION
This aligns FinalizationRegistry callbacks with Promise callbacks in
allowing web browsers to perform additional steps to save and restore
the correct incumbent settings object.

Context is that one of the blockers in the HTML integration PR is proper handling of backup incumbent settings objects. I won't recapture that horror here, but we went over it for the Promise machinery and got consensus to add the HostJobCallback machinery. This PR just makes use of that machinery too.

/cc @codehag since Firefox is the only one that implements this behavior. Chrome is interested in aligning with the spec here, but is not prioritizing the implementation work.

(I meant to do this before Stage 4, but I... guess I forgot.)