### PR TITLE
Editorial: nest ASI sections under "ASI" section

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -14513,43 +14513,43 @@
       <pre><code class="javascript">a = b + c(d + e).print()</code></pre>
       <p>In the circumstance that an assignment statement must begin with a left parenthesis, it is a good idea for the programmer to provide an explicit semicolon at the end of the preceding statement rather than to rely on automatic semicolon insertion.</p>
     </emu-clause>
-  </emu-clause>
-  <emu-clause id="sec-interesting-cases-of-automatic-semicolon-insertion">
-    <h1>Interesting Cases of Automatic Semicolon Insertion</h1>
-    <em>This section is non-normative.</em>
-    <p>ECMAScript programs can be written in a style with very few semicolons by relying on automatic semicolon insertion. As described above, semicolons are not inserted at every newline, and automatic semicolon insertion can depend on multiple tokens across line terminators.</p>
+    <emu-clause id="sec-interesting-cases-of-automatic-semicolon-insertion">
+      <h1>Interesting Cases of Automatic Semicolon Insertion</h1>
+      <em>This section is non-normative.</em>
+      <p>ECMAScript programs can be written in a style with very few semicolons by relying on automatic semicolon insertion. As described above, semicolons are not inserted at every newline, and automatic semicolon insertion can depend on multiple tokens across line terminators.</p>
 
-    <p>As new syntactic features are added to ECMAScript, additional grammar productions could be added that cause lines relying on automatic semicolon insertion preceding them to change grammar productions when parsed.</p>
+      <p>As new syntactic features are added to ECMAScript, additional grammar productions could be added that cause lines relying on automatic semicolon insertion preceding them to change grammar productions when parsed.</p>
 
-    <p>For the purposes of this section, a case of automatic semicolon insertion is considered interesting if it is a place where a semicolon may or may not be inserted, depending on the source text which precedes it. The rest of this section describes a number of interesting cases of automatic semicolon insertion in this version of ECMAScript.</p>
-    <emu-clause id="sec-asi-interesting-cases-in-statement-lists">
-      <h1>Interesting Cases of Automatic Semicolon Insertion in Statement Lists</h1>
-      <p>In a |StatementList|, many |StatementListItem|s end in semicolons, which may be omitted using automatic semicolon insertion. As a consequence of the rules above, at the end of a line ending an expression, a semicolon is required if the following line begins with any of the following:</p>
-      <ul>
-        <li><strong>An opening parenthesis (<code>(</code>)</strong>. Without a semicolon, the two lines together are treated as a |CallExpression|.</li>
-        <li><strong>An opening square bracket (<code>[</code>)</strong>. Without a semicolon, the two lines together are treated as property access, rather than an |ArrayLiteral| or |ArrayAssignmentPattern|.</li>
-        <li><strong>A template literal (<code>`</code>)</strong>. Without a semicolon, the two lines together are interpreted as a tagged Template (<emu-xref href="#sec-tagged-templates"></emu-xref>), with the previous expression as the |MemberExpression|.</li>
-        <li><strong>Unary <code>+</code> or <code>-</code></strong>. Without a semicolon, the two lines together are interpreted as a usage of the corresponding binary operator.</li>
-        <li><strong>A RegExp literal</strong>. Without a semicolon, the two lines together may be parsed instead as the `/` |MultiplicativeOperator|, for example if the RegExp has flags.</li>
-      </ul>
-    </emu-clause>
-  </emu-clause>
-  <emu-clause id="sec-asi-cases-with-no-lineterminator-here">
-    <h1>Cases of Automatic Semicolon Insertion and &ldquo;[no |LineTerminator| here]&rdquo;</h1>
-    <em>This section is non-normative.</em>
-    <p>ECMAScript contains grammar productions which include &ldquo;[no |LineTerminator| here]&rdquo;. These productions are sometimes a means to have optional operands in the grammar. Introducing a |LineTerminator| in these locations would change the grammar production of a source text by using the grammar production without the optional operand.</p>
+      <p>For the purposes of this section, a case of automatic semicolon insertion is considered interesting if it is a place where a semicolon may or may not be inserted, depending on the source text which precedes it. The rest of this section describes a number of interesting cases of automatic semicolon insertion in this version of ECMAScript.</p>
+      <emu-clause id="sec-asi-interesting-cases-in-statement-lists">
+        <h1>Interesting Cases of Automatic Semicolon Insertion in Statement Lists</h1>
+        <p>In a |StatementList|, many |StatementListItem|s end in semicolons, which may be omitted using automatic semicolon insertion. As a consequence of the rules above, at the end of a line ending an expression, a semicolon is required if the following line begins with any of the following:</p>
+        <ul>
+          <li><strong>An opening parenthesis (<code>(</code>)</strong>. Without a semicolon, the two lines together are treated as a |CallExpression|.</li>
+          <li><strong>An opening square bracket (<code>[</code>)</strong>. Without a semicolon, the two lines together are treated as property access, rather than an |ArrayLiteral| or |ArrayAssignmentPattern|.</li>
+          <li><strong>A template literal (<code>`</code>)</strong>. Without a semicolon, the two lines together are interpreted as a tagged Template (<emu-xref href="#sec-tagged-templates"></emu-xref>), with the previous expression as the |MemberExpression|.</li>
+          <li><strong>Unary <code>+</code> or <code>-</code></strong>. Without a semicolon, the two lines together are interpreted as a usage of the corresponding binary operator.</li>
+          <li><strong>A RegExp literal</strong>. Without a semicolon, the two lines together may be parsed instead as the `/` |MultiplicativeOperator|, for example if the RegExp has flags.</li>
+        </ul>
+      </emu-clause>
+      <emu-clause id="sec-asi-cases-with-no-lineterminator-here">
+        <h1>Cases of Automatic Semicolon Insertion and &ldquo;[no |LineTerminator| here]&rdquo;</h1>
+        <em>This section is non-normative.</em>
+        <p>ECMAScript contains grammar productions which include &ldquo;[no |LineTerminator| here]&rdquo;. These productions are sometimes a means to have optional operands in the grammar. Introducing a |LineTerminator| in these locations would change the grammar production of a source text by using the grammar production without the optional operand.</p>
 
-    <p>The rest of this section describes a number of productions using &ldquo;[no |LineTerminator| here]&rdquo; in this version of ECMAScript.</p>
-    <emu-clause id="sec-no-lineterminator-here-automatic-semicolon-insertion-list">
-      <h1>List of Grammar Productions with Optional Operands and &ldquo;[no |LineTerminator| here]&rdquo;</h1>
-      <ul>
-        <li>|UpdateExpression|.</li>
-        <li>|ContinueStatement|.</li>
-        <li>|BreakStatement|.</li>
-        <li>|ReturnStatement|.</li>
-        <li>|YieldExpression|.</li>
-        <li>Async Function Definitions (<emu-xref href="#sec-async-function-definitions"></emu-xref>) with relation to Function Definitions (<emu-xref href="#sec-function-definitions"></emu-xref>)</li>
-      </ul>
+        <p>The rest of this section describes a number of productions using &ldquo;[no |LineTerminator| here]&rdquo; in this version of ECMAScript.</p>
+        <emu-clause id="sec-no-lineterminator-here-automatic-semicolon-insertion-list">
+          <h1>List of Grammar Productions with Optional Operands and &ldquo;[no |LineTerminator| here]&rdquo;</h1>
+          <ul>
+            <li>|UpdateExpression|.</li>
+            <li>|ContinueStatement|.</li>
+            <li>|BreakStatement|.</li>
+            <li>|ReturnStatement|.</li>
+            <li>|YieldExpression|.</li>
+            <li>Async Function Definitions (<emu-xref href="#sec-async-function-definitions"></emu-xref>) with relation to Function Definitions (<emu-xref href="#sec-function-definitions"></emu-xref>)</li>
+          </ul>
+        </emu-clause>
+      </emu-clause>
     </emu-clause>
   </emu-clause>
 </emu-clause>


### PR DESCRIPTION
I noticed that https://tc39.es/ecma262/#sec-asi-cases-with-no-lineterminator-here seems oddly sitting as a sibling of https://tc39.es/ecma262/#sec-interesting-cases-of-automatic-semicolon-insertion, whereas it feels like 12.10 should be the container section for all ASI-related content.