### PR TITLE
Editorial: swap "about" and "contributing" sections in the intro

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -71,6 +71,8 @@
 </pre>
 <p><img src="img/ecma-logo.svg" id="ecma-logo"></p>
 <div id="metadata-block">
+  <h1>About this Specification</h1>
+  <p>The document at <a href="https://tc39.es/ecma262/">https://tc39.es/ecma262/</a> is the most accurate and up-to-date ECMAScript specification. It contains the content of the most recent yearly snapshot plus any <a href="https://github.com/tc39/proposals/blob/master/finished-proposals.md">finished proposals</a> (those that have reached Stage&nbsp;4 in the <a href="https://tc39.es/process-document/">proposal process</a> and thus are implemented in several implementations and will be in the next practical revision) since that snapshot was taken.</p>
   <h1>Contributing to this Specification</h1>
   <p>This specification is developed on GitHub with the help of the ECMAScript community. There are a number of ways to contribute to the development of this specification:</p>
   <ul>
@@ -97,8 +99,6 @@
     </li>
   </ul>
   <p>Refer to the <emu-xref href="#sec-colophon">colophon</emu-xref> for more information on how this document is created.</p>
-  <h1>About this Specification</h1>
-  <p>The document at <a href="https://tc39.es/ecma262/">https://tc39.es/ecma262/</a> is the most accurate and up-to-date ECMAScript specification. It contains the content of the most recent yearly snapshot plus any <a href="https://github.com/tc39/proposals/blob/master/finished-proposals.md">finished proposals</a> (those that have reached Stage&nbsp;4 in the <a href="https://tc39.es/process-document/">proposal process</a> and thus are implemented in several implementations and will be in the next practical revision) since that snapshot was taken.</p>
 </div>
 <emu-intro id="sec-intro">
   <h1>Introduction</h1>


### PR DESCRIPTION
As discussed, let's swap these sections.