### PR TITLE
Normative: specify creation order for capturing group properties

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -31035,7 +31035,7 @@ THH:mm:ss.sss
             1. Else,
               1. Let _groups_ be *undefined*.
             1. Perform ! CreateDataPropertyOrThrow(_A_, *"groups"*, _groups_).
-            1. For each integer _i_ such that _i_ &ge; 1 and _i_ &le; _n_, do
+            1. For each integer _i_ such that _i_ &ge; 1 and _i_ &le; _n_, in ascending order, do
               1. Let _captureI_ be _i_<sup>th</sup> element of _r_'s _captures_ List.
               1. If _captureI_ is *undefined*, let _capturedValue_ be *undefined*.
               1. Else if _fullUnicode_ is *true*, then


### PR DESCRIPTION
The order in which the non-numeric properties are created (i.e. those from named capturing groups) is observable with `Object.keys`.

This matches all the engines I have on hand. It's only very technically normative, and test262 already tests for this behavior ([x](https://github.com/tc39/test262/blob/c8daa32e48f05b9438f28df20ec0787807b230b3/test/built-ins/RegExp/named-groups/groups-properties.js#L18-L20), [x](https://github.com/tc39/test262/blob/c8daa32e48f05b9438f28df20ec0787807b230b3/test/built-ins/RegExp/named-groups/lookbehind.js#L43-L46)). Thanks to @jmdyck for pointing this out and linking the tests.