### PR TITLE
Editorial: Consistify some "For each" steps

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -34431,7 +34431,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_M_, [[MapData]]).
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
           1. Let _entries_ be the List that is _M_.[[MapData]].
-          1. For each Record { [[Key]], [[Value]] } _e_ of _entries_, in original key insertion order, do
+          1. For each Record { [[Key]], [[Value]] } _e_ of _entries_, do
             1. If _e_.[[Key]] is not ~empty~, then
               1. Perform ? Call(_callbackfn_, _thisArg_, &laquo; _e_.[[Value]], _e_.[[Key]], _M_ &raquo;).
           1. Return *undefined*.
@@ -34743,7 +34743,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_S_, [[SetData]]).
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
           1. Let _entries_ be the List that is _S_.[[SetData]].
-          1. For each element _e_ of _entries_, in original insertion order, do
+          1. For each element _e_ of _entries_, do
             1. If _e_ is not ~empty~, then
               1. Perform ? Call(_callbackfn_, _thisArg_, &laquo; _e_, _e_, _S_ &raquo;).
           1. Return *undefined*.
@@ -37906,9 +37906,9 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-triggerpromisereactions" aoid="TriggerPromiseReactions">
         <h1>TriggerPromiseReactions ( _reactions_, _argument_ )</h1>
-        <p>The abstract operation TriggerPromiseReactions takes arguments _reactions_ (a collection of PromiseReaction Records) and _argument_. It enqueues a new Job for each record in _reactions_. Each such Job processes the [[Type]] and [[Handler]] of the PromiseReaction Record, and if the [[Handler]] is not ~empty~, calls it passing the given argument. If the [[Handler]] is ~empty~, the behaviour is determined by the [[Type]]. It performs the following steps when called:</p>
+        <p>The abstract operation TriggerPromiseReactions takes arguments _reactions_ (a List of PromiseReaction Records) and _argument_. It enqueues a new Job for each record in _reactions_. Each such Job processes the [[Type]] and [[Handler]] of the PromiseReaction Record, and if the [[Handler]] is not ~empty~, calls it passing the given argument. If the [[Handler]] is ~empty~, the behaviour is determined by the [[Type]]. It performs the following steps when called:</p>
         <emu-alg>
-          1. For each element _reaction_ of _reactions_, in original insertion order, do
+          1. For each element _reaction_ of _reactions_, do
             1. Let _job_ be NewPromiseReactionJob(_reaction_, _argument_).
             1. Perform HostEnqueuePromiseJob(_job_.[[Job]], _job_.[[Realm]]).
           1. Return *undefined*.

--- a/spec.html
+++ b/spec.html
@@ -11445,7 +11445,7 @@
           1. Let _str_ be _O_.[[StringData]].
           1. Assert: Type(_str_) is String.
           1. Let _len_ be the length of _str_.
-          1. For each non-negative integer _i_ starting with 0 such that _i_ &lt; _len_, in ascending order, do
+          1. For each integer _i_ starting with 0 such that _i_ &lt; _len_, in ascending order, do
             1. Add ! ToString(𝔽(_i_)) as the last element of _keys_.
           1. For each own property key _P_ of _O_ such that _P_ is an array index and ! ToIntegerOrInfinity(_P_) &ge; _len_, in ascending numeric index order, do
             1. Add _P_ as the last element of _keys_.

--- a/spec.html
+++ b/spec.html
@@ -30140,7 +30140,7 @@ THH:mm:ss.sss
               1. If _max_ is +&infin;, let _max2_ be +&infin;; otherwise let _max2_ be _max_ - 1.
               1. Return ! RepeatMatcher(_m_, _min2_, _max2_, _greedy_, _y_, _c_, _parenIndex_, _parenCount_).
             1. Let _cap_ be a copy of _x_'s _captures_ List.
-            1. [id="step-repeatmatcher-clear-captures"] For each integer _k_ that satisfies _parenIndex_ &lt; _k_ and _k_ &le; _parenIndex_ + _parenCount_, set _cap_[_k_] to *undefined*.
+            1. [id="step-repeatmatcher-clear-captures"] For each integer _k_ such that _parenIndex_ &lt; _k_ and _k_ &le; _parenIndex_ + _parenCount_, set _cap_[_k_] to *undefined*.
             1. Let _e_ be _x_'s _endIndex_.
             1. Let _xr_ be the State (_e_, _cap_).
             1. If _min_ &ne; 0, return _m_(_xr_, _d_).


### PR DESCRIPTION
In the second commit (drop "non-negative"), you could certainly achieve consistency by going in the reverse direction
(add "non-negative" to all the "For each integer" steps); I just chose the smaller delta.

In the third commit (drop "in original [key] insertion order"), we could also add Notes to the effect that List order is insertion order, if you think it would be helpful. However, note that CreateMapIterator and CreateSetIterator don't bother pointing this out.