### PR TITLE
Editorial: Fix mistakes

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -940,7 +940,7 @@
         <li><em>Mathematical values</em>: Arbitrary real numbers, used as the default numeric type.</li>
         <li><em>Extended mathematical values</em>: Mathematical values together with +&infin; and -&infin;.</li>
         <li><em>Numbers</em>: IEEE 754-2019 double-precision floating point values.</li>
-        <li><em>BigInts</em>: ECMAScript values representing arbritary integers in a one-to-one correspondence.</li>
+        <li><em>BigInts</em>: ECMAScript values representing arbitrary integers in a one-to-one correspondence.</li>
       </ul>
 
       <p>In the language of this specification, numerical values are distinguished among different numeric kinds using subscript suffixes. The subscript <sub>𝔽</sub> refers to Numbers, and the subscript <sub>ℤ</sub> refers to BigInts. Numeric values without a subscript suffix refer to mathematical values.</p>
@@ -22219,7 +22219,7 @@
             <img alt="A module graph in which module A depends on module B and C, but module B also depends on module A" width="181" height="121" src="img/module-graph-cycle.svg">
           </emu-figure>
 
-          <p>Here we assume that the entry point is module _A_, so that the host proceeds by calling _A_.Link(), which performs InnerModuleLinking on _A_. This in turn calls InnerModuleLinking on _B_. Because of the cycle, this again triggers InnerModuleLinking on _A_, but at this point it is a no-op since _A_.[[Status]] is already ~linking~. _B_.[[Status]] itself remains ~linking~ when control gets back to _A_ and InnerModuleLinking is triggered on _C_. After this returns with _C_.[[Status]] being ~linked~ , both _A_ and _B_ transition from ~linking~ to ~linked~ together; this is by design, since they form a strongly connected component.</p>
+          <p>Here we assume that the entry point is module _A_, so that the host proceeds by calling _A_.Link(), which performs InnerModuleLinking on _A_. This in turn calls InnerModuleLinking on _B_. Because of the cycle, this again triggers InnerModuleLinking on _A_, but at this point it is a no-op since _A_.[[Status]] is already ~linking~. _B_.[[Status]] itself remains ~linking~ when control gets back to _A_ and InnerModuleLinking is triggered on _C_. After this returns with _C_.[[Status]] being ~linked~, both _A_ and _B_ transition from ~linking~ to ~linked~ together; this is by design, since they form a strongly connected component.</p>
 
           <p>An analogous story occurs for the evaluation phase of a cyclic module graph, in the success case.</p>
 
@@ -26507,7 +26507,7 @@
     <emu-clause id="sec-function-properties-of-the-math-object">
       <h1>Function Properties of the Math Object</h1>
       <emu-note>
-        <p>The behaviour of the functions `acos`, `acosh`, `asin`, `asinh`, `atan`, `atanh`, `atan2`, `cbrt`, `cos`, `cosh`, `exp`, `expm1`, `hypot`, `log`,`log1p`, `log2`, `log10`, `pow`, `random`, `sin`, `sinh`, `sqrt`, `tan`, and `tanh` is not precisely specified here except to require specific results for certain argument values that represent boundary cases of interest. For other argument values, these functions are intended to compute approximations to the results of familiar mathematical functions, but some latitude is allowed in the choice of approximation algorithms. The general intent is that an implementer should be able to use the same mathematical library for ECMAScript on a given hardware platform that is available to C programmers on that platform.</p>
+        <p>The behaviour of the functions `acos`, `acosh`, `asin`, `asinh`, `atan`, `atanh`, `atan2`, `cbrt`, `cos`, `cosh`, `exp`, `expm1`, `hypot`, `log`, `log1p`, `log2`, `log10`, `pow`, `random`, `sin`, `sinh`, `sqrt`, `tan`, and `tanh` is not precisely specified here except to require specific results for certain argument values that represent boundary cases of interest. For other argument values, these functions are intended to compute approximations to the results of familiar mathematical functions, but some latitude is allowed in the choice of approximation algorithms. The general intent is that an implementer should be able to use the same mathematical library for ECMAScript on a given hardware platform that is available to C programmers on that platform.</p>
         <p>Although the choice of algorithms is left to the implementation, it is recommended (but not specified by this standard) that implementations use the approximation algorithms for IEEE 754-2019 arithmetic contained in `fdlibm`, the freely distributable mathematical library from Sun Microsystems (<a href="http://www.netlib.org/fdlibm">http://www.netlib.org/fdlibm</a>).</p>
       </emu-note>
 
@@ -42169,7 +42169,7 @@ THH:mm:ss.sss
 
       <emu-annex id="sec-IsHTMLDDA-internal-slot-typeof">
         <h1>Changes to the `typeof` Operator</h1>
-        <p>The following table entry is inserted into <emu-xref href="#table-typeof-operator-results"></emu-xref> immediately preceeding the entry for "Object (implements [[Call]])":</p>
+        <p>The following table entry is inserted into <emu-xref href="#table-typeof-operator-results"></emu-xref> immediately preceding the entry for "Object (implements [[Call]])":</p>
         <emu-table>
           <emu-caption>
             Additional <emu-xref href="#sec-typeof-operator">`typeof`</emu-xref> Operator Results
@@ -42321,7 +42321,7 @@ THH:mm:ss.sss
   <p><emu-xref href="#sec-reference-record-specification-type"></emu-xref>: In ECMAScript 2015, Function calls are not allowed to return a Reference Record.</p>
   <p><emu-xref href="#sec-tonumber-applied-to-the-string-type"></emu-xref>: In ECMAScript 2015, ToNumber applied to a String value now recognizes and converts |BinaryIntegerLiteral| and |OctalIntegerLiteral| numeric strings. In previous editions such strings were converted to *NaN*.</p>
   <p><emu-xref href="#sec-code-realms"></emu-xref>: In ECMAScript 2018, Template objects are canonicalized based on Parse Node (source location), instead of across all occurrences of that template literal or tagged template in a Realm in previous editions.</p>
-  <p><emu-xref href="#sec-white-space"></emu-xref>: In ECMASCript 2016, Unicode 8.0.0 or higher is mandated, as opposed to ECMAScript 2015 which mandated Unicode 5.1. In particular, this caused U+180E MONGOLIAN VOWEL SEPARATOR, which was in the `Space_Separator` (`Zs`) category and thus treated as whitespace in ECMAScript 2015, to be moved to the `Format` (`Cf`) category (as of Unicode 6.3.0). This causes whitespace-sensitive methods to behave differently. For example, `"\u180E".trim().length` was `0` in previous editions, but `1` in ECMAScript 2016 and later. Additionally, ECMAScript 2017 mandated always using the latest version of the Unicode standard.</p>
+  <p><emu-xref href="#sec-white-space"></emu-xref>: In ECMAScript 2016, Unicode 8.0.0 or higher is mandated, as opposed to ECMAScript 2015 which mandated Unicode 5.1. In particular, this caused U+180E MONGOLIAN VOWEL SEPARATOR, which was in the `Space_Separator` (`Zs`) category and thus treated as whitespace in ECMAScript 2015, to be moved to the `Format` (`Cf`) category (as of Unicode 6.3.0). This causes whitespace-sensitive methods to behave differently. For example, `"\u180E".trim().length` was `0` in previous editions, but `1` in ECMAScript 2016 and later. Additionally, ECMAScript 2017 mandated always using the latest version of the Unicode standard.</p>
   <p><emu-xref href="#sec-names-and-keywords"></emu-xref>: In ECMAScript 2015, the valid code points for an |IdentifierName| are specified in terms of the Unicode properties &ldquo;ID_Start&rdquo; and &ldquo;ID_Continue&rdquo;. In previous editions, the valid |IdentifierName| or |Identifier| code points were specified by enumerating various Unicode code point categories.</p>
   <p><emu-xref href="#sec-rules-of-automatic-semicolon-insertion"></emu-xref>: In ECMAScript 2015, Automatic Semicolon Insertion adds a semicolon at the end of a do-while statement if the semicolon is missing. This change aligns the specification with the actual behaviour of most existing implementations.</p>
   <p><emu-xref href="#sec-object-initializer-static-semantics-early-errors"></emu-xref>: In ECMAScript 2015, it is no longer an early error to have duplicate property names in Object Initializers.</p>


### PR DESCRIPTION
I corrected a few mistakes such as `ECMASCript` (instead of `ECMAScript`) and `arbritary` (instead of `arbitrary`).