### PR TITLE
Normative: Don't coerce value if index is invalid in TypedArray [[Set]]

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -11785,6 +11785,7 @@
           1. If Type(_P_) is String, then
             1. Let _numericIndex_ be ! CanonicalNumericIndexString(_P_).
             1. If _numericIndex_ is not *undefined*, then
+              1. If ! IsValidIntegerIndex(_O_, _numericIndex_) is *false*, return *true*.
               1. Perform ? IntegerIndexedElementSet(_O_, _numericIndex_, _V_).
               1. Return *true*.
           1. Return ? OrdinarySet(_O_, _P_, _V_, _Receiver_).
@@ -11873,9 +11874,10 @@
         <p>The abstract operation IntegerIndexedElementSet takes arguments _O_, _index_ (a Number), and _value_. It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: _O_ is an Integer-Indexed exotic object.
+          1. Assert: ! IsValidIntegerIndex(_O_, _index_) is *true*.
           1. If _O_.[[ContentType]] is ~BigInt~, let _numValue_ be ? ToBigInt(_value_).
           1. Otherwise, let _numValue_ be ? ToNumber(_value_).
-          1. If ! IsValidIntegerIndex(_O_, _index_) is *true*, then
+          1. If ! IsDetachedBuffer(_O_.[[ViewedArrayBuffer]]) is *false*, then
             1. Let _offset_ be _O_.[[ByteOffset]].
             1. Let _arrayTypeName_ be the String value of _O_.[[TypedArrayName]].
             1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _arrayTypeName_.
@@ -11885,7 +11887,7 @@
           1. Return NormalCompletion(*undefined*).
         </emu-alg>
         <emu-note>
-          <p>This operation always appears to succeed, but it has no effect when attempting to write past the end of a TypedArray or to a TypedArray which is backed by a detached ArrayBuffer.</p>
+          <p>This operation always appears to succeed, but it has no effect when attempting to write to a TypedArray which is backed by a detached ArrayBuffer.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>


### PR DESCRIPTION
While all major engines currently perform value coercion for invalid indices, I believe it's not due to web-compatibility, but because of extensive [test262 coverage](https://github.com/tc39/test262/blob/c8daa32e48f05b9438f28df20ec0787807b230b3/test/built-ins/TypedArrayConstructors/internals/Set/tonumber-value-throws.js#L42-L44).

### Motivation

* Proposed behavior is more sane / expected because coercion result would be unused.
* Aligns with TypedArray's [`[[DefineOwnProperty]]`](https://tc39.es/ecma262/#sec-integer-indexed-exotic-objects-defineownproperty-p-desc), which doesn't coerce `[[Value]]` for invalid indices.
* In light of #1556, this PR will align value coercion in direct `[[Set]]` with receiver-altered one.
* Major runtimes implement indexed and non-index `[[Set]]` in different methods; this change will clean up [non-index method](https://github.com/WebKit/WebKit/blob/095a9ffdf9a23b4accf033d627840d431e85459d/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h#L382-L383) a bit.

### Implementation prospect

Given that #1556 requires TypedArray's `[[Set]]` to be adjusted in V8 / SM / JSC, this change can be implemented along.