### PR TITLE
Editorial: Align checks order in [[DefineOwnProperty]] overrides with ordinary method

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -11754,9 +11754,9 @@
             1. Let _numericIndex_ be ! CanonicalNumericIndexString(_P_).
             1. If _numericIndex_ is not *undefined*, then
               1. If ! IsValidIntegerIndex(_O_, _numericIndex_) is *false*, return *false*.
-              1. If IsAccessorDescriptor(_Desc_) is *true*, return *false*.
               1. If _Desc_ has a [[Configurable]] field and if _Desc_.[[Configurable]] is *false*, return *false*.
               1. If _Desc_ has an [[Enumerable]] field and if _Desc_.[[Enumerable]] is *false*, return *false*.
+              1. If ! IsAccessorDescriptor(_Desc_) is *true*, return *false*.
               1. If _Desc_ has a [[Writable]] field and if _Desc_.[[Writable]] is *false*, return *false*.
               1. If _Desc_ has a [[Value]] field, perform ? IntegerIndexedElementSet(_O_, _numericIndex_, _Desc_.[[Value]]).
               1. Return *true*.
@@ -11990,10 +11990,10 @@
           1. If Type(_P_) is Symbol, return OrdinaryDefineOwnProperty(_O_, _P_, _Desc_).
           1. Let _current_ be ? _O_.[[GetOwnProperty]](_P_).
           1. If _current_ is *undefined*, return *false*.
-          1. If IsAccessorDescriptor(_Desc_) is *true*, return *false*.
-          1. If _Desc_.[[Writable]] is present and has value *false*, return *false*.
-          1. If _Desc_.[[Enumerable]] is present and has value *false*, return *false*.
           1. If _Desc_.[[Configurable]] is present and has value *true*, return *false*.
+          1. If _Desc_.[[Enumerable]] is present and has value *false*, return *false*.
+          1. If ! IsAccessorDescriptor(_Desc_) is *true*, return *false*.
+          1. If _Desc_.[[Writable]] is present and has value *false*, return *false*.
           1. If _Desc_.[[Value]] is present, return SameValue(_Desc_.[[Value]], _current_.[[Value]]).
           1. Return *true*.
         </emu-alg>


### PR DESCRIPTION
With the current spec, if an engine precisely implements [`ValidateAndApplyPropertyDescriptor`](https://tc39.es/ecma262/#sec-validateandapplypropertydescriptor) and module namespace object's [`[[DefineOwnProperty]]`](https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-defineownproperty-p-desc) method, with descriptive error message for each failure, it would report different errors (given there is > 1 cause of failure) for the same `(CurrentDescriptor, Descriptor)` pair when called on ordinary object vs module namespace object.

<details>

<summary>Test case:</summary>

#### module.js:

```js
export let test = 42;
```

#### index.js:

```js
import("module.js").then(ns => {
    const desc = { get() {}, configurable: true };
    Object.defineProperty(ns, "test", desc); // => TypeError: Cannot change module namespace object's binding to accessor
    const plain = {};
    Object.defineProperty(plain, "test", Object.getOwnPropertyDescriptor(ns, "test"));
    Object.defineProperty(plain, "test", desc); // => TypeError: Attempting to change configurable attribute of unconfigurable property.
});
```

---

</details>

This change aligns descriptor validation order of TypedArray's and module namespace object's `[[DefineOwnProperty]]` methods with [`ValidateAndApplyPropertyDescriptor`](https://tc39.es/ecma262/#sec-validateandapplypropertydescriptor). For own non-configurable data descriptor, that is `[[Configurable]] => [[Enumerable]] => IsAccessorDescriptor => [[Writable]] => [[Value]]`.

The discrepancy this PR fixes is currently observable only in JSC.