### PR TITLE
Editorial: Check [[StringData]] first in String's [[GetOwnProperty]]

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -11418,9 +11418,11 @@
         <p>The [[GetOwnProperty]] internal method of a String exotic object _S_ takes argument _P_ (a property key). It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: IsPropertyKey(_P_) is *true*.
-          1. Let _desc_ be OrdinaryGetOwnProperty(_S_, _P_).
-          1. If _desc_ is not *undefined*, return _desc_.
-          1. Return ! StringGetOwnProperty(_S_, _P_).
+          1. Let _stringDesc_ be ! StringGetOwnProperty(_S_, _P_).
+          1. If _stringDesc_ is not *undefined*, then
+            1. Assert: _S_ does not have an own property with key _P_.
+            1. Return _stringDesc_.
+          1. Return ! OrdinaryGetOwnProperty(_S_, _P_).
         </emu-alg>
       </emu-clause>
 


### PR DESCRIPTION
This change tweaks String's [`[[GetOwnProperty]]`](https://tc39.es/ecma262/#sec-string-exotic-objects-getownproperty-p) method to perform [`StringGetOwnProperty`](https://tc39.es/ecma262/#sec-stringgetownproperty) before ordinary property lookup, which is a bit more intuitive and matches lookup order of its [`[[DefineOwnProperty]]`](https://tc39.es/ecma262/#sec-string-exotic-objects-defineownproperty-p-desc) method.

Also, adds an assert that String exotic object can't have own property at the same index as in its `[[StringData]]`, which is ensured by its [`[[DefineOwnProperty]]`](https://tc39.es/ecma262/#sec-string-exotic-objects-defineownproperty-p-desc) method.