### PR TITLE
Editorial: Define Module Namespace's [[GetPrototypeOf]] method

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -14542,7 +14542,7 @@
     <emu-clause id="sec-module-namespace-exotic-objects">
       <h1>Module Namespace Exotic Objects</h1>
       <p>A module namespace exotic object is an exotic object that exposes the bindings exported from an ECMAScript |Module| (See <emu-xref href="#sec-exports"></emu-xref>). There is a one-to-one correspondence between the String-keyed own properties of a module namespace exotic object and the binding names exported by the |Module|. The exported bindings include any bindings that are indirectly exported using `export *` export items. Each String-valued own property key is the StringValue of the corresponding exported binding name. These are the only String-keyed properties of a module namespace exotic object. Each such property has the attributes { [[Writable]]: *true*, [[Enumerable]]: *true*, [[Configurable]]: *false* }. Module namespace exotic objects are not extensible.</p>
-      <p>An object is a <dfn id="module-namespace-exotic-object" variants="module namespace exotic objects">module namespace exotic object</dfn> if its [[SetPrototypeOf]], [[IsExtensible]], [[PreventExtensions]], [[GetOwnProperty]], [[DefineOwnProperty]], [[HasProperty]], [[Get]], [[Set]], [[Delete]], and [[OwnPropertyKeys]] internal methods use the definitions in this section, and its other essential internal methods use the definitions found in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>. These methods are installed by ModuleNamespaceCreate.</p>
+      <p>An object is a <dfn id="module-namespace-exotic-object" variants="module namespace exotic objects">module namespace exotic object</dfn> if its [[GetPrototypeOf]], [[SetPrototypeOf]], [[IsExtensible]], [[PreventExtensions]], [[GetOwnProperty]], [[DefineOwnProperty]], [[HasProperty]], [[Get]], [[Set]], [[Delete]], and [[OwnPropertyKeys]] internal methods use the definitions in this section, and its other essential internal methods use the definitions found in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>. These methods are installed by ModuleNamespaceCreate.</p>
       <p>Module namespace exotic objects have the internal slots defined in <emu-xref href="#table-internal-slots-of-module-namespace-exotic-objects"></emu-xref>.</p>
       <emu-table id="table-internal-slots-of-module-namespace-exotic-objects" caption="Internal Slots of Module Namespace Exotic Objects" oldids="table-29">
         <table>
@@ -14580,21 +14580,17 @@
               A List whose elements are the String values of the exported names exposed as own properties of this object. The list is ordered as if an Array of those String values had been sorted using %Array.prototype.sort% using *undefined* as _comparefn_.
             </td>
           </tr>
-          <tr>
-            <td>
-              [[Prototype]]
-            </td>
-            <td>
-              Null
-            </td>
-            <td>
-              This slot always contains the value *null* (see <emu-xref href="#sec-module-namespace-exotic-objects-setprototypeof-v"></emu-xref>).
-            </td>
-          </tr>
           </tbody>
         </table>
       </emu-table>
-      <p>Module namespace exotic objects provide alternative definitions for all of the internal methods except [[GetPrototypeOf]], which behaves as defined in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots-getprototypeof"></emu-xref>.</p>
+
+      <emu-clause id="sec-module-namespace-exotic-objects-getprototypeof">
+        <h1>[[GetPrototypeOf]] ( )</h1>
+        <p>The [[GetPrototypeOf]] internal method of a module namespace exotic object takes no arguments. It performs the following steps when called:</p>
+        <emu-alg>
+          1. Return *null*.
+        </emu-alg>
+      </emu-clause>
 
       <emu-clause id="sec-module-namespace-exotic-objects-setprototypeof-v" type="internal method">
         <h1>
@@ -14791,7 +14787,6 @@
           1. Let _internalSlotsList_ be the internal slots listed in <emu-xref href="#table-internal-slots-of-module-namespace-exotic-objects"></emu-xref>.
           1. Let _M_ be ! MakeBasicObject(_internalSlotsList_).
           1. Set _M_'s essential internal methods to the definitions specified in <emu-xref href="#sec-module-namespace-exotic-objects"></emu-xref>.
-          1. Set _M_.[[Prototype]] to *null*.
           1. Set _M_.[[Module]] to _module_.
           1. Let _sortedExports_ be a List whose elements are the elements of _exports_ ordered as if an Array of the same values had been sorted using %Array.prototype.sort% using *undefined* as _comparefn_.
           1. Set _M_.[[Exports]] to _sortedExports_.


### PR DESCRIPTION
Module Namespace's [`[[GetPrototypeOf]]`](https://262.ecma-international.org/6.0/#sec-module-namespace-exotic-objects-getprototypeof) method, introduced in ES6, was replaced with a `[[Prototype]]` slot in #748 because [`SetImmutablePrototype`](https://tc39.es/ecma262/#sec-set-immutable-prototype) didn't call `[[GetPrototypeOf]]` at the time (fixed in #841).

This change makes definition of Module Namespace's `prototype` consistent with its definition of (non-)extensibility.
AWB argued for this approach in https://github.com/tc39/ecma262/pull/858#discussion_r136681103.