### PR TITLE
Editorial: Rework Module Namespace's [[Get]] method

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -11991,9 +11991,21 @@
           1. If Type(_P_) is Symbol, return OrdinaryGetOwnProperty(_O_, _P_).
           1. Let _exports_ be _O_.[[Exports]].
           1. If _P_ is not an element of _exports_, return *undefined*.
-          1. Let _value_ be ? _O_.[[Get]](_P_, _O_).
+          1. Let _m_ be _O_.[[Module]].
+          1. Let _binding_ be ! _m_.ResolveExport(_P_).
+          1. Assert: _binding_ is a ResolvedBinding Record.
+          1. Let _targetModule_ be _binding_.[[Module]].
+          1. Assert: _targetModule_ is not *undefined*.
+          1. If _binding_.[[BindingName]] is *"\*namespace\*"*, then
+            1. Return ? GetModuleNamespace(_targetModule_).
+          1. Let _targetEnv_ be _targetModule_.[[Environment]].
+          1. If _targetEnv_ is *undefined*, throw a *ReferenceError* exception.
+          1. Let _value_ be ? _targetEnv_.GetBindingValue(_binding_.[[BindingName]], *true*).
           1. Return PropertyDescriptor { [[Value]]: _value_, [[Writable]]: *true*, [[Enumerable]]: *true*, [[Configurable]]: *false* }.
         </emu-alg>
+        <emu-note>
+          <p>ResolveExport is side-effect free. Each time this operation is called with a specific _exportName_, _resolveSet_ pair as arguments it must return the same result. An implementation might choose to pre-compute or cache the ResolveExport results for the [[Exports]] of each module namespace exotic object.</p>
+        </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-module-namespace-exotic-objects-defineownproperty-p-desc">
@@ -12028,23 +12040,13 @@
         <p>The [[Get]] internal method of a module namespace exotic object _O_ takes arguments _P_ (a property key) and _Receiver_ (an ECMAScript language value). It performs the following steps when called:</p>
         <emu-alg>
           1. Assert: IsPropertyKey(_P_) is *true*.
-          1. If Type(_P_) is Symbol, then
-            1. Return ? OrdinaryGet(_O_, _P_, _Receiver_).
-          1. Let _exports_ be _O_.[[Exports]].
-          1. If _P_ is not an element of _exports_, return *undefined*.
-          1. Let _m_ be _O_.[[Module]].
-          1. Let _binding_ be ! _m_.ResolveExport(_P_).
-          1. Assert: _binding_ is a ResolvedBinding Record.
-          1. Let _targetModule_ be _binding_.[[Module]].
-          1. Assert: _targetModule_ is not *undefined*.
-          1. If _binding_.[[BindingName]] is *"\*namespace\*"*, then
-            1. Return ? GetModuleNamespace(_targetModule_).
-          1. Let _targetEnv_ be _targetModule_.[[Environment]].
-          1. If _targetEnv_ is *undefined*, throw a *ReferenceError* exception.
-          1. Return ? _targetEnv_.GetBindingValue(_binding_.[[BindingName]], *true*).
+          1. Let _desc_ be ? _O_.[[GetOwnProperty]](_P_).
+          1. If _desc_ is *undefined*, return *undefined*.
+          1. Assert: ! IsDataDescriptor(_desc_) is *true*.
+          1. Return _desc_.[[Value]].
         </emu-alg>
         <emu-note>
-          <p>ResolveExport is side-effect free. Each time this operation is called with a specific _exportName_, _resolveSet_ pair as arguments it must return the same result. An implementation might choose to pre-compute or cache the ResolveExport results for the [[Exports]] of each module namespace exotic object.</p>
+          <p>This method is just OrdinaryGet with irrelevant steps omitted.</p>
         </emu-note>
       </emu-clause>
 


### PR DESCRIPTION
This PR merely inlines Module Namespace's [`[[Get]]`](https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-get-p-receiver) into its [`[[GetOwnProperty]]`](https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-getownproperty-p) method because:
* [`[[Get]]`](https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-get-p-receiver) doesn't (need to) terminate prototype chain traversal, unlike TypedArray's [`[[Get]]`](https://tc39.es/ecma262/#sec-integer-indexed-exotic-objects-get-p-receiver), since module namespace object's prototype is `null` and it's non-extensible.
* Some Module Namespace's methods like [`[[HasProperty]]`](https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-hasproperty-p) or [`[[Delete]]`](https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-delete-p) are subtly different from ordinary ones: they prevent from calling into [`[[GetOwnProperty]]`](https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-getownproperty-p) that may throw. We should avoid having methods that are totally equivalent to ordinary ones, like [`[[Get]]`](https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-get-p-receiver), so they won't be accidentally ignored by implementors.
* It relieves runtimes from calling into [`[[Get]]`](https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-get-p-receiver) override, and continue performing [`OrdinaryGet`](https://tc39.es/ecma262/#sec-ordinaryget), which is preferred for simplicity / performance reasons.