### PR TITLE
Meta: better compression during preview uploads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -294,12 +294,29 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "requires": {
         "tweetnacl": "^0.14.3"
+      }
+    },
+    "bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
       }
     },
     "bluebird": {
@@ -320,6 +337,16 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
       "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow=="
+    },
+    "buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
     },
     "callsites": {
       "version": "3.1.0",
@@ -573,6 +600,15 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
+      "requires": {
+        "once": "^1.4.0"
+      }
     },
     "escape-html": {
       "version": "1.0.3",
@@ -839,6 +875,12 @@
         "mime-types": "^2.1.12"
       }
     },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -962,6 +1004,12 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
+    },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true
     },
     "ignore": {
       "version": "4.0.6",
@@ -1509,6 +1557,17 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
+    "readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
+    },
     "regexpp": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
@@ -1723,6 +1782,15 @@
         }
       }
     },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
@@ -1790,6 +1858,19 @@
             "ansi-regex": "^4.1.0"
           }
         }
+      }
+    },
+    "tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "requires": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
       }
     },
     "text-table": {
@@ -1876,6 +1957,12 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "uuid": {
       "version": "3.4.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@alrra/travis-scripts": "^2.1.0",
     "glob": "^7.1.6",
     "jsdom": "^15.0.0",
+    "tar-stream": "^2.2.0",
     "tiny-json-http": "^7.1.2"
   }
 }

--- a/scripts/publish-preview.js
+++ b/scripts/publish-preview.js
@@ -4,7 +4,9 @@ const { join } = require('path');
 const glob = require('glob').sync;
 const tiny = require('tiny-json-http');
 const fs = require('fs');
-const { gzipSync } = require('zlib');
+const zlib = require('zlib');
+const tar = require('tar-stream');
+
 
 async function go() {
 	const { TRAVIS_PULL_REQUEST, TRAVIS_PULL_REQUEST_SHA } = process.env;
@@ -19,21 +21,14 @@ async function go() {
 
 	console.log(`Publishing preview build of PR ${TRAVIS_PULL_REQUEST} (SHA ${TRAVIS_PULL_REQUEST_SHA})`);
 
+	const compressed = await compress(files, dir);
+	console.log(`Packed to ${compressed.length / 1000}kB`);
+
 	const data = {
 		pr: TRAVIS_PULL_REQUEST,
 		sha: TRAVIS_PULL_REQUEST_SHA,
-		files: [],
+		compressed,
 	};
-	for (const file of files) {
-		const filename = file.replace(dir, '').slice(1);
-		const contents = fs.readFileSync(file);
-		const body = gzipSync(contents).toString('base64');
-		console.log(`Packaging: ${filename} (${body.length / 1000}kB)`);
-		data.files.push({
-			filename: filename,
-			body: body,
-		});
-	}
 
 	const url = 'https://ci.tc39.es/preview/tc39/ecma262';
 
@@ -43,9 +38,56 @@ async function go() {
 		throw Error('Payloads must be under 6MB');
 	}
 
-	await tiny.post({ url: url, data: data });
+	await tiny.post({ url, data });
 	console.log('Sent to preview!')
 }
+
+async function compress(files, basedir) {
+	return new Promise((resolve, reject) => {
+		files = [...files];
+		const pack = tar.pack();
+
+		const compressStream = zlib.createBrotliCompress({
+			params: {
+				[zlib.constants.BROTLI_PARAM_QUALITY]: 5, // 30% larger and 100x faster than the default (11)
+			}
+		});
+
+		pack.on('error', reject);
+
+		function packEntry(err) {
+			if (err) {
+				reject(err);
+				return;
+			}
+			if (files.length === 0) {
+				pack.finalize();
+				return;
+			}
+
+			const file = files.pop();
+			const name = file.replace(basedir, '').slice(1);
+			const size = fs.statSync(file).size;
+			console.log(`Packaging: ${name} (${size / 1000}kB)`);
+
+			const entry = pack.entry({ name, size }, packEntry);
+
+			const readStream = fs.createReadStream(file);
+
+			readStream.on('error', reject);
+			readStream.pipe(entry);
+		}
+		packEntry();
+
+		const stream = pack.pipe(compressStream);
+		const chunks = [];
+		stream.on('data', (chunk) => chunks.push(chunk));
+		stream.on('error', reject);
+		stream.on('end', () => resolve(Buffer.concat(chunks).toString('base64')));
+	});
+}
+
+
 go().catch((err) => {
 	console.error(err);
 	process.exitCode = 1;


### PR DESCRIPTION
By compressing the whole archive (as a tarball) instead of compressing each file individually, and using brotli instead of gzip, we can considerably reduce the number of bits on the wire. This particularly matters for [multipage builds](https://github.com/tc39/ecma262/pull/2339).

Corresponding tc39-ci PR [here](https://github.com/ljharb/tc39-ci/pull/11). Marked as draft until that lands.