### PR TITLE
Editorial: use target alias name instead of "it"

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -35223,7 +35223,7 @@ THH:mm:ss.sss
         <h1>IsDetachedBuffer ( _arrayBuffer_ )</h1>
         <p>The abstract operation IsDetachedBuffer takes argument _arrayBuffer_. It performs the following steps when called:</p>
         <emu-alg>
-          1. Assert: Type(_arrayBuffer_) is Object and it has an [[ArrayBufferData]] internal slot.
+          1. Assert: Type(_arrayBuffer_) is Object and _arrayBuffer_ has an [[ArrayBufferData]] internal slot.
           1. If _arrayBuffer_.[[ArrayBufferData]] is *null*, return *true*.
           1. Return *false*.
         </emu-alg>
@@ -35233,7 +35233,7 @@ THH:mm:ss.sss
         <h1>DetachArrayBuffer ( _arrayBuffer_ [ , _key_ ] )</h1>
         <p>The abstract operation DetachArrayBuffer takes argument _arrayBuffer_ and optional argument _key_. It performs the following steps when called:</p>
         <emu-alg>
-          1. Assert: Type(_arrayBuffer_) is Object and it has [[ArrayBufferData]], [[ArrayBufferByteLength]], and [[ArrayBufferDetachKey]] internal slots.
+          1. Assert: Type(_arrayBuffer_) is Object and _arrayBuffer_ has [[ArrayBufferData]], [[ArrayBufferByteLength]], and [[ArrayBufferDetachKey]] internal slots.
           1. Assert: IsSharedArrayBuffer(_arrayBuffer_) is *false*.
           1. If _key_ is not present, set _key_ to *undefined*.
           1. If SameValue(_arrayBuffer_.[[ArrayBufferDetachKey]], _key_) is *false*, throw a *TypeError* exception.
@@ -35250,7 +35250,7 @@ THH:mm:ss.sss
         <h1>CloneArrayBuffer ( _srcBuffer_, _srcByteOffset_, _srcLength_, _cloneConstructor_ )</h1>
         <p>The abstract operation CloneArrayBuffer takes arguments _srcBuffer_ (an ArrayBuffer object), _srcByteOffset_ (a non-negative integer), _srcLength_ (a non-negative integer), and _cloneConstructor_ (a constructor). It creates a new ArrayBuffer whose data is a copy of _srcBuffer_'s data over the range starting at _srcByteOffset_ and continuing for _srcLength_ bytes. It performs the following steps when called:</p>
         <emu-alg>
-          1. Assert: Type(_srcBuffer_) is Object and it has an [[ArrayBufferData]] internal slot.
+          1. Assert: Type(_srcBuffer_) is Object and _srcBuffer_ has an [[ArrayBufferData]] internal slot.
           1. Assert: IsConstructor(_cloneConstructor_) is *true*.
           1. Let _targetBuffer_ be ? AllocateArrayBuffer(_cloneConstructor_, _srcLength_).
           1. If IsDetachedBuffer(_srcBuffer_) is *true*, throw a *TypeError* exception.
@@ -35572,7 +35572,7 @@ THH:mm:ss.sss
         <h1>IsSharedArrayBuffer ( _obj_ )</h1>
         <p>The abstract operation IsSharedArrayBuffer takes argument _obj_. It tests whether an object is an ArrayBuffer, a SharedArrayBuffer, or a subtype of either. It performs the following steps when called:</p>
         <emu-alg>
-          1. Assert: Type(_obj_) is Object and it has an [[ArrayBufferData]] internal slot.
+          1. Assert: Type(_obj_) is Object and _obj_ has an [[ArrayBufferData]] internal slot.
           1. Let _bufferData_ be _obj_.[[ArrayBufferData]].
           1. If _bufferData_ is *null*, return *false*.
           1. If _bufferData_ is a Data Block, return *false*.


### PR DESCRIPTION
I noticed this when reviewing [the ResizableArrayBuffer proposal](https://tc39.es/proposal-resizablearraybuffer/), which has this same pattern.
