### PR TITLE
Editorial: remove redundant `index.html`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,9 +24,9 @@
       "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
     },
     "@babel/highlight": {
-      "version": "7.13.8",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.8.tgz",
-      "integrity": "sha512-4vrIhfJyfNf+lCtXC2ck1rKSzDwciqF7IWFhXXrSOUC2O5DrVp+w4c6ed4AllTxhTkUP5x2tYj41VaxdVMMRDw==",
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
+      "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
       "requires": {
         "@babel/helper-validator-identifier": "^7.12.11",
         "chalk": "^2.0.0",
@@ -538,9 +538,9 @@
       }
     },
     "ecmarkup": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-7.0.2.tgz",
-      "integrity": "sha512-Jb/aEgJZQsa97bUy+r1xkSATGyZq5wDtxP6wrxjdSfl4uhNlcJy3M3fqjustYmTEb7qozPWAmIooGaAuj+xyew==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-7.0.3.tgz",
+      "integrity": "sha512-+E4t/eoV1ohNlZxBCMQkcf/lZSBiDJHTo8FtOdJ984hNcAkiXjK5H71bLWw7U6Ps83v57dx2J2abb+nvvlJ7mA==",
       "requires": {
         "bluebird": "^3.7.2",
         "chalk": "^1.1.3",
@@ -913,9 +913,9 @@
       }
     },
     "glob-parent": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "requires": {
         "is-glob": "^4.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "license": "SEE LICENSE IN https://tc39.es/ecma262/#sec-copyright-and-software-license",
   "homepage": "https://tc39.es/ecma262/",
   "dependencies": {
-    "ecmarkup": "^7.0.2"
+    "ecmarkup": "^7.0.3"
   },
   "devDependencies": {
     "@alrra/travis-scripts": "^2.1.0",

--- a/spec.html
+++ b/spec.html
@@ -55,7 +55,7 @@
 <div id="metadata-block">
   <h1>About this Specification</h1>
   <p>The document at <a href="https://tc39.es/ecma262/">https://tc39.es/ecma262/</a> is the most accurate and up-to-date ECMAScript specification. It contains the content of the most recent yearly snapshot plus any <a href="https://github.com/tc39/proposals/blob/master/finished-proposals.md">finished proposals</a> (those that have reached Stage&nbsp;4 in the <a href="https://tc39.es/process-document/">proposal process</a> and thus are implemented in several implementations and will be in the next practical revision) since that snapshot was taken.</p>
-  <p>This document is available as <a href="">a single page</a> and as <a href="multipage/index.html">multiple pages</a>.</p>
+  <p>This document is available as <a href="">a single page</a> and as <a href="multipage/">multiple pages</a>.</p>
   <h1>Contributing to this Specification</h1>
   <p>This specification is developed on GitHub with the help of the ECMAScript community. There are a number of ways to contribute to the development of this specification:</p>
   <ul>


### PR DESCRIPTION
There was some discussion on removing it here: https://github.com/tc39/ecma262/pull/2339#discussion_r585946339 So I wanted to offer this patch in case this was overlooked.