### PR TITLE
Editorial: clean up wording of Array methods

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -31601,7 +31601,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-array.from">
         <h1>Array.from ( _items_ [ , _mapfn_ [ , _thisArg_ ] ] )</h1>
-        <p>When the `from` method is called with argument _items_ and optional arguments _mapfn_ and _thisArg_, the following steps are taken:</p>
+        <p>When the `from` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _C_ be the *this* value.
           1. If _mapfn_ is *undefined*, let _mapping_ be *false*.
@@ -31660,7 +31660,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-array.isarray">
         <h1>Array.isArray ( _arg_ )</h1>
-        <p>The `isArray` function takes one argument _arg_, and performs the following steps:</p>
+        <p>When the `isArray` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Return ? IsArray(_arg_).
         </emu-alg>
@@ -31668,7 +31668,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-array.of">
         <h1>Array.of ( ..._items_ )</h1>
-        <p>When the `of` method is called with any number of arguments, the following steps are taken:</p>
+        <p>When the `of` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _len_ be the number of elements in _items_.
           1. Let _lenNumber_ be 𝔽(_len_).
@@ -31699,7 +31699,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-get-array-@@species">
         <h1>get Array [ @@species ]</h1>
-        <p>`Array[@@species]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
+        <p>`Array[@@species]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Return the *this* value.
         </emu-alg>
@@ -31725,8 +31725,8 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-array.prototype.concat">
         <h1>Array.prototype.concat ( ..._items_ )</h1>
-        <p>When the `concat` method is called with zero or more arguments, it returns an array containing the array elements of the object followed by the array elements of each argument.</p>
-        <p>The following steps are taken:</p>
+        <p>Returns an array containing the array elements of the object followed by the array elements of each argument.</p>
+        <p>When the `concat` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _A_ be ? ArraySpeciesCreate(_O_, 0).
@@ -31781,11 +31781,13 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-array.prototype.copywithin">
         <h1>Array.prototype.copyWithin ( _target_, _start_ [ , _end_ ] )</h1>
-        <p>The `copyWithin` method takes up to three arguments _target_, _start_ and _end_.</p>
         <emu-note>
-          <p>The _end_ argument is optional with the length of the *this* value as its default value. If _target_ is negative, it is treated as <emu-eqn>_length_ + _target_</emu-eqn> where _length_ is the length of the array. If _start_ is negative, it is treated as <emu-eqn>_length_ + _start_</emu-eqn>. If _end_ is negative, it is treated as <emu-eqn>_length_ + _end_</emu-eqn>.</p>
+          <p>The _end_ argument is optional. If it is not provided, the length of the *this* value is used.</p>
         </emu-note>
-        <p>The following steps are taken:</p>
+        <emu-note>
+          <p>If _target_ is negative, it is treated as <emu-eqn>_length_ + _target_</emu-eqn> where _length_ is the length of the array. If _start_ is negative, it is treated as <emu-eqn>_length_ + _start_</emu-eqn>. If _end_ is negative, it is treated as <emu-eqn>_length_ + _end_</emu-eqn>.</p>
+        </emu-note>
+        <p>When the `copyWithin` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
@@ -31830,7 +31832,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-array.prototype.entries">
         <h1>Array.prototype.entries ( )</h1>
-        <p>The following steps are taken:</p>
+        <p>When the `entries` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Return CreateArrayIterator(_O_, ~key+value~).
@@ -31846,7 +31848,7 @@ THH:mm:ss.sss
           <p>`every` does not directly mutate the object on which it is called but the object may be mutated by the calls to _callbackfn_.</p>
           <p>The range of elements processed by `every` is set before the first call to _callbackfn_. Elements which are appended to the array after the call to `every` begins will not be visited by _callbackfn_. If existing elements of the array are changed, their value as passed to _callbackfn_ will be the value at the time `every` visits them; elements that are deleted after the call to `every` begins and before being visited are not visited. `every` acts like the "for all" quantifier in mathematics. In particular, for an empty array, it returns *true*.</p>
         </emu-note>
-        <p>When the `every` method is called with one or two arguments, the following steps are taken:</p>
+        <p>When the `every` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
@@ -31869,11 +31871,14 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-array.prototype.fill">
         <h1>Array.prototype.fill ( _value_ [ , _start_ [ , _end_ ] ] )</h1>
-        <p>The `fill` method takes up to three arguments _value_, _start_ and _end_.</p>
         <emu-note>
-          <p>The _start_ and _end_ arguments are optional with default values of 0 and the length of the *this* value. If _start_ is negative, it is treated as <emu-eqn>_length_ + _start_</emu-eqn> where _length_ is the length of the array. If _end_ is negative, it is treated as <emu-eqn>_length_ + _end_</emu-eqn>.</p>
+          <p>The _start_ argument is optional. If it is not provided, *+0*<sub>𝔽</sub> is used.</p>
+          <p>The _end_ argument is optional. If it is not provided, the length of the *this* value is used.</p>
         </emu-note>
-        <p>The following steps are taken:</p>
+        <emu-note>
+          <p>If _start_ is negative, it is treated as <emu-eqn>_length_ + _start_</emu-eqn> where _length_ is the length of the array. If _end_ is negative, it is treated as <emu-eqn>_length_ + _end_</emu-eqn>.</p>
+        </emu-note>
+        <p>When the `fill` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
@@ -31905,7 +31910,7 @@ THH:mm:ss.sss
           <p>`filter` does not directly mutate the object on which it is called but the object may be mutated by the calls to _callbackfn_.</p>
           <p>The range of elements processed by `filter` is set before the first call to _callbackfn_. Elements which are appended to the array after the call to `filter` begins will not be visited by _callbackfn_. If existing elements of the array are changed their value as passed to _callbackfn_ will be the value at the time `filter` visits them; elements that are deleted after the call to `filter` begins and before being visited are not visited.</p>
         </emu-note>
-        <p>When the `filter` method is called with one or two arguments, the following steps are taken:</p>
+        <p>When the `filter` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
@@ -31932,7 +31937,6 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-array.prototype.find">
         <h1>Array.prototype.find ( _predicate_ [ , _thisArg_ ] )</h1>
-        <p>The `find` method is called with one or two arguments, _predicate_ and _thisArg_.</p>
         <emu-note>
           <p>_predicate_ should be a function that accepts three arguments and returns a value that is coercible to a Boolean value. `find` calls _predicate_ once for each element of the array, in ascending order, until it finds one where _predicate_ returns *true*. If such an element is found, `find` immediately returns that element value. Otherwise, `find` returns *undefined*.</p>
           <p>If a _thisArg_ parameter is provided, it will be used as the *this* value for each invocation of _predicate_. If it is not provided, *undefined* is used instead.</p>
@@ -31968,7 +31972,7 @@ THH:mm:ss.sss
           <p>`findIndex` does not directly mutate the object on which it is called but the object may be mutated by the calls to _predicate_.</p>
           <p>The range of elements processed by `findIndex` is set before the first call to _predicate_. Elements that are appended to the array after the call to `findIndex` begins will not be visited by _predicate_. If existing elements of the array are changed, their value as passed to _predicate_ will be the value at the time that `findIndex` visits them; elements that are deleted after the call to `findIndex` begins and before being visited are not visited.</p>
         </emu-note>
-        <p>When the `findIndex` method is called with one or two arguments, the following steps are taken:</p>
+        <p>When the `findIndex` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
@@ -31989,7 +31993,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-array.prototype.flat">
         <h1>Array.prototype.flat ( [ _depth_ ] )</h1>
-        <p>When the `flat` method is called with zero or one arguments, the following steps are taken:</p>
+        <p>When the `flat` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _sourceLen_ be ? LengthOfArrayLike(_O_).
@@ -32038,7 +32042,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-array.prototype.flatmap">
         <h1>Array.prototype.flatMap ( _mapperFunction_ [ , _thisArg_ ] )</h1>
-        <p>When the `flatMap` method is called with one or two arguments, the following steps are taken:</p>
+        <p>When the `flatMap` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _sourceLen_ be ? LengthOfArrayLike(_O_).
@@ -32058,7 +32062,7 @@ THH:mm:ss.sss
           <p>`forEach` does not directly mutate the object on which it is called but the object may be mutated by the calls to _callbackfn_.</p>
           <p>The range of elements processed by `forEach` is set before the first call to _callbackfn_. Elements which are appended to the array after the call to `forEach` begins will not be visited by _callbackfn_. If existing elements of the array are changed, their value as passed to _callbackfn_ will be the value at the time `forEach` visits them; elements that are deleted after the call to `forEach` begins and before being visited are not visited.</p>
         </emu-note>
-        <p>When the `forEach` method is called with one or two arguments, the following steps are taken:</p>
+        <p>When the `forEach` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
@@ -32080,14 +32084,11 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-array.prototype.includes">
         <h1>Array.prototype.includes ( _searchElement_ [ , _fromIndex_ ] )</h1>
-
         <emu-note>
           <p>`includes` compares _searchElement_ to the elements of the array, in ascending order, using the SameValueZero algorithm, and if found at any position, returns *true*; otherwise, *false* is returned.</p>
-
           <p>The optional second argument _fromIndex_ defaults to *+0*<sub>𝔽</sub> (i.e. the whole array is searched). If it is greater than or equal to the length of the array, *false* is returned, i.e. the array will not be searched. If it is less than *+0*<sub>𝔽</sub>, it is used as the offset from the end of the array to compute _fromIndex_. If the computed index is less than *+0*<sub>𝔽</sub>, the whole array will be searched.</p>
         </emu-note>
         <p>When the `includes` method is called, the following steps are taken:</p>
-
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
@@ -32107,11 +32108,9 @@ THH:mm:ss.sss
             1. Set _k_ to _k_ + 1.
           1. Return *false*.
         </emu-alg>
-
         <emu-note>
           <p>The `includes` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
-
         <emu-note>
           <p>The `includes` method intentionally differs from the similar `indexOf` method in two ways. First, it uses the SameValueZero algorithm, instead of Strict Equality Comparison, allowing it to detect *NaN* array elements. Second, it does not skip missing array elements, instead treating them as *undefined*.</p>
         </emu-note>
@@ -32119,11 +32118,11 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-array.prototype.indexof">
         <h1>Array.prototype.indexOf ( _searchElement_ [ , _fromIndex_ ] )</h1>
+        <p>`indexOf` compares _searchElement_ to the elements of the array, in ascending order, using the Strict Equality Comparison algorithm, and if found at one or more indices, returns the smallest such index; otherwise, *-1*<sub>𝔽</sub> is returned.</p>
         <emu-note>
-          <p>`indexOf` compares _searchElement_ to the elements of the array, in ascending order, using the Strict Equality Comparison algorithm, and if found at one or more indices, returns the smallest such index; otherwise, *-1*<sub>𝔽</sub> is returned.</p>
           <p>The optional second argument _fromIndex_ defaults to *+0*<sub>𝔽</sub> (i.e. the whole array is searched). If it is greater than or equal to the length of the array, *-1*<sub>𝔽</sub> is returned, i.e. the array will not be searched. If it is less than *+0*<sub>𝔽</sub>, it is used as the offset from the end of the array to compute _fromIndex_. If the computed index is less than *+0*<sub>𝔽</sub>, the whole array will be searched.</p>
         </emu-note>
-        <p>When the `indexOf` method is called with one or two arguments, the following steps are taken:</p>
+        <p>When the `indexOf` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
@@ -32153,10 +32152,8 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-array.prototype.join">
         <h1>Array.prototype.join ( _separator_ )</h1>
-        <emu-note>
-          <p>The elements of the array are converted to Strings, and these Strings are then concatenated, separated by occurrences of the _separator_. If no separator is provided, a single comma is used as the separator.</p>
-        </emu-note>
-        <p>The `join` method takes one argument, _separator_, and performs the following steps:</p>
+        <p>The elements of the array are converted to Strings, and these Strings are then concatenated, separated by occurrences of the _separator_. If no separator is provided, a single comma is used as the separator.</p>
+        <p>When the `join` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
@@ -32179,7 +32176,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-array.prototype.keys">
         <h1>Array.prototype.keys ( )</h1>
-        <p>The following steps are taken:</p>
+        <p>When the `keys` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Return CreateArrayIterator(_O_, ~key~).
@@ -32192,7 +32189,7 @@ THH:mm:ss.sss
           <p>`lastIndexOf` compares _searchElement_ to the elements of the array in descending order using the Strict Equality Comparison algorithm, and if found at one or more indices, returns the largest such index; otherwise, *-1*<sub>𝔽</sub> is returned.</p>
           <p>The optional second argument _fromIndex_ defaults to the array's length minus one (i.e. the whole array is searched). If it is greater than or equal to the length of the array, the whole array will be searched. If it is less than *+0*<sub>𝔽</sub>, it is used as the offset from the end of the array to compute _fromIndex_. If the computed index is less than *+0*<sub>𝔽</sub>, *-1*<sub>𝔽</sub> is returned.</p>
         </emu-note>
-        <p>When the `lastIndexOf` method is called with one or two arguments, the following steps are taken:</p>
+        <p>When the `lastIndexOf` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
@@ -32226,7 +32223,7 @@ THH:mm:ss.sss
           <p>`map` does not directly mutate the object on which it is called but the object may be mutated by the calls to _callbackfn_.</p>
           <p>The range of elements processed by `map` is set before the first call to _callbackfn_. Elements which are appended to the array after the call to `map` begins will not be visited by _callbackfn_. If existing elements of the array are changed, their value as passed to _callbackfn_ will be the value at the time `map` visits them; elements that are deleted after the call to `map` begins and before being visited are not visited.</p>
         </emu-note>
-        <p>When the `map` method is called with one or two arguments, the following steps are taken:</p>
+        <p>When the `map` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
@@ -32279,7 +32276,7 @@ THH:mm:ss.sss
         <emu-note>
           <p>The arguments are appended to the end of the array, in the order in which they appear. The new length of the array is returned as the result of the call.</p>
         </emu-note>
-        <p>When the `push` method is called with zero or more arguments, the following steps are taken:</p>
+        <p>When the `push` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
@@ -32305,7 +32302,7 @@ THH:mm:ss.sss
           <p>`reduce` does not directly mutate the object on which it is called but the object may be mutated by the calls to _callbackfn_.</p>
           <p>The range of elements processed by `reduce` is set before the first call to _callbackfn_. Elements that are appended to the array after the call to `reduce` begins will not be visited by _callbackfn_. If existing elements of the array are changed, their value as passed to _callbackfn_ will be the value at the time `reduce` visits them; elements that are deleted after the call to `reduce` begins and before being visited are not visited.</p>
         </emu-note>
-        <p>When the `reduce` method is called with one or two arguments, the following steps are taken:</p>
+        <p>When the `reduce` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
@@ -32346,7 +32343,7 @@ THH:mm:ss.sss
           <p>`reduceRight` does not directly mutate the object on which it is called but the object may be mutated by the calls to _callbackfn_.</p>
           <p>The range of elements processed by `reduceRight` is set before the first call to _callbackfn_. Elements that are appended to the array after the call to `reduceRight` begins will not be visited by _callbackfn_. If existing elements of the array are changed by _callbackfn_, their value as passed to _callbackfn_ will be the value at the time `reduceRight` visits them; elements that are deleted after the call to `reduceRight` begins and before being visited are not visited.</p>
         </emu-note>
-        <p>When the `reduceRight` method is called with one or two arguments, the following steps are taken:</p>
+        <p>When the `reduceRight` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
@@ -32422,9 +32419,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-array.prototype.shift">
         <h1>Array.prototype.shift ( )</h1>
-        <emu-note>
-          <p>The first element of the array is removed from the array and returned.</p>
-        </emu-note>
+        <p>The first element of the array is removed from the array and returned.</p>
         <p>When the `shift` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
@@ -32456,10 +32451,8 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-array.prototype.slice">
         <h1>Array.prototype.slice ( _start_, _end_ )</h1>
-        <emu-note>
-          <p>The `slice` method takes two arguments, _start_ and _end_, and returns an array containing the elements of the array from element _start_ up to, but not including, element _end_ (or through the end of the array if _end_ is *undefined*). If _start_ is negative, it is treated as <emu-eqn>_length_ + _start_</emu-eqn> where _length_ is the length of the array. If _end_ is negative, it is treated as <emu-eqn>_length_ + _end_</emu-eqn> where _length_ is the length of the array.</p>
-        </emu-note>
-        <p>The following steps are taken:</p>
+        <p>The `slice` method returns an array containing the elements of the array from element _start_ up to, but not including, element _end_ (or through the end of the array if _end_ is *undefined*). If _start_ is negative, it is treated as <emu-eqn>_length_ + _start_</emu-eqn> where _length_ is the length of the array. If _end_ is negative, it is treated as <emu-eqn>_length_ + _end_</emu-eqn> where _length_ is the length of the array.</p>
+        <p>When the `slice` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
@@ -32502,7 +32495,7 @@ THH:mm:ss.sss
           <p>`some` does not directly mutate the object on which it is called but the object may be mutated by the calls to _callbackfn_.</p>
           <p>The range of elements processed by `some` is set before the first call to _callbackfn_. Elements that are appended to the array after the call to `some` begins will not be visited by _callbackfn_. If existing elements of the array are changed, their value as passed to _callbackfn_ will be the value at the time that `some` visits them; elements that are deleted after the call to `some` begins and before being visited are not visited. `some` acts like the "exists" quantifier in mathematics. In particular, for an empty array, it returns *false*.</p>
         </emu-note>
-        <p>When the `some` method is called with one or two arguments, the following steps are taken:</p>
+        <p>When the `some` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
@@ -32525,8 +32518,8 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-array.prototype.sort">
         <h1>Array.prototype.sort ( _comparefn_ )</h1>
-        <p>The elements of this array are sorted. The sort must be stable (that is, elements that compare equal must remain in their original order). If _comparefn_ is not *undefined*, it should be a function that accepts two arguments _x_ and _y_ and returns a negative value if _x_ &lt; _y_, zero if _x_ = _y_, or a positive value if _x_ &gt; _y_.</p>
-        <p>The following steps are taken:</p>
+        <p>The elements of this array are sorted. The sort must be stable (that is, elements that compare equal must remain in their original order). If _comparefn_ is not *undefined*, it should be a function that accepts two arguments _x_ and _y_ and returns a negative Number if _x_ &lt; _y_, a positive Number if _x_ &gt; _y_, or a zero otherwise.</p>
+        <p>When the `sort` method is called, the following steps are taken:</p>
         <emu-alg>
           1. [id="step-array-sort-comparefn"] If _comparefn_ is not *undefined* and IsCallable(_comparefn_) is *false*, throw a *TypeError* exception.
           1. Let _obj_ be ? ToObject(*this* value).
@@ -32636,9 +32629,9 @@ THH:mm:ss.sss
       <emu-clause id="sec-array.prototype.splice">
         <h1>Array.prototype.splice ( _start_, _deleteCount_, ..._items_ )</h1>
         <emu-note>
-          <p>When the `splice` method is called with two or more arguments _start_, _deleteCount_ and zero or more _items_, the _deleteCount_ elements of the array starting at integer index _start_ are replaced by the elements of _items_. An Array object containing the deleted elements (if any) is returned.</p>
+          <p>The _deleteCount_ elements of the array starting at integer index _start_ are replaced by the elements of _items_. An Array object containing the deleted elements (if any) is returned.</p>
         </emu-note>
-        <p>The following steps are taken:</p>
+        <p>When the `splice` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
@@ -32720,7 +32713,7 @@ THH:mm:ss.sss
           <p>The first edition of ECMA-402 did not include a replacement specification for the `Array.prototype.toLocaleString` method.</p>
         </emu-note>
         <p>The meanings of the optional parameters to this method are defined in the ECMA-402 specification; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
-        <p>The following steps are taken:</p>
+        <p>When the `toLocaleString` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _array_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_array_).
@@ -32761,10 +32754,8 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-array.prototype.unshift">
         <h1>Array.prototype.unshift ( ..._items_ )</h1>
-        <emu-note>
-          <p>The arguments are prepended to the start of the array, such that their order within the array is the same as the order in which they appear in the argument list.</p>
-        </emu-note>
-        <p>When the `unshift` method is called with zero or more arguments _item1_, _item2_, etc., the following steps are taken:</p>
+        <p>The arguments are prepended to the start of the array, such that their order within the array is the same as the order in which they appear in the argument list.</p>
+        <p>When the `unshift` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
@@ -32798,7 +32789,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-array.prototype.values">
         <h1>Array.prototype.values ( )</h1>
-        <p>The following steps are taken:</p>
+        <p>When the `values` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Return CreateArrayIterator(_O_, ~value~).
@@ -32893,6 +32884,7 @@ THH:mm:ss.sss
 
         <emu-clause id="sec-%arrayiteratorprototype%.next">
           <h1>%ArrayIteratorPrototype%.next ( )</h1>
+          <p>When the `next` method is called, the following steps are taken:</p>
           <emu-alg>
             1. Return ? GeneratorResume(*this* value, ~empty~, *"%ArrayIteratorPrototype%"*).
           </emu-alg>
@@ -33155,7 +33147,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-%typedarray%">
         <h1>%TypedArray% ( )</h1>
-        <p>The %TypedArray% constructor performs the following steps:</p>
+        <p>The %TypedArray% constructor performs the following steps when called:</p>
         <emu-alg>
           1. Throw a *TypeError* exception.
         </emu-alg>
@@ -33174,7 +33166,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-%typedarray%.from">
         <h1>%TypedArray%.from ( _source_ [ , _mapfn_ [ , _thisArg_ ] ] )</h1>
-        <p>When the `from` method is called with argument _source_, and optional arguments _mapfn_ and _thisArg_, the following steps are taken:</p>
+        <p>When the `from` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _C_ be the *this* value.
           1. If IsConstructor(_C_) is *false*, throw a *TypeError* exception.
@@ -33217,7 +33209,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-%typedarray%.of">
         <h1>%TypedArray%.of ( ..._items_ )</h1>
-        <p>When the `of` method is called with any number of arguments, the following steps are taken:</p>
+        <p>When the `of` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _len_ be the number of elements in _items_.
           1. Let _C_ be the *this* value.
@@ -33241,7 +33233,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-get-%typedarray%-@@species">
         <h1>get %TypedArray% [ @@species ]</h1>
-        <p>%TypedArray%`[@@species]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
+        <p>%TypedArray%`[@@species]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Return the *this* value.
         </emu-alg>
@@ -33264,7 +33256,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-get-%typedarray%.prototype.buffer">
         <h1>get %TypedArray%.prototype.buffer</h1>
-        <p>%TypedArray%`.prototype.buffer` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
+        <p>%TypedArray%`.prototype.buffer` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? RequireInternalSlot(_O_, [[TypedArrayName]]).
@@ -33276,7 +33268,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-get-%typedarray%.prototype.bytelength">
         <h1>get %TypedArray%.prototype.byteLength</h1>
-        <p>%TypedArray%`.prototype.byteLength` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
+        <p>%TypedArray%`.prototype.byteLength` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? RequireInternalSlot(_O_, [[TypedArrayName]]).
@@ -33290,7 +33282,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-get-%typedarray%.prototype.byteoffset">
         <h1>get %TypedArray%.prototype.byteOffset</h1>
-        <p>%TypedArray%`.prototype.byteOffset` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
+        <p>%TypedArray%`.prototype.byteOffset` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? RequireInternalSlot(_O_, [[TypedArrayName]]).
@@ -33310,7 +33302,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-%typedarray%.prototype.copywithin">
         <h1>%TypedArray%.prototype.copyWithin ( _target_, _start_ [ , _end_ ] )</h1>
         <p>The interpretation and use of the arguments of %TypedArray%`.prototype.copyWithin` are the same as for `Array.prototype.copyWithin` as defined in <emu-xref href="#sec-array.prototype.copywithin"></emu-xref>.</p>
-        <p>The following steps are taken:</p>
+        <p>When the `copyWithin` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
@@ -33356,7 +33348,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-%typedarray%.prototype.entries">
         <h1>%TypedArray%.prototype.entries ( )</h1>
-        <p>The following steps are taken:</p>
+        <p>When the `entries` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
@@ -33367,7 +33359,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-%typedarray%.prototype.every">
         <h1>%TypedArray%.prototype.every ( _callbackfn_ [ , _thisArg_ ] )</h1>
         <p>The interpretation and use of the arguments of %TypedArray%`.prototype.every` are the same as for `Array.prototype.every` as defined in <emu-xref href="#sec-array.prototype.every"></emu-xref>.</p>
-        <p>When the `every` method is called with one or two arguments, the following steps are taken:</p>
+        <p>When the `every` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
@@ -33388,7 +33380,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-%typedarray%.prototype.fill">
         <h1>%TypedArray%.prototype.fill ( _value_ [ , _start_ [ , _end_ ] ] )</h1>
         <p>The interpretation and use of the arguments of %TypedArray%`.prototype.fill` are the same as for `Array.prototype.fill` as defined in <emu-xref href="#sec-array.prototype.fill"></emu-xref>.</p>
-        <p>The following steps are taken:</p>
+        <p>When the `fill` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
@@ -33415,7 +33407,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-%typedarray%.prototype.filter">
         <h1>%TypedArray%.prototype.filter ( _callbackfn_ [ , _thisArg_ ] )</h1>
         <p>The interpretation and use of the arguments of %TypedArray%`.prototype.filter` are the same as for `Array.prototype.filter` as defined in <emu-xref href="#sec-array.prototype.filter"></emu-xref>.</p>
-        <p>When the `filter` method is called with one or two arguments, the following steps are taken:</p>
+        <p>When the `filter` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
@@ -33445,7 +33437,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-%typedarray%.prototype.find">
         <h1>%TypedArray%.prototype.find ( _predicate_ [ , _thisArg_ ] )</h1>
         <p>The interpretation and use of the arguments of %TypedArray%`.prototype.find` are the same as for `Array.prototype.find` as defined in <emu-xref href="#sec-array.prototype.find"></emu-xref>.</p>
-        <p>When the `find` method is called with one or two arguments, the following steps are taken:</p>
+        <p>When the `find` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
@@ -33466,7 +33458,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-%typedarray%.prototype.findindex">
         <h1>%TypedArray%.prototype.findIndex ( _predicate_ [ , _thisArg_ ] )</h1>
         <p>The interpretation and use of the arguments of %TypedArray%`.prototype.findIndex` are the same as for `Array.prototype.findIndex` as defined in <emu-xref href="#sec-array.prototype.findindex"></emu-xref>.</p>
-        <p>When the `findIndex` method is called with one or two arguments, the following steps are taken:</p>
+        <p>When the `findIndex` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
@@ -33487,7 +33479,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-%typedarray%.prototype.foreach">
         <h1>%TypedArray%.prototype.forEach ( _callbackfn_ [ , _thisArg_ ] )</h1>
         <p>The interpretation and use of the arguments of %TypedArray%`.prototype.forEach` are the same as for `Array.prototype.forEach` as defined in <emu-xref href="#sec-array.prototype.foreach"></emu-xref>.</p>
-        <p>When the `forEach` method is called with one or two arguments, the following steps are taken:</p>
+        <p>When the `forEach` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
@@ -33507,7 +33499,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-%typedarray%.prototype.includes">
         <h1>%TypedArray%.prototype.includes ( _searchElement_ [ , _fromIndex_ ] )</h1>
         <p>The interpretation and use of the arguments of %TypedArray%`.prototype.includes` are the same as for `Array.prototype.includes` as defined in <emu-xref href="#sec-array.prototype.includes"></emu-xref>.</p>
-        <p>When the `includes` method is called with one or two arguments, the following steps are taken:</p>
+        <p>When the `includes` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
@@ -33534,7 +33526,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-%typedarray%.prototype.indexof">
         <h1>%TypedArray%.prototype.indexOf ( _searchElement_ [ , _fromIndex_ ] )</h1>
         <p>The interpretation and use of the arguments of %TypedArray%`.prototype.indexOf` are the same as for `Array.prototype.indexOf` as defined in <emu-xref href="#sec-array.prototype.indexof"></emu-xref>.</p>
-        <p>When the `indexOf` method is called with one or two arguments, the following steps are taken:</p>
+        <p>When the `indexOf` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
@@ -33564,7 +33556,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-%typedarray%.prototype.join">
         <h1>%TypedArray%.prototype.join ( _separator_ )</h1>
         <p>The interpretation and use of the arguments of %TypedArray%`.prototype.join` are the same as for `Array.prototype.join` as defined in <emu-xref href="#sec-array.prototype.join"></emu-xref>.</p>
-        <p>When the `join` method is called with one argument _separator_, the following steps are taken:</p>
+        <p>When the `join` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
@@ -33586,7 +33578,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-%typedarray%.prototype.keys">
         <h1>%TypedArray%.prototype.keys ( )</h1>
-        <p>The following steps are taken:</p>
+        <p>When the `keys` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
@@ -33597,7 +33589,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-%typedarray%.prototype.lastindexof">
         <h1>%TypedArray%.prototype.lastIndexOf ( _searchElement_ [ , _fromIndex_ ] )</h1>
         <p>The interpretation and use of the arguments of %TypedArray%`.prototype.lastIndexOf` are the same as for `Array.prototype.lastIndexOf` as defined in <emu-xref href="#sec-array.prototype.lastindexof"></emu-xref>.</p>
-        <p>When the `lastIndexOf` method is called with one or two arguments, the following steps are taken:</p>
+        <p>When the `lastIndexOf` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
@@ -33623,7 +33615,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-get-%typedarray%.prototype.length">
         <h1>get %TypedArray%.prototype.length</h1>
-        <p>%TypedArray%`.prototype.length` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
+        <p>%TypedArray%`.prototype.length` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? RequireInternalSlot(_O_, [[TypedArrayName]]).
@@ -33639,7 +33631,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-%typedarray%.prototype.map">
         <h1>%TypedArray%.prototype.map ( _callbackfn_ [ , _thisArg_ ] )</h1>
         <p>The interpretation and use of the arguments of %TypedArray%`.prototype.map` are the same as for `Array.prototype.map` as defined in <emu-xref href="#sec-array.prototype.map"></emu-xref>.</p>
-        <p>When the `map` method is called with one or two arguments, the following steps are taken:</p>
+        <p>When the `map` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
@@ -33661,7 +33653,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-%typedarray%.prototype.reduce">
         <h1>%TypedArray%.prototype.reduce ( _callbackfn_ [ , _initialValue_ ] )</h1>
         <p>The interpretation and use of the arguments of %TypedArray%`.prototype.reduce` are the same as for `Array.prototype.reduce` as defined in <emu-xref href="#sec-array.prototype.reduce"></emu-xref>.</p>
-        <p>When the `reduce` method is called with one or two arguments, the following steps are taken:</p>
+        <p>When the `reduce` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
@@ -33689,7 +33681,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-%typedarray%.prototype.reduceright">
         <h1>%TypedArray%.prototype.reduceRight ( _callbackfn_ [ , _initialValue_ ] )</h1>
         <p>The interpretation and use of the arguments of %TypedArray%`.prototype.reduceRight` are the same as for `Array.prototype.reduceRight` as defined in <emu-xref href="#sec-array.prototype.reduceright"></emu-xref>.</p>
-        <p>When the `reduceRight` method is called with one or two arguments, the following steps are taken:</p>
+        <p>When the `reduceRight` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
@@ -33743,6 +33735,7 @@ THH:mm:ss.sss
         <p>%TypedArray%`.prototype.set` is a function whose behaviour differs based upon the type of its first argument.</p>
         <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
         <p>Sets multiple values in this _TypedArray_, reading the values from _source_. The optional _offset_ value indicates the first element index in this _TypedArray_ where values are written. If omitted, it is assumed to be 0.</p>
+        <p>When the `set` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _target_ be the *this* value.
           1. Perform ? RequireInternalSlot(_target_, [[TypedArrayName]]).
@@ -33840,6 +33833,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-%typedarray%.prototype.slice">
         <h1>%TypedArray%.prototype.slice ( _start_, _end_ )</h1>
         <p>The interpretation and use of the arguments of %TypedArray%`.prototype.slice` are the same as for `Array.prototype.slice` as defined in <emu-xref href="#sec-array.prototype.slice"></emu-xref>. The following steps are taken:</p>
+        <p>When the `slice` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
@@ -33890,7 +33884,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-%typedarray%.prototype.some">
         <h1>%TypedArray%.prototype.some ( _callbackfn_ [ , _thisArg_ ] )</h1>
         <p>The interpretation and use of the arguments of %TypedArray%`.prototype.some` are the same as for `Array.prototype.some` as defined in <emu-xref href="#sec-array.prototype.some"></emu-xref>.</p>
-        <p>When the `some` method is called with one or two arguments, the following steps are taken:</p>
+        <p>When the `some` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
@@ -33945,6 +33939,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-%typedarray%.prototype.subarray">
         <h1>%TypedArray%.prototype.subarray ( _begin_, _end_ )</h1>
         <p>Returns a new _TypedArray_ object whose element type is the same as this _TypedArray_ and whose ArrayBuffer is the same as the ArrayBuffer of this _TypedArray_, referencing the elements at _begin_, inclusive, up to _end_, exclusive. If either _begin_ or _end_ is negative, it refers to an index from the end of the array, as opposed to from the beginning.</p>
+        <p>When the `subarray` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? RequireInternalSlot(_O_, [[TypedArrayName]]).
@@ -33986,7 +33981,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-%typedarray%.prototype.values">
         <h1>%TypedArray%.prototype.values ( )</h1>
-        <p>The following steps are taken:</p>
+        <p>When the `values` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
@@ -34001,7 +33996,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-get-%typedarray%.prototype-@@tostringtag">
         <h1>get %TypedArray%.prototype [ @@toStringTag ]</h1>
-        <p>%TypedArray%`.prototype[@@toStringTag]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
+        <p>%TypedArray%`.prototype[@@toStringTag]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. If Type(_O_) is not Object, return *undefined*.


### PR DESCRIPTION
Obsoletes #2294. I moved a few paragraphs outside of the `<emu-note>` because they weren't notes, they were summaries of the method.