### PR TITLE
Editorial: Simplify CreateDynamicFunction

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -24955,21 +24955,21 @@
             1. Perform ? HostEnsureCanCompileStrings(_callerRealm_, _calleeRealm_).
             1. If _newTarget_ is *undefined*, set _newTarget_ to _constructor_.
             1. If _kind_ is ~normal~, then
-              1. Let _goal_ be the grammar symbol |FunctionBody[~Yield, ~Await]|.
-              1. Let _parameterGoal_ be the grammar symbol |FormalParameters[~Yield, ~Await]|.
+              1. Let _exprSym_ be the grammar symbol |FunctionExpression|.
+              1. Let _bodySym_ be the grammar symbol |FunctionBody|.
               1. Let _fallbackProto_ be *"%Function.prototype%"*.
             1. Else if _kind_ is ~generator~, then
-              1. Let _goal_ be the grammar symbol |GeneratorBody|.
-              1. Let _parameterGoal_ be the grammar symbol |FormalParameters[+Yield, ~Await]|.
+              1. Let _exprSym_ be the grammar symbol |GeneratorExpression|.
+              1. Let _bodySym_ be the grammar symbol |GeneratorBody|.
               1. Let _fallbackProto_ be *"%GeneratorFunction.prototype%"*.
             1. Else if _kind_ is ~async~, then
-              1. Let _goal_ be the grammar symbol |AsyncFunctionBody|.
-              1. Let _parameterGoal_ be the grammar symbol |FormalParameters[~Yield, +Await]|.
+              1. Let _exprSym_ be the grammar symbol |AsyncFunctionExpression|.
+              1. Let _bodySym_ be the grammar symbol |AsyncFunctionBody|.
               1. Let _fallbackProto_ be *"%AsyncFunction.prototype%"*.
             1. Else,
               1. Assert: _kind_ is ~asyncGenerator~.
-              1. Let _goal_ be the grammar symbol |AsyncGeneratorBody|.
-              1. Let _parameterGoal_ be the grammar symbol |FormalParameters[+Yield, +Await]|.
+              1. Let _exprSym_ be the grammar symbol |AsyncGeneratorExpression|.
+              1. Let _bodySym_ be the grammar symbol |AsyncGeneratorBody|.
               1. Let _fallbackProto_ be *"%AsyncGeneratorFunction.prototype%"*.
             1. Let _argCount_ be the number of elements in _args_.
             1. Let _P_ be the empty String.
@@ -24990,25 +24990,10 @@
             1. Let _prefix_ be the prefix associated with _kind_ in <emu-xref href="#table-dynamic-function-sourcetext-prefixes"></emu-xref>.
             1. Let _sourceString_ be the string-concatenation of _prefix_, *" anonymous("*, _P_, 0x000A (LINE FEED), *") {"*, _bodyString_, and *"}"*.
             1. Let _sourceText_ be ! StringToCodePoints(_sourceString_).
-            1. Perform the following substeps in an implementation-defined order, possibly interleaving parsing and error detection:
-              1. Let _parameters_ be ParseText(! StringToCodePoints(_P_), _parameterGoal_).
-              1. If _parameters_ is a List of errors, throw a *SyntaxError* exception.
-              1. Let _body_ be ParseText(! StringToCodePoints(_bodyString_), _goal_).
-              1. If _body_ is a List of errors, throw a *SyntaxError* exception.
-              1. Let _strict_ be FunctionBodyContainsUseStrict of _body_.
-              1. If _strict_ is *true*, apply the early error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> to _parameters_.
-              1. If _strict_ is *true* and IsSimpleParameterList of _parameters_ is *false*, throw a *SyntaxError* exception.
-              1. If any element of the BoundNames of _parameters_ also occurs in the LexicallyDeclaredNames of _body_, throw a *SyntaxError* exception.
-              1. If _body_ Contains |SuperCall| is *true*, throw a *SyntaxError* exception.
-              1. If _parameters_ Contains |SuperCall| is *true*, throw a *SyntaxError* exception.
-              1. If _body_ Contains |SuperProperty| is *true*, throw a *SyntaxError* exception.
-              1. If _parameters_ Contains |SuperProperty| is *true*, throw a *SyntaxError* exception.
-              1. If _kind_ is ~generator~ or ~asyncGenerator~, then
-                1. If _parameters_ Contains |YieldExpression| is *true*, throw a *SyntaxError* exception.
-              1. If _kind_ is ~async~ or ~asyncGenerator~, then
-                1. If _parameters_ Contains |AwaitExpression| is *true*, throw a *SyntaxError* exception.
-              1. If _strict_ is *true*, then
-                1. If BoundNames of _parameters_ contains any duplicate elements, throw a *SyntaxError* exception.
+            1. Let _expr_ be ParseText(_sourceText_, _exprSym_).
+            1. If _expr_ is a List of errors, throw a *SyntaxError* exception.
+            1. Let _parameters_ be the |FormalParameters| of _expr_.
+            1. Let _body_ be the child of _expr_ that is an instance of _bodySym_.
             1. Let _proto_ be ? GetPrototypeFromConstructor(_newTarget_, _fallbackProto_).
             1. Let _realmF_ be the current Realm Record.
             1. Let _scope_ be _realmF_.[[GlobalEnv]].


### PR DESCRIPTION
Formerly, CreateDynamicFunction would parse the text for the parameters and body *separately*, so we didn't have a complete function decl/expr, so the Early Error rules for the function decl/expr production didn't apply automatically, so we had to apply them "manually".

Instead, parse the text of a complete function expr (which text already exists in `_sourceText_`!), so that all the relevant Early Error rules apply automatically.

I left a Note for the benefit of anyone who wonders where all the error-checking went, but it might be deemed unnecessary. (No other call to ParseText is accompanied by such a Note.)

This change has a side-benefit in that it will allow a simplification of the definition of "function code" (and strict function code). Currently, it's complicated by this one case (set of cases) where the Parameters and Body (and BindingIdentifier) of a function are not simply the children of a Declaration or Expression. This change will eliminate such cases.