### PR TITLE
Editorial: Eliminate `CoveredFoo` SDOs

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -19920,8 +19920,7 @@
         1. If _name_ is not present, set _name_ to *""*.
         1. Let _scope_ be the LexicalEnvironment of the running execution context.
         1. Let _sourceText_ be the source text matched by |ArrowFunction|.
-        1. Let _parameters_ be CoveredFormalsList of |ArrowParameters|.
-        1. [id="step-arrowfunction-evaluation-functioncreate"] Let _closure_ be OrdinaryFunctionCreate(%Function.prototype%, _sourceText_, _parameters_, |ConciseBody|, ~lexical-this~, _scope_).
+        1. [id="step-arrowfunction-evaluation-functioncreate"] Let _closure_ be OrdinaryFunctionCreate(%Function.prototype%, _sourceText_, |ArrowParameters|, |ConciseBody|, ~lexical-this~, _scope_).
         1. Perform SetFunctionName(_closure_, _name_).
         1. Return _closure_.
       </emu-alg>

--- a/spec.html
+++ b/spec.html
@@ -15636,16 +15636,6 @@
           </li>
         </ul>
       </emu-clause>
-
-      <emu-clause id="sec-left-hand-side-expressions-static-semantics-coveredcallexpression" type="sdo" aoid="CoveredCallExpression">
-        <h1>Static Semantics: CoveredCallExpression</h1>
-        <emu-grammar>
-          CoverCallExpressionAndAsyncArrowHead : MemberExpression Arguments
-        </emu-grammar>
-        <emu-alg>
-          1. Return the |CallMemberExpression| that is covered by |CoverCallExpressionAndAsyncArrowHead|.
-        </emu-alg>
-      </emu-clause>
     </emu-clause>
 
     <emu-clause id="sec-property-accessors">
@@ -15776,7 +15766,7 @@
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>CallExpression : CoverCallExpressionAndAsyncArrowHead</emu-grammar>
         <emu-alg>
-          1. Let _expr_ be CoveredCallExpression of |CoverCallExpressionAndAsyncArrowHead|.
+          1. Let _expr_ be the |CallMemberExpression| that is covered by |CoverCallExpressionAndAsyncArrowHead|.
           1. Let _memberExpr_ be the |MemberExpression| of _expr_.
           1. Let _arguments_ be the |Arguments| of _expr_.
           1. Let _ref_ be the result of evaluating _memberExpr_.

--- a/spec.html
+++ b/spec.html
@@ -5846,7 +5846,7 @@
       </emu-alg>
       <emu-grammar>ArrowParameters : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
       <emu-alg>
-        1. Let _formals_ be CoveredFormalsList of |CoverParenthesizedExpressionAndArrowParameterList|.
+        1. Let _formals_ be the |ArrowFormalParameters| that is covered by |CoverParenthesizedExpressionAndArrowParameterList|.
         1. Return the BoundNames of _formals_.
       </emu-alg>
       <emu-grammar>GeneratorDeclaration : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
@@ -7707,7 +7707,7 @@
       </emu-alg>
       <emu-grammar>ArrowParameters : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
       <emu-alg>
-        1. Let _formals_ be CoveredFormalsList of |CoverParenthesizedExpressionAndArrowParameterList|.
+        1. Let _formals_ be the |ArrowFormalParameters| that is covered by |CoverParenthesizedExpressionAndArrowParameterList|.
         1. Return _formals_ Contains _symbol_.
       </emu-alg>
       <emu-grammar>
@@ -8071,7 +8071,7 @@
       </emu-alg>
       <emu-grammar>ArrowParameters : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
       <emu-alg>
-        1. Let _formals_ be CoveredFormalsList of |CoverParenthesizedExpressionAndArrowParameterList|.
+        1. Let _formals_ be the |ArrowFormalParameters| that is covered by |CoverParenthesizedExpressionAndArrowParameterList|.
         1. Return IteratorBindingInitialization of _formals_ with arguments _iteratorRecord_ and _environment_.
       </emu-alg>
       <emu-grammar>
@@ -19481,7 +19481,7 @@
       </emu-alg>
       <emu-grammar>ArrowParameters : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
       <emu-alg>
-        1. Let _formals_ be CoveredFormalsList of |CoverParenthesizedExpressionAndArrowParameterList|.
+        1. Let _formals_ be the |ArrowFormalParameters| that is covered by |CoverParenthesizedExpressionAndArrowParameterList|.
         1. Return ContainsExpression of _formals_.
       </emu-alg>
       <emu-grammar>
@@ -19537,7 +19537,7 @@
       </emu-alg>
       <emu-grammar>ArrowParameters : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
       <emu-alg>
-        1. Let _formals_ be CoveredFormalsList of |CoverParenthesizedExpressionAndArrowParameterList|.
+        1. Let _formals_ be the |ArrowFormalParameters| that is covered by |CoverParenthesizedExpressionAndArrowParameterList|.
         1. Return IsSimpleParameterList of _formals_.
       </emu-alg>
       <emu-grammar>
@@ -19614,7 +19614,7 @@
       </emu-alg>
       <emu-grammar>ArrowParameters : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
       <emu-alg>
-        1. Let _formals_ be CoveredFormalsList of |CoverParenthesizedExpressionAndArrowParameterList|.
+        1. Let _formals_ be the |ArrowFormalParameters| that is covered by |CoverParenthesizedExpressionAndArrowParameterList|.
         1. Return ExpectedArgumentCount of _formals_.
       </emu-alg>
       <emu-grammar>PropertySetParameterList : FormalParameter</emu-grammar>
@@ -19864,7 +19864,7 @@
           It is a Syntax Error if |CoverParenthesizedExpressionAndArrowParameterList| is not covering an |ArrowFormalParameters|.
         </li>
         <li>
-          All early error rules for |ArrowFormalParameters| and its derived productions also apply to CoveredFormalsList of |CoverParenthesizedExpressionAndArrowParameterList|.
+          All early error rules for |ArrowFormalParameters| and its derived productions also apply to the |ArrowFormalParameters| that is covered by |CoverParenthesizedExpressionAndArrowParameterList|.
         </li>
       </ul>
     </emu-clause>
@@ -19878,27 +19878,6 @@
       <emu-grammar>ConciseBody : `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Return FunctionBodyContainsUseStrict of |FunctionBody|.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-static-semantics-coveredformalslist" type="sdo" aoid="CoveredFormalsList">
-      <h1>Static Semantics: CoveredFormalsList</h1>
-      <emu-grammar>ArrowParameters : BindingIdentifier</emu-grammar>
-      <emu-alg>
-        1. Return this |ArrowParameters|.
-      </emu-alg>
-      <emu-grammar>
-        CoverParenthesizedExpressionAndArrowParameterList :
-          `(` Expression `)`
-          `(` Expression `,` `)`
-          `(` `)`
-          `(` `...` BindingIdentifier `)`
-          `(` `...` BindingPattern `)`
-          `(` Expression `,` `...` BindingIdentifier `)`
-          `(` Expression `,` `...` BindingPattern `)`
-      </emu-grammar>
-      <emu-alg>
-        1. Return the |ArrowFormalParameters| that is covered by |CoverParenthesizedExpressionAndArrowParameterList|.
       </emu-alg>
     </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -7345,7 +7345,7 @@
       <h1>Static Semantics: HasName</h1>
       <emu-grammar>PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
       <emu-alg>
-        1. Let _expr_ be CoveredParenthesizedExpression of |CoverParenthesizedExpressionAndArrowParameterList|.
+        1. Let _expr_ be the |ParenthesizedExpression| that is covered by |CoverParenthesizedExpressionAndArrowParameterList|.
         1. If IsFunctionDefinition of _expr_ is *false*, return *false*.
         1. Return HasName of _expr_.
       </emu-alg>
@@ -7398,7 +7398,7 @@
       <h1>Static Semantics: IsFunctionDefinition</h1>
       <emu-grammar>PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
       <emu-alg>
-        1. Let _expr_ be CoveredParenthesizedExpression of |CoverParenthesizedExpressionAndArrowParameterList|.
+        1. Let _expr_ be the |ParenthesizedExpression| that is covered by |CoverParenthesizedExpressionAndArrowParameterList|.
         1. Return IsFunctionDefinition of _expr_.
       </emu-alg>
       <emu-grammar>
@@ -7587,7 +7587,7 @@
       <p>With parameter _name_.</p>
       <emu-grammar>PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
       <emu-alg>
-        1. Let _expr_ be CoveredParenthesizedExpression of |CoverParenthesizedExpressionAndArrowParameterList|.
+        1. Let _expr_ be the |ParenthesizedExpression| that is covered by |CoverParenthesizedExpressionAndArrowParameterList|.
         1. Return the result of performing NamedEvaluation for _expr_ with argument _name_.
       </emu-alg>
       <emu-grammar>ParenthesizedExpression : `(` Expression `)`</emu-grammar>
@@ -8121,7 +8121,7 @@
           CoverParenthesizedExpressionAndArrowParameterList
       </emu-grammar>
       <emu-alg>
-        1. Let _expr_ be CoveredParenthesizedExpression of |CoverParenthesizedExpressionAndArrowParameterList|.
+        1. Let _expr_ be the |ParenthesizedExpression| that is covered by |CoverParenthesizedExpressionAndArrowParameterList|.
         1. Return AssignmentTargetType of _expr_.
       </emu-alg>
       <emu-grammar>
@@ -14798,18 +14798,6 @@
         `(` Expression[+In, ?Yield, ?Await] `)`
     </emu-grammar>
 
-    <emu-clause id="sec-primary-expression-semantics">
-      <h1>Semantics</h1>
-
-      <emu-clause id="sec-static-semantics-coveredparenthesizedexpression" type="sdo" aoid="CoveredParenthesizedExpression">
-        <h1>Static Semantics: CoveredParenthesizedExpression</h1>
-        <emu-grammar>CoverParenthesizedExpressionAndArrowParameterList : `(` Expression `)`</emu-grammar>
-        <emu-alg>
-          1. Return the |ParenthesizedExpression| that is covered by |CoverParenthesizedExpressionAndArrowParameterList|.
-        </emu-alg>
-      </emu-clause>
-    </emu-clause>
-
     <emu-clause id="sec-this-keyword">
       <h1>The `this` Keyword</h1>
 
@@ -15498,7 +15486,7 @@
             It is a Syntax Error if |CoverParenthesizedExpressionAndArrowParameterList| is not covering a |ParenthesizedExpression|.
           </li>
           <li>
-            All Early Error rules for |ParenthesizedExpression| and its derived productions also apply to CoveredParenthesizedExpression of |CoverParenthesizedExpressionAndArrowParameterList|.
+            All Early Error rules for |ParenthesizedExpression| and its derived productions also apply to the |ParenthesizedExpression| that is covered by |CoverParenthesizedExpressionAndArrowParameterList|.
           </li>
         </ul>
       </emu-clause>
@@ -15507,7 +15495,7 @@
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
         <emu-alg>
-          1. Let _expr_ be CoveredParenthesizedExpression of |CoverParenthesizedExpressionAndArrowParameterList|.
+          1. Let _expr_ be the |ParenthesizedExpression| that is covered by |CoverParenthesizedExpressionAndArrowParameterList|.
           1. Return the result of evaluating _expr_.
         </emu-alg>
         <emu-grammar>ParenthesizedExpression : `(` Expression `)`</emu-grammar>
@@ -21470,7 +21458,7 @@
         </emu-alg>
         <emu-grammar>PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
         <emu-alg>
-          1. Let _expr_ be CoveredParenthesizedExpression of |CoverParenthesizedExpressionAndArrowParameterList|.
+          1. Let _expr_ be the |ParenthesizedExpression| that is covered by |CoverParenthesizedExpressionAndArrowParameterList|.
           1. Return HasCallInTailPosition of _expr_ with argument _call_.
         </emu-alg>
         <emu-grammar>

--- a/spec.html
+++ b/spec.html
@@ -5889,7 +5889,7 @@
         CoverCallExpressionAndAsyncArrowHead : MemberExpression Arguments
       </emu-grammar>
       <emu-alg>
-        1. Let _head_ be CoveredAsyncArrowHead of |CoverCallExpressionAndAsyncArrowHead|.
+        1. Let _head_ be the |AsyncArrowHead| that is covered by |CoverCallExpressionAndAsyncArrowHead|.
         1. Return the BoundNames of _head_.
       </emu-alg>
       <emu-grammar>ImportDeclaration : `import` ImportClause FromClause `;`</emu-grammar>
@@ -7722,7 +7722,7 @@
       </emu-grammar>
       <emu-alg>
         1. If _symbol_ is not one of |NewTarget|, |SuperProperty|, |SuperCall|, `super`, or `this`, return *false*.
-        1. Let _head_ be CoveredAsyncArrowHead of |CoverCallExpressionAndAsyncArrowHead|.
+        1. Let _head_ be the |AsyncArrowHead| that is covered by |CoverCallExpressionAndAsyncArrowHead|.
         1. If _head_ Contains _symbol_ is *true*, return *true*.
         1. Return |AsyncConciseBody| Contains _symbol_.
       </emu-alg>
@@ -19550,7 +19550,7 @@
         CoverCallExpressionAndAsyncArrowHead : MemberExpression Arguments
       </emu-grammar>
       <emu-alg>
-        1. Let _head_ be CoveredAsyncArrowHead of |CoverCallExpressionAndAsyncArrowHead|.
+        1. Let _head_ be the |AsyncArrowHead| that is covered by |CoverCallExpressionAndAsyncArrowHead|.
         1. Return IsSimpleParameterList of _head_.
       </emu-alg>
     </emu-clause>
@@ -21034,18 +21034,8 @@
         <li>It is a Syntax Error if |CoverCallExpressionAndAsyncArrowHead| is not covering an |AsyncArrowHead|.</li>
         <li>It is a Syntax Error if any element of the BoundNames of |CoverCallExpressionAndAsyncArrowHead| also occurs in the LexicallyDeclaredNames of |AsyncConciseBody|.</li>
         <li>It is a Syntax Error if AsyncConciseBodyContainsUseStrict of |AsyncConciseBody| is *true* and IsSimpleParameterList of |CoverCallExpressionAndAsyncArrowHead| is *false*.</li>
-        <li>All Early Error rules for |AsyncArrowHead| and its derived productions apply to CoveredAsyncArrowHead of |CoverCallExpressionAndAsyncArrowHead|.</li>
+        <li>All Early Error rules for |AsyncArrowHead| and its derived productions apply to the |AsyncArrowHead| that is covered by |CoverCallExpressionAndAsyncArrowHead|.</li>
       </ul>
-    </emu-clause>
-
-    <emu-clause id="sec-async-arrow-function-definitions-static-semantics-CoveredAsyncArrowHead" type="sdo" aoid="CoveredAsyncArrowHead">
-      <h1>Static Semantics: CoveredAsyncArrowHead</h1>
-      <emu-grammar>
-        CoverCallExpressionAndAsyncArrowHead : MemberExpression Arguments
-      </emu-grammar>
-      <emu-alg>
-        1. Return the |AsyncArrowHead| that is covered by |CoverCallExpressionAndAsyncArrowHead|.
-      </emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-static-semantics-asyncconcisebodycontainsusestrict" oldids="sec-async-arrow-function-definitions-static-semantics-containsusestrict" type="sdo" aoid="AsyncConciseBodyContainsUseStrict">
@@ -21099,7 +21089,7 @@
         1. If _name_ is not present, set _name_ to *""*.
         1. Let _scope_ be the LexicalEnvironment of the running execution context.
         1. Let _sourceText_ be the source text matched by |AsyncArrowFunction|.
-        1. Let _head_ be CoveredAsyncArrowHead of |CoverCallExpressionAndAsyncArrowHead|.
+        1. Let _head_ be the |AsyncArrowHead| that is covered by |CoverCallExpressionAndAsyncArrowHead|.
         1. Let _parameters_ be the |ArrowFormalParameters| of _head_.
         1. Let _closure_ be ! OrdinaryFunctionCreate(%AsyncFunction.prototype%, _sourceText_, _parameters_, |AsyncConciseBody|, ~lexical-this~, _scope_).
         1. Perform SetFunctionName(_closure_, _name_).


### PR DESCRIPTION
When the first two of these were introduced (in ES6), they were useful because they encapsulated a sizeable amount of pseudocode. But after successive rewordings (in PRs #692, #971, #890), the underlying pseudocode is almost as brief as invoking the SDO. So I think their benefit (in terms of conciseness or encapsulation) is now outweighed by their cost (in terms of indirection); eliminating them will make it slightly easier to understand how the spec uses cover grammars.

(For comparison, note that we don't bother to define similar SDOs for:
`the |AssignmentPattern| that is covered by |LeftHandSideExpression|`
or
`the |AssignmentPattern| that is covered by |DestructuringAssignmentTarget|`
We just use those phrases directly in algorithms.)

This PR undefines the following ids, because there didn't seem to be a good place to make them oldids:
- sec-primary-expression-semantics
- sec-static-semantics-coveredparenthesizedexpression
- sec-left-hand-side-expressions-static-semantics-coveredcallexpression
- sec-async-arrow-function-definitions-static-semantics-CoveredAsyncArrowHead
- sec-static-semantics-coveredformalslist
