### PR TITLE
Editorial: Have RequireInternalSlot return the object

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -10608,6 +10608,7 @@
       <emu-alg>
         1. If Type(_O_) is not Object, throw a *TypeError* exception.
         1. If _O_ does not have an _internalSlot_ internal slot, throw a *TypeError* exception.
+        1. Return _O_.
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -30986,8 +30987,7 @@ THH:mm:ss.sss
         <p>Performs a regular expression match of _string_ against the regular expression and returns an Array object containing the results of the match, or *null* if _string_ did not match.</p>
         <p>The String ToString(_string_) is searched for an occurrence of the regular expression pattern as follows:</p>
         <emu-alg>
-          1. Let _R_ be the *this* value.
-          1. Perform ? RequireInternalSlot(_R_, [[RegExpMatcher]]).
+          1. Let _R_ be ? RequireInternalSlot(*this* value, [[RegExpMatcher]]).
           1. Let _S_ be ? ToString(_string_).
           1. Return ? RegExpBuiltinExec(_R_, _S_).
         </emu-alg>
@@ -33266,8 +33266,7 @@ THH:mm:ss.sss
         <h1>get %TypedArray%.prototype.buffer</h1>
         <p>%TypedArray%`.prototype.buffer` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
         <emu-alg>
-          1. Let _O_ be the *this* value.
-          1. Perform ? RequireInternalSlot(_O_, [[TypedArrayName]]).
+          1. Let _O_ be ? RequireInternalSlot(*this* value, [[TypedArrayName]]).
           1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
           1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
           1. Return _buffer_.
@@ -33278,8 +33277,7 @@ THH:mm:ss.sss
         <h1>get %TypedArray%.prototype.byteLength</h1>
         <p>%TypedArray%`.prototype.byteLength` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
         <emu-alg>
-          1. Let _O_ be the *this* value.
-          1. Perform ? RequireInternalSlot(_O_, [[TypedArrayName]]).
+          1. Let _O_ be ? RequireInternalSlot(*this* value, [[TypedArrayName]]).
           1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
           1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
           1. If IsDetachedBuffer(_buffer_) is *true*, return *+0*<sub>𝔽</sub>.
@@ -33292,8 +33290,7 @@ THH:mm:ss.sss
         <h1>get %TypedArray%.prototype.byteOffset</h1>
         <p>%TypedArray%`.prototype.byteOffset` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
         <emu-alg>
-          1. Let _O_ be the *this* value.
-          1. Perform ? RequireInternalSlot(_O_, [[TypedArrayName]]).
+          1. Let _O_ be ? RequireInternalSlot(*this* value, [[TypedArrayName]]).
           1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
           1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
           1. If IsDetachedBuffer(_buffer_) is *true*, return *+0*<sub>𝔽</sub>.
@@ -33625,8 +33622,7 @@ THH:mm:ss.sss
         <h1>get %TypedArray%.prototype.length</h1>
         <p>%TypedArray%`.prototype.length` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
         <emu-alg>
-          1. Let _O_ be the *this* value.
-          1. Perform ? RequireInternalSlot(_O_, [[TypedArrayName]]).
+          1. Let _O_ be ? RequireInternalSlot(*this* value, [[TypedArrayName]]).
           1. Assert: _O_ has [[ViewedArrayBuffer]] and [[ArrayLength]] internal slots.
           1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
           1. If IsDetachedBuffer(_buffer_) is *true*, return *+0*<sub>𝔽</sub>.
@@ -33744,8 +33740,7 @@ THH:mm:ss.sss
         <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
         <p>Sets multiple values in this _TypedArray_, reading the values from _source_. The optional _offset_ value indicates the first element index in this _TypedArray_ where values are written. If omitted, it is assumed to be 0.</p>
         <emu-alg>
-          1. Let _target_ be the *this* value.
-          1. Perform ? RequireInternalSlot(_target_, [[TypedArrayName]]).
+          1. Let _target_ be ? RequireInternalSlot(*this* value, [[TypedArrayName]]).
           1. Assert: _target_ has a [[ViewedArrayBuffer]] internal slot.
           1. Let _targetOffset_ be ? ToIntegerOrInfinity(_offset_).
           1. If _targetOffset_ &lt; 0, throw a *RangeError* exception.
@@ -33946,8 +33941,7 @@ THH:mm:ss.sss
         <h1>%TypedArray%.prototype.subarray ( _begin_, _end_ )</h1>
         <p>Returns a new _TypedArray_ object whose element type is the same as this _TypedArray_ and whose ArrayBuffer is the same as the ArrayBuffer of this _TypedArray_, referencing the elements at _begin_, inclusive, up to _end_, exclusive. If either _begin_ or _end_ is negative, it refers to an index from the end of the array, as opposed to from the beginning.</p>
         <emu-alg>
-          1. Let _O_ be the *this* value.
-          1. Perform ? RequireInternalSlot(_O_, [[TypedArrayName]]).
+          1. Let _O_ be ? RequireInternalSlot(*this* value, [[TypedArrayName]]).
           1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
           1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
           1. Let _srcLength_ be _O_.[[ArrayLength]].
@@ -34401,8 +34395,7 @@ THH:mm:ss.sss
         <h1>Map.prototype.clear ( )</h1>
         <p>The following steps are taken:</p>
         <emu-alg>
-          1. Let _M_ be the *this* value.
-          1. Perform ? RequireInternalSlot(_M_, [[MapData]]).
+          1. Let _M_ be ? RequireInternalSlot(*this* value, [[MapData]]).
           1. Let _entries_ be the List that is _M_.[[MapData]].
           1. For each Record { [[Key]], [[Value]] } _p_ of _entries_, do
             1. Set _p_.[[Key]] to ~empty~.
@@ -34423,8 +34416,7 @@ THH:mm:ss.sss
         <h1>Map.prototype.delete ( _key_ )</h1>
         <p>The following steps are taken:</p>
         <emu-alg>
-          1. Let _M_ be the *this* value.
-          1. Perform ? RequireInternalSlot(_M_, [[MapData]]).
+          1. Let _M_ be ? RequireInternalSlot(*this* value, [[MapData]]).
           1. Let _entries_ be the List that is _M_.[[MapData]].
           1. For each Record { [[Key]], [[Value]] } _p_ of _entries_, do
             1. If _p_.[[Key]] is not ~empty~ and SameValueZero(_p_.[[Key]], _key_) is *true*, then
@@ -34451,8 +34443,7 @@ THH:mm:ss.sss
         <h1>Map.prototype.forEach ( _callbackfn_ [ , _thisArg_ ] )</h1>
         <p>When the `forEach` method is called with one or two arguments, the following steps are taken:</p>
         <emu-alg>
-          1. Let _M_ be the *this* value.
-          1. Perform ? RequireInternalSlot(_M_, [[MapData]]).
+          1. Let _M_ be ? RequireInternalSlot(*this* value, [[MapData]]).
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
           1. Let _entries_ be the List that is _M_.[[MapData]].
           1. For each Record { [[Key]], [[Value]] } _e_ of _entries_, do
@@ -34472,8 +34463,7 @@ THH:mm:ss.sss
         <h1>Map.prototype.get ( _key_ )</h1>
         <p>The following steps are taken:</p>
         <emu-alg>
-          1. Let _M_ be the *this* value.
-          1. Perform ? RequireInternalSlot(_M_, [[MapData]]).
+          1. Let _M_ be ? RequireInternalSlot(*this* value, [[MapData]]).
           1. Let _entries_ be the List that is _M_.[[MapData]].
           1. For each Record { [[Key]], [[Value]] } _p_ of _entries_, do
             1. If _p_.[[Key]] is not ~empty~ and SameValueZero(_p_.[[Key]], _key_) is *true*, return _p_.[[Value]].
@@ -34485,8 +34475,7 @@ THH:mm:ss.sss
         <h1>Map.prototype.has ( _key_ )</h1>
         <p>The following steps are taken:</p>
         <emu-alg>
-          1. Let _M_ be the *this* value.
-          1. Perform ? RequireInternalSlot(_M_, [[MapData]]).
+          1. Let _M_ be ? RequireInternalSlot(*this* value, [[MapData]]).
           1. Let _entries_ be the List that is _M_.[[MapData]].
           1. For each Record { [[Key]], [[Value]] } _p_ of _entries_, do
             1. If _p_.[[Key]] is not ~empty~ and SameValueZero(_p_.[[Key]], _key_) is *true*, return *true*.
@@ -34507,8 +34496,7 @@ THH:mm:ss.sss
         <h1>Map.prototype.set ( _key_, _value_ )</h1>
         <p>The following steps are taken:</p>
         <emu-alg>
-          1. Let _M_ be the *this* value.
-          1. Perform ? RequireInternalSlot(_M_, [[MapData]]).
+          1. Let _M_ be ? RequireInternalSlot(*this* value, [[MapData]]).
           1. Let _entries_ be the List that is _M_.[[MapData]].
           1. For each Record { [[Key]], [[Value]] } _p_ of _entries_, do
             1. If _p_.[[Key]] is not ~empty~ and SameValueZero(_p_.[[Key]], _key_) is *true*, then
@@ -34525,8 +34513,7 @@ THH:mm:ss.sss
         <h1>get Map.prototype.size</h1>
         <p>`Map.prototype.size` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
         <emu-alg>
-          1. Let _M_ be the *this* value.
-          1. Perform ? RequireInternalSlot(_M_, [[MapData]]).
+          1. Let _M_ be ? RequireInternalSlot(*this* value, [[MapData]]).
           1. Let _entries_ be the List that is _M_.[[MapData]].
           1. Let _count_ be 0.
           1. For each Record { [[Key]], [[Value]] } _p_ of _entries_, do
@@ -34696,8 +34683,7 @@ THH:mm:ss.sss
         <h1>Set.prototype.add ( _value_ )</h1>
         <p>The following steps are taken:</p>
         <emu-alg>
-          1. Let _S_ be the *this* value.
-          1. Perform ? RequireInternalSlot(_S_, [[SetData]]).
+          1. Let _S_ be ? RequireInternalSlot(*this* value, [[SetData]]).
           1. Let _entries_ be the List that is _S_.[[SetData]].
           1. For each element _e_ of _entries_, do
             1. If _e_ is not ~empty~ and SameValueZero(_e_, _value_) is *true*, then
@@ -34712,8 +34698,7 @@ THH:mm:ss.sss
         <h1>Set.prototype.clear ( )</h1>
         <p>The following steps are taken:</p>
         <emu-alg>
-          1. Let _S_ be the *this* value.
-          1. Perform ? RequireInternalSlot(_S_, [[SetData]]).
+          1. Let _S_ be ? RequireInternalSlot(*this* value, [[SetData]]).
           1. Let _entries_ be the List that is _S_.[[SetData]].
           1. For each element _e_ of _entries_, do
             1. Replace the element of _entries_ whose value is _e_ with an element whose value is ~empty~.
@@ -34733,8 +34718,7 @@ THH:mm:ss.sss
         <h1>Set.prototype.delete ( _value_ )</h1>
         <p>The following steps are taken:</p>
         <emu-alg>
-          1. Let _S_ be the *this* value.
-          1. Perform ? RequireInternalSlot(_S_, [[SetData]]).
+          1. Let _S_ be ? RequireInternalSlot(*this* value, [[SetData]]).
           1. Let _entries_ be the List that is _S_.[[SetData]].
           1. For each element _e_ of _entries_, do
             1. If _e_ is not ~empty~ and SameValueZero(_e_, _value_) is *true*, then
@@ -34763,8 +34747,7 @@ THH:mm:ss.sss
         <h1>Set.prototype.forEach ( _callbackfn_ [ , _thisArg_ ] )</h1>
         <p>When the `forEach` method is called with one or two arguments, the following steps are taken:</p>
         <emu-alg>
-          1. Let _S_ be the *this* value.
-          1. Perform ? RequireInternalSlot(_S_, [[SetData]]).
+          1. Let _S_ be ? RequireInternalSlot(*this* value, [[SetData]]).
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
           1. Let _entries_ be the List that is _S_.[[SetData]].
           1. For each element _e_ of _entries_, do
@@ -34786,8 +34769,7 @@ THH:mm:ss.sss
         <h1>Set.prototype.has ( _value_ )</h1>
         <p>The following steps are taken:</p>
         <emu-alg>
-          1. Let _S_ be the *this* value.
-          1. Perform ? RequireInternalSlot(_S_, [[SetData]]).
+          1. Let _S_ be ? RequireInternalSlot(*this* value, [[SetData]]).
           1. Let _entries_ be the List that is _S_.[[SetData]].
           1. For each element _e_ of _entries_, do
             1. If _e_ is not ~empty~ and SameValueZero(_e_, _value_) is *true*, return *true*.
@@ -34807,8 +34789,7 @@ THH:mm:ss.sss
         <h1>get Set.prototype.size</h1>
         <p>`Set.prototype.size` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
         <emu-alg>
-          1. Let _S_ be the *this* value.
-          1. Perform ? RequireInternalSlot(_S_, [[SetData]]).
+          1. Let _S_ be ? RequireInternalSlot(*this* value, [[SetData]]).
           1. Let _entries_ be the List that is _S_.[[SetData]].
           1. Let _count_ be 0.
           1. For each element _e_ of _entries_, do
@@ -34972,8 +34953,7 @@ THH:mm:ss.sss
         <h1>WeakMap.prototype.delete ( _key_ )</h1>
         <p>The following steps are taken:</p>
         <emu-alg>
-          1. Let _M_ be the *this* value.
-          1. Perform ? RequireInternalSlot(_M_, [[WeakMapData]]).
+          1. Let _M_ be ? RequireInternalSlot(*this* value, [[WeakMapData]]).
           1. Let _entries_ be the List that is _M_.[[WeakMapData]].
           1. If Type(_key_) is not Object, return *false*.
           1. For each Record { [[Key]], [[Value]] } _p_ of _entries_, do
@@ -34992,8 +34972,7 @@ THH:mm:ss.sss
         <h1>WeakMap.prototype.get ( _key_ )</h1>
         <p>The following steps are taken:</p>
         <emu-alg>
-          1. Let _M_ be the *this* value.
-          1. Perform ? RequireInternalSlot(_M_, [[WeakMapData]]).
+          1. Let _M_ be ? RequireInternalSlot(*this* value, [[WeakMapData]]).
           1. Let _entries_ be the List that is _M_.[[WeakMapData]].
           1. If Type(_key_) is not Object, return *undefined*.
           1. For each Record { [[Key]], [[Value]] } _p_ of _entries_, do
@@ -35006,8 +34985,7 @@ THH:mm:ss.sss
         <h1>WeakMap.prototype.has ( _key_ )</h1>
         <p>The following steps are taken:</p>
         <emu-alg>
-          1. Let _M_ be the *this* value.
-          1. Perform ? RequireInternalSlot(_M_, [[WeakMapData]]).
+          1. Let _M_ be ? RequireInternalSlot(*this* value, [[WeakMapData]]).
           1. Let _entries_ be the List that is _M_.[[WeakMapData]].
           1. If Type(_key_) is not Object, return *false*.
           1. For each Record { [[Key]], [[Value]] } _p_ of _entries_, do
@@ -35020,8 +34998,7 @@ THH:mm:ss.sss
         <h1>WeakMap.prototype.set ( _key_, _value_ )</h1>
         <p>The following steps are taken:</p>
         <emu-alg>
-          1. Let _M_ be the *this* value.
-          1. Perform ? RequireInternalSlot(_M_, [[WeakMapData]]).
+          1. Let _M_ be ? RequireInternalSlot(*this* value, [[WeakMapData]]).
           1. Let _entries_ be the List that is _M_.[[WeakMapData]].
           1. If Type(_key_) is not Object, throw a *TypeError* exception.
           1. For each Record { [[Key]], [[Value]] } _p_ of _entries_, do
@@ -35117,8 +35094,7 @@ THH:mm:ss.sss
         <h1>WeakSet.prototype.add ( _value_ )</h1>
         <p>The following steps are taken:</p>
         <emu-alg>
-          1. Let _S_ be the *this* value.
-          1. Perform ? RequireInternalSlot(_S_, [[WeakSetData]]).
+          1. Let _S_ be ? RequireInternalSlot(*this* value, [[WeakSetData]]).
           1. If Type(_value_) is not Object, throw a *TypeError* exception.
           1. Let _entries_ be the List that is _S_.[[WeakSetData]].
           1. For each element _e_ of _entries_, do
@@ -35138,8 +35114,7 @@ THH:mm:ss.sss
         <h1>WeakSet.prototype.delete ( _value_ )</h1>
         <p>The following steps are taken:</p>
         <emu-alg>
-          1. Let _S_ be the *this* value.
-          1. Perform ? RequireInternalSlot(_S_, [[WeakSetData]]).
+          1. Let _S_ be ? RequireInternalSlot(*this* value, [[WeakSetData]]).
           1. If Type(_value_) is not Object, return *false*.
           1. Let _entries_ be the List that is _S_.[[WeakSetData]].
           1. For each element _e_ of _entries_, do
@@ -35157,8 +35132,7 @@ THH:mm:ss.sss
         <h1>WeakSet.prototype.has ( _value_ )</h1>
         <p>The following steps are taken:</p>
         <emu-alg>
-          1. Let _S_ be the *this* value.
-          1. Perform ? RequireInternalSlot(_S_, [[WeakSetData]]).
+          1. Let _S_ be ? RequireInternalSlot(*this* value, [[WeakSetData]]).
           1. Let _entries_ be the List that is _S_.[[WeakSetData]].
           1. If Type(_value_) is not Object, return *false*.
           1. For each element _e_ of _entries_, do
@@ -35487,8 +35461,7 @@ THH:mm:ss.sss
         <h1>get ArrayBuffer.prototype.byteLength</h1>
         <p>`ArrayBuffer.prototype.byteLength` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
         <emu-alg>
-          1. Let _O_ be the *this* value.
-          1. Perform ? RequireInternalSlot(_O_, [[ArrayBufferData]]).
+          1. Let _O_ be ? RequireInternalSlot(*this* value, [[ArrayBufferData]]).
           1. If IsSharedArrayBuffer(_O_) is *true*, throw a *TypeError* exception.
           1. If IsDetachedBuffer(_O_) is *true*, return *+0*<sub>𝔽</sub>.
           1. Let _length_ be _O_.[[ArrayBufferByteLength]].
@@ -35505,8 +35478,7 @@ THH:mm:ss.sss
         <h1>ArrayBuffer.prototype.slice ( _start_, _end_ )</h1>
         <p>The following steps are taken:</p>
         <emu-alg>
-          1. Let _O_ be the *this* value.
-          1. Perform ? RequireInternalSlot(_O_, [[ArrayBufferData]]).
+          1. Let _O_ be ? RequireInternalSlot(*this* value, [[ArrayBufferData]]).
           1. If IsSharedArrayBuffer(_O_) is *true*, throw a *TypeError* exception.
           1. If IsDetachedBuffer(_O_) is *true*, throw a *TypeError* exception.
           1. Let _len_ be _O_.[[ArrayBufferByteLength]].
@@ -35648,8 +35620,7 @@ THH:mm:ss.sss
         <h1>get SharedArrayBuffer.prototype.byteLength</h1>
         <p>`SharedArrayBuffer.prototype.byteLength` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
         <emu-alg>
-          1. Let _O_ be the *this* value.
-          1. Perform ? RequireInternalSlot(_O_, [[ArrayBufferData]]).
+          1. Let _O_ be ? RequireInternalSlot(*this* value, [[ArrayBufferData]]).
           1. If IsSharedArrayBuffer(_O_) is *false*, throw a *TypeError* exception.
           1. Let _length_ be _O_.[[ArrayBufferByteLength]].
           1. Return 𝔽(_length_).
@@ -35665,8 +35636,7 @@ THH:mm:ss.sss
         <h1>SharedArrayBuffer.prototype.slice ( _start_, _end_ )</h1>
         <p>The following steps are taken:</p>
         <emu-alg>
-          1. Let _O_ be the *this* value.
-          1. Perform ? RequireInternalSlot(_O_, [[ArrayBufferData]]).
+          1. Let _O_ be ? RequireInternalSlot(*this* value, [[ArrayBufferData]]).
           1. If IsSharedArrayBuffer(_O_) is *false*, throw a *TypeError* exception.
           1. Let _len_ be _O_.[[ArrayBufferByteLength]].
           1. Let _relativeStart_ be ? ToIntegerOrInfinity(_start_).
@@ -35820,8 +35790,7 @@ THH:mm:ss.sss
         <h1>get DataView.prototype.buffer</h1>
         <p>`DataView.prototype.buffer` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
         <emu-alg>
-          1. Let _O_ be the *this* value.
-          1. Perform ? RequireInternalSlot(_O_, [[DataView]]).
+          1. Let _O_ be ? RequireInternalSlot(*this* value, [[DataView]]).
           1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
           1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
           1. Return _buffer_.
@@ -35832,8 +35801,7 @@ THH:mm:ss.sss
         <h1>get DataView.prototype.byteLength</h1>
         <p>`DataView.prototype.byteLength` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
         <emu-alg>
-          1. Let _O_ be the *this* value.
-          1. Perform ? RequireInternalSlot(_O_, [[DataView]]).
+          1. Let _O_ be ? RequireInternalSlot(*this* value, [[DataView]]).
           1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
           1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
           1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
@@ -35846,8 +35814,7 @@ THH:mm:ss.sss
         <h1>get DataView.prototype.byteOffset</h1>
         <p>`DataView.prototype.byteOffset` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
         <emu-alg>
-          1. Let _O_ be the *this* value.
-          1. Perform ? RequireInternalSlot(_O_, [[DataView]]).
+          1. Let _O_ be ? RequireInternalSlot(*this* value, [[DataView]]).
           1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
           1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
           1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
@@ -37009,8 +36976,7 @@ THH:mm:ss.sss
         <h1>WeakRef.prototype.deref ( )</h1>
         <p>The following steps are taken:</p>
         <emu-alg>
-          1. Let _weakRef_ be the *this* value.
-          1. Perform ? RequireInternalSlot(_weakRef_, [[WeakRefTarget]]).
+          1. Let _weakRef_ be ? RequireInternalSlot(*this* value, [[WeakRefTarget]]).
           1. Return ! WeakRefDeref(_weakRef_).
         </emu-alg>
 
@@ -37142,8 +37108,7 @@ THH:mm:ss.sss
         <h1>FinalizationRegistry.prototype.register ( _target_, _heldValue_ [ , _unregisterToken_ ] )</h1>
         <p>The following steps are taken:</p>
         <emu-alg>
-          1. Let _finalizationRegistry_ be the *this* value.
-          1. Perform ? RequireInternalSlot(_finalizationRegistry_, [[Cells]]).
+          1. Let _finalizationRegistry_ be ? RequireInternalSlot(*this* value, [[Cells]]).
           1. If Type(_target_) is not Object, throw a *TypeError* exception.
           1. If SameValue(_target_, _heldValue_) is *true*, throw a *TypeError* exception.
           1. If Type(_unregisterToken_) is not Object, then
@@ -37163,8 +37128,7 @@ THH:mm:ss.sss
         <h1>FinalizationRegistry.prototype.unregister ( _unregisterToken_ )</h1>
         <p>The following steps are taken:</p>
         <emu-alg>
-          1. Let _finalizationRegistry_ be the *this* value.
-          1. Perform ? RequireInternalSlot(_finalizationRegistry_, [[Cells]]).
+          1. Let _finalizationRegistry_ be ? RequireInternalSlot(*this* value, [[Cells]]).
           1. If Type(_unregisterToken_) is not Object, throw a *TypeError* exception.
           1. Let _removed_ be *false*.
           1. For each Record { [[WeakRefTarget]], [[HeldValue]], [[UnregisterToken]] } _cell_ of _finalizationRegistry_.[[Cells]], do
@@ -41782,8 +41746,7 @@ THH:mm:ss.sss
         <h1>RegExp.prototype.compile ( _pattern_, _flags_ )</h1>
         <p>When the `compile` method is called with arguments _pattern_ and _flags_, the following steps are taken:</p>
         <emu-alg>
-          1. Let _O_ be the *this* value.
-          1. Perform ? RequireInternalSlot(_O_, [[RegExpMatcher]]).
+          1. Let _O_ be ? RequireInternalSlot(*this* value, [[RegExpMatcher]]).
           1. If Type(_pattern_) is Object and _pattern_ has a [[RegExpMatcher]] internal slot, then
             1. If _flags_ is not *undefined*, throw a *TypeError* exception.
             1. Let _P_ be _pattern_.[[OriginalSource]].


### PR DESCRIPTION
Most invocations of RequireInternalSlot take the form:
```
    1. Let _O_ be the *this* value.
    2. Perform ? RequireInternalSlot(_O_, [[Foo]]).
```

If we modify RequireInternalSlot to return the object (when successful), we can reduce this idiom to:
```
    1. Let _O_ be ? RequireInternalSlot(*this* value, [[Foo]]).
```

I think this is slightly better, because it tells you in a single line that there are requirements on the *this* value.