### PR TITLE
Editorial: Fix early error rules of 'IfStatement'

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -18048,11 +18048,16 @@
 
     <emu-clause id="sec-if-statement-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
-      <emu-grammar>
-        IfStatement :
-          `if` `(` Expression `)` Statement `else` Statement
-          `if` `(` Expression `)` Statement
-      </emu-grammar>
+      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
+      <ul>
+        <li>
+          It is a Syntax Error if IsLabelledFunction(the first |Statement|) is *true*.
+        </li>
+        <li>
+          It is a Syntax Error if IsLabelledFunction(the second |Statement|) is *true*.
+        </li>
+      </ul>
+      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if IsLabelledFunction(|Statement|) is *true*.


### PR DESCRIPTION
In [14.6.1 Static Semantics: Early Errors](https://tc39.es/ecma262/#sec-if-statement-static-semantics-early-errors), first production of `IfStatement` contains two `Statement`. However, early error rule of `IfStatement` only mentions about single `Statement`, which seems to be fixed by this PR.