### PR TITLE
Editorial: Remove 'designed to be subclassable'

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -27944,7 +27944,7 @@
         <li>is the initial value of the *"Object"* property of the global object.</li>
         <li>creates a new ordinary object when called as a constructor.</li>
         <li>performs a type conversion when called as a function rather than as a constructor.</li>
-        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition.</li>
+        <li>may be used as the value of an `extends` clause of a class definition.</li>
       </ul>
 
       <emu-clause id="sec-object-value">
@@ -28388,7 +28388,7 @@
         <li>is <dfn>%Function%</dfn>.</li>
         <li>is the initial value of the *"Function"* property of the global object.</li>
         <li>creates and initializes a new function object when called as a function rather than as a constructor. Thus the function call `Function(&hellip;)` is equivalent to the object creation expression `new Function(&hellip;)` with the same arguments.</li>
-        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified Function behaviour must include a `super` call to the Function constructor to create and initialize a subclass instance with the internal slots necessary for built-in function behaviour. All ECMAScript syntactic forms for defining function objects create instances of Function. There is no syntactic means to create instances of Function subclasses except for the built-in GeneratorFunction, AsyncFunction, and AsyncGeneratorFunction subclasses.</li>
+        <li>may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified Function behaviour must include a `super` call to the Function constructor to create and initialize a subclass instance with the internal slots necessary for built-in function behaviour. All ECMAScript syntactic forms for defining function objects create instances of Function. There is no syntactic means to create instances of Function subclasses except for the built-in GeneratorFunction, AsyncFunction, and AsyncGeneratorFunction subclasses.</li>
       </ul>
 
       <emu-clause id="sec-function-p1-p2-pn-body">
@@ -28723,7 +28723,7 @@
         <li>is the initial value of the *"Boolean"* property of the global object.</li>
         <li>creates and initializes a new Boolean object when called as a constructor.</li>
         <li>performs a type conversion when called as a function rather than as a constructor.</li>
-        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified Boolean behaviour must include a `super` call to the Boolean constructor to create and initialize the subclass instance with a [[BooleanData]] internal slot.</li>
+        <li>may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified Boolean behaviour must include a `super` call to the Boolean constructor to create and initialize the subclass instance with a [[BooleanData]] internal slot.</li>
       </ul>
 
       <emu-clause id="sec-boolean-constructor-boolean-value">
@@ -29095,7 +29095,7 @@
         <li>is <dfn>%Error%</dfn>.</li>
         <li>is the initial value of the *"Error"* property of the global object.</li>
         <li>creates and initializes a new Error object when called as a function rather than as a constructor. Thus the function call `Error(&hellip;)` is equivalent to the object creation expression `new Error(&hellip;)` with the same arguments.</li>
-        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified Error behaviour must include a `super` call to the Error constructor to create and initialize subclass instances with an [[ErrorData]] internal slot.</li>
+        <li>may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified Error behaviour must include a `super` call to the Error constructor to create and initialize subclass instances with an [[ErrorData]] internal slot.</li>
       </ul>
 
       <emu-clause id="sec-error-message">
@@ -29226,7 +29226,7 @@
         <p>Each _NativeError_ constructor:</p>
         <ul>
           <li>creates and initializes a new _NativeError_ object when called as a function rather than as a constructor. A call of the object as a function is equivalent to calling it as a constructor with the same arguments. Thus the function call <code><var>NativeError</var>(&hellip;)</code> is equivalent to the object creation expression <code>new <var>NativeError</var>(&hellip;)</code> with the same arguments.</li>
-          <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified _NativeError_ behaviour must include a `super` call to the _NativeError_ constructor to create and initialize subclass instances with an [[ErrorData]] internal slot.</li>
+          <li>may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified _NativeError_ behaviour must include a `super` call to the _NativeError_ constructor to create and initialize subclass instances with an [[ErrorData]] internal slot.</li>
         </ul>
 
         <emu-clause id="sec-nativeerror">
@@ -29302,7 +29302,7 @@
           <li>is <dfn>%AggregateError%</dfn>.</li>
           <li>is the initial value of the *"AggregateError"* property of the global object.</li>
           <li>creates and initializes a new AggregateError object when called as a function rather than as a constructor. Thus the function call `AggregateError(&hellip;)` is equivalent to the object creation expression `new AggregateError(&hellip;)` with the same arguments.</li>
-          <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified AggregateError behaviour must include a `super` call to the AggregateError constructor to create and initialize subclass instances with an [[ErrorData]] internal slot.</li>
+          <li>may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified AggregateError behaviour must include a `super` call to the AggregateError constructor to create and initialize subclass instances with an [[ErrorData]] internal slot.</li>
         </ul>
 
         <emu-clause id="sec-aggregate-error">
@@ -29385,7 +29385,7 @@
         <li>is the initial value of the *"Number"* property of the global object.</li>
         <li>creates and initializes a new Number object when called as a constructor.</li>
         <li>performs a type conversion when called as a function rather than as a constructor.</li>
-        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified Number behaviour must include a `super` call to the Number constructor to create and initialize the subclass instance with a [[NumberData]] internal slot.</li>
+        <li>may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified Number behaviour must include a `super` call to the Number constructor to create and initialize the subclass instance with a [[NumberData]] internal slot.</li>
       </ul>
 
       <emu-clause id="sec-number-constructor-number-value">
@@ -30897,7 +30897,7 @@ THH:mm:ss.sss
         <li>creates and initializes a new Date object when called as a constructor.</li>
         <li>returns a String representing the current time (UTC) when called as a function rather than as a constructor.</li>
         <li>is a function whose behaviour differs based upon the number and types of its arguments.</li>
-        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified Date behaviour must include a `super` call to the Date constructor to create and initialize the subclass instance with a [[DateValue]] internal slot.</li>
+        <li>may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified Date behaviour must include a `super` call to the Date constructor to create and initialize the subclass instance with a [[DateValue]] internal slot.</li>
         <li>has a *"length"* property whose value is *7*<sub>𝔽</sub>.</li>
       </ul>
 
@@ -31879,7 +31879,7 @@ THH:mm:ss.sss
         <li>is the initial value of the *"String"* property of the global object.</li>
         <li>creates and initializes a new String object when called as a constructor.</li>
         <li>performs a type conversion when called as a function rather than as a constructor.</li>
-        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified String behaviour must include a `super` call to the String constructor to create and initialize the subclass instance with a [[StringData]] internal slot.</li>
+        <li>may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified String behaviour must include a `super` call to the String constructor to create and initialize the subclass instance with a [[StringData]] internal slot.</li>
       </ul>
 
       <emu-clause id="sec-string-constructor-string-value">
@@ -34405,7 +34405,7 @@ THH:mm:ss.sss
         <li>is <dfn>%RegExp%</dfn>.</li>
         <li>is the initial value of the *"RegExp"* property of the global object.</li>
         <li>creates and initializes a new RegExp object when called as a function rather than as a constructor. Thus the function call `RegExp(&hellip;)` is equivalent to the object creation expression `new RegExp(&hellip;)` with the same arguments.</li>
-        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified RegExp behaviour must include a `super` call to the RegExp constructor to create and initialize subclass instances with the necessary internal slots.</li>
+        <li>may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified RegExp behaviour must include a `super` call to the RegExp constructor to create and initialize subclass instances with the necessary internal slots.</li>
       </ul>
 
       <emu-clause id="sec-regexp-pattern-flags">
@@ -35177,7 +35177,7 @@ THH:mm:ss.sss
         <li>creates and initializes a new Array exotic object when called as a constructor.</li>
         <li>also creates and initializes a new Array object when called as a function rather than as a constructor. Thus the function call `Array(&hellip;)` is equivalent to the object creation expression `new Array(&hellip;)` with the same arguments.</li>
         <li>is a function whose behaviour differs based upon the number and types of its arguments.</li>
-        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the exotic Array behaviour must include a `super` call to the Array constructor to initialize subclass instances that are Array exotic objects. However, most of the `Array.prototype` methods are generic methods that are not dependent upon their *this* value being an Array exotic object.</li>
+        <li>may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the exotic Array behaviour must include a `super` call to the Array constructor to initialize subclass instances that are Array exotic objects. However, most of the `Array.prototype` methods are generic methods that are not dependent upon their *this* value being an Array exotic object.</li>
         <li>has a *"length"* property whose value is *1*<sub>𝔽</sub>.</li>
       </ul>
 
@@ -37755,7 +37755,7 @@ THH:mm:ss.sss
         <li>is an intrinsic object that has the structure described below, differing only in the name used as the constructor name instead of _TypedArray_, in <emu-xref href="#table-the-typedarray-constructors"></emu-xref>.</li>
         <li>is a function whose behaviour differs based upon the number and types of its arguments. The actual behaviour of a call of _TypedArray_ depends upon the number and kind of arguments that are passed to it.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
-        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified _TypedArray_ behaviour must include a `super` call to the _TypedArray_ constructor to create and initialize the subclass instance with the internal state necessary to support the %TypedArray%`.prototype` built-in methods.</li>
+        <li>may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified _TypedArray_ behaviour must include a `super` call to the _TypedArray_ constructor to create and initialize the subclass instance with the internal state necessary to support the %TypedArray%`.prototype` built-in methods.</li>
         <li>has a *"length"* property whose value is *3*<sub>𝔽</sub>.</li>
       </ul>
 
@@ -38049,7 +38049,7 @@ THH:mm:ss.sss
         <li>is the initial value of the *"Map"* property of the global object.</li>
         <li>creates and initializes a new Map object when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
-        <li>is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified Map behaviour must include a `super` call to the Map constructor to create and initialize the subclass instance with the internal state necessary to support the `Map.prototype` built-in methods.</li>
+        <li>may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified Map behaviour must include a `super` call to the Map constructor to create and initialize the subclass instance with the internal state necessary to support the `Map.prototype` built-in methods.</li>
       </ul>
 
       <emu-clause id="sec-map-iterable">
@@ -38383,7 +38383,7 @@ THH:mm:ss.sss
         <li>is the initial value of the *"Set"* property of the global object.</li>
         <li>creates and initializes a new Set object when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
-        <li>is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified Set behaviour must include a `super` call to the Set constructor to create and initialize the subclass instance with the internal state necessary to support the `Set.prototype` built-in methods.</li>
+        <li>may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified Set behaviour must include a `super` call to the Set constructor to create and initialize the subclass instance with the internal state necessary to support the `Set.prototype` built-in methods.</li>
       </ul>
 
       <emu-clause id="sec-set-iterable">
@@ -38678,7 +38678,7 @@ THH:mm:ss.sss
         <li>is the initial value of the *"WeakMap"* property of the global object.</li>
         <li>creates and initializes a new WeakMap object when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
-        <li>is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified WeakMap behaviour must include a `super` call to the WeakMap constructor to create and initialize the subclass instance with the internal state necessary to support the `WeakMap.prototype` built-in methods.</li>
+        <li>may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified WeakMap behaviour must include a `super` call to the WeakMap constructor to create and initialize the subclass instance with the internal state necessary to support the `WeakMap.prototype` built-in methods.</li>
       </ul>
 
       <emu-clause id="sec-weakmap-iterable">
@@ -38824,7 +38824,7 @@ THH:mm:ss.sss
         <li>is the initial value of the *"WeakSet"* property of the global object.</li>
         <li>creates and initializes a new WeakSet object when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
-        <li>is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified WeakSet behaviour must include a `super` call to the WeakSet constructor to create and initialize the subclass instance with the internal state necessary to support the `WeakSet.prototype` built-in methods.</li>
+        <li>may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified WeakSet behaviour must include a `super` call to the WeakSet constructor to create and initialize the subclass instance with the internal state necessary to support the `WeakSet.prototype` built-in methods.</li>
       </ul>
 
       <emu-clause id="sec-weakset-iterable">
@@ -39283,7 +39283,7 @@ THH:mm:ss.sss
         <li>is the initial value of the *"ArrayBuffer"* property of the global object.</li>
         <li>creates and initializes a new ArrayBuffer object when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
-        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified ArrayBuffer behaviour must include a `super` call to the ArrayBuffer constructor to create and initialize subclass instances with the internal state necessary to support the `ArrayBuffer.prototype` built-in methods.</li>
+        <li>may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified ArrayBuffer behaviour must include a `super` call to the ArrayBuffer constructor to create and initialize subclass instances with the internal state necessary to support the `ArrayBuffer.prototype` built-in methods.</li>
       </ul>
 
       <emu-clause id="sec-arraybuffer-length">
@@ -39466,7 +39466,7 @@ THH:mm:ss.sss
         <li>is the initial value of the *"SharedArrayBuffer"* property of the global object, if that property is present (see below).</li>
         <li>creates and initializes a new SharedArrayBuffer object when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
-        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified SharedArrayBuffer behaviour must include a `super` call to the SharedArrayBuffer constructor to create and initialize subclass instances with the internal state necessary to support the `SharedArrayBuffer.prototype` built-in methods.</li>
+        <li>may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified SharedArrayBuffer behaviour must include a `super` call to the SharedArrayBuffer constructor to create and initialize subclass instances with the internal state necessary to support the `SharedArrayBuffer.prototype` built-in methods.</li>
       </ul>
 
       <p>Whenever a host does not provide concurrent access to SharedArrayBuffer objects it may omit the *"SharedArrayBuffer"* property of the global object.</p>
@@ -39660,7 +39660,7 @@ THH:mm:ss.sss
         <li>is the initial value of the *"DataView"* property of the global object.</li>
         <li>creates and initializes a new DataView object when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
-        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified DataView behaviour must include a `super` call to the DataView constructor to create and initialize subclass instances with the internal state necessary to support the `DataView.prototype` built-in methods.</li>
+        <li>may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified DataView behaviour must include a `super` call to the DataView constructor to create and initialize subclass instances with the internal state necessary to support the `DataView.prototype` built-in methods.</li>
       </ul>
 
       <emu-clause id="sec-dataview-buffer-byteoffset-bytelength">
@@ -40981,7 +40981,7 @@ THH:mm:ss.sss
           is not intended to be called as a function and will throw an exception when called in that manner.
         </li>
         <li>
-          is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `WeakRef` behaviour must include a `super` call to the `WeakRef` constructor to create and initialize the subclass instance with the internal state necessary to support the `WeakRef.prototype` built-in methods.
+          may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `WeakRef` behaviour must include a `super` call to the `WeakRef` constructor to create and initialize the subclass instance with the internal state necessary to support the `WeakRef.prototype` built-in methods.
         </li>
       </ul>
 
@@ -41118,7 +41118,7 @@ THH:mm:ss.sss
           is not intended to be called as a function and will throw an exception when called in that manner.
         </li>
         <li>
-          is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `FinalizationRegistry` behaviour must include a `super` call to the `FinalizationRegistry` constructor to create and initialize the subclass instance with the internal state necessary to support the `FinalizationRegistry.prototype` built-in methods.
+          may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `FinalizationRegistry` behaviour must include a `super` call to the `FinalizationRegistry` constructor to create and initialize the subclass instance with the internal state necessary to support the `FinalizationRegistry.prototype` built-in methods.
         </li>
       </ul>
 
@@ -42115,7 +42115,7 @@ THH:mm:ss.sss
         <li>is the initial value of the *"Promise"* property of the global object.</li>
         <li>creates and initializes a new Promise object when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
-        <li>is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified Promise behaviour must include a `super` call to the Promise constructor to create and initialize the subclass instance with the internal state necessary to support the `Promise` and `Promise.prototype` built-in methods.</li>
+        <li>may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified Promise behaviour must include a `super` call to the Promise constructor to create and initialize the subclass instance with the internal state necessary to support the `Promise` and `Promise.prototype` built-in methods.</li>
       </ul>
 
       <emu-clause id="sec-promise-executor">
@@ -42797,7 +42797,7 @@ THH:mm:ss.sss
         <li>is <dfn>%GeneratorFunction%</dfn>.</li>
         <li>is a subclass of `Function`.</li>
         <li>creates and initializes a new GeneratorFunction object when called as a function rather than as a constructor. Thus the function call `GeneratorFunction (&hellip;)` is equivalent to the object creation expression `new GeneratorFunction (&hellip;)` with the same arguments.</li>
-        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified GeneratorFunction behaviour must include a `super` call to the GeneratorFunction constructor to create and initialize subclass instances with the internal slots necessary for built-in GeneratorFunction behaviour. All ECMAScript syntactic forms for defining generator function objects create direct instances of GeneratorFunction. There is no syntactic means to create instances of GeneratorFunction subclasses.</li>
+        <li>may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified GeneratorFunction behaviour must include a `super` call to the GeneratorFunction constructor to create and initialize subclass instances with the internal slots necessary for built-in GeneratorFunction behaviour. All ECMAScript syntactic forms for defining generator function objects create direct instances of GeneratorFunction. There is no syntactic means to create instances of GeneratorFunction subclasses.</li>
       </ul>
 
       <emu-clause id="sec-generatorfunction">
@@ -42903,7 +42903,7 @@ THH:mm:ss.sss
         <li>is <dfn>%AsyncGeneratorFunction%</dfn>.</li>
         <li>is a subclass of `Function`.</li>
         <li>creates and initializes a new AsyncGeneratorFunction object when called as a function rather than as a constructor. Thus the function call `AsyncGeneratorFunction (...)` is equivalent to the object creation expression `new AsyncGeneratorFunction (...)` with the same arguments.</li>
-        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified AsyncGeneratorFunction behaviour must include a `super` call to the AsyncGeneratorFunction constructor to create and initialize subclass instances with the internal slots necessary for built-in AsyncGeneratorFunction behaviour. All ECMAScript syntactic forms for defining async generator function objects create direct instances of AsyncGeneratorFunction. There is no syntactic means to create instances of AsyncGeneratorFunction subclasses.</li>
+        <li>may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified AsyncGeneratorFunction behaviour must include a `super` call to the AsyncGeneratorFunction constructor to create and initialize subclass instances with the internal slots necessary for built-in AsyncGeneratorFunction behaviour. All ECMAScript syntactic forms for defining async generator function objects create direct instances of AsyncGeneratorFunction. There is no syntactic means to create instances of AsyncGeneratorFunction subclasses.</li>
       </ul>
 
       <emu-clause id="sec-asyncgeneratorfunction">
@@ -43737,7 +43737,7 @@ THH:mm:ss.sss
         <li>is <dfn>%AsyncFunction%</dfn>.</li>
         <li>is a subclass of `Function`.</li>
         <li>creates and initializes a new AsyncFunction object when called as a function rather than as a constructor. Thus the function call `AsyncFunction(&hellip;)` is equivalent to the object creation expression `new AsyncFunction(&hellip;)` with the same arguments.</li>
-        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified AsyncFunction behaviour must include a `super` call to the AsyncFunction constructor to create and initialize a subclass instance with the internal slots necessary for built-in async function behaviour. All ECMAScript syntactic forms for defining async function objects create direct instances of AsyncFunction. There is no syntactic means to create instances of AsyncFunction subclasses.</li>
+        <li>may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified AsyncFunction behaviour must include a `super` call to the AsyncFunction constructor to create and initialize a subclass instance with the internal slots necessary for built-in async function behaviour. All ECMAScript syntactic forms for defining async function objects create direct instances of AsyncFunction. There is no syntactic means to create instances of AsyncFunction subclasses.</li>
       </ul>
 
       <emu-clause id="sec-async-function-constructor-arguments">


### PR DESCRIPTION
As discussed during the March 2021 plenary, this note on "is designed to
be subclassable" can be read as an encouragement or value judgement on
whether it is desirable to subclass built-in classes like Boolean. We
don't want to actively encourage this.

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
