### PR TITLE
Editorial: Fix Contains algorithm of ClassTail

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -7680,8 +7680,8 @@
         1. If _symbol_ is |ClassBody|, return *true*.
         1. If _symbol_ is |ClassHeritage|, then
           1. If |ClassHeritage| is present, return *true*; otherwise return *false*.
-        1. Let _inHeritage_ be |ClassHeritage| Contains _symbol_.
-        1. If _inHeritage_ is *true*, return *true*.
+        1. If |ClassHeritage| is present, then
+          1. If |ClassHeritage| Contains _symbol_ is *true*, return *true*.
         1. Return the result of ComputedPropertyContains for |ClassBody| with argument _symbol_.
       </emu-alg>
       <emu-note>


### PR DESCRIPTION
There seems to exist bug in step 3 of `ClassTail : ClassHeritage_opt { ClassBody }` case of [8.4.1 Static Semantics: Contains](https://tc39.es/ecma262/#sec-static-semantics-contains). Since `ClassHeritage` may not be defined, I think checking whether `ClassHeritage` is present is needed before invoking `Contains` of `ClassHeritage`.