### PR TITLE
Editorial: Consistent notation of newly created error object

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -38252,7 +38252,7 @@ THH:mm:ss.sss
                 1. Set _iteratorRecord_.[[Done]] to *true*.
                 1. Set _remainingElementsCount_.[[Value]] to _remainingElementsCount_.[[Value]] - 1.
                 1. If _remainingElementsCount_.[[Value]] is 0, then
-                  1. Let _error_ be a newly created `AggregateError` object.
+                  1. Let _error_ be a newly created *AggregateError* object.
                   1. Perform ! DefinePropertyOrThrow(_error_, *"errors"*, PropertyDescriptor { [[Configurable]]: *true*, [[Enumerable]]: *false*, [[Writable]]: *true*, [[Value]]: ! CreateArrayFromList(_errors_) }).
                   1. Return ThrowCompletion(_error_).
                 1. Return _resultCapability_.[[Promise]].
@@ -38290,7 +38290,7 @@ THH:mm:ss.sss
             1. Set _errors_[_index_] to _x_.
             1. Set _remainingElementsCount_.[[Value]] to _remainingElementsCount_.[[Value]] - 1.
             1. If _remainingElementsCount_.[[Value]] is 0, then
-              1. Let _error_ be a newly created `AggregateError` object.
+              1. Let _error_ be a newly created *AggregateError* object.
               1. Perform ! DefinePropertyOrThrow(_error_, *"errors"*, PropertyDescriptor { [[Configurable]]: *true*, [[Enumerable]]: *false*, [[Writable]]: *true*, [[Value]]: ! CreateArrayFromList(_errors_) }).
               1. Return ? Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _error_ &raquo;).
             1. Return *undefined*.


### PR DESCRIPTION
In algorithm steps, it seems to be common to use value notation when creating TypeError object(e.g. [5.2.3.2 Throw an Exception](https://tc39.es/ecma262/#sec-throw-an-exception), ...). Therefore, it'd be better to use same notation for AggregateError object.