### PR TITLE
Editorial: Correct usage of 'Let'/'Set' in various algorithms

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -6911,10 +6911,8 @@
       <emu-grammar>CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
       <emu-alg>
         1. If the first |CaseClauses| is present, then
-          1. Let _hasDuplicates_ be ContainsDuplicateLabels of the first |CaseClauses| with argument _labelSet_.
-          1. If _hasDuplicates_ is *true*, return *true*.
-        1. Let _hasDuplicates_ be ContainsDuplicateLabels of |DefaultClause| with argument _labelSet_.
-        1. If _hasDuplicates_ is *true*, return *true*.
+          1. If ContainsDuplicateLabels of the first |CaseClauses| with argument _labelSet_ is *true*, return *true*.
+        1. If ContainsDuplicateLabels of |DefaultClause| with argument _labelSet_ is *true*, return *true*.
         1. If the second |CaseClauses| is not present, return *false*.
         1. Return ContainsDuplicateLabels of the second |CaseClauses| with argument _labelSet_.
       </emu-alg>
@@ -6959,10 +6957,8 @@
       </emu-alg>
       <emu-grammar>TryStatement : `try` Block Catch Finally</emu-grammar>
       <emu-alg>
-        1. Let _hasDuplicates_ be ContainsDuplicateLabels of |Block| with argument _labelSet_.
-        1. If _hasDuplicates_ is *true*, return *true*.
-        1. Let _hasDuplicates_ be ContainsDuplicateLabels of |Catch| with argument _labelSet_.
-        1. If _hasDuplicates_ is *true*, return *true*.
+        1. If ContainsDuplicateLabels of |Block| with argument _labelSet_ is *true*, return *true*.
+        1. If ContainsDuplicateLabels of |Catch| with argument _labelSet_ is *true*, return *true*.
         1. Return ContainsDuplicateLabels of |Finally| with argument _labelSet_.
       </emu-alg>
       <emu-grammar>Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
@@ -7084,10 +7080,8 @@
       <emu-grammar>CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
       <emu-alg>
         1. If the first |CaseClauses| is present, then
-          1. Let _hasUndefinedLabels_ be ContainsUndefinedBreakTarget of the first |CaseClauses| with argument _labelSet_.
-          1. If _hasUndefinedLabels_ is *true*, return *true*.
-        1. Let _hasUndefinedLabels_ be ContainsUndefinedBreakTarget of |DefaultClause| with argument _labelSet_.
-        1. If _hasUndefinedLabels_ is *true*, return *true*.
+          1. If ContainsUndefinedBreakTarget of the first |CaseClauses| with argument _labelSet_ is *true*, return *true*.
+        1. If ContainsUndefinedBreakTarget of |DefaultClause| with argument _labelSet_ is *true*, return *true*.
         1. If the second |CaseClauses| is not present, return *false*.
         1. Return ContainsUndefinedBreakTarget of the second |CaseClauses| with argument _labelSet_.
       </emu-alg>
@@ -7131,10 +7125,8 @@
       </emu-alg>
       <emu-grammar>TryStatement : `try` Block Catch Finally</emu-grammar>
       <emu-alg>
-        1. Let _hasUndefinedLabels_ be ContainsUndefinedBreakTarget of |Block| with argument _labelSet_.
-        1. If _hasUndefinedLabels_ is *true*, return *true*.
-        1. Let _hasUndefinedLabels_ be ContainsUndefinedBreakTarget of |Catch| with argument _labelSet_.
-        1. If _hasUndefinedLabels_ is *true*, return *true*.
+        1. If ContainsUndefinedBreakTarget of |Block| with argument _labelSet_ is *true*, return *true*.
+        1. If ContainsUndefinedBreakTarget of |Catch| with argument _labelSet_ is *true*, return *true*.
         1. Return ContainsUndefinedBreakTarget of |Finally| with argument _labelSet_.
       </emu-alg>
       <emu-grammar>Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
@@ -7261,10 +7253,8 @@
       <emu-grammar>CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
       <emu-alg>
         1. If the first |CaseClauses| is present, then
-          1. Let _hasUndefinedLabels_ be ContainsUndefinedContinueTarget of the first |CaseClauses| with arguments _iterationSet_ and &laquo; &raquo;.
-          1. If _hasUndefinedLabels_ is *true*, return *true*.
-        1. Let _hasUndefinedLabels_ be ContainsUndefinedContinueTarget of |DefaultClause| with arguments _iterationSet_ and &laquo; &raquo;.
-        1. If _hasUndefinedLabels_ is *true*, return *true*.
+          1. If ContainsUndefinedContinueTarget of the first |CaseClauses| with arguments _iterationSet_ and &laquo; &raquo; is *true*, return *true*.
+        1. If ContainsUndefinedContinueTarget of |DefaultClause| with arguments _iterationSet_ and &laquo; &raquo; is *true*, return *true*.
         1. If the second |CaseClauses| is not present, return *false*.
         1. Return ContainsUndefinedContinueTarget of the second |CaseClauses| with arguments _iterationSet_ and &laquo; &raquo;.
       </emu-alg>
@@ -7308,10 +7298,8 @@
       </emu-alg>
       <emu-grammar>TryStatement : `try` Block Catch Finally</emu-grammar>
       <emu-alg>
-        1. Let _hasUndefinedLabels_ be ContainsUndefinedContinueTarget of |Block| with arguments _iterationSet_ and &laquo; &raquo;.
-        1. If _hasUndefinedLabels_ is *true*, return *true*.
-        1. Let _hasUndefinedLabels_ be ContainsUndefinedContinueTarget of |Catch| with arguments _iterationSet_ and &laquo; &raquo;.
-        1. If _hasUndefinedLabels_ is *true*, return *true*.
+        1. If ContainsUndefinedContinueTarget of |Block| with arguments _iterationSet_ and &laquo; &raquo; is *true*, return *true*.
+        1. If ContainsUndefinedContinueTarget of |Catch| with arguments _iterationSet_ and &laquo; &raquo; is *true*, return *true*.
         1. Return ContainsUndefinedContinueTarget of |Finally| with arguments _iterationSet_ and &laquo; &raquo;.
       </emu-alg>
       <emu-grammar>Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
@@ -11342,7 +11330,7 @@
             1. If _succeeded_ is *false*, return *false*.
             1. If _index_ &ge; _oldLen_, then
               1. Set _oldLenDesc_.[[Value]] to _index_ + *1*<sub>𝔽</sub>.
-              1. Let _succeeded_ be OrdinaryDefineOwnProperty(_A_, *"length"*, _oldLenDesc_).
+              1. Set _succeeded_ to OrdinaryDefineOwnProperty(_A_, *"length"*, _oldLenDesc_).
               1. Assert: _succeeded_ is *true*.
             1. Return *true*.
           1. Return OrdinaryDefineOwnProperty(_A_, _P_, _Desc_).
@@ -11420,7 +11408,7 @@
               1. Perform ! OrdinaryDefineOwnProperty(_A_, *"length"*, _newLenDesc_).
               1. Return *false*.
           1. If _newWritable_ is *false*, then
-            1. Let _succeeded_ be ! OrdinaryDefineOwnProperty(_A_, *"length"*, PropertyDescriptor { [[Writable]]: *false* }).
+            1. Set _succeeded_ to ! OrdinaryDefineOwnProperty(_A_, *"length"*, PropertyDescriptor { [[Writable]]: *false* }).
             1. Assert: _succeeded_ is *true*.
           1. Return *true*.
         </emu-alg>
@@ -11671,7 +11659,7 @@
             1. Set _index_ to _index_ + 1.
           1. Perform ! DefinePropertyOrThrow(_obj_, *"length"*, PropertyDescriptor { [[Value]]: 𝔽(_len_), [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
           1. Let _mappedNames_ be a new empty List.
-          1. Let _index_ be _numberOfParameters_ - 1.
+          1. Set _index_ to _numberOfParameters_ - 1.
           1. Repeat, while _index_ &ge; 0,
             1. Let _name_ be _parameterNames_[_index_].
             1. If _name_ is not an element of _mappedNames_, then


### PR DESCRIPTION
There are some algorithms where same variable is defined twice :
- [8.2.1 Static Semantics: ContainsDuplicateLabels](https://tc39.es/ecma262/#sec-static-semantics-containsduplicatelabels)
- [8.2.2 Static Semantics: ContainsUndefinedBreakTarget](https://tc39.es/ecma262/#sec-static-semantics-containsundefinedbreaktarget)
- [8.2.3 Static Semantics: ContainsUndefinedContinueTarget](https://tc39.es/ecma262/#sec-static-semantics-containsundefinedcontinuetarget)
- [10.4.2.1 \[\[DefineOwnProperty\]\]](https://tc39.es/ecma262/#sec-array-exotic-objects-defineownproperty-p-desc)
- [10.4.2.4 ArraySetLength](https://tc39.es/ecma262/#sec-arraysetlength)
- [10.4.4.7 CreateMappedArgumentsObject](https://tc39.es/ecma262/#sec-createmappedargumentsobject)

Plus, for notation consistency, it might be better to remove variables named `hasXX` in 8.2.