### PR TITLE
Editorial: add usage note

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -40814,6 +40814,17 @@ THH:mm:ss.sss
 
 <emu-annex id="sec-additional-ecmascript-features-for-web-browsers" namespace="annexB" normative>
   <h1>Additional ECMAScript Features for Web Browsers</h1>
+  <div style=" padding-left: 1.3em; border-left: 1em solid; border-image: repeating-linear-gradient(45deg,#f8f552,#f8f552 0.5em,#000 0.5em,#000 1em) 22; font-size: 1.3em;">
+    <p>This place is a message... and part of a system of messages... pay attention to it!</p>
+    <p>Sending this message was important to us. We considered ourselves to be a powerful culture.</p>
+    <p>This place is not a place of honor... no highly esteemed deed is commemorated here... nothing valued is here.</p>
+    <p>What is here was dangerous and repulsive to us. This message is a warning about danger.</p>
+    <p>The danger is in a particular location... it increases towards a center... the center of danger is here... of a particular size and shape, and below us.</p>
+    <p>The danger is still present, in your time, as it was in ours.</p>
+    <p>The danger is to the body, and it can kill.</p>
+    <p>The form of the danger is an emanation of energy.</p>
+    <p>The danger is unleashed only if you substantially disturb this place physically. This place is best shunned and left uninhabited.</p>
+  </div>
   <p>The ECMAScript language syntax and semantics defined in this annex are required when the ECMAScript host is a web browser. The content of this annex is normative but optional if the ECMAScript host is not a web browser.</p>
   <emu-note>
     <p>This annex describes various legacy features and other characteristics of web browser ECMAScript hosts. All of the language features and behaviours specified in this annex have one or more undesirable characteristics and in the absence of legacy usage would be removed from this specification. However, the usage of these features by large numbers of existing web pages means that web browsers must continue to support them. The specifications in this annex define the requirements for interoperable implementations of these legacy features.</p>


### PR DESCRIPTION
I felt that Annex B was not sufficiently clear about its contents, so I've added a [note](https://en.wikipedia.org/wiki/Long-time_nuclear_waste_warning_messages#Message) about the intent of that section.

We can discuss in plenary the possibility of having this to apply to the whole spec. I'm sure everyone will think it's a good idea; I'll add a five-minute agenda item.

<details>
<summary>rendered</summary>
<img width="935" alt="Screen Shot 2021-04-01 at 8 40 13 AM" src="https://user-images.githubusercontent.com/1653598/113319067-ee59b080-92c5-11eb-8f35-a771b54bcb7d.png">
</details>