### PR TITLE
Editorial: Minor fix in evaluation of 'YieldExpression' and Arguments Exotic Object

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -11542,7 +11542,7 @@
           1. Let _map_ be _args_.[[ParameterMap]].
           1. Let _isMapped_ be ! HasOwnProperty(_map_, _P_).
           1. If _isMapped_ is *true*, then
-            1. Set _desc_.[[Value]] to Get(_map_, _P_).
+            1. Set _desc_.[[Value]] to ! Get(_map_, _P_).
           1. Return _desc_.
         </emu-alg>
       </emu-clause>
@@ -11557,7 +11557,7 @@
           1. If _isMapped_ is *true* and IsDataDescriptor(_Desc_) is *true*, then
             1. If _Desc_.[[Value]] is not present and _Desc_.[[Writable]] is present and its value is *false*, then
               1. Set _newArgDesc_ to a copy of _Desc_.
-              1. Set _newArgDesc_.[[Value]] to Get(_map_, _P_).
+              1. Set _newArgDesc_.[[Value]] to ! Get(_map_, _P_).
           1. Let _allowed_ be ? OrdinaryDefineOwnProperty(_args_, _P_, _newArgDesc_).
           1. If _allowed_ is *false*, return *false*.
           1. If _isMapped_ is *true*, then

--- a/spec.html
+++ b/spec.html
@@ -20335,7 +20335,7 @@
             1. If Type(_innerReturnResult_) is not Object, throw a *TypeError* exception.
             1. Let _done_ be ? IteratorComplete(_innerReturnResult_).
             1. If _done_ is *true*, then
-              1. Let _value_ be ? IteratorValue(_innerReturnResult_).
+              1. Set _value_ to ? IteratorValue(_innerReturnResult_).
               1. Return Completion { [[Type]]: ~return~, [[Value]]: _value_, [[Target]]: ~empty~ }.
             1. If _generatorKind_ is ~async~, set _received_ to AsyncGeneratorYield(? IteratorValue(_innerReturnResult_)).
             1. Else, set _received_ to GeneratorYield(_innerReturnResult_).


### PR DESCRIPTION
- In [15.5.5 Evaluation](https://tc39.es/ecma262/#sec-generator-function-definitions-runtime-semantics-evaluation), `value` is  defined twice in step 3 and step 7.c.viii.1. I think using `Set ~ to ~` notation is more proper in step 7.c.viii.1.
- In [[DefineOwnProperty]] and [[GetOwnProperty]] of  [10.4.4 Arguments Exotic Object](https://tc39.es/ecma262/#sec-arguments-exotic-objects), abstract operation `Get` should not return abrupt completion since existence of property `P` in `map` is checked by `HasOwnProperty`.