### PR TITLE
Editorial: Split the "TV and TRV" clause into 2 clauses

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -16976,21 +16976,21 @@
         <p>|TemplateSubstitutionTail| is used by the |InputElementTemplateTail| alternative lexical goal.</p>
       </emu-note>
 
-      <emu-clause id="sec-static-semantics-tv-and-trv">
-        <h1>Static Semantics: TV and TRV</h1>
-        <p>A template literal component is interpreted by TV and TRV as a value of the String type. TV is used to construct the indexed components of a template object (colloquially, the template values), and TRV is used to construct their raw counterparts (colloquially, the template raw values). In TV, escape sequences are replaced by the UTF-16 code unit(s) of the Unicode code point represented by the escape sequence. TRV is similar to TV with the difference being that in TRV, escape sequences are interpreted as they appear in the literal.</p>
+      <emu-clause id="sec-static-semantics-tv" type="sdo" aoid="TV" oldids="sec-static-semantics-tv-and-trv">
+        <h1>Static Semantics: TV</h1>
+        <p>A template literal component is interpreted by TV as a value of the String type. TV is used to construct the indexed components of a template object (colloquially, the template values). In TV, escape sequences are replaced by the UTF-16 code unit(s) of the Unicode code point represented by the escape sequence.</p>
         <ul>
           <li>
-            The TV and TRV of <emu-grammar>NoSubstitutionTemplate :: ``` ```</emu-grammar> is the empty String.
+            The TV of <emu-grammar>NoSubstitutionTemplate :: ``` ```</emu-grammar> is the empty String.
           </li>
           <li>
-            The TV and TRV of <emu-grammar>TemplateHead :: ``` `${`</emu-grammar> is the empty String.
+            The TV of <emu-grammar>TemplateHead :: ``` `${`</emu-grammar> is the empty String.
           </li>
           <li>
-            The TV and TRV of <emu-grammar>TemplateMiddle :: `}` `${`</emu-grammar> is the empty String.
+            The TV of <emu-grammar>TemplateMiddle :: `}` `${`</emu-grammar> is the empty String.
           </li>
           <li>
-            The TV and TRV of <emu-grammar>TemplateTail :: `}` ```</emu-grammar> is the empty String.
+            The TV of <emu-grammar>TemplateTail :: `}` ```</emu-grammar> is the empty String.
           </li>
           <li>
             The TV of <emu-grammar>TemplateCharacters :: TemplateCharacter TemplateCharacters</emu-grammar> is *undefined* if either the TV of |TemplateCharacter| is *undefined* or the TV of |TemplateCharacters| is *undefined*. Otherwise, it is the string-concatenation of the TV of |TemplateCharacter| and the TV of |TemplateCharacters|.
@@ -17012,6 +17012,25 @@
           </li>
           <li>
             The TV of <emu-grammar>LineContinuation :: `\` LineTerminatorSequence</emu-grammar> is the empty String.
+          </li>
+        </ul>
+      </emu-clause>
+
+      <emu-clause id="sec-static-semantics-trv" type="sdo" aoid="TRV">
+        <h1>Static Semantics: TRV</h1>
+        <p>A template literal component is interpreted by TRV as a value of the String type. TRV is used to construct the raw components of a template object (colloquially, the template raw values). TRV is similar to TV with the difference being that in TRV, escape sequences are interpreted as they appear in the literal.</p>
+        <ul>
+          <li>
+            The TRV of <emu-grammar>NoSubstitutionTemplate :: ``` ```</emu-grammar> is the empty String.
+          </li>
+          <li>
+            The TRV of <emu-grammar>TemplateHead :: ``` `${`</emu-grammar> is the empty String.
+          </li>
+          <li>
+            The TRV of <emu-grammar>TemplateMiddle :: `}` `${`</emu-grammar> is the empty String.
+          </li>
+          <li>
+            The TRV of <emu-grammar>TemplateTail :: `}` ```</emu-grammar> is the empty String.
           </li>
           <li>
             The TRV of <emu-grammar>TemplateCharacters :: TemplateCharacter TemplateCharacters</emu-grammar> is the string-concatenation of the TRV of |TemplateCharacter| and the TRV of |TemplateCharacters|.


### PR DESCRIPTION
... one for TV and one for TRV.

(This duplicates 4 cases, but they're very simple.)

In the status quo rendering, uses of TV and TRV aren't autolinked. With this change, they are.

Alternatively, @bakkot suggested having the two new clauses nested within the current clause 12.8.6.1, with the prose (and the final NOTE?) remaining in 12.8.6.1. I can do it that way if the editors prefer. 