### PR TITLE
Editorial: Change ValidateTypedArray to not return the buffer

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -34727,7 +34727,8 @@ THH:mm:ss.sss
         <emu-alg>
           1. If _comparefn_ is not *undefined* and IsCallable(_comparefn_) is *false*, throw a *TypeError* exception.
           1. Let _obj_ be the *this* value.
-          1. Let _buffer_ be ? ValidateTypedArray(_obj_).
+          1. Perform ? ValidateTypedArray(_obj_).
+          1. Let _buffer_ be _obj_.[[ViewedArrayBuffer]].
           1. Let _len_ be _obj_.[[ArrayLength]].
         </emu-alg>
         <p>The following version of SortCompare is used by %TypedArray%`.prototype.sort`. It performs a numeric comparison rather than the string comparison used in <emu-xref href="#sec-array.prototype.sort"></emu-xref>.</p>
@@ -34864,7 +34865,6 @@ THH:mm:ss.sss
           1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
           1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
           1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
-          1. Return _buffer_.
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -36905,7 +36905,8 @@ THH:mm:ss.sss
         <p>The abstract operation ValidateIntegerTypedArray takes argument _typedArray_ and optional argument _waitable_ (a Boolean). It performs the following steps when called:</p>
         <emu-alg>
           1. If _waitable_ is not present, set _waitable_ to *false*.
-          1. Let _buffer_ be ? ValidateTypedArray(_typedArray_).
+          1. Perform ? ValidateTypedArray(_typedArray_).
+          1. Let _buffer_ be _typedArray_.[[ViewedArrayBuffer]].
           1. Let _typeName_ be _typedArray_.[[TypedArrayName]].
           1. Let _type_ be the Element Type value in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _typeName_.
           1. If _waitable_ is *true*, then


### PR DESCRIPTION
See https://github.com/tc39/ecma262/pull/2355#issuecomment-815296498

Downstream: No uses of ValidateTypedArray in WebIDL, HTML, Intl.

Note that ValidateIntegerTypedArray also returns the buffer, so you might want that handled similarly.

Also, ValidateAtomicAccess returns a value, but changing it to not return that value would be more disruptive. Perhaps it should change its name to something that emphasizes the value it computes, rather than any validation it does.