### PR TITLE
Editorial: Simplify getting the Element Type/Size for a TypedArray

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -14741,10 +14741,9 @@
         <emu-alg>
           1. If IsValidIntegerIndex(_O_, _index_) is *false*, return *undefined*.
           1. Let _offset_ be _O_.[[ByteOffset]].
-          1. Let _arrayTypeName_ be the String value of _O_.[[TypedArrayName]].
-          1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _arrayTypeName_.
+          1. Let _elementSize_ be TypedArrayElementSize(_O_).
           1. Let _indexedPosition_ be (ℝ(_index_) &times; _elementSize_) + _offset_.
-          1. Let _elementType_ be the Element Type value in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _arrayTypeName_.
+          1. Let _elementType_ be TypedArrayElementType(_O_).
           1. Return GetValueFromBuffer(_O_.[[ViewedArrayBuffer]], _indexedPosition_, _elementType_, *true*, ~Unordered~).
         </emu-alg>
       </emu-clause>
@@ -14764,10 +14763,9 @@
           1. Otherwise, let _numValue_ be ? ToNumber(_value_).
           1. If IsValidIntegerIndex(_O_, _index_) is *true*, then
             1. Let _offset_ be _O_.[[ByteOffset]].
-            1. Let _arrayTypeName_ be the String value of _O_.[[TypedArrayName]].
-            1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _arrayTypeName_.
+            1. Let _elementSize_ be TypedArrayElementSize(_O_).
             1. Let _indexedPosition_ be (ℝ(_index_) &times; _elementSize_) + _offset_.
-            1. Let _elementType_ be the Element Type value in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _arrayTypeName_.
+            1. Let _elementType_ be TypedArrayElementType(_O_).
             1. Perform SetValueInBuffer(_O_.[[ViewedArrayBuffer]], _indexedPosition_, _elementType_, _numValue_, *true*, ~Unordered~).
           1. Return ~unused~.
         </emu-alg>
@@ -38433,8 +38431,7 @@ THH:mm:ss.sss
             1. NOTE: The copying must be performed in a manner that preserves the bit-level encoding of the source data.
             1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
             1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
-            1. Let _typedArrayName_ be the String value of _O_.[[TypedArrayName]].
-            1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _typedArrayName_.
+            1. Let _elementSize_ be TypedArrayElementSize(_O_).
             1. Let _byteOffset_ be _O_.[[ByteOffset]].
             1. Let _toByteIndex_ be _to_ &times; _elementSize_ + _byteOffset_.
             1. Let _fromByteIndex_ be _from_ &times; _elementSize_ + _byteOffset_.
@@ -38876,13 +38873,11 @@ THH:mm:ss.sss
             1. Let _targetLength_ be _target_.[[ArrayLength]].
             1. Let _srcBuffer_ be _source_.[[ViewedArrayBuffer]].
             1. If IsDetachedBuffer(_srcBuffer_) is *true*, throw a *TypeError* exception.
-            1. Let _targetName_ be the String value of _target_.[[TypedArrayName]].
-            1. Let _targetType_ be the Element Type value in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _targetName_.
-            1. Let _targetElementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _targetName_.
+            1. Let _targetType_ be TypedArrayElementType(_target_).
+            1. Let _targetElementSize_ be TypedArrayElementSize(_target_).
             1. Let _targetByteOffset_ be _target_.[[ByteOffset]].
-            1. Let _srcName_ be the String value of _source_.[[TypedArrayName]].
-            1. Let _srcType_ be the Element Type value in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _srcName_.
-            1. Let _srcElementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _srcName_.
+            1. Let _srcType_ be TypedArrayElementType(_source_).
+            1. Let _srcElementSize_ be TypedArrayElementSize(_source_).
             1. Let _srcLength_ be _source_.[[ArrayLength]].
             1. Let _srcByteOffset_ be _source_.[[ByteOffset]].
             1. If _targetOffset_ is +&infin;, throw a *RangeError* exception.
@@ -38932,9 +38927,8 @@ THH:mm:ss.sss
             1. Let _targetBuffer_ be _target_.[[ViewedArrayBuffer]].
             1. If IsDetachedBuffer(_targetBuffer_) is *true*, throw a *TypeError* exception.
             1. Let _targetLength_ be _target_.[[ArrayLength]].
-            1. Let _targetName_ be the String value of _target_.[[TypedArrayName]].
-            1. Let _targetElementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _targetName_.
-            1. Let _targetType_ be the Element Type value in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _targetName_.
+            1. Let _targetElementSize_ be TypedArrayElementSize(_target_).
+            1. Let _targetType_ be TypedArrayElementType(_target_).
             1. Let _targetByteOffset_ be _target_.[[ByteOffset]].
             1. Let _src_ be ? ToObject(_source_).
             1. Let _srcLength_ be ? LengthOfArrayLike(_src_).
@@ -38977,10 +38971,8 @@ THH:mm:ss.sss
           1. Let _A_ be ? TypedArraySpeciesCreate(_O_, &laquo; 𝔽(_count_) &raquo;).
           1. If _count_ &gt; 0, then
             1. If IsDetachedBuffer(_O_.[[ViewedArrayBuffer]]) is *true*, throw a *TypeError* exception.
-            1. Let _srcName_ be the String value of _O_.[[TypedArrayName]].
-            1. Let _srcType_ be the Element Type value in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _srcName_.
-            1. Let _targetName_ be the String value of _A_.[[TypedArrayName]].
-            1. Let _targetType_ be the Element Type value in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _targetName_.
+            1. Let _srcType_ be TypedArrayElementType(_O_).
+            1. Let _targetType_ be TypedArrayElementType(_A_).
             1. If _srcType_ is different from _targetType_, then
               1. Let _n_ be 0.
               1. Repeat, while _k_ &lt; _final_,
@@ -38992,7 +38984,7 @@ THH:mm:ss.sss
             1. Else,
               1. Let _srcBuffer_ be _O_.[[ViewedArrayBuffer]].
               1. Let _targetBuffer_ be _A_.[[ViewedArrayBuffer]].
-              1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for Element Type _srcType_.
+              1. Let _elementSize_ be TypedArrayElementSize(_O_).
               1. NOTE: If _srcType_ and _targetType_ are the same, the transfer must be performed in a manner that preserves the bit-level encoding of the source data.
               1. Let _srcByteOffset_ be _O_.[[ByteOffset]].
               1. Let _targetByteIndex_ be _A_.[[ByteOffset]].
@@ -39095,8 +39087,7 @@ THH:mm:ss.sss
           1. Else if _relativeEnd_ &lt; 0, let _endIndex_ be max(_srcLength_ + _relativeEnd_, 0).
           1. Else, let _endIndex_ be min(_relativeEnd_, _srcLength_).
           1. Let _newLength_ be max(_endIndex_ - _beginIndex_, 0).
-          1. Let _constructorName_ be the String value of _O_.[[TypedArrayName]].
-          1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _constructorName_.
+          1. Let _elementSize_ be TypedArrayElementSize(_O_).
           1. Let _srcByteOffset_ be _O_.[[ByteOffset]].
           1. Let _beginByteOffset_ be _srcByteOffset_ + _beginIndex_ &times; _elementSize_.
           1. Let _argumentsList_ be &laquo; _buffer_, 𝔽(_beginByteOffset_), 𝔽(_newLength_) &raquo;.
@@ -39210,6 +39201,32 @@ THH:mm:ss.sss
           1. Return ~unused~.
         </emu-alg>
       </emu-clause>
+
+      <emu-clause id="sec-typedarrayelementsize" type="abstract operation">
+        <h1>
+          TypedArrayElementSize (
+            _O_: a TypedArray,
+          ): a non-negative integer
+        </h1>
+        <dl class="header">
+        </dl>
+        <emu-alg>
+          1. Return the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _O_.[[TypedArrayName]].
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-typedarrayelementtype" type="abstract operation">
+        <h1>
+          TypedArrayElementType (
+            _O_: a TypedArray,
+          ): a TypedArray element type
+        </h1>
+        <dl class="header">
+        </dl>
+        <emu-alg>
+          1. Return the Element Type value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _O_.[[TypedArrayName]].
+        </emu-alg>
+      </emu-clause>
     </emu-clause>
 
     <emu-clause id="sec-typedarray-constructors">
@@ -39301,14 +39318,12 @@ THH:mm:ss.sss
           <emu-alg>
             1. Let _srcData_ be _srcArray_.[[ViewedArrayBuffer]].
             1. If IsDetachedBuffer(_srcData_) is *true*, throw a *TypeError* exception.
-            1. Let _constructorName_ be the String value of _O_.[[TypedArrayName]].
-            1. Let _elementType_ be the Element Type value in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _constructorName_.
-            1. Let _elementLength_ be _srcArray_.[[ArrayLength]].
-            1. Let _srcName_ be the String value of _srcArray_.[[TypedArrayName]].
-            1. Let _srcType_ be the Element Type value in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _srcName_.
-            1. Let _srcElementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _srcName_.
+            1. Let _elementType_ be TypedArrayElementType(_O_).
+            1. Let _elementSize_ be TypedArrayElementSize(_O_).
+            1. Let _srcType_ be TypedArrayElementType(_srcArray_).
+            1. Let _srcElementSize_ be TypedArrayElementSize(_srcArray_).
             1. Let _srcByteOffset_ be _srcArray_.[[ByteOffset]].
-            1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _constructorName_.
+            1. Let _elementLength_ be _srcArray_.[[ArrayLength]].
             1. Let _byteLength_ be _elementSize_ &times; _elementLength_.
             1. If IsSharedArrayBuffer(_srcData_) is *false*, then
               1. Let _bufferConstructor_ be ? SpeciesConstructor(_srcData_, %ArrayBuffer%).
@@ -39349,8 +39364,7 @@ THH:mm:ss.sss
           <dl class="header">
           </dl>
           <emu-alg>
-            1. Let _constructorName_ be the String value of _O_.[[TypedArrayName]].
-            1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _constructorName_.
+            1. Let _elementSize_ be TypedArrayElementSize(_O_).
             1. Let _offset_ be ? ToIndex(_byteOffset_).
             1. If _offset_ modulo _elementSize_ &ne; 0, throw a *RangeError* exception.
             1. If _length_ is not *undefined*, then
@@ -39430,8 +39444,7 @@ THH:mm:ss.sss
           </dl>
           <emu-alg>
             1. Assert: _O_.[[ViewedArrayBuffer]] is *undefined*.
-            1. Let _constructorName_ be the String value of _O_.[[TypedArrayName]].
-            1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _constructorName_.
+            1. Let _elementSize_ be TypedArrayElementSize(_O_).
             1. Let _byteLength_ be _elementSize_ &times; _length_.
             1. Let _data_ be ? <emu-meta suppress-effects="user-code">AllocateArrayBuffer(%ArrayBuffer%, _byteLength_)</emu-meta>.
             1. Set _O_.[[ViewedArrayBuffer]] to _data_.
@@ -41461,11 +41474,10 @@ THH:mm:ss.sss
           1. If _waitable_ is not present, set _waitable_ to *false*.
           1. Perform ? ValidateTypedArray(_typedArray_).
           1. Let _buffer_ be _typedArray_.[[ViewedArrayBuffer]].
-          1. Let _typeName_ be _typedArray_.[[TypedArrayName]].
-          1. Let _type_ be the Element Type value in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _typeName_.
           1. If _waitable_ is *true*, then
-            1. If _typeName_ is not *"Int32Array"* or *"BigInt64Array"*, throw a *TypeError* exception.
+            1. If _typedArray_.[[TypedArrayName]] is not *"Int32Array"* or *"BigInt64Array"*, throw a *TypeError* exception.
           1. Else,
+            1. Let _type_ be TypedArrayElementType(_typedArray_).
             1. If IsUnclampedIntegerElementType(_type_) is *false* and IsBigIntElementType(_type_) is *false*, throw a *TypeError* exception.
           1. Return _buffer_.
         </emu-alg>
@@ -41485,8 +41497,7 @@ THH:mm:ss.sss
           1. Let _accessIndex_ be ? ToIndex(_requestIndex_).
           1. Assert: _accessIndex_ &ge; 0.
           1. If _accessIndex_ &ge; _length_, throw a *RangeError* exception.
-          1. Let _arrayTypeName_ be _typedArray_.[[TypedArrayName]].
-          1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _arrayTypeName_.
+          1. Let _elementSize_ be TypedArrayElementSize(_typedArray_).
           1. Let _offset_ be _typedArray_.[[ByteOffset]].
           1. Return (_accessIndex_ &times; _elementSize_) + _offset_.
         </emu-alg>
@@ -41666,12 +41677,11 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _buffer_ be ? ValidateIntegerTypedArray(_typedArray_).
           1. Let _indexedPosition_ be ? ValidateAtomicAccess(_typedArray_, _index_).
-          1. Let _arrayTypeName_ be _typedArray_.[[TypedArrayName]].
           1. If _typedArray_.[[ContentType]] is ~BigInt~, let _v_ be ? ToBigInt(_value_).
           1. Otherwise, let _v_ be 𝔽(? ToIntegerOrInfinity(_value_)).
           1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
           1. NOTE: The above check is not redundant with the check in ValidateIntegerTypedArray because the call to ToBigInt or ToIntegerOrInfinity on the preceding lines can have arbitrary side effects, which could cause the buffer to become detached.
-          1. Let _elementType_ be the Element Type value in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _arrayTypeName_.
+          1. Let _elementType_ be TypedArrayElementType(_typedArray_).
           1. Return GetModifySetValueInBuffer(_buffer_, _indexedPosition_, _elementType_, _v_, _op_).
         </emu-alg>
       </emu-clause>
@@ -41728,7 +41738,7 @@ THH:mm:ss.sss
       <h1>Atomics.add ( _typedArray_, _index_, _value_ )</h1>
       <p>The following steps are taken:</p>
       <emu-alg>
-        1. Let _type_ be the Element Type value in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _typedArray_.[[TypedArrayName]].
+        1. Let _type_ be TypedArrayElementType(_typedArray_).
         1. Let _isLittleEndian_ be the value of the [[LittleEndian]] field of the surrounding agent's Agent Record.
         1. Let _add_ be a new read-modify-write modification function with parameters (_xBytes_, _yBytes_) that captures _type_ and _isLittleEndian_ and performs the following steps atomically when called:
           1. Let _x_ be RawBytesToNumeric(_type_, _xBytes_, _isLittleEndian_).
@@ -41762,7 +41772,6 @@ THH:mm:ss.sss
         1. Let _buffer_ be ? ValidateIntegerTypedArray(_typedArray_).
         1. Let _block_ be _buffer_.[[ArrayBufferData]].
         1. Let _indexedPosition_ be ? ValidateAtomicAccess(_typedArray_, _index_).
-        1. Let _arrayTypeName_ be _typedArray_.[[TypedArrayName]].
         1. If _typedArray_.[[ContentType]] is ~BigInt~, then
           1. Let _expected_ be ? ToBigInt(_expectedValue_).
           1. Let _replacement_ be ? ToBigInt(_replacementValue_).
@@ -41771,8 +41780,8 @@ THH:mm:ss.sss
           1. Let _replacement_ be 𝔽(? ToIntegerOrInfinity(_replacementValue_)).
         1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
         1. NOTE: The above check is not redundant with the check in ValidateIntegerTypedArray because the call to ToBigInt or ToIntegerOrInfinity on the preceding lines can have arbitrary side effects, which could cause the buffer to become detached.
-        1. Let _elementType_ be the Element Type value in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _arrayTypeName_.
-        1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for Element Type _elementType_.
+        1. Let _elementType_ be TypedArrayElementType(_typedArray_).
+        1. Let _elementSize_ be TypedArrayElementSize(_typedArray_).
         1. Let _isLittleEndian_ be the value of the [[LittleEndian]] field of the surrounding agent's Agent Record.
         1. Let _expectedBytes_ be NumericToRawBytes(_elementType_, _expected_, _isLittleEndian_).
         1. Let _replacementBytes_ be NumericToRawBytes(_elementType_, _replacement_, _isLittleEndian_).
@@ -41835,8 +41844,7 @@ THH:mm:ss.sss
         1. Let _indexedPosition_ be ? ValidateAtomicAccess(_typedArray_, _index_).
         1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
         1. NOTE: The above check is not redundant with the check in ValidateIntegerTypedArray because the call to ValidateAtomicAccess on the preceding line can have arbitrary side effects, which could cause the buffer to become detached.
-        1. Let _arrayTypeName_ be _typedArray_.[[TypedArrayName]].
-        1. Let _elementType_ be the Element Type value in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _arrayTypeName_.
+        1. Let _elementType_ be TypedArrayElementType(_typedArray_).
         1. Return GetValueFromBuffer(_buffer_, _indexedPosition_, _elementType_, *true*, ~SeqCst~).
       </emu-alg>
     </emu-clause>
@@ -41857,12 +41865,11 @@ THH:mm:ss.sss
       <emu-alg>
         1. Let _buffer_ be ? ValidateIntegerTypedArray(_typedArray_).
         1. Let _indexedPosition_ be ? ValidateAtomicAccess(_typedArray_, _index_).
-        1. Let _arrayTypeName_ be _typedArray_.[[TypedArrayName]].
-        1. If _arrayTypeName_ is *"BigUint64Array"* or *"BigInt64Array"*, let _v_ be ? ToBigInt(_value_).
+        1. If _typedArray_.[[ContentType]] is ~BigInt~, let _v_ be ? ToBigInt(_value_).
         1. Otherwise, let _v_ be 𝔽(? ToIntegerOrInfinity(_value_)).
         1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
         1. NOTE: The above check is not redundant with the check in ValidateIntegerTypedArray because the call to ToBigInt or ToIntegerOrInfinity on the preceding lines can have arbitrary side effects, which could cause the buffer to become detached.
-        1. Let _elementType_ be the Element Type value in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _arrayTypeName_.
+        1. Let _elementType_ be TypedArrayElementType(_typedArray_).
         1. Perform SetValueInBuffer(_buffer_, _indexedPosition_, _elementType_, _v_, *true*, ~SeqCst~).
         1. Return _v_.
       </emu-alg>
@@ -41872,7 +41879,7 @@ THH:mm:ss.sss
       <h1>Atomics.sub ( _typedArray_, _index_, _value_ )</h1>
       <p>The following steps are taken:</p>
       <emu-alg>
-        1. Let _type_ be the Element Type value in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _typedArray_.[[TypedArrayName]].
+        1. Let _type_ be TypedArrayElementType(_typedArray_).
         1. Let _isLittleEndian_ be the value of the [[LittleEndian]] field of the surrounding agent's Agent Record.
         1. Let _subtract_ be a new read-modify-write modification function with parameters (_xBytes_, _yBytes_) that captures _type_ and _isLittleEndian_ and performs the following steps atomically when called:
           1. Let _x_ be RawBytesToNumeric(_type_, _xBytes_, _isLittleEndian_).
@@ -41896,8 +41903,7 @@ THH:mm:ss.sss
         1. Let _buffer_ be ? ValidateIntegerTypedArray(_typedArray_, *true*).
         1. If IsSharedArrayBuffer(_buffer_) is *false*, throw a *TypeError* exception.
         1. Let _indexedPosition_ be ? ValidateAtomicAccess(_typedArray_, _index_).
-        1. Let _arrayTypeName_ be _typedArray_.[[TypedArrayName]].
-        1. If _arrayTypeName_ is *"BigInt64Array"*, let _v_ be ? ToBigInt64(_value_).
+        1. If _typedArray_.[[TypedArrayName]] is *"BigInt64Array"*, let _v_ be ? ToBigInt64(_value_).
         1. Otherwise, let _v_ be ? ToInt32(_value_).
         1. Let _q_ be ? ToNumber(_timeout_).
         1. If _q_ is *NaN* or *+&infin;*<sub>𝔽</sub>, let _t_ be +&infin;; else if _q_ is *-&infin;*<sub>𝔽</sub>, let _t_ be 0; else let _t_ be max(ℝ(_q_), 0).
@@ -41906,7 +41912,7 @@ THH:mm:ss.sss
         1. Let _block_ be _buffer_.[[ArrayBufferData]].
         1. Let _WL_ be GetWaiterList(_block_, _indexedPosition_).
         1. Perform EnterCriticalSection(_WL_).
-        1. Let _elementType_ be the Element Type value in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _arrayTypeName_.
+        1. Let _elementType_ be TypedArrayElementType(_typedArray_).
         1. Let _w_ be GetValueFromBuffer(_buffer_, _indexedPosition_, _elementType_, *true*, ~SeqCst~).
         1. If _v_ &ne; _w_, then
           1. Perform LeaveCriticalSection(_WL_).


### PR DESCRIPTION
The first commit shows my initial plan: factor out 2 operations that, while simple, improve the readability of the algorithms in which they appear.

But then a different approach occurred to me: since the results of these operations are fixed for the lifetime of a Typed Array object, compute them just once when the object is created, and put them in new internal slots.

I've kept them separate in case you prefer the first, but I prefer the second.  If you do too, the two commits can be squashed.
