### PR TITLE
Editorial: Recast comparison algorithms as proper abstract operations

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1397,7 +1397,7 @@
             </td>
             <td>
               <emu-xref href="#sec-equality-operators" title></emu-xref>,
-              via <emu-xref href="#sec-strict-equality-comparison" title></emu-xref>
+              via <emu-xref href="#sec-isstrictlyequal" title></emu-xref>
             </td>
             <td>
               Boolean
@@ -5204,7 +5204,7 @@
         1. Return ! SameValueNonNumeric(_x_, _y_).
       </emu-alg>
       <emu-note>
-        <p>This algorithm differs from the Strict Equality Comparison Algorithm in its treatment of signed zeroes and NaNs.</p>
+        <p>This algorithm differs from the IsStrictlyEqual Algorithm in its treatment of signed zeroes and NaNs.</p>
       </emu-note>
     </emu-clause>
 
@@ -5290,7 +5290,7 @@
       <p>The abstract operation IsLooselyEqual takes arguments _x_ (an ECMAScript language value) and _y_ (an ECMAScript language value). It provides the semantics for the comparison _x_ == _y_, returning *true* or *false*. It performs the following steps when called:</p>
       <emu-alg>
         1. If Type(_x_) is the same as Type(_y_), then
-          1. Return the result of performing Strict Equality Comparison _x_ === _y_.
+          1. Return IsStrictlyEqual(_x_, _y_).
         1. If _x_ is *null* and _y_ is *undefined*, return *true*.
         1. If _x_ is *undefined* and _y_ is *null*, return *true*.
         1. [id="step-abstract-equality-comparison-web-compat-insertion-point"] NOTE: This step is replaced in section <emu-xref href="#sec-IsHTMLDDA-internal-slot-aec"></emu-xref>.
@@ -5312,9 +5312,9 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-strict-equality-comparison" aoid="Strict Equality Comparison">
-      <h1>Strict Equality Comparison</h1>
-      <p>The comparison _x_ === _y_, where _x_ and _y_ are values, produces *true* or *false*. Such a comparison is performed as follows:</p>
+    <emu-clause id="sec-isstrictlyequal" aoid="IsStrictlyEqual" oldids="sec-strict-equality-comparison">
+      <h1>IsStrictlyEqual ( _x_, _y_ )</h1>
+      <p>The abstract operation IsStrictlyEqual takes arguments _x_ (an ECMAScript language value) and _y_ (an ECMAScript language value). It provides the semantics for the comparison _x_ === _y_, returning *true* or *false*. It performs the following steps when called:</p>
       <emu-alg>
         1. If Type(_x_) is different from Type(_y_), return *false*.
         1. If Type(_x_) is Number or BigInt, then
@@ -17290,7 +17290,7 @@
         1. Let _lval_ be ? GetValue(_lref_).
         1. Let _rref_ be the result of evaluating |RelationalExpression|.
         1. Let _rval_ be ? GetValue(_rref_).
-        1. Return the result of performing Strict Equality Comparison _rval_ === _lval_.
+        1. Return IsStrictlyEqual(_rval_, _lval_).
       </emu-alg>
       <emu-grammar>EqualityExpression : EqualityExpression `!==` RelationalExpression</emu-grammar>
       <emu-alg>
@@ -17298,9 +17298,8 @@
         1. Let _lval_ be ? GetValue(_lref_).
         1. Let _rref_ be the result of evaluating |RelationalExpression|.
         1. Let _rval_ be ? GetValue(_rref_).
-        1. Let _r_ be the result of performing Strict Equality Comparison _rval_ === _lval_.
-        1. Assert: _r_ is a normal completion.
-        1. If _r_.[[Value]] is *true*, return *false*. Otherwise, return *true*.
+        1. Let _r_ be ! IsStrictlyEqual(_rval_, _lval_).
+        1. If _r_ is *true*, return *false*. Otherwise, return *true*.
       </emu-alg>
       <emu-note>
         <p>Given the above definition of equality:</p>
@@ -19542,7 +19541,7 @@
         1. Assert: _C_ is an instance of the production <emu-grammar>CaseClause : `case` Expression `:` StatementList?</emu-grammar>.
         1. Let _exprRef_ be the result of evaluating the |Expression| of _C_.
         1. Let _clauseSelector_ be ? GetValue(_exprRef_).
-        1. Return the result of performing Strict Equality Comparison _input_ === _clauseSelector_.
+        1. Return IsStrictlyEqual(_input_, _clauseSelector_).
       </emu-alg>
       <emu-note>
         <p>This operation does not execute _C_'s |StatementList| (if any). The |CaseBlock| algorithm uses its return value to determine which |StatementList| to start executing.</p>
@@ -32926,13 +32925,13 @@ THH:mm:ss.sss
           <p>The `includes` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
         <emu-note>
-          <p>The `includes` method intentionally differs from the similar `indexOf` method in two ways. First, it uses the SameValueZero algorithm, instead of Strict Equality Comparison, allowing it to detect *NaN* array elements. Second, it does not skip missing array elements, instead treating them as *undefined*.</p>
+          <p>The `includes` method intentionally differs from the similar `indexOf` method in two ways. First, it uses the SameValueZero algorithm, instead of IsStrictlyEqual, allowing it to detect *NaN* array elements. Second, it does not skip missing array elements, instead treating them as *undefined*.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-array.prototype.indexof">
         <h1>Array.prototype.indexOf ( _searchElement_ [ , _fromIndex_ ] )</h1>
-        <p>`indexOf` compares _searchElement_ to the elements of the array, in ascending order, using the Strict Equality Comparison algorithm, and if found at one or more indices, returns the smallest such index; otherwise, *-1*<sub>𝔽</sub> is returned.</p>
+        <p>`indexOf` compares _searchElement_ to the elements of the array, in ascending order, using the IsStrictlyEqual algorithm, and if found at one or more indices, returns the smallest such index; otherwise, *-1*<sub>𝔽</sub> is returned.</p>
         <emu-note>
           <p>The optional second argument _fromIndex_ defaults to *+0*<sub>𝔽</sub> (i.e. the whole array is searched). If it is greater than or equal to the length of the array, *-1*<sub>𝔽</sub> is returned, i.e. the array will not be searched. If it is less than *+0*<sub>𝔽</sub>, it is used as the offset from the end of the array to compute _fromIndex_. If the computed index is less than *+0*<sub>𝔽</sub>, the whole array will be searched.</p>
         </emu-note>
@@ -32954,7 +32953,7 @@ THH:mm:ss.sss
             1. Let _kPresent_ be ? HasProperty(_O_, ! ToString(𝔽(_k_))).
             1. If _kPresent_ is *true*, then
               1. Let _elementK_ be ? Get(_O_, ! ToString(𝔽(_k_))).
-              1. Let _same_ be the result of performing Strict Equality Comparison _searchElement_ === _elementK_.
+              1. Let _same_ be IsStrictlyEqual(_searchElement_, _elementK_).
               1. If _same_ is *true*, return 𝔽(_k_).
             1. Set _k_ to _k_ + 1.
           1. Return *-1*<sub>𝔽</sub>.
@@ -33000,7 +32999,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-array.prototype.lastindexof">
         <h1>Array.prototype.lastIndexOf ( _searchElement_ [ , _fromIndex_ ] )</h1>
         <emu-note>
-          <p>`lastIndexOf` compares _searchElement_ to the elements of the array in descending order using the Strict Equality Comparison algorithm, and if found at one or more indices, returns the largest such index; otherwise, *-1*<sub>𝔽</sub> is returned.</p>
+          <p>`lastIndexOf` compares _searchElement_ to the elements of the array in descending order using the IsStrictlyEqual algorithm, and if found at one or more indices, returns the largest such index; otherwise, *-1*<sub>𝔽</sub> is returned.</p>
           <p>The optional second argument _fromIndex_ defaults to the array's length minus one (i.e. the whole array is searched). If it is greater than or equal to the length of the array, the whole array will be searched. If it is less than *+0*<sub>𝔽</sub>, it is used as the offset from the end of the array to compute _fromIndex_. If the computed index is less than *+0*<sub>𝔽</sub>, *-1*<sub>𝔽</sub> is returned.</p>
         </emu-note>
         <p>When the `lastIndexOf` method is called, the following steps are taken:</p>
@@ -33018,7 +33017,7 @@ THH:mm:ss.sss
             1. Let _kPresent_ be ? HasProperty(_O_, ! ToString(𝔽(_k_))).
             1. If _kPresent_ is *true*, then
               1. Let _elementK_ be ? Get(_O_, ! ToString(𝔽(_k_))).
-              1. Let _same_ be the result of performing Strict Equality Comparison _searchElement_ === _elementK_.
+              1. Let _same_ be IsStrictlyEqual(_searchElement_, _elementK_).
               1. If _same_ is *true*, return 𝔽(_k_).
             1. Set _k_ to _k_ - 1.
           1. Return *-1*<sub>𝔽</sub>.
@@ -34359,7 +34358,7 @@ THH:mm:ss.sss
             1. Let _kPresent_ be ! HasProperty(_O_, ! ToString(𝔽(_k_))).
             1. If _kPresent_ is *true*, then
               1. Let _elementK_ be ! Get(_O_, ! ToString(𝔽(_k_))).
-              1. Let _same_ be the result of performing Strict Equality Comparison _searchElement_ === _elementK_.
+              1. Let _same_ be IsStrictlyEqual(_searchElement_, _elementK_).
               1. If _same_ is *true*, return 𝔽(_k_).
             1. Set _k_ to _k_ + 1.
           1. Return *-1*<sub>𝔽</sub>.
@@ -34419,7 +34418,7 @@ THH:mm:ss.sss
             1. Let _kPresent_ be ! HasProperty(_O_, ! ToString(𝔽(_k_))).
             1. If _kPresent_ is *true*, then
               1. Let _elementK_ be ! Get(_O_, ! ToString(𝔽(_k_))).
-              1. Let _same_ be the result of performing Strict Equality Comparison _searchElement_ === _elementK_.
+              1. Let _same_ be IsStrictlyEqual(_searchElement_, _elementK_).
               1. If _same_ is *true*, return 𝔽(_k_).
             1. Set _k_ to _k_ - 1.
           1. Return *-1*<sub>𝔽</sub>.

--- a/spec.html
+++ b/spec.html
@@ -1382,7 +1382,7 @@
             </td>
             <td>
               <emu-xref href="#sec-relational-operators" title></emu-xref>,
-              via <emu-xref href="#sec-abstract-relational-comparison" title></emu-xref>
+              via <emu-xref href="#sec-islessthan" title></emu-xref>
             </td>
             <td>
               Boolean or *undefined* (for unordered inputs)
@@ -5240,9 +5240,9 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-abstract-relational-comparison" aoid="Abstract Relational Comparison">
-      <h1>Abstract Relational Comparison</h1>
-      <p>The comparison _x_ &lt; _y_, where _x_ and _y_ are values, produces *true*, *false*, or *undefined* (which indicates that at least one operand is *NaN*). In addition to _x_ and _y_ the algorithm takes a Boolean flag named _LeftFirst_ as a parameter. The flag is used to control the order in which operations with potentially visible side-effects are performed upon _x_ and _y_. It is necessary because ECMAScript specifies left to right evaluation of expressions. The default value of _LeftFirst_ is *true* and indicates that the _x_ parameter corresponds to an expression that occurs to the left of the _y_ parameter's corresponding expression. If _LeftFirst_ is *false*, the reverse is the case and operations must be performed upon _y_ before _x_. Such a comparison is performed as follows:</p>
+    <emu-clause id="sec-islessthan" aoid="IsLessThan" oldids="sec-abstract-relational-comparison">
+      <h1>IsLessThan ( _x_, _y_ [ , _LeftFirst_ ] )</h1>
+      <p>The abstract operation IsLessThan takes arguments _x_ (an ECMAScript language value) and _y_ (an ECMAScript language value), and optional argument _LeftFirst_ (a Boolean). It provides the semantics for the comparison _x_ &lt; _y_, returning *true*, *false*, or *undefined* (which indicates that at least one operand is *NaN*). The _LeftFirst_ flag is used to control the order in which operations with potentially visible side-effects are performed upon _x_ and _y_. It is necessary because ECMAScript specifies left to right evaluation of expressions. The default value of _LeftFirst_ is *true* and indicates that the _x_ parameter corresponds to an expression that occurs to the left of the _y_ parameter's corresponding expression. If _LeftFirst_ is *false*, the reverse is the case and operations must be performed upon _y_ before _x_. It performs the following steps when called:</p>
       <emu-alg>
         1. If the _LeftFirst_ flag is *true*, then
           1. Let _px_ be ? ToPrimitive(_x_, ~number~).
@@ -17184,8 +17184,7 @@
         1. Let _lval_ be ? GetValue(_lref_).
         1. Let _rref_ be the result of evaluating |ShiftExpression|.
         1. Let _rval_ be ? GetValue(_rref_).
-        1. Let _r_ be the result of performing Abstract Relational Comparison _lval_ &lt; _rval_.
-        1. ReturnIfAbrupt(_r_).
+        1. Let _r_ be ? IsLessThan(_lval_, _rval_).
         1. If _r_ is *undefined*, return *false*. Otherwise, return _r_.
       </emu-alg>
       <emu-grammar>RelationalExpression : RelationalExpression `&gt;` ShiftExpression</emu-grammar>
@@ -17194,8 +17193,7 @@
         1. Let _lval_ be ? GetValue(_lref_).
         1. Let _rref_ be the result of evaluating |ShiftExpression|.
         1. Let _rval_ be ? GetValue(_rref_).
-        1. Let _r_ be the result of performing Abstract Relational Comparison _rval_ &lt; _lval_ with _LeftFirst_ equal to *false*.
-        1. ReturnIfAbrupt(_r_).
+        1. Let _r_ be ? IsLessThan(_rval_, _lval_, *false*).
         1. If _r_ is *undefined*, return *false*. Otherwise, return _r_.
       </emu-alg>
       <emu-grammar>RelationalExpression : RelationalExpression `&lt;=` ShiftExpression</emu-grammar>
@@ -17204,8 +17202,7 @@
         1. Let _lval_ be ? GetValue(_lref_).
         1. Let _rref_ be the result of evaluating |ShiftExpression|.
         1. Let _rval_ be ? GetValue(_rref_).
-        1. Let _r_ be the result of performing Abstract Relational Comparison _rval_ &lt; _lval_ with _LeftFirst_ equal to *false*.
-        1. ReturnIfAbrupt(_r_).
+        1. Let _r_ be ? IsLessThan(_rval_, _lval_, *false*).
         1. If _r_ is *true* or *undefined*, return *false*. Otherwise, return *true*.
       </emu-alg>
       <emu-grammar>RelationalExpression : RelationalExpression `&gt;=` ShiftExpression</emu-grammar>
@@ -17214,8 +17211,7 @@
         1. Let _lval_ be ? GetValue(_lref_).
         1. Let _rref_ be the result of evaluating |ShiftExpression|.
         1. Let _rval_ be ? GetValue(_rref_).
-        1. Let _r_ be the result of performing Abstract Relational Comparison _lval_ &lt; _rval_.
-        1. ReturnIfAbrupt(_r_).
+        1. Let _r_ be ? IsLessThan(_lval_, _rval_).
         1. If _r_ is *true* or *undefined*, return *false*. Otherwise, return *true*.
       </emu-alg>
       <emu-grammar>RelationalExpression : RelationalExpression `instanceof` ShiftExpression</emu-grammar>
@@ -17663,7 +17659,7 @@
         <p>No hint is provided in the calls to ToPrimitive in steps <emu-xref href="#step-binary-op-toprimitive-lval"></emu-xref> and <emu-xref href="#step-binary-op-toprimitive-rval"></emu-xref>. All standard objects except Date objects handle the absence of a hint as if ~number~ were given; Date objects handle the absence of a hint as if ~string~ were given. Exotic objects may handle the absence of a hint in some other manner.</p>
       </emu-note>
       <emu-note>
-        <p>Step <emu-xref href="#step-binary-op-string-check"></emu-xref> differs from step <emu-xref href="#step-arc-string-check"></emu-xref> of the Abstract Relational Comparison algorithm, by using the logical-or operation instead of the logical-and operation.</p>
+        <p>Step <emu-xref href="#step-binary-op-string-check"></emu-xref> differs from step <emu-xref href="#step-arc-string-check"></emu-xref> of the IsLessThan algorithm, by using the logical-or operation instead of the logical-and operation.</p>
       </emu-note>
     </emu-clause>
 
@@ -27722,7 +27718,7 @@
           1. Return _highest_.
         </emu-alg>
         <emu-note>
-          <p>The comparison of values to determine the largest value is done using the Abstract Relational Comparison algorithm except that *+0*<sub>𝔽</sub> is considered to be larger than *-0*<sub>𝔽</sub>.</p>
+          <p>The comparison of values to determine the largest value is done using the IsLessThan algorithm except that *+0*<sub>𝔽</sub> is considered to be larger than *-0*<sub>𝔽</sub>.</p>
         </emu-note>
         <p>The *"length"* property of the `max` method is *2*<sub>𝔽</sub>.</p>
       </emu-clause>
@@ -27744,7 +27740,7 @@
           1. Return _lowest_.
         </emu-alg>
         <emu-note>
-          <p>The comparison of values to determine the largest value is done using the Abstract Relational Comparison algorithm except that *+0*<sub>𝔽</sub> is considered to be larger than *-0*<sub>𝔽</sub>.</p>
+          <p>The comparison of values to determine the largest value is done using the IsLessThan algorithm except that *+0*<sub>𝔽</sub> is considered to be larger than *-0*<sub>𝔽</sub>.</p>
         </emu-note>
         <p>The *"length"* property of the `min` method is *2*<sub>𝔽</sub>.</p>
       </emu-clause>
@@ -33430,9 +33426,9 @@ THH:mm:ss.sss
               1. Return _v_.
             1. [id="step-sortcompare-tostring-x"] Let _xString_ be ? ToString(_x_).
             1. [id="step-sortcompare-tostring-y"] Let _yString_ be ? ToString(_y_).
-            1. Let _xSmaller_ be the result of performing Abstract Relational Comparison _xString_ &lt; _yString_.
+            1. Let _xSmaller_ be IsLessThan(_xString_, _yString_).
             1. If _xSmaller_ is *true*, return *-1*<sub>𝔽</sub>.
-            1. Let _ySmaller_ be the result of performing Abstract Relational Comparison _yString_ &lt; _xString_.
+            1. Let _ySmaller_ be IsLessThan(_yString_, _xString_).
             1. If _ySmaller_ is *true*, return *1*<sub>𝔽</sub>.
             1. Return *+0*<sub>𝔽</sub>.
           </emu-alg>

--- a/spec.html
+++ b/spec.html
@@ -5241,8 +5241,8 @@
     </emu-clause>
 
     <emu-clause id="sec-islessthan" aoid="IsLessThan" oldids="sec-abstract-relational-comparison">
-      <h1>IsLessThan ( _x_, _y_ [ , _LeftFirst_ ] )</h1>
-      <p>The abstract operation IsLessThan takes arguments _x_ (an ECMAScript language value) and _y_ (an ECMAScript language value), and optional argument _LeftFirst_ (a Boolean). It provides the semantics for the comparison _x_ &lt; _y_, returning *true*, *false*, or *undefined* (which indicates that at least one operand is *NaN*). The _LeftFirst_ flag is used to control the order in which operations with potentially visible side-effects are performed upon _x_ and _y_. It is necessary because ECMAScript specifies left to right evaluation of expressions. The default value of _LeftFirst_ is *true* and indicates that the _x_ parameter corresponds to an expression that occurs to the left of the _y_ parameter's corresponding expression. If _LeftFirst_ is *false*, the reverse is the case and operations must be performed upon _y_ before _x_. It performs the following steps when called:</p>
+      <h1>IsLessThan ( _x_, _y_, _LeftFirst_ )</h1>
+      <p>The abstract operation IsLessThan takes arguments _x_ (an ECMAScript language value), _y_ (an ECMAScript language value), and _LeftFirst_ (a Boolean). It provides the semantics for the comparison _x_ &lt; _y_, returning *true*, *false*, or *undefined* (which indicates that at least one operand is *NaN*). The _LeftFirst_ flag is used to control the order in which operations with potentially visible side-effects are performed upon _x_ and _y_. It is necessary because ECMAScript specifies left to right evaluation of expressions. If _LeftFirst_ is *true*, the _x_ parameter corresponds to an expression that occurs to the left of the _y_ parameter's corresponding expression. If _LeftFirst_ is *false*, the reverse is the case and operations must be performed upon _y_ before _x_. It performs the following steps when called:</p>
       <emu-alg>
         1. If the _LeftFirst_ flag is *true*, then
           1. Let _px_ be ? ToPrimitive(_x_, ~number~).
@@ -17184,7 +17184,7 @@
         1. Let _lval_ be ? GetValue(_lref_).
         1. Let _rref_ be the result of evaluating |ShiftExpression|.
         1. Let _rval_ be ? GetValue(_rref_).
-        1. Let _r_ be ? IsLessThan(_lval_, _rval_).
+        1. Let _r_ be ? IsLessThan(_lval_, _rval_, *true*).
         1. If _r_ is *undefined*, return *false*. Otherwise, return _r_.
       </emu-alg>
       <emu-grammar>RelationalExpression : RelationalExpression `&gt;` ShiftExpression</emu-grammar>
@@ -17211,7 +17211,7 @@
         1. Let _lval_ be ? GetValue(_lref_).
         1. Let _rref_ be the result of evaluating |ShiftExpression|.
         1. Let _rval_ be ? GetValue(_rref_).
-        1. Let _r_ be ? IsLessThan(_lval_, _rval_).
+        1. Let _r_ be ? IsLessThan(_lval_, _rval_, *true*).
         1. If _r_ is *true* or *undefined*, return *false*. Otherwise, return *true*.
       </emu-alg>
       <emu-grammar>RelationalExpression : RelationalExpression `instanceof` ShiftExpression</emu-grammar>
@@ -33424,9 +33424,9 @@ THH:mm:ss.sss
               1. Return _v_.
             1. [id="step-sortcompare-tostring-x"] Let _xString_ be ? ToString(_x_).
             1. [id="step-sortcompare-tostring-y"] Let _yString_ be ? ToString(_y_).
-            1. Let _xSmaller_ be IsLessThan(_xString_, _yString_).
+            1. Let _xSmaller_ be IsLessThan(_xString_, _yString_, *true*).
             1. If _xSmaller_ is *true*, return *-1*<sub>𝔽</sub>.
-            1. Let _ySmaller_ be IsLessThan(_yString_, _xString_).
+            1. Let _ySmaller_ be IsLessThan(_yString_, _xString_, *true*).
             1. If _ySmaller_ is *true*, return *1*<sub>𝔽</sub>.
             1. Return *+0*<sub>𝔽</sub>.
           </emu-alg>

--- a/spec.html
+++ b/spec.html
@@ -5285,26 +5285,26 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-abstract-equality-comparison" aoid="Abstract Equality Comparison">
-      <h1>Abstract Equality Comparison</h1>
-      <p>The comparison _x_ == _y_, where _x_ and _y_ are values, produces *true* or *false*. Such a comparison is performed as follows:</p>
+    <emu-clause id="sec-islooselyequal" aoid="IsLooselyEqual" oldids="sec-abstract-equality-comparison">
+      <h1>IsLooselyEqual ( _x_, _y_ )</h1>
+      <p>The abstract operation IsLooselyEqual takes arguments _x_ (an ECMAScript language value) and _y_ (an ECMAScript language value). It provides the semantics for the comparison _x_ == _y_, returning *true* or *false*. It performs the following steps when called:</p>
       <emu-alg>
         1. If Type(_x_) is the same as Type(_y_), then
           1. Return the result of performing Strict Equality Comparison _x_ === _y_.
         1. If _x_ is *null* and _y_ is *undefined*, return *true*.
         1. If _x_ is *undefined* and _y_ is *null*, return *true*.
         1. [id="step-abstract-equality-comparison-web-compat-insertion-point"] NOTE: This step is replaced in section <emu-xref href="#sec-IsHTMLDDA-internal-slot-aec"></emu-xref>.
-        1. If Type(_x_) is Number and Type(_y_) is String, return the result of the comparison _x_ == ! ToNumber(_y_).
-        1. If Type(_x_) is String and Type(_y_) is Number, return the result of the comparison ! ToNumber(_x_) == _y_.
+        1. If Type(_x_) is Number and Type(_y_) is String, return IsLooselyEqual(_x_, ! ToNumber(_y_)).
+        1. If Type(_x_) is String and Type(_y_) is Number, return IsLooselyEqual(! ToNumber(_x_), _y_).
         1. If Type(_x_) is BigInt and Type(_y_) is String, then
           1. Let _n_ be ! StringToBigInt(_y_).
           1. If _n_ is *NaN*, return *false*.
-          1. Return the result of the comparison _x_ == _n_.
-        1. If Type(_x_) is String and Type(_y_) is BigInt, return the result of the comparison _y_ == _x_.
-        1. If Type(_x_) is Boolean, return the result of the comparison ! ToNumber(_x_) == _y_.
-        1. If Type(_y_) is Boolean, return the result of the comparison _x_ == ! ToNumber(_y_).
-        1. If Type(_x_) is either String, Number, BigInt, or Symbol and Type(_y_) is Object, return the result of the comparison _x_ == ? ToPrimitive(_y_).
-        1. If Type(_x_) is Object and Type(_y_) is either String, Number, BigInt, or Symbol, return the result of the comparison ? ToPrimitive(_x_) == _y_.
+          1. Return IsLooselyEqual(_x_, _n_).
+        1. If Type(_x_) is String and Type(_y_) is BigInt, return IsLooselyEqual(_y_, _x_).
+        1. If Type(_x_) is Boolean, return IsLooselyEqual(! ToNumber(_x_), _y_).
+        1. If Type(_y_) is Boolean, return IsLooselyEqual(_x_, ! ToNumber(_y_)).
+        1. If Type(_x_) is either String, Number, BigInt, or Symbol and Type(_y_) is Object, return IsLooselyEqual(_x_, ? ToPrimitive(_y_)).
+        1. If Type(_x_) is Object and Type(_y_) is either String, Number, BigInt, or Symbol, return IsLooselyEqual(? ToPrimitive(_x_), _y_).
         1. If Type(_x_) is BigInt and Type(_y_) is Number, or if Type(_x_) is Number and Type(_y_) is BigInt, then
           1. If _x_ or _y_ are any of *NaN*, *+&infin;*<sub>𝔽</sub>, or *-&infin;*<sub>𝔽</sub>, return *false*.
           1. If ℝ(_x_) = ℝ(_y_), return *true*; otherwise return *false*.
@@ -17273,7 +17273,7 @@
         1. Let _lval_ be ? GetValue(_lref_).
         1. Let _rref_ be the result of evaluating |RelationalExpression|.
         1. Let _rval_ be ? GetValue(_rref_).
-        1. Return the result of performing Abstract Equality Comparison _rval_ == _lval_.
+        1. Return IsLooselyEqual(_rval_, _lval_).
       </emu-alg>
       <emu-grammar>EqualityExpression : EqualityExpression `!=` RelationalExpression</emu-grammar>
       <emu-alg>
@@ -17281,8 +17281,7 @@
         1. Let _lval_ be ? GetValue(_lref_).
         1. Let _rref_ be the result of evaluating |RelationalExpression|.
         1. Let _rval_ be ? GetValue(_rref_).
-        1. Let _r_ be the result of performing Abstract Equality Comparison _rval_ == _lval_.
-        1. ReturnIfAbrupt(_r_).
+        1. Let _r_ be ? IsLooselyEqual(_rval_, _lval_).
         1. If _r_ is *true*, return *false*. Otherwise, return *true*.
       </emu-alg>
       <emu-grammar>EqualityExpression : EqualityExpression `===` RelationalExpression</emu-grammar>
@@ -42987,7 +42986,7 @@ THH:mm:ss.sss
 
     <emu-annex id="sec-IsHTMLDDA-internal-slot">
       <h1>The [[IsHTMLDDA]] Internal Slot</h1>
-      <p>An <dfn>[[IsHTMLDDA]] internal slot</dfn> may exist on host-defined objects. Objects with an [[IsHTMLDDA]] internal slot behave like *undefined* in the <emu-xref href="#sec-toboolean">ToBoolean</emu-xref> and <emu-xref href="#sec-abstract-equality-comparison">Abstract Equality Comparison</emu-xref> abstract operations and when used as an operand for the <emu-xref href="#sec-typeof-operator">`typeof` operator</emu-xref>.</p>
+      <p>An <dfn>[[IsHTMLDDA]] internal slot</dfn> may exist on host-defined objects. Objects with an [[IsHTMLDDA]] internal slot behave like *undefined* in the <emu-xref href="#sec-toboolean">ToBoolean</emu-xref> and IsLooselyEqual abstract operations and when used as an operand for the <emu-xref href="#sec-typeof-operator">`typeof` operator</emu-xref>.</p>
       <emu-note>
         <p>Objects with an [[IsHTMLDDA]] internal slot are never created by this specification. However, the <a href="https://html.spec.whatwg.org/multipage/obsolete.html#dom-document-all"><code>document.all</code> object</a> in web browsers is a host-defined exotic object with this slot that exists for web compatibility purposes. There are no other known examples of this type of object and implementations should not create any with the exception of `document.all`.</p>
       </emu-note>
@@ -43002,8 +43001,8 @@ THH:mm:ss.sss
       </emu-annex>
 
       <emu-annex id="sec-IsHTMLDDA-internal-slot-aec">
-        <h1>Changes to Abstract Equality Comparison</h1>
-        <p>The following steps replace step <emu-xref href="#step-abstract-equality-comparison-web-compat-insertion-point"></emu-xref> of the <emu-xref href="#sec-abstract-equality-comparison">Abstract Equality Comparison</emu-xref> algorithm:</p>
+        <h1>Changes to IsLooselyEqual</h1>
+        <p>The following steps replace step <emu-xref href="#step-abstract-equality-comparison-web-compat-insertion-point"></emu-xref> of the IsLooselyEqual algorithm:</p>
         <emu-alg>
           1. If Type(_x_) is Object and _x_ has an [[IsHTMLDDA]] internal slot and _y_ is either *null* or *undefined*, return *true*.
           1. If _x_ is either *null* or *undefined* and Type(_y_) is Object and _y_ has an [[IsHTMLDDA]] internal slot, return *true*.


### PR DESCRIPTION
Specifically:
- Abstract Relational Comparison
- Abstract Equality Comparison
- Strict Equality Comparison

See https://github.com/tc39/ecma262/pull/545#issuecomment-815314218 (third bullet).

Downstream: HTML refers to Abstract Equality Comparison and Strict Equality Comparison. (But the link will still work.)