### PR TITLE
Editorial: Explicitly define default value of 'internalSlotsList' in OrdinaryCreateFromConstructor

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -10569,6 +10569,7 @@
       <emu-alg>
         1. Assert: _intrinsicDefaultProto_ is a String value that is this specification's name of an intrinsic object. The corresponding object must be an intrinsic that is intended to be used as the [[Prototype]] value of an object.
         1. Let _proto_ be ? GetPrototypeFromConstructor(_constructor_, _intrinsicDefaultProto_).
+        1. If _internalSlotsList_ is not present, set _internalSlotsList_ to a new empty List.
         1. Return ! OrdinaryObjectCreate(_proto_, _internalSlotsList_).
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
In [10.1.13 OrdinaryCreateFromConstructor](https://tc39.es/ecma262/#sec-ordinarycreatefromconstructor), it might be better to explicitly define default value of `internalSlotsList` when it is not provided.