### PR TITLE
Editorial: More info in 'PromiseCapability Record' table

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -37573,10 +37573,10 @@ THH:mm:ss.sss
                 [[Promise]]
               </td>
               <td>
-                An object
+                An object | *undefined*
               </td>
               <td>
-                An object that is usable as a promise.
+                An object that is usable as a promise. *undefined* if not yet assigned.
               </td>
             </tr>
             <tr>
@@ -37584,10 +37584,10 @@ THH:mm:ss.sss
                 [[Resolve]]
               </td>
               <td>
-                A function object
+                A function object | *undefined*
               </td>
               <td>
-                The function that is used to resolve the given promise object.
+                The function that is used to resolve the given promise object. *undefined* if not yet assigned.
               </td>
             </tr>
             <tr>
@@ -37595,10 +37595,10 @@ THH:mm:ss.sss
                 [[Reject]]
               </td>
               <td>
-                A function object
+                A function object | *undefined*
               </td>
               <td>
-                The function that is used to reject the given promise object.
+                The function that is used to reject the given promise object. *undefined* if not yet assigned.
               </td>
             </tr>
             </tbody>


### PR DESCRIPTION
In [27.2.1.1 PromiseCapability Records](https://tc39.es/ecma262/#sec-promisecapability-records), all properties of `PromiseCapability Record` are initialized to `undefined` in `NewPromiseCapability` operation. It might be better to explicitly describe them in table.