### PR TITLE
Editorial: Simplify RegExpInitialize

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -35820,15 +35820,14 @@ THH:mm:ss.sss
             1. If _F_ contains *"u"*, let _u_ be *true*; else let _u_ be *false*.
             1. If _u_ is *true*, then
               1. Let _patternText_ be ! StringToCodePoints(_P_).
-              1. Let _patternCharacters_ be a List whose elements are the code points of _patternText_.
             1. Else,
               1. Let _patternText_ be the result of interpreting each of _P_'s 16-bit elements as a Unicode BMP code point. UTF-16 decoding is not applied to the elements.
-              1. Let _patternCharacters_ be a List whose elements are the code unit elements of _P_.
             1. Let _parseResult_ be ParsePattern(_patternText_, _u_).
             1. If _parseResult_ is a non-empty List of *SyntaxError* objects, throw a *SyntaxError* exception.
             1. Assert: _parseResult_ is a |Pattern| Parse Node.
             1. Set _obj_.[[OriginalSource]] to _P_.
             1. Set _obj_.[[OriginalFlags]] to _F_.
+            1. NOTE: The definitions of _DotAll_, _IgnoreCase_, _Multiline_, and _Unicode_ in <emu-xref href="#sec-notation"></emu-xref> refer to this value of _obj_.[[OriginalFlags]].
             1. Set _obj_.[[RegExpMatcher]] to CompilePattern of _parseResult_.
             1. Perform ? Set(_obj_, *"lastIndex"*, *+0*<sub>𝔽</sub>, *true*).
             1. Return _obj_.


### PR DESCRIPTION
In the current spec, step 14 of RegExpInitialize says:
> Set _obj_.[[RegExpMatcher]] to the Abstract Closure that evaluates _parseResult_ by applying the semantics provided in [22.2.2](https://tc39.es/ecma262/#sec-pattern-semantics) using _patternCharacters_ as the pattern's List of _SourceCharacter_ values and _F_ as the flag parameters.

This PR examines that step and proposes 3 simplifications.

----
(1)

> the Abstract Closure that evaluates _parseResult_ by applying the semantics provided in 22.2.2

The Abstract Closure in question doesn't evaluate _parseResult_, rather it's the **result** of evaluating _parseResult_ (using 22.2.2's sense of "evaluate").

So we could change the quoted phrase to
> the Abstract Closure that results from evaluating _parseResult_ by applying [...]

However, I don't think this step needs to talk about both "evaluating" and "applying semantics", so I suggest dropping the former:
> the Abstract Closure that results from applying the semantics of 22.2.2 to _parseResult_

(If/when 22.2.2 ever adopts a proper SDO name, we can use that.)

[Later: 22.2.2 adopted the name CompilePattern in PR #2531, and changed this step accordingly.]

----
(2)

> using _patternCharacters_ as the pattern's List of _SourceCharacter_ values

This is presumably an allusion to 22.2.2's 3rd para (emphasis mine):

> The syntax and semantics of _Pattern_ is defined as if the source code for the _Pattern_ was a **List of _SourceCharacter_ values** where each _SourceCharacter_ corresponds to a Unicode code point.

But it's odd that RegExpInitialize would specify this, since at step 9, it already called `ParsePattern` (on _patternText_). This seems to say to use _patternText_ for syntax but _patternCharacters_ for semantics. How would that even work?

Luckily, I think the resolution is easy: _patternText_ and _patternCharacters_ are basically the same thing. So I suggest dropping _patternCharacters_ and the quoted phrase.

[Later: PR #2531 dropped the quoted phrase, so now _patternCharacters_ is defined but not used.]

----
(3)

> and _F_ as the flag parameters

It's unclear exactly what this is alluding to, since there's no other mention of "flag parameters" in the spec. I suppose it's meant to supply values for the _DotAll_, _IgnoreCase_, _Multiline_, and _Unicode_ aliases that appear in 22.2.2's semantics. However, [22.2.2.1 Notation](https://tc39.es/ecma262/#sec-notation) is clear that these aliases are set based on "the RegExp object's [[OriginalFlags]] internal slot", and RegExpInitialize just set _obj_.[[OriginalFlags]] to _F_ on the previous step, so there's no need to supply _F_ separately here.

So I suggest just dropping this phrase. [Later: PR #2531 dropped the phrase.]

(If you want to make the connection, I think a better way would be to add a NOTE after step 13. E.g.: "The definitions of _DotAll_, _IgnoreCase_, _Multiline_, and _Unicode_ in 22.2.2.1 refer to this value of _obj_.[[OriginalFlags]].")
