### PR TITLE
Editorial: Improve specification of [RegExp]IdentifierNames

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -16215,15 +16215,54 @@
         <emu-grammar>IdentifierStart :: `\` UnicodeEscapeSequence</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the SV of |UnicodeEscapeSequence| is not ! UTF16EncodeCodePoint(_cp_) for some Unicode code point _cp_ matched by the |IdentifierStartChar| lexical grammar production.
+            It is a Syntax Error if IdentifierCodePoint of |UnicodeEscapeSequence| is not some Unicode code point matched by the |IdentifierStartChar| lexical grammar production.
           </li>
         </ul>
         <emu-grammar>IdentifierPart :: `\` UnicodeEscapeSequence</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the SV of |UnicodeEscapeSequence| is not ! UTF16EncodeCodePoint(_cp_) for some Unicode code point _cp_ matched by the |IdentifierPartChar| lexical grammar production.
+            It is a Syntax Error if IdentifierCodePoint of |UnicodeEscapeSequence| is not some Unicode code point matched by the |IdentifierPartChar| lexical grammar production.
           </li>
         </ul>
+      </emu-clause>
+
+      <emu-clause id="sec-identifiercodepoints" type="sdo">
+        <h1>Static Semantics: IdentifierCodePoints</h1>
+        <dl class="header">
+        </dl>
+        <emu-grammar>IdentifierName :: IdentifierStart</emu-grammar>
+        <emu-alg>
+          1. Let _cp_ be IdentifierCodePoint of |IdentifierStart|.
+          1. Return &laquo; _cp_ &raquo;.
+        </emu-alg>
+        <emu-grammar>IdentifierName :: IdentifierName IdentifierPart</emu-grammar>
+        <emu-alg>
+          1. Let _cps_ be IdentifierCodePoints of the derived |IdentifierName|.
+          1. Let _cp_ be IdentifierCodePoint of |IdentifierPart|.
+          1. Return the list-concatenation of _cps_ and &laquo; _cp_ &raquo;.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-identifiercodepoint" type="sdo">
+        <h1>Static Semantics: IdentifierCodePoint</h1>
+        <dl class="header">
+        </dl>
+        <emu-grammar>IdentifierStart :: IdentifierStartChar</emu-grammar>
+        <emu-alg>
+          1. Return the code point matched by |IdentifierStartChar|.
+        </emu-alg>
+        <emu-grammar>IdentifierPart :: IdentifierPartChar</emu-grammar>
+        <emu-alg>
+          1. Return the code point matched by |IdentifierPartChar|.
+        </emu-alg>
+        <emu-grammar>UnicodeEscapeSequence :: `u` Hex4Digits</emu-grammar>
+        <emu-alg>
+          1. Return the code point whose numeric value is the MV of |Hex4Digits|.
+        </emu-alg>
+        <emu-grammar>UnicodeEscapeSequence :: `u{` CodePoint `}`</emu-grammar>
+        <emu-alg>
+          1. Return the code point whose numeric value is the MV of |CodePoint|.
+        </emu-alg>
       </emu-clause>
     </emu-clause>
 
@@ -17672,8 +17711,7 @@
           IdentifierName IdentifierPart
       </emu-grammar>
       <emu-alg>
-        1. Let _idText_ be the source text matched by |IdentifierName|.
-        1. Let _idTextUnescaped_ be the result of replacing any occurrences of `\\` |UnicodeEscapeSequence| in _idText_ with the code point represented by the |UnicodeEscapeSequence|.
+        1. Let _idTextUnescaped_ be IdentifierCodePoints of |IdentifierName|.
         1. Return ! CodePointsToString(_idTextUnescaped_).
       </emu-alg>
       <emu-grammar>
@@ -34415,7 +34453,7 @@ THH:mm:ss.sss
         <emu-grammar>RegExpIdentifierStart :: UnicodeLeadSurrogate UnicodeTrailSurrogate</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the result of performing UTF16SurrogatePairToCodePoint on the two code points matched by |UnicodeLeadSurrogate| and |UnicodeTrailSurrogate| respectively is not matched by the |UnicodeIDStart| lexical grammar production.
+            It is a Syntax Error if RegExpIdentifierCodePoint of |RegExpIdentifierStart| is not matched by the |UnicodeIDStart| lexical grammar production.
           </li>
         </ul>
         <emu-grammar>RegExpIdentifierPart :: `\` RegExpUnicodeEscapeSequence</emu-grammar>
@@ -34427,7 +34465,7 @@ THH:mm:ss.sss
         <emu-grammar>RegExpIdentifierPart :: UnicodeLeadSurrogate UnicodeTrailSurrogate</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the result of performing UTF16SurrogatePairToCodePoint on the two code points matched by |UnicodeLeadSurrogate| and |UnicodeTrailSurrogate| respectively is not matched by the |UnicodeIDContinue| lexical grammar production.
+            It is a Syntax Error if RegExpIdentifierCodePoint of |RegExpIdentifierPart| is not matched by the |UnicodeIDContinue| lexical grammar production.
           </li>
         </ul>
         <emu-grammar>UnicodePropertyValueExpression :: UnicodePropertyName `=` UnicodePropertyValue</emu-grammar>
@@ -34710,9 +34748,57 @@ THH:mm:ss.sss
             RegExpIdentifierName RegExpIdentifierPart
         </emu-grammar>
         <emu-alg>
-          1. Let _idText_ be the source text matched by |RegExpIdentifierName|.
-          1. Let _idTextUnescaped_ be the result of replacing any occurrences of `\\` |RegExpUnicodeEscapeSequence| in _idText_ with the code point represented by the |RegExpUnicodeEscapeSequence|.
+          1. Let _idTextUnescaped_ be RegExpIdentifierCodePoints of |RegExpIdentifierName|.
           1. Return ! CodePointsToString(_idTextUnescaped_).
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-regexpidentifiercodepoints" type="sdo">
+        <h1>Static Semantics: RegExpIdentifierCodePoints</h1>
+        <dl class="header">
+        </dl>
+        <emu-grammar>RegExpIdentifierName :: RegExpIdentifierStart</emu-grammar>
+        <emu-alg>
+          1. Let _cp_ be RegExpIdentifierCodePoint of |RegExpIdentifierStart|.
+          1. Return &laquo; _cp_ &raquo;.
+        </emu-alg>
+        <emu-grammar>RegExpIdentifierName :: RegExpIdentifierName RegExpIdentifierPart</emu-grammar>
+        <emu-alg>
+          1. Let _cps_ be RegExpIdentifierCodePoints of the derived |RegExpIdentifierName|.
+          1. Let _cp_ be RegExpIdentifierCodePoint of |RegExpIdentifierPart|.
+          1. Return the list-concatenation of _cps_ and &laquo; _cp_ &raquo;.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-regexpidentifiercodepoint" type="sdo">
+        <h1>Static Semantics: RegExpIdentifierCodePoint</h1>
+        <dl class="header">
+        </dl>
+        <emu-grammar>RegExpIdentifierStart :: IdentifierStartChar</emu-grammar>
+        <emu-alg>
+          1. Return the code point matched by |IdentifierStartChar|.
+        </emu-alg>
+        <emu-grammar>RegExpIdentifierPart :: IdentifierPartChar</emu-grammar>
+        <emu-alg>
+          1. Return the code point matched by |IdentifierPartChar|.
+        </emu-alg>
+        <emu-grammar>
+          RegExpIdentifierStart :: `\` RegExpUnicodeEscapeSequence
+
+          RegExpIdentifierPart :: `\` RegExpUnicodeEscapeSequence
+        </emu-grammar>
+        <emu-alg>
+          1. Return the code point whose numeric value is the CharacterValue of |RegExpUnicodeEscapeSequence|.
+        </emu-alg>
+        <emu-grammar>
+          RegExpIdentifierStart :: UnicodeLeadSurrogate UnicodeTrailSurrogate
+
+          RegExpIdentifierPart :: UnicodeLeadSurrogate UnicodeTrailSurrogate
+        </emu-grammar>
+        <emu-alg>
+          1. Let _lead_ be the code unit whose numeric value is that of the code point matched by |UnicodeLeadSurrogate|.
+          1. Let _trail_ be the code unit whose numeric value is that of the code point matched by |UnicodeTrailSurrogate|.
+          1. Return UTF16SurrogatePairToCodePoint(_lead_, _trail_).
         </emu-alg>
       </emu-clause>
     </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -16163,8 +16163,6 @@
     <emu-note>
       <p>This standard specifies specific code point additions: U+0024 (DOLLAR SIGN) and U+005F (LOW LINE) are permitted anywhere in an |IdentifierName|, and the code points U+200C (ZERO WIDTH NON-JOINER) and U+200D (ZERO WIDTH JOINER) are permitted anywhere after the first code point of an |IdentifierName|.</p>
     </emu-note>
-    <p>Unicode escape sequences are permitted in an |IdentifierName|, where they contribute a single Unicode code point to the |IdentifierName|. The code point is expressed by the |CodePoint| of the |UnicodeEscapeSequence| (see <emu-xref href="#sec-literals-string-literals"></emu-xref>). The `\\` preceding the |UnicodeEscapeSequence| and the `u` and `{ }` code units, if they appear, do not contribute code points to the |IdentifierName|. A |UnicodeEscapeSequence| cannot be used to put a code point into an |IdentifierName| that would otherwise be illegal. In other words, if a `\\` |UnicodeEscapeSequence| sequence were replaced by the |SourceCharacter| it contributes, the result must still be a valid |IdentifierName| that has the exact same sequence of |SourceCharacter| elements as the original |IdentifierName|. All interpretations of |IdentifierName| within this specification are based upon their actual code points regardless of whether or not an escape sequence was used to contribute any particular code point.</p>
-    <p>Two |IdentifierName|s that are canonically equivalent according to the Unicode standard are <em>not</em> equal unless, after replacement of each |UnicodeEscapeSequence|, they are represented by the exact same sequence of code points.</p>
     <h2>Syntax</h2>
     <emu-grammar type="definition">
       PrivateIdentifier ::
@@ -16209,6 +16207,8 @@
 
     <emu-clause id="sec-identifier-names">
       <h1>Identifier Names</h1>
+      <p>Unicode escape sequences are permitted in an |IdentifierName|, where they contribute a single Unicode code point to the |IdentifierName|. The code point is expressed by the |CodePoint| of the |UnicodeEscapeSequence| (see <emu-xref href="#sec-literals-string-literals"></emu-xref>). The `\\` preceding the |UnicodeEscapeSequence| and the `u` and `{ }` code units, if they appear, do not contribute code points to the |IdentifierName|. A |UnicodeEscapeSequence| cannot be used to put a code point into an |IdentifierName| that would otherwise be illegal. In other words, if a `\\` |UnicodeEscapeSequence| sequence were replaced by the |SourceCharacter| it contributes, the result must still be a valid |IdentifierName| that has the exact same sequence of |SourceCharacter| elements as the original |IdentifierName|. All interpretations of |IdentifierName| within this specification are based upon their actual code points regardless of whether or not an escape sequence was used to contribute any particular code point.</p>
+      <p>Two |IdentifierName|s that are canonically equivalent according to the Unicode standard are <em>not</em> equal unless, after replacement of each |UnicodeEscapeSequence|, they are represented by the exact same sequence of code points.</p>
 
       <emu-clause id="sec-identifier-names-static-semantics-early-errors">
         <h1>Static Semantics: Early Errors</h1>

--- a/spec.html
+++ b/spec.html
@@ -16175,15 +16175,21 @@
         IdentifierName IdentifierPart
 
       IdentifierStart ::
-        UnicodeIDStart
-        `$`
-        `_`
+        IdentifierStartChar
         `\` UnicodeEscapeSequence
 
       IdentifierPart ::
+        IdentifierPartChar
+        `\` UnicodeEscapeSequence
+
+      IdentifierStartChar ::
+        UnicodeIDStart
+        `$`
+        `_`
+
+      IdentifierPartChar ::
         UnicodeIDContinue
         `$`
-        `\` UnicodeEscapeSequence
         &lt;ZWNJ&gt;
         &lt;ZWJ&gt;
 
@@ -16209,13 +16215,13 @@
         <emu-grammar>IdentifierStart :: `\` UnicodeEscapeSequence</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the SV of |UnicodeEscapeSequence| is none of *"$"*, or *"_"*, or ! UTF16EncodeCodePoint(_cp_) for some Unicode code point _cp_ matched by the |UnicodeIDStart| lexical grammar production.
+            It is a Syntax Error if the SV of |UnicodeEscapeSequence| is not ! UTF16EncodeCodePoint(_cp_) for some Unicode code point _cp_ matched by the |IdentifierStartChar| lexical grammar production.
           </li>
         </ul>
         <emu-grammar>IdentifierPart :: `\` UnicodeEscapeSequence</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the SV of |UnicodeEscapeSequence| is none of *"$"*, *"_"*, ! UTF16EncodeCodePoint(&lt;ZWNJ&gt;), ! UTF16EncodeCodePoint(&lt;ZWJ&gt;), or ! UTF16EncodeCodePoint(_cp_) for some Unicode code point _cp_ that would be matched by the |UnicodeIDContinue| lexical grammar production.
+            It is a Syntax Error if the SV of |UnicodeEscapeSequence| is not ! UTF16EncodeCodePoint(_cp_) for some Unicode code point _cp_ matched by the |IdentifierPartChar| lexical grammar production.
           </li>
         </ul>
       </emu-clause>
@@ -17057,21 +17063,11 @@
 
         RegularExpressionFlags ::
           [empty]
-          RegularExpressionFlags IdentifierPart
+          RegularExpressionFlags IdentifierPartChar
       </emu-grammar>
       <emu-note>
         <p>Regular expression literals may not be empty; instead of representing an empty regular expression literal, the code unit sequence `//` starts a single-line comment. To specify an empty regular expression, use: `/(?:)/`.</p>
       </emu-note>
-
-      <emu-clause id="sec-literals-regular-expression-literals-static-semantics-early-errors">
-        <h1>Static Semantics: Early Errors</h1>
-        <emu-grammar>RegularExpressionFlags :: RegularExpressionFlags IdentifierPart</emu-grammar>
-        <ul>
-          <li>
-            It is a Syntax Error if |IdentifierPart| contains a Unicode escape sequence.
-          </li>
-        </ul>
-      </emu-clause>
 
       <emu-clause id="sec-static-semantics-bodytext" type="sdo">
         <h1>Static Semantics: BodyText</h1>
@@ -34244,19 +34240,14 @@ THH:mm:ss.sss
           RegExpIdentifierName[?UnicodeMode] RegExpIdentifierPart[?UnicodeMode]
 
         RegExpIdentifierStart[UnicodeMode] ::
-          UnicodeIDStart
-          `$`
-          `_`
+          IdentifierStartChar
           `\` RegExpUnicodeEscapeSequence[+UnicodeMode]
           [~UnicodeMode] UnicodeLeadSurrogate UnicodeTrailSurrogate
 
         RegExpIdentifierPart[UnicodeMode] ::
-          UnicodeIDContinue
-          `$`
+          IdentifierPartChar
           `\` RegExpUnicodeEscapeSequence[+UnicodeMode]
           [~UnicodeMode] UnicodeLeadSurrogate UnicodeTrailSurrogate
-          &lt;ZWNJ&gt;
-          &lt;ZWJ&gt;
 
         RegExpUnicodeEscapeSequence[UnicodeMode] ::
           [+UnicodeMode] `u` HexLeadSurrogate `\u` HexTrailSurrogate
@@ -34418,7 +34409,7 @@ THH:mm:ss.sss
         <emu-grammar>RegExpIdentifierStart :: `\` RegExpUnicodeEscapeSequence</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the CharacterValue of |RegExpUnicodeEscapeSequence| is not the code point value of *"$"*, *"_"*, or some code point matched by the |UnicodeIDStart| lexical grammar production.
+            It is a Syntax Error if the CharacterValue of |RegExpUnicodeEscapeSequence| is not the code point value of some code point matched by the |IdentifierStartChar| lexical grammar production.
           </li>
         </ul>
         <emu-grammar>RegExpIdentifierStart :: UnicodeLeadSurrogate UnicodeTrailSurrogate</emu-grammar>
@@ -34430,7 +34421,7 @@ THH:mm:ss.sss
         <emu-grammar>RegExpIdentifierPart :: `\` RegExpUnicodeEscapeSequence</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the CharacterValue of |RegExpUnicodeEscapeSequence| is not the code point value of *"$"*, *"_"*, &lt;ZWNJ&gt;, &lt;ZWJ&gt;, or some code point matched by the |UnicodeIDContinue| lexical grammar production.
+            It is a Syntax Error if the CharacterValue of |RegExpUnicodeEscapeSequence| is not the code point value of some code point matched by the |IdentifierPartChar| lexical grammar production.
           </li>
         </ul>
         <emu-grammar>RegExpIdentifierPart :: UnicodeLeadSurrogate UnicodeTrailSurrogate</emu-grammar>
@@ -46020,6 +46011,8 @@ THH:mm:ss.sss
     <emu-prodref name="IdentifierName"></emu-prodref>
     <emu-prodref name="IdentifierStart"></emu-prodref>
     <emu-prodref name="IdentifierPart"></emu-prodref>
+    <emu-prodref name="IdentifierStartChar"></emu-prodref>
+    <emu-prodref name="IdentifierPartChar"></emu-prodref>
     <emu-prodref name="UnicodeIDStart"></emu-prodref>
     <emu-prodref name="UnicodeIDContinue"></emu-prodref>
     <emu-prodref name="ReservedWord"></emu-prodref>


### PR DESCRIPTION
Currently, the algorithm for `StringValue` of _IdentifierName_ has the step:
```
Let _idTextUnescaped_ be the result of
  replacing any occurrences of `\\` |UnicodeEscapeSequence| in _idText_
  with the code point represented by the |UnicodeEscapeSequence|.
```
(And the algorithm for `CapturingGroupName` of _RegExpIdentifierName_ has something quite similar.)

In https://github.com/tc39/ecma262/pull/1552#discussion_r338854947, @michaelficarra said of this step:
> This language is a little less precise than I would prefer. Could we define a syntax-directed operation [to specify "the code point represented by the |UnicodeEscapeSequence|"]

This PR does so.

The first commit refactors the grammar slightly, and the second introduces 4 SDOs.  The first makes the second easier, but it also has benefits of its own. I think they're easier to understand as separate commits.

The third commit just moves some pre-existing prose. The connection between the prose and the Early Error rules + SDOs could maybe be improved, but that wasn't my focus. 

<strike>Note that the second commit uses `list-concatenation` in two spots, so if PR #2382 isn't accepted, I'll have to do something else there.</strike>

