### PR TITLE
Normative: Make SharedArrayBuffer's sole parameter required

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -36412,8 +36412,8 @@ THH:mm:ss.sss
       </emu-note>
 
       <emu-clause id="sec-sharedarraybuffer-length">
-        <h1>SharedArrayBuffer ( [ _length_ ] )</h1>
-        <p>When the `SharedArrayBuffer` function is called with optional argument _length_, the following steps are taken:</p>
+        <h1>SharedArrayBuffer ( _length_ )</h1>
+        <p>When the `SharedArrayBuffer` function is called with argument _length_, the following steps are taken:</p>
         <emu-alg>
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
           1. Let _byteLength_ be ? ToIndex(_length_).


### PR DESCRIPTION
SharedArrayBuffer.length is 1 on all web engines (as is
ArrayBuffer.length). Unsure why this was made optional.

eshost output for `print(SharedArrayBuffer.length)`:

```
#### jsc
1

#### sm
1

#### v8
1

#### xs
1
```

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
