### PR TITLE
Editorial: have CreateIteratorFromClosure provide a new execution context to GeneratorStart

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -39816,7 +39816,15 @@ THH:mm:ss.sss
           1. Let _generator_ be ! OrdinaryObjectCreate(_generatorPrototype_, _internalSlotsList_).
           1. Set _generator_.[[GeneratorBrand]] to _generatorBrand_.
           1. Set _generator_.[[GeneratorState]] to *undefined*.
+          1. Let _callerContext_ be the running execution context.
+          1. Let _calleeContext_ be a new execution context.
+          1. Set the Function of _calleeContext_ to *null*.
+          1. Set the Realm of _calleeContext_ to the current Realm Record.
+          1. Set the ScriptOrModule of _calleeContext_ to _callerContext_'s ScriptOrModule.
+          1. If _callerContext_ is not already suspended, suspend _callerContext_.
+          1. Push _calleeContext_ onto the execution context stack; _calleeContext_ is now the running execution context.
           1. Perform ! GeneratorStart(_generator_, _closure_).
+          1. Remove _calleeContext_ from the execution context stack and restore _callerContext_ as the running execution context.
           1. Return _generator_.
         </emu-alg>
       </emu-clause>
@@ -40115,7 +40123,15 @@ THH:mm:ss.sss
           1. Let _generator_ be ! OrdinaryObjectCreate(_generatorPrototype_, _internalSlotsList_).
           1. Set _generator_.[[GeneratorBrand]] to _generatorBrand_.
           1. Set _generator_.[[AsyncGeneratorState]] to *undefined*.
+          1. Let _callerContext_ be the running execution context.
+          1. Let _calleeContext_ be a new execution context.
+          1. Set the Function of _calleeContext_ to *null*.
+          1. Set the Realm of _calleeContext_ to the current Realm Record.
+          1. Set the ScriptOrModule of _calleeContext_ to _callerContext_'s ScriptOrModule.
+          1. If _callerContext_ is not already suspended, suspend _callerContext_.
+          1. Push _calleeContext_ onto the execution context stack; _calleeContext_ is now the running execution context.
           1. Perform ! AsyncGeneratorStart(_generator_, _closure_).
+          1. Remove _calleeContext_ from the execution context stack and restore _callerContext_ as the running execution context.
           1. Return _generator_.
         </emu-alg>
       </emu-clause>


### PR DESCRIPTION
See more complete discussion in https://es.discourse.group/t/execution-context-suspension-and-resumption/756. I'll summarize:

[GeneratorStart](https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-generatorstart) manipulates the code evaluation state of the running execution context, and also stores that context on the generator object. Prior to https://github.com/tc39/ecma262/pull/2045, the sole caller of GeneratorStart was in [EvaluateGeneratorBody](https://tc39.es/ecma262/multipage/#sec-runtime-semantics-evaluategeneratorbody) (although it wasn't called that at the time). So, in particular, GeneratorStart was only invoked in step 7 of [[[Call]] for ordinary functions](https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-ecmascript-function-objects-call-thisargument-argumentslist), at which time the running execution context would have been one created specifically for the evaluation of the generator in step 3 of [[Call]] - that is, the execution state being manipulated and stored would have been created specifically for the generator. And it would be removed from the execution context stack immediately after the call to GeneratorStart (in step 8 of [[Call]]) (and so implicitly suspended), so it makes sense to be describing what should happen after resumption at this point.

But https://github.com/tc39/ecma262/pull/2045 introduced a new callsite for GeneratorStart, [CreateIteratorFromClosure](https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-createiteratorfromclosure). Here the execution context is not created for the "generator"; it's just whatever happens to be running at the time. This doesn't really make sense - you don't want to be manipulating the execution state of the caller of CreateIteratorFromClosure!

The fix, I believe, is to have CreateIteratorFromClosure create a push a new context before calling GeneratorStart, and pop it after. That way it can "belong" to the synthetic generator it's creating. That is what this PR does.

---

Note to self: this needs to address CreateAsyncIteratorFromClosure in the same way.