### PR TITLE
Editorial: Explicitly define ambiguous namespace properties as undefined

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -12039,6 +12039,8 @@
           1. Assert: _targetModule_ is not *undefined*.
           1. If _binding_.[[BindingName]] is *"\*namespace\*"*, then
             1. Return ? GetModuleNamespace(_targetModule_).
+          1. If _binding_.[[BindingName]] is *"\*ambiguous\*"*, then
+            1. Return *undefined*.
           1. Let _targetEnv_ be _targetModule_.[[Environment]].
           1. If _targetEnv_ is *undefined*, throw a *ReferenceError* exception.
           1. Return ? _targetEnv_.GetBindingValue(_binding_.[[BindingName]], *true*).


### PR DESCRIPTION
This ensures that the spec is explicit about ambiguous bindings on module namespaces that have not otherwise been imported in a way that would throw an error will always be `undefined` on the namespace, effectively skipping the unnecessary call to `_targetEnv_.getBindingValue`.

See issue https://github.com/tc39/ecma262/issues/2399 for the exact details and scenario to which this applies.