### PR TITLE
Editorial: add missing constructor property of the global object

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -28642,6 +28642,11 @@
   <emu-clause id="sec-constructor-properties-of-the-global-object">
     <h1>Constructor Properties of the Global Object</h1>
 
+    <emu-clause id="sec-constructor-properties-of-the-global-object-aggregate-error">
+      <h1>AggregateError ( . . . )</h1>
+      <p>See <emu-xref href="#sec-aggregate-error-constructor"></emu-xref>.</p>
+    </emu-clause>
+
     <emu-clause id="sec-constructor-properties-of-the-global-object-array">
       <h1>Array ( . . . )</h1>
       <p>See <emu-xref href="#sec-array-constructor"></emu-xref>.</p>


### PR DESCRIPTION
`AggregateError` is not listed in section 19.3, while it is specd as available on the global object in section 20.5.7.1.
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
