### PR TITLE
Editorial: `meta` should be listed alongside `target`

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -13870,7 +13870,7 @@
           <p>Those that are contextually disallowed as identifiers, in strict mode code: `let`, `static`, `implements`, `interface`, `package`, `private`, `protected`, and `public`;</p>
         </li>
         <li>
-          <p>Those that are always allowed as identifiers, but also appear as keywords within certain syntactic productions, at places where |Identifier| is not allowed: `as`, `async`, `from`, `get`, `of`, `set`, and `target`.</p>
+          <p>Those that are always allowed as identifiers, but also appear as keywords within certain syntactic productions, at places where |Identifier| is not allowed: `as`, `async`, `from`, `get`, `meta`, `of`, `set`, and `target`.</p>
         </li>
       </ul>
       <p>The term <dfn>conditional keyword</dfn>, or <dfn>contextual keyword</dfn>, is sometimes used to refer to the keywords that fall in the last three categories, and thus can be used as identifiers in some contexts and as keywords in others.</p>


### PR DESCRIPTION
Fixes #2298 