### PR TITLE
[Normative] Add RegExp `v` flag with set notation and properties of strings

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -31965,6 +31965,8 @@ THH:mm:ss.sss
           1. If _dotAll_ is *true*, append the code unit 0x0073 (LATIN SMALL LETTER S) as the last code unit of _result_.
           1. Let _unicode_ be ! ToBoolean(? Get(_R_, *"unicode"*)).
           1. If _unicode_ is *true*, append the code unit 0x0075 (LATIN SMALL LETTER U) as the last code unit of _result_.
+          1. Let _unicodeSet_ be ! ToBoolean(? Get(_R_, *"unicodeSet"*)).
+          1. If _unicodeSet_ is *true*, append the code unit 0x0076 (LATIN SMALL LETTER V) as the last code unit of _result_.
           1. Let _sticky_ be ! ToBoolean(? Get(_R_, *"sticky"*)).
           1. If _sticky_ is *true*, append the code unit 0x0079 (LATIN SMALL LETTER Y) as the last code unit of _result_.
           1. Return _result_.


### PR DESCRIPTION
Proposal repo: https://github.com/tc39/proposal-regexp-set-notation

**Note:** This is a placeholder PR that allows us to set up a preview link for the spec changes in the future. For now we’ll continue to iterate on the draft spec in [the Google doc](https://docs.google.com/document/d/1Tbv3hfX9CxQtzH9r-JdxJsQZhmmDsidRUKKxg345JV0/edit).