### PR TITLE
Editorial: fix note about var decls in eval in parameter initializers

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -11587,9 +11587,6 @@
       <emu-note>
         <p><emu-xref href="#sec-block-level-function-declarations-web-legacy-compatibility-semantics"></emu-xref> provides an extension to the above algorithm that is necessary for backwards compatibility with web browser implementations of ECMAScript that predate ECMAScript 2015.</p>
       </emu-note>
-      <emu-note>
-        <p>Parameter |Initializer|s may contain direct eval expressions. Any top level declarations of such evals are only visible to the eval code (<emu-xref href="#sec-types-of-source-code"></emu-xref>). The creation of the environment for such declarations is described in <emu-xref href="#sec-runtime-semantics-iteratorbindinginitialization"></emu-xref>.</p>
-      </emu-note>
     </emu-clause>
   </emu-clause>
 
@@ -24619,7 +24616,7 @@
           1. Return Completion(_result_).
         </emu-alg>
         <emu-note>
-          <p>The eval code cannot instantiate variable or function bindings in the variable environment of the calling context that invoked the eval if the calling context is evaluating formal parameter initializers or if either the code of the calling context or the eval code is strict mode code. Instead such bindings are instantiated in a new VariableEnvironment that is only accessible to the eval code. Bindings introduced by `let`, `const`, or `class` declarations are always instantiated in a new LexicalEnvironment.</p>
+          <p>The eval code cannot instantiate variable or function bindings in the variable environment of the calling context that invoked the eval if either the code of the calling context or the eval code is strict mode code. Instead such bindings are instantiated in a new VariableEnvironment that is only accessible to the eval code. Bindings introduced by `let`, `const`, or `class` declarations are always instantiated in a new LexicalEnvironment.</p>
         </emu-note>
       </emu-clause>
 


### PR DESCRIPTION
As pointed out [here](https://stackoverflow.com/questions/67855714/eval-declaration-instantiation-when-calling-context-is-evaluating-formal-param), this note in `PerformEval` no longer reflects the specified behavior, which changed in #1046.