### PR TITLE
Normative: restrict abstract op. completion type

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -24623,7 +24623,7 @@
       <emu-clause id="sec-hostensurecancompilestrings" aoid="HostEnsureCanCompileStrings">
         <h1>HostEnsureCanCompileStrings ( _callerRealm_, _calleeRealm_ )</h1>
         <p>The host-defined abstract operation HostEnsureCanCompileStrings takes arguments _callerRealm_ (a Realm Record) and _calleeRealm_ (a Realm Record). It allows host environments to block certain ECMAScript functions which allow developers to compile strings into ECMAScript code.</p>
-        <p>An implementation of HostEnsureCanCompileStrings may complete normally or abruptly. Any abrupt completions will be propagated to its callers. The default implementation of HostEnsureCanCompileStrings is to unconditionally return an empty normal completion.</p>
+        <p>An implementation of HostEnsureCanCompileStrings may return a normal completion or an abrupt throw completion. Any throw completions will be propagated to its callers. The default implementation of HostEnsureCanCompileStrings is to unconditionally return an empty normal completion.</p>
       </emu-clause>
 
       <emu-clause id="sec-evaldeclarationinstantiation" aoid="EvalDeclarationInstantiation">


### PR DESCRIPTION
Specify two acceptable completion types for implementations of
HostEnsureCanCompileStrings.

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
