### PR TITLE
Normative: allow named backreferences without `u` flag in core grammar

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -36289,13 +36289,14 @@ THH:mm:ss.sss
         </h1>
         <dl class="header">
         </dl>
+        <emu-note>
+          <p>This section is amended in <emu-xref href="#sec-parsepattern-annexb"></emu-xref>.</p>
+        </emu-note>
         <emu-alg>
           1. If _u_ is *true*, then
             1. Let _parseResult_ be ParseText(_patternText_, |Pattern[+UnicodeMode, +N]|).
           1. Else,
-            1. Let _parseResult_ be ParseText(_patternText_, |Pattern[~UnicodeMode, ~N]|).
-            1. If _parseResult_ is a Parse Node and _parseResult_ contains a |GroupName|, then
-              1. Set _parseResult_ to ParseText(_patternText_, |Pattern[~UnicodeMode, +N]|).
+            1. Let _parseResult_ be ParseText(_patternText_, |Pattern[~U, +N]|).
           1. Return _parseResult_.
         </emu-alg>
       </emu-clause>
@@ -47633,6 +47634,21 @@ THH:mm:ss.sss
             1. Return CharacterRange(_A_, _B_).
           </emu-alg>
         </emu-annex>
+      </emu-annex>
+
+      <emu-annex id="sec-parsepattern-annexb">
+        <h1>Static Semantics: ParsePattern ( _patternText_, _u_ )</h1>
+        <p>The semantics of <emu-xref href="#sec-parsepattern"></emu-xref> is extended as follows:</p>
+        <p>The abstract operation ParsePattern takes arguments _patternText_ (a sequence of Unicode code points) and _u_ (a Boolean). It performs the following steps when called:</p>
+        <emu-alg>
+          1. If _u_ is *true*, then
+            1. Let _parseResult_ be ParseText(_patternText_, |Pattern[+U, +N]|).
+          1. Else,
+            1. Let _parseResult_ be ParseText(_patternText_, |Pattern[~U, ~N]|).
+            1. If _parseResult_ is a Parse Node and _parseResult_ contains a |GroupName|, then
+              1. Set _parseResult_ to ParseText(_patternText_, |Pattern[~U, +N]|).
+          1. Return _parseResult_.
+        </emu-alg>
       </emu-annex>
     </emu-annex>
   </emu-annex>


### PR DESCRIPTION
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->

This PR fixes #2434.

In the core grammar, named backreferences have been syntax errors if no `u` flag. For example, `/(?<foo>A)\k<foo>/` is a syntax error unless using Annex B.

This PR fixes that by moving two passes parsing to Annex B.

> https://arai-a.github.io/ecma262-compare/?pr=2436&collapsed=1