### PR TITLE
Editorial: use abstract closures for anonymous functions in more places

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -38339,17 +38339,6 @@ THH:mm:ss.sss
             1. Return ! AsyncFromSyncIteratorContinuation(_result_, _promiseCapability_).
           </emu-alg>
         </emu-clause>
-
-        <emu-clause id="sec-async-from-sync-iterator-value-unwrap-functions">
-          <h1>Async-from-Sync Iterator Value Unwrap Functions</h1>
-          <p>An async-from-sync iterator value unwrap function is an anonymous built-in function that is used by AsyncFromSyncIteratorContinuation when processing the *"value"* property of an <i>IteratorResult</i> object, in order to wait for its value if it is a promise and re-package the result in a new "unwrapped" <i>IteratorResult</i> object. Each async-from-sync iterator value unwrap function has a [[Done]] internal slot.</p>
-          <p>When an async-from-sync iterator value unwrap function is called with argument _value_, the following steps are taken:</p>
-
-          <emu-alg>
-            1. Let _F_ be the active function object.
-            1. Return ! CreateIterResultObject(_value_, _F_.[[Done]]).
-          </emu-alg>
-        </emu-clause>
       </emu-clause>
 
       <emu-clause id="sec-properties-of-async-from-sync-iterator-instances">
@@ -38381,7 +38370,7 @@ THH:mm:ss.sss
         </emu-table>
       </emu-clause>
 
-      <emu-clause id="sec-asyncfromsynciteratorcontinuation" aoid="AsyncFromSyncIteratorContinuation">
+      <emu-clause id="sec-asyncfromsynciteratorcontinuation" oldids="sec-async-from-sync-iterator-value-unwrap-functions" aoid="AsyncFromSyncIteratorContinuation">
         <h1>AsyncFromSyncIteratorContinuation ( _result_, _promiseCapability_ )</h1>
         <p>The abstract operation AsyncFromSyncIteratorContinuation takes arguments _result_ and _promiseCapability_ (a PromiseCapability Record). It performs the following steps when called:</p>
 
@@ -38392,10 +38381,10 @@ THH:mm:ss.sss
           1. IfAbruptRejectPromise(_value_, _promiseCapability_).
           1. Let _valueWrapper_ be PromiseResolve(%Promise%, _value_).
           1. IfAbruptRejectPromise(_valueWrapper_, _promiseCapability_).
-          1. Let _steps_ be the algorithm steps defined in <emu-xref href="#sec-async-from-sync-iterator-value-unwrap-functions" title></emu-xref>.
-          1. Let _length_ be the number of non-optional parameters of the function definition in <emu-xref href="#sec-async-from-sync-iterator-value-unwrap-functions" title></emu-xref>.
-          1. Let _onFulfilled_ be ! CreateBuiltinFunction(_steps_, _length_, *""*, &laquo; [[Done]] &raquo;).
-          1. Set _onFulfilled_.[[Done]] to _done_.
+          1. Let _unwrap_ be a new Abstract Closure with parameters (_value_) that captures _done_ and performs the following steps when called:
+            1. Return ! CreateIterResultObject(_value_, _done_).
+          1. Let _onFulfilled_ be ! CreateBuiltinFunction(_unwrap_, 1, *""*, &laquo; &raquo;).
+          1. NOTE: _onFulfilled_ is used when processing the *"value"* property of an IteratorResult object in order to wait for its value if it is a promise and re-package the result in a new "unwrapped" IteratorResult object.
           1. Perform ! PerformPromiseThen(_valueWrapper_, _onFulfilled_, *undefined*, _promiseCapability_).
           1. Return _promiseCapability_.[[Promise]].
         </emu-alg>

--- a/spec.html
+++ b/spec.html
@@ -38619,17 +38619,20 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-newpromisecapability" aoid="NewPromiseCapability">
+      <emu-clause id="sec-newpromisecapability" oldids="sec-getcapabilitiesexecutor-functions" aoid="NewPromiseCapability">
         <h1>NewPromiseCapability ( _C_ )</h1>
         <p>The abstract operation NewPromiseCapability takes argument _C_. It attempts to use _C_ as a constructor in the fashion of the built-in Promise constructor to create a Promise object and extract its `resolve` and `reject` functions. The Promise object plus the `resolve` and `reject` functions are used to initialize a new PromiseCapability Record. It performs the following steps when called:</p>
         <emu-alg>
           1. If IsConstructor(_C_) is *false*, throw a *TypeError* exception.
           1. NOTE: _C_ is assumed to be a constructor function that supports the parameter conventions of the Promise constructor (see <emu-xref href="#sec-promise-executor"></emu-xref>).
           1. Let _promiseCapability_ be the PromiseCapability Record { [[Promise]]: *undefined*, [[Resolve]]: *undefined*, [[Reject]]: *undefined* }.
-          1. Let _steps_ be the algorithm steps defined in <emu-xref href="#sec-getcapabilitiesexecutor-functions" title></emu-xref>.
-          1. Let _length_ be the number of non-optional parameters of the function definition in <emu-xref href="#sec-getcapabilitiesexecutor-functions" title></emu-xref>.
-          1. Let _executor_ be ! CreateBuiltinFunction(_steps_, _length_, *""*, &laquo; [[Capability]] &raquo;).
-          1. Set _executor_.[[Capability]] to _promiseCapability_.
+          1. Let _executorClosure_ be a new Abstract Closure with parameters (_resolve_, _reject_) that captures _promiseCapability_ and performs the following steps when called:
+            1. If _promiseCapability_.[[Resolve]] is not *undefined*, throw a *TypeError* exception.
+            1. If _promiseCapability_.[[Reject]] is not *undefined*, throw a *TypeError* exception.
+            1. Set _promiseCapability_.[[Resolve]] to _resolve_.
+            1. Set _promiseCapability_.[[Reject]] to _reject_.
+            1. Return *undefined*.
+          1. Let _executor_ be ! CreateBuiltinFunction(_executorClosure_, 2, *""*, &laquo; &raquo;).
           1. Let _promise_ be ? Construct(_C_, &laquo; _executor_ &raquo;).
           1. If IsCallable(_promiseCapability_.[[Resolve]]) is *false*, throw a *TypeError* exception.
           1. If IsCallable(_promiseCapability_.[[Reject]]) is *false*, throw a *TypeError* exception.
@@ -38639,23 +38642,6 @@ THH:mm:ss.sss
         <emu-note>
           <p>This abstract operation supports Promise subclassing, as it is generic on any constructor that calls a passed executor function argument in the same way as the Promise constructor. It is used to generalize static methods of the Promise constructor to any subclass.</p>
         </emu-note>
-
-        <emu-clause id="sec-getcapabilitiesexecutor-functions">
-          <h1>GetCapabilitiesExecutor Functions</h1>
-          <p>A GetCapabilitiesExecutor function is an anonymous built-in function that has a [[Capability]] internal slot.</p>
-          <p>When a GetCapabilitiesExecutor function is called with arguments _resolve_ and _reject_, the following steps are taken:</p>
-          <emu-alg>
-            1. Let _F_ be the active function object.
-            1. Assert: _F_ has a [[Capability]] internal slot whose value is a PromiseCapability Record.
-            1. Let _promiseCapability_ be _F_.[[Capability]].
-            1. If _promiseCapability_.[[Resolve]] is not *undefined*, throw a *TypeError* exception.
-            1. If _promiseCapability_.[[Reject]] is not *undefined*, throw a *TypeError* exception.
-            1. Set _promiseCapability_.[[Resolve]] to _resolve_.
-            1. Set _promiseCapability_.[[Reject]] to _reject_.
-            1. Return *undefined*.
-          </emu-alg>
-          <p>The *"length"* property of a GetCapabilitiesExecutor function is *2*<sub>𝔽</sub>.</p>
-        </emu-clause>
       </emu-clause>
 
       <emu-clause id="sec-ispromise" aoid="IsPromise">

--- a/spec.html
+++ b/spec.html
@@ -39234,7 +39234,7 @@ THH:mm:ss.sss
         <p>The initial value of `Promise.prototype.constructor` is %Promise%.</p>
       </emu-clause>
 
-      <emu-clause id="sec-promise.prototype.finally">
+      <emu-clause id="sec-promise.prototype.finally" oldids="sec-thenfinallyfunctions,sec-catchfinallyfunctions">
         <h1>Promise.prototype.finally ( _onFinally_ )</h1>
         <p>When the `finally` method is called with argument _onFinally_, the following steps are taken:</p>
         <emu-alg>
@@ -39246,54 +39246,24 @@ THH:mm:ss.sss
             1. Let _thenFinally_ be _onFinally_.
             1. Let _catchFinally_ be _onFinally_.
           1. Else,
-            1. Let _stepsThenFinally_ be the algorithm steps defined in <emu-xref href="#sec-thenfinallyfunctions" title></emu-xref>.
-            1. Let _lengthThenFinally_ be the number of non-optional parameters of the function definition in <emu-xref href="#sec-thenfinallyfunctions" title></emu-xref>.
-            1. Let _thenFinally_ be ! CreateBuiltinFunction(_stepsThenFinally_, _lengthThenFinally_, *""*, &laquo; [[Constructor]], [[OnFinally]] &raquo;).
-            1. Set _thenFinally_.[[Constructor]] to _C_.
-            1. Set _thenFinally_.[[OnFinally]] to _onFinally_.
-            1. Let _stepsCatchFinally_ be the algorithm steps defined in <emu-xref href="#sec-catchfinallyfunctions" title></emu-xref>.
-            1. Let _lengthCatchFinally_ be the number of non-optional parameters of the function definition in <emu-xref href="#sec-catchfinallyfunctions" title></emu-xref>.
-            1. Let _catchFinally_ be ! CreateBuiltinFunction(_stepsCatchFinally_, _lengthCatchFinally_, *""*, &laquo; [[Constructor]], [[OnFinally]] &raquo;).
-            1. Set _catchFinally_.[[Constructor]] to _C_.
-            1. Set _catchFinally_.[[OnFinally]] to _onFinally_.
+            1. Let _thenFinallyClosure_ be a new Abstract Closure with parameters (_value_) that captures _onFinally_ and _C_ and performs the following steps when called:
+              1. Let _result_ be ? Call(_onFinally_, *undefined*).
+              1. Let _promise_ be ? PromiseResolve(_C_, _result_).
+              1. Let _returnValue_ be a new Abstract Closure with no parameters that captures _value_ and performs the following steps when called:
+                1. Return _value_.
+              1. Let _valueThunk_ be ! CreateBuiltinFunction(_returnValue_, 0, *""*, &laquo; &raquo;).
+              1. Return ? Invoke(_promise_, *"then"*, &laquo; _valueThunk_ &raquo;).
+            1. Let _thenFinally_ be ! CreateBuiltinFunction(_thenFinallyClosure_, 1, *""*, &laquo; &raquo;).
+            1. Let _catchFinallyClosure_ be a new Abstract Closure with parameters (_reason_) that captures _onFinally_ and _C_ and performs the following steps when called:
+              1. Let _result_ be ? Call(_onFinally_, *undefined*).
+              1. Let _promise_ be ? PromiseResolve(_C_, _result_).
+              1. Let _throwReason_ be a new Abstract Closure with no parameters that captures _reason_ and performs the following steps when called:
+                1. Return ThrowCompletion(_reason_).
+              1. Let _thrower_ be ! CreateBuiltinFunction(_throwReason_, 0, *""*, &laquo; &raquo;).
+              1. Return ? Invoke(_promise_, *"then"*, &laquo; _thrower_ &raquo;).
+            1. Let _catchFinally_ be ! CreateBuiltinFunction(_catchFinallyClosure_, 1, *""*, &laquo; &raquo;).
           1. Return ? Invoke(_promise_, *"then"*, &laquo; _thenFinally_, _catchFinally_ &raquo;).
         </emu-alg>
-
-        <emu-clause id="sec-thenfinallyfunctions">
-          <h1>Then Finally Functions</h1>
-          <p>A Then Finally function is an anonymous built-in function that has a [[Constructor]] and an [[OnFinally]] internal slot. The value of the [[Constructor]] internal slot is a `Promise`-like constructor function object, and the value of the [[OnFinally]] internal slot is a function object.</p>
-          <p>When a Then Finally function is called with argument _value_, the following steps are taken:</p>
-          <emu-alg>
-            1. Let _F_ be the active function object.
-            1. Let _onFinally_ be _F_.[[OnFinally]].
-            1. Assert: IsCallable(_onFinally_) is *true*.
-            1. Let _result_ be ? Call(_onFinally_, *undefined*).
-            1. Let _C_ be _F_.[[Constructor]].
-            1. Assert: IsConstructor(_C_) is *true*.
-            1. Let _promise_ be ? PromiseResolve(_C_, _result_).
-            1. Let _valueThunk_ be equivalent to a function that returns _value_.
-            1. Return ? Invoke(_promise_, *"then"*, &laquo; _valueThunk_ &raquo;).
-          </emu-alg>
-          <p>The *"length"* property of a Then Finally function is *1*<sub>𝔽</sub>.</p>
-        </emu-clause>
-
-        <emu-clause id="sec-catchfinallyfunctions">
-          <h1>Catch Finally Functions</h1>
-          <p>A Catch Finally function is an anonymous built-in function that has a [[Constructor]] and an [[OnFinally]] internal slot. The value of the [[Constructor]] internal slot is a `Promise`-like constructor function object, and the value of the [[OnFinally]] internal slot is a function object.</p>
-          <p>When a Catch Finally function is called with argument _reason_, the following steps are taken:</p>
-          <emu-alg>
-            1. Let _F_ be the active function object.
-            1. Let _onFinally_ be _F_.[[OnFinally]].
-            1. Assert: IsCallable(_onFinally_) is *true*.
-            1. Let _result_ be ? Call(_onFinally_, *undefined*).
-            1. Let _C_ be _F_.[[Constructor]].
-            1. Assert: IsConstructor(_C_) is *true*.
-            1. Let _promise_ be ? PromiseResolve(_C_, _result_).
-            1. Let _thrower_ be equivalent to a function that throws _reason_.
-            1. Return ? Invoke(_promise_, *"then"*, &laquo; _thrower_ &raquo;).
-          </emu-alg>
-          <p>The *"length"* property of a Catch Finally function is *1*<sub>𝔽</sub>.</p>
-        </emu-clause>
       </emu-clause>
 
       <emu-clause id="sec-promise.prototype.then">

--- a/spec.html
+++ b/spec.html
@@ -12108,46 +12108,24 @@
           <h1>MakeArgGetter ( _name_, _env_ )</h1>
           <p>The abstract operation MakeArgGetter takes arguments _name_ (a String) and _env_ (an Environment Record). It creates a built-in function object that when executed returns the value bound for _name_ in _env_. It performs the following steps when called:</p>
           <emu-alg>
-            1. Let _steps_ be the steps of an ArgGetter function as specified below.
-            1. Let _length_ be the number of non-optional parameters of an ArgGetter function as specified below.
-            1. Let _getter_ be ! CreateBuiltinFunction(_steps_, _length_, *""*, &laquo; [[Name]], [[Env]] &raquo;).
-            1. Set _getter_.[[Name]] to _name_.
-            1. Set _getter_.[[Env]] to _env_.
+            1. Let _getterClosure_ be a new Abstract Closure with no parameters that captures _name_ and _env_ and performs the following steps when called:
+              1. Return _env_.GetBindingValue(_name_, *false*).
+            1. Let _getter_ be ! CreateBuiltinFunction(_getterClosure_, 0, *""*, &laquo; &raquo;).
+            1. NOTE: _getter_ is never directly accessible to ECMAScript code.
             1. Return _getter_.
           </emu-alg>
-          <p>An ArgGetter function is an anonymous built-in function with [[Name]] and [[Env]] internal slots. When an ArgGetter function that expects no arguments is called it performs the following steps:</p>
-          <emu-alg>
-            1. Let _f_ be the active function object.
-            1. Let _name_ be _f_.[[Name]].
-            1. Let _env_ be _f_.[[Env]].
-            1. Return _env_.GetBindingValue(_name_, *false*).
-          </emu-alg>
-          <emu-note>
-            <p>ArgGetter functions are never directly accessible to ECMAScript code.</p>
-          </emu-note>
         </emu-clause>
 
         <emu-clause id="sec-makeargsetter" aoid="MakeArgSetter">
           <h1>MakeArgSetter ( _name_, _env_ )</h1>
           <p>The abstract operation MakeArgSetter takes arguments _name_ (a String) and _env_ (an Environment Record). It creates a built-in function object that when executed sets the value bound for _name_ in _env_. It performs the following steps when called:</p>
           <emu-alg>
-            1. Let _steps_ be the steps of an ArgSetter function as specified below.
-            1. Let _length_ be the number of non-optional parameters of an ArgSetter function as specified below.
-            1. Let _setter_ be ! CreateBuiltinFunction(_steps_, _length_, *""*, &laquo; [[Name]], [[Env]] &raquo;).
-            1. Set _setter_.[[Name]] to _name_.
-            1. Set _setter_.[[Env]] to _env_.
+            1. Let _setterClosure_ be a new Abstract Closure with parameters (_value_) that captures _name_ and _env_ and performs the following steps when called:
+              1. Return _env_.SetMutableBinding(_name_, _value_, *false*).
+            1. Let _setter_ be ! CreateBuiltinFunction(_setterClosure_, 1, *""*, &laquo; &raquo;).
+            1. NOTE: _setter_ is never directly accessible to ECMAScript code.
             1. Return _setter_.
           </emu-alg>
-          <p>An ArgSetter function is an anonymous built-in function with [[Name]] and [[Env]] internal slots. When an ArgSetter function is called with argument _value_ it performs the following steps:</p>
-          <emu-alg>
-            1. Let _f_ be the active function object.
-            1. Let _name_ be _f_.[[Name]].
-            1. Let _env_ be _f_.[[Env]].
-            1. Return _env_.SetMutableBinding(_name_, _value_, *false*).
-          </emu-alg>
-          <emu-note>
-            <p>ArgSetter functions are never directly accessible to ECMAScript code.</p>
-          </emu-note>
         </emu-clause>
       </emu-clause>
     </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -21438,7 +21438,7 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-runtime-semantics-classdefinitionevaluation" type="sdo" aoid="ClassDefinitionEvaluation">
+    <emu-clause id="sec-runtime-semantics-classdefinitionevaluation" oldids="sec-default-constructor-functions" type="sdo" aoid="ClassDefinitionEvaluation">
       <h1>Runtime Semantics: ClassDefinitionEvaluation</h1>
       <p>With parameters _classBinding_ and _className_.</p>
       <emu-note>
@@ -21484,8 +21484,19 @@
         1. Set the running execution context's LexicalEnvironment to _classScope_.
         1. Set the running execution context's PrivateEnvironment to _classPrivateEnvironment_.
         1. If _constructor_ is ~empty~, then
-          1. Let _steps_ be the algorithm steps defined in <emu-xref href="#sec-default-constructor-functions" title></emu-xref>.
-          1. Let _F_ be ! CreateBuiltinFunction(_steps_, 0, _className_, &laquo; [[ConstructorKind]], [[SourceText]] &raquo;, the current Realm Record, _constructorParent_).
+          1. Let _defaultConstructor_ be a new Abstract Closure with no parameters that captures nothing and performs the following steps when called:
+            1. Let _args_ be the List of arguments that was passed to this function by [[Call]] or [[Construct]].
+            1. If NewTarget is *undefined*, throw a *TypeError* exception.
+            1. Let _F_ be the active function object.
+            1. If _F_.[[ConstructorKind]] is ~derived~, then
+              1. NOTE: This branch behaves similarly to `constructor(...args) { super(...args); }`. The most notable distinction is that while the aforementioned ECMAScript source text observably calls the @@iterator method on `%Array.prototype%`, this function does not.
+              1. Let _func_ be ! _F_.[[GetPrototypeOf]]().
+              1. If IsConstructor(_func_) is *false*, throw a *TypeError* exception.
+              1. Return ? Construct(_func_, _args_, NewTarget).
+            1. Else,
+              1. NOTE: This branch behaves similarly to `constructor() {}`.
+              1. Return ? OrdinaryCreateFromConstructor(NewTarget, *"%Object.prototype%"*).
+          1. Let _F_ be ! CreateBuiltinFunction(_defaultConstructor_, 0, _className_, &laquo; [[ConstructorKind]], [[SourceText]] &raquo;, the current Realm Record, _constructorParent_).
         1. Else,
           1. Let _constructorInfo_ be ! DefineMethod of _constructor_ with arguments _proto_ and _constructorParent_.
           1. Let _F_ be _constructorInfo_.[[Closure]].
@@ -21542,24 +21553,6 @@
         1. Set the running execution context's PrivateEnvironment to _outerPrivateEnvironment_.
         1. Return _F_.
       </emu-alg>
-
-      <emu-clause id="sec-default-constructor-functions">
-        <h1>Default Constructor Functions</h1>
-        <p>When a Default Constructor Function is called with zero or more arguments which form the rest parameter ..._args_, the following steps are taken:</p>
-        <emu-alg>
-          1. If NewTarget is *undefined*, throw a *TypeError* exception.
-          1. Let _F_ be the active function object.
-          1. If _F_.[[ConstructorKind]] is ~derived~, then
-            1. NOTE: This branch behaves similarly to `constructor(...args) { super(...args); }`. The most notable distinction is that while the aforementioned ECMAScript source text observably calls the @@iterator method on `%Array.prototype%`, a Default Constructor Function does not.
-            1. Let _func_ be ! _F_.[[GetPrototypeOf]]().
-            1. If IsConstructor(_func_) is *false*, throw a *TypeError* exception.
-            1. Return ? Construct(_func_, _args_, NewTarget).
-          1. Else,
-            1. NOTE: This branch behaves similarly to `constructor() {}`.
-            1. Return ? OrdinaryCreateFromConstructor(NewTarget, *"%Object.prototype%"*).
-        </emu-alg>
-        <p>The *"length"* property of a default constructor function is *+0*<sub>𝔽</sub>.</p>
-      </emu-clause>
     </emu-clause>
 
     <emu-clause id="sec-runtime-semantics-bindingclassdeclarationevaluation" type="sdo" aoid="BindingClassDeclarationEvaluation">

--- a/spec.html
+++ b/spec.html
@@ -40466,27 +40466,12 @@ THH:mm:ss.sss
         <li>has the following properties:</li>
       </ul>
 
-      <emu-clause id="sec-proxy.revocable">
+      <emu-clause id="sec-proxy.revocable" oldids="sec-proxy-revocation-functions">
         <h1>Proxy.revocable ( _target_, _handler_ )</h1>
         <p>The `Proxy.revocable` function is used to create a revocable Proxy object. When `Proxy.revocable` is called with arguments _target_ and _handler_, the following steps are taken:</p>
         <emu-alg>
           1. Let _p_ be ? ProxyCreate(_target_, _handler_).
-          1. Let _steps_ be the algorithm steps defined in <emu-xref href="#sec-proxy-revocation-functions" title></emu-xref>.
-          1. Let _length_ be the number of non-optional parameters of the function definition in <emu-xref href="#sec-proxy-revocation-functions" title></emu-xref>.
-          1. Let _revoker_ be ! CreateBuiltinFunction(_steps_, _length_, *""*, &laquo; [[RevocableProxy]] &raquo;).
-          1. Set _revoker_.[[RevocableProxy]] to _p_.
-          1. Let _result_ be ! OrdinaryObjectCreate(%Object.prototype%).
-          1. Perform ! CreateDataPropertyOrThrow(_result_, *"proxy"*, _p_).
-          1. Perform ! CreateDataPropertyOrThrow(_result_, *"revoke"*, _revoker_).
-          1. Return _result_.
-        </emu-alg>
-
-        <emu-clause id="sec-proxy-revocation-functions">
-          <h1>Proxy Revocation Functions</h1>
-          <p>A Proxy revocation function is an anonymous built-in function that has the ability to invalidate a specific Proxy object.</p>
-          <p>Each Proxy revocation function has a [[RevocableProxy]] internal slot.</p>
-          <p>When a Proxy revocation function is called, the following steps are taken:</p>
-          <emu-alg>
+          1. Let _revokerClosure_ be a new Abstract Closure with no parameters that captures nothing and performs the following steps when called:
             1. Let _F_ be the active function object.
             1. Let _p_ be _F_.[[RevocableProxy]].
             1. If _p_ is *null*, return *undefined*.
@@ -40495,9 +40480,13 @@ THH:mm:ss.sss
             1. Set _p_.[[ProxyTarget]] to *null*.
             1. Set _p_.[[ProxyHandler]] to *null*.
             1. Return *undefined*.
-          </emu-alg>
-          <p>The *"length"* property of a Proxy revocation function is *+0*<sub>𝔽</sub>.</p>
-        </emu-clause>
+          1. Let _revoker_ be ! CreateBuiltinFunction(_revokerClosure_, 0, *""*, &laquo; [[RevocableProxy]] &raquo;).
+          1. Set _revoker_.[[RevocableProxy]] to _p_.
+          1. Let _result_ be ! OrdinaryObjectCreate(%Object.prototype%).
+          1. Perform ! CreateDataPropertyOrThrow(_result_, *"proxy"*, _p_).
+          1. Perform ! CreateDataPropertyOrThrow(_result_, *"revoke"*, _revoker_).
+          1. Return _result_.
+        </emu-alg>
       </emu-clause>
     </emu-clause>
   </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -40037,7 +40037,7 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-asyncgeneratorresumenext" aoid="AsyncGeneratorResumeNext">
+      <emu-clause id="sec-asyncgeneratorresumenext" oldids="async-generator-resume-next-return-processor-fulfilled,async-generator-resume-next-return-processor-rejected" aoid="AsyncGeneratorResumeNext">
         <h1>AsyncGeneratorResumeNext ( _generator_ )</h1>
         <p>The abstract operation AsyncGeneratorResumeNext takes argument _generator_. It performs the following steps when called:</p>
         <emu-alg>
@@ -40058,14 +40058,14 @@ THH:mm:ss.sss
               1. If _completion_.[[Type]] is ~return~, then
                 1. Set _generator_.[[AsyncGeneratorState]] to ~awaiting-return~.
                 1. Let _promise_ be ? PromiseResolve(%Promise%, _completion_.[[Value]]).
-                1. Let _stepsFulfilled_ be the algorithm steps defined in <emu-xref href="#async-generator-resume-next-return-processor-fulfilled" title></emu-xref>.
-                1. Let _lengthFulfilled_ be the number of non-optional parameters of the function definition in <emu-xref href="#async-generator-resume-next-return-processor-fulfilled" title></emu-xref>.
-                1. Let _onFulfilled_ be ! CreateBuiltinFunction(_stepsFulfilled_, _lengthFulfilled_, *""*, &laquo; [[Generator]] &raquo;).
-                1. Set _onFulfilled_.[[Generator]] to _generator_.
-                1. Let _stepsRejected_ be the algorithm steps defined in <emu-xref href="#async-generator-resume-next-return-processor-rejected" title></emu-xref>.
-                1. Let _lengthRejected_ be the number of non-optional parameters of the function definition in <emu-xref href="#async-generator-resume-next-return-processor-rejected" title></emu-xref>.
-                1. Let _onRejected_ be ! CreateBuiltinFunction(_stepsRejected_, _lengthRejected_, *""*, &laquo; [[Generator]] &raquo;).
-                1. Set _onRejected_.[[Generator]] to _generator_.
+                1. Let _fulfilledClosure_ be a new Abstract Closure with parameters (_value_) that captures _generator_ and performs the following steps when called:
+                  1. Set _generator_.[[AsyncGeneratorState]] to ~completed~.
+                  1. Return ! AsyncGeneratorResolve(_generator_, _value_, *true*).
+                1. Let _onFulfilled_ be ! CreateBuiltinFunction(_fulfilledClosure_, 1, *""*, &laquo; &raquo;).
+                1. Let _rejectedClosure_ be a new Abstract Closure with parameters (_reason_) that captures _generator_ and performs the following steps when called:
+                  1. Set _generator_.[[AsyncGeneratorState]] to ~completed~.
+                  1. Return ! AsyncGeneratorReject(_generator_, _reason_).
+                1. Let _onRejected_ be ! CreateBuiltinFunction(_rejectedClosure_, 1, *""*, &laquo; &raquo;).
                 1. Perform ! PerformPromiseThen(_promise_, _onFulfilled_, _onRejected_).
                 1. Return *undefined*.
               1. Else,
@@ -40084,34 +40084,6 @@ THH:mm:ss.sss
           1. Assert: When we return here, _genContext_ has already been removed from the execution context stack and _callerContext_ is the currently running execution context.
           1. Return *undefined*.
         </emu-alg>
-
-        <emu-clause id="async-generator-resume-next-return-processor-fulfilled">
-          <h1>AsyncGeneratorResumeNext Return Processor Fulfilled Functions</h1>
-          <p>An AsyncGeneratorResumeNext return processor fulfilled function is an anonymous built-in function that is used as part of the AsyncGeneratorResumeNext specification device to unwrap promises passed in to the <emu-xref href="#sec-asyncgenerator-prototype-return" title></emu-xref> method. Each AsyncGeneratorResumeNext return processor fulfilled function has a [[Generator]] internal slot.</p>
-          <p>When an AsyncGeneratorResumeNext return processor fulfilled function is called with argument _value_, the following steps are taken:</p>
-
-          <emu-alg>
-            1. Let _F_ be the active function object.
-            1. Set _F_.[[Generator]].[[AsyncGeneratorState]] to ~completed~.
-            1. Return ! AsyncGeneratorResolve(_F_.[[Generator]], _value_, *true*).
-          </emu-alg>
-
-          <p>The *"length"* property of an AsyncGeneratorResumeNext return processor fulfilled function is *1*<sub>𝔽</sub>.</p>
-        </emu-clause>
-
-        <emu-clause id="async-generator-resume-next-return-processor-rejected">
-          <h1>AsyncGeneratorResumeNext Return Processor Rejected Functions</h1>
-          <p>An AsyncGeneratorResumeNext return processor rejected function is an anonymous built-in function that is used as part of the AsyncGeneratorResumeNext specification device to unwrap promises passed in to the <emu-xref href="#sec-asyncgenerator-prototype-return" title></emu-xref> method. Each AsyncGeneratorResumeNext return processor rejected function has a [[Generator]] internal slot.</p>
-          <p>When an AsyncGeneratorResumeNext return processor rejected function is called with argument _reason_, the following steps are taken:</p>
-
-          <emu-alg>
-            1. Let _F_ be the active function object.
-            1. Set _F_.[[Generator]].[[AsyncGeneratorState]] to ~completed~.
-            1. Return ! AsyncGeneratorReject(_F_.[[Generator]], _reason_).
-          </emu-alg>
-
-          <p>The *"length"* property of an AsyncGeneratorResumeNext return processor rejected function is *1*<sub>𝔽</sub>.</p>
-        </emu-clause>
       </emu-clause>
 
       <emu-clause id="sec-asyncgeneratorenqueue" aoid="AsyncGeneratorEnqueue">

--- a/spec.html
+++ b/spec.html
@@ -3548,7 +3548,7 @@
       </emu-table>
       <p>The term &ldquo;<dfn>abrupt completion</dfn>&rdquo; refers to any completion with a [[Type]] value other than ~normal~.</p>
 
-      <emu-clause id="await" aoid="Await">
+      <emu-clause id="await" oldids="await-fulfilled,await-rejected" aoid="Await">
         <h1>Await</h1>
 
         <p>Algorithm steps that say</p>
@@ -3562,14 +3562,22 @@
         <emu-alg>
           1. Let _asyncContext_ be the running execution context.
           1. Let _promise_ be ? PromiseResolve(%Promise%, _value_).
-          1. Let _stepsFulfilled_ be the algorithm steps defined in <emu-xref href="#await-fulfilled" title></emu-xref>.
-          1. Let _lengthFulfilled_ be the number of non-optional parameters of the function definition in <emu-xref href="#await-fulfilled" title></emu-xref>.
-          1. Let _onFulfilled_ be ! CreateBuiltinFunction(_stepsFulfilled_, _lengthFulfilled_, *""*, &laquo; [[AsyncContext]] &raquo;).
-          1. Set _onFulfilled_.[[AsyncContext]] to _asyncContext_.
-          1. Let _stepsRejected_ be the algorithm steps defined in <emu-xref href="#await-rejected" title></emu-xref>.
-          1. Let _lengthRejected_ be the number of non-optional parameters of the function definition in <emu-xref href="#await-rejected" title></emu-xref>.
-          1. Let _onRejected_ be ! CreateBuiltinFunction(_stepsRejected_, _lengthRejected_, *""*, &laquo; [[AsyncContext]] &raquo;).
-          1. Set _onRejected_.[[AsyncContext]] to _asyncContext_.
+          1. Let _fulfilledClosure_ be a new Abstract Closure with parameters (_value_) that captures _asyncContext_ and performs the following steps when called:
+            1. Let _prevContext_ be the running execution context.
+            1. Suspend _prevContext_.
+            1. Push _asyncContext_ onto the execution context stack; _asyncContext_ is now the running execution context.
+            1. Resume the suspended evaluation of _asyncContext_ using NormalCompletion(_value_) as the result of the operation that suspended it.
+            1. Assert: When we reach this step, _asyncContext_ has already been removed from the execution context stack and _prevContext_ is the currently running execution context.
+            1. Return *undefined*.
+          1. Let _onFulfilled_ be ! CreateBuiltinFunction(_fulfilledClosure_, 1, *""*, &laquo; &raquo;).
+          1. Let _rejectedClosure_ be a new Abstract Closure with parameters (_reason_) that captures _asyncContext_ and performs the following steps when called:
+            1. Let _prevContext_ be the running execution context.
+            1. Suspend _prevContext_.
+            1. Push _asyncContext_ onto the execution context stack; _asyncContext_ is now the running execution context.
+            1. Resume the suspended evaluation of _asyncContext_ using ThrowCompletion(_reason_) as the result of the operation that suspended it.
+            1. Assert: When we reach this step, _asyncContext_ has already been removed from the execution context stack and _prevContext_ is the currently running execution context.
+            1. Return *undefined*.
+          1. Let _onRejected_ be ! CreateBuiltinFunction(_rejectedClosure_, 1, *""*, &laquo; &raquo;).
           1. Perform ! PerformPromiseThen(_promise_, _onFulfilled_, _onRejected_).
           1. Remove _asyncContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
           1. Set the code evaluation state of _asyncContext_ such that when evaluation is resumed with a Completion _completion_, the following steps of the algorithm that invoked Await will be performed, with _completion_ available.
@@ -3593,44 +3601,6 @@
             1. ReturnIfAbrupt(_result_).
           </emu-alg>
         </emu-note>
-
-        <emu-clause id="await-fulfilled">
-          <h1>Await Fulfilled Functions</h1>
-          <p>An Await fulfilled function is an anonymous built-in function that is used as part of the Await specification device to deliver the promise fulfillment value to the caller as a normal completion. Each Await fulfilled function has an [[AsyncContext]] internal slot.</p>
-          <p>When an Await fulfilled function is called with argument _value_, the following steps are taken:</p>
-
-          <emu-alg>
-            1. Let _F_ be the active function object.
-            1. Let _asyncContext_ be _F_.[[AsyncContext]].
-            1. Let _prevContext_ be the running execution context.
-            1. Suspend _prevContext_.
-            1. Push _asyncContext_ onto the execution context stack; _asyncContext_ is now the running execution context.
-            1. Resume the suspended evaluation of _asyncContext_ using NormalCompletion(_value_) as the result of the operation that suspended it.
-            1. Assert: When we reach this step, _asyncContext_ has already been removed from the execution context stack and _prevContext_ is the currently running execution context.
-            1. Return *undefined*.
-          </emu-alg>
-
-          <p>The *"length"* property of an Await fulfilled function is *1*<sub>𝔽</sub>.</p>
-        </emu-clause>
-
-        <emu-clause id="await-rejected">
-          <h1>Await Rejected Functions</h1>
-          <p>An Await rejected function is an anonymous built-in function that is used as part of the Await specification device to deliver the promise rejection reason to the caller as an abrupt throw completion. Each Await rejected function has an [[AsyncContext]] internal slot.</p>
-          <p>When an Await rejected function is called with argument _reason_, the following steps are taken:</p>
-
-          <emu-alg>
-            1. Let _F_ be the active function object.
-            1. Let _asyncContext_ be _F_.[[AsyncContext]].
-            1. Let _prevContext_ be the running execution context.
-            1. Suspend _prevContext_.
-            1. Push _asyncContext_ onto the execution context stack; _asyncContext_ is now the running execution context.
-            1. Resume the suspended evaluation of _asyncContext_ using ThrowCompletion(_reason_) as the result of the operation that suspended it.
-            1. Assert: When we reach this step, _asyncContext_ has already been removed from the execution context stack and _prevContext_ is the currently running execution context.
-            1. Return *undefined*.
-          </emu-alg>
-
-          <p>The *"length"* property of an Await rejected function is *1*<sub>𝔽</sub>.</p>
-        </emu-clause>
       </emu-clause>
 
       <emu-clause id="sec-normalcompletion" aoid="NormalCompletion">


### PR DESCRIPTION
Followup to #2109. Fixes #1894, fixes #933, fixes #1077 (in passing, in the "less handwaving" commit).

There's still six places where I haven't adopted the new style: two ([x](https://tc39.es/ecma262/multipage/#sec-promise-reject-functions), [x](https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise-resolve-functions)) in [CreateResolvingFunctions](https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-createresolvingfunctions) (used mainly in the Promise constructor), [one](https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise.all-resolve-element-functions) in [PerformPromiseAll](https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-performpromiseall), two ([x](https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise.allsettled-resolve-element-functions), [x](https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise.allsettled-reject-element-functions)) in [PerformPromiseAllSettled](https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-performpromiseallsettled), and [one](https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise.any-reject-element-functions) in [PerformPromiseAny](https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-performpromiseany).

These remaining cases generally seemed nontrivial enough that I didn't think it worth inlining them. I could, I suppose, replace each with an abstract operation which returns the appropriate abstract closure (or built-in function), but that doesn't seem like it would be much of an improvement.

This is mostly a mechanical transformation. Where there was non-mutable state provided by setting internal slots, I have instead had the abstract closure capture the relevant aliases. I've left mutable state as internal slots, since abstract closures can't write to captured aliases.

One thing of note is that the Default Constructor Functions took a rest parameter, which isn't something we have established syntax for with abstract closures; I decided to mostly mimic what we do in [the function constructor](https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-function-p1-p2-pn-body) and refer to "the List of arguments that was passed to this function by [[Call]] or [[Construct]]" explicitly, rather than introducing syntax for rest parameters in Abstract Closures.