### PR TITLE
Editorial: disambiguate `with` statement's status

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -21933,8 +21933,12 @@
     </emu-clause>
   </emu-clause>
 
-  <emu-clause id="sec-with-statement">
+  <emu-clause id="sec-with-statement" legacy>
     <h1>The `with` Statement</h1>
+    <emu-note>
+      <p>Use of the Legacy `with` statement is discouraged in new ECMAScript code. Consider alternatives that are permitted in both strict mode code and non-strict code, such as <emu-xref href="#sec-destructuring-assignment">destructuring assignment</emu-xref>.</p>
+    </emu-note>
+
     <h2>Syntax</h2>
     <emu-grammar type="definition">
       WithStatement[Yield, Await, Return] :


### PR DESCRIPTION
Currently, the spec sends mixed signals to programmers about the `with` statement; this PR attempts to clear up the ambiguity by adding text that explicitly discourages the use of the `with` statement in new ECMAScript code.

This is an attempt to solve a specific problem: developers and technical writers are unclear about the status of the `with` statement. See [this StackOverflow question](https://stackoverflow.com/questions/48810592/is-the-javascript-keyword-with-really-deprecated) or [this discussion in MDN Web Docs's browser-compat-data project](https://github.com/mdn/browser-compat-data/issues/10490) to get a taste. This makes it difficult to document on MDN Web Docs and elsewhere.

By forbidding `with` in strict mode code and cutting it off from many contemporary language features, the specification seems to imply that programmers shouldn't use `with`, but this is less explicit than other disfavored parts of the language (e.g., [the note for the `getYear` method](https://tc39.es/ecma262/#sec-date.prototype.getyear) or [the introduction to Annex B](https://tc39.es/ecma262/#sec-additional-ecmascript-features-for-web-browsers)). Because there's no single way that the spec indicates non-preferred features, developers and technical writers have to make do with close readings and interpretations.

Ideally, the specification could resolve the question definitively. This PR's fix to the problem is text that speaks directly to programmers, discouraging them from using the `with` statement. This is my attempt to put into words what I believe the existing text implies to programmers, but I'm open to making revisions which more accurately captures the posture toward `with` statement.

Thanks for considering this change!