### PR TITLE
Editorial: Drop grammatical parameters from 'use' productions

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -19991,7 +19991,7 @@
         1. Return IsSimpleParameterList of _formals_.
       </emu-alg>
       <emu-grammar>
-        AsyncArrowBindingIdentifier[Yield] : BindingIdentifier[?Yield, +Await]
+        AsyncArrowBindingIdentifier : BindingIdentifier
       </emu-grammar>
       <emu-alg>
         1. Return *true*.
@@ -30429,25 +30429,25 @@ THH:mm:ss.sss
             It is a Syntax Error if IsCharacterClass of |ClassAtomNoDash| is *false* and IsCharacterClass of |ClassAtom| is *false* and the CharacterValue of |ClassAtomNoDash| is larger than the CharacterValue of |ClassAtom|.
           </li>
         </ul>
-        <emu-grammar>RegExpIdentifierStart[U] :: `\` RegExpUnicodeEscapeSequence[+U]</emu-grammar>
+        <emu-grammar>RegExpIdentifierStart :: `\` RegExpUnicodeEscapeSequence</emu-grammar>
         <ul>
           <li>
             It is a Syntax Error if the CharacterValue of |RegExpUnicodeEscapeSequence| is not the code point value of *"$"*, *"_"*, or some code point matched by the |UnicodeIDStart| lexical grammar production.
           </li>
         </ul>
-        <emu-grammar>RegExpIdentifierStart[U] :: UnicodeLeadSurrogate UnicodeTrailSurrogate</emu-grammar>
+        <emu-grammar>RegExpIdentifierStart :: UnicodeLeadSurrogate UnicodeTrailSurrogate</emu-grammar>
         <ul>
           <li>
             It is a Syntax Error if the result of performing UTF16SurrogatePairToCodePoint on the two code points matched by |UnicodeLeadSurrogate| and |UnicodeTrailSurrogate| respectively is not matched by the |UnicodeIDStart| lexical grammar production.
           </li>
         </ul>
-        <emu-grammar>RegExpIdentifierPart[U] :: `\` RegExpUnicodeEscapeSequence[+U]</emu-grammar>
+        <emu-grammar>RegExpIdentifierPart :: `\` RegExpUnicodeEscapeSequence</emu-grammar>
         <ul>
           <li>
             It is a Syntax Error if the CharacterValue of |RegExpUnicodeEscapeSequence| is not the code point value of *"$"*, *"_"*, &lt;ZWNJ&gt;, &lt;ZWJ&gt;, or some code point matched by the |UnicodeIDContinue| lexical grammar production.
           </li>
         </ul>
-        <emu-grammar>RegExpIdentifierPart[U] :: UnicodeLeadSurrogate UnicodeTrailSurrogate</emu-grammar>
+        <emu-grammar>RegExpIdentifierPart :: UnicodeLeadSurrogate UnicodeTrailSurrogate</emu-grammar>
         <ul>
           <li>
             It is a Syntax Error if the result of performing UTF16SurrogatePairToCodePoint on the two code points matched by |UnicodeLeadSurrogate| and |UnicodeTrailSurrogate| respectively is not matched by the |UnicodeIDContinue| lexical grammar production.
@@ -30718,9 +30718,9 @@ THH:mm:ss.sss
       <emu-clause id="sec-static-semantics-capturinggroupname" oldids="sec-regexp-identifier-names-static-semantics-stringvalue" type="sdo" aoid="CapturingGroupName">
         <h1>Static Semantics: CapturingGroupName</h1>
         <emu-grammar>
-          RegExpIdentifierName[U] ::
-            RegExpIdentifierStart[?U]
-            RegExpIdentifierName[?U] RegExpIdentifierPart[?U]
+          RegExpIdentifierName ::
+            RegExpIdentifierStart
+            RegExpIdentifierName RegExpIdentifierPart
         </emu-grammar>
         <emu-alg>
           1. Let _idText_ be the source text matched by |RegExpIdentifierName|.


### PR DESCRIPTION
... since they aren't mentioned by the associated algorithm/rule.