### PR TITLE
Editorial: Delete redundant xrefs from Well-Known Intrinsics table

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -3029,7 +3029,7 @@
                 `AggregateError`
               </td>
               <td>
-                The `AggregateError` constructor (<emu-xref href="#sec-aggregate-error-constructor"></emu-xref>)
+                The `AggregateError` constructor
               </td>
             </tr>
             <tr>
@@ -3040,7 +3040,7 @@
                 `Array`
               </td>
               <td>
-                The Array constructor (<emu-xref href="#sec-array-constructor"></emu-xref>)
+                The Array constructor
               </td>
             </tr>
             <tr>
@@ -3051,7 +3051,7 @@
                 `ArrayBuffer`
               </td>
               <td>
-                The ArrayBuffer constructor (<emu-xref href="#sec-arraybuffer-constructor"></emu-xref>)
+                The ArrayBuffer constructor
               </td>
             </tr>
             <tr>
@@ -3081,7 +3081,7 @@
               <td>
               </td>
               <td>
-                The constructor of async function objects (<emu-xref href="#sec-async-function-constructor"></emu-xref>)
+                The constructor of async function objects
               </td>
             </tr>
             <tr>
@@ -3091,7 +3091,7 @@
               <td>
               </td>
               <td>
-                The constructor of async iterator objects (<emu-xref href="#sec-asyncgeneratorfunction-constructor"></emu-xref>)
+                The constructor of async iterator objects
               </td>
             </tr>
             <tr>
@@ -3112,7 +3112,7 @@
                 `Atomics`
               </td>
               <td>
-                The `Atomics` object (<emu-xref href="#sec-atomics-object"></emu-xref>)
+                The `Atomics` object
               </td>
             </tr>
             <tr>
@@ -3123,7 +3123,7 @@
                 `BigInt`
               </td>
               <td>
-                The BigInt constructor (<emu-xref href="#sec-bigint-constructor"></emu-xref>)
+                The BigInt constructor
               </td>
             </tr>
             <tr>
@@ -3134,7 +3134,7 @@
                 `BigInt64Array`
               </td>
               <td>
-                The BigInt64Array constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
+                The BigInt64Array constructor
               </td>
             </tr>
             <tr>
@@ -3145,7 +3145,7 @@
                 `BigUint64Array`
               </td>
               <td>
-                The BigUint64Array constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
+                The BigUint64Array constructor
               </td>
             </tr>
             <tr>
@@ -3156,7 +3156,7 @@
                 `Boolean`
               </td>
               <td>
-                The Boolean constructor (<emu-xref href="#sec-boolean-constructor"></emu-xref>)
+                The Boolean constructor
               </td>
             </tr>
             <tr>
@@ -3167,7 +3167,7 @@
                 `DataView`
               </td>
               <td>
-                The DataView constructor (<emu-xref href="#sec-dataview-constructor"></emu-xref>)
+                The DataView constructor
               </td>
             </tr>
             <tr>
@@ -3178,7 +3178,7 @@
                 `Date`
               </td>
               <td>
-                The Date constructor (<emu-xref href="#sec-date-constructor"></emu-xref>)
+                The Date constructor
               </td>
             </tr>
             <tr>
@@ -3189,7 +3189,7 @@
                 `decodeURI`
               </td>
               <td>
-                The `decodeURI` function (<emu-xref href="#sec-decodeuri-encodeduri"></emu-xref>)
+                The `decodeURI` function
               </td>
             </tr>
             <tr>
@@ -3200,7 +3200,7 @@
                 `decodeURIComponent`
               </td>
               <td>
-                The `decodeURIComponent` function (<emu-xref href="#sec-decodeuricomponent-encodeduricomponent"></emu-xref>)
+                The `decodeURIComponent` function
               </td>
             </tr>
             <tr>
@@ -3211,7 +3211,7 @@
                 `encodeURI`
               </td>
               <td>
-                The `encodeURI` function (<emu-xref href="#sec-encodeuri-uri"></emu-xref>)
+                The `encodeURI` function
               </td>
             </tr>
             <tr>
@@ -3222,7 +3222,7 @@
                 `encodeURIComponent`
               </td>
               <td>
-                The `encodeURIComponent` function (<emu-xref href="#sec-encodeuricomponent-uricomponent"></emu-xref>)
+                The `encodeURIComponent` function
               </td>
             </tr>
             <tr>
@@ -3233,7 +3233,7 @@
                 `Error`
               </td>
               <td>
-                The Error constructor (<emu-xref href="#sec-error-constructor"></emu-xref>)
+                The Error constructor
               </td>
             </tr>
             <tr>
@@ -3244,7 +3244,7 @@
                 `eval`
               </td>
               <td>
-                The `eval` function (<emu-xref href="#sec-eval-x"></emu-xref>)
+                The `eval` function
               </td>
             </tr>
             <tr>
@@ -3255,7 +3255,7 @@
                 `EvalError`
               </td>
               <td>
-                The EvalError constructor (<emu-xref href="#sec-native-error-types-used-in-this-standard-evalerror"></emu-xref>)
+                The EvalError constructor
               </td>
             </tr>
             <tr>
@@ -3266,7 +3266,7 @@
                 `FinalizationRegistry`
               </td>
               <td>
-                The FinalizationRegistry constructor (<emu-xref href="#sec-finalization-registry-constructor"></emu-xref>)
+                The FinalizationRegistry constructor
               </td>
             </tr>
             <tr>
@@ -3277,7 +3277,7 @@
                 `Float32Array`
               </td>
               <td>
-                The Float32Array constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
+                The Float32Array constructor
               </td>
             </tr>
             <tr>
@@ -3288,7 +3288,7 @@
                 `Float64Array`
               </td>
               <td>
-                The Float64Array constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
+                The Float64Array constructor
               </td>
             </tr>
             <tr>
@@ -3309,7 +3309,7 @@
                 `Function`
               </td>
               <td>
-                The Function constructor (<emu-xref href="#sec-function-constructor"></emu-xref>)
+                The Function constructor
               </td>
             </tr>
             <tr>
@@ -3319,7 +3319,7 @@
               <td>
               </td>
               <td>
-                The constructor of Generators (<emu-xref href="#sec-generatorfunction-constructor"></emu-xref>)
+                The constructor of Generators
               </td>
             </tr>
             <tr>
@@ -3330,7 +3330,7 @@
                 `Int8Array`
               </td>
               <td>
-                The Int8Array constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
+                The Int8Array constructor
               </td>
             </tr>
             <tr>
@@ -3341,7 +3341,7 @@
                 `Int16Array`
               </td>
               <td>
-                The Int16Array constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
+                The Int16Array constructor
               </td>
             </tr>
             <tr>
@@ -3352,7 +3352,7 @@
                 `Int32Array`
               </td>
               <td>
-                The Int32Array constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
+                The Int32Array constructor
               </td>
             </tr>
             <tr>
@@ -3363,7 +3363,7 @@
                 `isFinite`
               </td>
               <td>
-                The `isFinite` function (<emu-xref href="#sec-isfinite-number"></emu-xref>)
+                The `isFinite` function
               </td>
             </tr>
             <tr>
@@ -3374,7 +3374,7 @@
                 `isNaN`
               </td>
               <td>
-                The `isNaN` function (<emu-xref href="#sec-isnan-number"></emu-xref>)
+                The `isNaN` function
               </td>
             </tr>
             <tr>
@@ -3395,7 +3395,7 @@
                 `JSON`
               </td>
               <td>
-                The `JSON` object (<emu-xref href="#sec-json-object"></emu-xref>)
+                The `JSON` object
               </td>
             </tr>
             <tr>
@@ -3406,7 +3406,7 @@
                 `Map`
               </td>
               <td>
-                The Map constructor (<emu-xref href="#sec-map-constructor"></emu-xref>)
+                The Map constructor
               </td>
             </tr>
             <tr>
@@ -3427,7 +3427,7 @@
                 `Math`
               </td>
               <td>
-                The `Math` object (<emu-xref href="#sec-math-object"></emu-xref>)
+                The `Math` object
               </td>
             </tr>
             <tr>
@@ -3438,7 +3438,7 @@
                 `Number`
               </td>
               <td>
-                The Number constructor (<emu-xref href="#sec-number-constructor"></emu-xref>)
+                The Number constructor
               </td>
             </tr>
             <tr>
@@ -3449,7 +3449,7 @@
                 `Object`
               </td>
               <td>
-                The Object constructor (<emu-xref href="#sec-object-constructor"></emu-xref>)
+                The Object constructor
               </td>
             </tr>
             <tr>
@@ -3460,7 +3460,7 @@
                 `parseFloat`
               </td>
               <td>
-                The `parseFloat` function (<emu-xref href="#sec-parsefloat-string"></emu-xref>)
+                The `parseFloat` function
               </td>
             </tr>
             <tr>
@@ -3471,7 +3471,7 @@
                 `parseInt`
               </td>
               <td>
-                The `parseInt` function (<emu-xref href="#sec-parseint-string-radix"></emu-xref>)
+                The `parseInt` function
               </td>
             </tr>
             <tr>
@@ -3482,7 +3482,7 @@
                 `Promise`
               </td>
               <td>
-                The Promise constructor (<emu-xref href="#sec-promise-constructor"></emu-xref>)
+                The Promise constructor
               </td>
             </tr>
             <tr>
@@ -3493,7 +3493,7 @@
                 `Proxy`
               </td>
               <td>
-                The Proxy constructor (<emu-xref href="#sec-proxy-constructor"></emu-xref>)
+                The Proxy constructor
               </td>
             </tr>
             <tr>
@@ -3504,7 +3504,7 @@
                 `RangeError`
               </td>
               <td>
-                The RangeError constructor (<emu-xref href="#sec-native-error-types-used-in-this-standard-rangeerror"></emu-xref>)
+                The RangeError constructor
               </td>
             </tr>
             <tr>
@@ -3515,7 +3515,7 @@
                 `ReferenceError`
               </td>
               <td>
-                The ReferenceError constructor (<emu-xref href="#sec-native-error-types-used-in-this-standard-referenceerror"></emu-xref>)
+                The ReferenceError constructor
               </td>
             </tr>
             <tr>
@@ -3526,7 +3526,7 @@
                 `Reflect`
               </td>
               <td>
-                The `Reflect` object (<emu-xref href="#sec-reflect-object"></emu-xref>)
+                The `Reflect` object
               </td>
             </tr>
             <tr>
@@ -3537,7 +3537,7 @@
                 `RegExp`
               </td>
               <td>
-                The RegExp constructor (<emu-xref href="#sec-regexp-constructor"></emu-xref>)
+                The RegExp constructor
               </td>
             </tr>
             <tr>
@@ -3558,7 +3558,7 @@
                 `Set`
               </td>
               <td>
-                The Set constructor (<emu-xref href="#sec-set-constructor"></emu-xref>)
+                The Set constructor
               </td>
             </tr>
             <tr>
@@ -3579,7 +3579,7 @@
                 `SharedArrayBuffer`
               </td>
               <td>
-                The SharedArrayBuffer constructor (<emu-xref href="#sec-sharedarraybuffer-constructor"></emu-xref>)
+                The SharedArrayBuffer constructor
               </td>
             </tr>
             <tr>
@@ -3590,7 +3590,7 @@
                 `String`
               </td>
               <td>
-                The String constructor (<emu-xref href="#sec-string-constructor"></emu-xref>)
+                The String constructor
               </td>
             </tr>
             <tr>
@@ -3611,7 +3611,7 @@
                 `Symbol`
               </td>
               <td>
-                The Symbol constructor (<emu-xref href="#sec-symbol-constructor"></emu-xref>)
+                The Symbol constructor
               </td>
             </tr>
             <tr>
@@ -3622,7 +3622,7 @@
                 `SyntaxError`
               </td>
               <td>
-                The SyntaxError constructor (<emu-xref href="#sec-native-error-types-used-in-this-standard-syntaxerror"></emu-xref>)
+                The SyntaxError constructor
               </td>
             </tr>
             <tr>
@@ -3642,7 +3642,7 @@
               <td>
               </td>
               <td>
-                The super class of all typed Array constructors (<emu-xref href="#sec-%typedarray%-intrinsic-object"></emu-xref>)
+                The super class of all typed Array constructors
               </td>
             </tr>
             <tr>
@@ -3653,7 +3653,7 @@
                 `TypeError`
               </td>
               <td>
-                The TypeError constructor (<emu-xref href="#sec-native-error-types-used-in-this-standard-typeerror"></emu-xref>)
+                The TypeError constructor
               </td>
             </tr>
             <tr>
@@ -3664,7 +3664,7 @@
                 `Uint8Array`
               </td>
               <td>
-                The Uint8Array constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
+                The Uint8Array constructor
               </td>
             </tr>
             <tr>
@@ -3675,7 +3675,7 @@
                 `Uint8ClampedArray`
               </td>
               <td>
-                The Uint8ClampedArray constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
+                The Uint8ClampedArray constructor
               </td>
             </tr>
             <tr>
@@ -3686,7 +3686,7 @@
                 `Uint16Array`
               </td>
               <td>
-                The Uint16Array constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
+                The Uint16Array constructor
               </td>
             </tr>
             <tr>
@@ -3697,7 +3697,7 @@
                 `Uint32Array`
               </td>
               <td>
-                The Uint32Array constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
+                The Uint32Array constructor
               </td>
             </tr>
             <tr>
@@ -3708,7 +3708,7 @@
                 `URIError`
               </td>
               <td>
-                The URIError constructor (<emu-xref href="#sec-native-error-types-used-in-this-standard-urierror"></emu-xref>)
+                The URIError constructor
               </td>
             </tr>
             <tr>
@@ -3719,7 +3719,7 @@
                 `WeakMap`
               </td>
               <td>
-                The WeakMap constructor (<emu-xref href="#sec-weakmap-constructor"></emu-xref>)
+                The WeakMap constructor
               </td>
             </tr>
             <tr>
@@ -3730,7 +3730,7 @@
                 `WeakRef`
               </td>
               <td>
-                The WeakRef constructor (<emu-xref href="#sec-weak-ref-constructor"></emu-xref>)
+                The WeakRef constructor
               </td>
             </tr>
             <tr>
@@ -3741,7 +3741,7 @@
                 `WeakSet`
               </td>
               <td>
-                The WeakSet constructor (<emu-xref href="#sec-weakset-constructor"></emu-xref>)
+                The WeakSet constructor
               </td>
             </tr>
             </tbody>
@@ -46453,7 +46453,7 @@ THH:mm:ss.sss
               `escape`
             </td>
             <td>
-              The `escape` function (<emu-xref href="#sec-escape-string"></emu-xref>)
+              The `escape` function
             </td>
           </tr>
           <tr>
@@ -46464,7 +46464,7 @@ THH:mm:ss.sss
               `unescape`
             </td>
             <td>
-              The `unescape` function (<emu-xref href="#sec-unescape-string"></emu-xref>)
+              The `unescape` function
             </td>
           </tr>
           </tbody>


### PR DESCRIPTION
In the [Well-Known Intrinsic Objects](https://tc39.es/ecma262/multipage/ecmascript-data-types-and-values.html#table-well-known-intrinsic-objects) table (and the [Additional Well-known Intrinsic Objects](https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#table-additional-well-known-intrinsic-objects) table), under "ECMAScript Language Association", most entries have an `<emu-xref>`, but in most cases it links to the same place
as the "Intrinsic Name" will be auto-linked to. Delete all these redundant xrefs.

(The remaining 7 cases are all for %FooIteratorPrototype%, where the auto-link goes to the clause that 'declares' the intrinsic, but the "Language Association" xref goes to the clause that deals with Foo iterator objects in general.)