### PR TITLE
Normative: Restrict completion values callables can return

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -3836,6 +3836,8 @@
         </table>
       </emu-table>
       <p>The term &ldquo;<dfn>abrupt completion</dfn>&rdquo; refers to any completion with a [[Type]] value other than ~normal~.</p>
+      <p>Callable objects that are defined in this specification only return a normal completion or a throw completion. Returning any other kind of completion is considered an editorial error.</p>
+      <p>Implementation-defined callable objects must return either a normal completion or a throw completion.</p>
 
       <emu-clause id="await" oldids="await-fulfilled,await-rejected" aoid="Await">
         <h1>Await</h1>


### PR DESCRIPTION
This normatively constrains implementations to not have functions return control-flow altering completions other than `~throw~`. I expect nailing this down to be both a universal truth in all implementations and uncontroversial: calling a function shouldn't be able to e.g. break out of a loop.