### PR TITLE
Editorial: don't imply that SV, TV, and TRV are shorthands

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -16612,7 +16612,7 @@
 
       <emu-clause id="sec-static-semantics-sv" oldids="sec-string-literals-static-semantics-stringvalue" type="sdo" aoid="SV">
         <h1>Static Semantics: SV</h1>
-        <p>A string literal stands for a value of the String type. The String value (SV) of the literal is described in terms of String values contributed by the various parts of the string literal. As part of this process, some Unicode code points within the string literal are interpreted as having a mathematical value (MV), as described below or in <emu-xref href="#sec-literals-numeric-literals"></emu-xref>.</p>
+        <p>A string literal stands for a value of the String type. SV produces String values for string literals through recursive application on the various parts of the string literal. As part of this process, some Unicode code points within the string literal are interpreted as having a mathematical value, as described below or in <emu-xref href="#sec-literals-numeric-literals"></emu-xref>.</p>
         <ul>
           <li>
             The SV of <emu-grammar>StringLiteral :: `"` `"`</emu-grammar> is the empty String.
@@ -16974,7 +16974,7 @@
 
       <emu-clause id="sec-static-semantics-tv-and-trv">
         <h1>Static Semantics: TV and TRV</h1>
-        <p>A template literal component is interpreted as a sequence of Unicode code points. The Template Value (TV) of a literal component is described in terms of String values (SV, <emu-xref href="#sec-literals-string-literals"></emu-xref>) contributed by the various parts of the template literal component. As part of this process, some Unicode code points within the template component are interpreted as having a mathematical value (MV, <emu-xref href="#sec-literals-numeric-literals"></emu-xref>). In determining a TV, escape sequences are replaced by the UTF-16 code unit(s) of the Unicode code point represented by the escape sequence. The Template Raw Value (TRV) is similar to a Template Value with the difference that in TRVs escape sequences are interpreted literally.</p>
+        <p>A template literal component is interpreted by TV and TRV as a value of the String type. TV is used to construct the indexed components of a template object (colloquially, the template values), and TRV is used to construct their raw counterparts (colloquially, the template raw values). In TV, escape sequences are replaced by the UTF-16 code unit(s) of the Unicode code point represented by the escape sequence. TRV is similar to TV with the difference being that in TRV, escape sequences are interpreted as they appear in the literal.</p>
         <ul>
           <li>
             The TV and TRV of <emu-grammar>NoSubstitutionTemplate :: ``` ```</emu-grammar> is the empty String.


### PR DESCRIPTION
This was split out from #2435. I took issue with the way the usage of parentheses here implied that we were defining terms that were interchangeable (for example, wherever you use TV you may replace it with Template Value, and vice versa). In the process of removing these, I believe I also simplified the descriptions of the SDOs to get more to the point with less clutter.