### PR TITLE
Editorial: Fix wrong assertion in IsLessThan

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -5253,8 +5253,8 @@
             1. If _nx_ is *NaN*, return *undefined*.
             1. Return BigInt::lessThan(_nx_, _py_).
           1. NOTE: Because _px_ and _py_ are primitive values, evaluation order is not important.
-          1. Let _nx_ be ! ToNumeric(_px_).
-          1. Let _ny_ be ! ToNumeric(_py_).
+          1. Let _nx_ be ? ToNumeric(_px_).
+          1. Let _ny_ be ? ToNumeric(_py_).
           1. If Type(_nx_) is the same as Type(_ny_), return Type(_nx_)::lessThan(_nx_, _ny_).
           1. Assert: Type(_nx_) is BigInt and Type(_ny_) is Number, or Type(_nx_) is Number and Type(_ny_) is BigInt.
           1. If _nx_ or _ny_ is *NaN*, return *undefined*.


### PR DESCRIPTION
In step 4.d, 4.e of [7.2.13 IsLessThan](https://tc39.es/ecma262/#sec-islessthan) algorithm, current spec use `!` assertion on `ToNumeric` call. However, it seems that abrupt completion can be returned from `ToNumeric` calls in step 4.d and step 4.e. `px` and `py` can be symbol objects and `ToNumber` call in `ToNumeric` algorithm emits an abrupt completion, which is a `TypeError` exception. Here is JS code triggering assertion failure in current specification:

```js
Object.defineProperty(Symbol.prototype, Symbol.toPrimitive, { value: undefined });
Object(Symbol()) <= ""; // should throw TypeError, but assertion fail in spec
```

According to test262 and chrome browser, the above code should throw `TypeError` exception. Changing `!` to `?` in step 4.d and 4.e seems to be a plausible fix.

Related test262 cases: https://github.com/tc39/test262/blob/main/test/built-ins/Symbol/prototype/Symbol.toPrimitive/redefined-symbol-wrapper-ordinary-toprimitive.js