### PR TITLE
Editorial: Set [[Construct]] for default constructor in ClassDefiniti…

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -13175,6 +13175,8 @@
           1. Assert: IsConstructor(_F_) is *false*.
           1. Assert: _F_ is an extensible object that does not have a *"prototype"* own property.
           1. Set _F_.[[Construct]] to the definition specified in <emu-xref href="#sec-ecmascript-function-objects-construct-argumentslist-newtarget"></emu-xref>.
+        1. Else,
+          1. Set _F_.[[Construct]] to the definition specified in <emu-xref href="#sec-built-in-function-objects-construct-argumentslist-newtarget"></emu-xref>.
         1. Set _F_.[[ConstructorKind]] to ~base~.
         1. If _writablePrototype_ is not present, set _writablePrototype_ to *true*.
         1. If _prototype_ is not present, then


### PR DESCRIPTION
In [15.7.12 Runtime Semantics: ClassDefinitionEvaluation](https://tc39.es/ecma262/#sec-runtime-semantics-classdefinitionevaluation), when constructor is not specified in class, `F` use default constructor created in step 14. However, in this case, there is no explicit step which set `[[Construct]]` internal property of built-in function object `F`. As a result, when evaluating a new expression with class using default constructor, current spec throws `TypeError`. Here is JS code which seems to be problematic in current spec:

```js
class Rectangle {
a() { return 1; }
}

// 13.3.5.1.1 EvaluateNew throws TypeError exception in step 7
// since [[Construct]] internal property is not set
var rec = new Rectangle; 
```

Setting `[[Construct]]` for built-in function objects in [10.2.5. MakeConstructor](https://tc39.es/ecma262/#sec-makeconstructor) seems to be a plausible fix.