### PR TITLE
Editorial: Validate array length using `SameValueZero` in `ArraySetLength` and `Array`

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -13728,7 +13728,7 @@
           1. Let _newLenDesc_ be a copy of _Desc_.
           1. [id="step-arraysetlength-newlen"] Let _newLen_ be ? ToUint32(_Desc_.[[Value]]).
           1. [id="step-arraysetlength-numberlen"] Let _numberLen_ be ? ToNumber(_Desc_.[[Value]]).
-          1. If _newLen_ is not the same value as _numberLen_, throw a *RangeError* exception.
+          1. If SameValueZero(_newLen_, _numberLen_) is *false*, throw a *RangeError* exception.
           1. Set _newLenDesc_.[[Value]] to _newLen_.
           1. Let _oldLenDesc_ be OrdinaryGetOwnProperty(_A_, *"length"*).
           1. Assert: ! IsDataDescriptor(_oldLenDesc_) is *true*.
@@ -35206,7 +35206,7 @@ THH:mm:ss.sss
               1. Let _intLen_ be *1*<sub>𝔽</sub>.
             1. Else,
               1. Let _intLen_ be ! ToUint32(_len_).
-              1. If _intLen_ is not the same value as _len_, throw a *RangeError* exception.
+              1. If SameValueZero(_intLen_, _len_) is *false*, throw a *RangeError* exception.
             1. Perform ! Set(_array_, *"length"*, _intLen_, *true*).
             1. Return _array_.
           1. Else,


### PR DESCRIPTION
I believe that the `&ne;` (≠) notation should be used when comparing array lengths in [10.4.2.4 ArraySetLength](https://tc39.es/ecma262/#sec-arraysetlength)'s step `5`.

According to [test262/test/built-ins/Object/defineProperties/15.2.3.7-6-a-127.js](https://github.com/tc39/test262/blob/master/test/built-ins/Object/defineProperties/15.2.3.7-6-a-127.js), a `RangeError` must not be thrown, meaning that `newLen` and `numberLen`, which are `0` and `-0.0` in this case, should be "the same value". 

From what I've seen in #1963 and [one of the discussions](https://github.com/tc39/ecma262/pull/2007/files#r501329621) when the phrase "the same value" was first introduced, the likes of `=`, `≠` seem to be used for mathematical equality, which is what I think is a more suitable notation to express the comparison.