### PR TITLE
Editorial: avoid duplicate SetFunctionName in {async,}generator methods

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -13220,7 +13220,6 @@
       <dl class="header">
       </dl>
       <emu-alg>
-        1. Perform ! SetFunctionName(_closure_, _key_).
         1. If _key_ is a Private Name, then
           1. Return PrivateElement { [[Key]]: _key_, [[Kind]]: ~method~, [[Value]]: _closure_ }.
         1. Else,
@@ -22992,6 +22991,7 @@
       <emu-grammar>MethodDefinition : ClassElementName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Let _methodDef_ be ? DefineMethod of |MethodDefinition| with argument _object_.
+        1. Perform ! SetFunctionName(_methodDef_.[[Closure]], _methodDef_.[[Key]]).
         1. Return ? DefineMethodProperty(_methodDef_.[[Key]], _object_, _methodDef_.[[Closure]], _enumerable_).
       </emu-alg>
       <emu-grammar>MethodDefinition : `get` ClassElementName `(` `)` `{` FunctionBody `}`</emu-grammar>
@@ -23070,6 +23070,7 @@
         1. Let _sourceText_ be the source text matched by |AsyncMethod|.
         1. Let _closure_ be ! OrdinaryFunctionCreate(%AsyncFunction.prototype%, _sourceText_, |UniqueFormalParameters|, |AsyncFunctionBody|, ~non-lexical-this~, _scope_, _privateScope_).
         1. Perform ! MakeMethod(_closure_, _object_).
+        1. Perform ! SetFunctionName(_closure_, _propKey_).
         1. Return ? DefineMethodProperty(_propKey_, _object_, _closure_, _enumerable_).
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
#1668 introduced a `DefineMethodProperty` method for use when creating plain methods, generator methods, async methods, and async generator methods. In that PR it included a call to `SetFunctionName`, which was correspondingly factored out of the evaluation semantics of plain methods and async methods, but not generator methods or async generator methods. In the evaluation semantics for generator (and async generator) methods, there's another property (`.prototype`) which is added between the call to `SetFunctionName` and `DefineMethodProperty`, and since property creation order is observable dropping the first call and just letting it happen in `DefineMethodProperty` would be an observable change.

Instead, just remove `SetFunctionName` from `DefineMethodProperty`, and restore it to the evaluation semantics for plain and async methods. It doesn't really belong in `DefineMethodProperty`.

(I'm pretty sure I introduced this bug by accident rebasing #1668.)

This was definitely unintentional, and fails an assert (in `SetFunctionName`). So I'm calling it editorial.

Thanks to @devsnek for the catch.