### PR TITLE
Editorial: initialize missing slots in OrdinaryFunctionCreate

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -13108,6 +13108,8 @@
         1. Set _F_.[[ScriptOrModule]] to GetActiveScriptOrModule().
         1. Set _F_.[[Realm]] to the current Realm Record.
         1. Set _F_.[[HomeObject]] to *undefined*.
+        1. Set _F_.[[Fields]] to a new empty List.
+        1. Set _F_.[[PrivateMethods]] to a new empty List.
         1. Set _F_.[[ClassFieldInitializerName]] to ~empty~.
         1. Let _len_ be the ExpectedArgumentCount of _ParameterList_.
         1. Perform ! SetFunctionLength(_F_, _len_).


### PR DESCRIPTION
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->

These fields were not initialized at all, although they are present on every ordinary function according to table 33. Depending on how you view internal slots this either caused creating the object to be invalid, or it caused InitializeInstanceFields to be invalid.
