### PR TITLE
Editorial: Cleanup ValidateAndApplyPropertyDescriptor and own prop operations

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -2593,26 +2593,32 @@
 
       <emu-clause id="sec-property-attributes">
         <h1>Property Attributes</h1>
-        <p>Attributes are used in this specification to define and explain the state of Object properties. A data property associates a key value with the attributes listed in <emu-xref href="#table-data-property-attributes"></emu-xref>.</p>
-        <emu-table id="table-data-property-attributes" caption="Attributes of a Data Property" oldids="table-2">
+        <!--
+           TODO: merge this with sec-property-descriptor-specification-type?
+          cf. https://github.com/tc39/ecma262/issues/1067
+        -->
+        <p>Attributes are used in this specification to define and explain the state of Object properties as described in <emu-xref href="#table-object-property-attributes"></emu-xref>. Unless specified explicitly, the initial value of each attribute is its Default Value.</p>
+        <emu-table id="table-object-property-attributes" caption="Attributes of an Object property" oldids="table-2,table-3,table-4,table-data-property-attributes,table-accessor-property-attributes,table-default-attribute-values">
           <table>
             <tr>
-              <th>
-                Attribute Name
-              </th>
-              <th>
-                Value Domain
-              </th>
-              <th>
-                Description
-              </th>
+              <th>Attribute Name</th>
+              <th>Types of property for which it is present</th>
+              <th>Value Domain</th>
+              <th>Default Value</th>
+              <th>Description</th>
             </tr>
             <tr>
               <td>
                 [[Value]]
               </td>
               <td>
-                Any ECMAScript language type
+                data property
+              </td>
+              <td>
+                an ECMAScript language value
+              </td>
+              <td>
+                *undefined*
               </td>
               <td>
                 The value retrieved by a get access of the property.
@@ -2623,7 +2629,13 @@
                 [[Writable]]
               </td>
               <td>
-                Boolean
+                data property
+              </td>
+              <td>
+                a Boolean
+              </td>
+              <td>
+                *false*
               </td>
               <td>
                 If *false*, attempts by ECMAScript code to change the property's [[Value]] attribute using [[Set]] will not succeed.
@@ -2631,48 +2643,16 @@
             </tr>
             <tr>
               <td>
-                [[Enumerable]]
-              </td>
-              <td>
-                Boolean
-              </td>
-              <td>
-                If *true*, the property will be enumerated by a for-in enumeration (see <emu-xref href="#sec-for-in-and-for-of-statements"></emu-xref>). Otherwise, the property is said to be non-enumerable.
-              </td>
-            </tr>
-            <tr>
-              <td>
-                [[Configurable]]
-              </td>
-              <td>
-                Boolean
-              </td>
-              <td>
-                If *false*, attempts to delete the property, change the property to be an accessor property, or change its attributes (other than [[Value]], or changing [[Writable]] to *false*) will fail.
-              </td>
-            </tr>
-          </table>
-        </emu-table>
-        <p>An accessor property associates a key value with the attributes listed in <emu-xref href="#table-accessor-property-attributes"></emu-xref>.</p>
-        <emu-table id="table-accessor-property-attributes" caption="Attributes of an Accessor Property" oldids="table-3">
-          <table>
-            <tr>
-              <th>
-                Attribute Name
-              </th>
-              <th>
-                Value Domain
-              </th>
-              <th>
-                Description
-              </th>
-            </tr>
-            <tr>
-              <td>
                 [[Get]]
               </td>
               <td>
-                Object | Undefined
+                accessor property
+              </td>
+              <td>
+                an Object or *undefined*
+              </td>
+              <td>
+                *undefined*
               </td>
               <td>
                 If the value is an Object it must be a function object. The function's [[Call]] internal method (<emu-xref href="#table-additional-essential-internal-methods-of-function-objects"></emu-xref>) is called with an empty arguments list to retrieve the property value each time a get access of the property is performed.
@@ -2683,7 +2663,13 @@
                 [[Set]]
               </td>
               <td>
-                Object | Undefined
+                accessor property
+              </td>
+              <td>
+                an Object or *undefined*
+              </td>
+              <td>
+                *undefined*
               </td>
               <td>
                 If the value is an Object it must be a function object. The function's [[Call]] internal method (<emu-xref href="#table-additional-essential-internal-methods-of-function-objects"></emu-xref>) is called with an arguments list containing the assigned value as its sole argument each time a set access of the property is performed. The effect of a property's [[Set]] internal method may, but is not required to, have an effect on the value returned by subsequent calls to the property's [[Get]] internal method.
@@ -2694,10 +2680,16 @@
                 [[Enumerable]]
               </td>
               <td>
-                Boolean
+                data property or accessor property
               </td>
               <td>
-                If *true*, the property is to be enumerated by a for-in enumeration (see <emu-xref href="#sec-for-in-and-for-of-statements"></emu-xref>). Otherwise, the property is said to be non-enumerable.
+                a Boolean
+              </td>
+              <td>
+                *false*
+              </td>
+              <td>
+                If *true*, the property will be enumerated by a for-in enumeration (see <emu-xref href="#sec-for-in-and-for-of-statements"></emu-xref>). Otherwise, the property is said to be non-enumerable.
               </td>
             </tr>
             <tr>
@@ -2705,71 +2697,16 @@
                 [[Configurable]]
               </td>
               <td>
-                Boolean
+                data property or accessor property
               </td>
               <td>
-                If *false*, attempts to delete the property, change the property to be a data property, or change its attributes will fail.
-              </td>
-            </tr>
-          </table>
-        </emu-table>
-        <p>If the initial values of a property's attributes are not explicitly specified by this specification, the default value defined in <emu-xref href="#table-default-attribute-values"></emu-xref> is used.</p>
-        <emu-table id="table-default-attribute-values" caption="Default Attribute Values" oldids="table-4">
-          <table>
-            <tr>
-              <th>
-                Attribute Name
-              </th>
-              <th>
-                Default Value
-              </th>
-            </tr>
-            <tr>
-              <td>
-                [[Value]]
-              </td>
-              <td>
-                *undefined*
-              </td>
-            </tr>
-            <tr>
-              <td>
-                [[Get]]
-              </td>
-              <td>
-                *undefined*
-              </td>
-            </tr>
-            <tr>
-              <td>
-                [[Set]]
-              </td>
-              <td>
-                *undefined*
-              </td>
-            </tr>
-            <tr>
-              <td>
-                [[Writable]]
+                a Boolean
               </td>
               <td>
                 *false*
               </td>
-            </tr>
-            <tr>
               <td>
-                [[Enumerable]]
-              </td>
-              <td>
-                *false*
-              </td>
-            </tr>
-            <tr>
-              <td>
-                [[Configurable]]
-              </td>
-              <td>
-                *false*
+                If *false*, attempts to delete the property, change it from a data property to an accessor property or from an accessor property to a data property, or make any changes to its attributes (other than replacing an existing [[Value]] or setting [[Writable]] to *false*) will fail.
               </td>
             </tr>
           </table>
@@ -4333,8 +4270,9 @@
     <emu-clause id="sec-property-descriptor-specification-type">
       <h1>The Property Descriptor Specification Type</h1>
       <p>The <dfn variants="Property Descriptors">Property Descriptor</dfn> type is used to explain the manipulation and reification of Object property attributes. Values of the Property Descriptor type are Records. Each field's name is an attribute name and its value is a corresponding attribute value as specified in <emu-xref href="#sec-property-attributes"></emu-xref>. In addition, any field may be present or absent. The schema name used within this specification to tag literal descriptions of Property Descriptor records is &ldquo;PropertyDescriptor&rdquo;.</p>
-      <p>Property Descriptor values may be further classified as data Property Descriptors and accessor Property Descriptors based upon the existence or use of certain fields. A data Property Descriptor is one that includes any fields named either [[Value]] or [[Writable]]. An accessor Property Descriptor is one that includes any fields named either [[Get]] or [[Set]]. Any Property Descriptor may have fields named [[Enumerable]] and [[Configurable]]. A Property Descriptor value may not be both a data Property Descriptor and an accessor Property Descriptor; however, it may be neither. A generic Property Descriptor is a Property Descriptor value that is neither a data Property Descriptor nor an accessor Property Descriptor. A fully populated Property Descriptor is one that is either an accessor Property Descriptor or a data Property Descriptor and that has all of the fields that correspond to the property attributes defined in either <emu-xref href="#table-data-property-attributes"></emu-xref> or <emu-xref href="#table-accessor-property-attributes"></emu-xref>.</p>
+      <p>Property Descriptor values may be further classified as data Property Descriptors and accessor Property Descriptors based upon the existence or use of certain fields. A data Property Descriptor is one that includes any fields named either [[Value]] or [[Writable]]. An accessor Property Descriptor is one that includes any fields named either [[Get]] or [[Set]]. Any Property Descriptor may have fields named [[Enumerable]] and [[Configurable]]. A Property Descriptor value may not be both a data Property Descriptor and an accessor Property Descriptor; however, it may be neither (in which case it is a generic Property Descriptor). A <dfn>fully populated Property Descriptor</dfn> is one that is either an accessor Property Descriptor or a data Property Descriptor and that has all of the corresponding fields defined in <emu-xref href="#table-object-property-attributes"></emu-xref>.</p>
       <p>The following abstract operations are used in this specification to operate upon Property Descriptor values:</p>
+      <!-- TODO: replace Boolean-returning operations with PropertyDescriptorType → ~generic~ | ~data~ | ~accessor~? -->
 
       <emu-clause id="sec-isaccessordescriptor" type="abstract operation">
         <h1>
@@ -12653,7 +12591,7 @@
         <dl class="header">
         </dl>
         <emu-alg>
-          1. Return ValidateAndApplyPropertyDescriptor(*undefined*, *undefined*, _Extensible_, _Desc_, _Current_).
+          1. Return ValidateAndApplyPropertyDescriptor(*undefined*, *""*, _Extensible_, _Desc_, _Current_).
         </emu-alg>
       </emu-clause>
 
@@ -12664,51 +12602,46 @@
             _P_: a property key,
             _extensible_: a Boolean,
             _Desc_: a Property Descriptor,
-            _current_: a Property Descriptor,
+            _current_: a Property Descriptor or *undefined*,
           )
         </h1>
         <dl class="header">
+          <dt>description</dt>
+          <dd>It returns a Boolean value which is *true* if and only if _Desc_ can be applied as the property of an object with specified _extensibility_ and current property _current_ while upholding <emu-xref href="#sec-invariants-of-the-essential-internal-methods">invariants</emu-xref>. When such application is possible and _O_ is not *undefined*, it is performed for the property named _P_ (which is created if necessary).</dd>
         </dl>
-        <emu-note>
-          <p>If *undefined* is passed as _O_, only validation is performed and no object updates are performed.</p>
-        </emu-note>
-        <p>It performs the following steps when called:</p>
         <emu-alg>
-          1. Assert: If _O_ is not *undefined*, then IsPropertyKey(_P_) is *true*.
+          1. Assert: ! IsPropertyKey(_P_) is *true*.
           1. If _current_ is *undefined*, then
             1. If _extensible_ is *false*, return *false*.
-            1. Assert: _extensible_ is *true*.
-            1. If IsGenericDescriptor(_Desc_) is *true* or IsDataDescriptor(_Desc_) is *true*, then
-              1. If _O_ is not *undefined*, create an own data property named _P_ of object _O_ whose [[Value]], [[Writable]], [[Enumerable]], and [[Configurable]] attribute values are described by _Desc_. If the value of an attribute field of _Desc_ is absent, the attribute of the newly created property is set to its <emu-xref href="#table-default-attribute-values">default value</emu-xref>.
+            1. If _O_ is *undefined*, return *true*.
+            1. If ! IsAccessorDescriptor(_Desc_) is *true*, then
+              1. Create an own accessor property named _P_ of object _O_ whose [[Get]], [[Set]], [[Enumerable]], and [[Configurable]] attribute values are described by _Desc_. If the value of an attribute field of _Desc_ is absent, the attribute of the newly created property is set to its <emu-xref href="#table-object-property-attributes">default value</emu-xref>.
             1. Else,
-              1. Assert: ! IsAccessorDescriptor(_Desc_) is *true*.
-              1. If _O_ is not *undefined*, create an own accessor property named _P_ of object _O_ whose [[Get]], [[Set]], [[Enumerable]], and [[Configurable]] attribute values are described by _Desc_. If the value of an attribute field of _Desc_ is absent, the attribute of the newly created property is set to its <emu-xref href="#table-default-attribute-values">default value</emu-xref>.
+              1. Create an own data property named _P_ of object _O_ whose [[Value]], [[Writable]], [[Enumerable]], and [[Configurable]] attribute values are described by _Desc_. If the value of an attribute field of _Desc_ is absent, the attribute of the newly created property is set to its <emu-xref href="#table-object-property-attributes">default value</emu-xref>.
             1. Return *true*.
+          1. Assert: _current_ is a fully populated Property Descriptor.
           1. If every field in _Desc_ is absent, return *true*.
           1. If _current_.[[Configurable]] is *false*, then
             1. If _Desc_.[[Configurable]] is present and its value is *true*, return *false*.
             1. If _Desc_.[[Enumerable]] is present and ! SameValue(_Desc_.[[Enumerable]], _current_.[[Enumerable]]) is *false*, return *false*.
-          1. If ! IsGenericDescriptor(_Desc_) is *true*, then
-            1. NOTE: No further validation is required.
-          1. Else if ! SameValue(! IsDataDescriptor(_current_), ! IsDataDescriptor(_Desc_)) is *false*, then
-            1. If _current_.[[Configurable]] is *false*, return *false*.
-            1. If IsDataDescriptor(_current_) is *true*, then
-              1. If _O_ is not *undefined*, convert the property named _P_ of object _O_ from a data property to an accessor property. Preserve the existing values of the converted property's [[Configurable]] and [[Enumerable]] attributes and set the rest of the property's attributes to their <emu-xref href="#table-default-attribute-values">default values</emu-xref>.
-            1. Else,
-              1. If _O_ is not *undefined*, convert the property named _P_ of object _O_ from an accessor property to a data property. Preserve the existing values of the converted property's [[Configurable]] and [[Enumerable]] attributes and set the rest of the property's attributes to their <emu-xref href="#table-default-attribute-values">default values</emu-xref>.
-          1. Else if IsDataDescriptor(_current_) and IsDataDescriptor(_Desc_) are both *true*, then
-            1. If _current_.[[Configurable]] is *false* and _current_.[[Writable]] is *false*, then
+            1. If ! IsGenericDescriptor(_Desc_) is *false* and ! SameValue(IsAccessorDescriptor(_Desc_), IsAccessorDescriptor(_current_)) is *false*, return *false*.
+            1. If ! IsAccessorDescriptor(_Desc_) is *true*, then
+              1. If _Desc_.[[Get]] is present and ! SameValue(_Desc_.[[Get]], _current_.[[Get]]) is *false*, return *false*.
+              1. If _Desc_.[[Set]] is present and ! SameValue(_Desc_.[[Set]], _current_.[[Set]]) is *false*, return *false*.
+            1. Else if _current_.[[Writable]] is *false*, then
               1. If _Desc_.[[Writable]] is present and _Desc_.[[Writable]] is *true*, return *false*.
-              1. If _Desc_.[[Value]] is present and SameValue(_Desc_.[[Value]], _current_.[[Value]]) is *false*, return *false*.
-              1. Return *true*.
-          1. Else,
-            1. Assert: ! IsAccessorDescriptor(_current_) and ! IsAccessorDescriptor(_Desc_) are both *true*.
-            1. If _current_.[[Configurable]] is *false*, then
-              1. If _Desc_.[[Set]] is present and SameValue(_Desc_.[[Set]], _current_.[[Set]]) is *false*, return *false*.
-              1. If _Desc_.[[Get]] is present and SameValue(_Desc_.[[Get]], _current_.[[Get]]) is *false*, return *false*.
-              1. Return *true*.
+              1. If _Desc_.[[Value]] is present and ! SameValue(_Desc_.[[Value]], _current_.[[Value]]) is *false*, return *false*.
           1. If _O_ is not *undefined*, then
-            1. For each field of _Desc_ that is present, set the corresponding attribute of the property named _P_ of object _O_ to the value of the field.
+            1. If ! IsDataDescriptor(_current_) is *true* and ! IsAccessorDescriptor(_Desc_) is *true*, then
+              1. If _Desc_ has a [[Configurable]] field, let _configurable_ be Desc.[[Configurable]], else let _configurable_ be _current_.[[Configurable]].
+              1. If _Desc_ has a [[Enumerable]] field, let _enumerable_ be Desc.[[Enumerable]], else let _enumerable_ be _current_.[[Enumerable]].
+              1. Replace the property named _P_ of object _O_ with an accessor property having [[Configurable]] and [[Enumerable]] attributes set to _configurable_ and _enumerable_, respectively, and each other attribute set to its corresponding value in _Desc_ if present, otherwise to its <emu-xref href="#table-object-property-attributes">default value</emu-xref>.
+            1. Else if ! IsAccessorDescriptor(_current_) is *true* and ! IsDataDescriptor(_Desc_) is *true*, then
+              1. If _Desc_ has a [[Configurable]] field, let _configurable_ be Desc.[[Configurable]], else let _configurable_ be _current_.[[Configurable]].
+              1. If _Desc_ has a [[Enumerable]] field, let _enumerable_ be Desc.[[Enumerable]], else let _enumerable_ be _current_.[[Enumerable]].
+              1. Replace the property named _P_ of object _O_ with a data property having [[Configurable]] and [[Enumerable]] attributes set to _configurable_ and _enumerable_, respectively, and each other attribute set to its corresponding value in _Desc_ if present, otherwise to its <emu-xref href="#table-object-property-attributes">default value</emu-xref>.
+            1. Else,
+              1. For each field of _Desc_ that is present, set the corresponding attribute of the property named _P_ of object _O_ to the value of the field.
           1. Return *true*.
         </emu-alg>
       </emu-clause>
@@ -15337,6 +15270,7 @@
           1. If _targetDesc_ is *undefined* or _targetDesc_.[[Configurable]] is *true*, then
             1. Throw a *TypeError* exception.
           1. If _resultDesc_ has a [[Writable]] field and _resultDesc_.[[Writable]] is *false*, then
+            1. Assert: _targetDesc_ has a [[Writable]] field.
             1. If _targetDesc_.[[Writable]] is *true*, throw a *TypeError* exception.
         1. Return _resultDesc_.
       </emu-alg>
@@ -15350,10 +15284,10 @@
             A property cannot be reported as non-existent, if it exists as a non-configurable own property of the target object.
           </li>
           <li>
-            A property cannot be reported as non-existent, if the target object is not extensible, unless it does not exist as an own property of the target object.
+            A property cannot be reported as non-existent, if it exists as an own property of a non-extensible target object.
           </li>
           <li>
-            A property cannot be reported as existent, if the target object is not extensible, unless it exists as an own property of the target object.
+            A property cannot be reported as existent, if it does not exist as an own property of the target object and the target object is not extensible.
           </li>
           <li>
             A property cannot be reported as non-configurable, unless it exists as a non-configurable own property of the target object.


### PR DESCRIPTION
Fixes #2466

Commits can be reviewed sequentially, but the [build preview](https://ci.tc39.es/preview/tc39/ecma262/pull/2468) is probably best:
* [merged Property Attributes table](https://ci.tc39.es/preview/tc39/ecma262/pull/2468#sec-property-attributes)
* [indirect Record field references](https://ci.tc39.es/preview/tc39/ecma262/pull/2468#sec-list-and-record-specification-type) ([[\<_fieldName_>]])
* [ValidateAndApplyPropertyDescriptor](https://ci.tc39.es/preview/tc39/ecma262/pull/2468#sec-validateandapplypropertydescriptor)
* [Proxy [[GetOwnProperty]] note clarifications](https://ci.tc39.es/preview/tc39/ecma262/pull/2468#sec-proxy-object-internal-methods-and-internal-slots-getownproperty-p)