### PR TITLE
Markup: prefer `&notin;` over `&lt;!`

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -740,8 +740,8 @@
       <p>the definition:</p>
       <emu-grammar type="definition" example>
         LookaheadExample ::
-          `n` [lookahead &lt;! {`1`, `3`, `5`, `7`, `9`}] DecimalDigits
-          DecimalDigit [lookahead &lt;! DecimalDigit]
+          `n` [lookahead &notin; {`1`, `3`, `5`, `7`, `9`}] DecimalDigits
+          DecimalDigit [lookahead &notin; DecimalDigit]
       </emu-grammar>
       <p>matches either the letter `n` followed by one or more decimal digits the first of which is even, or a decimal digit not followed by another decimal digit.</p>
       <p>Note that when these phrases are used in the syntactic grammar, it may not be possible to unambiguously identify the immediately following token sequence because determining later tokens requires knowing which lexical goal symbol to use at later positions. As such, when these are used in the syntactic grammar, it is considered an editorial error for a token sequence _seq_ to appear in a lookahead restriction (including as part of a set of sequences) if the choices of lexical goal symbols to use could change whether or not _seq_ would be a prefix of the resulting token sequence.</p>
@@ -16189,7 +16189,7 @@
         OtherPunctuator
 
       OptionalChainingPunctuator ::
-        `?.` [lookahead &lt;! DecimalDigit]
+        `?.` [lookahead &notin; DecimalDigit]
 
       OtherPunctuator :: one of
         `{` `(` `)` `[` `]`
@@ -16575,7 +16575,7 @@
 
         EscapeSequence ::
           CharacterEscapeSequence
-          `0` [lookahead &lt;! DecimalDigit]
+          `0` [lookahead &notin; DecimalDigit]
           HexEscapeSequence
           UnicodeEscapeSequence
       </emu-grammar>
@@ -16953,15 +16953,15 @@
         NotEscapeSequence ::
           `0` DecimalDigit
           DecimalDigit but not `0`
-          `x` [lookahead &lt;! HexDigit]
-          `x` HexDigit [lookahead &lt;! HexDigit]
-          `u` [lookahead &lt;! HexDigit] [lookahead != `{`]
-          `u` HexDigit [lookahead &lt;! HexDigit]
-          `u` HexDigit HexDigit [lookahead &lt;! HexDigit]
-          `u` HexDigit HexDigit HexDigit [lookahead &lt;! HexDigit]
-          `u` `{` [lookahead &lt;! HexDigit]
-          `u` `{` NotCodePoint [lookahead &lt;! HexDigit]
-          `u` `{` CodePoint [lookahead &lt;! HexDigit] [lookahead != `}`]
+          `x` [lookahead &notin; HexDigit]
+          `x` HexDigit [lookahead &notin; HexDigit]
+          `u` [lookahead &notin; HexDigit] [lookahead != `{`]
+          `u` HexDigit [lookahead &notin; HexDigit]
+          `u` HexDigit HexDigit [lookahead &notin; HexDigit]
+          `u` HexDigit HexDigit HexDigit [lookahead &notin; HexDigit]
+          `u` `{` [lookahead &notin; HexDigit]
+          `u` `{` NotCodePoint [lookahead &notin; HexDigit]
+          `u` `{` CodePoint [lookahead &notin; HexDigit] [lookahead != `}`]
 
         NotCodePoint ::
           HexDigits[~Sep] [> but only if MV of |HexDigits| &gt; 0x10FFFF]
@@ -17033,31 +17033,31 @@
             The TRV of <emu-grammar>NotEscapeSequence :: `0` DecimalDigit</emu-grammar> is the string-concatenation of the code unit 0x0030 (DIGIT ZERO) and the TRV of |DecimalDigit|.
           </li>
           <li>
-            The TRV of <emu-grammar>NotEscapeSequence :: `x` [lookahead &lt;! HexDigit]</emu-grammar> is the String value consisting of the code unit 0x0078 (LATIN SMALL LETTER X).
+            The TRV of <emu-grammar>NotEscapeSequence :: `x` [lookahead &notin; HexDigit]</emu-grammar> is the String value consisting of the code unit 0x0078 (LATIN SMALL LETTER X).
           </li>
           <li>
-            The TRV of <emu-grammar>NotEscapeSequence :: `x` HexDigit [lookahead &lt;! HexDigit]</emu-grammar> is the string-concatenation of the code unit 0x0078 (LATIN SMALL LETTER X) and the TRV of |HexDigit|.
+            The TRV of <emu-grammar>NotEscapeSequence :: `x` HexDigit [lookahead &notin; HexDigit]</emu-grammar> is the string-concatenation of the code unit 0x0078 (LATIN SMALL LETTER X) and the TRV of |HexDigit|.
           </li>
           <li>
-            The TRV of <emu-grammar>NotEscapeSequence :: `u` [lookahead &lt;! HexDigit] [lookahead != `{`]</emu-grammar> is the String value consisting of the code unit 0x0075 (LATIN SMALL LETTER U).
+            The TRV of <emu-grammar>NotEscapeSequence :: `u` [lookahead &notin; HexDigit] [lookahead != `{`]</emu-grammar> is the String value consisting of the code unit 0x0075 (LATIN SMALL LETTER U).
           </li>
           <li>
-            The TRV of <emu-grammar>NotEscapeSequence :: `u` HexDigit [lookahead &lt;! HexDigit]</emu-grammar> is the string-concatenation of the code unit 0x0075 (LATIN SMALL LETTER U) and the TRV of |HexDigit|.
+            The TRV of <emu-grammar>NotEscapeSequence :: `u` HexDigit [lookahead &notin; HexDigit]</emu-grammar> is the string-concatenation of the code unit 0x0075 (LATIN SMALL LETTER U) and the TRV of |HexDigit|.
           </li>
           <li>
-            The TRV of <emu-grammar>NotEscapeSequence :: `u` HexDigit HexDigit [lookahead &lt;! HexDigit]</emu-grammar> is the string-concatenation of the code unit 0x0075 (LATIN SMALL LETTER U), the TRV of the first |HexDigit|, and the TRV of the second |HexDigit|.
+            The TRV of <emu-grammar>NotEscapeSequence :: `u` HexDigit HexDigit [lookahead &notin; HexDigit]</emu-grammar> is the string-concatenation of the code unit 0x0075 (LATIN SMALL LETTER U), the TRV of the first |HexDigit|, and the TRV of the second |HexDigit|.
           </li>
           <li>
-            The TRV of <emu-grammar>NotEscapeSequence :: `u` HexDigit HexDigit HexDigit [lookahead &lt;! HexDigit]</emu-grammar> is the string-concatenation of the code unit 0x0075 (LATIN SMALL LETTER U), the TRV of the first |HexDigit|, the TRV of the second |HexDigit|, and the TRV of the third |HexDigit|.
+            The TRV of <emu-grammar>NotEscapeSequence :: `u` HexDigit HexDigit HexDigit [lookahead &notin; HexDigit]</emu-grammar> is the string-concatenation of the code unit 0x0075 (LATIN SMALL LETTER U), the TRV of the first |HexDigit|, the TRV of the second |HexDigit|, and the TRV of the third |HexDigit|.
           </li>
           <li>
-            The TRV of <emu-grammar>NotEscapeSequence :: `u` `{` [lookahead &lt;! HexDigit]</emu-grammar> is the string-concatenation of the code unit 0x0075 (LATIN SMALL LETTER U) and the code unit 0x007B (LEFT CURLY BRACKET).
+            The TRV of <emu-grammar>NotEscapeSequence :: `u` `{` [lookahead &notin; HexDigit]</emu-grammar> is the string-concatenation of the code unit 0x0075 (LATIN SMALL LETTER U) and the code unit 0x007B (LEFT CURLY BRACKET).
           </li>
           <li>
-            The TRV of <emu-grammar>NotEscapeSequence :: `u` `{` NotCodePoint [lookahead &lt;! HexDigit]</emu-grammar> is the string-concatenation of the code unit 0x0075 (LATIN SMALL LETTER U), the code unit 0x007B (LEFT CURLY BRACKET), and the TRV of |NotCodePoint|.
+            The TRV of <emu-grammar>NotEscapeSequence :: `u` `{` NotCodePoint [lookahead &notin; HexDigit]</emu-grammar> is the string-concatenation of the code unit 0x0075 (LATIN SMALL LETTER U), the code unit 0x007B (LEFT CURLY BRACKET), and the TRV of |NotCodePoint|.
           </li>
           <li>
-            The TRV of <emu-grammar>NotEscapeSequence :: `u` `{` CodePoint [lookahead &lt;! HexDigit] [lookahead != `}`]</emu-grammar> is the string-concatenation of the code unit 0x0075 (LATIN SMALL LETTER U), the code unit 0x007B (LEFT CURLY BRACKET), and the TRV of |CodePoint|.
+            The TRV of <emu-grammar>NotEscapeSequence :: `u` `{` CodePoint [lookahead &notin; HexDigit] [lookahead != `}`]</emu-grammar> is the string-concatenation of the code unit 0x0075 (LATIN SMALL LETTER U), the code unit 0x007B (LEFT CURLY BRACKET), and the TRV of |CodePoint|.
           </li>
           <li>
             The TRV of <emu-grammar>DecimalDigit :: one of `0` `1` `2` `3` `4` `5` `6` `7` `8` `9`</emu-grammar> is the result of performing UTF16EncodeCodePoint on the single code point matched by this production.
@@ -20881,7 +20881,7 @@
     <h2>Syntax</h2>
     <emu-grammar type="definition">
       ExpressionStatement[Yield, Await] :
-        [lookahead &lt;! {`{`, `function`, `async` [no |LineTerminator| here] `function`, `class`, `let` `[`}] Expression[+In, ?Yield, ?Await] `;`
+        [lookahead &notin; {`{`, `function`, `async` [no |LineTerminator| here] `function`, `class`, `let` `[`}] Expression[+In, ?Yield, ?Await] `;`
     </emu-grammar>
     <emu-note>
       <p>An |ExpressionStatement| cannot start with a U+007B (LEFT CURLY BRACKET) because that might make it ambiguous with a |Block|. An |ExpressionStatement| cannot start with the `function` or `class` keywords because that would make it ambiguous with a |FunctionDeclaration|, a |GeneratorDeclaration|, or a |ClassDeclaration|. An |ExpressionStatement| cannot start with `async function` because that would make it ambiguous with an |AsyncFunctionDeclaration| or a |AsyncGeneratorDeclaration|. An |ExpressionStatement| cannot start with the two token sequence `let [` because that would make it ambiguous with a `let` |LexicalDeclaration| whose first |LexicalBinding| was an |ArrayBindingPattern|.</p>
@@ -26635,7 +26635,7 @@
           `export` Declaration[~Yield, ~Await]
           `export` `default` HoistableDeclaration[~Yield, ~Await, +Default]
           `export` `default` ClassDeclaration[~Yield, ~Await, +Default]
-          `export` `default` [lookahead &lt;! {`function`, `async` [no |LineTerminator| here] `function`, `class`}] AssignmentExpression[+In, ~Yield, ~Await] `;`
+          `export` `default` [lookahead &notin; {`function`, `async` [no |LineTerminator| here] `function`, `class`}] AssignmentExpression[+In, ~Yield, ~Await] `;`
 
         ExportFromClause :
           `*`
@@ -33151,7 +33151,7 @@ THH:mm:ss.sss
         CharacterEscape[U] ::
           ControlEscape
           `c` ControlLetter
-          `0` [lookahead &lt;! DecimalDigit]
+          `0` [lookahead &notin; DecimalDigit]
           HexEscapeSequence
           RegExpUnicodeEscapeSequence[?U]
           IdentityEscape[?U]
@@ -33220,7 +33220,7 @@ THH:mm:ss.sss
           [~U] SourceCharacter but not UnicodeIDContinue
 
         DecimalEscape ::
-          NonZeroDigit DecimalDigits[~Sep]? [lookahead &lt;! DecimalDigit]
+          NonZeroDigit DecimalDigits[~Sep]? [lookahead &notin; DecimalDigit]
 
         CharacterClassEscape[U] ::
           `d`
@@ -33577,7 +33577,7 @@ THH:mm:ss.sss
           1. Let _i_ be _ch_'s code point value.
           1. Return the remainder of dividing _i_ by 32.
         </emu-alg>
-        <emu-grammar>CharacterEscape :: `0` [lookahead &lt;! DecimalDigit]</emu-grammar>
+        <emu-grammar>CharacterEscape :: `0` [lookahead &notin; DecimalDigit]</emu-grammar>
         <emu-alg>
           1. Return the code point value of U+0000 (NULL).
         </emu-alg>
@@ -34322,7 +34322,7 @@ THH:mm:ss.sss
           CharacterEscape ::
             ControlEscape
             `c` ControlLetter
-            `0` [lookahead &lt;! DecimalDigit]
+            `0` [lookahead &notin; DecimalDigit]
             HexEscapeSequence
             RegExpUnicodeEscapeSequence
             IdentityEscape
@@ -45419,8 +45419,8 @@ THH:mm:ss.sss
           UnicodeEscapeSequence
 
         LegacyOctalEscapeSequence ::
-          OctalDigit [lookahead &lt;! OctalDigit]
-          ZeroToThree OctalDigit [lookahead &lt;! OctalDigit]
+          OctalDigit [lookahead &notin; OctalDigit]
+          ZeroToThree OctalDigit [lookahead &notin; OctalDigit]
           FourToSeven OctalDigit
           ZeroToThree OctalDigit OctalDigit
 
@@ -45601,7 +45601,7 @@ THH:mm:ss.sss
         CharacterEscape[U, N] ::
           ControlEscape
           `c` ControlLetter
-          `0` [lookahead &lt;! DecimalDigit]
+          `0` [lookahead &notin; DecimalDigit]
           HexEscapeSequence
           RegExpUnicodeEscapeSequence[?U]
           [~U] LegacyOctalEscapeSequence


### PR DESCRIPTION
The inverse of #2327. I find this easier to understand.