### PR TITLE
Editorial: tweak PropertyDefinitionEvaluation and ClassElementEvaluation

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -17845,7 +17845,7 @@
         </emu-grammar>
         <emu-alg>
           1. Let _obj_ be ! OrdinaryObjectCreate(%Object.prototype%).
-          1. Perform ? PropertyDefinitionEvaluation of |PropertyDefinitionList| with arguments _obj_ and *true*.
+          1. Perform ? PropertyDefinitionEvaluation of |PropertyDefinitionList| with argument _obj_.
           1. Return _obj_.
         </emu-alg>
         <emu-grammar>LiteralPropertyName : IdentifierName</emu-grammar>
@@ -17870,11 +17870,11 @@
       </emu-clause>
       <emu-clause id="sec-runtime-semantics-propertydefinitionevaluation" oldids="sec-object-initializer-runtime-semantics-propertydefinitionevaluation" type="sdo" aoid="PropertyDefinitionEvaluation">
         <h1>Runtime Semantics: PropertyDefinitionEvaluation</h1>
-        <p>With parameters _object_ and _enumerable_.</p>
+        <p>With parameter _object_.</p>
         <emu-grammar>PropertyDefinitionList : PropertyDefinitionList `,` PropertyDefinition</emu-grammar>
         <emu-alg>
-          1. Perform ? PropertyDefinitionEvaluation of |PropertyDefinitionList| with arguments _object_ and _enumerable_.
-          1. Return the result of performing PropertyDefinitionEvaluation of |PropertyDefinition| with arguments _object_ and _enumerable_.
+          1. Perform ? PropertyDefinitionEvaluation of |PropertyDefinitionList| with argument _object_.
+          1. Return the result of performing PropertyDefinitionEvaluation of |PropertyDefinition| with argument _object_.
         </emu-alg>
         <emu-grammar>PropertyDefinition : `...` AssignmentExpression</emu-grammar>
         <emu-alg>
@@ -17888,7 +17888,6 @@
           1. Let _propName_ be StringValue of |IdentifierReference|.
           1. Let _exprValue_ be the result of evaluating |IdentifierReference|.
           1. Let _propValue_ be ? GetValue(_exprValue_).
-          1. Assert: _enumerable_ is *true*.
           1. Assert: _object_ is an ordinary, extensible object with no non-configurable properties.
           1. Return ! CreateDataPropertyOrThrow(_object_, _propName_, _propValue_).
         </emu-alg>
@@ -17911,7 +17910,6 @@
             1. If Type(_propValue_) is either Object or Null, then
               1. Return ! _object_.[[SetPrototypeOf]](_propValue_).
             1. Return NormalCompletion(~empty~).
-          1. Assert: _enumerable_ is *true*.
           1. Assert: _object_ is an ordinary, extensible object with no non-configurable properties.
           1. Return ! CreateDataPropertyOrThrow(_object_, _propKey_, _propValue_).
         </emu-alg>
@@ -17922,23 +17920,23 @@
             `set` ClassElementName `(` PropertySetParameterList `)` `{` FunctionBody `}`
         </emu-grammar>
         <emu-alg>
-          1. Return ? MethodDefinitionEvaluation of |MethodDefinition| with arguments _object_ and _enumerable_.
+          1. Return ? MethodDefinitionEvaluation of |MethodDefinition| with arguments _object_ and *true*.
         </emu-alg>
         <emu-grammar>GeneratorMethod : `*` ClassElementName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
         <emu-alg>
-          1. Return ? MethodDefinitionEvaluation of |GeneratorMethod| with arguments _object_ and _enumerable_.
+          1. Return ? MethodDefinitionEvaluation of |GeneratorMethod| with arguments _object_ and *true*.
         </emu-alg>
         <emu-grammar>
           AsyncGeneratorMethod : `async` `*` ClassElementName `(` UniqueFormalParameters `)` `{` AsyncGeneratorBody `}`
         </emu-grammar>
         <emu-alg>
-          1. Return ? MethodDefinitionEvaluation of |AsyncGeneratorMethod| with arguments _object_ and _enumerable_.
+          1. Return ? MethodDefinitionEvaluation of |AsyncGeneratorMethod| with arguments _object_ and *true*.
         </emu-alg>
         <emu-grammar>
           AsyncMethod : `async` ClassElementName `(` UniqueFormalParameters `)` `{` AsyncFunctionBody `}`
         </emu-grammar>
         <emu-alg>
-          1. Return ? MethodDefinitionEvaluation of |AsyncMethod| with arguments _object_ and _enumerable_.
+          1. Return ? MethodDefinitionEvaluation of |AsyncMethod| with arguments _object_ and *true*.
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -23916,7 +23914,7 @@
 
     <emu-clause id="sec-static-semantics-classelementevaluation" type="sdo" aoid="ClassElementEvaluation">
       <h1>Runtime Semantics: ClassElementEvaluation</h1>
-      <p>With parameters _object_ and _enumerable_.</p>
+      <p>With parameter _object_.</p>
 
       <emu-grammar>
         ClassElement : FieldDefinition `;`
@@ -23933,7 +23931,7 @@
         ClassElement : `static` MethodDefinition
       </emu-grammar>
       <emu-alg>
-        1. Return MethodDefinitionEvaluation of |MethodDefinition| with arguments _object_ and _enumerable_.
+        1. Return MethodDefinitionEvaluation of |MethodDefinition| with arguments _object_ and *false*.
       </emu-alg>
 
       <emu-grammar>
@@ -24019,9 +24017,9 @@
         1. Let _staticFields_ be a new empty List.
         1. For each |ClassElement| _e_ of _elements_, do
           1. If IsStatic of _e_ is *false*, then
-            1. Let _field_ be ClassElementEvaluation of _e_ with arguments _proto_ and *false*.
+            1. Let _field_ be ClassElementEvaluation of _e_ with argument _proto_.
           1. Else,
-            1. Let _field_ be ClassElementEvaluation of _e_ with arguments _F_ and *false*.
+            1. Let _field_ be ClassElementEvaluation of _e_ with argument _F_.
           1. If _field_ is an abrupt completion, then
             1. Set the running execution context's LexicalEnvironment to _env_.
             1. Set the running execution context's PrivateEnvironment to _outerPrivateEnvironment_.

--- a/spec.html
+++ b/spec.html
@@ -17913,30 +17913,9 @@
           1. Assert: _object_ is an ordinary, extensible object with no non-configurable properties.
           1. Return ! CreateDataPropertyOrThrow(_object_, _propKey_, _propValue_).
         </emu-alg>
-        <emu-grammar>
-          MethodDefinition :
-            ClassElementName `(` UniqueFormalParameters `)` `{` FunctionBody `}`
-            `get` ClassElementName `(` `)` `{` FunctionBody `}`
-            `set` ClassElementName `(` PropertySetParameterList `)` `{` FunctionBody `}`
-        </emu-grammar>
+        <emu-grammar>PropertyDefinition : MethodDefinition</emu-grammar>
         <emu-alg>
           1. Return ? MethodDefinitionEvaluation of |MethodDefinition| with arguments _object_ and *true*.
-        </emu-alg>
-        <emu-grammar>GeneratorMethod : `*` ClassElementName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
-        <emu-alg>
-          1. Return ? MethodDefinitionEvaluation of |GeneratorMethod| with arguments _object_ and *true*.
-        </emu-alg>
-        <emu-grammar>
-          AsyncGeneratorMethod : `async` `*` ClassElementName `(` UniqueFormalParameters `)` `{` AsyncGeneratorBody `}`
-        </emu-grammar>
-        <emu-alg>
-          1. Return ? MethodDefinitionEvaluation of |AsyncGeneratorMethod| with arguments _object_ and *true*.
-        </emu-alg>
-        <emu-grammar>
-          AsyncMethod : `async` ClassElementName `(` UniqueFormalParameters `)` `{` AsyncFunctionBody `}`
-        </emu-grammar>
-        <emu-alg>
-          1. Return ? MethodDefinitionEvaluation of |AsyncMethod| with arguments _object_ and *true*.
         </emu-alg>
       </emu-clause>
     </emu-clause>


### PR DESCRIPTION
For the first commit: The `_enumerable_` parameter for `PropertyDefinitionEvaluation` was always true; the parameter of the same name for `ClassElementEvaluation` was always false. Prior to #1668 PropertyDefinitionEvaluation was used for both object literals and classes. When it was split, the parameter because redundant.

The second commit just fixes an oversight of mine from fe6b5ef37b0b740e1d66be671137a6161035021a (part of #2271).