### PR TITLE
Editorial: Change |PropertyDefinition| to |ObjectLiteral|

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -17947,7 +17947,7 @@
         </emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if PropertyNameList of |PropertyDefinitionList| contains any duplicate entries for *"__proto__"* and at least two of those entries were obtained from productions of the form <emu-grammar>PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar>. This rule is not applied if this |PropertyDefinition| is contained within a |Script| that is being parsed for JSON.parse (see step <emu-xref href="#step-json-parse-parse"></emu-xref> of <emu-xref href="#sec-json.parse">JSON.parse</emu-xref>).
+            It is a Syntax Error if PropertyNameList of |PropertyDefinitionList| contains any duplicate entries for *"__proto__"* and at least two of those entries were obtained from productions of the form <emu-grammar>PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar>. This rule is not applied if this |ObjectLiteral| is contained within a |Script| that is being parsed for JSON.parse (see step <emu-xref href="#step-json-parse-parse"></emu-xref> of <emu-xref href="#sec-json.parse">JSON.parse</emu-xref>).
           </li>
         </ul>
         <emu-note>


### PR DESCRIPTION
... in the early error rule for ObjectLiteral. When you're deciding whether to apply the rule, "this |PropertyDefinition|" isn't well-defined.

(This was introduced in PR #2125. It's probably just a copypasta of similar text in [13.2.5.5 PropertyDefinitionEvaluation](https://tc39.es/ecma262/#sec-runtime-semantics-propertydefinitionevaluation), where "this |PropertyDefinition|" *is* well-defined.)