### PR TITLE
Editorial: Update restricted productions summary

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -17331,13 +17331,40 @@
           ThrowStatement[Yield, Await] :
             `throw` [no LineTerminator here] Expression[+In, ?Yield, ?Await] `;`
 
-          ArrowFunction[In, Yield, Await] :
-            ArrowParameters[?Yield, ?Await] [no LineTerminator here] `=>` ConciseBody[?In]
-
           YieldExpression[In, Await] :
             `yield`
             `yield` [no LineTerminator here] AssignmentExpression[?In, +Yield, ?Await]
             `yield` [no LineTerminator here] `*` AssignmentExpression[?In, +Yield, ?Await]
+
+          ArrowFunction[In, Yield, Await] :
+            ArrowParameters[?Yield, ?Await] [no LineTerminator here] `=>` ConciseBody[?In]
+
+          AsyncFunctionDeclaration[Yield, Await, Default] :
+            `async` [no LineTerminator here] `function` BindingIdentifier[?Yield, ?Await] `(` FormalParameters[~Yield, +Await] `)` `{` AsyncFunctionBody `}`
+            [+Default] `async` [no LineTerminator here] `function` `(` FormalParameters[~Yield, +Await] `)` `{` AsyncFunctionBody `}`
+
+          AsyncFunctionExpression :
+            `async` [no LineTerminator here] `function` BindingIdentifier[~Yield, +Await]? `(` FormalParameters[~Yield, +Await] `)` `{` AsyncFunctionBody `}`
+
+          AsyncMethod[Yield, Await] :
+            `async` [no LineTerminator here] ClassElementName[?Yield, ?Await] `(` UniqueFormalParameters[~Yield, +Await] `)` `{` AsyncFunctionBody `}`
+
+          AsyncGeneratorDeclaration[Yield, Await, Default] :
+            `async` [no LineTerminator here] `function` `*` BindingIdentifier[?Yield, ?Await] `(` FormalParameters[+Yield, +Await] `)` `{` AsyncGeneratorBody `}`
+            [+Default] `async` [no LineTerminator here] `function` `*` `(` FormalParameters[+Yield, +Await] `)` `{` AsyncGeneratorBody `}`
+
+          AsyncGeneratorExpression :
+            `async` [no LineTerminator here] `function` `*` BindingIdentifier[+Yield, +Await]? `(` FormalParameters[+Yield, +Await] `)` `{` AsyncGeneratorBody `}`
+
+          AsyncGeneratorMethod[Yield, Await] :
+            `async` [no LineTerminator here] `*` ClassElementName[?Yield, ?Await] `(` UniqueFormalParameters[+Yield, +Await] `)` `{` AsyncGeneratorBody `}`
+
+          AsyncArrowFunction[In, Yield, Await] :
+            `async` [no LineTerminator here] AsyncArrowBindingIdentifier[?Yield] [no LineTerminator here] `=>` AsyncConciseBody[?In]
+            CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await] [no LineTerminator here] `=>` AsyncConciseBody[?In] #callcover
+
+          AsyncArrowHead :
+            `async` [no LineTerminator here] ArrowFormalParameters[~Yield, +Await]
         </emu-grammar>
         <p>The practical effect of these restricted productions is as follows:</p>
         <ul>
@@ -17347,17 +17374,32 @@
           <li>
             When a `continue`, `break`, `return`, `throw`, or `yield` token is encountered and a |LineTerminator| is encountered before the next token, a semicolon is automatically inserted after the `continue`, `break`, `return`, `throw`, or `yield` token.
           </li>
+          <li>
+            When arrow function parameter(s) are followed by a |LineTerminator| before a `=>` token, a semicolon is automatically inserted and the punctuator causes a syntax error.
+          </li>
+          <li>
+            When an `async` token is followed by a |LineTerminator| before a `function` or |IdentifierName| or `(` token, a semicolon is automatically inserted and the `async` token is not treated as part of the same expression or class element as the following tokens.
+          </li>
+          <li>
+            When an `async` token is followed by a |LineTerminator| before a `*` token, a semicolon is automatically inserted and the punctuator causes a syntax error.
+          </li>
         </ul>
         <p>The resulting practical advice to ECMAScript programmers is:</p>
         <ul>
           <li>
-            A postfix `++` or `--` operator should appear on the same line as its operand.
+            A postfix `++` or `--` operator should be on the same line as its operand.
           </li>
           <li>
             An |Expression| in a `return` or `throw` statement or an |AssignmentExpression| in a `yield` expression should start on the same line as the `return`, `throw`, or `yield` token.
           </li>
           <li>
             A |LabelIdentifier| in a `break` or `continue` statement should be on the same line as the `break` or `continue` token.
+          </li>
+          <li>
+            The end of an arrow function's parameter(s) and its `=>` should be on the same line.
+          </li>
+          <li>
+            The `async` token preceding an asynchronous function or method should be on the same line as the immediately following token.
           </li>
         </ul>
       </emu-note>
@@ -23449,15 +23491,15 @@
     <h1>Async Generator Function Definitions</h1>
     <h2>Syntax</h2>
     <emu-grammar type="definition">
-      AsyncGeneratorMethod[Yield, Await] :
-        `async` [no LineTerminator here] `*` ClassElementName[?Yield, ?Await] `(` UniqueFormalParameters[+Yield, +Await] `)` `{` AsyncGeneratorBody `}`
-
       AsyncGeneratorDeclaration[Yield, Await, Default] :
         `async` [no LineTerminator here] `function` `*` BindingIdentifier[?Yield, ?Await] `(` FormalParameters[+Yield, +Await] `)` `{` AsyncGeneratorBody `}`
         [+Default] `async` [no LineTerminator here] `function` `*` `(` FormalParameters[+Yield, +Await] `)` `{` AsyncGeneratorBody `}`
 
       AsyncGeneratorExpression :
         `async` [no LineTerminator here] `function` `*` BindingIdentifier[+Yield, +Await]? `(` FormalParameters[+Yield, +Await] `)` `{` AsyncGeneratorBody `}`
+
+      AsyncGeneratorMethod[Yield, Await] :
+        `async` [no LineTerminator here] `*` ClassElementName[?Yield, ?Await] `(` UniqueFormalParameters[+Yield, +Await] `)` `{` AsyncGeneratorBody `}`
 
       AsyncGeneratorBody :
         FunctionBody[+Yield, +Await]


### PR DESCRIPTION
The "_The following are the only restricted productions in the grammar_" note has fallen out of date; it is missing many `[no LineTerminator here]` productions. This PR adds them, along with corresponding additions to practical effects and practical advice. It also incidentally improves consistency in the relative ordering of Declaration/Expression/Method productions.