### PR TITLE
Editorial: Fix alias use in IteratorBindingInitialization

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -9253,16 +9253,16 @@
       <emu-alg>
         1. Let _bindingId_ be StringValue of |BindingIdentifier|.
         1. Let _lhs_ be ? ResolveBinding(_bindingId_, _environment_).
+        1. Let _v_ be *undefined*.
         1. If _iteratorRecord_.[[Done]] is *false*, then
           1. Let _next_ be IteratorStep(_iteratorRecord_).
           1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
           1. ReturnIfAbrupt(_next_).
           1. If _next_ is *false*, set _iteratorRecord_.[[Done]] to *true*.
           1. Else,
-            1. Let _v_ be IteratorValue(_next_).
+            1. Set _v_ to IteratorValue(_next_).
             1. If _v_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
             1. ReturnIfAbrupt(_v_).
-        1. If _iteratorRecord_.[[Done]] is *true*, let _v_ be *undefined*.
         1. If |Initializer| is present and _v_ is *undefined*, then
           1. If IsAnonymousFunctionDefinition(|Initializer|) is *true*, then
             1. Set _v_ to the result of performing NamedEvaluation for |Initializer| with argument _bindingId_.
@@ -9274,16 +9274,16 @@
       </emu-alg>
       <emu-grammar>BindingElement : BindingPattern Initializer?</emu-grammar>
       <emu-alg>
+        1. Let _v_ be *undefined*.
         1. If _iteratorRecord_.[[Done]] is *false*, then
           1. Let _next_ be IteratorStep(_iteratorRecord_).
           1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
           1. ReturnIfAbrupt(_next_).
           1. If _next_ is *false*, set _iteratorRecord_.[[Done]] to *true*.
           1. Else,
-            1. Let _v_ be IteratorValue(_next_).
+            1. Set _v_ to IteratorValue(_next_).
             1. If _v_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
             1. ReturnIfAbrupt(_v_).
-        1. If _iteratorRecord_.[[Done]] is *true*, let _v_ be *undefined*.
         1. If |Initializer| is present and _v_ is *undefined*, then
           1. Let _defaultValue_ be the result of evaluating |Initializer|.
           1. Set _v_ to ? GetValue(_defaultValue_).
@@ -9343,16 +9343,16 @@
       </emu-alg>
       <emu-grammar>ArrowParameters : BindingIdentifier</emu-grammar>
       <emu-alg>
+        1. Let _v_ be *undefined*.
         1. Assert: _iteratorRecord_.[[Done]] is *false*.
         1. Let _next_ be IteratorStep(_iteratorRecord_).
         1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
         1. ReturnIfAbrupt(_next_).
         1. If _next_ is *false*, set _iteratorRecord_.[[Done]] to *true*.
         1. Else,
-          1. Let _v_ be IteratorValue(_next_).
+          1. Set _v_ to IteratorValue(_next_).
           1. If _v_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
           1. ReturnIfAbrupt(_v_).
-        1. If _iteratorRecord_.[[Done]] is *true*, let _v_ be *undefined*.
         1. Return the result of performing BindingInitialization for |BindingIdentifier| using _v_ and _environment_ as the arguments.
       </emu-alg>
       <emu-grammar>ArrowParameters : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
@@ -9364,16 +9364,16 @@
         AsyncArrowBindingIdentifier : BindingIdentifier
       </emu-grammar>
       <emu-alg>
+        1. Let _v_ be *undefined*.
         1. Assert: _iteratorRecord_.[[Done]] is *false*.
         1. Let _next_ be IteratorStep(_iteratorRecord_).
         1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
         1. ReturnIfAbrupt(_next_).
         1. If _next_ is *false*, set _iteratorRecord_.[[Done]] to *true*.
         1. Else,
-          1. Let _v_ be IteratorValue(_next_).
+          1. Set _v_ to IteratorValue(_next_).
           1. If _v_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
           1. ReturnIfAbrupt(_v_).
-        1. If _iteratorRecord_.[[Done]] is *true*, let _v_ be *undefined*.
         1. Return the result of performing BindingInitialization for |BindingIdentifier| using _v_ and _environment_ as the arguments.
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
It's cleaner and (IMO) more comprehensible to have a single Let.