### PR TITLE
Normative: `continue` labels should not pass through blocks

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -8475,6 +8475,10 @@
       <emu-alg>
         1. Return *false*.
       </emu-alg>
+      <emu-grammar>Statement : BlockStatement</emu-grammar>
+      <emu-alg>
+        1. Return ContainsUndefinedContinueTarget of |BlockStatement| with arguments _iterationSet_ and &laquo; &raquo;.
+      </emu-alg>
       <emu-grammar>BreakableStatement : IterationStatement</emu-grammar>
       <emu-alg>
         1. Let _newIterationSet_ be the list-concatenation of _iterationSet_ and _labelSet_.


### PR DESCRIPTION
Fixes #2481. Without this, the spec permits `lbl : { for ( ;; ) continue lbl ; }`, contrary to all implementations I have on hand.

There's a few different productions which would work here - adding a definition for any of `BlockStatement : Block`, `Block : { StatementList }`, `StatementList : StatementListItem`, or `StatementListItem : Statement` would work, in addition to `Statement : BlockStatement` as chosen in this PR. I think `Statement : BlockStatement` is clearest, but it doesn't really matter.