### PR TITLE
Editorial: "an Array", not "an Array object" [etc]

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -3319,7 +3319,7 @@
               <td>
               </td>
               <td>
-                The constructor of generator objects (<emu-xref href="#sec-generatorfunction-constructor"></emu-xref>)
+                The constructor of Generators (<emu-xref href="#sec-generatorfunction-constructor"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3772,7 +3772,7 @@
 
     <emu-clause id="sec-set-and-relation-specification-type">
       <h1>The Set and Relation Specification Types</h1>
-      <p>The <em>Set</em> type is used to explain a collection of unordered elements for use in the memory model. Values of the Set type are simple collections of elements, where no element appears more than once. Elements may be added to and removed from Sets. Sets may be unioned, intersected, or subtracted from each other.</p>
+      <p>The <em>Set</em> type is used to explain a collection of unordered elements for use in the memory model. It is distinct from the ECMAScript collection type of the same name. To disambiguate, instances of the ECMAScript collection are consistently referred to as "Set objects" within this specification. Values of the Set type are simple collections of elements, where no element appears more than once. Elements may be added to and removed from Sets. Sets may be unioned, intersected, or subtracted from each other.</p>
       <p>The <dfn>Relation</dfn> type is used to explain constraints on Sets. Values of the Relation type are Sets of ordered pairs of values from its value domain. For example, a Relation on events is a set of ordered pairs of events. For a Relation _R_ and two values _a_ and _b_ in the value domain of _R_, _a_ _R_ _b_ is shorthand for saying the ordered pair (_a_, _b_) is a member of _R_. A Relation is least with respect to some conditions when it is the smallest Relation that satisfies those conditions.</p>
       <p>A <dfn variants="strict partial orders">strict partial order</dfn> is a Relation value _R_ that satisfies the following.</p>
       <ul>
@@ -4628,7 +4628,7 @@
         1. Return _input_.
       </emu-alg>
       <emu-note>
-        <p>When ToPrimitive is called with no hint, then it generally behaves as if the hint were ~number~. However, objects may over-ride this behaviour by defining a @@toPrimitive method. Of the objects defined in this specification only Date objects (see <emu-xref href="#sec-date.prototype-@@toprimitive"></emu-xref>) and Symbol objects (see <emu-xref href="#sec-symbol.prototype-@@toprimitive"></emu-xref>) over-ride the default ToPrimitive behaviour. Date objects treat no hint as if the hint were ~string~.</p>
+        <p>When ToPrimitive is called with no hint, then it generally behaves as if the hint were ~number~. However, objects may over-ride this behaviour by defining a @@toPrimitive method. Of the objects defined in this specification only Dates (see <emu-xref href="#sec-date.prototype-@@toprimitive"></emu-xref>) and Symbol objects (see <emu-xref href="#sec-symbol.prototype-@@toprimitive"></emu-xref>) over-ride the default ToPrimitive behaviour. Dates treat no hint as if the hint were ~string~.</p>
       </emu-note>
 
       <emu-clause id="sec-ordinarytoprimitive" type="abstract operation">
@@ -6399,7 +6399,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It is used to create an Array object whose elements are provided by _elements_.</dd>
+        <dd>It is used to create an Array whose elements are provided by _elements_.</dd>
       </dl>
       <emu-alg>
         1. Assert: _elements_ is a List whose elements are all ECMAScript language values.
@@ -6431,7 +6431,7 @@
         Typically, an array-like object would also have some properties with integer index names. However, that is not a requirement of this definition.
       </emu-note>
       <emu-note>
-        Array objects and String objects are examples of array-like objects.
+        Arrays and String objects are examples of array-like objects.
       </emu-note>
     </emu-clause>
 
@@ -11476,7 +11476,7 @@
       </table>
     </emu-table>
     <p>The LexicalEnvironment and VariableEnvironment components of an execution context are always Environment Records.</p>
-    <p>Execution contexts representing the evaluation of generator objects have the additional state components listed in <emu-xref href="#table-additional-state-components-for-generator-execution-contexts"></emu-xref>.</p>
+    <p>Execution contexts representing the evaluation of Generators have the additional state components listed in <emu-xref href="#table-additional-state-components-for-generator-execution-contexts"></emu-xref>.</p>
     <emu-table id="table-additional-state-components-for-generator-execution-contexts" caption="Additional State Components for Generator Execution Contexts" oldids="table-24">
       <table>
         <tbody>
@@ -11493,7 +11493,7 @@
             Generator
           </td>
           <td>
-            The generator object that this execution context is evaluating.
+            The Generator that this execution context is evaluating.
           </td>
         </tr>
         </tbody>
@@ -11887,7 +11887,7 @@
     <p>An <dfn variants="agent clusters">agent cluster</dfn> is a maximal set of agents that can communicate by operating on shared memory.</p>
 
     <emu-note>
-      <p>Programs within different agents may share memory by unspecified means. At a minimum, the backing memory for SharedArrayBuffer objects can be shared among the agents in the cluster.</p>
+      <p>Programs within different agents may share memory by unspecified means. At a minimum, the backing memory for SharedArrayBuffers can be shared among the agents in the cluster.</p>
 
       <p>There may be agents that can communicate by message passing that cannot share memory; they are never in the same agent cluster.</p>
     </emu-note>
@@ -11957,7 +11957,7 @@
 
       <p>This specification does not make any guarantees that any object will be garbage collected. Objects which are not live may be released after long periods of time, or never at all. For this reason, this specification uses the term "may" when describing behaviour triggered by garbage collection.</p>
 
-      <p>The semantics of WeakRef and FinalizationRegistry objects is based on two operations which happen at particular points in time:</p>
+      <p>The semantics of WeakRefs and FinalizationRegistrys is based on two operations which happen at particular points in time:</p>
 
       <ul>
         <li>
@@ -12919,7 +12919,7 @@
         1. Return NormalCompletion(*undefined*).
       </emu-alg>
       <emu-note>
-        <p>When _calleeContext_ is removed from the execution context stack in step <emu-xref href="#step-call-pop-context-stack"></emu-xref> it must not be destroyed if it is suspended and retained for later resumption by an accessible generator object.</p>
+        <p>When _calleeContext_ is removed from the execution context stack in step <emu-xref href="#step-call-pop-context-stack"></emu-xref> it must not be destroyed if it is suspended and retained for later resumption by an accessible Generator.</p>
       </emu-note>
 
       <emu-clause id="sec-prepareforordinarycall" type="abstract operation">
@@ -13463,7 +13463,7 @@
         1. Return _result_.
       </emu-alg>
       <emu-note>
-        <p>When _calleeContext_ is removed from the execution context stack it must not be destroyed if it has been suspended and retained by an accessible generator object for later resumption.</p>
+        <p>When _calleeContext_ is removed from the execution context stack it must not be destroyed if it has been suspended and retained by an accessible Generator for later resumption.</p>
       </emu-note>
     </emu-clause>
 
@@ -13659,12 +13659,12 @@
 
     <emu-clause id="sec-array-exotic-objects">
       <h1>Array Exotic Objects</h1>
-      <p>An Array object is an exotic object that gives special treatment to array index property keys (see <emu-xref href="#sec-object-type"></emu-xref>). A property whose property name is an array index is also called an <em>element</em>. Every Array object has a non-configurable *"length"* property whose value is always a non-negative integral Number whose mathematical value is less than 2<sup>32</sup>. The value of the *"length"* property is numerically greater than the name of every own property whose name is an array index; whenever an own property of an Array object is created or changed, other properties are adjusted as necessary to maintain this invariant. Specifically, whenever an own property is added whose name is an array index, the value of the *"length"* property is changed, if necessary, to be one more than the numeric value of that array index; and whenever the value of the *"length"* property is changed, every own property whose name is an array index whose value is not smaller than the new length is deleted. This constraint applies only to own properties of an Array object and is unaffected by *"length"* or array index properties that may be inherited from its prototypes.</p>
+      <p>An Array is an exotic object that gives special treatment to array index property keys (see <emu-xref href="#sec-object-type"></emu-xref>). A property whose property name is an array index is also called an <em>element</em>. Every Array has a non-configurable *"length"* property whose value is always a non-negative integral Number whose mathematical value is less than 2<sup>32</sup>. The value of the *"length"* property is numerically greater than the name of every own property whose name is an array index; whenever an own property of an Array is created or changed, other properties are adjusted as necessary to maintain this invariant. Specifically, whenever an own property is added whose name is an array index, the value of the *"length"* property is changed, if necessary, to be one more than the numeric value of that array index; and whenever the value of the *"length"* property is changed, every own property whose name is an array index whose value is not smaller than the new length is deleted. This constraint applies only to own properties of an Array and is unaffected by *"length"* or array index properties that may be inherited from its prototypes.</p>
       <emu-note>
         <p>A String property name _P_ is an <em>array index</em> if and only if ToString(ToUint32(_P_)) equals _P_ and ToUint32(_P_) is not the same value as 𝔽(<emu-eqn>2<sup>32</sup> - 1</emu-eqn>).</p>
       </emu-note>
 
-      <p>An object is an <dfn id="array-exotic-object" variants="Array exotic objects">Array exotic object</dfn> (or simply, an Array object) if its [[DefineOwnProperty]] internal method uses the following implementation, and its other essential internal methods use the definitions found in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>. These methods are installed in ArrayCreate.</p>
+      <p>An object is an <dfn id="array-exotic-object" variants="Array exotic objects">Array exotic object</dfn> (or simply, an Array) if its [[DefineOwnProperty]] internal method uses the following implementation, and its other essential internal methods use the definitions found in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>. These methods are installed in ArrayCreate.</p>
 
       <emu-clause id="sec-array-exotic-objects-defineownproperty-p-desc" type="internal method">
         <h1>
@@ -13709,7 +13709,7 @@
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It is used to specify the creation of new Array exotic objects.</dd>
+          <dd>It is used to specify the creation of new Arrays.</dd>
         </dl>
         <emu-alg>
           1. If _length_ &gt; 2<sup>32</sup> - 1, throw a *RangeError* exception.
@@ -13731,7 +13731,7 @@
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It is used to specify the creation of a new Array object using a constructor function that is derived from _originalArray_.</dd>
+          <dd>It is used to specify the creation of a new Array or similar object using a constructor function that is derived from _originalArray_. It does not enforce that the constructor function returns an Array.</dd>
         </dl>
         <emu-alg>
           1. Let _isArray_ be ? IsArray(_originalArray_).
@@ -13757,7 +13757,7 @@
       <emu-clause id="sec-arraysetlength" type="abstract operation">
         <h1>
           ArraySetLength (
-            _A_: an Array object,
+            _A_: an Array,
             _Desc_: a Property Descriptor,
           )
         </h1>
@@ -14754,7 +14754,7 @@
 
   <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots">
     <h1>Proxy Object Internal Methods and Internal Slots</h1>
-    <p>A proxy object is an exotic object whose essential internal methods are partially implemented using ECMAScript code. Every proxy object has an internal slot called [[ProxyHandler]]. The value of [[ProxyHandler]] is an object, called the proxy's <em>handler object</em>, or *null*. Methods (see <emu-xref href="#table-proxy-handler-methods"></emu-xref>) of a handler object may be used to augment the implementation for one or more of the proxy object's internal methods. Every proxy object also has an internal slot called [[ProxyTarget]] whose value is either an object or the *null* value. This object is called the proxy's <em>target object</em>.</p>
+    <p>A Proxy object is an exotic object whose essential internal methods are partially implemented using ECMAScript code. Every Proxy object has an internal slot called [[ProxyHandler]]. The value of [[ProxyHandler]] is an object, called the proxy's <em>handler object</em>, or *null*. Methods (see <emu-xref href="#table-proxy-handler-methods"></emu-xref>) of a handler object may be used to augment the implementation for one or more of the Proxy object's internal methods. Every Proxy object also has an internal slot called [[ProxyTarget]] whose value is either an object or the *null* value. This object is called the proxy's <em>target object</em>.</p>
 
     <p>An object is a <dfn id="proxy-exotic-object" variants="Proxy exotic objects">Proxy exotic object</dfn> if its essential internal methods (including [[Call]] and [[Construct]], if applicable) use the definitions in this section. These internal methods are installed in ProxyCreate.</p>
 
@@ -14876,10 +14876,10 @@
         </tbody>
       </table>
     </emu-table>
-    <p>When a handler method is called to provide the implementation of a proxy object internal method, the handler method is passed the proxy's target object as a parameter. A proxy's handler object does not necessarily have a method corresponding to every essential internal method. Invoking an internal method on the proxy results in the invocation of the corresponding internal method on the proxy's target object if the handler object does not have a method corresponding to the internal trap.</p>
-    <p>The [[ProxyHandler]] and [[ProxyTarget]] internal slots of a proxy object are always initialized when the object is created and typically may not be modified. Some proxy objects are created in a manner that permits them to be subsequently <em>revoked</em>. When a proxy is revoked, its [[ProxyHandler]] and [[ProxyTarget]] internal slots are set to *null* causing subsequent invocations of internal methods on that proxy object to throw a *TypeError* exception.</p>
-    <p>Because proxy objects permit the implementation of internal methods to be provided by arbitrary ECMAScript code, it is possible to define a proxy object whose handler methods violates the invariants defined in <emu-xref href="#sec-invariants-of-the-essential-internal-methods"></emu-xref>. Some of the internal method invariants defined in <emu-xref href="#sec-invariants-of-the-essential-internal-methods"></emu-xref> are essential integrity invariants. These invariants are explicitly enforced by the proxy object internal methods specified in this section. An ECMAScript implementation must be robust in the presence of all possible invariant violations.</p>
-    <p>In the following algorithm descriptions, assume _O_ is an ECMAScript proxy object, _P_ is a property key value, _V_ is any ECMAScript language value and _Desc_ is a Property Descriptor record.</p>
+    <p>When a handler method is called to provide the implementation of a Proxy object internal method, the handler method is passed the proxy's target object as a parameter. A proxy's handler object does not necessarily have a method corresponding to every essential internal method. Invoking an internal method on the proxy results in the invocation of the corresponding internal method on the proxy's target object if the handler object does not have a method corresponding to the internal trap.</p>
+    <p>The [[ProxyHandler]] and [[ProxyTarget]] internal slots of a Proxy object are always initialized when the object is created and typically may not be modified. Some Proxy objects are created in a manner that permits them to be subsequently <em>revoked</em>. When a proxy is revoked, its [[ProxyHandler]] and [[ProxyTarget]] internal slots are set to *null* causing subsequent invocations of internal methods on that Proxy object to throw a *TypeError* exception.</p>
+    <p>Because Proxy objects permit the implementation of internal methods to be provided by arbitrary ECMAScript code, it is possible to define a Proxy object whose handler methods violates the invariants defined in <emu-xref href="#sec-invariants-of-the-essential-internal-methods"></emu-xref>. Some of the internal method invariants defined in <emu-xref href="#sec-invariants-of-the-essential-internal-methods"></emu-xref> are essential integrity invariants. These invariants are explicitly enforced by the Proxy object internal methods specified in this section. An ECMAScript implementation must be robust in the presence of all possible invariant violations.</p>
+    <p>In the following algorithm descriptions, assume _O_ is an ECMAScript Proxy object, _P_ is a property key value, _V_ is any ECMAScript language value and _Desc_ is a Property Descriptor record.</p>
 
     <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-getprototypeof" type="internal method">
       <h1>[[GetPrototypeOf]] ( )</h1>
@@ -14904,13 +14904,13 @@
         1. Return _handlerProto_.
       </emu-alg>
       <emu-note>
-        <p>[[GetPrototypeOf]] for proxy objects enforces the following invariants:</p>
+        <p>[[GetPrototypeOf]] for Proxy objects enforces the following invariants:</p>
         <ul>
           <li>
             The result of [[GetPrototypeOf]] must be either an Object or *null*.
           </li>
           <li>
-            If the target object is not extensible, [[GetPrototypeOf]] applied to the proxy object must return the same value as [[GetPrototypeOf]] applied to the proxy object's target object.
+            If the target object is not extensible, [[GetPrototypeOf]] applied to the Proxy object must return the same value as [[GetPrototypeOf]] applied to the Proxy object's target object.
           </li>
         </ul>
       </emu-note>
@@ -14944,7 +14944,7 @@
         1. Return *true*.
       </emu-alg>
       <emu-note>
-        <p>[[SetPrototypeOf]] for proxy objects enforces the following invariants:</p>
+        <p>[[SetPrototypeOf]] for Proxy objects enforces the following invariants:</p>
         <ul>
           <li>
             The result of [[SetPrototypeOf]] is a Boolean value.
@@ -14976,13 +14976,13 @@
         1. Return _booleanTrapResult_.
       </emu-alg>
       <emu-note>
-        <p>[[IsExtensible]] for proxy objects enforces the following invariants:</p>
+        <p>[[IsExtensible]] for Proxy objects enforces the following invariants:</p>
         <ul>
           <li>
             The result of [[IsExtensible]] is a Boolean value.
           </li>
           <li>
-            [[IsExtensible]] applied to the proxy object must return the same value as [[IsExtensible]] applied to the proxy object's target object with the same argument.
+            [[IsExtensible]] applied to the Proxy object must return the same value as [[IsExtensible]] applied to the Proxy object's target object with the same argument.
           </li>
         </ul>
       </emu-note>
@@ -15009,13 +15009,13 @@
         1. Return _booleanTrapResult_.
       </emu-alg>
       <emu-note>
-        <p>[[PreventExtensions]] for proxy objects enforces the following invariants:</p>
+        <p>[[PreventExtensions]] for Proxy objects enforces the following invariants:</p>
         <ul>
           <li>
             The result of [[PreventExtensions]] is a Boolean value.
           </li>
           <li>
-            [[PreventExtensions]] applied to the proxy object only returns *true* if [[IsExtensible]] applied to the proxy object's target object is *false*.
+            [[PreventExtensions]] applied to the Proxy object only returns *true* if [[IsExtensible]] applied to the Proxy object's target object is *false*.
           </li>
         </ul>
       </emu-note>
@@ -15062,7 +15062,7 @@
         1. Return _resultDesc_.
       </emu-alg>
       <emu-note>
-        <p>[[GetOwnProperty]] for proxy objects enforces the following invariants:</p>
+        <p>[[GetOwnProperty]] for Proxy objects enforces the following invariants:</p>
         <ul>
           <li>
             The result of [[GetOwnProperty]] must be either an Object or *undefined*.
@@ -15125,7 +15125,7 @@
         1. Return *true*.
       </emu-alg>
       <emu-note>
-        <p>[[DefineOwnProperty]] for proxy objects enforces the following invariants:</p>
+        <p>[[DefineOwnProperty]] for Proxy objects enforces the following invariants:</p>
         <ul>
           <li>
             The result of [[DefineOwnProperty]] is a Boolean value.
@@ -15175,7 +15175,7 @@
         1. Return _booleanTrapResult_.
       </emu-alg>
       <emu-note>
-        <p>[[HasProperty]] for proxy objects enforces the following invariants:</p>
+        <p>[[HasProperty]] for Proxy objects enforces the following invariants:</p>
         <ul>
           <li>
             The result of [[HasProperty]] is a Boolean value.
@@ -15220,7 +15220,7 @@
         1. Return _trapResult_.
       </emu-alg>
       <emu-note>
-        <p>[[Get]] for proxy objects enforces the following invariants:</p>
+        <p>[[Get]] for Proxy objects enforces the following invariants:</p>
         <ul>
           <li>
             The value reported for a property must be the same as the value of the corresponding target object property if the target object property is a non-writable, non-configurable own data property.
@@ -15264,7 +15264,7 @@
         1. Return *true*.
       </emu-alg>
       <emu-note>
-        <p>[[Set]] for proxy objects enforces the following invariants:</p>
+        <p>[[Set]] for Proxy objects enforces the following invariants:</p>
         <ul>
           <li>
             The result of [[Set]] is a Boolean value.
@@ -15308,7 +15308,7 @@
         1. Return *true*.
       </emu-alg>
       <emu-note>
-        <p>[[Delete]] for proxy objects enforces the following invariants:</p>
+        <p>[[Delete]] for Proxy objects enforces the following invariants:</p>
         <ul>
           <li>
             The result of [[Delete]] is a Boolean value.
@@ -15366,7 +15366,7 @@
         1. Return _trapResult_.
       </emu-alg>
       <emu-note>
-        <p>[[OwnPropertyKeys]] for proxy objects enforces the following invariants:</p>
+        <p>[[OwnPropertyKeys]] for Proxy objects enforces the following invariants:</p>
         <ul>
           <li>
             The result of [[OwnPropertyKeys]] is a List.
@@ -15443,7 +15443,7 @@
         <p>A Proxy exotic object only has a [[Construct]] internal method if the initial value of its [[ProxyTarget]] internal slot is an object that has a [[Construct]] internal method.</p>
       </emu-note>
       <emu-note>
-        <p>[[Construct]] for proxy objects enforces the following invariants:</p>
+        <p>[[Construct]] for Proxy objects enforces the following invariants:</p>
         <ul>
           <li>
             The result of [[Construct]] must be an Object.
@@ -15461,7 +15461,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It is used to specify the creation of new Proxy exotic objects.</dd>
+        <dd>It is used to specify the creation of new Proxy objects.</dd>
       </dl>
       <emu-alg>
         1. If Type(_target_) is not Object, throw a *TypeError* exception.
@@ -17752,7 +17752,7 @@
     <emu-clause id="sec-array-initializer">
       <h1>Array Initializer</h1>
       <emu-note>
-        <p>An |ArrayLiteral| is an expression describing the initialization of an Array object, using a list, of zero or more expressions each of which represents an array element, enclosed in square brackets. The elements need not be literals; they are evaluated each time the array initializer is evaluated.</p>
+        <p>An |ArrayLiteral| is an expression describing the initialization of an Array, using a list, of zero or more expressions each of which represents an array element, enclosed in square brackets. The elements need not be literals; they are evaluated each time the array initializer is evaluated.</p>
       </emu-note>
       <p>Array elements may be elided at the beginning, middle or end of the element list. Whenever a comma in the element list is not preceded by an |AssignmentExpression| (i.e., a comma at the beginning or after another comma), the missing array element contributes to the length of the Array and increases the index of subsequent elements. Elided array elements are not defined. If an element is elided at the end of an array, that element does not contribute to the length of the Array.</p>
       <h2>Syntax</h2>
@@ -20173,7 +20173,7 @@
         1. Return ? _operation_(_lnum_, _rnum_).
       </emu-alg>
       <emu-note>
-        <p>No hint is provided in the calls to ToPrimitive in steps <emu-xref href="#step-binary-op-toprimitive-lval"></emu-xref> and <emu-xref href="#step-binary-op-toprimitive-rval"></emu-xref>. All standard objects except Date objects handle the absence of a hint as if ~number~ were given; Date objects handle the absence of a hint as if ~string~ were given. Exotic objects may handle the absence of a hint in some other manner.</p>
+        <p>No hint is provided in the calls to ToPrimitive in steps <emu-xref href="#step-binary-op-toprimitive-lval"></emu-xref> and <emu-xref href="#step-binary-op-toprimitive-rval"></emu-xref>. All standard objects except Dates handle the absence of a hint as if ~number~ were given; Dates handle the absence of a hint as if ~string~ were given. Exotic objects may handle the absence of a hint in some other manner.</p>
       </emu-note>
       <emu-note>
         <p>Step <emu-xref href="#step-binary-op-string-check"></emu-xref> differs from step <emu-xref href="#step-arc-string-check"></emu-xref> of the IsLessThan algorithm, by using the logical-or operation instead of the logical-and operation.</p>
@@ -23252,10 +23252,10 @@
       <p>The syntactic context immediately following `yield` requires use of the |InputElementRegExpOrTemplateTail| lexical goal.</p>
     </emu-note>
     <emu-note>
-      <p>|YieldExpression| cannot be used within the |FormalParameters| of a generator function because any expressions that are part of |FormalParameters| are evaluated before the resulting generator object is in a resumable state.</p>
+      <p>|YieldExpression| cannot be used within the |FormalParameters| of a generator function because any expressions that are part of |FormalParameters| are evaluated before the resulting Generator is in a resumable state.</p>
     </emu-note>
     <emu-note>
-      <p>Abstract operations relating to generator objects are defined in <emu-xref href="#sec-generator-abstract-operations"></emu-xref>.</p>
+      <p>Abstract operations relating to Generators are defined in <emu-xref href="#sec-generator-abstract-operations"></emu-xref>.</p>
     </emu-note>
 
     <emu-clause id="sec-generator-function-definitions-static-semantics-early-errors">
@@ -23482,10 +23482,10 @@
         FunctionBody[+Yield, +Await]
     </emu-grammar>
     <emu-note>
-      <p>|YieldExpression| and |AwaitExpression| cannot be used within the |FormalParameters| of an async generator function because any expressions that are part of |FormalParameters| are evaluated before the resulting async generator object is in a resumable state.</p>
+      <p>|YieldExpression| and |AwaitExpression| cannot be used within the |FormalParameters| of an async generator function because any expressions that are part of |FormalParameters| are evaluated before the resulting AsyncGenerator is in a resumable state.</p>
     </emu-note>
     <emu-note>
-      <p>Abstract operations relating to async generator objects are defined in <emu-xref href="#sec-asyncgenerator-abstract-operations"></emu-xref>.</p>
+      <p>Abstract operations relating to AsyncGenerators are defined in <emu-xref href="#sec-asyncgenerator-abstract-operations"></emu-xref>.</p>
     </emu-note>
 
     <emu-clause id="sec-async-generator-function-definitions-static-semantics-early-errors">
@@ -31809,7 +31809,7 @@ THH:mm:ss.sss
       <ul>
         <li>is <dfn>%Date%</dfn>.</li>
         <li>is the initial value of the *"Date"* property of the global object.</li>
-        <li>creates and initializes a new Date object when called as a constructor.</li>
+        <li>creates and initializes a new Date when called as a constructor.</li>
         <li>returns a String representing the current time (UTC) when called as a function rather than as a constructor.</li>
         <li>is a function whose behaviour differs based upon the number and types of its arguments.</li>
         <li>may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified Date behaviour must include a `super` call to the Date constructor to create and initialize the subclass instance with a [[DateValue]] internal slot.</li>
@@ -31877,7 +31877,7 @@ THH:mm:ss.sss
         <h1>Date.parse ( _string_ )</h1>
         <p>The `parse` function applies the ToString operator to its argument. If ToString results in an abrupt completion the Completion Record is immediately returned. Otherwise, `parse` interprets the resulting String as a date and time; it returns a Number, the UTC time value corresponding to the date and time. The String may be interpreted as a local time, a UTC time, or a time in some other time zone, depending on the contents of the String. The function first attempts to parse the String according to the format described in Date Time String Format (<emu-xref href="#sec-date-time-string-format"></emu-xref>), including expanded years. If the String does not conform to that format the function may fall back to any implementation-specific heuristics or implementation-specific date formats. Strings that are unrecognizable or contain out-of-bounds format element values shall cause `Date.parse` to return *NaN*.</p>
         <p>If the String conforms to the <emu-xref href="#sec-date-time-string-format">Date Time String Format</emu-xref>, substitute values take the place of absent format elements. When the `MM` or `DD` elements are absent, *"01"* is used. When the `HH`, `mm`, or `ss` elements are absent, *"00"* is used. When the `sss` element is absent, *"000"* is used. When the UTC offset representation is absent, date-only forms are interpreted as a UTC time and date-time forms are interpreted as a local time.</p>
-        <p>If `x` is any Date object whose milliseconds amount is zero within a particular implementation of ECMAScript, then all of the following expressions should produce the same numeric value in that implementation, if all the properties referenced have their initial values:</p>
+        <p>If `x` is any Date whose milliseconds amount is zero within a particular implementation of ECMAScript, then all of the following expressions should produce the same numeric value in that implementation, if all the properties referenced have their initial values:</p>
         <pre><code class="javascript">
           x.valueOf()
           Date.parse(x.toString())
@@ -31916,7 +31916,7 @@ THH:mm:ss.sss
         </emu-alg>
         <p>The *"length"* property of the `UTC` function is *7*<sub>𝔽</sub>.</p>
         <emu-note>
-          <p>The `UTC` function differs from the Date constructor in two ways: it returns a time value as a Number, rather than creating a Date object, and it interprets the arguments in UTC rather than as local time.</p>
+          <p>The `UTC` function differs from the Date constructor in two ways: it returns a time value as a Number, rather than creating a Date, and it interprets the arguments in UTC rather than as local time.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -32403,7 +32403,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype.tojson">
         <h1>Date.prototype.toJSON ( _key_ )</h1>
-        <p>This function provides a String representation of a Date object for use by `JSON.stringify` (<emu-xref href="#sec-json.stringify"></emu-xref>).</p>
+        <p>This function provides a String representation of a Date for use by `JSON.stringify` (<emu-xref href="#sec-json.stringify"></emu-xref>).</p>
         <p>When the `toJSON` method is called with argument _key_, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
@@ -32415,7 +32415,7 @@ THH:mm:ss.sss
           <p>The argument is ignored.</p>
         </emu-note>
         <emu-note>
-          <p>The `toJSON` function is intentionally generic; it does not require that its *this* value be a Date object. Therefore, it can be transferred to other kinds of objects for use as a method. However, it does require that any such object have a `toISOString` method.</p>
+          <p>The `toJSON` function is intentionally generic; it does not require that its *this* value be a Date. Therefore, it can be transferred to other kinds of objects for use as a method. However, it does require that any such object have a `toISOString` method.</p>
         </emu-note>
       </emu-clause>
 
@@ -32448,10 +32448,10 @@ THH:mm:ss.sss
           1. Return ToDateString(_tv_).
         </emu-alg>
         <emu-note>
-          <p>For any Date object `d` such that `d.[[DateValue]]` is evenly divisible by 1000, the result of `Date.parse(d.toString())` = `d.valueOf()`. See <emu-xref href="#sec-date.parse"></emu-xref>.</p>
+          <p>For any Date `d` such that `d.[[DateValue]]` is evenly divisible by 1000, the result of `Date.parse(d.toString())` = `d.valueOf()`. See <emu-xref href="#sec-date.parse"></emu-xref>.</p>
         </emu-note>
         <emu-note>
-          <p>The `toString` function is not generic; it throws a *TypeError* exception if its *this* value is not a Date object. Therefore, it cannot be transferred to other kinds of objects for use as a method.</p>
+          <p>The `toString` function is not generic; it throws a *TypeError* exception if its *this* value is not a Date. Therefore, it cannot be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
 
         <emu-clause id="sec-timestring" type="abstract operation">
@@ -32730,7 +32730,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype.toutcstring">
         <h1>Date.prototype.toUTCString ( )</h1>
-        <p>The `toUTCString` method returns a String value representing the instance in time corresponding to this time value. The format of the String is based upon "HTTP-date" from RFC 7231, generalized to support the full range of times supported by ECMAScript Date objects. It performs the following steps when called:</p>
+        <p>The `toUTCString` method returns a String value representing the instance in time corresponding to this time value. The format of the String is based upon "HTTP-date" from RFC 7231, generalized to support the full range of times supported by ECMAScript Dates. It performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be this Date object.
           1. Let _tv_ be ? thisTimeValue(_O_).
@@ -32756,7 +32756,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype-@@toprimitive">
         <h1>Date.prototype [ @@toPrimitive ] ( _hint_ )</h1>
-        <p>This function is called by ECMAScript language operators to convert a Date object to a primitive value. The allowed values for _hint_ are *"default"*, *"number"*, and *"string"*. Date objects, are unique among built-in ECMAScript object in that they treat *"default"* as being equivalent to *"string"*, All other built-in ECMAScript objects treat *"default"* as being equivalent to *"number"*.</p>
+        <p>This function is called by ECMAScript language operators to convert a Date to a primitive value. The allowed values for _hint_ are *"default"*, *"number"*, and *"string"*. Dates are unique among built-in ECMAScript object in that they treat *"default"* as being equivalent to *"string"*, All other built-in ECMAScript objects treat *"default"* as being equivalent to *"number"*.</p>
         <p>When the `@@toPrimitive` method is called with argument _hint_, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
@@ -32775,7 +32775,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-properties-of-date-instances">
       <h1>Properties of Date Instances</h1>
-      <p>Date instances are ordinary objects that inherit properties from the Date prototype object. Date instances also have a [[DateValue]] internal slot. The [[DateValue]] internal slot is the time value represented by this Date object.</p>
+      <p>Date instances are ordinary objects that inherit properties from the Date prototype object. Date instances also have a [[DateValue]] internal slot. The [[DateValue]] internal slot is the time value represented by this Date.</p>
     </emu-clause>
   </emu-clause>
 </emu-clause>
@@ -33137,7 +33137,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-string.prototype.matchall">
         <h1>String.prototype.matchAll ( _regexp_ )</h1>
-        <p>Performs a regular expression match of the String representing the *this* value against _regexp_ and returns an iterator. Each iteration result's value is an Array object containing the results of the match, or *null* if the String did not match.</p>
+        <p>Performs a regular expression match of the String representing the *this* value against _regexp_ and returns an iterator. Each iteration result's value is an Array containing the results of the match, or *null* if the String did not match.</p>
         <p>When the `matchAll` method is called, the following steps are taken:</p>
 
         <emu-alg>
@@ -33520,7 +33520,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-string.prototype.split">
         <h1>String.prototype.split ( _separator_, _limit_ )</h1>
-        <p>Returns an Array object into which substrings of the result of converting this object to a String have been stored. The substrings are determined by searching from left to right for occurrences of _separator_; these occurrences are not part of any String in the returned array, but serve to divide up the String value. The value of _separator_ may be a String of any length or it may be an object, such as a RegExp, that has a @@split method.</p>
+        <p>Returns an Array into which substrings of the result of converting this object to a String have been stored. The substrings are determined by searching from left to right for occurrences of _separator_; these occurrences are not part of any String in the returned array, but serve to divide up the String value. The value of _separator_ may be a String of any length or it may be an object, such as a RegExp, that has a @@split method.</p>
         <p>When the `split` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
@@ -35506,7 +35506,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-regexp.prototype.exec">
         <h1>RegExp.prototype.exec ( _string_ )</h1>
-        <p>Performs a regular expression match of _string_ against the regular expression and returns an Array object containing the results of the match, or *null* if _string_ did not match.</p>
+        <p>Performs a regular expression match of _string_ against the regular expression and returns an Array containing the results of the match, or *null* if _string_ did not match.</p>
         <p>The String ToString(_string_) is searched for an occurrence of the regular expression pattern as follows:</p>
         <emu-alg>
           1. Let _R_ be the *this* value.
@@ -35884,7 +35884,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-regexp.prototype-@@split">
         <h1>RegExp.prototype [ @@split ] ( _string_, _limit_ )</h1>
         <emu-note>
-          <p>Returns an Array object into which substrings of the result of converting _string_ to a String have been stored. The substrings are determined by searching from left to right for matches of the *this* value regular expression; these occurrences are not part of any String in the returned array, but serve to divide up the String value.</p>
+          <p>Returns an Array into which substrings of the result of converting _string_ to a String have been stored. The substrings are determined by searching from left to right for matches of the *this* value regular expression; these occurrences are not part of any String in the returned array, but serve to divide up the String value.</p>
           <p>The *this* value may be an empty regular expression or a regular expression that can match an empty String. In this case, the regular expression does not match the empty <emu-not-ref>substring</emu-not-ref> at the beginning or end of the input String, nor does it match the empty <emu-not-ref>substring</emu-not-ref> at the end of the previous separator match. (For example, if the regular expression matches the empty String, the String is split up into individual code unit elements; the length of the result array equals the length of the String, and each <emu-not-ref>substring</emu-not-ref> contains one code unit.) Only the first match at a given index of the String is considered, even if backtracking could yield a non-empty <emu-not-ref>substring</emu-not-ref> match at that index. (For example, `/a*?/[Symbol.split]("ab")` evaluates to the array `["a", "b"]`, while `/a*/[Symbol.split]("ab")` evaluates to the array `["","b"]`.)</p>
           <p>If _string_ is (or converts to) the empty String, the result depends on whether the regular expression can match the empty String. If it can, the result array contains no elements. Otherwise, the result array contains one element, which is the empty String.</p>
           <p>If the regular expression contains capturing parentheses, then each time _separator_ is matched the results (including any *undefined* results) of the capturing parentheses are spliced into the output array. For example,</p>
@@ -36081,7 +36081,7 @@ THH:mm:ss.sss
 
   <emu-clause id="sec-array-objects">
     <h1>Array Objects</h1>
-    <p>Array objects are exotic objects that give special treatment to a certain class of property names. See <emu-xref href="#sec-array-exotic-objects"></emu-xref> for a definition of this special treatment.</p>
+    <p>Arrays are exotic objects that give special treatment to a certain class of property names. See <emu-xref href="#sec-array-exotic-objects"></emu-xref> for a definition of this special treatment.</p>
 
     <emu-clause id="sec-array-constructor">
       <h1>The Array Constructor</h1>
@@ -36089,8 +36089,8 @@ THH:mm:ss.sss
       <ul>
         <li>is <dfn>%Array%</dfn>.</li>
         <li>is the initial value of the *"Array"* property of the global object.</li>
-        <li>creates and initializes a new Array exotic object when called as a constructor.</li>
-        <li>also creates and initializes a new Array object when called as a function rather than as a constructor. Thus the function call `Array(&hellip;)` is equivalent to the object creation expression `new Array(&hellip;)` with the same arguments.</li>
+        <li>creates and initializes a new Array when called as a constructor.</li>
+        <li>also creates and initializes a new Array when called as a function rather than as a constructor. Thus the function call `Array(&hellip;)` is equivalent to the object creation expression `new Array(&hellip;)` with the same arguments.</li>
         <li>is a function whose behaviour differs based upon the number and types of its arguments.</li>
         <li>may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the exotic Array behaviour must include a `super` call to the Array constructor to initialize subclass instances that are Array exotic objects. However, most of the `Array.prototype` methods are generic methods that are not dependent upon their *this* value being an Array exotic object.</li>
         <li>has a *"length"* property whose value is *1*<sub>𝔽</sub>.</li>
@@ -36299,7 +36299,7 @@ THH:mm:ss.sss
           <p>The explicit setting of the *"length"* property in step <emu-xref href="#step-array-proto-concat-set-length"></emu-xref> is necessary to ensure that its value is correct in situations where the trailing elements of the result Array are not present.</p>
         </emu-note>
         <emu-note>
-          <p>The `concat` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>The `concat` function is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
 
         <emu-clause id="sec-isconcatspreadable" type="abstract operation">
@@ -36371,7 +36371,7 @@ THH:mm:ss.sss
           1. Return _O_.
         </emu-alg>
         <emu-note>
-          <p>The `copyWithin` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>The `copyWithin` function is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
@@ -36410,7 +36410,7 @@ THH:mm:ss.sss
           1. Return *true*.
         </emu-alg>
         <emu-note>
-          <p>The `every` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>The `every` function is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
@@ -36442,7 +36442,7 @@ THH:mm:ss.sss
           1. Return _O_.
         </emu-alg>
         <emu-note>
-          <p>The `fill` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>The `fill` function is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
@@ -36476,7 +36476,7 @@ THH:mm:ss.sss
           1. Return _A_.
         </emu-alg>
         <emu-note>
-          <p>The `filter` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>The `filter` function is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
@@ -36504,7 +36504,7 @@ THH:mm:ss.sss
           1. Return *undefined*.
         </emu-alg>
         <emu-note>
-          <p>The `find` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>The `find` function is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
@@ -36532,7 +36532,7 @@ THH:mm:ss.sss
           1. Return *-1*<sub>𝔽</sub>.
         </emu-alg>
         <emu-note>
-          <p>The `findIndex` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>The `findIndex` function is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
@@ -36634,7 +36634,7 @@ THH:mm:ss.sss
           1. Return *undefined*.
         </emu-alg>
         <emu-note>
-          <p>The `forEach` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>The `forEach` function is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
@@ -36665,7 +36665,7 @@ THH:mm:ss.sss
           1. Return *false*.
         </emu-alg>
         <emu-note>
-          <p>The `includes` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>The `includes` function is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
         <emu-note>
           <p>The `includes` method intentionally differs from the similar `indexOf` method in two ways. First, it uses the SameValueZero algorithm, instead of IsStrictlyEqual, allowing it to detect *NaN* array elements. Second, it does not skip missing array elements, instead treating them as *undefined*.</p>
@@ -36702,7 +36702,7 @@ THH:mm:ss.sss
           1. Return *-1*<sub>𝔽</sub>.
         </emu-alg>
         <emu-note>
-          <p>The `indexOf` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>The `indexOf` function is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
@@ -36726,7 +36726,7 @@ THH:mm:ss.sss
           1. Return _R_.
         </emu-alg>
         <emu-note>
-          <p>The `join` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
+          <p>The `join` function is intentionally generic; it does not require that its *this* value be an Array. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
@@ -36766,7 +36766,7 @@ THH:mm:ss.sss
           1. Return *-1*<sub>𝔽</sub>.
         </emu-alg>
         <emu-note>
-          <p>The `lastIndexOf` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>The `lastIndexOf` function is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
@@ -36797,7 +36797,7 @@ THH:mm:ss.sss
           1. Return _A_.
         </emu-alg>
         <emu-note>
-          <p>The `map` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>The `map` function is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
@@ -36823,7 +36823,7 @@ THH:mm:ss.sss
             1. Return _element_.
         </emu-alg>
         <emu-note>
-          <p>The `pop` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>The `pop` function is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
@@ -36846,7 +36846,7 @@ THH:mm:ss.sss
         </emu-alg>
         <p>The *"length"* property of the `push` method is *1*<sub>𝔽</sub>.</p>
         <emu-note>
-          <p>The `push` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>The `push` function is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
@@ -36887,7 +36887,7 @@ THH:mm:ss.sss
           1. Return _accumulator_.
         </emu-alg>
         <emu-note>
-          <p>The `reduce` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>The `reduce` function is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
@@ -36928,7 +36928,7 @@ THH:mm:ss.sss
           1. Return _accumulator_.
         </emu-alg>
         <emu-note>
-          <p>The `reduceRight` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>The `reduceRight` function is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
@@ -36969,7 +36969,7 @@ THH:mm:ss.sss
           1. Return _O_.
         </emu-alg>
         <emu-note>
-          <p>The `reverse` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
+          <p>The `reverse` function is intentionally generic; it does not require that its *this* value be an Array. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
@@ -37001,7 +37001,7 @@ THH:mm:ss.sss
           1. Return _first_.
         </emu-alg>
         <emu-note>
-          <p>The `shift` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>The `shift` function is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
@@ -37038,7 +37038,7 @@ THH:mm:ss.sss
           <p>The explicit setting of the *"length"* property of the result Array in step <emu-xref href="#step-array-proto-slice-set-length"></emu-xref> was necessary in previous editions of ECMAScript to ensure that its length was correct in situations where the trailing elements of the result Array were not present. Setting *"length"* became unnecessary starting in ES2015 when the result Array was initialized to its proper length rather than an empty Array but is carried forward to preserve backward compatibility.</p>
         </emu-note>
         <emu-note>
-          <p>The `slice` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>The `slice` function is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
@@ -37068,7 +37068,7 @@ THH:mm:ss.sss
           1. Return *false*.
         </emu-alg>
         <emu-note>
-          <p>The `some` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>The `some` function is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
@@ -37151,7 +37151,7 @@ THH:mm:ss.sss
           <p>The above conditions are necessary and sufficient to ensure that _comparefn_ divides the set _S_ into equivalence classes and that these equivalence classes are totally ordered.</p>
         </emu-note>
         <emu-note>
-          <p>The `sort` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
+          <p>The `sort` function is intentionally generic; it does not require that its *this* value be an Array. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
 
         <emu-clause id="sec-sortcompare" type="abstract operation">
@@ -37193,7 +37193,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-array.prototype.splice">
         <h1>Array.prototype.splice ( _start_, _deleteCount_, ..._items_ )</h1>
         <emu-note>
-          <p>The _deleteCount_ elements of the array starting at integer index _start_ are replaced by the elements of _items_. An Array object containing the deleted elements (if any) is returned.</p>
+          <p>The _deleteCount_ elements of the array starting at integer index _start_ are replaced by the elements of _items_. An Array containing the deleted elements (if any) is returned.</p>
         </emu-note>
         <p>When the `splice` method is called, the following steps are taken:</p>
         <emu-alg>
@@ -37266,7 +37266,7 @@ THH:mm:ss.sss
           <p>The explicit setting of the *"length"* property of the result Array in step <emu-xref href="#step-array-proto-splice-set-length"></emu-xref> was necessary in previous editions of ECMAScript to ensure that its length was correct in situations where the trailing elements of the result Array were not present. Setting *"length"* became unnecessary starting in ES2015 when the result Array was initialized to its proper length rather than an empty Array but is carried forward to preserve backward compatibility.</p>
         </emu-note>
         <emu-note>
-          <p>The `splice` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>The `splice` function is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
@@ -37298,7 +37298,7 @@ THH:mm:ss.sss
           <p>The elements of the array are converted to Strings using their `toLocaleString` methods, and these Strings are then concatenated, separated by occurrences of a separator String that has been derived in an implementation-defined locale-specific way. The result of calling this function is intended to be analogous to the result of `toString`, except that the result of this function is intended to be locale-specific.</p>
         </emu-note>
         <emu-note>
-          <p>The `toLocaleString` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>The `toLocaleString` function is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
@@ -37312,7 +37312,7 @@ THH:mm:ss.sss
           1. Return ? Call(_func_, _array_).
         </emu-alg>
         <emu-note>
-          <p>The `toString` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>The `toString` function is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
@@ -37347,7 +37347,7 @@ THH:mm:ss.sss
         </emu-alg>
         <p>The *"length"* property of the `unshift` method is *1*<sub>𝔽</sub>.</p>
         <emu-note>
-          <p>The `unshift` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>The `unshift` function is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
@@ -37384,7 +37384,7 @@ THH:mm:ss.sss
         </emu-alg>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
         <emu-note>
-          <p>The own property names of this object are property names that were not included as standard properties of `Array.prototype` prior to the ECMAScript 2015 specification. These names are ignored for `with` statement binding purposes in order to preserve the behaviour of existing code that might use one of these names as a binding in an outer scope that is shadowed by a `with` statement whose binding object is an Array object.</p>
+          <p>The own property names of this object are property names that were not included as standard properties of `Array.prototype` prior to the ECMAScript 2015 specification. These names are ignored for `with` statement binding purposes in order to preserve the behaviour of existing code that might use one of these names as a binding in an outer scope that is shadowed by a `with` statement whose binding object is an Array.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -37399,7 +37399,7 @@ THH:mm:ss.sss
         <p>The *"length"* property of an Array instance is a data property whose value is always numerically greater than the name of every configurable own property whose name is an array index.</p>
         <p>The *"length"* property initially has the attributes { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
         <emu-note>
-          <p>Reducing the value of the *"length"* property has the side-effect of deleting own array elements whose array index is between the old and new length values. However, non-configurable properties can not be deleted. Attempting to set the *"length"* property of an Array object to a value that is numerically less than or equal to the largest numeric own property name of an existing non-configurable <emu-xref href="#array-index">array-indexed</emu-xref> property of the array will result in the length being set to a numeric value that is one greater than that non-configurable numeric own property name. See <emu-xref href="#sec-array-exotic-objects-defineownproperty-p-desc"></emu-xref>.</p>
+          <p>Reducing the value of the *"length"* property has the side-effect of deleting own array elements whose array index is between the old and new length values. However, non-configurable properties can not be deleted. Attempting to set the *"length"* property of an Array to a value that is numerically less than or equal to the largest numeric own property name of an existing non-configurable <emu-xref href="#array-index">array-indexed</emu-xref> property of the array will result in the length being set to a numeric value that is one greater than that non-configurable numeric own property name. See <emu-xref href="#sec-array-exotic-objects-defineownproperty-p-desc"></emu-xref>.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -37472,7 +37472,7 @@ THH:mm:ss.sss
 
   <emu-clause id="sec-typedarray-objects">
     <h1>TypedArray Objects</h1>
-    <p>_TypedArray_ objects present an array-like view of an underlying binary data buffer (<emu-xref href="#sec-arraybuffer-objects"></emu-xref>). A <dfn variants="TypedArray element types">TypedArray element type</dfn> is the underlying binary scalar data type that all elements of a _TypedArray_ instance have. There is a distinct _TypedArray_ constructor, listed in <emu-xref href="#table-the-typedarray-constructors"></emu-xref>, for each of the supported element types. Each constructor in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> has a corresponding distinct prototype object.</p>
+    <p>A _TypedArray_ presents an array-like view of an underlying binary data buffer (<emu-xref href="#sec-arraybuffer-objects"></emu-xref>). A <dfn variants="TypedArray element types">TypedArray element type</dfn> is the underlying binary scalar data type that all elements of a _TypedArray_ instance have. There is a distinct _TypedArray_ constructor, listed in <emu-xref href="#table-the-typedarray-constructors"></emu-xref>, for each of the supported element types. Each constructor in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> has a corresponding distinct prototype object.</p>
     <emu-table id="table-the-typedarray-constructors" caption="The TypedArray Constructors" oldids="table-49">
       <table>
         <tbody>
@@ -38323,9 +38323,9 @@ THH:mm:ss.sss
         <emu-clause id="sec-settypedarrayfromtypedarray" type="abstract operation" oldids="sec-%typedarray%.prototype.set-typedarray-offset">
           <h1>
             SetTypedArrayFromTypedArray (
-              _target_: a TypedArray object,
+              _target_: a TypedArray,
               _targetOffset_: a non-negative integer or +&infin;,
-              _source_: a TypedArray object,
+              _source_: a TypedArray,
             )
           </h1>
           <dl class="header">
@@ -38381,9 +38381,9 @@ THH:mm:ss.sss
         <emu-clause id="sec-settypedarrayfromarraylike" type="abstract operation" oldids="sec-%typedarray%.prototype.set-array-offset">
           <h1>
             SetTypedArrayFromArrayLike (
-              _target_: a TypedArray object,
+              _target_: a TypedArray,
               _targetOffset_: a non-negative integer or +&infin;,
-              _source_: an ECMAScript value other than a TypedArray object,
+              _source_: an ECMAScript value other than a TypedArray,
             )
           </h1>
           <dl class="header">
@@ -38528,7 +38528,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-%typedarray%.prototype.subarray">
         <h1>%TypedArray%.prototype.subarray ( _begin_, _end_ )</h1>
-        <p>Returns a new _TypedArray_ object whose element type is the same as this _TypedArray_ and whose ArrayBuffer is the same as the ArrayBuffer of this _TypedArray_, referencing the elements at _begin_, inclusive, up to _end_, exclusive. If either _begin_ or _end_ is negative, it refers to an index from the end of the array, as opposed to from the beginning.</p>
+        <p>Returns a new _TypedArray_ whose element type is the same as this _TypedArray_ and whose ArrayBuffer is the same as the ArrayBuffer of this _TypedArray_, referencing the elements at _begin_, inclusive, up to _end_, exclusive. If either _begin_ or _end_ is negative, it refers to an index from the end of the array, as opposed to from the beginning.</p>
         <p>When the `subarray` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
@@ -38612,7 +38612,7 @@ THH:mm:ss.sss
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It is used to specify the creation of a new TypedArray object using a constructor function that is derived from _exemplar_.</dd>
+          <dd>It is used to specify the creation of a new TypedArray using a constructor function that is derived from _exemplar_. Unlike ArraySpeciesCreate, which can create non-Array objects through the use of @@species, this operation enforces that the constructor function creates an actual TypedArray.</dd>
         </dl>
         <emu-alg>
           1. Assert: _exemplar_ is an Object that has [[TypedArrayName]] and [[ContentType]] internal slots.
@@ -38634,7 +38634,7 @@ THH:mm:ss.sss
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It is used to specify the creation of a new TypedArray object using a constructor function.</dd>
+          <dd>It is used to specify the creation of a new TypedArray using a constructor function.</dd>
         </dl>
         <emu-alg>
           1. Let _newTypedArray_ be ? Construct(_constructor_, _argumentList_).
@@ -38742,8 +38742,8 @@ THH:mm:ss.sss
         <emu-clause id="sec-initializetypedarrayfromtypedarray" type="abstract operation" oldids="sec-typedarray-typedarray">
           <h1>
             InitializeTypedArrayFromTypedArray (
-              _O_: a TypedArray object,
-              _srcArray_: a TypedArray object,
+              _O_: a TypedArray,
+              _srcArray_: a TypedArray,
             )
           </h1>
           <dl class="header">
@@ -38791,8 +38791,8 @@ THH:mm:ss.sss
         <emu-clause id="sec-initializetypedarrayfromarraybuffer" type="abstract operation" oldids="sec-typedarray-buffer-byteoffset-length">
           <h1>
             InitializeTypedArrayFromArrayBuffer (
-              _O_: a TypedArray object,
-              _buffer_: an ArrayBuffer object,
+              _O_: a TypedArray,
+              _buffer_: an ArrayBuffer,
               _byteOffset_: an ECMAScript language value,
               _length_: an ECMAScript language value,
             )
@@ -38827,7 +38827,7 @@ THH:mm:ss.sss
         <emu-clause id="sec-initializetypedarrayfromlist" type="abstract operation">
           <h1>
             InitializeTypedArrayFromList (
-              _O_: a TypedArray object,
+              _O_: a TypedArray,
               _values_: a List of ECMAScript language values,
             )
           </h1>
@@ -38850,8 +38850,8 @@ THH:mm:ss.sss
         <emu-clause id="sec-initializetypedarrayfromarraylike" type="abstract operation">
           <h1>
             InitializeTypedArrayFromArrayLike (
-              _O_: a TypedArray object,
-              _arrayLike_: an Object that is neither a TypedArray object nor an ArrayBuffer object,
+              _O_: a TypedArray,
+              _arrayLike_: an Object that is neither a TypedArray nor an ArrayBuffer,
             )
           </h1>
           <dl class="header">
@@ -38872,7 +38872,7 @@ THH:mm:ss.sss
         <emu-clause id="sec-allocatetypedarraybuffer" type="abstract operation">
           <h1>
             AllocateTypedArrayBuffer (
-              _O_: a TypedArray object,
+              _O_: a TypedArray,
               _length_: a non-negative integer,
             )
           </h1>
@@ -38952,8 +38952,8 @@ THH:mm:ss.sss
 
   <emu-clause id="sec-map-objects">
     <h1>Map Objects</h1>
-    <p>Map objects are collections of key/value pairs where both the keys and values may be arbitrary ECMAScript language values. A distinct key value may only occur in one key/value pair within the Map's collection. Distinct key values are discriminated using the SameValueZero comparison algorithm.</p>
-    <p>Map object must be implemented using either hash tables or other mechanisms that, on average, provide access times that are sublinear on the number of elements in the collection. The data structures used in this Map objects specification is only intended to describe the required observable semantics of Map objects. It is not intended to be a viable implementation model.</p>
+    <p>Maps are collections of key/value pairs where both the keys and values may be arbitrary ECMAScript language values. A distinct key value may only occur in one key/value pair within the Map's collection. Distinct key values are discriminated using the SameValueZero comparison algorithm.</p>
+    <p>Maps must be implemented using either hash tables or other mechanisms that, on average, provide access times that are sublinear on the number of elements in the collection. The data structure used in this specification is only intended to describe the required observable semantics of Maps. It is not intended to be a viable implementation model.</p>
 
     <emu-clause id="sec-map-constructor">
       <h1>The Map Constructor</h1>
@@ -38961,7 +38961,7 @@ THH:mm:ss.sss
       <ul>
         <li>is <dfn>%Map%</dfn>.</li>
         <li>is the initial value of the *"Map"* property of the global object.</li>
-        <li>creates and initializes a new Map object when called as a constructor.</li>
+        <li>creates and initializes a new Map when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
         <li>may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified Map behaviour must include a `super` call to the Map constructor to create and initialize the subclass instance with the internal state necessary to support the `Map.prototype` built-in methods.</li>
       </ul>
@@ -39119,9 +39119,9 @@ THH:mm:ss.sss
           1. Return *undefined*.
         </emu-alg>
         <emu-note>
-          <p>_callbackfn_ should be a function that accepts three arguments. `forEach` calls _callbackfn_ once for each key/value pair present in the map object, in key insertion order. _callbackfn_ is called only for keys of the map which actually exist; it is not called for keys that have been deleted from the map.</p>
+          <p>_callbackfn_ should be a function that accepts three arguments. `forEach` calls _callbackfn_ once for each key/value pair present in the Map, in key insertion order. _callbackfn_ is called only for keys of the Map which actually exist; it is not called for keys that have been deleted from the Map.</p>
           <p>If a _thisArg_ parameter is provided, it will be used as the *this* value for each invocation of _callbackfn_. If it is not provided, *undefined* is used instead.</p>
-          <p>_callbackfn_ is called with three arguments: the value of the item, the key of the item, and the Map object being traversed.</p>
+          <p>_callbackfn_ is called with three arguments: the value of the item, the key of the item, and the Map being traversed.</p>
           <p>`forEach` does not directly mutate the object on which it is called but the object may be mutated by the calls to _callbackfn_. Each entry of a map's [[MapData]] is only visited once. New keys added after the call to `forEach` begins are visited. A key will be revisited if it is deleted after it has been visited and then re-added before the `forEach` call completes. Keys that are deleted after the call to `forEach` begins and before being visited are not visited unless the key is added again before the `forEach` call completes.</p>
         </emu-note>
       </emu-clause>
@@ -39287,7 +39287,7 @@ THH:mm:ss.sss
   <emu-clause id="sec-set-objects">
     <h1>Set Objects</h1>
     <p>Set objects are collections of ECMAScript language values. A distinct value may only occur once as an element of a Set's collection. Distinct values are discriminated using the SameValueZero comparison algorithm.</p>
-    <p>Set objects must be implemented using either hash tables or other mechanisms that, on average, provide access times that are sublinear on the number of elements in the collection. The data structures used in this Set objects specification is only intended to describe the required observable semantics of Set objects. It is not intended to be a viable implementation model.</p>
+    <p>Set objects must be implemented using either hash tables or other mechanisms that, on average, provide access times that are sublinear on the number of elements in the collection. The data structure used in this specification is only intended to describe the required observable semantics of Set objects. It is not intended to be a viable implementation model.</p>
 
     <emu-clause id="sec-set-constructor">
       <h1>The Set Constructor</h1>
@@ -39439,7 +39439,7 @@ THH:mm:ss.sss
           1. Return *undefined*.
         </emu-alg>
         <emu-note>
-          <p>_callbackfn_ should be a function that accepts three arguments. `forEach` calls _callbackfn_ once for each value present in the set object, in value insertion order. _callbackfn_ is called only for values of the Set which actually exist; it is not called for keys that have been deleted from the set.</p>
+          <p>_callbackfn_ should be a function that accepts three arguments. `forEach` calls _callbackfn_ once for each value present in the Set object, in value insertion order. _callbackfn_ is called only for values of the Set which actually exist; it is not called for keys that have been deleted from the set.</p>
           <p>If a _thisArg_ parameter is provided, it will be used as the *this* value for each invocation of _callbackfn_. If it is not provided, *undefined* is used instead.</p>
           <p>_callbackfn_ is called with three arguments: the first two arguments are a value contained in the Set. The same value is passed for both arguments. The Set object being traversed is passed as the third argument.</p>
           <p>The _callbackfn_ is called with three arguments to be consistent with the call back functions used by `forEach` methods for Map and Array. For Sets, each item value is considered to be both the key and the value.</p>
@@ -39575,9 +39575,9 @@ THH:mm:ss.sss
 
   <emu-clause id="sec-weakmap-objects">
     <h1>WeakMap Objects</h1>
-    <p>WeakMap objects are collections of key/value pairs where the keys are objects and values may be arbitrary ECMAScript language values. A WeakMap may be queried to see if it contains a key/value pair with a specific key, but no mechanism is provided for enumerating the objects it holds as keys. In certain conditions, objects which are not live are removed as WeakMap keys, as described in <emu-xref href="#sec-weakref-execution"></emu-xref>.</p>
+    <p>WeakMaps are collections of key/value pairs where the keys are objects and values may be arbitrary ECMAScript language values. A WeakMap may be queried to see if it contains a key/value pair with a specific key, but no mechanism is provided for enumerating the objects it holds as keys. In certain conditions, objects which are not live are removed as WeakMap keys, as described in <emu-xref href="#sec-weakref-execution"></emu-xref>.</p>
     <p>An implementation may impose an arbitrarily determined latency between the time a key/value pair of a WeakMap becomes inaccessible and the time when the key/value pair is removed from the WeakMap. If this latency was observable to ECMAScript program, it would be a source of indeterminacy that could impact program execution. For that reason, an ECMAScript implementation must not provide any means to observe a key of a WeakMap that does not require the observer to present the observed key.</p>
-    <p>WeakMap objects must be implemented using either hash tables or other mechanisms that, on average, provide access times that are sublinear on the number of key/value pairs in the collection. The data structure used in this WeakMap objects specification are only intended to describe the required observable semantics of WeakMap objects. It is not intended to be a viable implementation model.</p>
+    <p>WeakMaps must be implemented using either hash tables or other mechanisms that, on average, provide access times that are sublinear on the number of key/value pairs in the collection. The data structure used in this specification is only intended to describe the required observable semantics of WeakMaps. It is not intended to be a viable implementation model.</p>
     <emu-note>
       <p>WeakMap and WeakSets are intended to provide mechanisms for dynamically associating state with an object in a manner that does not &ldquo;leak&rdquo; memory resources if, in the absence of the WeakMap or WeakSet, the object otherwise became inaccessible and subject to resource reclamation by the implementation's garbage collection mechanisms. This characteristic can be achieved by using an inverted per-object mapping of weak map instances to keys. Alternatively each weak map may internally store its key to value mappings but this approach requires coordination between the WeakMap or WeakSet implementation and the garbage collector. The following references describe mechanism that may be useful to implementations of WeakMap and WeakSets:</p>
       <p>Barry Hayes. 1997. Ephemerons: a new finalization mechanism. In <i>Proceedings of the 12th ACM SIGPLAN conference on Object-oriented programming, systems, languages, and applications (OOPSLA '97)</i>, A. Michael Berman (Ed.). ACM, New York, NY, USA, 176-183, <a href="http://doi.acm.org/10.1145/263698.263733">http://doi.acm.org/10.1145/263698.263733</a>.</p>
@@ -39590,7 +39590,7 @@ THH:mm:ss.sss
       <ul>
         <li>is <dfn>%WeakMap%</dfn>.</li>
         <li>is the initial value of the *"WeakMap"* property of the global object.</li>
-        <li>creates and initializes a new WeakMap object when called as a constructor.</li>
+        <li>creates and initializes a new WeakMap when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
         <li>may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified WeakMap behaviour must include a `super` call to the WeakMap constructor to create and initialize the subclass instance with the internal state necessary to support the `WeakMap.prototype` built-in methods.</li>
       </ul>
@@ -39723,9 +39723,9 @@ THH:mm:ss.sss
 
   <emu-clause id="sec-weakset-objects">
     <h1>WeakSet Objects</h1>
-    <p>WeakSet objects are collections of objects. A distinct object may only occur once as an element of a WeakSet's collection. A WeakSet may be queried to see if it contains a specific object, but no mechanism is provided for enumerating the objects it holds. In certain conditions, objects which are not live are removed as WeakSet elements, as described in <emu-xref href="#sec-weakref-execution"></emu-xref>.</p>
+    <p>WeakSets are collections of objects. A distinct object may only occur once as an element of a WeakSet's collection. A WeakSet may be queried to see if it contains a specific object, but no mechanism is provided for enumerating the objects it holds. In certain conditions, objects which are not live are removed as WeakSet elements, as described in <emu-xref href="#sec-weakref-execution"></emu-xref>.</p>
     <p>An implementation may impose an arbitrarily determined latency between the time an object contained in a WeakSet becomes inaccessible and the time when the object is removed from the WeakSet. If this latency was observable to ECMAScript program, it would be a source of indeterminacy that could impact program execution. For that reason, an ECMAScript implementation must not provide any means to determine if a WeakSet contains a particular object that does not require the observer to present the observed object.</p>
-    <p>WeakSet objects must be implemented using either hash tables or other mechanisms that, on average, provide access times that are sublinear on the number of elements in the collection. The data structure used in this WeakSet objects specification is only intended to describe the required observable semantics of WeakSet objects. It is not intended to be a viable implementation model.</p>
+    <p>WeakSets must be implemented using either hash tables or other mechanisms that, on average, provide access times that are sublinear on the number of elements in the collection. The data structure used in this specification is only intended to describe the required observable semantics of WeakSets. It is not intended to be a viable implementation model.</p>
     <emu-note>
       <p>See the NOTE in <emu-xref href="#sec-weakmap-objects"></emu-xref>.</p>
     </emu-note>
@@ -39736,7 +39736,7 @@ THH:mm:ss.sss
       <ul>
         <li>is <dfn>%WeakSet%</dfn>.</li>
         <li>is the initial value of the *"WeakSet"* property of the global object.</li>
-        <li>creates and initializes a new WeakSet object when called as a constructor.</li>
+        <li>creates and initializes a new WeakSet when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
         <li>may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified WeakSet behaviour must include a `super` call to the WeakSet constructor to create and initialize the subclass instance with the internal state necessary to support the `WeakSet.prototype` built-in methods.</li>
       </ul>
@@ -39890,7 +39890,7 @@ THH:mm:ss.sss
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It is used to create an ArrayBuffer object.</dd>
+          <dd>It is used to create an ArrayBuffer.</dd>
         </dl>
         <emu-alg>
           1. Let _obj_ be ? OrdinaryCreateFromConstructor(_constructor_, *"%ArrayBuffer.prototype%"*, &laquo; [[ArrayBufferData]], [[ArrayBufferByteLength]], [[ArrayBufferDetachKey]] &raquo;).
@@ -39942,7 +39942,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-clonearraybuffer" type="abstract operation">
         <h1>
           CloneArrayBuffer (
-            _srcBuffer_: an ArrayBuffer object,
+            _srcBuffer_: an ArrayBuffer,
             _srcByteOffset_: a non-negative integer,
             _srcLength_: a non-negative integer,
             _cloneConstructor_: a constructor,
@@ -40154,7 +40154,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-getmodifysetvalueinbuffer" type="abstract operation">
         <h1>
           GetModifySetValueInBuffer (
-            _arrayBuffer_: an ArrayBuffer object or a SharedArrayBuffer object,
+            _arrayBuffer_: an ArrayBuffer or a SharedArrayBuffer,
             _byteIndex_: a non-negative integer,
             _type_: a TypedArray element type,
             _value_: a Number or a BigInt,
@@ -40195,7 +40195,7 @@ THH:mm:ss.sss
       <ul>
         <li>is <dfn>%ArrayBuffer%</dfn>.</li>
         <li>is the initial value of the *"ArrayBuffer"* property of the global object.</li>
-        <li>creates and initializes a new ArrayBuffer object when called as a constructor.</li>
+        <li>creates and initializes a new ArrayBuffer when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
         <li>may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified ArrayBuffer behaviour must include a `super` call to the ArrayBuffer constructor to create and initialize subclass instances with the internal state necessary to support the `ArrayBuffer.prototype` built-in methods.</li>
       </ul>
@@ -40340,7 +40340,7 @@ THH:mm:ss.sss
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It is used to create a SharedArrayBuffer object.</dd>
+          <dd>It is used to create a SharedArrayBuffer.</dd>
         </dl>
         <emu-alg>
           1. Let _obj_ be ? OrdinaryCreateFromConstructor(_constructor_, *"%SharedArrayBuffer.prototype%"*, &laquo; [[ArrayBufferData]], [[ArrayBufferByteLength]] &raquo;).
@@ -40378,12 +40378,12 @@ THH:mm:ss.sss
       <ul>
         <li>is <dfn>%SharedArrayBuffer%</dfn>.</li>
         <li>is the initial value of the *"SharedArrayBuffer"* property of the global object, if that property is present (see below).</li>
-        <li>creates and initializes a new SharedArrayBuffer object when called as a constructor.</li>
+        <li>creates and initializes a new SharedArrayBuffer when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
         <li>may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified SharedArrayBuffer behaviour must include a `super` call to the SharedArrayBuffer constructor to create and initialize subclass instances with the internal state necessary to support the `SharedArrayBuffer.prototype` built-in methods.</li>
       </ul>
 
-      <p>Whenever a host does not provide concurrent access to SharedArrayBuffer objects it may omit the *"SharedArrayBuffer"* property of the global object.</p>
+      <p>Whenever a host does not provide concurrent access to SharedArrayBuffers it may omit the *"SharedArrayBuffer"* property of the global object.</p>
 
       <emu-note>
         <p>Unlike an `ArrayBuffer`, a `SharedArrayBuffer` cannot become detached, and its internal [[ArrayBufferData]] slot is never *null*.</p>
@@ -40572,7 +40572,7 @@ THH:mm:ss.sss
       <ul>
         <li>is <dfn>%DataView%</dfn>.</li>
         <li>is the initial value of the *"DataView"* property of the global object.</li>
-        <li>creates and initializes a new DataView object when called as a constructor.</li>
+        <li>creates and initializes a new DataView when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
         <li>may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified DataView behaviour must include a `super` call to the DataView constructor to create and initialize subclass instances with the internal state necessary to support the `DataView.prototype` built-in methods.</li>
       </ul>
@@ -41891,7 +41891,7 @@ THH:mm:ss.sss
           is the initial value of the *"WeakRef"* property of the global object.
         </li>
         <li>
-          creates and initializes a new WeakRef object when called as a constructor.
+          creates and initializes a new WeakRef when called as a constructor.
         </li>
         <li>
           is not intended to be called as a function and will throw an exception when called in that manner.
@@ -42028,7 +42028,7 @@ THH:mm:ss.sss
           is the initial value of the *"FinalizationRegistry"* property of the global object.
         </li>
         <li>
-          creates and initializes a new FinalizationRegistry object when called as a constructor.
+          creates and initializes a new FinalizationRegistry when called as a constructor.
         </li>
         <li>
           is not intended to be called as a function and will throw an exception when called in that manner.
@@ -42594,7 +42594,7 @@ THH:mm:ss.sss
   <emu-clause id="sec-promise-objects">
     <h1>Promise Objects</h1>
     <p>A Promise is an object that is used as a placeholder for the eventual results of a deferred (and possibly asynchronous) computation.</p>
-    <p>Any Promise object is in one of three mutually exclusive states: <em>fulfilled</em>, <em>rejected</em>, and <em>pending</em>:</p>
+    <p>Any Promise is in one of three mutually exclusive states: <em>fulfilled</em>, <em>rejected</em>, and <em>pending</em>:</p>
     <ul>
       <li>
         A promise `p` is fulfilled if `p.then(f, r)` will immediately enqueue a Job to call the function `f`.
@@ -42614,7 +42614,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-promisecapability-records">
         <h1>PromiseCapability Records</h1>
-        <p>A <dfn variants="PromiseCapability Records">PromiseCapability Record</dfn> is a Record value used to encapsulate a promise object along with the functions that are capable of resolving or rejecting that promise object. PromiseCapability Records are produced by the NewPromiseCapability abstract operation.</p>
+        <p>A <dfn variants="PromiseCapability Records">PromiseCapability Record</dfn> is a Record value used to encapsulate a Promise or promise-like object along with the functions that are capable of resolving or rejecting that promise. PromiseCapability Records are produced by the NewPromiseCapability abstract operation.</p>
         <p>PromiseCapability Records have the fields listed in <emu-xref href="#table-promisecapability-record-fields"></emu-xref>.</p>
         <emu-table id="table-promisecapability-record-fields" caption="PromiseCapability Record Fields" oldids="table-57">
           <table>
@@ -42649,7 +42649,7 @@ THH:mm:ss.sss
                 A function object
               </td>
               <td>
-                The function that is used to resolve the given promise object.
+                The function that is used to resolve the given promise.
               </td>
             </tr>
             <tr>
@@ -42660,7 +42660,7 @@ THH:mm:ss.sss
                 A function object
               </td>
               <td>
-                The function that is used to reject the given promise object.
+                The function that is used to reject the given promise.
               </td>
             </tr>
             </tbody>
@@ -42837,7 +42837,7 @@ THH:mm:ss.sss
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It attempts to use _C_ as a constructor in the fashion of the built-in Promise constructor to create a Promise object and extract its `resolve` and `reject` functions. The Promise object plus the `resolve` and `reject` functions are used to initialize a new PromiseCapability Record.</dd>
+          <dd>It attempts to use _C_ as a constructor in the fashion of the built-in Promise constructor to create a promise and extract its `resolve` and `reject` functions. The promise plus the `resolve` and `reject` functions are used to initialize a new PromiseCapability Record.</dd>
         </dl>
         <emu-alg>
           1. If IsConstructor(_C_) is *false*, throw a *TypeError* exception.
@@ -43033,7 +43033,7 @@ THH:mm:ss.sss
       <ul>
         <li>is <dfn>%Promise%</dfn>.</li>
         <li>is the initial value of the *"Promise"* property of the global object.</li>
-        <li>creates and initializes a new Promise object when called as a constructor.</li>
+        <li>creates and initializes a new Promise when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
         <li>may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified Promise behaviour must include a `super` call to the Promise constructor to create and initialize the subclass instance with the internal state necessary to support the `Promise` and `Promise.prototype` built-in methods.</li>
       </ul>
@@ -43056,8 +43056,8 @@ THH:mm:ss.sss
           1. Return _promise_.
         </emu-alg>
         <emu-note>
-          <p>The _executor_ argument must be a function object. It is called for initiating and reporting completion of the possibly deferred action represented by this Promise object. The executor is called with two arguments: _resolve_ and _reject_. These are functions that may be used by the _executor_ function to report eventual completion or failure of the deferred computation. Returning from the executor function does not mean that the deferred action has been completed but only that the request to eventually perform the deferred action has been accepted.</p>
-          <p>The _resolve_ function that is passed to an _executor_ function accepts a single argument. The _executor_ code may eventually call the _resolve_ function to indicate that it wishes to resolve the associated Promise object. The argument passed to the _resolve_ function represents the eventual value of the deferred action and can be either the actual fulfillment value or another Promise object which will provide the value if it is fulfilled.</p>
+          <p>The _executor_ argument must be a function object. It is called for initiating and reporting completion of the possibly deferred action represented by this Promise. The executor is called with two arguments: _resolve_ and _reject_. These are functions that may be used by the _executor_ function to report eventual completion or failure of the deferred computation. Returning from the executor function does not mean that the deferred action has been completed but only that the request to eventually perform the deferred action has been accepted.</p>
+          <p>The _resolve_ function that is passed to an _executor_ function accepts a single argument. The _executor_ code may eventually call the _resolve_ function to indicate that it wishes to resolve the associated Promise. The argument passed to the _resolve_ function represents the eventual value of the deferred action and can be either the actual fulfillment value or another promise which will provide the value if it is fulfilled.</p>
           <p>The _reject_ function that is passed to an _executor_ function accepts a single argument. The _executor_ code may eventually call the _reject_ function to indicate that the associated Promise is rejected and will never be fulfilled. The argument passed to the _reject_ function is used as the rejection value of the promise. Typically it will be an Error object.</p>
           <p>The resolve and reject functions passed to an _executor_ function by the Promise constructor have the capability to actually resolve and reject the associated promise. Subclasses may have different constructor behaviour that passes in customized values for resolve and reject.</p>
         </emu-note>
@@ -43705,7 +43705,7 @@ THH:mm:ss.sss
 
   <emu-clause id="sec-generatorfunction-objects">
     <h1>GeneratorFunction Objects</h1>
-    <p>GeneratorFunction objects are functions that are usually created by evaluating |GeneratorDeclaration|s, |GeneratorExpression|s, and |GeneratorMethod|s. They may also be created by calling the %GeneratorFunction% intrinsic.</p>
+    <p>GeneratorFunctions are functions that are usually created by evaluating |GeneratorDeclaration|s, |GeneratorExpression|s, and |GeneratorMethod|s. They may also be created by calling the %GeneratorFunction% intrinsic.</p>
     <emu-figure id="figure-2" caption="Generator Objects Relationships" informative>
       <img alt="A staggering variety of boxes and arrows." src="img/figure-2.png">
     </emu-figure>
@@ -43716,7 +43716,7 @@ THH:mm:ss.sss
       <ul>
         <li>is <dfn>%GeneratorFunction%</dfn>.</li>
         <li>is a subclass of `Function`.</li>
-        <li>creates and initializes a new GeneratorFunction object when called as a function rather than as a constructor. Thus the function call `GeneratorFunction (&hellip;)` is equivalent to the object creation expression `new GeneratorFunction (&hellip;)` with the same arguments.</li>
+        <li>creates and initializes a new GeneratorFunction when called as a function rather than as a constructor. Thus the function call `GeneratorFunction (&hellip;)` is equivalent to the object creation expression `new GeneratorFunction (&hellip;)` with the same arguments.</li>
         <li>may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified GeneratorFunction behaviour must include a `super` call to the GeneratorFunction constructor to create and initialize subclass instances with the internal slots necessary for built-in GeneratorFunction behaviour. All ECMAScript syntactic forms for defining generator function objects create direct instances of GeneratorFunction. There is no syntactic means to create instances of GeneratorFunction subclasses.</li>
       </ul>
 
@@ -43803,7 +43803,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-generatorfunction-instances-prototype">
         <h1>prototype</h1>
-        <p>Whenever a GeneratorFunction instance is created another ordinary object is also created and is the initial value of the generator function's *"prototype"* property. The value of the prototype property is used to initialize the [[Prototype]] internal slot of a newly created Generator object when the generator function object is invoked using [[Call]].</p>
+        <p>Whenever a GeneratorFunction instance is created another ordinary object is also created and is the initial value of the generator function's *"prototype"* property. The value of the prototype property is used to initialize the [[Prototype]] internal slot of a newly created Generator when the generator function object is invoked using [[Call]].</p>
         <p>This property has the attributes { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
         <emu-note>
           <p>Unlike Function instances, the object that is the value of the a GeneratorFunction's *"prototype"* property does not have a *"constructor"* property whose value is the GeneratorFunction instance.</p>
@@ -43814,7 +43814,7 @@ THH:mm:ss.sss
 
   <emu-clause id="sec-asyncgeneratorfunction-objects">
     <h1>AsyncGeneratorFunction Objects</h1>
-    <p>AsyncGeneratorFunction objects are functions that are usually created by evaluating |AsyncGeneratorDeclaration|, |AsyncGeneratorExpression|, and |AsyncGeneratorMethod| syntactic productions. They may also be created by calling the %AsyncGeneratorFunction% intrinsic.</p>
+    <p>AsyncGeneratorFunctions are functions that are usually created by evaluating |AsyncGeneratorDeclaration|, |AsyncGeneratorExpression|, and |AsyncGeneratorMethod| syntactic productions. They may also be created by calling the %AsyncGeneratorFunction% intrinsic.</p>
 
     <emu-clause id="sec-asyncgeneratorfunction-constructor">
       <h1>The AsyncGeneratorFunction Constructor</h1>
@@ -43822,7 +43822,7 @@ THH:mm:ss.sss
       <ul>
         <li>is <dfn>%AsyncGeneratorFunction%</dfn>.</li>
         <li>is a subclass of `Function`.</li>
-        <li>creates and initializes a new AsyncGeneratorFunction object when called as a function rather than as a constructor. Thus the function call `AsyncGeneratorFunction (...)` is equivalent to the object creation expression `new AsyncGeneratorFunction (...)` with the same arguments.</li>
+        <li>creates and initializes a new AsyncGeneratorFunction when called as a function rather than as a constructor. Thus the function call `AsyncGeneratorFunction (...)` is equivalent to the object creation expression `new AsyncGeneratorFunction (...)` with the same arguments.</li>
         <li>may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified AsyncGeneratorFunction behaviour must include a `super` call to the AsyncGeneratorFunction constructor to create and initialize subclass instances with the internal slots necessary for built-in AsyncGeneratorFunction behaviour. All ECMAScript syntactic forms for defining async generator function objects create direct instances of AsyncGeneratorFunction. There is no syntactic means to create instances of AsyncGeneratorFunction subclasses.</li>
       </ul>
 
@@ -43910,7 +43910,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-asyncgeneratorfunction-instance-prototype">
         <h1>prototype</h1>
-        <p>Whenever an AsyncGeneratorFunction instance is created another ordinary object is also created and is the initial value of the async generator function's *"prototype"* property. The value of the prototype property is used to initialize the [[Prototype]] internal slot of a newly created AsyncGenerator object when the generator function object is invoked using [[Call]].</p>
+        <p>Whenever an AsyncGeneratorFunction instance is created another ordinary object is also created and is the initial value of the async generator function's *"prototype"* property. The value of the prototype property is used to initialize the [[Prototype]] internal slot of a newly created AsyncGenerator when the generator function object is invoked using [[Call]].</p>
         <p>This property has the attributes { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
         <emu-note>
           <p>Unlike function instances, the object that is the value of the an AsyncGeneratorFunction's *"prototype"* property does not have a *"constructor"* property whose value is the AsyncGeneratorFunction instance.</p>
@@ -43921,7 +43921,7 @@ THH:mm:ss.sss
 
   <emu-clause id="sec-generator-objects">
     <h1>Generator Objects</h1>
-    <p>A Generator object is an instance of a generator function and conforms to both the <i>Iterator</i> and <i>Iterable</i> interfaces.</p>
+    <p>A Generator is an instance of a generator function and conforms to both the <i>Iterator</i> and <i>Iterable</i> interfaces.</p>
     <p>Generator instances directly inherit properties from the object that is the initial value of the *"prototype"* property of the Generator function that created the instance. Generator instances indirectly inherit properties from the Generator Prototype intrinsic, %GeneratorFunction.prototype.prototype%.</p>
 
     <emu-clause id="sec-properties-of-generator-prototype">
@@ -44218,7 +44218,7 @@ THH:mm:ss.sss
 
   <emu-clause id="sec-asyncgenerator-objects">
     <h1>AsyncGenerator Objects</h1>
-    <p>An AsyncGenerator object is an instance of an async generator function and conforms to both the AsyncIterator and AsyncIterable interfaces.</p>
+    <p>An AsyncGenerator is an instance of an async generator function and conforms to both the AsyncIterator and AsyncIterable interfaces.</p>
 
     <p>AsyncGenerator instances directly inherit properties from the object that is the initial value of the *"prototype"* property of the AsyncGenerator function that created the instance. AsyncGenerator instances indirectly inherit properties from the AsyncGenerator Prototype intrinsic, %AsyncGeneratorFunction.prototype.prototype%.</p>
 
@@ -44645,7 +44645,7 @@ THH:mm:ss.sss
 
   <emu-clause id="sec-async-function-objects">
     <h1>AsyncFunction Objects</h1>
-    <p>AsyncFunction objects are functions that are usually created by evaluating |AsyncFunctionDeclaration|s, |AsyncFunctionExpression|s, |AsyncMethod|s, and |AsyncArrowFunction|s. They may also be created by calling the %AsyncFunction% intrinsic.</p>
+    <p>AsyncFunctions are functions that are usually created by evaluating |AsyncFunctionDeclaration|s, |AsyncFunctionExpression|s, |AsyncMethod|s, and |AsyncArrowFunction|s. They may also be created by calling the %AsyncFunction% intrinsic.</p>
 
     <emu-clause id="sec-async-function-constructor">
       <h1>The AsyncFunction Constructor</h1>
@@ -44654,7 +44654,7 @@ THH:mm:ss.sss
       <ul>
         <li>is <dfn>%AsyncFunction%</dfn>.</li>
         <li>is a subclass of `Function`.</li>
-        <li>creates and initializes a new AsyncFunction object when called as a function rather than as a constructor. Thus the function call `AsyncFunction(&hellip;)` is equivalent to the object creation expression `new AsyncFunction(&hellip;)` with the same arguments.</li>
+        <li>creates and initializes a new AsyncFunction when called as a function rather than as a constructor. Thus the function call `AsyncFunction(&hellip;)` is equivalent to the object creation expression `new AsyncFunction(&hellip;)` with the same arguments.</li>
         <li>may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified AsyncFunction behaviour must include a `super` call to the AsyncFunction constructor to create and initialize a subclass instance with the internal slots necessary for built-in async function behaviour. All ECMAScript syntactic forms for defining async function objects create direct instances of AsyncFunction. There is no syntactic means to create instances of AsyncFunction subclasses.</li>
       </ul>
 
@@ -44963,7 +44963,7 @@ THH:mm:ss.sss
       <ul>
         <li>is <dfn>%Proxy%</dfn>.</li>
         <li>is the initial value of the *"Proxy"* property of the global object.</li>
-        <li>creates and initializes a new Proxy exotic object when called as a constructor.</li>
+        <li>creates and initializes a new Proxy object when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
       </ul>
 
@@ -44982,7 +44982,7 @@ THH:mm:ss.sss
       <p>The Proxy constructor:</p>
       <ul>
         <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
-        <li>does not have a *"prototype"* property because Proxy exotic objects do not have a [[Prototype]] internal slot that requires initialization.</li>
+        <li>does not have a *"prototype"* property because Proxy objects do not have a [[Prototype]] internal slot that requires initialization.</li>
         <li>has the following properties:</li>
       </ul>
 
@@ -47280,7 +47280,7 @@ THH:mm:ss.sss
   <h1>Corrections and Clarifications in ECMAScript 2015 with Possible Compatibility Impact</h1>
   <p><emu-xref href="#sec-candeclareglobalvar"></emu-xref>-<emu-xref href="#sec-createglobalfunctionbinding"></emu-xref> Edition 5 and 5.1 used a property existence test to determine whether a global object property corresponding to a new global declaration already existed. ECMAScript 2015 uses an own property existence test. This corresponds to what has been most commonly implemented by web browsers.</p>
   <p><emu-xref href="#sec-array-exotic-objects-defineownproperty-p-desc"></emu-xref>: The 5<sup>th</sup> Edition moved the capture of the current array length prior to the integer conversion of the array index or new length value. However, the captured length value could become invalid if the conversion process has the side-effect of changing the array length. ECMAScript 2015 specifies that the current array length must be captured after the possible occurrence of such side-effects.</p>
-  <p><emu-xref href="#sec-timeclip"></emu-xref>: Previous editions permitted the TimeClip abstract operation to return either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub> as the representation of a 0 time value. ECMAScript 2015 specifies that *+0*<sub>𝔽</sub> always returned. This means that for ECMAScript 2015 the time value of a Date object is never observably *-0*<sub>𝔽</sub> and methods that return time values never return *-0*<sub>𝔽</sub>.</p>
+  <p><emu-xref href="#sec-timeclip"></emu-xref>: Previous editions permitted the TimeClip abstract operation to return either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub> as the representation of a 0 time value. ECMAScript 2015 specifies that *+0*<sub>𝔽</sub> always returned. This means that for ECMAScript 2015 the time value of a Date is never observably *-0*<sub>𝔽</sub> and methods that return time values never return *-0*<sub>𝔽</sub>.</p>
   <p><emu-xref href="#sec-date-time-string-format"></emu-xref>: If a UTC offset representation is not present, the local time zone is used. Edition 5.1 incorrectly stated that a missing time zone should be interpreted as *"z"*.</p>
   <p><emu-xref href="#sec-date.prototype.toisostring"></emu-xref>: If the year cannot be represented using the Date Time String Format specified in <emu-xref href="#sec-date-time-string-format"></emu-xref> a RangeError exception is thrown. Previous editions did not specify the behaviour for that case.</p>
   <p><emu-xref href="#sec-date.prototype.tostring"></emu-xref>: Previous editions did not specify the value returned by `Date.prototype.toString` when this time value is *NaN*. ECMAScript 2015 specifies the result to be the String value *"Invalid Date"*.</p>


### PR DESCRIPTION
https://github.com/tc39/ecma262/pull/2483 proposes to change a few occurrences of "TypedArray object" to "TypedArray". (There were some usages of the latter form already.) That seems better, so we might as well do that everywhere it makes sense to do so.

I've changed most uses of "an X object" to be "an X", with the following exceptions:

- when referring to an exotic object in a context which emphasizes its exotic nature, I've left it as "an X exotic object"
- "Set object" remains as-is, to distinguish from the built-in type of the same name (I've also added a note calling attention to this)
- "Error object" and variants remain as-is, to make it clear it's talking about a value rather than an exceptional condition
- the various boxed primitive types remain "a Boolean object" (etc), to distinguish from the primitives
- "RegExp object" remains as-is to distinguish it from RegExp literals (this one I could go either way)
- "Proxy object" remains as-is because it read a little better to me (this one I could go either way)