### PR TITLE
Markup: auto-link plural forms of terms

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -505,9 +505,9 @@
       }
     },
     "ecmarkup": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-8.0.1.tgz",
-      "integrity": "sha512-Vn+W2lQmft0rzMT+1e5dyHtyPyVAUIkN5JaeLSdkP9HhNWrh2P2jQKzLY4bqn7DXijqUoj0IJDQ9Bgf8+Bm0Kg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-9.0.0.tgz",
+      "integrity": "sha512-3wf+Er3lWNLhkyfRqP/qZtKGWtW+rno6AUGlq6a6hJA676dS/xqPtZdZ6HLX/MsOCOnvVI2EJ0cgpC+Cas93qA==",
       "requires": {
         "chalk": "^1.1.3",
         "ecmarkdown": "^6.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,9 @@
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.8.tgz",
-      "integrity": "sha512-ZGy6/XQjllhYQrNw/3zfWRwZCTVSiBLZ9DHVZxn9n2gip/7ab8mv2TWlKPIBk26RwedCBoWdjLmn+t9na2Gcow=="
+      "version": "7.14.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+      "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g=="
     },
     "@babel/highlight": {
       "version": "7.14.5",
@@ -505,9 +505,9 @@
       }
     },
     "ecmarkup": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-9.0.0.tgz",
-      "integrity": "sha512-3wf+Er3lWNLhkyfRqP/qZtKGWtW+rno6AUGlq6a6hJA676dS/xqPtZdZ6HLX/MsOCOnvVI2EJ0cgpC+Cas93qA==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-9.1.0.tgz",
+      "integrity": "sha512-tR/4rI3jiGij0/qOau+5om6LYDBRgbyQzEM9Y3ksO5+sAS2idWhniIYguE2WUWuilxpD4e+cQesVZuOg6014QQ==",
       "requires": {
         "chalk": "^1.1.3",
         "ecmarkdown": "^6.0.0",
@@ -607,9 +607,9 @@
       }
     },
     "eslint": {
-      "version": "7.31.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.31.0.tgz",
-      "integrity": "sha512-vafgJpSh2ia8tnTkNUkwxGmnumgckLh5aAbLa1xRmIn9+owi8qBNGKL+B881kNKNTy7FFqTEkpNkUvmw0n6PkA==",
+      "version": "7.32.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
+      "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
       "requires": {
         "@babel/code-frame": "7.12.11",
         "@eslint/eslintrc": "^0.4.3",
@@ -667,9 +667,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -890,9 +890,9 @@
       }
     },
     "flatted": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.1.tgz",
-      "integrity": "sha512-OMQjaErSFHmHqZe+PSidH5n8j3O0F2DdnVh8JB4j4eUQ2k6KvB0qGfrKIhapvez5JerBbmWkaLYUYWISaESoXg=="
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
+      "integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA=="
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -955,9 +955,9 @@
       }
     },
     "globals": {
-      "version": "13.10.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.10.0.tgz",
-      "integrity": "sha512-piHC3blgLGFjvOuMmWZX60f+na1lXFDhQXBf1UYp2fXPXqvEUbOhNwi6BsQ0bQishwedgnjkwv1d9zKf+MWw3g==",
+      "version": "13.11.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.11.0.tgz",
+      "integrity": "sha512-08/xrJ7wQjK9kkkRoI3OFUBbLx4f+6x3SGwcPvQ0QH6goFDrOU2oyAWrmh3dJezu65buo+HBMzAMQy6rovVC3g==",
       "requires": {
         "type-fest": "^0.20.2"
       }
@@ -1822,9 +1822,9 @@
       }
     },
     "tslib": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
-      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "license": "SEE LICENSE IN https://tc39.es/ecma262/#sec-copyright-and-software-license",
   "homepage": "https://tc39.es/ecma262/",
   "dependencies": {
-    "ecmarkup": "^8.0.1"
+    "ecmarkup": "^9.0.0"
   },
   "devDependencies": {
     "glob": "^7.1.6",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "license": "SEE LICENSE IN https://tc39.es/ecma262/#sec-copyright-and-software-license",
   "homepage": "https://tc39.es/ecma262/",
   "dependencies": {
-    "ecmarkup": "^9.0.0"
+    "ecmarkup": "^9.1.0"
   },
   "devDependencies": {
     "glob": "^7.1.6",

--- a/spec.html
+++ b/spec.html
@@ -187,13 +187,13 @@
     <p>An <em id="implementation">implementation</em> is an external source that further defines facilities enumerated in Annex <emu-xref href="#sec-host-layering-points"></emu-xref> or those that are marked as implementation-defined or implementation-approximated. In informal use, an implementation refers to a concrete artefact, such as a particular web browser.</p>
     <p>An <dfn id="implementation-defined">implementation-defined</dfn> facility is one that defers its definition to an external source without further qualification. This specification does not make any recommendations for particular behaviours, and conforming implementations are free to choose any behaviour within the constraints put forth by this specification.</p>
     <p>An <dfn id="implementation-approximated">implementation-approximated</dfn> facility is one that defers its definition to an external source while recommending an ideal behaviour. While conforming implementations are free to choose any behaviour within the constraints put forth by this specification, they are encouraged to strive to approximate the ideal. Some mathematical operations, such as <emu-xref href="#sec-math.exp"><code>Math.exp</code></emu-xref>, are implementation-approximated.</p>
-    <p>A <dfn id="host">host</dfn> is an external source that further defines facilities listed in Annex <emu-xref href="#sec-host-layering-points"></emu-xref> but does not further define other implementation-defined or implementation-approximated facilities. In informal use, a host refers to the set of all implementations, such as the set of all web browsers, that interface with this specification in the same way via Annex <emu-xref href="#sec-host-layering-points"></emu-xref>. A host is often an external specification, such as WHATWG HTML (<a href="https://html.spec.whatwg.org/">https://html.spec.whatwg.org/</a>). In other words, facilities that are host-defined are often further defined in external specifications.</p>
-    <p>A <dfn id="host-hook">host hook</dfn> is an abstract operation that is defined in whole or in part by an external source. All host hooks must be listed in Annex <emu-xref href="#sec-host-layering-points"></emu-xref>. A host hook must conform to at least the following requirements:</p>
+    <p>A <dfn id="host" variants="hosts">host</dfn> is an external source that further defines facilities listed in Annex <emu-xref href="#sec-host-layering-points"></emu-xref> but does not further define other implementation-defined or implementation-approximated facilities. In informal use, a host refers to the set of all implementations, such as the set of all web browsers, that interface with this specification in the same way via Annex <emu-xref href="#sec-host-layering-points"></emu-xref>. A host is often an external specification, such as WHATWG HTML (<a href="https://html.spec.whatwg.org/">https://html.spec.whatwg.org/</a>). In other words, facilities that are host-defined are often further defined in external specifications.</p>
+    <p>A <dfn id="host-hook" variants="host hooks">host hook</dfn> is an abstract operation that is defined in whole or in part by an external source. All host hooks must be listed in Annex <emu-xref href="#sec-host-layering-points"></emu-xref>. A host hook must conform to at least the following requirements:</p>
     <ul>
       <li>It must return either a normal completion or a throw completion.</li>
     </ul>
     <p>A <dfn id="host-defined">host-defined</dfn> facility is one that defers its definition to an external source without further qualification and is listed in Annex <emu-xref href="#sec-host-layering-points"></emu-xref>. Implementations that are not hosts may also provide definitions for host-defined facilities.</p>
-    <p>A <dfn id="host-environment">host environment</dfn> is a particular choice of definition for all host-defined facilities. A host environment typically includes objects or functions which allow obtaining input and providing output as host-defined properties of the global object.</p>
+    <p>A <dfn id="host-environment" variants="host environments">host environment</dfn> is a particular choice of definition for all host-defined facilities. A host environment typically includes objects or functions which allow obtaining input and providing output as host-defined properties of the global object.</p>
     <p>This specification follows the editorial convention of always using the most specific term. For example, if a facility is host-defined, it should not be referred to as implementation-defined.</p>
     <p>Both hosts and implementations may interface with this specification via the language types, specification types, abstract operations, grammar productions, intrinsic objects, and intrinsic symbols defined herein.</p>
   </emu-clause>
@@ -513,8 +513,8 @@
     <emu-clause id="sec-context-free-grammars">
       <h1>Context-Free Grammars</h1>
       <p>A <em>context-free grammar</em> consists of a number of <em>productions</em>. Each production has an abstract symbol called a <em>nonterminal</em> as its <em>left-hand side</em>, and a sequence of zero or more nonterminal and <em>terminal</em> symbols as its <em>right-hand side</em>. For each grammar, the terminal symbols are drawn from a specified alphabet.</p>
-      <p>A <dfn>chain production</dfn> is a production that has exactly one nonterminal symbol on its right-hand side along with zero or more terminal symbols.</p>
-      <p>Starting from a sentence consisting of a single distinguished nonterminal, called the <dfn>goal symbol</dfn>, a given context-free grammar specifies a <em>language</em>, namely, the (perhaps infinite) set of possible sequences of terminal symbols that can result from repeatedly replacing any nonterminal in the sequence with a right-hand side of a production for which the nonterminal is the left-hand side.</p>
+      <p>A <dfn variants="chain productions">chain production</dfn> is a production that has exactly one nonterminal symbol on its right-hand side along with zero or more terminal symbols.</p>
+      <p>Starting from a sentence consisting of a single distinguished nonterminal, called the <dfn variants="goal symbols">goal symbol</dfn>, a given context-free grammar specifies a <em>language</em>, namely, the (perhaps infinite) set of possible sequences of terminal symbols that can result from repeatedly replacing any nonterminal in the sequence with a right-hand side of a production for which the nonterminal is the left-hand side.</p>
     </emu-clause>
 
     <emu-clause id="sec-lexical-and-regexp-grammars">
@@ -535,7 +535,7 @@
       <h1>The Syntactic Grammar</h1>
       <p>The <em>syntactic grammar</em> for ECMAScript is given in clauses <emu-xref href="#sec-ecmascript-language-expressions"></emu-xref> through <emu-xref href="#sec-ecmascript-language-scripts-and-modules"></emu-xref>. This grammar has ECMAScript tokens defined by the lexical grammar as its terminal symbols (<emu-xref href="#sec-lexical-and-regexp-grammars"></emu-xref>). It defines a set of productions, starting from two alternative goal symbols |Script| and |Module|, that describe how sequences of tokens form syntactically correct independent components of ECMAScript programs.</p>
       <p>When a stream of code points is to be parsed as an ECMAScript |Script| or |Module|, it is first converted to a stream of input elements by repeated application of the lexical grammar; this stream of input elements is then parsed by a single application of the syntactic grammar. The input stream is syntactically in error if the tokens in the stream of input elements cannot be parsed as a single instance of the goal nonterminal (|Script| or |Module|), with no tokens left over.</p>
-      <p>When a parse is successful, it constructs a <em>parse tree</em>, a rooted tree structure in which each node is a <dfn>Parse Node</dfn>. Each Parse Node is an <em>instance</em> of a symbol in the grammar; it represents a span of the source text that can be derived from that symbol. The root node of the parse tree, representing the whole of the source text, is an instance of the parse's goal symbol. When a Parse Node is an instance of a nonterminal, it is also an instance of some production that has that nonterminal as its left-hand side. Moreover, it has zero or more <em>children</em>, one for each symbol on the production's right-hand side: each child is a Parse Node that is an instance of the corresponding symbol.</p>
+      <p>When a parse is successful, it constructs a <em>parse tree</em>, a rooted tree structure in which each node is a <dfn variants="Parse Nodes">Parse Node</dfn>. Each Parse Node is an <em>instance</em> of a symbol in the grammar; it represents a span of the source text that can be derived from that symbol. The root node of the parse tree, representing the whole of the source text, is an instance of the parse's goal symbol. When a Parse Node is an instance of a nonterminal, it is also an instance of some production that has that nonterminal as its left-hand side. Moreover, it has zero or more <em>children</em>, one for each symbol on the production's right-hand side: each child is a Parse Node that is an instance of the corresponding symbol.</p>
       <p>New Parse Nodes are instantiated for each invocation of the parser and never reused between parses even of identical source text. Parse Nodes are considered <dfn>the same Parse Node</dfn> if and only if they represent the same span of source text, are instances of the same grammar symbol, and resulted from the same parser invocation.</p>
       <emu-note>
         <p>Parsing the same String multiple times will lead to different Parse Nodes. For example, consider:</p>
@@ -804,7 +804,7 @@
 
     <emu-clause id="sec-algorithm-conventions-syntax-directed-operations" namespace="algorithm-conventions">
       <h1>Syntax-Directed Operations</h1>
-      <p>A <dfn>syntax-directed operation</dfn> is a named operation whose definition consists of algorithms, each of which is associated with one or more productions from one of the ECMAScript grammars. A production that has multiple alternative definitions will typically have a distinct algorithm for each alternative. When an algorithm is associated with a grammar production, it may reference the terminal and nonterminal symbols of the production alternative as if they were parameters of the algorithm. When used in this manner, nonterminal symbols refer to the actual alternative definition that is matched when parsing the source text. The <dfn>source text matched by</dfn> a grammar production is the portion of the source text that starts at the beginning of the first terminal that participated in the match and ends at the end of the last terminal that participated in the match.</p>
+      <p>A <dfn variants="syntax-directed operations">syntax-directed operation</dfn> is a named operation whose definition consists of algorithms, each of which is associated with one or more productions from one of the ECMAScript grammars. A production that has multiple alternative definitions will typically have a distinct algorithm for each alternative. When an algorithm is associated with a grammar production, it may reference the terminal and nonterminal symbols of the production alternative as if they were parameters of the algorithm. When used in this manner, nonterminal symbols refer to the actual alternative definition that is matched when parsing the source text. The <dfn>source text matched by</dfn> a grammar production is the portion of the source text that starts at the beginning of the first terminal that participated in the match and ends at the end of the last terminal that participated in the match.</p>
       <p>When an algorithm is associated with a production alternative, the alternative is typically shown without any &ldquo;[ ]&rdquo; grammar annotations. Such annotations should only affect the syntactic recognition of the alternative and have no effect on the associated semantics for the alternative.</p>
       <p>Syntax-directed operations are invoked with a parse node and, optionally, other parameters by using the conventions on steps <emu-xref href="#step-sdo-invocation-example-1"></emu-xref>, <emu-xref href="#step-sdo-invocation-example-2"></emu-xref>, and <emu-xref href="#step-sdo-invocation-example-3"></emu-xref> in the following algorithm:</p>
       <emu-alg example>
@@ -952,7 +952,7 @@
       <p>In general, when this specification refers to a numerical value, such as in the phrase, "the length of _y_" or "the integer represented by the four hexadecimal digits ...", without explicitly specifying a numeric kind, the phrase refers to a mathematical value. Phrases which refer to a Number or a BigInt value are explicitly annotated as such; for example, "the Number value for the number of code points in &hellip;" or "the BigInt value for &hellip;".</p>
       <p>Numeric operators applied to mixed-type operands (such as a Number and a mathematical value) are not defined and should be considered an editorial error in this specification.</p>
       <p>This specification denotes most numeric values in base 10; it also uses numeric values of the form 0x followed by digits 0-9 or A-F as base-16 values.</p>
-      <p>When the term <dfn id="integer" oldids="mathematical integer">integer</dfn> is used in this specification, it refers to a mathematical value which is in the set of integers, unless otherwise stated. When the term <dfn id="integral-number">integral Number</dfn> is used in this specification, it refers to a Number value whose mathematical value is in the set of integers.</p>
+      <p>When the term <dfn id="integer" oldids="mathematical integer" variants="integers">integer</dfn> is used in this specification, it refers to a mathematical value which is in the set of integers, unless otherwise stated. When the term <dfn id="integral-number"variants="integral Numbers">integral Number</dfn> is used in this specification, it refers to a Number value whose mathematical value is in the set of integers.</p>
       <p>Conversions between mathematical values and Numbers or BigInts are always explicit in this document. A conversion from a mathematical value or extended mathematical value _x_ to a Number is denoted as "the Number value for _x_" or <dfn id="𝔽">𝔽</dfn>(_x_), and is defined in <emu-xref href="#sec-ecmascript-language-types-number-type"></emu-xref>. A conversion from an integer _x_ to a BigInt is denoted as "the BigInt value for _x_" or <dfn id="ℤ">ℤ</dfn>(_x_). A conversion from a Number or BigInt _x_ to a mathematical value is denoted as "the <dfn id="mathematical-value">mathematical value</dfn> of _x_", or <dfn id="ℝ">ℝ</dfn>(_x_). The mathematical value of *+0*<sub>𝔽</sub> and *-0*<sub>𝔽</sub> is the mathematical value 0. The mathematical value of non-finite values is not defined. The <dfn id="extended-mathematical-value">extended mathematical value</dfn> of _x_ is the mathematical value of _x_ for finite values, and is +&infin; and -&infin; for *+&infin;*<sub>𝔽</sub> and *-&infin;*<sub>𝔽</sub> respectively; it is not defined for *NaN*.</p>
       <p>The mathematical function <emu-eqn id="eqn-abs" aoid="abs">abs(_x_)</emu-eqn> produces the absolute value of _x_, which is <emu-eqn>-_x_</emu-eqn> if _x_ &lt; 0 and otherwise is _x_ itself.</p>
       <p>The mathematical function <emu-eqn id="eqn-min" aoid="min">min(_x1_, _x2_, &hellip; , _xN_)</emu-eqn> produces the mathematically smallest of <emu-eqn>_x1_</emu-eqn> through <emu-eqn>_xN_</emu-eqn>. The mathematical function <emu-eqn id="eqn-max" aoid="max">max(_x1_, _x2_, ..., _xN_)</emu-eqn> produces the mathematically largest of <emu-eqn>_x1_</emu-eqn> through <emu-eqn>_xN_</emu-eqn>. The domain and range of these mathematical functions are the extended mathematical values.</p>
@@ -975,11 +975,11 @@
 <emu-clause id="sec-ecmascript-data-types-and-values" aoid="Type">
   <h1>ECMAScript Data Types and Values</h1>
   <p>Algorithms within this specification manipulate values each of which has an associated type. The possible value types are exactly those defined in this clause. Types are further subclassified into ECMAScript language types and specification types.</p>
-  <p>Within this specification, the notation &ldquo;Type(_x_)&rdquo; is used as shorthand for &ldquo;the <dfn id="type">type</dfn> of _x_&rdquo; where &ldquo;type&rdquo; refers to the ECMAScript language and specification types defined in this clause. When the term &ldquo;empty&rdquo; is used as if it was naming a value, it is equivalent to saying &ldquo;no value of any type&rdquo;.</p>
+  <p>Within this specification, the notation &ldquo;Type(_x_)&rdquo; is used as shorthand for &ldquo;the <em>type</em> of _x_&rdquo; where &ldquo;type&rdquo; refers to the ECMAScript language and specification types defined in this clause. When the term &ldquo;empty&rdquo; is used as if it was naming a value, it is equivalent to saying &ldquo;no value of any type&rdquo;.</p>
 
   <emu-clause id="sec-ecmascript-language-types">
     <h1>ECMAScript Language Types</h1>
-    <p>An <dfn>ECMAScript language type</dfn> corresponds to values that are directly manipulated by an ECMAScript programmer using the ECMAScript language. The ECMAScript language types are Undefined, Null, Boolean, String, Symbol, Number, BigInt, and Object. An <dfn>ECMAScript language value</dfn> is a value that is characterized by an ECMAScript language type.</p>
+    <p>An <dfn variants="ECMAScript language types">ECMAScript language type</dfn> corresponds to values that are directly manipulated by an ECMAScript programmer using the ECMAScript language. The ECMAScript language types are Undefined, Null, Boolean, String, Symbol, Number, BigInt, and Object. An <dfn variants="ECMAScript language values">ECMAScript language value</dfn> is a value that is characterized by an ECMAScript language type.</p>
 
     <emu-clause id="sec-ecmascript-language-types-undefined-type">
       <h1>The Undefined Type</h1>
@@ -999,13 +999,13 @@
     <emu-clause id="sec-ecmascript-language-types-string-type">
       <h1>The String Type</h1>
       <p>The String type is the set of all ordered sequences of zero or more 16-bit unsigned integer values (&ldquo;elements&rdquo;) up to a maximum length of 2<sup>53</sup> - 1 elements. The String type is generally used to represent textual data in a running ECMAScript program, in which case each element in the String is treated as a UTF-16 code unit value. Each element is regarded as occupying a position within the sequence. These positions are indexed with non-negative integers. The first element (if any) is at index 0, the next element (if any) at index 1, and so on. The length of a String is the number of elements (i.e., 16-bit values) within it. The empty String has length zero and therefore contains no elements.</p>
-      <p>ECMAScript operations that do not interpret String contents apply no further semantics. Operations that do interpret String values treat each element as a single UTF-16 code unit. However, ECMAScript does not restrict the value of or relationships between these code units, so operations that further interpret String contents as sequences of Unicode code points encoded in UTF-16 must account for ill-formed subsequences. Such operations apply special treatment to every code unit with a numeric value in the inclusive range 0xD800 to 0xDBFF (defined by the Unicode Standard as a <dfn id="leading-surrogate">leading surrogate</dfn>, or more formally as a <dfn id="high-surrogate-code-unit">high-surrogate code unit</dfn>) and every code unit with a numeric value in the inclusive range 0xDC00 to 0xDFFF (defined as a <dfn id="trailing-surrogate">trailing surrogate</dfn>, or more formally as a <dfn id="low-surrogate-code-unit">low-surrogate code unit</dfn>) using the following rules:</p>
+      <p>ECMAScript operations that do not interpret String contents apply no further semantics. Operations that do interpret String values treat each element as a single UTF-16 code unit. However, ECMAScript does not restrict the value of or relationships between these code units, so operations that further interpret String contents as sequences of Unicode code points encoded in UTF-16 must account for ill-formed subsequences. Such operations apply special treatment to every code unit with a numeric value in the inclusive range 0xD800 to 0xDBFF (defined by the Unicode Standard as a <dfn id="leading-surrogate" variants="leading surrogates">leading surrogate</dfn>, or more formally as a <dfn id="high-surrogate-code-unit" variants="high-surrogate code units">high-surrogate code unit</dfn>) and every code unit with a numeric value in the inclusive range 0xDC00 to 0xDFFF (defined as a <dfn id="trailing-surrogate" variants="trailing surrogates">trailing surrogate</dfn>, or more formally as a <dfn id="low-surrogate-code-unit" variants="low-surrogate code units">low-surrogate code unit</dfn>) using the following rules:</p>
       <ul>
         <li>
           A code unit that is not a <emu-xref href="#leading-surrogate"></emu-xref> and not a <emu-xref href="#trailing-surrogate"></emu-xref> is interpreted as a code point with the same value.
         </li>
         <li>
-          A sequence of two code units, where the first code unit _c1_ is a <emu-xref href="#leading-surrogate"></emu-xref> and the second code unit _c2_ a <emu-xref href="#trailing-surrogate"></emu-xref>, is a <dfn id="surrogate-pair">surrogate pair</dfn> and is interpreted as a code point with the value (_c1_ - 0xD800) &times; 0x400 + (_c2_ - 0xDC00) + 0x10000. (See <emu-xref href="#sec-utf16decodesurrogatepair"></emu-xref>)
+          A sequence of two code units, where the first code unit _c1_ is a <emu-xref href="#leading-surrogate"></emu-xref> and the second code unit _c2_ a <emu-xref href="#trailing-surrogate"></emu-xref>, is a <dfn id="surrogate-pair" variants="surrogate pairs">surrogate pair</dfn> and is interpreted as a code point with the value (_c1_ - 0xD800) &times; 0x400 + (_c2_ - 0xDC00) + 0x10000. (See <emu-xref href="#sec-utf16decodesurrogatepair"></emu-xref>)
         </li>
         <li>
           A code unit that is a <emu-xref href="#leading-surrogate"></emu-xref> or <emu-xref href="#trailing-surrogate"></emu-xref>, but is not part of a <emu-xref href="#surrogate-pair"></emu-xref>, is interpreted as a code point with the same value.
@@ -2406,14 +2406,14 @@
       <p>An Object is logically a collection of properties. Each property is either a data property, or an accessor property:</p>
       <ul>
         <li>
-          A <dfn>data property</dfn> associates a key value with an ECMAScript language value and a set of Boolean attributes.
+          A <dfn variants="data properties">data property</dfn> associates a key value with an ECMAScript language value and a set of Boolean attributes.
         </li>
         <li>
-          An <dfn>accessor property</dfn> associates a key value with one or two accessor functions, and a set of Boolean attributes. The accessor functions are used to store or retrieve an ECMAScript language value that is associated with the property.
+          An <dfn variants="accessor properties">accessor property</dfn> associates a key value with one or two accessor functions, and a set of Boolean attributes. The accessor functions are used to store or retrieve an ECMAScript language value that is associated with the property.
         </li>
       </ul>
       <p>Properties are identified using key values. A property key value is either an ECMAScript String value or a Symbol value. All String and Symbol values, including the empty String, are valid as property keys. A <dfn id="property-name">property name</dfn> is a property key that is a String value.</p>
-      <p>An <dfn id="integer-index">integer index</dfn> is a String-valued property key that is a canonical numeric String (see <emu-xref href="#sec-canonicalnumericindexstring"></emu-xref>) and whose numeric value is either *+0*<sub>𝔽</sub> or a positive integral Number &le; 𝔽(2<sup>53</sup> - 1). An <dfn id="array-index">array index</dfn> is an integer index whose numeric value _i_ is in the range <emu-eqn>*+0*<sub>𝔽</sub> &le; _i_ &lt; 𝔽(2<sup>32</sup> - 1)</emu-eqn>.</p>
+      <p>An <dfn id="integer-index" variants="integer indices">integer index</dfn> is a String-valued property key that is a canonical numeric String (see <emu-xref href="#sec-canonicalnumericindexstring"></emu-xref>) and whose numeric value is either *+0*<sub>𝔽</sub> or a positive integral Number &le; 𝔽(2<sup>53</sup> - 1). An <dfn id="array-index" variants="array indices">array index</dfn> is an integer index whose numeric value _i_ is in the range <emu-eqn>*+0*<sub>𝔽</sub> &le; _i_ &lt; 𝔽(2<sup>32</sup> - 1)</emu-eqn>.</p>
       <p>Property keys are used to access properties and their values. There are two kinds of access for properties: <em>get</em> and <em>set</em>, corresponding to value retrieval and assignment, respectively. The properties accessible via get and set access includes both <em>own properties</em> that are a direct part of an object and <em>inherited properties</em> which are provided by another associated object via a property inheritance relationship. Inherited properties may be either own or inherited properties of the associated object. Each own property of an object must each have a key value that is distinct from the key values of the other own properties of that object.</p>
       <p>All objects are logically collections of properties, but there are multiple forms of objects that differ in their semantics for accessing and manipulating their properties. Please see <emu-xref href="#sec-object-internal-methods-and-internal-slots"></emu-xref> for definitions of the multiple forms of objects.</p>
 
@@ -2616,7 +2616,7 @@
         <p>All objects have an internal slot named [[PrivateElements]], which is a List of PrivateElements. This List represents the values of the private fields, methods, and accessors for the object. Initially, it is an empty List.</p>
         <p>Internal methods and internal slots are identified within this specification using names enclosed in double square brackets [[ ]].</p>
         <p><emu-xref href="#table-essential-internal-methods"></emu-xref> summarizes the <em>essential internal methods</em> used by this specification that are applicable to all objects created or manipulated by ECMAScript code. Every object must have algorithms for all of the essential internal methods. However, all objects do not necessarily use the same algorithms for those methods.</p>
-        <p>An <dfn id="ordinary-object">ordinary object</dfn> is an object that satisfies all of the following criteria:</p>
+        <p>An <dfn id="ordinary-object" variants="ordinary objects">ordinary object</dfn> is an object that satisfies all of the following criteria:</p>
         <ul>
           <li>
             For the internal methods listed in <emu-xref href="#table-essential-internal-methods"></emu-xref>, the object uses those defined in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>.
@@ -2628,7 +2628,7 @@
             If the object has a [[Construct]] internal method, it uses the one defined in <emu-xref href="#sec-ecmascript-function-objects-construct-argumentslist-newtarget"></emu-xref>.
           </li>
         </ul>
-        <p>An <dfn id="exotic-object">exotic object</dfn> is an object that is not an ordinary object.</p>
+        <p>An <dfn id="exotic-object" variants="exotic objects">exotic object</dfn> is an object that is not an ordinary object.</p>
         <p>This specification recognizes different kinds of exotic objects by those objects' internal methods. An object that is behaviourally equivalent to a particular kind of exotic object (such as an Array exotic object or a bound function exotic object), but does not have the same collection of internal methods specified for that kind, is not recognized as that kind of exotic object.</p>
         <p>The &ldquo;Signature&rdquo; column of <emu-xref href="#table-essential-internal-methods"></emu-xref> and other similar tables describes the invocation pattern for each internal method. The invocation pattern always includes a parenthesized list of descriptive parameter names. If a parameter name is the same as an ECMAScript type name then the name describes the required type of the parameter value. If an internal method explicitly returns a value, its parameter list is followed by the symbol &ldquo;&rarr;&rdquo; and the type name of the returned value. The type names used in signatures refer to the types defined in clause <emu-xref href="#sec-ecmascript-data-types-and-values"></emu-xref> augmented by the following additional names. &ldquo;<em>any</em>&rdquo; means the value may be any ECMAScript language type.</p>
         <p>In addition to its parameters, an internal method always has access to the object that is the target of the method invocation.</p>
@@ -2771,7 +2771,7 @@
             </tbody>
           </table>
         </emu-table>
-        <p><emu-xref href="#table-additional-essential-internal-methods-of-function-objects"></emu-xref> summarizes additional essential internal methods that are supported by objects that may be called as functions. A <dfn id="function-object">function object</dfn> is an object that supports the [[Call]] internal method. A <dfn id="constructor">constructor</dfn> is an object that supports the [[Construct]] internal method. Every object that supports [[Construct]] must support [[Call]]; that is, every constructor must be a function object. Therefore, a constructor may also be referred to as a <em>constructor function</em> or <em>constructor function object</em>.</p>
+        <p><emu-xref href="#table-additional-essential-internal-methods-of-function-objects"></emu-xref> summarizes additional essential internal methods that are supported by objects that may be called as functions. A <dfn id="function-object" variants="function objects">function object</dfn> is an object that supports the [[Call]] internal method. A <dfn id="constructor" variants="constructors">constructor</dfn> is an object that supports the [[Construct]] internal method. Every object that supports [[Construct]] must support [[Call]]; that is, every constructor must be a function object. Therefore, a constructor may also be referred to as a <em>constructor function</em> or <em>constructor function object</em>.</p>
         <emu-table id="table-additional-essential-internal-methods-of-function-objects" caption="Additional Essential Internal Methods of Function Objects" oldids="table-6">
           <table>
             <tbody>
@@ -3760,11 +3760,11 @@
 
     <emu-clause id="sec-list-and-record-specification-type">
       <h1>The List and Record Specification Types</h1>
-      <p>The <dfn>List</dfn> type is used to explain the evaluation of argument lists (see <emu-xref href="#sec-argument-lists"></emu-xref>) in `new` expressions, in function calls, and in other algorithms where a simple ordered list of values is needed. Values of the List type are simply ordered sequences of list elements containing the individual values. These sequences may be of any length. The elements of a list may be randomly accessed using 0-origin indices. For notational convenience an array-like syntax can be used to access List elements. For example, _arguments_[2] is shorthand for saying the 3<sup>rd</sup> element of the List _arguments_.</p>
+      <p>The <dfn variants="Lists">List</dfn> type is used to explain the evaluation of argument lists (see <emu-xref href="#sec-argument-lists"></emu-xref>) in `new` expressions, in function calls, and in other algorithms where a simple ordered list of values is needed. Values of the List type are simply ordered sequences of list elements containing the individual values. These sequences may be of any length. The elements of a list may be randomly accessed using 0-origin indices. For notational convenience an array-like syntax can be used to access List elements. For example, _arguments_[2] is shorthand for saying the 3<sup>rd</sup> element of the List _arguments_.</p>
       <p>When an algorithm iterates over the elements of a List without specifying an order, the order used is the order of the elements in the List.</p>
       <p>For notational convenience within this specification, a literal syntax can be used to express a new List value. For example, &laquo; 1, 2 &raquo; defines a List value that has two elements each of which is initialized to a specific value. A new empty List can be expressed as &laquo; &raquo;.</p>
       <p>In this specification, the phrase "the <dfn id="list-concatenation">list-concatenation</dfn> of _A_, _B_, ..." (where each argument is a possibly empty List) denotes a new List value whose elements are the concatenation of the elements (in order) of each of the arguments (in order).</p>
-      <p>The <dfn>Record</dfn> type is used to describe data aggregations within the algorithms of this specification. A Record type value consists of one or more named fields. The value of each field is either an ECMAScript value or an abstract value represented by a name associated with the Record type. Field names are always enclosed in double brackets, for example [[Value]].</p>
+      <p>The <dfn variants="Records">Record</dfn> type is used to describe data aggregations within the algorithms of this specification. A Record type value consists of one or more named fields. The value of each field is either an ECMAScript value or an abstract value represented by a name associated with the Record type. Field names are always enclosed in double brackets, for example [[Value]].</p>
       <p>For notational convenience within this specification, an object literal-like syntax can be used to express a Record value. For example, { [[Field1]]: 42, [[Field2]]: *false*, [[Field3]]: ~empty~ } defines a Record value that has three fields, each of which is initialized to a specific value. Field name order is not significant. Any fields that are not explicitly listed are considered to be absent.</p>
       <p>In specification text and algorithms, dot notation may be used to refer to a specific field of a Record value. For example, if R is the record shown in the previous paragraph then R.[[Field2]] is shorthand for &ldquo;the field of R named [[Field2]]&rdquo;.</p>
       <p>Schema for commonly used Record field combinations may be named, and that name may be used as a prefix to a literal Record value to identify the specific kind of aggregations that is being described. For example: PropertyDescriptor { [[Value]]: 42, [[Writable]]: *false*, [[Configurable]]: *true* }.</p>
@@ -3772,9 +3772,9 @@
 
     <emu-clause id="sec-set-and-relation-specification-type">
       <h1>The Set and Relation Specification Types</h1>
-      <p>The <dfn>Set</dfn> type is used to explain a collection of unordered elements for use in the memory model. Values of the Set type are simple collections of elements, where no element appears more than once. Elements may be added to and removed from Sets. Sets may be unioned, intersected, or subtracted from each other.</p>
+      <p>The <em>Set</em> type is used to explain a collection of unordered elements for use in the memory model. Values of the Set type are simple collections of elements, where no element appears more than once. Elements may be added to and removed from Sets. Sets may be unioned, intersected, or subtracted from each other.</p>
       <p>The <dfn>Relation</dfn> type is used to explain constraints on Sets. Values of the Relation type are Sets of ordered pairs of values from its value domain. For example, a Relation on events is a set of ordered pairs of events. For a Relation _R_ and two values _a_ and _b_ in the value domain of _R_, _a_ _R_ _b_ is shorthand for saying the ordered pair (_a_, _b_) is a member of _R_. A Relation is least with respect to some conditions when it is the smallest Relation that satisfies those conditions.</p>
-      <p>A <dfn>strict partial order</dfn> is a Relation value _R_ that satisfies the following.</p>
+      <p>A <dfn variants="strict partial orders">strict partial order</dfn> is a Relation value _R_ that satisfies the following.</p>
       <ul>
         <li>
           <p>For all _a_, _b_, and _c_ in _R_'s domain:</p>
@@ -3787,7 +3787,7 @@
       <emu-note>
         <p>The two properties above are called irreflexivity and transitivity, respectively.</p>
       </emu-note>
-      <p>A <dfn>strict total order</dfn> is a Relation value _R_ that satisfies the following.</p>
+      <p>A <dfn variants="strict total orders">strict total order</dfn> is a Relation value _R_ that satisfies the following.</p>
       <ul>
         <li>
           <p>For all _a_, _b_, and _c_ in _R_'s domain:</p>
@@ -3806,7 +3806,7 @@
     <emu-clause id="sec-completion-record-specification-type" aoid="Completion">
       <h1>The Completion Record Specification Type</h1>
       <p>The Completion type is a Record used to explain the runtime propagation of values and control flow such as the behaviour of statements (`break`, `continue`, `return` and `throw`) that perform nonlocal transfers of control.</p>
-      <p>Values of the Completion type are Record values whose fields are defined by <emu-xref href="#table-completion-record-fields"></emu-xref>. Such values are referred to as <dfn>Completion Record</dfn>s.</p>
+      <p>Values of the Completion type are Record values whose fields are defined by <emu-xref href="#table-completion-record-fields"></emu-xref>. Such values are referred to as <dfn variants="Completion Record">Completion Records</dfn>.</p>
       <emu-table id="table-completion-record-fields" caption="Completion Record Fields" oldids="table-8">
         <table>
           <tbody>
@@ -3859,12 +3859,12 @@
       </emu-table>
       <p>The following shorthand terms are sometimes used to refer to completions.</p>
       <ul>
-        <li><dfn>normal completion</dfn> refers to any completion with a [[Type]] value of ~normal~.</li>
-        <li><dfn>break completion</dfn> refers to any completion with a [[Type]] value of ~break~.</li>
-        <li><dfn>continue completion</dfn> refers to any completion with a [[Type]] value of ~continue~.</li>
-        <li><dfn>return completion</dfn> refers to any completion with a [[Type]] value of ~return~.</li>
-        <li><dfn>throw completion</dfn> refers to any completion with a [[Type]] value of ~throw~.</li>
-        <li><dfn>abrupt completion</dfn> refers to any completion with a [[Type]] value other than ~normal~.</li>
+        <li><dfn variants="normal completions">normal completion</dfn> refers to any completion with a [[Type]] value of ~normal~.</li>
+        <li><dfn variants="break completions">break completion</dfn> refers to any completion with a [[Type]] value of ~break~.</li>
+        <li><dfn variants="continue completions">continue completion</dfn> refers to any completion with a [[Type]] value of ~continue~.</li>
+        <li><dfn variants="return completions">return completion</dfn> refers to any completion with a [[Type]] value of ~return~.</li>
+        <li><dfn variants="throw completions">throw completion</dfn> refers to any completion with a [[Type]] value of ~throw~.</li>
+        <li><dfn variants="abrupt completions">abrupt completion</dfn> refers to any completion with a [[Type]] value other than ~normal~.</li>
       </ul>
       <p>Callable objects that are defined in this specification only return a normal completion or a throw completion. Returning any other kind of completion is considered an editorial error.</p>
       <p>Implementation-defined callable objects must return either a normal completion or a throw completion.</p>
@@ -3969,7 +3969,7 @@
 
     <emu-clause id="sec-reference-record-specification-type" oldids="sec-reference-specification-type">
       <h1>The Reference Record Specification Type</h1>
-      <p>The <dfn>Reference Record</dfn> type is used to explain the behaviour of such operators as `delete`, `typeof`, the assignment operators, the `super` keyword and other language features. For example, the left-hand operand of an assignment is expected to produce a Reference Record.</p>
+      <p>The <dfn variants="Reference Records">Reference Record</dfn> type is used to explain the behaviour of such operators as `delete`, `typeof`, the assignment operators, the `super` keyword and other language features. For example, the left-hand operand of an assignment is expected to produce a Reference Record.</p>
       <p>A Reference Record is a resolved name or property binding; its fields are defined by <emu-xref href="#table-reference-record-fields"></emu-xref>.</p>
 
       <emu-table id="table-reference-record-fields" caption="Reference Record Fields">
@@ -4011,7 +4011,7 @@
             <tr>
               <td>[[ThisValue]]</td>
               <td>any ECMAScript language value or ~empty~</td>
-              <td>If not ~empty~, the Reference Record represents a property binding that was expressed using the `super` keyword; it is called a <dfn id="super-reference-record" oldids="super-reference">Super Reference Record</dfn> and its [[Base]] value will never be an Environment Record. In that case, the [[ThisValue]] field holds the *this* value at the time the Reference Record was created.</td>
+              <td>If not ~empty~, the Reference Record represents a property binding that was expressed using the `super` keyword; it is called a <dfn id="super-reference-record" oldids="super-reference" variants="Super Reference Records">Super Reference Record</dfn> and its [[Base]] value will never be an Environment Record. In that case, the [[ThisValue]] field holds the *this* value at the time the Reference Record was created.</td>
             </tr>
           </tbody>
         </table>
@@ -4191,7 +4191,7 @@
 
     <emu-clause id="sec-property-descriptor-specification-type">
       <h1>The Property Descriptor Specification Type</h1>
-      <p>The <dfn>Property Descriptor</dfn> type is used to explain the manipulation and reification of Object property attributes. Values of the Property Descriptor type are Records. Each field's name is an attribute name and its value is a corresponding attribute value as specified in <emu-xref href="#sec-property-attributes"></emu-xref>. In addition, any field may be present or absent. The schema name used within this specification to tag literal descriptions of Property Descriptor records is &ldquo;PropertyDescriptor&rdquo;.</p>
+      <p>The <dfn variants="Property Descriptors">Property Descriptor</dfn> type is used to explain the manipulation and reification of Object property attributes. Values of the Property Descriptor type are Records. Each field's name is an attribute name and its value is a corresponding attribute value as specified in <emu-xref href="#sec-property-attributes"></emu-xref>. In addition, any field may be present or absent. The schema name used within this specification to tag literal descriptions of Property Descriptor records is &ldquo;PropertyDescriptor&rdquo;.</p>
       <p>Property Descriptor values may be further classified as data Property Descriptors and accessor Property Descriptors based upon the existence or use of certain fields. A data Property Descriptor is one that includes any fields named either [[Value]] or [[Writable]]. An accessor Property Descriptor is one that includes any fields named either [[Get]] or [[Set]]. Any Property Descriptor may have fields named [[Enumerable]] and [[Configurable]]. A Property Descriptor value may not be both a data Property Descriptor and an accessor Property Descriptor; however, it may be neither. A generic Property Descriptor is a Property Descriptor value that is neither a data Property Descriptor nor an accessor Property Descriptor. A fully populated Property Descriptor is one that is either an accessor Property Descriptor or a data Property Descriptor and that has all of the fields that correspond to the property attributes defined in either <emu-xref href="#table-data-property-attributes"></emu-xref> or <emu-xref href="#table-accessor-property-attributes"></emu-xref>.</p>
       <p>The following abstract operations are used in this specification to operate upon Property Descriptor values:</p>
 
@@ -4342,7 +4342,7 @@
 
     <emu-clause id="sec-abstract-closure">
       <h1>The Abstract Closure Specification Type</h1>
-      <p>The <dfn>Abstract Closure</dfn> specification type is used to refer to algorithm steps together with a collection of values. Abstract Closures are meta-values and are invoked using function application style such as _closure_(_arg1_, _arg2_). Like abstract operations, invocations perform the algorithm steps described by the Abstract Closure.</p>
+      <p>The <dfn variants="Abstract Closures">Abstract Closure</dfn> specification type is used to refer to algorithm steps together with a collection of values. Abstract Closures are meta-values and are invoked using function application style such as _closure_(_arg1_, _arg2_). Like abstract operations, invocations perform the algorithm steps described by the Abstract Closure.</p>
       <p>In algorithm steps that create an Abstract Closure, values are captured with the verb "capture" followed by a list of aliases. When an Abstract Closure is created, it captures the value that is associated with each alias at that time. In steps that specify the algorithm to be performed when an Abstract Closure is called, each captured value is referred to by the alias that was used to capture the value.</p>
       <p>If an Abstract Closure returns a Completion Record, that Completion Record's [[Type]] must be either ~normal~ or ~throw~.</p>
       <p>Abstract Closures are created inline as part of other algorithms, shown in the following example.</p>
@@ -4357,9 +4357,9 @@
 
     <emu-clause id="sec-data-blocks">
       <h1>Data Blocks</h1>
-      <p>The <dfn>Data Block</dfn> specification type is used to describe a distinct and mutable sequence of byte-sized (8 bit) numeric values. A <dfn>byte value</dfn> is an integer value in the range 0 through 255, inclusive. A Data Block value is created with a fixed number of bytes that each have the initial value 0.</p>
+      <p>The <dfn variants="Data Blocks">Data Block</dfn> specification type is used to describe a distinct and mutable sequence of byte-sized (8 bit) numeric values. A <dfn variants="byte values">byte value</dfn> is an integer value in the range 0 through 255, inclusive. A Data Block value is created with a fixed number of bytes that each have the initial value 0.</p>
       <p>For notational convenience within this specification, an array-like syntax can be used to access the individual bytes of a Data Block value. This notation presents a Data Block value as a 0-origined integer-indexed sequence of bytes. For example, if _db_ is a 5 byte Data Block value then _db_[2] can be used to access its 3<sup>rd</sup> byte.</p>
-      <p>A data block that resides in memory that can be referenced from multiple agents concurrently is designated a <dfn>Shared Data Block</dfn>. A Shared Data Block has an identity (for the purposes of equality testing Shared Data Block values) that is <em>address-free</em>: it is tied not to the virtual addresses the block is mapped to in any process, but to the set of locations in memory that the block represents. Two data blocks are equal only if the sets of the locations they contain are equal; otherwise, they are not equal and the intersection of the sets of locations they contain is empty. Finally, Shared Data Blocks can be distinguished from Data Blocks.</p>
+      <p>A data block that resides in memory that can be referenced from multiple agents concurrently is designated a <dfn variants="Shared Data Blocks">Shared Data Block</dfn>. A Shared Data Block has an identity (for the purposes of equality testing Shared Data Block values) that is <em>address-free</em>: it is tied not to the virtual addresses the block is mapped to in any process, but to the set of locations in memory that the block represents. Two data blocks are equal only if the sets of the locations they contain are equal; otherwise, they are not equal and the intersection of the sets of locations they contain is empty. Finally, Shared Data Blocks can be distinguished from Data Blocks.</p>
       <p>The semantics of Shared Data Blocks is defined using Shared Data Block events by the memory model. Abstract operations below introduce Shared Data Block events and act as the interface between evaluation semantics and the event semantics of the memory model. The events form a candidate execution, on which the memory model acts as a filter. Please consult the memory model for full semantics.</p>
       <p>Shared Data Block events are modeled by Records, defined in the memory model.</p>
       <p>The following abstract operations are used in this specification to operate upon Data Block values:</p>
@@ -4445,7 +4445,7 @@
     <emu-clause id="sec-privateelement-specification-type">
       <h1>The PrivateElement Specification Type</h1>
       <p>The PrivateElement type is a Record used in the specification of private class fields, methods, and accessors. Although Property Descriptors are not used for private elements, private fields behave similarly to non-configurable, non-enumerable, writable data properties, private methods behave similarly to non-configurable, non-enumerable, non-writable data properties, and private accessors behave similarly to non-configurable, non-enumerable accessor properties.</p>
-      <p>Values of the PrivateElement type are Record values whose fields are defined by <emu-xref href="#table-privateelement-fields"></emu-xref>. Such values are referred to as <dfn>PrivateElement</dfn>s.</p>
+      <p>Values of the PrivateElement type are Record values whose fields are defined by <emu-xref href="#table-privateelement-fields"></emu-xref>. Such values are referred to as <dfn variants="PrivateElement">PrivateElements</dfn>.</p>
       <emu-table id="table-privateelement-fields" caption="PrivateElement Fields">
         <table>
           <tbody>
@@ -4541,7 +4541,7 @@
     <emu-clause id="sec-classfielddefinition-record-specification-type">
       <h1>The ClassFieldDefinition Record Specification Type</h1>
       <p>The ClassFieldDefinition type is a Record used in the specification of class fields.</p>
-      <p>Values of the ClassFieldDefinition type are Record values whose fields are defined by <emu-xref href="#table-classfielddefinition-fields"></emu-xref>. Such values are referred to as <dfn>ClassFieldDefinition Record</dfn>s.</p>
+      <p>Values of the ClassFieldDefinition type are Record values whose fields are defined by <emu-xref href="#table-classfielddefinition-fields"></emu-xref>. Such values are referred to as <dfn variants="ClassFieldDefinition Record">ClassFieldDefinition Records</dfn>.</p>
       <emu-table id="table-classfielddefinition-fields" caption="ClassFieldDefinition Record Fields">
         <table>
           <tbody>
@@ -4585,7 +4585,7 @@
 
     <emu-clause id="sec-private-names">
       <h1>Private Names</h1>
-      <p>The <dfn>Private Name</dfn> specification type is used to describe a globally unique value (one which differs from any other Private Name, even if they are otherwise indistinguishable) which represents the key of a private class element (field, method, or accessor). Each Private Name has an associated immutable [[Description]] which is a String value. A Private Name may be installed on any ECMAScript object with PrivateFieldAdd or PrivateMethodOrAccessorAdd, and then read or written using PrivateGet and PrivateSet.</p>
+      <p>The <dfn variants="Private Names">Private Name</dfn> specification type is used to describe a globally unique value (one which differs from any other Private Name, even if they are otherwise indistinguishable) which represents the key of a private class element (field, method, or accessor). Each Private Name has an associated immutable [[Description]] which is a String value. A Private Name may be installed on any ECMAScript object with PrivateFieldAdd or PrivateMethodOrAccessorAdd, and then read or written using PrivateGet and PrivateSet.</p>
     </emu-clause>
   </emu-clause>
 </emu-clause>
@@ -6426,7 +6426,7 @@
         1. Assert: Type(_obj_) is Object.
         1. Return ℝ(? ToLength(? Get(_obj_, *"length"*))).
       </emu-alg>
-      <p>An <dfn>array-like object</dfn> is any object for which this operation returns an integer rather than an abrupt completion.</p>
+      <p>An <dfn variants="array-like objects">array-like object</dfn> is any object for which this operation returns an integer rather than an abrupt completion.</p>
       <emu-note>
         Typically, an array-like object would also have some properties with integer index names. However, that is not a requirement of this definition.
       </emu-note>
@@ -9625,7 +9625,7 @@
 
   <emu-clause id="sec-environment-records" oldids="sec-lexical-environments">
     <h1>Environment Records</h1>
-    <p><dfn>Environment Record</dfn> is a specification type used to define the association of |Identifier|s to specific variables and functions, based upon the lexical nesting structure of ECMAScript code. Usually an Environment Record is associated with some specific syntactic structure of ECMAScript code such as a |FunctionDeclaration|, a |BlockStatement|, or a |Catch| clause of a |TryStatement|. Each time such code is evaluated, a new Environment Record is created to record the identifier bindings that are created by that code.</p>
+    <p><dfn variants="Environment Records">Environment Record</dfn> is a specification type used to define the association of |Identifier|s to specific variables and functions, based upon the lexical nesting structure of ECMAScript code. Usually an Environment Record is associated with some specific syntactic structure of ECMAScript code such as a |FunctionDeclaration|, a |BlockStatement|, or a |Catch| clause of a |TryStatement|. Each time such code is evaluated, a new Environment Record is created to record the identifier bindings that are created by that code.</p>
     <p>Every Environment Record has an [[OuterEnv]] field, which is either *null* or a reference to an outer Environment Record. This is used to model the logical nesting of Environment Record values. The outer reference of an (inner) Environment Record is a reference to the Environment Record that logically surrounds the inner Environment Record. An outer Environment Record may, of course, have its own outer Environment Record. An Environment Record may serve as the outer environment for multiple inner Environment Records. For example, if a |FunctionDeclaration| contains two nested |FunctionDeclaration|s then the Environment Records of each of the nested functions will have as their outer Environment Record the Environment Record of the current evaluation of the surrounding function.</p>
     <p>Environment Records are purely specification mechanisms and need not correspond to any specific artefact of an ECMAScript implementation. It is impossible for an ECMAScript program to directly access or manipulate such values.</p>
 
@@ -9755,7 +9755,7 @@
 
       <emu-clause id="sec-declarative-environment-records">
         <h1>Declarative Environment Records</h1>
-        <p>Each <dfn>declarative Environment Record</dfn> is associated with an ECMAScript program scope containing variable, constant, let, class, module, import, and/or function declarations. A declarative Environment Record binds the set of identifiers defined by the declarations contained within its scope.</p>
+        <p>Each <dfn variants="declarative Environment Records">declarative Environment Record</dfn> is associated with an ECMAScript program scope containing variable, constant, let, class, module, import, and/or function declarations. A declarative Environment Record binds the set of identifiers defined by the declarations contained within its scope.</p>
         <p>The behaviour of the concrete specification methods for declarative Environment Records is defined by the following algorithms.</p>
 
         <emu-clause id="sec-declarative-environment-records-hasbinding-n" type="concrete method">
@@ -9960,7 +9960,7 @@
 
       <emu-clause id="sec-object-environment-records">
         <h1>Object Environment Records</h1>
-        <p>Each <dfn>object Environment Record</dfn> is associated with an object called its <em>binding object</em>. An object Environment Record binds the set of string identifier names that directly correspond to the property names of its binding object. Property keys that are not strings in the form of an |IdentifierName| are not included in the set of bound identifiers. Both own and inherited properties are included in the set regardless of the setting of their [[Enumerable]] attribute. Because properties can be dynamically added and deleted from objects, the set of identifiers bound by an object Environment Record may potentially change as a side-effect of any operation that adds or deletes properties. Any bindings that are created as a result of such a side-effect are considered to be a mutable binding even if the Writable attribute of the corresponding property has the value *false*. Immutable bindings do not exist for object Environment Records.</p>
+        <p>Each <dfn variants="object Environment Records">object Environment Record</dfn> is associated with an object called its <em>binding object</em>. An object Environment Record binds the set of string identifier names that directly correspond to the property names of its binding object. Property keys that are not strings in the form of an |IdentifierName| are not included in the set of bound identifiers. Both own and inherited properties are included in the set regardless of the setting of their [[Enumerable]] attribute. Because properties can be dynamically added and deleted from objects, the set of identifiers bound by an object Environment Record may potentially change as a side-effect of any operation that adds or deletes properties. Any bindings that are created as a result of such a side-effect are considered to be a mutable binding even if the Writable attribute of the corresponding property has the value *false*. Immutable bindings do not exist for object Environment Records.</p>
         <p>Object Environment Records created for `with` statements (<emu-xref href="#sec-with-statement"></emu-xref>) can provide their binding object as an implicit *this* value for use in function calls. The capability is controlled by a Boolean [[IsWithEnvironment]] field.</p>
         <p>Object Environment Records have the additional state fields listed in <emu-xref href="#table-additional-fields-of-object-environment-records"></emu-xref>.</p>
         <emu-table id="table-additional-fields-of-object-environment-records" caption="Additional Fields of Object Environment Records">
@@ -10188,7 +10188,7 @@
 
       <emu-clause id="sec-function-environment-records" oldids="function-environment">
         <h1>Function Environment Records</h1>
-        <p>A <dfn>function Environment Record</dfn> is a declarative Environment Record that is used to represent the top-level scope of a function and, if the function is not an |ArrowFunction|, provides a `this` binding. If a function is not an |ArrowFunction| function and references `super`, its function Environment Record also contains the state that is used to perform `super` method invocations from within the function.</p>
+        <p>A <dfn variants="function Environment Records">function Environment Record</dfn> is a declarative Environment Record that is used to represent the top-level scope of a function and, if the function is not an |ArrowFunction|, provides a `this` binding. If a function is not an |ArrowFunction| function and references `super`, its function Environment Record also contains the state that is used to perform `super` method invocations from within the function.</p>
         <p>Function Environment Records have the additional state fields listed in <emu-xref href="#table-additional-fields-of-function-environment-records"></emu-xref>.</p>
         <emu-table id="table-additional-fields-of-function-environment-records" caption="Additional Fields of Function Environment Records" oldids="table-16">
           <table>
@@ -10364,7 +10364,7 @@
 
       <emu-clause id="sec-global-environment-records" oldids="global-environment">
         <h1>Global Environment Records</h1>
-        <p>A <dfn>global Environment Record</dfn> is used to represent the outer most scope that is shared by all of the ECMAScript |Script| elements that are processed in a common realm. A global Environment Record provides the bindings for built-in globals (clause <emu-xref href="#sec-global-object"></emu-xref>), properties of the global object, and for all top-level declarations (<emu-xref href="#sec-static-semantics-toplevellexicallyscopeddeclarations"></emu-xref>, <emu-xref href="#sec-static-semantics-toplevelvarscopeddeclarations"></emu-xref>) that occur within a |Script|.</p>
+        <p>A <dfn variants="global Environment Records">global Environment Record</dfn> is used to represent the outer most scope that is shared by all of the ECMAScript |Script| elements that are processed in a common realm. A global Environment Record provides the bindings for built-in globals (clause <emu-xref href="#sec-global-object"></emu-xref>), properties of the global object, and for all top-level declarations (<emu-xref href="#sec-static-semantics-toplevellexicallyscopeddeclarations"></emu-xref>, <emu-xref href="#sec-static-semantics-toplevelvarscopeddeclarations"></emu-xref>) that occur within a |Script|.</p>
         <p>A global Environment Record is logically a single record but it is specified as a composite encapsulating an object Environment Record and a declarative Environment Record. The object Environment Record has as its base object the global object of the associated Realm Record. This global object is the value returned by the global Environment Record's GetThisBinding concrete method. The object Environment Record component of a global Environment Record contains the bindings for all built-in globals (clause <emu-xref href="#sec-global-object"></emu-xref>) and all bindings introduced by a |FunctionDeclaration|, |GeneratorDeclaration|, |AsyncFunctionDeclaration|, |AsyncGeneratorDeclaration|, or |VariableStatement| contained in global code. The bindings for all other ECMAScript declarations in global code are contained in the declarative Environment Record component of the global Environment Record.</p>
         <p>Properties may be created directly on a global object. Hence, the object Environment Record component of a global Environment Record may contain both bindings created explicitly by |FunctionDeclaration|, |GeneratorDeclaration|, |AsyncFunctionDeclaration|, |AsyncGeneratorDeclaration|, or |VariableDeclaration| declarations and bindings created implicitly as properties of the global object. In order to identify which bindings were explicitly created using declarations, a global Environment Record maintains a list of the names bound using its CreateGlobalVarBinding and CreateGlobalFunctionBinding concrete methods.</p>
         <p>Global Environment Records have the additional fields listed in <emu-xref href="#table-additional-fields-of-global-environment-records"></emu-xref> and the additional methods listed in <emu-xref href="#table-additional-methods-of-global-environment-records"></emu-xref>.</p>
@@ -10901,7 +10901,7 @@
 
       <emu-clause id="sec-module-environment-records" oldids="module-environment">
         <h1>Module Environment Records</h1>
-        <p>A <dfn>module Environment Record</dfn> is a declarative Environment Record that is used to represent the outer scope of an ECMAScript |Module|. In additional to normal mutable and immutable bindings, module Environment Records also provide immutable import bindings which are bindings that provide indirect access to a target binding that exists in another Environment Record.</p>
+        <p>A <dfn variants="module Environment Records">module Environment Record</dfn> is a declarative Environment Record that is used to represent the outer scope of an ECMAScript |Module|. In additional to normal mutable and immutable bindings, module Environment Records also provide immutable import bindings which are bindings that provide indirect access to a target binding that exists in another Environment Record.</p>
         <p>Module Environment Records support all of the declarative Environment Record methods listed in <emu-xref href="#table-abstract-methods-of-environment-records"></emu-xref> and share the same specifications for all of those methods except for GetBindingValue, DeleteBinding, HasThisBinding and GetThisBinding. In addition, module Environment Records support the methods listed in <emu-xref href="#table-additional-methods-of-module-environment-records"></emu-xref>:</p>
         <emu-table id="table-additional-methods-of-module-environment-records" caption="Additional Methods of Module Environment Records" oldids="table-20">
           <table>
@@ -11147,7 +11147,7 @@
 
   <emu-clause id="sec-privateenvironment-records">
     <h1>PrivateEnvironment Records</h1>
-    <p>A <dfn id="privateenvironment-record">PrivateEnvironment Record</dfn> is a specification mechanism used to track Private Names based upon the lexical nesting structure of |ClassDeclaration|s and |ClassExpression|s in ECMAScript code. They are similar to, but distinct from, Environment Records. Each PrivateEnvironment Record is associated with a |ClassDeclaration| or |ClassExpression|. Each time such a class is evaluated, a new PrivateEnvironment Record is created to record the Private Names declared by that class.</p>
+    <p>A <dfn id="privateenvironment-record" variants="PrivateEnvironment Records">PrivateEnvironment Record</dfn> is a specification mechanism used to track Private Names based upon the lexical nesting structure of |ClassDeclaration|s and |ClassExpression|s in ECMAScript code. They are similar to, but distinct from, Environment Records. Each PrivateEnvironment Record is associated with a |ClassDeclaration| or |ClassExpression|. Each time such a class is evaluated, a new PrivateEnvironment Record is created to record the Private Names declared by that class.</p>
     <p>Each PrivateEnvironment Record has the fields defined in <emu-xref href="#table-privateenvironment-records"></emu-xref>.</p>
     <emu-table id="table-privateenvironment-records" caption="PrivateEnvironment Record Fields">
       <table>
@@ -11234,8 +11234,8 @@
 
   <emu-clause id="sec-code-realms">
     <h1>Realms</h1>
-    <p>Before it is evaluated, all ECMAScript code must be associated with a <dfn id="realm">realm</dfn>. Conceptually, a realm consists of a set of intrinsic objects, an ECMAScript global environment, all of the ECMAScript code that is loaded within the scope of that global environment, and other associated state and resources.</p>
-    <p>A realm is represented in this specification as a <dfn id="realm-record">Realm Record</dfn> with the fields specified in <emu-xref href="#table-realm-record-fields"></emu-xref>:</p>
+    <p>Before it is evaluated, all ECMAScript code must be associated with a <dfn id="realm" variants="realms">realm</dfn>. Conceptually, a realm consists of a set of intrinsic objects, an ECMAScript global environment, all of the ECMAScript code that is loaded within the scope of that global environment, and other associated state and resources.</p>
+    <p>A realm is represented in this specification as a <dfn id="realm-record" variants="Realm Records">Realm Record</dfn> with the fields specified in <emu-xref href="#table-realm-record-fields"></emu-xref>:</p>
     <emu-table id="table-realm-record-fields" caption="Realm Record Fields" oldids="table-21">
       <table>
         <tbody>
@@ -11385,8 +11385,8 @@
 
   <emu-clause id="sec-execution-contexts">
     <h1>Execution Contexts</h1>
-    <p>An <dfn>execution context</dfn> is a specification device that is used to track the runtime evaluation of code by an ECMAScript implementation. At any point in time, there is at most one execution context per agent that is actually executing code. This is known as the agent's <dfn id="running-execution-context">running execution context</dfn>. All references to the running execution context in this specification denote the running execution context of the surrounding agent.</p>
-    <p>The <dfn id="execution-context-stack">execution context stack</dfn> is used to track execution contexts. The running execution context is always the top element of this stack. A new execution context is created whenever control is transferred from the executable code associated with the currently running execution context to executable code that is not associated with that execution context. The newly created execution context is pushed onto the stack and becomes the running execution context.</p>
+    <p>An <dfn variants="execution contexts">execution context</dfn> is a specification device that is used to track the runtime evaluation of code by an ECMAScript implementation. At any point in time, there is at most one execution context per agent that is actually executing code. This is known as the agent's <dfn id="running-execution-context" variants="running execution contexts">running execution context</dfn>. All references to the running execution context in this specification denote the running execution context of the surrounding agent.</p>
+    <p>The <dfn id="execution-context-stack" variants="execution context stacks">execution context stack</dfn> is used to track execution contexts. The running execution context is always the top element of this stack. A new execution context is created whenever control is transferred from the executable code associated with the currently running execution context to executable code that is not associated with that execution context. The newly created execution context is pushed onto the stack and becomes the running execution context.</p>
     <p>An execution context contains whatever implementation specific state is necessary to track the execution progress of its associated code. Each execution context has at least the state components listed in <emu-xref href="#table-state-components-for-all-execution-contexts"></emu-xref>.</p>
     <emu-table id="table-state-components-for-all-execution-contexts" caption="State Components for All Execution Contexts" oldids="table-22">
       <table>
@@ -11599,7 +11599,7 @@
 
   <emu-clause id="sec-jobs" oldids="sec-jobs-and-job-queues,sec-enqueuejob,sec-runjobs,job-queue">
     <h1>Jobs and Host Operations to Enqueue Jobs</h1>
-    <p>A <dfn id="job">Job</dfn> is an Abstract Closure with no parameters that initiates an ECMAScript computation when no other ECMAScript computation is currently in progress.</p>
+    <p>A <dfn id="job" variants="Jobs">Job</dfn> is an Abstract Closure with no parameters that initiates an ECMAScript computation when no other ECMAScript computation is currently in progress.</p>
     <p>Jobs are scheduled for execution by ECMAScript host environments. This specification describes the host hook HostEnqueuePromiseJob to schedule one kind of job; hosts may define additional abstract operations which schedule jobs. Such operations accept a Job Abstract Closure as the parameter and schedule it to be performed at some future time. Their implementations must conform to the following requirements:</p>
 
     <ul>
@@ -11640,7 +11640,7 @@
 
     <emu-clause id="sec-jobcallback-records">
       <h1>JobCallback Records</h1>
-      <p>A <dfn>JobCallback Record</dfn> is a Record value used to store a function object and a host-defined value. Function objects that are invoked via a Job enqueued by the host may have additional host-defined context. To propagate the state, Job Abstract Closures should not capture and call function objects directly. Instead, use HostMakeJobCallback and HostCallJobCallback.</p>
+      <p>A <dfn variants="JobCallback Records">JobCallback Record</dfn> is a Record value used to store a function object and a host-defined value. Function objects that are invoked via a Job enqueued by the host may have additional host-defined context. To propagate the state, Job Abstract Closures should not capture and call function objects directly. Instead, use HostMakeJobCallback and HostCallJobCallback.</p>
       <emu-note>
         <p>The WHATWG HTML specification (<a href="https://html.spec.whatwg.org/">https://html.spec.whatwg.org/</a>), for example, uses the host-defined value to propagate the incumbent settings object for Promise callbacks.</p>
       </emu-note>
@@ -11783,12 +11783,12 @@
   <emu-clause id="sec-agents">
     <h1>Agents</h1>
 
-    <p>An <dfn id="agent">agent</dfn> comprises a set of ECMAScript execution contexts, an execution context stack, a running execution context, an <dfn id="agent-record">Agent Record</dfn>, and an <dfn id="executing-thread">executing thread</dfn>. Except for the executing thread, the constituents of an agent belong exclusively to that agent.</p>
+    <p>An <dfn id="agent" variants="agents">agent</dfn> comprises a set of ECMAScript execution contexts, an execution context stack, a running execution context, an <dfn id="agent-record" variants="Agent Records">Agent Record</dfn>, and an <dfn id="executing-thread" variants="executing threads">executing thread</dfn>. Except for the executing thread, the constituents of an agent belong exclusively to that agent.</p>
     <p>An agent's executing thread executes a job on the agent's execution contexts independently of other agents, except that an executing thread may be used as the executing thread by multiple agents, provided none of the agents sharing the thread have an Agent Record whose [[CanBlock]] property is *true*.</p>
     <emu-note>
       <p>Some web browsers share a single executing thread across multiple unrelated tabs of a browser window, for example.</p>
     </emu-note>
-    <p>While an agent's executing thread executes jobs, the agent is the <dfn id="surrounding-agent">surrounding agent</dfn> for the code in those jobs. The code uses the surrounding agent to access the specification level execution objects held within the agent: the running execution context, the execution context stack, and the Agent Record's fields.</p>
+    <p>While an agent's executing thread executes jobs, the agent is the <dfn id="surrounding-agent" variants="surrounding agents">surrounding agent</dfn> for the code in those jobs. The code uses the surrounding agent to access the specification level execution objects held within the agent: the running execution context, the execution context stack, and the Agent Record's fields.</p>
     <emu-table id="table-agent-record" caption="Agent Record Fields">
       <table>
         <tbody>
@@ -11815,17 +11815,17 @@
           <tr>
             <td>[[IsLockFree1]]</td>
             <td>Boolean</td>
-            <td>*true* if atomic operations on one-byte values are lock-free, *false* otherwise.</td>
+            <td>*true* if atomic operations on one-<emu-not-ref>byte values</emu-not-ref> are lock-free, *false* otherwise.</td>
           </tr>
           <tr>
             <td>[[IsLockFree2]]</td>
             <td>Boolean</td>
-            <td>*true* if atomic operations on two-byte values are lock-free, *false* otherwise.</td>
+            <td>*true* if atomic operations on two-<emu-not-ref>byte values</emu-not-ref> are lock-free, *false* otherwise.</td>
           </tr>
           <tr>
             <td>[[IsLockFree8]]</td>
             <td>Boolean</td>
-            <td>*true* if atomic operations on eight-byte values are lock-free, *false* otherwise.</td>
+            <td>*true* if atomic operations on eight-<emu-not-ref>byte values</emu-not-ref> are lock-free, *false* otherwise.</td>
           </tr>
           <tr>
             <td>[[CandidateExecution]]</td>
@@ -11884,7 +11884,7 @@
   <emu-clause id="sec-agent-clusters">
     <h1>Agent Clusters</h1>
 
-    <p>An <dfn>agent cluster</dfn> is a maximal set of agents that can communicate by operating on shared memory.</p>
+    <p>An <dfn variants="agent clusters">agent cluster</dfn> is a maximal set of agents that can communicate by operating on shared memory.</p>
 
     <emu-note>
       <p>Programs within different agents may share memory by unspecified means. At a minimum, the backing memory for SharedArrayBuffer objects can be shared among the agents in the cluster.</p>
@@ -12704,7 +12704,7 @@
 
   <emu-clause id="sec-ecmascript-function-objects">
     <h1>ECMAScript Function Objects</h1>
-    <p>ECMAScript function objects encapsulate parameterized ECMAScript code closed over a lexical environment and support the dynamic evaluation of that code. An ECMAScript function object is an ordinary object and has the same internal slots and the same internal methods as other ordinary objects. The code of an ECMAScript function object may be either strict mode code (<emu-xref href="#sec-strict-mode-code"></emu-xref>) or non-strict code. An ECMAScript function object whose code is strict mode code is called a <dfn id="strict-function">strict function</dfn>. One whose code is not strict mode code is called a <dfn id="non-strict-function">non-strict function</dfn>.</p>
+    <p>ECMAScript function objects encapsulate parameterized ECMAScript code closed over a lexical environment and support the dynamic evaluation of that code. An ECMAScript function object is an ordinary object and has the same internal slots and the same internal methods as other ordinary objects. The code of an ECMAScript function object may be either strict mode code (<emu-xref href="#sec-strict-mode-code"></emu-xref>) or non-strict code. An ECMAScript function object whose code is strict mode code is called a <dfn id="strict-function" variants="strict functions">strict function</dfn>. One whose code is not strict mode code is called a <dfn id="non-strict-function" variants="non-strict functions">non-strict function</dfn>.</p>
     <p>In addition to [[Extensible]] and [[Prototype]], ECMAScript function objects also have the internal slots listed in <emu-xref href="#table-internal-slots-of-ecmascript-function-objects"></emu-xref>.</p>
     <emu-table id="table-internal-slots-of-ecmascript-function-objects" caption="Internal Slots of ECMAScript Function Objects" oldids="table-27">
       <table>
@@ -13533,7 +13533,7 @@
       <h1>Bound Function Exotic Objects</h1>
       <p>A bound function exotic object is an exotic object that wraps another function object. A bound function exotic object is callable (it has a [[Call]] internal method and may have a [[Construct]] internal method). Calling a bound function exotic object generally results in a call of its wrapped function.</p>
 
-      <p>An object is a <dfn id="bound-function-exotic-object">bound function exotic object</dfn> if its [[Call]] and (if applicable) [[Construct]] internal methods use the following implementations, and its other essential internal methods use the definitions found in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>. These methods are installed in BoundFunctionCreate.</p>
+      <p>An object is a <dfn id="bound-function-exotic-object" variants="bound function exotic objects">bound function exotic object</dfn> if its [[Call]] and (if applicable) [[Construct]] internal methods use the following implementations, and its other essential internal methods use the definitions found in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>. These methods are installed in BoundFunctionCreate.</p>
 
       <p>Bound function exotic objects do not have the internal slots of ECMAScript function objects listed in <emu-xref href="#table-internal-slots-of-ecmascript-function-objects"></emu-xref>. Instead they have the internal slots listed in <emu-xref href="#table-internal-slots-of-bound-function-exotic-objects"></emu-xref>, in addition to [[Prototype]] and [[Extensible]].</p>
       <emu-table id="table-internal-slots-of-bound-function-exotic-objects" caption="Internal Slots of Bound Function Exotic Objects" oldids="table-28">
@@ -13664,7 +13664,7 @@
         <p>A String property name _P_ is an <em>array index</em> if and only if ToString(ToUint32(_P_)) equals _P_ and ToUint32(_P_) is not the same value as 𝔽(<emu-eqn>2<sup>32</sup> - 1</emu-eqn>).</p>
       </emu-note>
 
-      <p>An object is an <dfn id="array-exotic-object">Array exotic object</dfn> (or simply, an Array object) if its [[DefineOwnProperty]] internal method uses the following implementation, and its other essential internal methods use the definitions found in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>. These methods are installed in ArrayCreate.</p>
+      <p>An object is an <dfn id="array-exotic-object" variants="Array exotic objects">Array exotic object</dfn> (or simply, an Array object) if its [[DefineOwnProperty]] internal method uses the following implementation, and its other essential internal methods use the definitions found in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>. These methods are installed in ArrayCreate.</p>
 
       <emu-clause id="sec-array-exotic-objects-defineownproperty-p-desc" type="internal method">
         <h1>
@@ -13807,7 +13807,7 @@
       <h1>String Exotic Objects</h1>
       <p>A String object is an exotic object that encapsulates a String value and exposes virtual integer-indexed data properties corresponding to the individual code unit elements of the String value. String exotic objects always have a data property named *"length"* whose value is the number of code unit elements in the encapsulated String value. Both the code unit data properties and the *"length"* property are non-writable and non-configurable.</p>
 
-      <p>An object is a <dfn id="string-exotic-object">String exotic object</dfn> (or simply, a String object) if its [[GetOwnProperty]], [[DefineOwnProperty]], and [[OwnPropertyKeys]] internal methods use the following implementations, and its other essential internal methods use the definitions found in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>. These methods are installed in StringCreate.</p>
+      <p>An object is a <dfn id="string-exotic-object" variants="String exotic objects">String exotic object</dfn> (or simply, a String object) if its [[GetOwnProperty]], [[DefineOwnProperty]], and [[OwnPropertyKeys]] internal methods use the following implementations, and its other essential internal methods use the definitions found in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>. These methods are installed in StringCreate.</p>
 
       <p>String exotic objects have the same internal slots as ordinary objects. They also have a [[StringData]] internal slot.</p>
 
@@ -13929,7 +13929,7 @@
 
       <p>Most ECMAScript functions make an arguments object available to their code. Depending upon the characteristics of the function definition, its arguments object is either an ordinary object or an arguments exotic object. An arguments exotic object is an exotic object whose array index properties map to the formal parameters bindings of an invocation of its associated ECMAScript function.</p>
 
-      <p>An object is an <dfn id="arguments-exotic-object">arguments exotic object</dfn> if its internal methods use the following implementations, with the ones not specified here using those found in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>. These methods are installed in CreateMappedArgumentsObject.</p>
+      <p>An object is an <dfn id="arguments-exotic-object" variants="arguments exotic objects">arguments exotic object</dfn> if its internal methods use the following implementations, with the ones not specified here using those found in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>. These methods are installed in CreateMappedArgumentsObject.</p>
 
       <emu-note>
         <p>While CreateUnmappedArgumentsObject is grouped into this clause, it creates an ordinary object, not an arguments exotic object.</p>
@@ -14189,7 +14189,7 @@
       <h1>Integer-Indexed Exotic Objects</h1>
       <p>An Integer-Indexed exotic object is an exotic object that performs special handling of integer index property keys.</p>
       <p><emu-xref href="#integer-indexed-exotic-object">Integer-Indexed exotic objects</emu-xref> have the same internal slots as ordinary objects and additionally [[ViewedArrayBuffer]], [[ArrayLength]], [[ByteOffset]], [[ContentType]], and [[TypedArrayName]] internal slots.</p>
-      <p>An object is an <dfn id="integer-indexed-exotic-object">Integer-Indexed exotic object</dfn> if its [[GetOwnProperty]], [[HasProperty]], [[DefineOwnProperty]], [[Get]], [[Set]], [[Delete]], and [[OwnPropertyKeys]] internal methods use the definitions in this section, and its other essential internal methods use the definitions found in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>. These methods are installed by IntegerIndexedObjectCreate.</p>
+      <p>An object is an <dfn id="integer-indexed-exotic-object" variants="Integer-Indexed exotic objects">Integer-Indexed exotic object</dfn> if its [[GetOwnProperty]], [[HasProperty]], [[DefineOwnProperty]], [[Get]], [[Set]], [[Delete]], and [[OwnPropertyKeys]] internal methods use the definitions in this section, and its other essential internal methods use the definitions found in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>. These methods are installed by IntegerIndexedObjectCreate.</p>
 
       <emu-clause id="sec-integer-indexed-exotic-objects-getownproperty-p" type="internal method">
         <h1>
@@ -14444,7 +14444,7 @@
     <emu-clause id="sec-module-namespace-exotic-objects">
       <h1>Module Namespace Exotic Objects</h1>
       <p>A module namespace exotic object is an exotic object that exposes the bindings exported from an ECMAScript |Module| (See <emu-xref href="#sec-exports"></emu-xref>). There is a one-to-one correspondence between the String-keyed own properties of a module namespace exotic object and the binding names exported by the |Module|. The exported bindings include any bindings that are indirectly exported using `export *` export items. Each String-valued own property key is the StringValue of the corresponding exported binding name. These are the only String-keyed properties of a module namespace exotic object. Each such property has the attributes { [[Writable]]: *true*, [[Enumerable]]: *true*, [[Configurable]]: *false* }. Module namespace exotic objects are not extensible.</p>
-      <p>An object is a <dfn id="module-namespace-exotic-object">module namespace exotic object</dfn> if its [[SetPrototypeOf]], [[IsExtensible]], [[PreventExtensions]], [[GetOwnProperty]], [[DefineOwnProperty]], [[HasProperty]], [[Get]], [[Set]], [[Delete]], and [[OwnPropertyKeys]] internal methods use the definitions in this section, and its other essential internal methods use the definitions found in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>. These methods are installed by ModuleNamespaceCreate.</p>
+      <p>An object is a <dfn id="module-namespace-exotic-object" variants="module namespace exotic objects">module namespace exotic object</dfn> if its [[SetPrototypeOf]], [[IsExtensible]], [[PreventExtensions]], [[GetOwnProperty]], [[DefineOwnProperty]], [[HasProperty]], [[Get]], [[Set]], [[Delete]], and [[OwnPropertyKeys]] internal methods use the definitions in this section, and its other essential internal methods use the definitions found in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>. These methods are installed by ModuleNamespaceCreate.</p>
       <p>Module namespace exotic objects have the internal slots defined in <emu-xref href="#table-internal-slots-of-module-namespace-exotic-objects"></emu-xref>.</p>
       <emu-table id="table-internal-slots-of-module-namespace-exotic-objects" caption="Internal Slots of Module Namespace Exotic Objects" oldids="table-29">
         <table>
@@ -14712,7 +14712,7 @@
       <h1>Immutable Prototype Exotic Objects</h1>
       <p>An immutable prototype exotic object is an exotic object that has a [[Prototype]] internal slot that will not change once it is initialized.</p>
 
-      <p>An object is an <dfn id="immutable-prototype-exotic-object">immutable prototype exotic object</dfn> if its [[SetPrototypeOf]] internal method uses the following implementation. (Its other essential internal methods may use any implementation, depending on the specific immutable prototype exotic object in question.)</p>
+      <p>An object is an <dfn id="immutable-prototype-exotic-object" variants="immutable prototype exotic objects">immutable prototype exotic object</dfn> if its [[SetPrototypeOf]] internal method uses the following implementation. (Its other essential internal methods may use any implementation, depending on the specific immutable prototype exotic object in question.)</p>
 
       <emu-note>
         <p>Unlike other exotic objects, there is not a dedicated creation abstract operation provided for immutable prototype exotic objects. This is because they are only used by %Object.prototype% and by host environments, and in host environments, the relevant objects are potentially exotic in other ways and thus need their own dedicated creation operation.</p>
@@ -14756,7 +14756,7 @@
     <h1>Proxy Object Internal Methods and Internal Slots</h1>
     <p>A proxy object is an exotic object whose essential internal methods are partially implemented using ECMAScript code. Every proxy object has an internal slot called [[ProxyHandler]]. The value of [[ProxyHandler]] is an object, called the proxy's <em>handler object</em>, or *null*. Methods (see <emu-xref href="#table-proxy-handler-methods"></emu-xref>) of a handler object may be used to augment the implementation for one or more of the proxy object's internal methods. Every proxy object also has an internal slot called [[ProxyTarget]] whose value is either an object or the *null* value. This object is called the proxy's <em>target object</em>.</p>
 
-    <p>An object is a <dfn id="proxy-exotic-object">Proxy exotic object</dfn> if its essential internal methods (including [[Call]] and [[Construct]], if applicable) use the definitions in this section. These internal methods are installed in ProxyCreate.</p>
+    <p>An object is a <dfn id="proxy-exotic-object" variants="Proxy exotic objects">Proxy exotic object</dfn> if its essential internal methods (including [[Call]] and [[Construct]], if applicable) use the definitions in this section. These internal methods are installed in ProxyCreate.</p>
 
     <emu-table id="table-proxy-handler-methods" caption="Proxy Handler Methods" oldids="table-30">
       <table>
@@ -15657,8 +15657,8 @@
 
     <emu-clause id="sec-directive-prologues-and-the-use-strict-directive">
       <h1>Directive Prologues and the Use Strict Directive</h1>
-      <p>A <dfn id="directive-prologue">Directive Prologue</dfn> is the longest sequence of |ExpressionStatement|s occurring as the initial |StatementListItem|s or |ModuleItem|s of a |FunctionBody|, a |ScriptBody|, or a |ModuleBody| and where each |ExpressionStatement| in the sequence consists entirely of a |StringLiteral| token followed by a semicolon. The semicolon may appear explicitly or may be inserted by automatic semicolon insertion (<emu-xref href="#sec-automatic-semicolon-insertion"></emu-xref>). A Directive Prologue may be an empty sequence.</p>
-      <p>A <dfn id="use-strict-directive">Use Strict Directive</dfn> is an |ExpressionStatement| in a Directive Prologue whose |StringLiteral| is either of the exact code point sequences `"use strict"` or `'use strict'`. A Use Strict Directive may not contain an |EscapeSequence| or |LineContinuation|.</p>
+      <p>A <dfn id="directive-prologue" variants="Directive Prologues">Directive Prologue</dfn> is the longest sequence of |ExpressionStatement|s occurring as the initial |StatementListItem|s or |ModuleItem|s of a |FunctionBody|, a |ScriptBody|, or a |ModuleBody| and where each |ExpressionStatement| in the sequence consists entirely of a |StringLiteral| token followed by a semicolon. The semicolon may appear explicitly or may be inserted by automatic semicolon insertion (<emu-xref href="#sec-automatic-semicolon-insertion"></emu-xref>). A Directive Prologue may be an empty sequence.</p>
+      <p>A <dfn id="use-strict-directive" variants="Use Strict Directives">Use Strict Directive</dfn> is an |ExpressionStatement| in a Directive Prologue whose |StringLiteral| is either of the exact code point sequences `"use strict"` or `'use strict'`. A Use Strict Directive may not contain an |EscapeSequence| or |LineContinuation|.</p>
       <p>A Directive Prologue may contain more than one Use Strict Directive. However, an implementation may issue a warning if this occurs.</p>
       <emu-note>
         <p>The |ExpressionStatement|s of a Directive Prologue are evaluated normally during evaluation of the containing production. Implementations may define implementation specific meanings for |ExpressionStatement|s which are not a Use Strict Directive and which occur in a Directive Prologue. If an appropriate notification mechanism exists, an implementation should issue a warning if it encounters in a Directive Prologue an |ExpressionStatement| that is not a Use Strict Directive and which does not have a meaning defined by the implementation.</p>
@@ -16142,8 +16142,8 @@
 
     <emu-clause id="sec-keywords-and-reserved-words" oldids="sec-reserved-words,sec-keywords,sec-future-reserved-words">
       <h1>Keywords and Reserved Words</h1>
-      <p>A <dfn>keyword</dfn> is a token that matches |IdentifierName|, but also has a syntactic use; that is, it appears literally, in a `fixed width` font, in some syntactic production. The keywords of ECMAScript include `if`, `while`, `async`, `await`, and many others.</p>
-      <p>A <dfn>reserved word</dfn> is an |IdentifierName| that cannot be used as an identifier. Many keywords are reserved words, but some are not, and some are reserved only in certain contexts. `if` and `while` are reserved words. `await` is reserved only inside async functions and modules. `async` is not reserved; it can be used as a variable name or statement label without restriction.</p>
+      <p>A <dfn variants="keywords">keyword</dfn> is a token that matches |IdentifierName|, but also has a syntactic use; that is, it appears literally, in a `fixed width` font, in some syntactic production. The keywords of ECMAScript include `if`, `while`, `async`, `await`, and many others.</p>
+      <p>A <dfn variants="reserved words">reserved word</dfn> is an |IdentifierName| that cannot be used as an identifier. Many keywords are reserved words, but some are not, and some are reserved only in certain contexts. `if` and `while` are reserved words. `await` is reserved only inside async functions and modules. `async` is not reserved; it can be used as a variable name or statement label without restriction.</p>
       <p>This specification uses a combination of grammatical productions and early error rules to specify which names are valid identifiers and which are reserved words. All tokens in the |ReservedWord| list below, except for `await` and `yield`, are unconditionally reserved. Exceptions for `await` and `yield` are specified in <emu-xref href="#sec-identifiers"></emu-xref>, using parameterized syntactic productions. Lastly, several early error rules restrict the set of valid identifiers. See <emu-xref href="#sec-identifiers-static-semantics-early-errors"></emu-xref>, <emu-xref href="#sec-let-and-const-declarations-static-semantics-early-errors"></emu-xref>, <emu-xref href="#sec-for-in-and-for-of-statements-static-semantics-early-errors"></emu-xref>, and <emu-xref href="#sec-class-definitions-static-semantics-early-errors"></emu-xref>. In summary, there are five categories of identifier names:</p>
       <ul>
         <li>
@@ -16162,7 +16162,7 @@
           <p>Those that are always allowed as identifiers, but also appear as keywords within certain syntactic productions, at places where |Identifier| is not allowed: `as`, `async`, `from`, `get`, `meta`, `of`, `set`, and `target`.</p>
         </li>
       </ul>
-      <p>The term <dfn>conditional keyword</dfn>, or <dfn>contextual keyword</dfn>, is sometimes used to refer to the keywords that fall in the last three categories, and thus can be used as identifiers in some contexts and as keywords in others.</p>
+      <p>The term <dfn variants="conditional keywords">conditional keyword</dfn>, or <dfn variants="contextual keywords">contextual keyword</dfn>, is sometimes used to refer to the keywords that fall in the last three categories, and thus can be used as identifiers in some contexts and as keywords in others.</p>
       <h2>Syntax</h2>
       <emu-grammar type="definition">
         ReservedWord :: one of
@@ -18731,7 +18731,7 @@
           1. Let _tailCall_ be IsInTailPosition(_thisCall_).
           1. Return ? EvaluateCall(_func_, _ref_, _arguments_, _tailCall_).
         </emu-alg>
-        <p>A |CallExpression| evaluation that executes step <emu-xref href="#step-callexpression-evaluation-direct-eval"></emu-xref> is a <dfn>direct eval</dfn>.</p>
+        <p>A |CallExpression| evaluation that executes step <emu-xref href="#step-callexpression-evaluation-direct-eval"></emu-xref> is a <dfn variants="direct evals">direct eval</dfn>.</p>
         <emu-grammar>CallExpression : CallExpression Arguments</emu-grammar>
         <emu-alg>
           1. Let _ref_ be the result of evaluating |CallExpression|.
@@ -24987,7 +24987,7 @@
     <emu-clause id="sec-script-records">
       <h1>Script Records</h1>
 
-      <p>A <dfn id="script-record">Script Record</dfn> encapsulates information about a script being evaluated. Each script record contains the fields listed in <emu-xref href="#table-script-records"></emu-xref>.</p>
+      <p>A <dfn id="script-record" variants="Script Records">Script Record</dfn> encapsulates information about a script being evaluated. Each script record contains the fields listed in <emu-xref href="#table-script-records"></emu-xref>.</p>
 
       <emu-table id="table-script-records" caption="Script Record Fields">
         <table>
@@ -25311,7 +25311,7 @@
 
       <emu-clause id="sec-abstract-module-records">
         <h1>Abstract Module Records</h1>
-        <p>A <dfn>Module Record</dfn> encapsulates structural information about the imports and exports of a single module. This information is used to link the imports and exports of sets of connected modules. A Module Record includes four fields that are only used when evaluating a module.</p>
+        <p>A <dfn variants="Module Records">Module Record</dfn> encapsulates structural information about the imports and exports of a single module. This information is used to link the imports and exports of sets of connected modules. A Module Record includes four fields that are only used when evaluating a module.</p>
         <p>For specification purposes Module Record values are values of the Record specification type and can be thought of as existing in a simple object-oriented hierarchy where Module Record is an abstract class with both abstract and concrete subclasses. This specification defines the abstract subclass named Cyclic Module Record and its concrete subclass named Source Text Module Record. Other specifications and implementations may define additional Module Record subclasses corresponding to alternative module definition facilities that they defined.</p>
         <p>Module Record defines the fields listed in <emu-xref href="#table-module-record-fields"></emu-xref>. All Module Definition subclasses include at least those fields. Module Record also defines the abstract method list in <emu-xref href="#table-abstract-methods-of-module-records"></emu-xref>. All Module definition subclasses must provide concrete implementations of these abstract methods.</p>
         <emu-table id="table-module-record-fields" caption="Module Record Fields" oldids="table-36">
@@ -25401,7 +25401,7 @@
                 ResolveExport(_exportName_ [, _resolveSet_])
               </td>
               <td>
-                <p>Return the binding of a name exported by this module. Bindings are represented by a <dfn id="resolvedbinding-record">ResolvedBinding Record</dfn>, of the form { [[Module]]: Module Record, [[BindingName]]: String }. If the export is a Module Namespace Object without a direct binding in any module, [[BindingName]] will be set to *"\*namespace\*"*. Return *null* if the name cannot be resolved, or *"ambiguous"* if multiple bindings were found.</p>
+                <p>Return the binding of a name exported by this module. Bindings are represented by a <dfn id="resolvedbinding-record" variants="ResolvedBinding Records">ResolvedBinding Record</dfn>, of the form { [[Module]]: Module Record, [[BindingName]]: String }. If the export is a Module Namespace Object without a direct binding in any module, [[BindingName]] will be set to *"\*namespace\*"*. Return *null* if the name cannot be resolved, or *"ambiguous"* if multiple bindings were found.</p>
                 <p>Each time this operation is called with a specific _exportName_, _resolveSet_ pair as arguments it must return the same result if it completes normally.</p>
               </td>
             </tr>
@@ -25429,7 +25429,7 @@
 
       <emu-clause id="sec-cyclic-module-records">
         <h1>Cyclic Module Records</h1>
-        <p>A <dfn id="cyclic-module-record">Cyclic Module Record</dfn> is used to represent information about a module that can participate in dependency cycles with other modules that are subclasses of the Cyclic Module Record type. Module Records that are not subclasses of the Cyclic Module Record type must not participate in dependency cycles with Source Text Module Records.</p>
+        <p>A <dfn id="cyclic-module-record" variants="Cyclic Module Records">Cyclic Module Record</dfn> is used to represent information about a module that can participate in dependency cycles with other modules that are subclasses of the Cyclic Module Record type. Module Records that are not subclasses of the Cyclic Module Record type must not participate in dependency cycles with Source Text Module Records.</p>
         <p>In addition to the fields defined in <emu-xref href="#table-module-record-fields"></emu-xref> Cyclic Module Records have the additional fields listed in <emu-xref href="#table-cyclic-module-fields"></emu-xref></p>
         <emu-table id="table-cyclic-module-fields" caption="Additional Fields of Cyclic Module Records">
           <table>
@@ -26327,7 +26327,7 @@
       <emu-clause id="sec-source-text-module-records">
         <h1>Source Text Module Records</h1>
 
-        <p>A <dfn id="sourctextmodule-record">Source Text Module Record</dfn> is used to represent information about a module that was defined from ECMAScript source text (<emu-xref href="#sec-ecmascript-language-source-code"></emu-xref>) that was parsed using the goal symbol |Module|. Its fields contain digested information about the names that are imported by the module and its concrete methods use this digest to link, link, and evaluate the module.</p>
+        <p>A <dfn id="sourctextmodule-record" variants="Source Text Module Records">Source Text Module Record</dfn> is used to represent information about a module that was defined from ECMAScript source text (<emu-xref href="#sec-ecmascript-language-source-code"></emu-xref>) that was parsed using the goal symbol |Module|. Its fields contain digested information about the names that are imported by the module and its concrete methods use this digest to link, link, and evaluate the module.</p>
 
         <p>A Source Text Module Record can exist in a module graph with other subclasses of the abstract Module Record type, and can participate in cycles with other subclasses of the Cyclic Module Record type.</p>
 
@@ -26426,7 +26426,7 @@
             </tbody>
           </table>
         </emu-table>
-        <p>An <dfn id="importentry-record">ImportEntry Record</dfn> is a Record that digests information about a single declarative import. Each ImportEntry Record has the fields defined in <emu-xref href="#table-importentry-record-fields"></emu-xref>:</p>
+        <p>An <dfn id="importentry-record" variants="ImportEntry Records">ImportEntry Record</dfn> is a Record that digests information about a single declarative import. Each ImportEntry Record has the fields defined in <emu-xref href="#table-importentry-record-fields"></emu-xref>:</p>
         <emu-table id="table-importentry-record-fields" caption="ImportEntry Record Fields" oldids="table-39">
           <table>
             <tbody>
@@ -26564,7 +26564,7 @@
             </table>
           </emu-table>
         </emu-note>
-        <p>An <dfn id="exportentry-record">ExportEntry Record</dfn> is a Record that digests information about a single declarative export. Each ExportEntry Record has the fields defined in <emu-xref href="#table-exportentry-records"></emu-xref>:</p>
+        <p>An <dfn id="exportentry-record" variants="ExportEntry Records">ExportEntry Record</dfn> is a Record that digests information about a single declarative export. Each ExportEntry Record has the fields defined in <emu-xref href="#table-exportentry-records"></emu-xref>:</p>
         <emu-table id="table-exportentry-records" caption="ExportEntry Record Fields" oldids="table-41">
           <table>
             <tbody>
@@ -27763,7 +27763,7 @@
 
 <emu-clause id="sec-error-handling-and-language-extensions">
   <h1>Error Handling and Language Extensions</h1>
-  <p>An implementation must report most errors at the time the relevant ECMAScript language construct is evaluated. An <dfn id="early-error">early error</dfn> is an error that can be detected and reported prior to the evaluation of any construct in the |Script| containing the error. The presence of an early error prevents the evaluation of the construct. An implementation must report early errors in a |Script| as part of parsing that |Script| in ParseScript. Early errors in a |Module| are reported at the point when the |Module| would be evaluated and the |Module| is never initialized. Early errors in <b>eval</b> code are reported at the time `eval` is called and prevent evaluation of the <b>eval</b> code. All errors that are not early errors are runtime errors.</p>
+  <p>An implementation must report most errors at the time the relevant ECMAScript language construct is evaluated. An <dfn id="early-error" variants="early errors">early error</dfn> is an error that can be detected and reported prior to the evaluation of any construct in the |Script| containing the error. The presence of an early error prevents the evaluation of the construct. An implementation must report early errors in a |Script| as part of parsing that |Script| in ParseScript. Early errors in a |Module| are reported at the point when the |Module| would be evaluated and the |Module| is never initialized. Early errors in <b>eval</b> code are reported at the time `eval` is called and prevent evaluation of the <b>eval</b> code. All errors that are not early errors are runtime errors.</p>
   <p>An implementation must report as an early error any occurrence of a condition that is listed in a &ldquo;Static Semantics: Early Errors&rdquo; subclause of this specification.</p>
   <p>An implementation shall not treat other kinds of errors as early errors even if the compiler can prove that a construct cannot execute without error under any circumstances. An implementation may issue an early warning in such a case, but it should not report the error until the relevant construct is actually executed.</p>
   <p>An implementation shall report all errors as specified, except for the following:</p>
@@ -27846,7 +27846,7 @@
 
 <emu-clause id="sec-global-object">
   <h1>The Global Object</h1>
-  <p>The <dfn>global object</dfn>:</p>
+  <p>The <dfn variants="global objects">global object</dfn>:</p>
   <ul>
     <li>is created before control enters any execution context.</li>
     <li>does not have a [[Construct]] internal method; it cannot be used as a constructor with the `new` operator.</li>
@@ -31382,7 +31382,7 @@
       <emu-clause id="sec-time-values-and-time-range">
         <h1>Time Values and Time Range</h1>
         <p>Time measurement in ECMAScript is analogous to time measurement in POSIX, in particular sharing definition in terms of the proleptic Gregorian calendar, an epoch of midnight at the beginning of 1 January 1970 UTC, and an accounting of every day as comprising exactly 86,400 seconds (each of which is 1000 milliseconds long).</p>
-        <p>An ECMAScript <dfn>time value</dfn> is a Number, either a finite integral Number representing an instant in time to millisecond precision or *NaN* representing no specific instant. A time value that is a multiple of <emu-eqn>24 &times; 60 &times; 60 &times; 1000 = 86,400,000</emu-eqn> (i.e., is equal to 86,400,000 &times; _d_ for some integer _d_) represents the instant at the start of the UTC day that follows the epoch by _d_ whole UTC days (preceding the epoch for negative _d_). Every other finite time value _t_ is defined relative to the greatest preceding time value _s_ that is such a multiple, and represents the instant that occurs within the same UTC day as _s_ but follows it by _t_ &minus; _s_ milliseconds.</p>
+        <p>An ECMAScript <dfn variants="time values">time value</dfn> is a Number, either a finite integral Number representing an instant in time to millisecond precision or *NaN* representing no specific instant. A time value that is a multiple of <emu-eqn>24 &times; 60 &times; 60 &times; 1000 = 86,400,000</emu-eqn> (i.e., is equal to 86,400,000 &times; _d_ for some integer _d_) represents the instant at the start of the UTC day that follows the epoch by _d_ whole UTC days (preceding the epoch for negative _d_). Every other finite time value _t_ is defined relative to the greatest preceding time value _s_ that is such a multiple, and represents the instant that occurs within the same UTC day as _s_ but follows it by _t_ &minus; _s_ milliseconds.</p>
         <p>Time values do not account for UTC leap seconds&mdash;there are no time values representing instants within positive leap seconds, and there are time values representing instants removed from the UTC timeline by negative leap seconds. However, the definition of time values nonetheless yields piecewise alignment with UTC, with discontinuities only at leap second boundaries and zero difference outside of leap seconds.</p>
         <p>A Number can exactly represent all integers from -9,007,199,254,740,992 to 9,007,199,254,740,992 (<emu-xref href="#sec-number.min_safe_integer"></emu-xref> and <emu-xref href="#sec-number.max_safe_integer"></emu-xref>). A time value supports a slightly smaller range of -8,640,000,000,000,000 to 8,640,000,000,000,000 milliseconds. This yields a supported time value range of exactly -100,000,000 days to 100,000,000 days relative to midnight at the beginning of 1 January 1970 UTC.</p>
         <p>The exact moment of midnight at the beginning of 1 January 1970 UTC is represented by the time value *+0*<sub>𝔽</sub>.</p>
@@ -37100,7 +37100,7 @@ THH:mm:ss.sss
             1. Set _j_ to _j_ + 1.
           1. Return _obj_.
         </emu-alg>
-        <p>The <em>sort order</em> is the ordering, after completion of this function, of the <emu-xref href="#integer-index">integer-indexed</emu-xref> property values of _obj_ whose integer indexes are less than _len_. The result of the `sort` function is then determined as follows:</p>
+        <p>The <em>sort order</em> is the ordering, after completion of this function, of the <emu-xref href="#integer-index">integer-indexed</emu-xref> property values of _obj_ whose integer indices are less than _len_. The result of the `sort` function is then determined as follows:</p>
         <p>The sort order is implementation-defined if any of the following conditions is true:</p>
         <ul>
           <li>
@@ -37472,7 +37472,7 @@ THH:mm:ss.sss
 
   <emu-clause id="sec-typedarray-objects">
     <h1>TypedArray Objects</h1>
-    <p>_TypedArray_ objects present an array-like view of an underlying binary data buffer (<emu-xref href="#sec-arraybuffer-objects"></emu-xref>). A <dfn>TypedArray element type</dfn> is the underlying binary scalar data type that all elements of a _TypedArray_ instance have. There is a distinct _TypedArray_ constructor, listed in <emu-xref href="#table-the-typedarray-constructors"></emu-xref>, for each of the supported element types. Each constructor in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> has a corresponding distinct prototype object.</p>
+    <p>_TypedArray_ objects present an array-like view of an underlying binary data buffer (<emu-xref href="#sec-arraybuffer-objects"></emu-xref>). A <dfn variants="TypedArray element types">TypedArray element type</dfn> is the underlying binary scalar data type that all elements of a _TypedArray_ instance have. There is a distinct _TypedArray_ constructor, listed in <emu-xref href="#table-the-typedarray-constructors"></emu-xref>, for each of the supported element types. Each constructor in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> has a corresponding distinct prototype object.</p>
     <emu-table id="table-the-typedarray-constructors" caption="The TypedArray Constructors" oldids="table-49">
       <table>
         <tbody>
@@ -39864,7 +39864,7 @@ THH:mm:ss.sss
     <emu-clause id="sec-arraybuffer-notation">
       <h1>Notation</h1>
       <p>The descriptions below in this section, <emu-xref href="#sec-atomics-object"></emu-xref>, and <emu-xref href="#sec-memory-model"></emu-xref> use the read-modify-write modification function internal data structure.</p>
-      <p>A <dfn>read-modify-write modification function</dfn> is a mathematical function that is notationally represented as an abstract closure that takes two Lists of byte values as arguments and returns a List of byte values. These abstract closures satisfy all of the following properties:</p>
+      <p>A <dfn variants="read-modify-write modification functions">read-modify-write modification function</dfn> is a mathematical function that is notationally represented as an abstract closure that takes two Lists of byte values as arguments and returns a List of byte values. These abstract closures satisfy all of the following properties:</p>
       <ul>
         <li>They perform all their algorithm steps atomically.</li>
         <li>Their individual algorithm steps are not observable.</li>
@@ -40898,10 +40898,10 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-waiterlist-objects">
       <h1>WaiterList Objects</h1>
-      <p>A <dfn>WaiterList</dfn> is a semantic object that contains an ordered list of those agents that are waiting on a location (_block_, _i_) in shared memory; _block_ is a Shared Data Block and _i_ a byte offset into the memory of _block_. A WaiterList object also optionally contains a Synchronize event denoting the previous leaving of its critical section.</p>
+      <p>A <dfn variants="WaiterLists">WaiterList</dfn> is a semantic object that contains an ordered list of those agents that are waiting on a location (_block_, _i_) in shared memory; _block_ is a Shared Data Block and _i_ a byte offset into the memory of _block_. A WaiterList object also optionally contains a Synchronize event denoting the previous leaving of its critical section.</p>
       <p>Initially a WaiterList object has an empty list and no Synchronize event.</p>
       <p>The agent cluster has a store of WaiterList objects; the store is indexed by (_block_, _i_). WaiterLists are agent-independent: a lookup in the store of WaiterLists by (_block_, _i_) will result in the same WaiterList object in any agent in the agent cluster.</p>
-      <p>Each WaiterList has a <dfn>critical section</dfn> that controls exclusive access to that WaiterList during evaluation. Only a single agent may enter a WaiterList's critical section at one time. Entering and leaving a WaiterList's critical section is controlled by the abstract operations EnterCriticalSection and LeaveCriticalSection. Operations on a WaiterList&mdash;adding and removing waiting agents, traversing the list of agents, suspending and notifying agents on the list, setting and retrieving the Synchronize event&mdash;may only be performed by agents that have entered the WaiterList's critical section.</p>
+      <p>Each WaiterList has a <dfn variants="critical sections">critical section</dfn> that controls exclusive access to that WaiterList during evaluation. Only a single agent may enter a WaiterList's critical section at one time. Entering and leaving a WaiterList's critical section is controlled by the abstract operations EnterCriticalSection and LeaveCriticalSection. Operations on a WaiterList&mdash;adding and removing waiting agents, traversing the list of agents, suspending and notifying agents on the list, setting and retrieving the Synchronize event&mdash;may only be performed by agents that have entered the WaiterList's critical section.</p>
     </emu-clause>
 
     <emu-clause id="sec-abstract-operations-for-atomics">
@@ -41862,7 +41862,7 @@ THH:mm:ss.sss
           1. Return _final_.
         </emu-alg>
         <emu-note>
-          <p>The representation of arrays includes only the elements between zero and <emu-eqn>`array.length` - 1</emu-eqn> inclusive. Properties whose keys are not <emu-xref href="#array-index">array indexes</emu-xref> are excluded from the stringification. An array is stringified as an opening LEFT SQUARE BRACKET, elements separated by COMMA, and a closing RIGHT SQUARE BRACKET.</p>
+          <p>The representation of arrays includes only the elements between zero and <emu-eqn>`array.length` - 1</emu-eqn> inclusive. Properties whose keys are not array indices are excluded from the stringification. An array is stringified as an opening LEFT SQUARE BRACKET, elements separated by COMMA, and a closing RIGHT SQUARE BRACKET.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -41884,7 +41884,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-weak-ref-constructor">
       <h1>The WeakRef Constructor</h1>
-      <p>The <dfn>WeakRef</dfn> constructor:</p>
+      <p>The <dfn variants="WeakRefs">WeakRef</dfn> constructor:</p>
       <ul>
         <li>is <dfn>%WeakRef%</dfn>.</li>
         <li>
@@ -42021,7 +42021,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-finalization-registry-constructor">
       <h1>The FinalizationRegistry Constructor</h1>
-      <p>The <dfn>FinalizationRegistry</dfn> constructor:</p>
+      <p>The <dfn variants="FinalizationRegistrys">FinalizationRegistry</dfn> constructor:</p>
       <ul>
         <li>is <dfn>%FinalizationRegistry%</dfn>.</li>
         <li>
@@ -42614,7 +42614,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-promisecapability-records">
         <h1>PromiseCapability Records</h1>
-        <p>A <dfn>PromiseCapability Record</dfn> is a Record value used to encapsulate a promise object along with the functions that are capable of resolving or rejecting that promise object. PromiseCapability Records are produced by the NewPromiseCapability abstract operation.</p>
+        <p>A <dfn variants="PromiseCapability Records">PromiseCapability Record</dfn> is a Record value used to encapsulate a promise object along with the functions that are capable of resolving or rejecting that promise object. PromiseCapability Records are produced by the NewPromiseCapability abstract operation.</p>
         <p>PromiseCapability Records have the fields listed in <emu-xref href="#table-promisecapability-record-fields"></emu-xref>.</p>
         <emu-table id="table-promisecapability-record-fields" caption="PromiseCapability Record Fields" oldids="table-57">
           <table>
@@ -44348,7 +44348,7 @@ THH:mm:ss.sss
       <h1>AsyncGenerator Abstract Operations</h1>
       <emu-clause id="sec-asyncgeneratorrequest-records">
         <h1>AsyncGeneratorRequest Records</h1>
-        <p>An <dfn>AsyncGeneratorRequest</dfn> is a Record value used to store information about how an async generator should be resumed and contains capabilities for fulfilling or rejecting the corresponding promise.</p>
+        <p>An <dfn variants="AsyncGeneratorRequests">AsyncGeneratorRequest</dfn> is a Record value used to store information about how an async generator should be resumed and contains capabilities for fulfilling or rejecting the corresponding promise.</p>
         <p>They have the following fields:</p>
         <emu-table caption="AsyncGeneratorRequest Record Fields">
           <table>
@@ -45038,7 +45038,7 @@ THH:mm:ss.sss
     <emu-note>
       <p>No orderings weaker than sequentially consistent and stronger than unordered, such as release-acquire, are supported.</p>
     </emu-note>
-    <p>A <dfn>Shared Data Block event</dfn> is either a <dfn>ReadSharedMemory</dfn>, <dfn>WriteSharedMemory</dfn>, or <dfn>ReadModifyWriteSharedMemory</dfn> Record.</p>
+    <p>A <dfn variants="Shared Data Block events">Shared Data Block event</dfn> is either a <dfn>ReadSharedMemory</dfn>, <dfn>WriteSharedMemory</dfn>, or <dfn>ReadModifyWriteSharedMemory</dfn> Record.</p>
 
     <emu-table id="table-readsharedmemory-fields" caption="ReadSharedMemory Event Fields">
       <table>
@@ -45167,7 +45167,7 @@ THH:mm:ss.sss
     </emu-table>
 
     <p>These events are introduced by abstract operations or by methods on the Atomics object.</p>
-    <p>Some operations may also introduce <dfn>Synchronize</dfn> events. A <dfn>Synchronize event</dfn> has no fields, and exists purely to directly constrain the permitted orderings of other events.</p>
+    <p>Some operations may also introduce <dfn>Synchronize</dfn> events. A <dfn variants="Synchronize events">Synchronize event</dfn> has no fields, and exists purely to directly constrain the permitted orderings of other events.</p>
     <p>In addition to Shared Data Block and Synchronize events, there are host-specific events.</p>
     <p>Let the range of a ReadSharedMemory, WriteSharedMemory, or ReadModifyWriteSharedMemory event be the Set of contiguous integers from its [[ByteIndex]] to [[ByteIndex]] + [[ElementSize]] - 1. Two events' ranges are equal when the events have the same [[Block]], and the ranges are element-wise equal. Two events' ranges are overlapping when the events have the same [[Block]], the ranges are not equal and their intersection is non-empty. Two events' ranges are disjoint when the events do not have the same [[Block]] or their ranges are neither equal nor overlapping.</p>
     <emu-note>
@@ -45178,7 +45178,7 @@ THH:mm:ss.sss
 
   <emu-clause id="sec-agent-event-records">
     <h1>Agent Events Records</h1>
-    <p>An <dfn>Agent Events Record</dfn> is a Record with the following fields.</p>
+    <p>An <dfn variants="Agent Events Records">Agent Events Record</dfn> is a Record with the following fields.</p>
     <emu-table id="table-agent-events-records" caption="Agent Events Record Fields">
       <table>
         <tbody>
@@ -45209,7 +45209,7 @@ THH:mm:ss.sss
 
   <emu-clause id="sec-chosen-value-records">
     <h1>Chosen Value Records</h1>
-    <p>A <dfn>Chosen Value Record</dfn> is a Record with the following fields.</p>
+    <p>A <dfn variants="Chosen Value Records">Chosen Value Record</dfn> is a Record with the following fields.</p>
     <emu-table id="table-chosen-value-records" caption="Chosen Value Record Fields">
       <table>
         <tbody>
@@ -45235,7 +45235,7 @@ THH:mm:ss.sss
 
   <emu-clause id="sec-candidate-executions">
     <h1>Candidate Executions</h1>
-    <p>A <dfn>candidate execution</dfn> of the evaluation of an agent cluster is a Record with the following fields.</p>
+    <p>A <dfn variants="candidate executions">candidate execution</dfn> of the evaluation of an agent cluster is a Record with the following fields.</p>
     <emu-table id="table-candidate-execution-records" caption="Candidate Execution Record Fields">
       <table>
         <tbody>
@@ -45288,7 +45288,7 @@ THH:mm:ss.sss
       </table>
     </emu-table>
 
-    <p>An <dfn>empty candidate execution</dfn> is a candidate execution Record whose fields are empty Lists and Relations.</p>
+    <p>An <dfn variants="empty candidate executions">empty candidate execution</dfn> is a candidate execution Record whose fields are empty Lists and Relations.</p>
   </emu-clause>
 
   <emu-clause id="sec-abstract-operations-for-the-memory-model" oldids="sec-synchronizeeventset">
@@ -45643,7 +45643,7 @@ THH:mm:ss.sss
     <emu-note>
       <p>The following are guidelines for ECMAScript implementers writing compiler transformations for programs using shared memory.</p>
       <p>It is desirable to allow most program transformations that are valid in a single-agent setting in a multi-agent setting, to ensure that the performance of each agent in a multi-agent program is as good as it would be in a single-agent setting. Frequently these transformations are hard to judge. We outline some rules about program transformations that are intended to be taken as normative (in that they are implied by the memory model or stronger than what the memory model implies) but which are likely not exhaustive. These rules are intended to apply to program transformations that precede the introductions of the events that make up the agent-order.</p>
-      <p>Let an <dfn>agent-order slice</dfn> be the subset of the agent-order pertaining to a single agent.</p>
+      <p>Let an <dfn variants="agent-order slices">agent-order slice</dfn> be the subset of the agent-order pertaining to a single agent.</p>
       <p>Let <dfn>possible read values</dfn> of a read event be the set of all values of ValueOfReadEvent for that event across all valid executions.</p>
       <p>Any transformation of an agent-order slice that is valid in the absence of shared memory is valid in the presence of shared memory, with the following exceptions.</p>
       <ul>


### PR DESCRIPTION
I [just added](https://github.com/tc39/ecmarkup/pull/346) support in ecmarkup for `dfn` tags to define other forms of the terms they define. This PR bumps ecmarkup to that version and makes use of the new attribute as appropriate for plural forms of defined nouns and noun phrases.