### PR TITLE
Normative: phrase tail calls as discarding resources rather than popping execution context stack

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -18753,7 +18753,6 @@
           1. If IsCallable(_func_) is *false*, throw a *TypeError* exception.
           1. If _tailPosition_ is *true*, perform PrepareForTailCall().
           1. Let _result_ be Call(_func_, _thisValue_, _argList_).
-          1. Assert: If _tailPosition_ is *true*, the above call will not return here, but instead evaluation will continue as if the following return has already occurred.
           1. Assert: If _result_ is not an abrupt completion, then Type(_result_) is an ECMAScript language type.
           1. Return _result_.
         </emu-alg>
@@ -24977,10 +24976,8 @@
       <dl class="header">
       </dl>
       <emu-alg>
-        1. Let _leafContext_ be the running execution context.
-        1. Suspend _leafContext_.
-        1. Pop _leafContext_ from the execution context stack. The execution context now on the top of the stack becomes the running execution context.
-        1. Assert: _leafContext_ has no further use. It will never be activated as the running execution context.
+        1. Assert: The current execution context will not subsequently be used for the evaluation of any ECMAScript code or built-in functions. The invocation of Call subsequent to the invocation of this abstract operation will create and push a new execution context before performing any such evaluation.
+        1. Discard all resources associated with the current execution context.
       </emu-alg>
       <p>A tail position call must either release any transient internal resources associated with the currently executing function execution context before invoking the target function or reuse those resources in support of the target function.</p>
       <emu-note>


### PR DESCRIPTION
In https://github.com/tc39/ecma262/issues/2409, https://github.com/tc39/ecma262/issues/2400, https://github.com/tc39/ecma262/pull/2429, https://github.com/tc39/ecma262/pull/2413, and other issues, we've been trying to clarify how execution contexts work within the spec. I think I have a good handle on how to clarify all of the sources of confusion with some editorial tweaks, with the exception of [PrepareForTailCall](https://tc39.es/ecma262/#sec-preparefortailcall).

PrepareForTailCall is particularly strange. Unlike everywhere else in the spec (as of #2413), it pops the execution context stack without immediately resuming the execution context which is now at the top of the stack, leaving the spec's abstract machine in an odd state where the "running execution context" (defined to be the top of the stack) is not actually running in the sense of "not suspended".

I talked to @allenwb about the intended interpretation of PrepareForTailCall (thanks Allen!). He explained that the actual goal of the AO is just to require engines discard the resources associated with the current call - popping the execution context stack and discarding the former top-of-stack is intended to signify that. But manipulating the execution context stack has other consequences with regards to the transfer of control within the specification's abstract machine, and I don't have a good way to make that coherent for PrepareForTailCall as currently phrased.

Instead, this PR replaces PrepareForTailCall's pop of the execution context stack with an explicit instruction to discard the resources associated with the running execution context, without actually removing it from the execution context stack in the specification's abstract machine.

Unfortunately, this has observable consequences for the realm of the TypeError which results when tail-calling a revoked proxy (although no other observable consequences, that I can tell), which is why this is Normative. Concretely, in

```js
let F = evalInNewRealm(`
  (function F() {
    let { proxy, revoke } = Proxy.revocable(() => {}, {});
    revoke();
    return proxy();
  })
`);

try {
  F();
} catch (e) {
  console.log(e instanceof TypeError);
}
```

prior to this PR the above snippet would return _true_ (because the TypeError is created in the realm of the code which _invokes_ `F`, since `F`'s execution context is discarded from the stack before the TypeError is thrown), and with this PR it would return _false_ (because `F`'s execution context is still on top of the stack at the time the TypeError is thrown).

Of the engines I tested, only JavaScriptCore and XS implemented tail calls. I couldn't figure out how to observe the realm for error objects in XS, and in JSC the error is always created in the realm of the Proxy object itself, which is wrong both before and after this PR. So I don't think there's any web-reality issues with this PR.

This PR is an alternative to https://github.com/tc39/ecma262/pull/2430.