### PR TITLE
Editorial: tweak note in FunctionDeclarationInstantiation

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -13369,7 +13369,7 @@
           1. If *"arguments"* is an element of _functionNames_ or if *"arguments"* is an element of _lexicalNames_, then
             1. Set _argumentsObjectNeeded_ to *false*.
         1. If _strict_ is *true* or if _hasParameterExpressions_ is *false*, then
-          1. NOTE: Only a single Environment Record is needed for the parameters and top-level vars.
+          1. NOTE: Only a single Environment Record is needed for the parameters, since calls to `eval` in strict mode code cannot create new bindings which are visible outside of the `eval`.
           1. Let _env_ be the LexicalEnvironment of _calleeContext_.
         1. Else,
           1. NOTE: A separate Environment Record is needed to ensure that bindings created by direct eval calls in the formal parameter list are outside the environment where parameters are declared.


### PR DESCRIPTION
I noticed in [this thread](https://es.discourse.group/t/why-are-parameter-bindings-of-non-strict-functions-instantiated-in-a-new-environment-if-default-value-initialisers-exist/941/12) that [FunctionDeclarationInstantiation](https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-functiondeclarationinstantiation) step 19.a is misleading. It reads

> 19. If strict is true or if hasParameterExpressions is false, then
>   a. NOTE: Only a single Environment Record is needed for the parameters and top-level vars.

The NOTE is identical to that in step 27.a, from which it was presumably copied:

> 27. If hasParameterExpressions is false, then
>    a. NOTE: Only a single Environment Record is needed for the parameters and top-level vars.

But the conditions are different, and in a relevant way. Step 19 actually has nothing to do with top-level `var` declarations; rather, it's about where to put `var` declarations arising from sloppy-mode direct calls to `eval` in parameter expressions. (Step 27/28 is what governs where to put `var` declarations from the function body.)

So the NOTE in step 19 is misleading. I've changed it to talk about `eval` instead.

This was introduced in #1046. See also #623 for discussion of whether to keep these branches at all - they're not actually observable to user code (that is, taking the "else" branch in both cases is equivalent to the current state). I think we should probably pursue that eventually, but in the mean time the notes should at least be correct.