### PR TITLE
Editorial: make the order of parameters for class field AOs more consistent

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -6595,8 +6595,8 @@
     <emu-clause id="sec-privateelementfind" type="abstract operation">
       <h1>
         PrivateElementFind (
-          _P_: a Private Name,
           _O_: an Object,
+          _P_: a Private Name,
         )
       </h1>
       <dl class="header">
@@ -6620,7 +6620,7 @@
       <dl class="header">
       </dl>
       <emu-alg>
-        1. Let _entry_ be ! PrivateElementFind(_P_, _O_).
+        1. Let _entry_ be ! PrivateElementFind(_O_, _P_).
         1. If _entry_ is not ~empty~, throw a *TypeError* exception.
         1. Append PrivateElement { [[Key]]: _P_, [[Kind]]: ~field~, [[Value]]: _value_ } to _O_.[[PrivateElements]].
       </emu-alg>
@@ -6637,7 +6637,7 @@
       </dl>
       <emu-alg>
         1. Assert: _method_.[[Kind]] is either ~method~ or ~accessor~.
-        1. Let _entry_ be ! PrivateElementFind(_method_.[[Key]], _O_).
+        1. Let _entry_ be ! PrivateElementFind(_O_, _method_.[[Key]]).
         1. If _entry_ is not ~empty~, throw a *TypeError* exception.
         1. Append _method_ to _O_.[[PrivateElements]].
         1. NOTE: The values for private methods and accessors are shared across instances. This step does not create a new copy of the method or accessor.
@@ -6654,7 +6654,7 @@
       <dl class="header">
       </dl>
       <emu-alg>
-        1. Let _entry_ be ! PrivateElementFind(_P_, _O_).
+        1. Let _entry_ be ! PrivateElementFind(_O_, _P_).
         1. If _entry_ is ~empty~, throw a *TypeError* exception.
         1. If _entry_.[[Kind]] is ~field~ or ~method~, then
           1. Return _entry_.[[Value]].
@@ -6676,7 +6676,7 @@
       <dl class="header">
       </dl>
       <emu-alg>
-        1. Let _entry_ be ! PrivateElementFind(_P_, _O_).
+        1. Let _entry_ be ! PrivateElementFind(_O_, _P_).
         1. If _entry_ is ~empty~, throw a *TypeError* exception.
         1. If _entry_.[[Kind]] is ~field~, then
           1. Set _entry_.[[Value]] to _value_.
@@ -19762,7 +19762,7 @@
         1. If Type(_rval_) is not Object, throw a *TypeError* exception.
         1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
         1. Let _privateName_ be ! ResolvePrivateIdentifier(_privateEnv_, _privateIdentifier_).
-        1. If ! PrivateElementFind(_privateName_, _rval_) is not ~empty~, return *true*.
+        1. If ! PrivateElementFind(_rval_, _privateName_) is not ~empty~, return *true*.
         1. Return *false*.
       </emu-alg>
     </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -6629,8 +6629,8 @@
     <emu-clause id="sec-privatemethodoraccessoradd" type="abstract operation">
       <h1>
         PrivateMethodOrAccessorAdd (
-          _method_: a PrivateElement,
           _O_: an Object,
+          _method_: a PrivateElement,
         )
       </h1>
       <dl class="header">
@@ -6725,7 +6725,7 @@
       <emu-alg>
         1. Let _methods_ be the value of _constructor_.[[PrivateMethods]].
         1. For each PrivateElement _method_ of _methods_, do
-          1. Perform ? PrivateMethodOrAccessorAdd(_method_, _O_).
+          1. Perform ? PrivateMethodOrAccessorAdd(_O_, _method_).
         1. Let _fields_ be the value of _constructor_.[[Fields]].
         1. For each element _fieldRecord_ of _fields_, do
           1. Perform ? DefineField(_O_, _fieldRecord_).
@@ -24286,7 +24286,7 @@
         1. Set _F_.[[PrivateMethods]] to _instancePrivateMethods_.
         1. Set _F_.[[Fields]] to _instanceFields_.
         1. For each PrivateElement _method_ of _staticPrivateMethods_, do
-          1. Perform ! PrivateMethodOrAccessorAdd(_method_, _F_).
+          1. Perform ! PrivateMethodOrAccessorAdd(_F_, _method_).
         1. For each element _elementRecord_ of _staticElements_, do
           1. If _elementRecord_ is a ClassFieldDefinition Record, then
             1. Let _result_ be DefineField(_F_, _elementRecord_).

--- a/spec.html
+++ b/spec.html
@@ -4076,7 +4076,7 @@
           1. If IsPropertyReference(_V_) is *true*, then
             1. [id="step-getvalue-toobject"] Let _baseObj_ be ? ToObject(_V_.[[Base]]).
             1. If IsPrivateReference(_V_) is *true*, then
-              1. Return ? PrivateGet(_V_.[[ReferencedName]], _baseObj_).
+              1. Return ? PrivateGet(_baseObj_, _V_.[[ReferencedName]]).
             1. Return ? _baseObj_.[[Get]](_V_.[[ReferencedName]], GetThisValue(_V_)).
           1. Else,
             1. Let _base_ be _V_.[[Base]].
@@ -6647,8 +6647,8 @@
     <emu-clause id="sec-privateget" type="abstract operation">
       <h1>
         PrivateGet (
-          _P_: a Private Name,
           _O_: an Object,
+          _P_: a Private Name,
         )
       </h1>
       <dl class="header">

--- a/spec.html
+++ b/spec.html
@@ -13252,8 +13252,8 @@
     <emu-clause id="sec-definemethodproperty" type="abstract operation">
       <h1>
         DefineMethodProperty (
-          _key_: a property key or Private Name,
           _homeObject_: an Object,
+          _key_: a property key or Private Name,
           _closure_: a function object,
           _enumerable_: a Boolean,
         )
@@ -23169,7 +23169,7 @@
       <emu-alg>
         1. Let _methodDef_ be ? DefineMethod of |MethodDefinition| with argument _object_.
         1. Perform ! SetFunctionName(_methodDef_.[[Closure]], _methodDef_.[[Key]]).
-        1. Return ? DefineMethodProperty(_methodDef_.[[Key]], _object_, _methodDef_.[[Closure]], _enumerable_).
+        1. Return ? DefineMethodProperty(_object_, _methodDef_.[[Key]], _methodDef_.[[Closure]], _enumerable_).
       </emu-alg>
       <emu-grammar>MethodDefinition : `get` ClassElementName `(` `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
@@ -23218,7 +23218,7 @@
         1. Perform SetFunctionName(_closure_, _propKey_).
         1. Let _prototype_ be ! OrdinaryObjectCreate(%GeneratorFunction.prototype.prototype%).
         1. Perform ! DefinePropertyOrThrow(_closure_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
-        1. Return ? DefineMethodProperty(_propKey_, _object_, _closure_, _enumerable_).
+        1. Return ? DefineMethodProperty(_object_, _propKey_, _closure_, _enumerable_).
       </emu-alg>
       <emu-grammar>
         AsyncGeneratorMethod : `async` `*` ClassElementName `(` UniqueFormalParameters `)` `{` AsyncGeneratorBody `}`
@@ -23234,7 +23234,7 @@
         1. Perform ! SetFunctionName(_closure_, _propKey_).
         1. Let _prototype_ be ! OrdinaryObjectCreate(%AsyncGeneratorFunction.prototype.prototype%).
         1. Perform ! DefinePropertyOrThrow(_closure_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
-        1. Return ? DefineMethodProperty(_propKey_, _object_, _closure_, _enumerable_).
+        1. Return ? DefineMethodProperty(_object_, _propKey_, _closure_, _enumerable_).
       </emu-alg>
       <emu-grammar>
         AsyncMethod : `async` ClassElementName `(` UniqueFormalParameters `)` `{` AsyncFunctionBody `}`
@@ -23248,7 +23248,7 @@
         1. Let _closure_ be ! OrdinaryFunctionCreate(%AsyncFunction.prototype%, _sourceText_, |UniqueFormalParameters|, |AsyncFunctionBody|, ~non-lexical-this~, _scope_, _privateScope_).
         1. Perform ! MakeMethod(_closure_, _object_).
         1. Perform ! SetFunctionName(_closure_, _propKey_).
-        1. Return ? DefineMethodProperty(_propKey_, _object_, _closure_, _enumerable_).
+        1. Return ? DefineMethodProperty(_object_, _propKey_, _closure_, _enumerable_).
       </emu-alg>
     </emu-clause>
   </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -6612,8 +6612,8 @@
     <emu-clause id="sec-privatefieldadd" type="abstract operation">
       <h1>
         PrivateFieldAdd (
-          _P_: a Private Name,
           _O_: an Object,
+          _P_: a Private Name,
           _value_: an ECMAScript language value,
         )
       </h1>
@@ -6706,7 +6706,7 @@
           1. Let _initValue_ be ? Call(_initializer_, _receiver_).
         1. Else, let _initValue_ be *undefined*.
         1. If _fieldName_ is a Private Name, then
-          1. Perform ? PrivateFieldAdd(_fieldName_, _receiver_, _initValue_).
+          1. Perform ? PrivateFieldAdd(_receiver_, _fieldName_, _initValue_).
         1. Else,
           1. Assert: ! IsPropertyKey(_fieldName_) is *true*.
           1. Perform ? CreateDataPropertyOrThrow(_receiver_, _fieldName_, _initValue_).

--- a/spec.html
+++ b/spec.html
@@ -4108,7 +4108,7 @@
           1. If IsPropertyReference(_V_) is *true*, then
             1. [id="step-putvalue-toobject"] Let _baseObj_ be ? ToObject(_V_.[[Base]]).
             1. If IsPrivateReference(_V_) is *true*, then
-              1. Return ? PrivateSet(_V_.[[ReferencedName]], _baseObj_, _W_).
+              1. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
             1. Let _succeeded_ be ? _baseObj_.[[Set]](_V_.[[ReferencedName]], _W_, GetThisValue(_V_)).
             1. If _succeeded_ is *false* and _V_.[[Strict]] is *true*, throw a *TypeError* exception.
             1. Return.
@@ -6668,8 +6668,8 @@
     <emu-clause id="sec-privateset" type="abstract operation">
       <h1>
         PrivateSet (
-          _P_: a Private Name,
           _O_: an Object,
+          _P_: a Private Name,
           _value_: an ECMAScript language value,
         )
       </h1>


### PR DESCRIPTION
Various of the abstract operations introduced in #1668 took their parameters in the order (key, object) or (key, object, value), rather than the prevailing convention of (object, key) or (object, key, value) respectively (as in [Get](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-get-o-p), [Set](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-set-o-p-v-throw), etc). (Thanks to @devsnek for [pointing this out](https://matrixlogs.bakkot.com/TC39_General/2021-07-17#L10).)

This PR swaps the order of the parameters for those methods to match the prior convention.