### PR TITLE
Normative: add missing AsyncGenerator cases to ContainsArguments

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -23967,11 +23967,26 @@
       </emu-alg>
 
       <emu-grammar>
-        FunctionDeclaration : `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`
+        FunctionDeclaration :
+          `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`
+          `function` `(` FormalParameters `)` `{` FunctionBody `}`
 
-        FunctionDeclaration : `function` `(` FormalParameters `)` `{` FunctionBody `}`
+        FunctionExpression :
+          `function` BindingIdentifier? `(` FormalParameters `)` `{` FunctionBody `}`
 
-        FunctionExpression : `function` BindingIdentifier? `(` FormalParameters `)` `{` FunctionBody `}`
+        GeneratorDeclaration :
+          `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`
+          `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`
+
+        GeneratorExpression :
+          `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` GeneratorBody `}`
+
+        AsyncFunctionDeclaration :
+          `async` `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
+          `async` `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
+
+        AsyncFunctionExpression :
+          `async` `function` BindingIdentifier? `(` FormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
       <emu-alg>
         1. Return *false*.
@@ -23982,47 +23997,15 @@
           ClassElementName `(` UniqueFormalParameters `)` `{` FunctionBody `}`
           `get` ClassElementName `(` `)` `{` FunctionBody `}`
           `set` ClassElementName `(` PropertySetParameterList `)` `{` FunctionBody `}`
+
+        GeneratorMethod :
+          `*` ClassElementName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`
+
+        AsyncMethod :
+          `async` ClassElementName `(` UniqueFormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
       <emu-alg>
         1. Return ContainsArguments of |ClassElementName|.
-      </emu-alg>
-
-      <emu-grammar>
-        GeneratorMethod : `*` ClassElementName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`
-      </emu-grammar>
-      <emu-alg>
-        1. Return ContainsArguments of |ClassElementName|.
-      </emu-alg>
-
-      <emu-grammar>
-        GeneratorDeclaration : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`
-
-        GeneratorDeclaration : `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`
-
-        GeneratorExpression : `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` GeneratorBody `}`
-      </emu-grammar>
-      <emu-alg>
-        1. Return *false*.
-      </emu-alg>
-
-      <emu-grammar>
-        AsyncMethod : `async` ClassElementName `(` UniqueFormalParameters `)` `{` AsyncFunctionBody `}`
-      </emu-grammar>
-      <emu-alg>
-        1. Return ContainsArguments of |ClassElementName|.
-      </emu-alg>
-
-      <emu-grammar>
-        AsyncFunctionDeclaration : `async` `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
-
-        AsyncFunctionDeclaration : `async` `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
-
-        AsyncFunctionExpression : `async` `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
-
-        AsyncFunctionExpression : `async` `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
-      </emu-grammar>
-      <emu-alg>
-        1. Return *false*.
       </emu-alg>
     </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -23981,6 +23981,13 @@
         GeneratorExpression :
           `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` GeneratorBody `}`
 
+        AsyncGeneratorDeclaration :
+          `async` `function` `*` BindingIdentifier `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+          `async` `function` `*` `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+
+        AsyncGeneratorExpression :
+          `async` `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+
         AsyncFunctionDeclaration :
           `async` `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
           `async` `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
@@ -24000,6 +24007,9 @@
 
         GeneratorMethod :
           `*` ClassElementName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`
+
+        AsyncGeneratorMethod :
+          `async` `*` ClassElementName `(` UniqueFormalParameters `)` `{` AsyncGeneratorBody `}`
 
         AsyncMethod :
           `async` ClassElementName `(` UniqueFormalParameters `)` `{` AsyncFunctionBody `}`


### PR DESCRIPTION
ContainsArguments, added in #1668, is used to forbid class field initializers which refer to the outer `arguments` binding. It's not intended to descend into non-arrow functions, since those introduce their own binding for `arguments`, which is fine. Unfortunately it was accidentally missing the `AsyncGenerator` cases, meaning that, as written, `(class { x = async function*(){ arguments } })` was an Early Error, unlike `(class { x = function*(){ arguments } })` or `(class { x = async function(){ arguments } })`.

Engine262 actually implements the specified behavior, but no other engine I tested did.

This is technically normative, because the current semantics are coherent, but I think we need not seek consensus for it - it was definitely just an oversight.

The first commit is just a reorganization of the SDO to make it easier to read. I suggest reviewing (and landing) the commits separately.