### PR TITLE
Editorial: fix typos in Math.cos and Math.cosh

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -31155,8 +31155,8 @@
         <p>When the `Math.cos` method is called with argument _x_, the following steps are taken:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
-          1. If _n_ is *NaN*, _n_ is *+0*<sub>𝔽</sub>, or _n_ is *-0*<sub>𝔽</sub>, return _n_.
-          1. If _n_ is *+&infin;*<sub>𝔽</sub> or _n_ is *-&infin;*<sub>𝔽</sub>, return *NaN*.
+          1. If _n_ is *NaN*, _n_ is *+&infin;*<sub>𝔽</sub>, or _n_ is *-&infin;*<sub>𝔽</sub>, return *NaN*.
+          1. If _n_ is *+0*<sub>𝔽</sub> or _n_ is *-0*<sub>𝔽</sub>, return *1*<sub>𝔽</sub>.
           1. Return an implementation-approximated value representing the result of the cosine of ℝ(_n_).
         </emu-alg>
       </emu-clause>
@@ -31167,7 +31167,8 @@
         <p>When the `Math.cosh` method is called with argument _x_, the following steps are taken:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
-          1. If _n_ is *NaN*, _n_ is *+&infin;*<sub>𝔽</sub>, or _n_ is *-&infin;*<sub>𝔽</sub>, return _n_.
+          1. If _n_ is *NaN*, return *NaN*.
+          1. If _n_ is *+&infin;*<sub>𝔽</sub> or _n_ is *-&infin;*<sub>𝔽</sub>, return *+&infin;*<sub>𝔽</sub>.
           1. If _n_ is *+0*<sub>𝔽</sub> or _n_ is *-0*<sub>𝔽</sub>, return *1*<sub>𝔽</sub>.
           1. Return an implementation-approximated value representing the result of the hyperbolic cosine of ℝ(_n_).
         </emu-alg>


### PR DESCRIPTION
Fixes #2508.

Hopefully the last typo from #2122. I've checked all the boundary cases again, but I did that before and clearly managed to miss this one, so there might well still be some lurking.

I'm calling this editorial because that's what we've been doing in #2185, #2450, etc.