### PR TITLE
Editorial: Make the behavior of SameValue and SameValueZero a little more clear

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1433,6 +1433,7 @@
               _T_::sameValue(x,&nbsp;y)
             </td>
             <td>
+              `Object.is(x, y)`
             </td>
             <td>
               Object internal methods,
@@ -1448,11 +1449,12 @@
               _T_::sameValueZero(x,&nbsp;y)
             </td>
             <td>
+              `[x].includes(y)`
             </td>
             <td>
               Array, Map, and Set methods,
               via <emu-xref href="#sec-samevaluezero" title></emu-xref>,
-              to test value equality ignoring differences among members of the zero cohort (i.e., *-0*<sub>𝔽</sub> and *+0*<sub>𝔽</sub>)
+              to test value equality ignoring differences between Numbers in the zero cohort (i.e., *-0*<sub>𝔽</sub> and *+0*<sub>𝔽</sub>)
             </td>
             <td>
               Boolean
@@ -5865,7 +5867,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It returns a completion record whose [[Type]] is ~normal~ and whose [[Value]] is a Boolean.</dd>
+        <dd>It returns a completion record whose [[Type]] is ~normal~ and whose [[Value]] is a Boolean indicating whether or not the two arguments are the same value.</dd>
       </dl>
       <emu-alg>
         1. If Type(_x_) is different from Type(_y_), return *false*.
@@ -5874,7 +5876,7 @@
         1. Return ! SameValueNonNumeric(_x_, _y_).
       </emu-alg>
       <emu-note>
-        <p>This algorithm differs from the IsStrictlyEqual Algorithm in its treatment of signed zeroes and NaNs.</p>
+        <p>This algorithm differs from the IsStrictlyEqual Algorithm by treating all *NaN* values as equivalent and by differentiating *+0*<sub>𝔽</sub> from *-0*<sub>𝔽</sub>.</p>
       </emu-note>
     </emu-clause>
 
@@ -5887,7 +5889,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It returns a completion record whose [[Type]] is ~normal~ and whose [[Value]] is a Boolean.</dd>
+        <dd>It returns a completion record whose [[Type]] is ~normal~ and whose [[Value]] is a Boolean indicating whether or not the two arguments are the same value (ignoring the difference between *+0*<sub>𝔽</sub> and *-0*<sub>𝔽</sub>).</dd>
       </dl>
       <emu-alg>
         1. If Type(_x_) is different from Type(_y_), return *false*.
@@ -5896,7 +5898,7 @@
         1. Return ! SameValueNonNumeric(_x_, _y_).
       </emu-alg>
       <emu-note>
-        <p>SameValueZero differs from SameValue only in its treatment of *+0*<sub>𝔽</sub> and *-0*<sub>𝔽</sub>.</p>
+        <p>SameValueZero differs from SameValue only in that it treats *+0*<sub>𝔽</sub> and *-0*<sub>𝔽</sub> as equivalent.</p>
       </emu-note>
     </emu-clause>
 


### PR DESCRIPTION
Every time I encounter a reference to one of the two operations, there's a momentary pause while I remember with differentiates +0 from -0. This should shorten that time by a bit, and make the text slightly more approachable for everyone (especially since `::sameValue` and `::sameValueZero` are not currently links).