### PR TITLE
Markup: have SDOs use structured headers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,9 @@
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.14.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
-      "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g=="
+      "version": "7.15.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w=="
     },
     "@babel/highlight": {
       "version": "7.14.5",
@@ -505,9 +505,9 @@
       }
     },
     "ecmarkup": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-9.1.0.tgz",
-      "integrity": "sha512-tR/4rI3jiGij0/qOau+5om6LYDBRgbyQzEM9Y3ksO5+sAS2idWhniIYguE2WUWuilxpD4e+cQesVZuOg6014QQ==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-9.2.0.tgz",
+      "integrity": "sha512-bWAJJsKlXmenaG8B2TJtDodIXVoANg3pq7a4ZG14/CyxTx4f6c/0ZiFlI/M0rp9/goD6y0Y/G0CRB3tWggJ17w==",
       "requires": {
         "chalk": "^1.1.3",
         "ecmarkdown": "^6.0.0",
@@ -654,9 +654,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
         },
         "ansi-styles": {
           "version": "4.3.0",
@@ -1690,9 +1690,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
         },
         "strip-ansi": {
           "version": "6.0.0",
@@ -1750,9 +1750,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "8.6.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.2.tgz",
-          "integrity": "sha512-9807RlWAgT564wT+DjeyU5OFMPjmzxVobvDFmNAhY+5zD6A2ly3jDp6sgnfyDtlIQ+7H97oc/DGCzzfu9rjw9w==",
+          "version": "8.6.3",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.3.tgz",
+          "integrity": "sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -1761,9 +1761,9 @@
           }
         },
         "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
         },
         "json-schema-traverse": {
           "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "license": "SEE LICENSE IN https://tc39.es/ecma262/#sec-copyright-and-software-license",
   "homepage": "https://tc39.es/ecma262/",
   "dependencies": {
-    "ecmarkup": "^9.1.0"
+    "ecmarkup": "9.2.0"
   },
   "devDependencies": {
     "glob": "^7.1.6",

--- a/spec.html
+++ b/spec.html
@@ -4957,9 +4957,13 @@
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-runtime-semantics-stringnumericvalue" type="sdo" aoid="StringNumericValue" oldids="sec-runtime-semantics-mv-s">
+        <emu-clause id="sec-runtime-semantics-stringnumericvalue" type="sdo" oldids="sec-runtime-semantics-mv-s">
           <h1>Runtime Semantics: StringNumericValue</h1>
-          <p>The conversion of a |StringNumericLiteral| to a Number value is similar overall to the determination of the NumericValue of a |NumericLiteral| (see <emu-xref href="#sec-literals-numeric-literals"></emu-xref>), but some of the details are different.</p>
+          <dl class="header">
+          </dl>
+          <emu-note>
+            <p>The conversion of a |StringNumericLiteral| to a Number value is similar overall to the determination of the NumericValue of a |NumericLiteral| (see <emu-xref href="#sec-literals-numeric-literals"></emu-xref>), but some of the details are different.</p>
+          </emu-note>
           <emu-grammar>StringNumericLiteral ::: StrWhiteSpace?</emu-grammar>
           <emu-alg>
             1. Return *+0*<sub>𝔽</sub>.
@@ -6980,8 +6984,10 @@
   <emu-clause id="sec-syntax-directed-operations-scope-analysis">
     <h1>Scope Analysis</h1>
 
-    <emu-clause id="sec-static-semantics-boundnames" oldids="sec-identifiers-static-semantics-boundnames,sec-let-and-const-declarations-static-semantics-boundnames,sec-variable-statement-static-semantics-boundnames,sec-destructuring-binding-patterns-static-semantics-boundnames,sec-for-in-and-for-of-statements-static-semantics-boundnames,sec-function-definitions-static-semantics-boundnames,sec-arrow-function-definitions-static-semantics-boundnames,sec-generator-function-definitions-static-semantics-boundnames,sec-async-generator-function-definitions-static-semantics-boundnames,sec-class-definitions-static-semantics-boundnames,sec-async-function-definitions-static-semantics-BoundNames,sec-async-arrow-function-definitions-static-semantics-BoundNames,sec-imports-static-semantics-boundnames,sec-exports-static-semantics-boundnames" type="sdo" aoid="BoundNames">
+    <emu-clause id="sec-static-semantics-boundnames" oldids="sec-identifiers-static-semantics-boundnames,sec-let-and-const-declarations-static-semantics-boundnames,sec-variable-statement-static-semantics-boundnames,sec-destructuring-binding-patterns-static-semantics-boundnames,sec-for-in-and-for-of-statements-static-semantics-boundnames,sec-function-definitions-static-semantics-boundnames,sec-arrow-function-definitions-static-semantics-boundnames,sec-generator-function-definitions-static-semantics-boundnames,sec-async-generator-function-definitions-static-semantics-boundnames,sec-class-definitions-static-semantics-boundnames,sec-async-function-definitions-static-semantics-BoundNames,sec-async-arrow-function-definitions-static-semantics-BoundNames,sec-imports-static-semantics-boundnames,sec-exports-static-semantics-boundnames" type="sdo">
       <h1>Static Semantics: BoundNames</h1>
+      <dl class="header">
+      </dl>
       <emu-note>
         <p>*"\*default\*"* is used within this specification as a synthetic name for hoistable anonymous functions that are defined using export declarations.</p>
       </emu-note>
@@ -7229,8 +7235,10 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-static-semantics-declarationpart" type="sdo" aoid="DeclarationPart">
+    <emu-clause id="sec-static-semantics-declarationpart" type="sdo">
       <h1>Static Semantics: DeclarationPart</h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>HoistableDeclaration : FunctionDeclaration</emu-grammar>
       <emu-alg>
         1. Return |FunctionDeclaration|.
@@ -7257,8 +7265,10 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-static-semantics-isconstantdeclaration" oldids="sec-let-and-const-declarations-static-semantics-isconstantdeclaration,sec-function-definitions-static-semantics-isconstantdeclaration,sec-generator-function-definitions-static-semantics-isconstantdeclaration,sec-async-generator-function-definitions-static-semantics-isconstantdeclaration,sec-class-definitions-static-semantics-isconstantdeclaration,sec-async-function-definitions-static-semantics-IsConstantDeclaration,sec-exports-static-semantics-isconstantdeclaration" type="sdo" aoid="IsConstantDeclaration">
+    <emu-clause id="sec-static-semantics-isconstantdeclaration" oldids="sec-let-and-const-declarations-static-semantics-isconstantdeclaration,sec-function-definitions-static-semantics-isconstantdeclaration,sec-generator-function-definitions-static-semantics-isconstantdeclaration,sec-async-generator-function-definitions-static-semantics-isconstantdeclaration,sec-class-definitions-static-semantics-isconstantdeclaration,sec-async-function-definitions-static-semantics-IsConstantDeclaration,sec-exports-static-semantics-isconstantdeclaration" type="sdo">
       <h1>Static Semantics: IsConstantDeclaration</h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>LexicalDeclaration : LetOrConst BindingList `;`</emu-grammar>
       <emu-alg>
         1. Return IsConstantDeclaration of |LetOrConst|.
@@ -7313,8 +7323,10 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-static-semantics-lexicallydeclarednames" oldids="sec-block-static-semantics-lexicallydeclarednames,sec-switch-statement-static-semantics-lexicallydeclarednames,sec-labelled-statements-static-semantics-lexicallydeclarednames,sec-function-definitions-static-semantics-lexicallydeclarednames,sec-arrow-function-definitions-static-semantics-lexicallydeclarednames,sec-async-arrow-function-definitions-static-semantics-LexicallyDeclaredNames,sec-scripts-static-semantics-lexicallydeclarednames,sec-module-semantics-static-semantics-lexicallydeclarednames" type="sdo" aoid="LexicallyDeclaredNames">
+    <emu-clause id="sec-static-semantics-lexicallydeclarednames" oldids="sec-block-static-semantics-lexicallydeclarednames,sec-switch-statement-static-semantics-lexicallydeclarednames,sec-labelled-statements-static-semantics-lexicallydeclarednames,sec-function-definitions-static-semantics-lexicallydeclarednames,sec-arrow-function-definitions-static-semantics-lexicallydeclarednames,sec-async-arrow-function-definitions-static-semantics-LexicallyDeclaredNames,sec-scripts-static-semantics-lexicallydeclarednames,sec-module-semantics-static-semantics-lexicallydeclarednames" type="sdo">
       <h1>Static Semantics: LexicallyDeclaredNames</h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>Block : `{` `}`</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
@@ -7439,8 +7451,10 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-static-semantics-lexicallyscopeddeclarations" oldids="sec-block-static-semantics-lexicallyscopeddeclarations,sec-switch-statement-static-semantics-lexicallyscopeddeclarations,sec-labelled-statements-static-semantics-lexicallyscopeddeclarations,sec-function-definitions-static-semantics-lexicallyscopeddeclarations,sec-arrow-function-definitions-static-semantics-lexicallyscopeddeclarations,sec-async-arrow-function-definitions-static-semantics-LexicallyScopedDeclarations,sec-scripts-static-semantics-lexicallyscopeddeclarations,sec-module-semantics-static-semantics-lexicallyscopeddeclarations,sec-exports-static-semantics-lexicallyscopeddeclarations" type="sdo" aoid="LexicallyScopedDeclarations">
+    <emu-clause id="sec-static-semantics-lexicallyscopeddeclarations" oldids="sec-block-static-semantics-lexicallyscopeddeclarations,sec-switch-statement-static-semantics-lexicallyscopeddeclarations,sec-labelled-statements-static-semantics-lexicallyscopeddeclarations,sec-function-definitions-static-semantics-lexicallyscopeddeclarations,sec-arrow-function-definitions-static-semantics-lexicallyscopeddeclarations,sec-async-arrow-function-definitions-static-semantics-LexicallyScopedDeclarations,sec-scripts-static-semantics-lexicallyscopeddeclarations,sec-module-semantics-static-semantics-lexicallyscopeddeclarations,sec-exports-static-semantics-lexicallyscopeddeclarations" type="sdo">
       <h1>Static Semantics: LexicallyScopedDeclarations</h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
       <emu-alg>
         1. Let _declarations1_ be LexicallyScopedDeclarations of |StatementList|.
@@ -7572,8 +7586,10 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-static-semantics-vardeclarednames" oldids="sec-statement-semantics-static-semantics-vardeclarednames,sec-block-static-semantics-vardeclarednames,sec-variable-statement-static-semantics-vardeclarednames,sec-if-statement-static-semantics-vardeclarednames,sec-do-while-statement-static-semantics-vardeclarednames,sec-while-statement-static-semantics-vardeclarednames,sec-for-statement-static-semantics-vardeclarednames,sec-for-in-and-for-of-statements-static-semantics-vardeclarednames,sec-with-statement-static-semantics-vardeclarednames,sec-switch-statement-static-semantics-vardeclarednames,sec-labelled-statements-static-semantics-vardeclarednames,sec-try-statement-static-semantics-vardeclarednames,sec-function-definitions-static-semantics-vardeclarednames,sec-arrow-function-definitions-static-semantics-vardeclarednames,sec-async-arrow-function-definitions-static-semantics-VarDeclaredNames,sec-scripts-static-semantics-vardeclarednames,sec-module-semantics-static-semantics-vardeclarednames" type="sdo" aoid="VarDeclaredNames">
+    <emu-clause id="sec-static-semantics-vardeclarednames" oldids="sec-statement-semantics-static-semantics-vardeclarednames,sec-block-static-semantics-vardeclarednames,sec-variable-statement-static-semantics-vardeclarednames,sec-if-statement-static-semantics-vardeclarednames,sec-do-while-statement-static-semantics-vardeclarednames,sec-while-statement-static-semantics-vardeclarednames,sec-for-statement-static-semantics-vardeclarednames,sec-for-in-and-for-of-statements-static-semantics-vardeclarednames,sec-with-statement-static-semantics-vardeclarednames,sec-switch-statement-static-semantics-vardeclarednames,sec-labelled-statements-static-semantics-vardeclarednames,sec-try-statement-static-semantics-vardeclarednames,sec-function-definitions-static-semantics-vardeclarednames,sec-arrow-function-definitions-static-semantics-vardeclarednames,sec-async-arrow-function-definitions-static-semantics-VarDeclaredNames,sec-scripts-static-semantics-vardeclarednames,sec-module-semantics-static-semantics-vardeclarednames" type="sdo">
       <h1>Static Semantics: VarDeclaredNames</h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>
         Statement :
           EmptyStatement
@@ -7782,8 +7798,10 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-static-semantics-varscopeddeclarations" oldids="sec-statement-semantics-static-semantics-varscopeddeclarations,sec-block-static-semantics-varscopeddeclarations,sec-variable-statement-static-semantics-varscopeddeclarations,sec-if-statement-static-semantics-varscopeddeclarations,sec-do-while-statement-static-semantics-varscopeddeclarations,sec-while-statement-static-semantics-varscopeddeclarations,sec-for-statement-static-semantics-varscopeddeclarations,sec-for-in-and-for-of-statements-static-semantics-varscopeddeclarations,sec-with-statement-static-semantics-varscopeddeclarations,sec-switch-statement-static-semantics-varscopeddeclarations,sec-labelled-statements-static-semantics-varscopeddeclarations,sec-try-statement-static-semantics-varscopeddeclarations,sec-function-definitions-static-semantics-varscopeddeclarations,sec-arrow-function-definitions-static-semantics-varscopeddeclarations,sec-async-arrow-function-definitions-static-semantics-VarScopedDeclarations,sec-scripts-static-semantics-varscopeddeclarations,sec-module-semantics-static-semantics-varscopeddeclarations" type="sdo" aoid="VarScopedDeclarations">
+    <emu-clause id="sec-static-semantics-varscopeddeclarations" oldids="sec-statement-semantics-static-semantics-varscopeddeclarations,sec-block-static-semantics-varscopeddeclarations,sec-variable-statement-static-semantics-varscopeddeclarations,sec-if-statement-static-semantics-varscopeddeclarations,sec-do-while-statement-static-semantics-varscopeddeclarations,sec-while-statement-static-semantics-varscopeddeclarations,sec-for-statement-static-semantics-varscopeddeclarations,sec-for-in-and-for-of-statements-static-semantics-varscopeddeclarations,sec-with-statement-static-semantics-varscopeddeclarations,sec-switch-statement-static-semantics-varscopeddeclarations,sec-labelled-statements-static-semantics-varscopeddeclarations,sec-try-statement-static-semantics-varscopeddeclarations,sec-function-definitions-static-semantics-varscopeddeclarations,sec-arrow-function-definitions-static-semantics-varscopeddeclarations,sec-async-arrow-function-definitions-static-semantics-VarScopedDeclarations,sec-scripts-static-semantics-varscopeddeclarations,sec-module-semantics-static-semantics-varscopeddeclarations" type="sdo">
       <h1>Static Semantics: VarScopedDeclarations</h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>
         Statement :
           EmptyStatement
@@ -8001,8 +8019,10 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-static-semantics-toplevellexicallydeclarednames" oldids="sec-block-static-semantics-toplevellexicallydeclarednames,sec-labelled-statements-static-semantics-toplevellexicallydeclarednames" type="sdo" aoid="TopLevelLexicallyDeclaredNames">
+    <emu-clause id="sec-static-semantics-toplevellexicallydeclarednames" oldids="sec-block-static-semantics-toplevellexicallydeclarednames,sec-labelled-statements-static-semantics-toplevellexicallydeclarednames" type="sdo">
       <h1>Static Semantics: TopLevelLexicallyDeclaredNames</h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
       <emu-alg>
         1. Let _names1_ be TopLevelLexicallyDeclaredNames of |StatementList|.
@@ -8024,8 +8044,10 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-static-semantics-toplevellexicallyscopeddeclarations" oldids="sec-block-static-semantics-toplevellexicallyscopeddeclarations,sec-labelled-statements-static-semantics-toplevellexicallyscopeddeclarations" type="sdo" aoid="TopLevelLexicallyScopedDeclarations">
+    <emu-clause id="sec-static-semantics-toplevellexicallyscopeddeclarations" oldids="sec-block-static-semantics-toplevellexicallyscopeddeclarations,sec-labelled-statements-static-semantics-toplevellexicallyscopeddeclarations" type="sdo">
       <h1>Static Semantics: TopLevelLexicallyScopedDeclarations</h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
       <emu-alg>
         1. Let _declarations1_ be TopLevelLexicallyScopedDeclarations of |StatementList|.
@@ -8044,8 +8066,10 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-static-semantics-toplevelvardeclarednames" oldids="sec-block-static-semantics-toplevelvardeclarednames,sec-labelled-statements-static-semantics-toplevelvardeclarednames" type="sdo" aoid="TopLevelVarDeclaredNames">
+    <emu-clause id="sec-static-semantics-toplevelvardeclarednames" oldids="sec-block-static-semantics-toplevelvardeclarednames,sec-labelled-statements-static-semantics-toplevelvardeclarednames" type="sdo">
       <h1>Static Semantics: TopLevelVarDeclaredNames</h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
       <emu-alg>
         1. Let _names1_ be TopLevelVarDeclaredNames of |StatementList|.
@@ -8081,8 +8105,10 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-static-semantics-toplevelvarscopeddeclarations" oldids="sec-block-static-semantics-toplevelvarscopeddeclarations,sec-labelled-statements-static-semantics-toplevelvarscopeddeclarations" type="sdo" aoid="TopLevelVarScopedDeclarations">
+    <emu-clause id="sec-static-semantics-toplevelvarscopeddeclarations" oldids="sec-block-static-semantics-toplevelvarscopeddeclarations,sec-labelled-statements-static-semantics-toplevelvarscopeddeclarations" type="sdo">
       <h1>Static Semantics: TopLevelVarScopedDeclarations</h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
       <emu-alg>
         1. Let _declarations1_ be TopLevelVarScopedDeclarations of |StatementList|.
@@ -8120,9 +8146,14 @@
   <emu-clause id="sec-syntax-directed-operations-labels">
     <h1>Labels</h1>
 
-    <emu-clause id="sec-static-semantics-containsduplicatelabels" oldids="sec-statement-semantics-static-semantics-containsduplicatelabels,sec-block-static-semantics-containsduplicatelabels,sec-if-statement-static-semantics-containsduplicatelabels,sec-do-while-statement-static-semantics-containsduplicatelabels,sec-while-statement-static-semantics-containsduplicatelabels,sec-for-statement-static-semantics-containsduplicatelabels,sec-for-in-and-for-of-statements-static-semantics-containsduplicatelabels,sec-with-statement-static-semantics-containsduplicatelabels,sec-switch-statement-static-semantics-containsduplicatelabels,sec-labelled-statements-static-semantics-containsduplicatelabels,sec-try-statement-static-semantics-containsduplicatelabels,sec-function-definitions-static-semantics-containsduplicatelabels,sec-module-semantics-static-semantics-containsduplicatelabels" type="sdo" aoid="ContainsDuplicateLabels">
-      <h1>Static Semantics: ContainsDuplicateLabels</h1>
-      <p>With parameter _labelSet_.</p>
+    <emu-clause id="sec-static-semantics-containsduplicatelabels" oldids="sec-statement-semantics-static-semantics-containsduplicatelabels,sec-block-static-semantics-containsduplicatelabels,sec-if-statement-static-semantics-containsduplicatelabels,sec-do-while-statement-static-semantics-containsduplicatelabels,sec-while-statement-static-semantics-containsduplicatelabels,sec-for-statement-static-semantics-containsduplicatelabels,sec-for-in-and-for-of-statements-static-semantics-containsduplicatelabels,sec-with-statement-static-semantics-containsduplicatelabels,sec-switch-statement-static-semantics-containsduplicatelabels,sec-labelled-statements-static-semantics-containsduplicatelabels,sec-try-statement-static-semantics-containsduplicatelabels,sec-function-definitions-static-semantics-containsduplicatelabels,sec-module-semantics-static-semantics-containsduplicatelabels" type="sdo">
+      <h1>
+        Static Semantics: ContainsDuplicateLabels (
+          _labelSet_: unknown,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>
         Statement :
           VariableStatement
@@ -8285,9 +8316,14 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-static-semantics-containsundefinedbreaktarget" oldids="sec-statement-semantics-static-semantics-containsundefinedbreaktarget,sec-block-static-semantics-containsundefinedbreaktarget,sec-if-statement-static-semantics-containsundefinedbreaktarget,sec-do-while-statement-static-semantics-containsundefinedbreaktarget,sec-while-statement-static-semantics-containsundefinedbreaktarget,sec-for-statement-static-semantics-containsundefinedbreaktarget,sec-for-in-and-for-of-statements-static-semantics-containsundefinedbreaktarget,sec-break-statement-static-semantics-containsundefinedbreaktarget,sec-with-statement-static-semantics-containsundefinedbreaktarget,sec-switch-statement-static-semantics-containsundefinedbreaktarget,sec-labelled-statements-static-semantics-containsundefinedbreaktarget,sec-try-statement-static-semantics-containsundefinedbreaktarget,sec-function-definitions-static-semantics-containsundefinedbreaktarget,sec-module-semantics-static-semantics-containsundefinedbreaktarget" type="sdo" aoid="ContainsUndefinedBreakTarget">
-      <h1>Static Semantics: ContainsUndefinedBreakTarget</h1>
-      <p>With parameter _labelSet_.</p>
+    <emu-clause id="sec-static-semantics-containsundefinedbreaktarget" oldids="sec-statement-semantics-static-semantics-containsundefinedbreaktarget,sec-block-static-semantics-containsundefinedbreaktarget,sec-if-statement-static-semantics-containsundefinedbreaktarget,sec-do-while-statement-static-semantics-containsundefinedbreaktarget,sec-while-statement-static-semantics-containsundefinedbreaktarget,sec-for-statement-static-semantics-containsundefinedbreaktarget,sec-for-in-and-for-of-statements-static-semantics-containsundefinedbreaktarget,sec-break-statement-static-semantics-containsundefinedbreaktarget,sec-with-statement-static-semantics-containsundefinedbreaktarget,sec-switch-statement-static-semantics-containsundefinedbreaktarget,sec-labelled-statements-static-semantics-containsundefinedbreaktarget,sec-try-statement-static-semantics-containsundefinedbreaktarget,sec-function-definitions-static-semantics-containsundefinedbreaktarget,sec-module-semantics-static-semantics-containsundefinedbreaktarget" type="sdo">
+      <h1>
+        Static Semantics: ContainsUndefinedBreakTarget (
+          _labelSet_: unknown,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>
         Statement :
           VariableStatement
@@ -8457,9 +8493,15 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-static-semantics-containsundefinedcontinuetarget" oldids="sec-statement-semantics-static-semantics-containsundefinedcontinuetarget,sec-block-static-semantics-containsundefinedcontinuetarget,sec-if-statement-static-semantics-containsundefinedcontinuetarget,sec-do-while-statement-static-semantics-containsundefinedcontinuetarget,sec-while-statement-static-semantics-containsundefinedcontinuetarget,sec-for-statement-static-semantics-containsundefinedcontinuetarget,sec-for-in-and-for-of-statements-static-semantics-containsundefinedcontinuetarget,sec-continue-statement-static-semantics-containsundefinedcontinuetarget,sec-with-statement-static-semantics-containsundefinedcontinuetarget,sec-switch-statement-static-semantics-containsundefinedcontinuetarget,sec-labelled-statements-static-semantics-containsundefinedcontinuetarget,sec-try-statement-static-semantics-containsundefinedcontinuetarget,sec-function-definitions-static-semantics-containsundefinedcontinuetarget,sec-module-semantics-static-semantics-containsundefinedcontinuetarget" type="sdo" aoid="ContainsUndefinedContinueTarget">
-      <h1>Static Semantics: ContainsUndefinedContinueTarget</h1>
-      <p>With parameters _iterationSet_ and _labelSet_.</p>
+    <emu-clause id="sec-static-semantics-containsundefinedcontinuetarget" oldids="sec-statement-semantics-static-semantics-containsundefinedcontinuetarget,sec-block-static-semantics-containsundefinedcontinuetarget,sec-if-statement-static-semantics-containsundefinedcontinuetarget,sec-do-while-statement-static-semantics-containsundefinedcontinuetarget,sec-while-statement-static-semantics-containsundefinedcontinuetarget,sec-for-statement-static-semantics-containsundefinedcontinuetarget,sec-for-in-and-for-of-statements-static-semantics-containsundefinedcontinuetarget,sec-continue-statement-static-semantics-containsundefinedcontinuetarget,sec-with-statement-static-semantics-containsundefinedcontinuetarget,sec-switch-statement-static-semantics-containsundefinedcontinuetarget,sec-labelled-statements-static-semantics-containsundefinedcontinuetarget,sec-try-statement-static-semantics-containsundefinedcontinuetarget,sec-function-definitions-static-semantics-containsundefinedcontinuetarget,sec-module-semantics-static-semantics-containsundefinedcontinuetarget" type="sdo">
+      <h1>
+        Static Semantics: ContainsUndefinedContinueTarget (
+          _iterationSet_: unknown,
+          _labelSet_: unknown,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>
         Statement :
           VariableStatement
@@ -8641,8 +8683,10 @@
 
   <emu-clause id="sec-syntax-directed-operations-function-name-inference">
     <h1>Function Name Inference</h1>
-    <emu-clause id="sec-static-semantics-hasname" oldids="sec-semantics-static-semantics-hasname,sec-function-definitions-static-semantics-hasname,sec-arrow-function-definitions-static-semantics-hasname,sec-generator-function-definitions-static-semantics-hasname,sec-async-generator-function-definitions-static-semantics-hasname,sec-class-definitions-static-semantics-hasname,sec-async-function-definitions-static-semantics-HasName,sec-async-arrow-function-definitions-static-semantics-HasName" type="sdo" aoid="HasName">
+    <emu-clause id="sec-static-semantics-hasname" oldids="sec-semantics-static-semantics-hasname,sec-function-definitions-static-semantics-hasname,sec-arrow-function-definitions-static-semantics-hasname,sec-generator-function-definitions-static-semantics-hasname,sec-async-generator-function-definitions-static-semantics-hasname,sec-class-definitions-static-semantics-hasname,sec-async-function-definitions-static-semantics-HasName,sec-async-arrow-function-definitions-static-semantics-HasName" type="sdo">
       <h1>Static Semantics: HasName</h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
       <emu-alg>
         1. Let _expr_ be the |ParenthesizedExpression| that is covered by |CoverParenthesizedExpressionAndArrowParameterList|.
@@ -8694,8 +8738,10 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-static-semantics-isfunctiondefinition" oldids="sec-semantics-static-semantics-isfunctiondefinition,sec-grouping-operator-static-semantics-isfunctiondefinition,sec-static-semantics-static-semantics-isfunctiondefinition,sec-update-expressions-static-semantics-isfunctiondefinition,sec-unary-operators-static-semantics-isfunctiondefinition,sec-exp-operator-static-semantics-isfunctiondefinition,sec-multiplicative-operators-static-semantics-isfunctiondefinition,sec-additive-operators-static-semantics-isfunctiondefinition,sec-bitwise-shift-operators-static-semantics-isfunctiondefinition,sec-relational-operators-static-semantics-isfunctiondefinition,sec-equality-operators-static-semantics-isfunctiondefinition,sec-binary-bitwise-operators-static-semantics-isfunctiondefinition,sec-binary-logical-operators-static-semantics-isfunctiondefinition,sec-conditional-operator-static-semantics-isfunctiondefinition,sec-assignment-operators-static-semantics-isfunctiondefinition,sec-comma-operator-static-semantics-isfunctiondefinition,sec-function-definitions-static-semantics-isfunctiondefinition,sec-generator-function-definitions-static-semantics-isfunctiondefinition,sec-async-generator-function-definitions-static-semantics-isfunctiondefinition,sec-class-definitions-static-semantics-isfunctiondefinition,sec-async-function-definitions-static-semantics-IsFunctionDefinition" type="sdo" aoid="IsFunctionDefinition">
+    <emu-clause id="sec-static-semantics-isfunctiondefinition" oldids="sec-semantics-static-semantics-isfunctiondefinition,sec-grouping-operator-static-semantics-isfunctiondefinition,sec-static-semantics-static-semantics-isfunctiondefinition,sec-update-expressions-static-semantics-isfunctiondefinition,sec-unary-operators-static-semantics-isfunctiondefinition,sec-exp-operator-static-semantics-isfunctiondefinition,sec-multiplicative-operators-static-semantics-isfunctiondefinition,sec-additive-operators-static-semantics-isfunctiondefinition,sec-bitwise-shift-operators-static-semantics-isfunctiondefinition,sec-relational-operators-static-semantics-isfunctiondefinition,sec-equality-operators-static-semantics-isfunctiondefinition,sec-binary-bitwise-operators-static-semantics-isfunctiondefinition,sec-binary-logical-operators-static-semantics-isfunctiondefinition,sec-conditional-operator-static-semantics-isfunctiondefinition,sec-assignment-operators-static-semantics-isfunctiondefinition,sec-comma-operator-static-semantics-isfunctiondefinition,sec-function-definitions-static-semantics-isfunctiondefinition,sec-generator-function-definitions-static-semantics-isfunctiondefinition,sec-async-generator-function-definitions-static-semantics-isfunctiondefinition,sec-class-definitions-static-semantics-isfunctiondefinition,sec-async-function-definitions-static-semantics-IsFunctionDefinition" type="sdo">
       <h1>Static Semantics: IsFunctionDefinition</h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
       <emu-alg>
         1. Let _expr_ be the |ParenthesizedExpression| that is covered by |CoverParenthesizedExpressionAndArrowParameterList|.
@@ -8850,8 +8896,10 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-static-semantics-isidentifierref" oldids="sec-semantics-static-semantics-isidentifierref,sec-static-semantics-static-semantics-isidentifierref" type="sdo" aoid="IsIdentifierRef">
+    <emu-clause id="sec-static-semantics-isidentifierref" oldids="sec-semantics-static-semantics-isidentifierref,sec-static-semantics-static-semantics-isidentifierref" type="sdo">
       <h1>Static Semantics: IsIdentifierRef</h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>PrimaryExpression : IdentifierReference</emu-grammar>
       <emu-alg>
         1. Return *true*.
@@ -8892,9 +8940,14 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-runtime-semantics-namedevaluation" oldids="sec-grouping-operator-runtime-semantics-namedevaluation,sec-function-definitions-runtime-semantics-namedevaluation,sec-arrow-function-definitions-runtime-semantics-namedevaluation,sec-generator-function-definitions-runtime-semantics-namedevaluation,sec-asyncgenerator-definitions-namedevaluation,sec-class-definitions-runtime-semantics-namedevaluation,sec-async-function-definitions-runtime-semantics-namedevaluation,sec-async-arrow-function-definitions-runtime-semantics-namedevaluation" type="sdo" aoid="NamedEvaluation">
-      <h1>Runtime Semantics: NamedEvaluation</h1>
-      <p>With parameter _name_.</p>
+    <emu-clause id="sec-runtime-semantics-namedevaluation" oldids="sec-grouping-operator-runtime-semantics-namedevaluation,sec-function-definitions-runtime-semantics-namedevaluation,sec-arrow-function-definitions-runtime-semantics-namedevaluation,sec-generator-function-definitions-runtime-semantics-namedevaluation,sec-asyncgenerator-definitions-namedevaluation,sec-class-definitions-runtime-semantics-namedevaluation,sec-async-function-definitions-runtime-semantics-namedevaluation,sec-async-arrow-function-definitions-runtime-semantics-namedevaluation" type="sdo">
+      <h1>
+        Runtime Semantics: NamedEvaluation (
+          _name_: unknown,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
       <emu-alg>
         1. Let _expr_ be the |ParenthesizedExpression| that is covered by |CoverParenthesizedExpressionAndArrowParameterList|.
@@ -8950,9 +9003,14 @@
   <emu-clause id="sec-syntax-directed-operations-contains">
     <h1>Contains</h1>
 
-    <emu-clause id="sec-static-semantics-contains" oldids="sec-object-initializer-static-semantics-contains,sec-static-semantics-static-semantics-contains,sec-function-definitions-static-semantics-contains,sec-arrow-function-definitions-static-semantics-contains,sec-generator-function-definitions-static-semantics-contains,sec-async-generator-function-definitions-static-semantics-contains,sec-class-definitions-static-semantics-contains,sec-async-function-definitions-static-semantics-Contains,sec-async-arrow-function-definitions-static-semantics-Contains" type="sdo" aoid="Contains">
-      <h1>Static Semantics: Contains</h1>
-      <p>With parameter _symbol_.</p>
+    <emu-clause id="sec-static-semantics-contains" oldids="sec-object-initializer-static-semantics-contains,sec-static-semantics-static-semantics-contains,sec-function-definitions-static-semantics-contains,sec-arrow-function-definitions-static-semantics-contains,sec-generator-function-definitions-static-semantics-contains,sec-async-generator-function-definitions-static-semantics-contains,sec-class-definitions-static-semantics-contains,sec-async-function-definitions-static-semantics-Contains,sec-async-arrow-function-definitions-static-semantics-Contains" type="sdo">
+      <h1>
+        Static Semantics: Contains (
+          _symbol_: unknown,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <p>Every grammar production alternative in this specification which is not listed below implicitly has the following default definition of Contains:</p>
       <emu-alg>
         1. For each child node _child_ of this Parse Node, do
@@ -9081,9 +9139,14 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-static-semantics-computedpropertycontains" oldids="sec-object-initializer-static-semantics-computedpropertycontains,sec-method-definitions-static-semantics-computedpropertycontains,sec-generator-function-definitions-static-semantics-computedpropertycontains,sec-async-generator-function-definitions-static-semantics-computedpropertycontains,sec-class-definitions-static-semantics-computedpropertycontains,sec-async-function-definitions-static-semantics-ComputedPropertyContains" type="sdo" aoid="ComputedPropertyContains">
-      <h1>Static Semantics: ComputedPropertyContains</h1>
-      <p>With parameter _symbol_.</p>
+    <emu-clause id="sec-static-semantics-computedpropertycontains" oldids="sec-object-initializer-static-semantics-computedpropertycontains,sec-method-definitions-static-semantics-computedpropertycontains,sec-generator-function-definitions-static-semantics-computedpropertycontains,sec-async-generator-function-definitions-static-semantics-computedpropertycontains,sec-class-definitions-static-semantics-computedpropertycontains,sec-async-function-definitions-static-semantics-ComputedPropertyContains" type="sdo">
+      <h1>
+        Static Semantics: ComputedPropertyContains (
+          _symbol_: unknown,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>
         ClassElementName : PrivateIdentifier
 
@@ -9146,9 +9209,15 @@
     <h1>Miscellaneous</h1>
     <p>These operations are used in multiple places throughout the specification.</p>
 
-    <emu-clause id="sec-runtime-semantics-instantiatefunctionobject" type="sdo" aoid="InstantiateFunctionObject">
-      <h1>Runtime Semantics: InstantiateFunctionObject</h1>
-      <p>With parameters _scope_ and _privateScope_.</p>
+    <emu-clause id="sec-runtime-semantics-instantiatefunctionobject" type="sdo">
+      <h1>
+        Runtime Semantics: InstantiateFunctionObject (
+          _scope_: unknown,
+          _privateScope_: unknown,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>
         FunctionDeclaration :
           `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`
@@ -9183,9 +9252,15 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-runtime-semantics-bindinginitialization" oldids="sec-identifiers-runtime-semantics-bindinginitialization,sec-destructuring-binding-patterns-runtime-semantics-bindinginitialization" type="sdo" aoid="BindingInitialization">
-      <h1>Runtime Semantics: BindingInitialization</h1>
-      <p>With parameters _value_ and _environment_.</p>
+    <emu-clause id="sec-runtime-semantics-bindinginitialization" oldids="sec-identifiers-runtime-semantics-bindinginitialization,sec-destructuring-binding-patterns-runtime-semantics-bindinginitialization" type="sdo">
+      <h1>
+        Runtime Semantics: BindingInitialization (
+          _value_: unknown,
+          _environment_: unknown,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-note>
         <p>*undefined* is passed for _environment_ to indicate that a PutValue operation should be used to assign the initialization value. This is the case for `var` statements and formal parameter lists of some non-strict functions (See <emu-xref href="#sec-functiondeclarationinstantiation"></emu-xref>). In those cases a lexical binding is hoisted and preinitialized prior to evaluation of its initializer.</p>
       </emu-note>
@@ -9258,9 +9333,15 @@
       </emu-clause>
     </emu-clause>
 
-    <emu-clause id="sec-runtime-semantics-iteratorbindinginitialization" oldids="sec-destructuring-binding-patterns-runtime-semantics-iteratorbindinginitialization,sec-function-definitions-runtime-semantics-iteratorbindinginitialization,sec-arrow-function-definitions-runtime-semantics-iteratorbindinginitialization,sec-async-arrow-function-definitions-IteratorBindingInitialization" type="sdo" aoid="IteratorBindingInitialization">
-      <h1>Runtime Semantics: IteratorBindingInitialization</h1>
-      <p>With parameters _iteratorRecord_ and _environment_.</p>
+    <emu-clause id="sec-runtime-semantics-iteratorbindinginitialization" oldids="sec-destructuring-binding-patterns-runtime-semantics-iteratorbindinginitialization,sec-function-definitions-runtime-semantics-iteratorbindinginitialization,sec-arrow-function-definitions-runtime-semantics-iteratorbindinginitialization,sec-async-arrow-function-definitions-IteratorBindingInitialization" type="sdo">
+      <h1>
+        Runtime Semantics: IteratorBindingInitialization (
+          _iteratorRecord_: unknown,
+          _environment_: unknown,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-note>
         <p>When *undefined* is passed for _environment_ it indicates that a PutValue operation should be used to assign the initialization value. This is the case for formal parameter lists of non-strict functions. In that case the formal parameter bindings are preinitialized in order to deal with the possibility of multiple parameters with the same name.</p>
       </emu-note>
@@ -9429,8 +9510,10 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-static-semantics-assignmenttargettype" oldids="sec-identifiers-static-semantics-assignmenttargettype,sec-identifiers-static-semantics-isvalidsimpleassignmenttarget,sec-semantics-static-semantics-assignmenttargettype,sec-semantics-static-semantics-isvalidsimpleassignmenttarget,sec-grouping-operator-static-semantics-assignmenttargettype,sec-grouping-operator-static-semantics-isvalidsimpleassignmenttarget,sec-static-semantics-static-semantics-assignmenttargettype,sec-static-semantics-static-semantics-isvalidsimpleassignmenttarget,sec-update-expressions-static-semantics-assignmenttargettype,sec-update-expressions-static-semantics-isvalidsimpleassignmenttarget,sec-unary-operators-static-semantics-assignmenttargettype,sec-unary-operators-static-semantics-isvalidsimpleassignmenttarget,sec-exp-operator-static-semantics-assignmenttargettype,sec-exp-operator-static-semantics-isvalidsimpleassignmenttarget,sec-multiplicative-operators-static-semantics-assignmenttargettype,sec-multiplicative-operators-static-semantics-isvalidsimpleassignmenttarget,sec-additive-operators-static-semantics-assignmenttargettype,sec-additive-operators-static-semantics-isvalidsimpleassignmenttarget,sec-bitwise-shift-operators-static-semantics-assignmenttargettype,sec-bitwise-shift-operators-static-semantics-isvalidsimpleassignmenttarget,sec-relational-operators-static-semantics-assignmenttargettype,sec-relational-operators-static-semantics-isvalidsimpleassignmenttarget,sec-equality-operators-static-semantics-assignmenttargettype,sec-equality-operators-static-semantics-isvalidsimpleassignmenttarget,sec-binary-bitwise-operators-static-semantics-assignmenttargettype,sec-binary-bitwise-operators-static-semantics-isvalidsimpleassignmenttarget,sec-binary-logical-operators-static-semantics-assignmenttargettype,sec-binary-logical-operators-static-semantics-isvalidsimpleassignmenttarget,sec-conditional-operator-static-semantics-assignmenttargettype,sec-conditional-operator-static-semantics-isvalidsimpleassignmenttarget,sec-assignment-operators-static-semantics-assignmenttargettype,sec-assignment-operators-static-semantics-isvalidsimpleassignmenttarget,sec-comma-operator-static-semantics-assignmenttargettype,sec-comma-operator-static-semantics-isvalidsimpleassignmenttarget" type="sdo" aoid="AssignmentTargetType">
+    <emu-clause id="sec-static-semantics-assignmenttargettype" oldids="sec-identifiers-static-semantics-assignmenttargettype,sec-identifiers-static-semantics-isvalidsimpleassignmenttarget,sec-semantics-static-semantics-assignmenttargettype,sec-semantics-static-semantics-isvalidsimpleassignmenttarget,sec-grouping-operator-static-semantics-assignmenttargettype,sec-grouping-operator-static-semantics-isvalidsimpleassignmenttarget,sec-static-semantics-static-semantics-assignmenttargettype,sec-static-semantics-static-semantics-isvalidsimpleassignmenttarget,sec-update-expressions-static-semantics-assignmenttargettype,sec-update-expressions-static-semantics-isvalidsimpleassignmenttarget,sec-unary-operators-static-semantics-assignmenttargettype,sec-unary-operators-static-semantics-isvalidsimpleassignmenttarget,sec-exp-operator-static-semantics-assignmenttargettype,sec-exp-operator-static-semantics-isvalidsimpleassignmenttarget,sec-multiplicative-operators-static-semantics-assignmenttargettype,sec-multiplicative-operators-static-semantics-isvalidsimpleassignmenttarget,sec-additive-operators-static-semantics-assignmenttargettype,sec-additive-operators-static-semantics-isvalidsimpleassignmenttarget,sec-bitwise-shift-operators-static-semantics-assignmenttargettype,sec-bitwise-shift-operators-static-semantics-isvalidsimpleassignmenttarget,sec-relational-operators-static-semantics-assignmenttargettype,sec-relational-operators-static-semantics-isvalidsimpleassignmenttarget,sec-equality-operators-static-semantics-assignmenttargettype,sec-equality-operators-static-semantics-isvalidsimpleassignmenttarget,sec-binary-bitwise-operators-static-semantics-assignmenttargettype,sec-binary-bitwise-operators-static-semantics-isvalidsimpleassignmenttarget,sec-binary-logical-operators-static-semantics-assignmenttargettype,sec-binary-logical-operators-static-semantics-isvalidsimpleassignmenttarget,sec-conditional-operator-static-semantics-assignmenttargettype,sec-conditional-operator-static-semantics-isvalidsimpleassignmenttarget,sec-assignment-operators-static-semantics-assignmenttargettype,sec-assignment-operators-static-semantics-isvalidsimpleassignmenttarget,sec-comma-operator-static-semantics-assignmenttargettype,sec-comma-operator-static-semantics-isvalidsimpleassignmenttarget" type="sdo">
       <h1>Static Semantics: AssignmentTargetType</h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>IdentifierReference : Identifier</emu-grammar>
       <emu-alg>
         1. If this |IdentifierReference| is contained in strict mode code and StringValue of |Identifier| is *"eval"* or *"arguments"*, return ~invalid~.
@@ -9585,8 +9668,10 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-static-semantics-propname" oldids="sec-object-initializer-static-semantics-propname,sec-method-definitions-static-semantics-propname,sec-generator-function-definitions-static-semantics-propname,sec-async-generator-function-definitions-static-semantics-propname,sec-class-definitions-static-semantics-propname,sec-async-function-definitions-static-semantics-PropName" type="sdo" aoid="PropName">
+    <emu-clause id="sec-static-semantics-propname" oldids="sec-object-initializer-static-semantics-propname,sec-method-definitions-static-semantics-propname,sec-generator-function-definitions-static-semantics-propname,sec-async-generator-function-definitions-static-semantics-propname,sec-class-definitions-static-semantics-propname,sec-async-function-definitions-static-semantics-PropName" type="sdo">
       <h1>Static Semantics: PropName</h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>PropertyDefinition : IdentifierReference</emu-grammar>
       <emu-alg>
         1. Return StringValue of |IdentifierReference|.
@@ -13009,9 +13094,15 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-runtime-semantics-evaluatebody" type="sdo" aoid="EvaluateBody">
-        <h1>Runtime Semantics: EvaluateBody</h1>
-        <p>With parameters _functionObject_ and _argumentsList_ (a List).</p>
+      <emu-clause id="sec-runtime-semantics-evaluatebody" type="sdo">
+        <h1>
+          Runtime Semantics: EvaluateBody (
+            _functionObject_: unknown,
+            _argumentsList_: a List,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-grammar>FunctionBody : FunctionStatementList</emu-grammar>
         <emu-alg>
           1. Return ? EvaluateFunctionBody of |FunctionBody| with arguments _functionObject_ and _argumentsList_.
@@ -16499,8 +16590,10 @@
         </ul>
       </emu-clause>
 
-      <emu-clause id="sec-numericvalue" type="sdo" aoid="NumericValue">
+      <emu-clause id="sec-numericvalue" type="sdo">
         <h1>Static Semantics: NumericValue</h1>
+        <dl class="header">
+        </dl>
         <emu-grammar>NumericLiteral :: DecimalLiteral</emu-grammar>
         <emu-alg>
           1. Return RoundMVResult(MV of |DecimalLiteral|).
@@ -16649,9 +16742,14 @@
         </emu-note>
       </emu-clause>
 
-      <emu-clause id="sec-static-semantics-sv" oldids="sec-string-literals-static-semantics-stringvalue,sec-additional-syntax-string-literals-static-semantics" type="sdo" aoid="SV">
+      <emu-clause id="sec-static-semantics-sv" oldids="sec-string-literals-static-semantics-stringvalue,sec-additional-syntax-string-literals-static-semantics" type="sdo">
         <h1>Static Semantics: SV</h1>
-        <p>A string literal stands for a value of the String type. SV produces String values for string literals through recursive application on the various parts of the string literal. As part of this process, some Unicode code points within the string literal are interpreted as having a mathematical value, as described below or in <emu-xref href="#sec-literals-numeric-literals"></emu-xref>.</p>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>
+            <p>A string literal stands for a value of the String type. SV produces String values for string literals through recursive application on the various parts of the string literal. As part of this process, some Unicode code points within the string literal are interpreted as having a mathematical value, as described below or in <emu-xref href="#sec-literals-numeric-literals"></emu-xref>.</p>
+          </dd>
+        </dl>
         <ul>
           <li>
             The SV of <emu-grammar>StringLiteral :: `"` `"`</emu-grammar> is the empty String.
@@ -16980,16 +17078,20 @@
         </ul>
       </emu-clause>
 
-      <emu-clause id="sec-static-semantics-bodytext" type="sdo" aoid="BodyText">
+      <emu-clause id="sec-static-semantics-bodytext" type="sdo">
         <h1>Static Semantics: BodyText</h1>
+        <dl class="header">
+        </dl>
         <emu-grammar>RegularExpressionLiteral :: `/` RegularExpressionBody `/` RegularExpressionFlags</emu-grammar>
         <emu-alg>
           1. Return the source text that was recognized as |RegularExpressionBody|.
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-static-semantics-flagtext" type="sdo" aoid="FlagText">
+      <emu-clause id="sec-static-semantics-flagtext" type="sdo">
         <h1>Static Semantics: FlagText</h1>
+        <dl class="header">
+        </dl>
         <emu-grammar>RegularExpressionLiteral :: `/` RegularExpressionBody `/` RegularExpressionFlags</emu-grammar>
         <emu-alg>
           1. Return the source text that was recognized as |RegularExpressionFlags|.
@@ -17061,9 +17163,12 @@
         <p>|TemplateSubstitutionTail| is used by the |InputElementTemplateTail| alternative lexical goal.</p>
       </emu-note>
 
-      <emu-clause id="sec-static-semantics-tv" type="sdo" aoid="TV" oldids="sec-static-semantics-tv-and-trv">
+      <emu-clause id="sec-static-semantics-tv" type="sdo" oldids="sec-static-semantics-tv-and-trv">
         <h1>Static Semantics: TV</h1>
-        <p>A template literal component is interpreted by TV as a value of the String type. TV is used to construct the indexed components of a template object (colloquially, the template values). In TV, escape sequences are replaced by the UTF-16 code unit(s) of the Unicode code point represented by the escape sequence.</p>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>A template literal component is interpreted by TV as a value of the String type. TV is used to construct the indexed components of a template object (colloquially, the template values). In TV, escape sequences are replaced by the UTF-16 code unit(s) of the Unicode code point represented by the escape sequence.</dd>
+        </dl>
         <ul>
           <li>
             The TV of <emu-grammar>NoSubstitutionTemplate :: ``` ```</emu-grammar> is the empty String.
@@ -17101,9 +17206,12 @@
         </ul>
       </emu-clause>
 
-      <emu-clause id="sec-static-semantics-trv" type="sdo" aoid="TRV">
+      <emu-clause id="sec-static-semantics-trv" type="sdo">
         <h1>Static Semantics: TRV</h1>
-        <p>A template literal component is interpreted by TRV as a value of the String type. TRV is used to construct the raw components of a template object (colloquially, the template raw values). TRV is similar to TV with the difference being that in TRV, escape sequences are interpreted as they appear in the literal.</p>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>A template literal component is interpreted by TRV as a value of the String type. TRV is used to construct the raw components of a template object (colloquially, the template raw values). TRV is similar to TV with the difference being that in TRV, escape sequences are interpreted as they appear in the literal.</dd>
+        </dl>
         <ul>
           <li>
             The TRV of <emu-grammar>NoSubstitutionTemplate :: ``` ```</emu-grammar> is the empty String.
@@ -17563,8 +17671,10 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-static-semantics-stringvalue" oldids="sec-identifiers-static-semantics-stringvalue,sec-identifier-names-static-semantics-stringvalue" type="sdo" aoid="StringValue">
+    <emu-clause id="sec-static-semantics-stringvalue" oldids="sec-identifiers-static-semantics-stringvalue,sec-identifier-names-static-semantics-stringvalue" type="sdo">
       <h1>Static Semantics: StringValue</h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>
         IdentifierName ::
           IdentifierStart
@@ -17747,9 +17857,15 @@
           `...` AssignmentExpression[+In, ?Yield, ?Await]
       </emu-grammar>
 
-      <emu-clause id="sec-runtime-semantics-arrayaccumulation" oldids="sec-static-semantics-elisionwidth" type="sdo" aoid="ArrayAccumulation">
-        <h1>Runtime Semantics: ArrayAccumulation</h1>
-        <p>With parameters _array_ and _nextIndex_.</p>
+      <emu-clause id="sec-runtime-semantics-arrayaccumulation" oldids="sec-static-semantics-elisionwidth" type="sdo">
+        <h1>
+          Runtime Semantics: ArrayAccumulation (
+            _array_: unknown,
+            _nextIndex_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-grammar>Elision : `,`</emu-grammar>
         <emu-alg>
           1. Let _len_ be _nextIndex_ + 1.
@@ -17930,8 +18046,10 @@
         </emu-note>
       </emu-clause>
 
-      <emu-clause id="sec-static-semantics-iscomputedpropertykey" type="sdo" aoid="IsComputedPropertyKey">
+      <emu-clause id="sec-static-semantics-iscomputedpropertykey" type="sdo">
         <h1>Static Semantics: IsComputedPropertyKey</h1>
+        <dl class="header">
+        </dl>
         <emu-grammar>PropertyName : LiteralPropertyName</emu-grammar>
         <emu-alg>
           1. Return *false*.
@@ -17942,8 +18060,10 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-static-semantics-propertynamelist" type="sdo" aoid="PropertyNameList">
+      <emu-clause id="sec-static-semantics-propertynamelist" type="sdo">
         <h1>Static Semantics: PropertyNameList</h1>
+        <dl class="header">
+        </dl>
         <emu-grammar>PropertyDefinitionList : PropertyDefinition</emu-grammar>
         <emu-alg>
           1. Let _propName_ be PropName of |PropertyDefinition|.
@@ -17995,9 +18115,14 @@
           1. Return ? ToPropertyKey(_propName_).
         </emu-alg>
       </emu-clause>
-      <emu-clause id="sec-runtime-semantics-propertydefinitionevaluation" oldids="sec-object-initializer-runtime-semantics-propertydefinitionevaluation" type="sdo" aoid="PropertyDefinitionEvaluation">
-        <h1>Runtime Semantics: PropertyDefinitionEvaluation</h1>
-        <p>With parameter _object_.</p>
+      <emu-clause id="sec-runtime-semantics-propertydefinitionevaluation" oldids="sec-object-initializer-runtime-semantics-propertydefinitionevaluation" type="sdo">
+        <h1>
+          Runtime Semantics: PropertyDefinitionEvaluation (
+            _object_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-grammar>PropertyDefinitionList : PropertyDefinitionList `,` PropertyDefinition</emu-grammar>
         <emu-alg>
           1. Perform ? PropertyDefinitionEvaluation of |PropertyDefinitionList| with argument _object_.
@@ -18174,9 +18299,14 @@
         </ul>
       </emu-clause>
 
-      <emu-clause id="sec-static-semantics-templatestrings" type="sdo" aoid="TemplateStrings">
-        <h1>Static Semantics: TemplateStrings</h1>
-        <p>With parameter _raw_.</p>
+      <emu-clause id="sec-static-semantics-templatestrings" type="sdo">
+        <h1>
+          Static Semantics: TemplateStrings (
+            _raw_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-grammar>TemplateLiteral : NoSubstitutionTemplate</emu-grammar>
         <emu-alg>
           1. If _raw_ is *false*, then
@@ -18275,8 +18405,10 @@
         </emu-note>
       </emu-clause>
 
-      <emu-clause id="sec-runtime-semantics-substitutionevaluation" type="sdo" aoid="SubstitutionEvaluation">
+      <emu-clause id="sec-runtime-semantics-substitutionevaluation" type="sdo">
         <h1>Runtime Semantics: SubstitutionEvaluation</h1>
+        <dl class="header">
+        </dl>
         <emu-grammar>TemplateSpans : TemplateTail</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
@@ -18821,8 +18953,10 @@
         <p>The evaluation of an argument list produces a List of values.</p>
       </emu-note>
 
-      <emu-clause id="sec-runtime-semantics-argumentlistevaluation" oldids="sec-template-literals-runtime-semantics-argumentlistevaluation,sec-argument-lists-runtime-semantics-argumentlistevaluation" type="sdo" aoid="ArgumentListEvaluation">
+      <emu-clause id="sec-runtime-semantics-argumentlistevaluation" oldids="sec-template-literals-runtime-semantics-argumentlistevaluation,sec-argument-lists-runtime-semantics-argumentlistevaluation" type="sdo">
         <h1>Runtime Semantics: ArgumentListEvaluation</h1>
+        <dl class="header">
+        </dl>
         <emu-grammar>Arguments : `(` `)`</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
@@ -18926,9 +19060,15 @@
           1. Return the result of performing ChainEvaluation of |OptionalChain| with arguments _baseValue_ and _baseReference_.
         </emu-alg>
       </emu-clause>
-      <emu-clause id="sec-optional-chaining-chain-evaluation" type="sdo" aoid="ChainEvaluation">
-        <h1>Runtime Semantics: ChainEvaluation</h1>
-        <p>With parameters _baseValue_ and _baseReference_.</p>
+      <emu-clause id="sec-optional-chaining-chain-evaluation" type="sdo">
+        <h1>
+          Runtime Semantics: ChainEvaluation (
+            _baseValue_: unknown,
+            _baseReference_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-grammar>OptionalChain : `?.` Arguments</emu-grammar>
         <emu-alg>
           1. Let _thisChain_ be this |OptionalChain|.
@@ -20249,9 +20389,14 @@
         </ul>
       </emu-clause>
 
-      <emu-clause id="sec-runtime-semantics-destructuringassignmentevaluation" type="sdo" aoid="DestructuringAssignmentEvaluation">
-        <h1>Runtime Semantics: DestructuringAssignmentEvaluation</h1>
-        <p>With parameter _value_.</p>
+      <emu-clause id="sec-runtime-semantics-destructuringassignmentevaluation" type="sdo">
+        <h1>
+          Runtime Semantics: DestructuringAssignmentEvaluation (
+            _value_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-grammar>ObjectAssignmentPattern : `{` `}`</emu-grammar>
         <emu-alg>
           1. Perform ? RequireObjectCoercible(_value_).
@@ -20330,12 +20475,16 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-runtime-semantics-propertydestructuringassignmentevaluation" type="sdo" aoid="PropertyDestructuringAssignmentEvaluation">
-        <h1>Runtime Semantics: PropertyDestructuringAssignmentEvaluation</h1>
-        <p>With parameter _value_.</p>
-
-        <emu-note>The following operations collect a list of all destructured property names.</emu-note>
-
+      <emu-clause id="sec-runtime-semantics-propertydestructuringassignmentevaluation" type="sdo">
+        <h1>
+          Runtime Semantics: PropertyDestructuringAssignmentEvaluation (
+            _value_: unknown,
+          )
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It collects a list of all destructured property names.</dd>
+        </dl>
         <emu-grammar>AssignmentPropertyList : AssignmentPropertyList `,` AssignmentProperty</emu-grammar>
         <emu-alg>
           1. Let _propertyNames_ be ? PropertyDestructuringAssignmentEvaluation of |AssignmentPropertyList| with argument _value_.
@@ -20367,10 +20516,15 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-runtime-semantics-restdestructuringassignmentevaluation" type="sdo" aoid="RestDestructuringAssignmentEvaluation">
-        <h1>Runtime Semantics: RestDestructuringAssignmentEvaluation</h1>
-        <p>With parameters _value_ and _excludedNames_.</p>
-
+      <emu-clause id="sec-runtime-semantics-restdestructuringassignmentevaluation" type="sdo">
+        <h1>
+          Runtime Semantics: RestDestructuringAssignmentEvaluation (
+            _value_: unknown,
+            _excludedNames_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-grammar>AssignmentRestProperty : `...` DestructuringAssignmentTarget</emu-grammar>
         <emu-alg>
           1. Let _lref_ be the result of evaluating |DestructuringAssignmentTarget|.
@@ -20381,9 +20535,14 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-runtime-semantics-iteratordestructuringassignmentevaluation" type="sdo" aoid="IteratorDestructuringAssignmentEvaluation">
-        <h1>Runtime Semantics: IteratorDestructuringAssignmentEvaluation</h1>
-        <p>With parameter _iteratorRecord_.</p>
+      <emu-clause id="sec-runtime-semantics-iteratordestructuringassignmentevaluation" type="sdo">
+        <h1>
+          Runtime Semantics: IteratorDestructuringAssignmentEvaluation (
+            _iteratorRecord_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-grammar>AssignmentElementList : AssignmentElisionElement</emu-grammar>
         <emu-alg>
           1. Return the result of performing IteratorDestructuringAssignmentEvaluation of |AssignmentElisionElement| using _iteratorRecord_ as the argument.
@@ -20476,9 +20635,15 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-runtime-semantics-keyeddestructuringassignmentevaluation" type="sdo" aoid="KeyedDestructuringAssignmentEvaluation">
-        <h1>Runtime Semantics: KeyedDestructuringAssignmentEvaluation</h1>
-        <p>With parameters _value_ and _propertyName_.</p>
+      <emu-clause id="sec-runtime-semantics-keyeddestructuringassignmentevaluation" type="sdo">
+        <h1>
+          Runtime Semantics: KeyedDestructuringAssignmentEvaluation (
+            _value_: unknown,
+            _propertyName_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-grammar>AssignmentElement : DestructuringAssignmentTarget Initializer?</emu-grammar>
         <emu-alg>
           1. If |DestructuringAssignmentTarget| is neither an |ObjectLiteral| nor an |ArrayLiteral|, then
@@ -20896,12 +21061,17 @@
           `...` BindingPattern[?Yield, ?Await]
       </emu-grammar>
 
-      <emu-clause id="sec-destructuring-binding-patterns-runtime-semantics-propertybindinginitialization" type="sdo" aoid="PropertyBindingInitialization">
-        <h1>Runtime Semantics: PropertyBindingInitialization</h1>
-        <p>With parameters _value_ and _environment_.</p>
-
-        <emu-note>These collect a list of all bound property names rather than just empty completion.</emu-note>
-
+      <emu-clause id="sec-destructuring-binding-patterns-runtime-semantics-propertybindinginitialization" type="sdo">
+        <h1>
+          Runtime Semantics: PropertyBindingInitialization (
+            _value_: unknown,
+            _environment_: unknown,
+          )
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It collects a list of all bound property names rather than just empty completion.</dd>
+        </dl>
         <emu-grammar>BindingPropertyList : BindingPropertyList `,` BindingProperty</emu-grammar>
         <emu-alg>
           1. Let _boundNames_ be ? PropertyBindingInitialization of |BindingPropertyList| with arguments _value_ and _environment_.
@@ -20925,10 +21095,16 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-destructuring-binding-patterns-runtime-semantics-restbindinginitialization" type="sdo" aoid="RestBindingInitialization">
-        <h1>Runtime Semantics: RestBindingInitialization</h1>
-        <p>With parameters _value_, _environment_, and _excludedNames_.</p>
-
+      <emu-clause id="sec-destructuring-binding-patterns-runtime-semantics-restbindinginitialization" type="sdo">
+        <h1>
+          Runtime Semantics: RestBindingInitialization (
+            _value_: unknown,
+            _environment_: unknown,
+            _excludedNames_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-grammar>BindingRestProperty : `...` BindingIdentifier</emu-grammar>
         <emu-alg>
           1. Let _lhs_ be ? ResolveBinding(StringValue of |BindingIdentifier|, _environment_).
@@ -20939,9 +21115,16 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-runtime-semantics-keyedbindinginitialization" type="sdo" aoid="KeyedBindingInitialization">
-        <h1>Runtime Semantics: KeyedBindingInitialization</h1>
-        <p>With parameters _value_, _environment_, and _propertyName_.</p>
+      <emu-clause id="sec-runtime-semantics-keyedbindinginitialization" type="sdo">
+        <h1>
+          Runtime Semantics: KeyedBindingInitialization (
+            _value_: unknown,
+            _environment_: unknown,
+            _propertyName_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-note>
           <p>When *undefined* is passed for _environment_ it indicates that a PutValue operation should be used to assign the initialization value. This is the case for formal parameter lists of non-strict functions. In that case the formal parameter bindings are preinitialized in order to deal with the possibility of multiple parameters with the same name.</p>
         </emu-note>
@@ -21101,9 +21284,14 @@
         </emu-note>
       </emu-clause>
 
-      <emu-clause id="sec-runtime-semantics-loopevaluation" type="sdo" aoid="LoopEvaluation">
-        <h1>Runtime Semantics: LoopEvaluation</h1>
-        <p>With parameter _labelSet_.</p>
+      <emu-clause id="sec-runtime-semantics-loopevaluation" type="sdo">
+        <h1>
+          Runtime Semantics: LoopEvaluation (
+            _labelSet_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-grammar>IterationStatement : DoWhileStatement</emu-grammar>
         <emu-alg>
           1. Return ? DoWhileLoopEvaluation of |DoWhileStatement| with argument _labelSet_.
@@ -21144,9 +21332,14 @@
         </emu-note>
       </emu-clause>
 
-      <emu-clause id="sec-runtime-semantics-dowhileloopevaluation" oldids="sec-do-while-statement-runtime-semantics-labelledevaluation" type="sdo" aoid="DoWhileLoopEvaluation">
-        <h1>Runtime Semantics: DoWhileLoopEvaluation</h1>
-        <p>With parameter _labelSet_.</p>
+      <emu-clause id="sec-runtime-semantics-dowhileloopevaluation" oldids="sec-do-while-statement-runtime-semantics-labelledevaluation" type="sdo">
+        <h1>
+          Runtime Semantics: DoWhileLoopEvaluation (
+            _labelSet_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-grammar>DoWhileStatement : `do` Statement `while` `(` Expression `)` `;`</emu-grammar>
         <emu-alg>
           1. Let _V_ be *undefined*.
@@ -21182,9 +21375,14 @@
         </emu-note>
       </emu-clause>
 
-      <emu-clause id="sec-runtime-semantics-whileloopevaluation" oldids="sec-while-statement-runtime-semantics-labelledevaluation" type="sdo" aoid="WhileLoopEvaluation">
-        <h1>Runtime Semantics: WhileLoopEvaluation</h1>
-        <p>With parameter _labelSet_.</p>
+      <emu-clause id="sec-runtime-semantics-whileloopevaluation" oldids="sec-while-statement-runtime-semantics-labelledevaluation" type="sdo">
+        <h1>
+          Runtime Semantics: WhileLoopEvaluation (
+            _labelSet_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-grammar>WhileStatement : `while` `(` Expression `)` Statement</emu-grammar>
         <emu-alg>
           1. Let _V_ be *undefined*.
@@ -21233,9 +21431,14 @@
         </ul>
       </emu-clause>
 
-      <emu-clause id="sec-runtime-semantics-forloopevaluation" oldids="sec-for-statement-runtime-semantics-labelledevaluation" type="sdo" aoid="ForLoopEvaluation">
-        <h1>Runtime Semantics: ForLoopEvaluation</h1>
-        <p>With parameter _labelSet_.</p>
+      <emu-clause id="sec-runtime-semantics-forloopevaluation" oldids="sec-for-statement-runtime-semantics-labelledevaluation" type="sdo">
+        <h1>
+          Runtime Semantics: ForLoopEvaluation (
+            _labelSet_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-grammar>ForStatement : `for` `(` Expression? `;` Expression? `;` Expression? `)` Statement</emu-grammar>
         <emu-alg>
           1. If the first |Expression| is present, then
@@ -21414,8 +21617,10 @@
         </ul>
       </emu-clause>
 
-      <emu-clause id="sec-static-semantics-isdestructuring" oldids="sec-static-semantics-static-semantics-isdestructuring,sec-for-in-and-for-of-statements-static-semantics-isdestructuring" type="sdo" aoid="IsDestructuring">
+      <emu-clause id="sec-static-semantics-isdestructuring" oldids="sec-static-semantics-static-semantics-isdestructuring,sec-for-in-and-for-of-statements-static-semantics-isdestructuring" type="sdo">
         <h1>Static Semantics: IsDestructuring</h1>
+        <dl class="header">
+        </dl>
         <emu-grammar>MemberExpression : PrimaryExpression</emu-grammar>
         <emu-alg>
           1. If |PrimaryExpression| is either an |ObjectLiteral| or an |ArrayLiteral|, return *true*.
@@ -21458,9 +21663,15 @@
         </emu-note>
       </emu-clause>
 
-      <emu-clause id="sec-runtime-semantics-fordeclarationbindinginitialization" oldids="sec-for-in-and-for-of-statements-runtime-semantics-bindinginitialization" type="sdo" aoid="ForDeclarationBindingInitialization">
-        <h1>Runtime Semantics: ForDeclarationBindingInitialization</h1>
-        <p>With parameters _value_ and _environment_.</p>
+      <emu-clause id="sec-runtime-semantics-fordeclarationbindinginitialization" oldids="sec-for-in-and-for-of-statements-runtime-semantics-bindinginitialization" type="sdo">
+        <h1>
+          Runtime Semantics: ForDeclarationBindingInitialization (
+            _value_: unknown,
+            _environment_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-note>
           <p>*undefined* is passed for _environment_ to indicate that a PutValue operation should be used to assign the initialization value. This is the case for `var` statements and the formal parameter lists of some non-strict functions (see <emu-xref href="#sec-functiondeclarationinstantiation"></emu-xref>). In those cases a lexical binding is hoisted and preinitialized prior to evaluation of its initializer.</p>
         </emu-note>
@@ -21470,9 +21681,14 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-runtime-semantics-fordeclarationbindinginstantiation" oldids="sec-runtime-semantics-bindinginstantiation" type="sdo" aoid="ForDeclarationBindingInstantiation">
-        <h1>Runtime Semantics: ForDeclarationBindingInstantiation</h1>
-        <p>With parameter _environment_.</p>
+      <emu-clause id="sec-runtime-semantics-fordeclarationbindinginstantiation" oldids="sec-runtime-semantics-bindinginstantiation" type="sdo">
+        <h1>
+          Runtime Semantics: ForDeclarationBindingInstantiation (
+            _environment_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-grammar>ForDeclaration : LetOrConst ForBinding</emu-grammar>
         <emu-alg>
           1. Assert: _environment_ is a declarative Environment Record.
@@ -21484,9 +21700,14 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-runtime-semantics-forinofloopevaluation" oldids="sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation" type="sdo" aoid="ForInOfLoopEvaluation">
-        <h1>Runtime Semantics: ForInOfLoopEvaluation</h1>
-        <p>With parameter _labelSet_.</p>
+      <emu-clause id="sec-runtime-semantics-forinofloopevaluation" oldids="sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation" type="sdo">
+        <h1>
+          Runtime Semantics: ForInOfLoopEvaluation (
+            _labelSet_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-grammar>ForInOfStatement : `for` `(` LeftHandSideExpression `in` Expression `)` Statement</emu-grammar>
         <emu-alg>
           1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(&laquo; &raquo;, |Expression|, ~enumerate~).
@@ -22026,9 +22247,14 @@
       </ul>
     </emu-clause>
 
-    <emu-clause id="sec-runtime-semantics-caseblockevaluation" type="sdo" aoid="CaseBlockEvaluation">
-      <h1>Runtime Semantics: CaseBlockEvaluation</h1>
-      <p>With parameter _input_.</p>
+    <emu-clause id="sec-runtime-semantics-caseblockevaluation" type="sdo">
+      <h1>
+        Runtime Semantics: CaseBlockEvaluation (
+          _input_: unknown,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>CaseBlock : `{` `}`</emu-grammar>
       <emu-alg>
         1. Return NormalCompletion(*undefined*).
@@ -22200,9 +22426,14 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-runtime-semantics-labelledevaluation" oldids="sec-statement-semantics-runtime-semantics-labelledevaluation,sec-labelled-statements-runtime-semantics-labelledevaluation" type="sdo" aoid="LabelledEvaluation">
-      <h1>Runtime Semantics: LabelledEvaluation</h1>
-      <p>With parameter _labelSet_.</p>
+    <emu-clause id="sec-runtime-semantics-labelledevaluation" oldids="sec-statement-semantics-runtime-semantics-labelledevaluation,sec-labelled-statements-runtime-semantics-labelledevaluation" type="sdo">
+      <h1>
+        Runtime Semantics: LabelledEvaluation (
+          _labelSet_: unknown,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>BreakableStatement : IterationStatement</emu-grammar>
       <emu-alg>
         1. Let _stmtResult_ be LoopEvaluation of |IterationStatement| with argument _labelSet_.
@@ -22323,9 +22554,14 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-runtime-semantics-catchclauseevaluation" type="sdo" aoid="CatchClauseEvaluation">
-      <h1>Runtime Semantics: CatchClauseEvaluation</h1>
-      <p>With parameter _thrownValue_.</p>
+    <emu-clause id="sec-runtime-semantics-catchclauseevaluation" type="sdo">
+      <h1>
+        Runtime Semantics: CatchClauseEvaluation (
+          _thrownValue_: unknown,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
       <emu-alg>
         1. Let _oldEnv_ be the running execution context's LexicalEnvironment.
@@ -22453,8 +22689,10 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-static-semantics-containsexpression" oldids="sec-destructuring-binding-patterns-static-semantics-containsexpression,sec-function-definitions-static-semantics-containsexpression,sec-arrow-function-definitions-static-semantics-containsexpression,sec-async-arrow-function-definitions-static-semantics-ContainsExpression" type="sdo" aoid="ContainsExpression">
+    <emu-clause id="sec-static-semantics-containsexpression" oldids="sec-destructuring-binding-patterns-static-semantics-containsexpression,sec-function-definitions-static-semantics-containsexpression,sec-arrow-function-definitions-static-semantics-containsexpression,sec-async-arrow-function-definitions-static-semantics-ContainsExpression" type="sdo">
       <h1>Static Semantics: ContainsExpression</h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>
         ObjectBindingPattern :
           `{` `}`
@@ -22558,8 +22796,10 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-static-semantics-issimpleparameterlist" oldids="sec-destructuring-binding-patterns-static-semantics-issimpleparameterlist,sec-function-definitions-static-semantics-issimpleparameterlist,sec-arrow-function-definitions-static-semantics-issimpleparameterlist,sec-async-arrow-function-definitions-static-semantics-IsSimpleParameterList" type="sdo" aoid="IsSimpleParameterList">
+    <emu-clause id="sec-static-semantics-issimpleparameterlist" oldids="sec-destructuring-binding-patterns-static-semantics-issimpleparameterlist,sec-function-definitions-static-semantics-issimpleparameterlist,sec-arrow-function-definitions-static-semantics-issimpleparameterlist,sec-async-arrow-function-definitions-static-semantics-IsSimpleParameterList" type="sdo">
       <h1>Static Semantics: IsSimpleParameterList</h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>BindingElement : BindingPattern</emu-grammar>
       <emu-alg>
         1. Return *false*.
@@ -22621,8 +22861,10 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-static-semantics-hasinitializer" oldids="sec-destructuring-binding-patterns-static-semantics-hasinitializer,sec-function-definitions-static-semantics-hasinitializer" type="sdo" aoid="HasInitializer">
+    <emu-clause id="sec-static-semantics-hasinitializer" oldids="sec-destructuring-binding-patterns-static-semantics-hasinitializer,sec-function-definitions-static-semantics-hasinitializer" type="sdo">
       <h1>Static Semantics: HasInitializer</h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>BindingElement : BindingPattern</emu-grammar>
       <emu-alg>
         1. Return *false*.
@@ -22646,8 +22888,10 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-static-semantics-expectedargumentcount" oldids="sec-function-definitions-static-semantics-expectedargumentcount,sec-arrow-function-definitions-static-semantics-expectedargumentcount,sec-method-definitions-static-semantics-expectedargumentcount,sec-async-arrow-function-definitions-static-semantics-ExpectedArgumentCount" type="sdo" aoid="ExpectedArgumentCount">
+    <emu-clause id="sec-static-semantics-expectedargumentcount" oldids="sec-function-definitions-static-semantics-expectedargumentcount,sec-arrow-function-definitions-static-semantics-expectedargumentcount,sec-method-definitions-static-semantics-expectedargumentcount,sec-async-arrow-function-definitions-static-semantics-ExpectedArgumentCount" type="sdo">
       <h1>Static Semantics: ExpectedArgumentCount</h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>
         FormalParameters :
           [empty]
@@ -22774,17 +23018,25 @@
       </ul>
     </emu-clause>
 
-    <emu-clause id="sec-static-semantics-functionbodycontainsusestrict" oldids="sec-function-definitions-static-semantics-containsusestrict" type="sdo" aoid="FunctionBodyContainsUseStrict">
+    <emu-clause id="sec-static-semantics-functionbodycontainsusestrict" oldids="sec-function-definitions-static-semantics-containsusestrict" type="sdo">
       <h1>Static Semantics: FunctionBodyContainsUseStrict</h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>FunctionBody : FunctionStatementList</emu-grammar>
       <emu-alg>
         1. If the Directive Prologue of |FunctionBody| contains a Use Strict Directive, return *true*; otherwise, return *false*.
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-runtime-semantics-evaluatefunctionbody" oldids="sec-function-definitions-runtime-semantics-evaluatebody" type="sdo" aoid="EvaluateFunctionBody">
-      <h1>Runtime Semantics: EvaluateFunctionBody</h1>
-      <p>With parameters _functionObject_ and _argumentsList_ (a List).</p>
+    <emu-clause id="sec-runtime-semantics-evaluatefunctionbody" oldids="sec-function-definitions-runtime-semantics-evaluatebody" type="sdo">
+      <h1>
+        Runtime Semantics: EvaluateFunctionBody (
+          _functionObject_: unknown,
+          _argumentsList_: a List,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>FunctionBody : FunctionStatementList</emu-grammar>
       <emu-alg>
         1. Perform ? FunctionDeclarationInstantiation(_functionObject_, _argumentsList_).
@@ -22792,9 +23044,15 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-runtime-semantics-instantiateordinaryfunctionobject" oldids="sec-function-definitions-runtime-semantics-instantiatefunctionobject" type="sdo" aoid="InstantiateOrdinaryFunctionObject">
-      <h1>Runtime Semantics: InstantiateOrdinaryFunctionObject</h1>
-      <p>With parameters _scope_ and _privateScope_.</p>
+    <emu-clause id="sec-runtime-semantics-instantiateordinaryfunctionobject" oldids="sec-function-definitions-runtime-semantics-instantiatefunctionobject" type="sdo">
+      <h1>
+        Runtime Semantics: InstantiateOrdinaryFunctionObject (
+          _scope_: unknown,
+          _privateScope_: unknown,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>FunctionDeclaration : `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Let _name_ be StringValue of |BindingIdentifier|.
@@ -22817,9 +23075,14 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-runtime-semantics-instantiateordinaryfunctionexpression" type="sdo" aoid="InstantiateOrdinaryFunctionExpression">
-      <h1>Runtime Semantics: InstantiateOrdinaryFunctionExpression</h1>
-      <p>With optional parameter _name_.</p>
+    <emu-clause id="sec-runtime-semantics-instantiateordinaryfunctionexpression" type="sdo">
+      <h1>
+        Runtime Semantics: InstantiateOrdinaryFunctionExpression (
+          optional _name_: unknown,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>FunctionExpression : `function` `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. If _name_ is not present, set _name_ to *""*.
@@ -22937,8 +23200,10 @@
       </ul>
     </emu-clause>
 
-    <emu-clause id="sec-static-semantics-concisebodycontainsusestrict" oldids="sec-arrow-function-definitions-static-semantics-containsusestrict" type="sdo" aoid="ConciseBodyContainsUseStrict">
+    <emu-clause id="sec-static-semantics-concisebodycontainsusestrict" oldids="sec-arrow-function-definitions-static-semantics-containsusestrict" type="sdo">
       <h1>Static Semantics: ConciseBodyContainsUseStrict</h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>ConciseBody : ExpressionBody</emu-grammar>
       <emu-alg>
         1. Return *false*.
@@ -22949,9 +23214,15 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-runtime-semantics-evaluateconcisebody" oldids="sec-arrow-function-definitions-runtime-semantics-evaluatebody" type="sdo" aoid="EvaluateConciseBody">
-      <h1>Runtime Semantics: EvaluateConciseBody</h1>
-      <p>With parameters _functionObject_ and _argumentsList_ (a List).</p>
+    <emu-clause id="sec-runtime-semantics-evaluateconcisebody" oldids="sec-arrow-function-definitions-runtime-semantics-evaluatebody" type="sdo">
+      <h1>
+        Runtime Semantics: EvaluateConciseBody (
+          _functionObject_: unknown,
+          _argumentsList_: a List,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>ConciseBody : ExpressionBody</emu-grammar>
       <emu-alg>
         1. Perform ? FunctionDeclarationInstantiation(_functionObject_, _argumentsList_).
@@ -22959,9 +23230,14 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-runtime-semantics-instantiatearrowfunctionexpression" type="sdo" aoid="InstantiateArrowFunctionExpression">
-      <h1>Runtime Semantics: InstantiateArrowFunctionExpression</h1>
-      <p>With optional parameter _name_.</p>
+    <emu-clause id="sec-runtime-semantics-instantiatearrowfunctionexpression" type="sdo">
+      <h1>
+        Runtime Semantics: InstantiateArrowFunctionExpression (
+          optional _name_: unknown,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>ArrowFunction : ArrowParameters `=>` ConciseBody</emu-grammar>
       <emu-alg>
         1. If _name_ is not present, set _name_ to *""*.
@@ -23033,8 +23309,10 @@
       </ul>
     </emu-clause>
 
-    <emu-clause id="sec-static-semantics-hasdirectsuper" oldids="sec-method-definitions-static-semantics-hasdirectsuper,sec-generator-function-definitions-static-semantics-hasdirectsuper,sec-async-generator-function-definitions-static-semantics-hasdirectsuper,sec-async-function-definitions-static-semantics-HasDirectSuper" type="sdo" aoid="HasDirectSuper">
+    <emu-clause id="sec-static-semantics-hasdirectsuper" oldids="sec-method-definitions-static-semantics-hasdirectsuper,sec-generator-function-definitions-static-semantics-hasdirectsuper,sec-async-generator-function-definitions-static-semantics-hasdirectsuper,sec-async-function-definitions-static-semantics-HasDirectSuper" type="sdo">
       <h1>Static Semantics: HasDirectSuper</h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>MethodDefinition : ClassElementName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. If |UniqueFormalParameters| Contains |SuperCall| is *true*, return *true*.
@@ -23068,8 +23346,10 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-static-semantics-specialmethod" type="sdo" aoid="SpecialMethod">
+    <emu-clause id="sec-static-semantics-specialmethod" type="sdo">
       <h1>Static Semantics: SpecialMethod</h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>MethodDefinition : ClassElementName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Return *false*.
@@ -23087,9 +23367,15 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-runtime-semantics-definemethod" type="sdo" aoid="DefineMethod">
-      <h1>Runtime Semantics: DefineMethod</h1>
-      <p>With parameter _object_ and optional parameter _functionPrototype_.</p>
+    <emu-clause id="sec-runtime-semantics-definemethod" type="sdo">
+      <h1>
+        Runtime Semantics: DefineMethod (
+          _object_: unknown,
+          optional _functionPrototype_: unknown,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>MethodDefinition : ClassElementName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Let _propKey_ be the result of evaluating |ClassElementName|.
@@ -23107,9 +23393,15 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-runtime-semantics-methoddefinitionevaluation" oldids="sec-method-definitions-runtime-semantics-propertydefinitionevaluation,sec-generator-function-definitions-runtime-semantics-propertydefinitionevaluation,sec-asyncgenerator-definitions-propertydefinitionevaluation,sec-async-function-definitions-PropertyDefinitionEvaluation" type="sdo" aoid="MethodDefinitionEvaluation">
-      <h1>Runtime Semantics: MethodDefinitionEvaluation</h1>
-      <p>With parameters _object_ and _enumerable_.</p>
+    <emu-clause id="sec-runtime-semantics-methoddefinitionevaluation" oldids="sec-method-definitions-runtime-semantics-propertydefinitionevaluation,sec-generator-function-definitions-runtime-semantics-propertydefinitionevaluation,sec-asyncgenerator-definitions-propertydefinitionevaluation,sec-async-function-definitions-PropertyDefinitionEvaluation" type="sdo">
+      <h1>
+        Runtime Semantics: MethodDefinitionEvaluation (
+          _object_: unknown,
+          _enumerable_: unknown,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>MethodDefinition : ClassElementName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Let _methodDef_ be ? DefineMethod of |MethodDefinition| with argument _object_.
@@ -23286,9 +23578,15 @@
       </ul>
     </emu-clause>
 
-    <emu-clause id="sec-runtime-semantics-evaluategeneratorbody" oldids="sec-generator-function-definitions-runtime-semantics-evaluatebody" type="sdo" aoid="EvaluateGeneratorBody">
-      <h1>Runtime Semantics: EvaluateGeneratorBody</h1>
-      <p>With parameters _functionObject_ and _argumentsList_ (a List).</p>
+    <emu-clause id="sec-runtime-semantics-evaluategeneratorbody" oldids="sec-generator-function-definitions-runtime-semantics-evaluatebody" type="sdo">
+      <h1>
+        Runtime Semantics: EvaluateGeneratorBody (
+          _functionObject_: unknown,
+          _argumentsList_: a List,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>GeneratorBody : FunctionBody</emu-grammar>
       <emu-alg>
         1. Perform ? FunctionDeclarationInstantiation(_functionObject_, _argumentsList_).
@@ -23299,9 +23597,15 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-runtime-semantics-instantiategeneratorfunctionobject" oldids="sec-generator-function-definitions-runtime-semantics-instantiatefunctionobject" type="sdo" aoid="InstantiateGeneratorFunctionObject">
-      <h1>Runtime Semantics: InstantiateGeneratorFunctionObject</h1>
-      <p>With parameters _scope_ and _privateScope_.</p>
+    <emu-clause id="sec-runtime-semantics-instantiategeneratorfunctionobject" oldids="sec-generator-function-definitions-runtime-semantics-instantiatefunctionobject" type="sdo">
+      <h1>
+        Runtime Semantics: InstantiateGeneratorFunctionObject (
+          _scope_: unknown,
+          _privateScope_: unknown,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>GeneratorDeclaration : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. Let _name_ be StringValue of |BindingIdentifier|.
@@ -23326,9 +23630,14 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-runtime-semantics-instantiategeneratorfunctionexpression" type="sdo" aoid="InstantiateGeneratorFunctionExpression">
-      <h1>Runtime Semantics: InstantiateGeneratorFunctionExpression</h1>
-      <p>With optional parameter _name_.</p>
+    <emu-clause id="sec-runtime-semantics-instantiategeneratorfunctionexpression" type="sdo">
+      <h1>
+        Runtime Semantics: InstantiateGeneratorFunctionExpression (
+          optional _name_: unknown,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>GeneratorExpression : `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. If _name_ is not present, set _name_ to *""*.
@@ -23492,9 +23801,15 @@
       </ul>
     </emu-clause>
 
-    <emu-clause id="sec-runtime-semantics-evaluateasyncgeneratorbody" oldids="sec-asyncgenerator-definitions-evaluatebody" type="sdo" aoid="EvaluateAsyncGeneratorBody">
-      <h1>Runtime Semantics: EvaluateAsyncGeneratorBody</h1>
-      <p>With parameters _functionObject_ and _argumentsList_ (a List).</p>
+    <emu-clause id="sec-runtime-semantics-evaluateasyncgeneratorbody" oldids="sec-asyncgenerator-definitions-evaluatebody" type="sdo">
+      <h1>
+        Runtime Semantics: EvaluateAsyncGeneratorBody (
+          _functionObject_: unknown,
+          _argumentsList_: a List,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>
         AsyncGeneratorBody : FunctionBody
       </emu-grammar>
@@ -23507,9 +23822,15 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-runtime-semantics-instantiateasyncgeneratorfunctionobject" oldids="sec-asyncgenerator-definitions-instantiatefunctionobject" type="sdo" aoid="InstantiateAsyncGeneratorFunctionObject">
-      <h1>Runtime Semantics: InstantiateAsyncGeneratorFunctionObject</h1>
-      <p>With parameters _scope_ and _privateScope_.</p>
+    <emu-clause id="sec-runtime-semantics-instantiateasyncgeneratorfunctionobject" oldids="sec-asyncgenerator-definitions-instantiatefunctionobject" type="sdo">
+      <h1>
+        Runtime Semantics: InstantiateAsyncGeneratorFunctionObject (
+          _scope_: unknown,
+          _privateScope_: unknown,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>
         AsyncGeneratorDeclaration : `async` `function` `*` BindingIdentifier `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
       </emu-grammar>
@@ -23538,9 +23859,14 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-runtime-semantics-instantiateasyncgeneratorfunctionexpression" type="sdo" aoid="InstantiateAsyncGeneratorFunctionExpression">
-      <h1>Runtime Semantics: InstantiateAsyncGeneratorFunctionExpression</h1>
-      <p>With optional parameter _name_.</p>
+    <emu-clause id="sec-runtime-semantics-instantiateasyncgeneratorfunctionexpression" type="sdo">
+      <h1>
+        Runtime Semantics: InstantiateAsyncGeneratorFunctionExpression (
+          optional _name_: unknown,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>
         AsyncGeneratorExpression : `async` `function` `*` `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
       </emu-grammar>
@@ -23737,8 +24063,10 @@
       </ul>
     </emu-clause>
 
-    <emu-clause id="sec-static-semantics-classelementkind" type="sdo" aoid="ClassElementKind">
+    <emu-clause id="sec-static-semantics-classelementkind" type="sdo">
       <h1>Static Semantics: ClassElementKind</h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>ClassElement : MethodDefinition</emu-grammar>
       <emu-alg>
         1. If PropName of |MethodDefinition| is *"constructor"*, return ~ConstructorMethod~.
@@ -23763,8 +24091,10 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-static-semantics-constructormethod" type="sdo" aoid="ConstructorMethod">
+    <emu-clause id="sec-static-semantics-constructormethod" type="sdo">
       <h1>Static Semantics: ConstructorMethod</h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>ClassElementList : ClassElement</emu-grammar>
       <emu-alg>
         1. If ClassElementKind of |ClassElement| is ~ConstructorMethod~, return |ClassElement|.
@@ -23782,8 +24112,10 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-static-semantics-isstatic" type="sdo" aoid="IsStatic">
+    <emu-clause id="sec-static-semantics-isstatic" type="sdo">
       <h1>Static Semantics: IsStatic</h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>ClassElement : MethodDefinition</emu-grammar>
       <emu-alg>
         1. Return *false*.
@@ -23810,8 +24142,10 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-static-semantics-nonconstructorelements" oldids="sec-static-semantics-nonconstructormethoddefinitions" type="sdo" aoid="NonConstructorElements">
+    <emu-clause id="sec-static-semantics-nonconstructorelements" oldids="sec-static-semantics-nonconstructormethoddefinitions" type="sdo">
       <h1>Static Semantics: NonConstructorElements</h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>ClassElementList : ClassElement</emu-grammar>
       <emu-alg>
         1. If ClassElementKind of |ClassElement| is ~NonConstructorMethod~, then
@@ -23827,8 +24161,10 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-static-semantics-prototypepropertynamelist" type="sdo" aoid="PrototypePropertyNameList">
+    <emu-clause id="sec-static-semantics-prototypepropertynamelist" type="sdo">
       <h1>Static Semantics: PrototypePropertyNameList</h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>ClassElementList : ClassElement</emu-grammar>
       <emu-alg>
         1. Let _propName_ be PropName of |ClassElement|.
@@ -23846,10 +24182,14 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-static-semantics-allprivateidentifiersvalid" type="sdo" aoid="AllPrivateIdentifiersValid">
-      <h1>Static Semantics: AllPrivateIdentifiersValid</h1>
-      <p>With parameter _names_.</p>
-
+    <emu-clause id="sec-static-semantics-allprivateidentifiersvalid" type="sdo">
+      <h1>
+        Static Semantics: AllPrivateIdentifiersValid (
+          _names_: unknown,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <p>Every grammar production alternative in this specification which is not listed below implicitly has the following default definition of AllPrivateIdentifiersValid:</p>
       <emu-alg>
         1. For each child node _child_ of this Parse Node, do
@@ -23899,8 +24239,10 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-static-semantics-privateboundidentifiers" type="sdo" aoid="PrivateBoundIdentifiers">
+    <emu-clause id="sec-static-semantics-privateboundidentifiers" type="sdo">
       <h1>Static Semantics: PrivateBoundIdentifiers</h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>
         FieldDefinition : ClassElementName Initializer?
       </emu-grammar>
@@ -23955,8 +24297,10 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-static-semantics-containsarguments" type="sdo" aoid="ContainsArguments">
+    <emu-clause id="sec-static-semantics-containsarguments" type="sdo">
       <h1>Static Semantics: ContainsArguments</h1>
+      <dl class="header">
+      </dl>
 
       <p>Every grammar production alternative in this specification which is not listed below implicitly has the following default definition of ContainsArguments:</p>
       <emu-alg>
@@ -24027,11 +24371,14 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-runtime-semantics-classfielddefinitionevaluation" type="sdo" aoid="ClassFieldDefinitionEvaluation">
-      <h1>Runtime Semantics: ClassFieldDefinitionEvaluation</h1>
-
-      <p>With parameter _homeObject_.</p>
-
+    <emu-clause id="sec-runtime-semantics-classfielddefinitionevaluation" type="sdo">
+      <h1>
+        Runtime Semantics: ClassFieldDefinitionEvaluation (
+          _homeObject_: unknown,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>
         FieldDefinition : ClassElementName Initializer?
       </emu-grammar>
@@ -24055,9 +24402,14 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-runtime-semantics-classstaticblockdefinitionevaluation" type="sdo" aoid="ClassStaticBlockDefinitionEvaluation">
-      <h1>Runtime Semantics: ClassStaticBlockDefinitionEvaluation</h1>
-      <p>With parameter _homeObject_.</p>
+    <emu-clause id="sec-runtime-semantics-classstaticblockdefinitionevaluation" type="sdo">
+      <h1>
+        Runtime Semantics: ClassStaticBlockDefinitionEvaluation (
+          _homeObject_: unknown,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>ClassStaticBlock : `static` `{` ClassStaticBlockBody `}`</emu-grammar>
       <emu-alg>
         1. Let _lex_ be the running execution context's LexicalEnvironment.
@@ -24071,9 +24423,14 @@
       <emu-note>The function _bodyFunction_ is never directly accessible to ECMAScript code.</emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-runtime-semantics-evaluateclassstaticblockbody" type="sdo" aoid="EvaluateClassStaticBlockBody">
-      <h1>Runtime Semantics: EvaluateClassStaticBlockBody</h1>
-      <p>With parameter _functionObject_.</p>
+    <emu-clause id="sec-runtime-semantics-evaluateclassstaticblockbody" type="sdo">
+      <h1>
+        Runtime Semantics: EvaluateClassStaticBlockBody (
+          _functionObject_: unknown,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>ClassStaticBlockBody : ClassStaticBlockStatementList</emu-grammar>
       <emu-alg>
         1. Perform ? FunctionDeclarationInstantiation(_functionObject_, &laquo; &raquo;).
@@ -24081,9 +24438,14 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-static-semantics-classelementevaluation" type="sdo" aoid="ClassElementEvaluation">
-      <h1>Runtime Semantics: ClassElementEvaluation</h1>
-      <p>With parameter _object_.</p>
+    <emu-clause id="sec-static-semantics-classelementevaluation" type="sdo">
+      <h1>
+        Runtime Semantics: ClassElementEvaluation (
+          _object_: unknown,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
 
       <emu-grammar>
         ClassElement : FieldDefinition `;`
@@ -24116,9 +24478,15 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-runtime-semantics-classdefinitionevaluation" oldids="sec-default-constructor-functions" type="sdo" aoid="ClassDefinitionEvaluation">
-      <h1>Runtime Semantics: ClassDefinitionEvaluation</h1>
-      <p>With parameters _classBinding_ and _className_.</p>
+    <emu-clause id="sec-runtime-semantics-classdefinitionevaluation" oldids="sec-default-constructor-functions" type="sdo">
+      <h1>
+        Runtime Semantics: ClassDefinitionEvaluation (
+          _classBinding_: unknown,
+          _className_: unknown,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-note>
         <p>For ease of specification, private methods and accessors are included alongside private fields in the [[PrivateElements]] slot of class instances. However, any given object has either all or none of the private methods and accessors defined by a given class. This feature has been designed so that implementations may choose to implement private methods and accessors using a strategy which does not require tracking each method or accessor individually.</p>
         <p>For example, an implementation could directly associate instance private methods with their corresponding Private Name and track, for each object, which class constructors have run with that object as their `this` value. Looking up an instance private method on an object then consists of checking that the class constructor which defines the method has been used to initialize the object, then returning the method associated with the Private Name.</p>
@@ -24239,8 +24607,10 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-runtime-semantics-bindingclassdeclarationevaluation" type="sdo" aoid="BindingClassDeclarationEvaluation">
+    <emu-clause id="sec-runtime-semantics-bindingclassdeclarationevaluation" type="sdo">
       <h1>Runtime Semantics: BindingClassDeclarationEvaluation</h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>ClassDeclaration : `class` BindingIdentifier ClassTail</emu-grammar>
       <emu-alg>
         1. Let _className_ be StringValue of |BindingIdentifier|.
@@ -24371,9 +24741,15 @@
       </ul>
     </emu-clause>
 
-    <emu-clause id="sec-runtime-semantics-instantiateasyncfunctionobject" oldids="sec-async-function-definitions-InstantiateFunctionObject" type="sdo" aoid="InstantiateAsyncFunctionObject">
-      <h1>Runtime Semantics: InstantiateAsyncFunctionObject</h1>
-      <p>With parameters _scope_ and _privateScope_.</p>
+    <emu-clause id="sec-runtime-semantics-instantiateasyncfunctionobject" oldids="sec-async-function-definitions-InstantiateFunctionObject" type="sdo">
+      <h1>
+        Runtime Semantics: InstantiateAsyncFunctionObject (
+          _scope_: unknown,
+          _privateScope_: unknown,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>
         AsyncFunctionDeclaration : `async` `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
@@ -24395,9 +24771,14 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-runtime-semantics-instantiateasyncfunctionexpression" type="sdo" aoid="InstantiateAsyncFunctionExpression">
-      <h1>Runtime Semantics: InstantiateAsyncFunctionExpression</h1>
-      <p>With optional parameter _name_.</p>
+    <emu-clause id="sec-runtime-semantics-instantiateasyncfunctionexpression" type="sdo">
+      <h1>
+        Runtime Semantics: InstantiateAsyncFunctionExpression (
+          optional _name_: unknown,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>
         AsyncFunctionExpression : `async` `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
@@ -24431,9 +24812,15 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-runtime-semantics-evaluateasyncfunctionbody" oldids="sec-async-function-definitions-EvaluateBody" type="sdo" aoid="EvaluateAsyncFunctionBody">
-      <h1>Runtime Semantics: EvaluateAsyncFunctionBody</h1>
-      <p>With parameters _functionObject_ and _argumentsList_ (a List).</p>
+    <emu-clause id="sec-runtime-semantics-evaluateasyncfunctionbody" oldids="sec-async-function-definitions-EvaluateBody" type="sdo">
+      <h1>
+        Runtime Semantics: EvaluateAsyncFunctionBody (
+          _functionObject_: unknown,
+          _argumentsList_: a List,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>
         AsyncFunctionBody : FunctionBody
       </emu-grammar>
@@ -24519,8 +24906,10 @@
       </ul>
     </emu-clause>
 
-    <emu-clause id="sec-static-semantics-asyncconcisebodycontainsusestrict" oldids="sec-async-arrow-function-definitions-static-semantics-containsusestrict" type="sdo" aoid="AsyncConciseBodyContainsUseStrict">
+    <emu-clause id="sec-static-semantics-asyncconcisebodycontainsusestrict" oldids="sec-async-arrow-function-definitions-static-semantics-containsusestrict" type="sdo">
       <h1>Static Semantics: AsyncConciseBodyContainsUseStrict</h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>AsyncConciseBody : ExpressionBody</emu-grammar>
       <emu-alg>
         1. Return *false*.
@@ -24531,9 +24920,15 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-runtime-semantics-evaluateasyncconcisebody" oldids="sec-async-arrow-function-definitions-EvaluateBody" type="sdo" aoid="EvaluateAsyncConciseBody">
-      <h1>Runtime Semantics: EvaluateAsyncConciseBody</h1>
-      <p>With parameters _functionObject_ and _argumentsList_ (a List).</p>
+    <emu-clause id="sec-runtime-semantics-evaluateasyncconcisebody" oldids="sec-async-arrow-function-definitions-EvaluateBody" type="sdo">
+      <h1>
+        Runtime Semantics: EvaluateAsyncConciseBody (
+          _functionObject_: unknown,
+          _argumentsList_: a List,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>
         AsyncConciseBody : ExpressionBody
       </emu-grammar>
@@ -24548,9 +24943,14 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-runtime-semantics-instantiateasyncarrowfunctionexpression" type="sdo" aoid="InstantiateAsyncArrowFunctionExpression">
-      <h1>Runtime Semantics: InstantiateAsyncArrowFunctionExpression</h1>
-      <p>With optional parameter _name_.</p>
+    <emu-clause id="sec-runtime-semantics-instantiateasyncarrowfunctionexpression" type="sdo">
+      <h1>
+        Runtime Semantics: InstantiateAsyncArrowFunctionExpression (
+          optional _name_: unknown,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>
         AsyncArrowFunction : `async` AsyncArrowBindingIdentifier `=>` AsyncConciseBody
       </emu-grammar>
@@ -24619,9 +25019,14 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-static-semantics-hascallintailposition" type="sdo" aoid="HasCallInTailPosition">
-      <h1>Static Semantics: HasCallInTailPosition</h1>
-      <p>With parameter _call_.</p>
+    <emu-clause id="sec-static-semantics-hascallintailposition" type="sdo">
+      <h1>
+        Static Semantics: HasCallInTailPosition (
+          _call_: unknown,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-note>
         <p>_call_ is a Parse Node that represents a specific range of source text. When the following algorithms compare _call_ to another Parse Node, it is a test of whether they represent the same source text.</p>
       </emu-note>
@@ -25007,8 +25412,10 @@
       </ul>
     </emu-clause>
 
-    <emu-clause id="sec-static-semantics-isstrict" type="sdo" aoid="IsStrict">
+    <emu-clause id="sec-static-semantics-isstrict" type="sdo">
       <h1>Static Semantics: IsStrict</h1>
+      <dl class="header">
+      </dl>
       <emu-grammar>Script : ScriptBody?</emu-grammar>
       <emu-alg>
         1. If |ScriptBody| is present and the Directive Prologue of |ScriptBody| contains a Use Strict Directive, return *true*; otherwise, return *false*.
@@ -25297,8 +25704,10 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-static-semantics-modulerequests" oldids="sec-module-semantics-static-semantics-modulerequests,sec-imports-static-semantics-modulerequests,sec-exports-static-semantics-modulerequests" type="sdo" aoid="ModuleRequests">
+      <emu-clause id="sec-static-semantics-modulerequests" oldids="sec-module-semantics-static-semantics-modulerequests,sec-imports-static-semantics-modulerequests,sec-exports-static-semantics-modulerequests" type="sdo">
         <h1>Static Semantics: ModuleRequests</h1>
+        <dl class="header">
+        </dl>
         <emu-grammar>Module : [empty]</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
@@ -27337,8 +27746,10 @@
         </ul>
       </emu-clause>
 
-      <emu-clause id="sec-static-semantics-importentries" oldids="sec-module-semantics-static-semantics-importentries,sec-imports-static-semantics-importentries" type="sdo" aoid="ImportEntries">
+      <emu-clause id="sec-static-semantics-importentries" oldids="sec-module-semantics-static-semantics-importentries,sec-imports-static-semantics-importentries" type="sdo">
         <h1>Static Semantics: ImportEntries</h1>
+        <dl class="header">
+        </dl>
         <emu-grammar>Module : [empty]</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
@@ -27368,9 +27779,14 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-static-semantics-importentriesformodule" type="sdo" aoid="ImportEntriesForModule">
-        <h1>Static Semantics: ImportEntriesForModule</h1>
-        <p>With parameter _module_.</p>
+      <emu-clause id="sec-static-semantics-importentriesformodule" type="sdo">
+        <h1>
+          Static Semantics: ImportEntriesForModule (
+            _module_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-grammar>ImportClause : ImportedDefaultBinding `,` NameSpaceImport</emu-grammar>
         <emu-alg>
           1. Let _entries1_ be ImportEntriesForModule of |ImportedDefaultBinding| with argument _module_.
@@ -27466,8 +27882,10 @@
         </emu-note>
       </emu-clause>
 
-      <emu-clause id="sec-static-semantics-exportedbindings" oldids="sec-module-semantics-static-semantics-exportedbindings,sec-exports-static-semantics-exportedbindings" type="sdo" aoid="ExportedBindings">
+      <emu-clause id="sec-static-semantics-exportedbindings" oldids="sec-module-semantics-static-semantics-exportedbindings,sec-exports-static-semantics-exportedbindings" type="sdo">
         <h1>Static Semantics: ExportedBindings</h1>
+        <dl class="header">
+        </dl>
         <emu-note>
           <p>ExportedBindings are the locally bound names that are explicitly associated with a |Module|'s ExportedNames.</p>
         </emu-note>
@@ -27533,8 +27951,10 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-static-semantics-exportednames" oldids="sec-module-semantics-static-semantics-exportednames,sec-exports-static-semantics-exportednames" type="sdo" aoid="ExportedNames">
+      <emu-clause id="sec-static-semantics-exportednames" oldids="sec-module-semantics-static-semantics-exportednames,sec-exports-static-semantics-exportednames" type="sdo">
         <h1>Static Semantics: ExportedNames</h1>
+        <dl class="header">
+        </dl>
         <emu-note>
           <p>ExportedNames are the externally visible names that a |Module| explicitly maps to one of its local name bindings.</p>
         </emu-note>
@@ -27609,8 +28029,10 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-static-semantics-exportentries" oldids="sec-module-semantics-static-semantics-exportentries,sec-exports-static-semantics-exportentries" type="sdo" aoid="ExportEntries">
+      <emu-clause id="sec-static-semantics-exportentries" oldids="sec-module-semantics-static-semantics-exportentries,sec-exports-static-semantics-exportentries" type="sdo">
         <h1>Static Semantics: ExportEntries</h1>
+        <dl class="header">
+        </dl>
         <emu-grammar>Module : [empty]</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
@@ -27676,9 +28098,14 @@
         </emu-note>
       </emu-clause>
 
-      <emu-clause id="sec-static-semantics-exportentriesformodule" type="sdo" aoid="ExportEntriesForModule">
-        <h1>Static Semantics: ExportEntriesForModule</h1>
-        <p>With parameter _module_.</p>
+      <emu-clause id="sec-static-semantics-exportentriesformodule" type="sdo">
+        <h1>
+          Static Semantics: ExportEntriesForModule (
+            _module_: unknown,
+          )
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-grammar>ExportFromClause : `*`</emu-grammar>
         <emu-alg>
           1. Let _entry_ be the ExportEntry Record { [[ModuleRequest]]: _module_, [[ImportName]]: *"\*"*, [[LocalName]]: *null*, [[ExportName]]: *null* }.
@@ -27725,8 +28152,10 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-static-semantics-referencedbindings" type="sdo" aoid="ReferencedBindings">
+      <emu-clause id="sec-static-semantics-referencedbindings" type="sdo">
         <h1>Static Semantics: ReferencedBindings</h1>
+        <dl class="header">
+        </dl>
         <emu-grammar>NamedExports : `{` `}`</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
@@ -34202,8 +34631,10 @@ THH:mm:ss.sss
         </ul>
       </emu-clause>
 
-      <emu-clause id="sec-patterns-static-semantics-capturing-group-number" type="sdo" aoid="CapturingGroupNumber">
+      <emu-clause id="sec-patterns-static-semantics-capturing-group-number" type="sdo">
         <h1>Static Semantics: CapturingGroupNumber</h1>
+        <dl class="header">
+        </dl>
         <emu-note>
           <p>This section is amended in <emu-xref href="#sec-patterns-static-semantics-early-errors-annexb"></emu-xref>.</p>
         </emu-note>
@@ -34219,8 +34650,10 @@ THH:mm:ss.sss
         <p>The definitions of &ldquo;the MV of |NonZeroDigit|&rdquo; and &ldquo;the MV of |DecimalDigits|&rdquo; are in <emu-xref href="#sec-literals-numeric-literals"></emu-xref>.</p>
       </emu-clause>
 
-      <emu-clause id="sec-patterns-static-semantics-is-character-class" type="sdo" aoid="IsCharacterClass">
+      <emu-clause id="sec-patterns-static-semantics-is-character-class" type="sdo">
         <h1>Static Semantics: IsCharacterClass</h1>
+        <dl class="header">
+        </dl>
         <emu-note>
           <p>This section is amended in <emu-xref href="#sec-patterns-static-semantics-is-character-class-annexb"></emu-xref>.</p>
         </emu-note>
@@ -34244,8 +34677,10 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-patterns-static-semantics-character-value" type="sdo" aoid="CharacterValue">
+      <emu-clause id="sec-patterns-static-semantics-character-value" type="sdo">
         <h1>Static Semantics: CharacterValue</h1>
+        <dl class="header">
+        </dl>
         <emu-note>
           <p>This section is amended in <emu-xref href="#sec-patterns-static-semantics-character-value-annexb"></emu-xref>.</p>
         </emu-note>
@@ -34435,8 +34870,10 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-static-semantics-sourcetext" type="sdo" aoid="SourceText">
+      <emu-clause id="sec-static-semantics-sourcetext" type="sdo">
         <h1>Static Semantics: SourceText</h1>
+        <dl class="header">
+        </dl>
         <emu-grammar>
           UnicodePropertyNameCharacters :: UnicodePropertyNameCharacter UnicodePropertyNameCharacters?
 
@@ -34447,8 +34884,10 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-static-semantics-capturinggroupname" oldids="sec-regexp-identifier-names-static-semantics-stringvalue" type="sdo" aoid="CapturingGroupName">
+      <emu-clause id="sec-static-semantics-capturinggroupname" oldids="sec-regexp-identifier-names-static-semantics-stringvalue" type="sdo">
         <h1>Static Semantics: CapturingGroupName</h1>
+        <dl class="header">
+        </dl>
         <emu-grammar>
           RegExpIdentifierName ::
             RegExpIdentifierStart


### PR DESCRIPTION
~Depends on https://github.com/tc39/ecmarkup/pull/358 and will not build until that's upstreamed. I've uploaded a rendered version built with that PR [here](https://bakkot.github.io/ecma262-previews/sdo-structured-header/multipage/).~

This now includes ecmarkup 9.2.0, which introduces support for this.

In a followup, now that the format accommodates it, I'll start adding descriptions and parameter types.