### PR TITLE
Normative: List new Unicode v14 `Script`/`Script_Extensions` values

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -35817,6 +35817,9 @@ THH:mm:ss.sss
           <emu-note>
             <p>This algorithm differs from <a href="https://unicode.org/reports/tr44/#Matching_Symbolic">the matching rules for symbolic values listed in UAX44</a>: case, <emu-xref href="#sec-white-space">white space</emu-xref>, U+002D (HYPHEN-MINUS), and U+005F (LOW LINE) are not ignored, and the `Is` prefix is not supported.</p>
           </emu-note>
+          <emu-note>
+            <p>The spellings of entries in these tables (including casing) were chosen to match the first occurrence of each property in the files <a href="https://unicode.org/Public/UCD/latest/ucd/PropertyAliases.txt"><code>PropertyAliases.txt</code></a> and <a href="https://unicode.org/Public/UCD/latest/ucd/PropertyValueAliases.txt"><code>PropertyValueAliases.txt</code></a> in the Unicode Character Database at the time each entry was added to this specification. However, because the precise spellings in those files are not guaranteed to be stable, implementations are required to follow this table rather than those files.</p>
+          </emu-note>
           <emu-import href="table-unicode-general-category-values.html"></emu-import>
           <emu-import href="table-unicode-script-values.html"></emu-import>
         </emu-clause>

--- a/table-unicode-script-values.html
+++ b/table-unicode-script-values.html
@@ -201,6 +201,13 @@
       <td>`Cprt`</td>
     </tr>
     <tr>
+      <td>`Cypro_Minoan`</td>
+      <td rowspan="2">`Cypro_Minoan`</td>
+    </tr>
+    <tr>
+      <td>`Cpmn`</td>
+    </tr>
+    <tr>
       <td>`Cyrillic`</td>
       <td rowspan="2">`Cyrillic`</td>
     </tr>
@@ -776,6 +783,13 @@
       <td>`Orkh`</td>
     </tr>
     <tr>
+      <td>`Old_Uyghur`</td>
+      <td rowspan="2">`Old_Uyghur`</td>
+    </tr>
+    <tr>
+      <td>`Ougr`</td>
+    </tr>
+    <tr>
       <td>`Oriya`</td>
       <td rowspan="2">`Oriya`</td>
     </tr>
@@ -993,6 +1007,13 @@
       <td>`Taml`</td>
     </tr>
     <tr>
+      <td>`Tangsa`</td>
+      <td rowspan="2">`Tangsa`</td>
+    </tr>
+    <tr>
+      <td>`Tnsa`</td>
+    </tr>
+    <tr>
       <td>`Tangut`</td>
       <td rowspan="2">`Tangut`</td>
     </tr>
@@ -1039,6 +1060,10 @@
       <td>`Tirh`</td>
     </tr>
     <tr>
+      <td>`Toto`</td>
+      <td>`Toto`</td>
+    </tr>
+    <tr>
       <td>`Ugaritic`</td>
       <td rowspan="2">`Ugaritic`</td>
     </tr>
@@ -1051,6 +1076,13 @@
     </tr>
     <tr>
       <td>`Vaii`</td>
+    </tr>
+    <tr>
+      <td>`Vithkuqi`</td>
+      <td rowspan="2">`Vithkuqi`</td>
+    </tr>
+    <tr>
+      <td>`Vith`</td>
     </tr>
     <tr>
       <td>`Wancho`</td>


### PR DESCRIPTION
The following new values for the already-supported properties `Script` and `Script_Extensions` are added:

- Cypro_Minoan (Cpmn)
- Old_Uyghur (Ougr)
- Tangsa (Tnsa)
- Toto (Toto)
- Vithkuqi (Vith)

Issue: https://github.com/tc39/ecma262/issues/2514
Tests: https://github.com/tc39/test262/pull/3199
