### PR TITLE
Meta: update static default branch name to a dynamic one

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,7 +4,7 @@ contact_links:
   - 
     about: "Feature requests for future versions of ECMAScript should not be made in this repository. See CONTRIBUTING.md for more details."
     name: "\U0001F680 Feature request"
-    url: "https://github.com/tc39/ecma262/blob/master/CONTRIBUTING.md#new-feature-proposals"
+    url: "https://github.com/tc39/ecma262/blob/HEAD/CONTRIBUTING.md#new-feature-proposals"
   - 
     about: "You can also ask questions and suggest ideas on the TC39 Discourse."
     name: "\U0001F4AC Discourse"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: 'ecma-262'
 on:
   push:
     branches:
-      - master
+      - $default-branch
 
 jobs:
   deploy:

--- a/FAQ.md
+++ b/FAQ.md
@@ -8,7 +8,7 @@ An index of frequently asked questions regarding all things ECMA-262.
 
 New features start life as a proposal to the [TC39](#what-is-a-tc39) committee and must be championed (or co-championed) by at least one member of the committee. Once the proposal is raised at a committee meeting, it will become a Stage 0 proposal and move along from there. For more details on how proposal stages work, check out the [proposal process document][proposal-process-document].
 
-If you would like to contribute, please check out [Contributing to ECMAScript](https://github.com/tc39/ecma262/blob/master/CONTRIBUTING.md).
+If you would like to contribute, please check out [Contributing to ECMAScript](https://github.com/tc39/ecma262/blob/HEAD/CONTRIBUTING.md).
 
 ##### What is a "TC39"?
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-This repository is licensed according to Ecma International TC39's [Intellectual Property Policy](https://github.com/tc39/how-we-work/blob/master/ip.md). In particular:
+This repository is licensed according to Ecma International TC39's [Intellectual Property Policy](https://github.com/tc39/how-we-work/blob/HEAD/ip.md). In particular:
 - Natural language text is licensed under [Ecma text copyright policy](https://www.ecma-international.org/memento/Ecma%20copyright%20faq.htm).
 - Source code is licensed under Ecma's MIT-style [Ecma International Policy on Submission, Inclusion and Licensing of Software](https://www.ecma-international.org/memento/Policies/Ecma_Policy_on_Submission_Inclusion_and_Licensing_of_Software.htm).
 - Contributions are only accepted from either representatives of Ecma members or signatories of TC39's [Contributor Form](https://tc39.github.io/agreements/contributor/).

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ If you want to explore how the specification was written, you can also view the 
 
 Proposals follow [the TC39 process](https://tc39.es/process-document/) and are tracked in the [proposals repository](https://github.com/tc39/proposals).
 
-* [Finished Proposals](https://github.com/tc39/proposals/blob/master/finished-proposals.md)
+* [Finished Proposals](https://github.com/tc39/proposals/blob/HEAD/finished-proposals.md)
 * [Active Proposals](https://github.com/tc39/proposals)
-* [Stage 1 Proposals](https://github.com/tc39/proposals/blob/master/stage-1-proposals.md)
-* [Stage 0 Proposals](https://github.com/tc39/proposals/blob/master/stage-0-proposals.md)
-* [Inactive Proposals](https://github.com/tc39/proposals/blob/master/inactive-proposals.md)
+* [Stage 1 Proposals](https://github.com/tc39/proposals/blob/HEAD/stage-1-proposals.md)
+* [Stage 0 Proposals](https://github.com/tc39/proposals/blob/HEAD/stage-0-proposals.md)
+* [Inactive Proposals](https://github.com/tc39/proposals/blob/HEAD/inactive-proposals.md)
 
 ### Contributing New Proposals
 

--- a/scripts/check-commit.js
+++ b/scripts/check-commit.js
@@ -4,7 +4,7 @@
 
 const exec = require('child_process').execSync;
 
-const oldestAncestor = String(exec(`bash -c 'diff -u <(git rev-list --first-parent "\${1:-origin/master}") <(git rev-list --first-parent "\${2:-HEAD}") | sed -ne "s/^ //p" | head -1' -`)).trim();
+const oldestAncestor = String(exec(`bash -c 'diff -u <(git rev-list --first-parent "\${1:-origin/HEAD}") <(git rev-list --first-parent "\${2:-HEAD}") | sed -ne "s/^ //p" | head -1' -`)).trim();
 
 console.log(`Oldest ancestor SHA: ${oldestAncestor}`);
 

--- a/scripts/check-form.js
+++ b/scripts/check-form.js
@@ -62,7 +62,7 @@ const request = async (url, method = 'GET', postData) => {
 	});
 };
 
-const branchURL = `https://api.github.com/repos/${slug}/compare/master...${branch}?anon=1`;
+const branchURL = `https://api.github.com/repos/${slug}/compare/HEAD...${branch}?anon=1`;
 
 const authors = request(branchURL).then((json) => JSON.parse(json)).then(data => {
 	return [...new Set(data.commits.map(x => x.author.login))];

--- a/spec.html
+++ b/spec.html
@@ -63,7 +63,7 @@
 <p><img src="img/ecma-logo.svg" id="ecma-logo"></p>
 <div id="metadata-block">
   <h1>About this Specification</h1>
-  <p>The document at <a href="https://tc39.es/ecma262/">https://tc39.es/ecma262/</a> is the most accurate and up-to-date ECMAScript specification. It contains the content of the most recent yearly snapshot plus any <a href="https://github.com/tc39/proposals/blob/master/finished-proposals.md">finished proposals</a> (those that have reached Stage&nbsp;4 in the <a href="https://tc39.es/process-document/">proposal process</a> and thus are implemented in several implementations and will be in the next practical revision) since that snapshot was taken.</p>
+  <p>The document at <a href="https://tc39.es/ecma262/">https://tc39.es/ecma262/</a> is the most accurate and up-to-date ECMAScript specification. It contains the content of the most recent yearly snapshot plus any <a href="https://github.com/tc39/proposals/blob/HEAD/finished-proposals.md">finished proposals</a> (those that have reached Stage&nbsp;4 in the <a href="https://tc39.es/process-document/">proposal process</a> and thus are implemented in several implementations and will be in the next practical revision) since that snapshot was taken.</p>
   <p>This document is available as <a href="">a single page</a> and as <a href="multipage/">multiple pages</a>.</p>
   <h1>Contributing to this Specification</h1>
   <p>This specification is developed on GitHub with the help of the ECMAScript community. There are a number of ways to contribute to the development of this specification:</p>

--- a/stage0.md
+++ b/stage0.md
@@ -2,4 +2,4 @@
 
 Stage 0 proposals have been presented to the committee and not rejected definitively, but have not yet achieved any of the criteria to get into stage 1.
 
-This list has moved [here](https://github.com/tc39/proposals/blob/master/stage-0-proposals.md).
+This list has moved [here](https://github.com/tc39/proposals/blob/HEAD/stage-0-proposals.md).

--- a/withdrawn-proposals.md
+++ b/withdrawn-proposals.md
@@ -1,3 +1,3 @@
 # Withdrawn Proposals
 
-This list has moved [here](https://github.com/tc39/proposals/blob/master/inactive-proposals.md).
+This list has moved [here](https://github.com/tc39/proposals/blob/HEAD/inactive-proposals.md).


### PR DESCRIPTION
This only leaves the word "master" hardcoded in build scripts, and contributor instructions prose.