### PR TITLE
Normative: require Number::exponentiate to return a Number value

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1622,7 +1622,7 @@
               1. If abs(ℝ(_base_)) &lt; 1, return *+&infin;*<sub>𝔽</sub>.
             1. Assert: _exponent_ is finite and is neither *+0*<sub>𝔽</sub> nor *-0*<sub>𝔽</sub>.
             1. If _base_ &lt; *+0*<sub>𝔽</sub> and _exponent_ is not an integral Number, return *NaN*.
-            1. Return an implementation-approximated value representing the result of raising ℝ(_base_) to the ℝ(_exponent_) power.
+            1. Return an implementation-approximated Number value representing the result of raising ℝ(_base_) to the ℝ(_exponent_) power.
           </emu-alg>
           <emu-note>
             <p>The result of _base_ `**` _exponent_ when _base_ is *1*<sub>𝔽</sub> or *-1*<sub>𝔽</sub> and _exponent_ is *+&infin;*<sub>𝔽</sub> or *-&infin;*<sub>𝔽</sub>, or when _base_ is *1*<sub>𝔽</sub> and _exponent_ is *NaN*, differs from IEEE 754-2019. The first edition of ECMAScript specified a result of *NaN* for this operation, whereas later versions of IEEE 754-2019 specified *1*<sub>𝔽</sub>. The historical ECMAScript behaviour is preserved for compatibility reasons.</p>


### PR DESCRIPTION
This is normative but I believe it was always what was intended, so we shouldn't need consensus on it.