### PR TITLE
Editorial: Provide `<emu-alg>` for 6 BigInt methods

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -2055,8 +2055,11 @@
           </h1>
           <dl class="header">
             <dt>description</dt>
-            <dd>It returns the one's complement of _x_; that is, -_x_ - *1*<sub>ℤ</sub>.</dd>
+            <dd>It returns the one's complement of _x_.</dd>
           </dl>
+          <emu-alg>
+            1. Return -_x_ - *1*<sub>ℤ</sub>.
+          </emu-alg>
         </emu-clause>
 
         <emu-clause id="sec-numeric-types-bigint-exponentiate" type="numeric method">
@@ -2083,9 +2086,10 @@
             )
           </h1>
           <dl class="header">
-            <dt>description</dt>
-            <dd>It returns the BigInt value that represents the result of multiplying _x_ and _y_.</dd>
           </dl>
+          <emu-alg>
+            1. Return the BigInt value that represents the product of _x_ and _y_.
+          </emu-alg>
           <emu-note>Even if the result has a much larger bit width than the input, the exact mathematical answer is given.</emu-note>
         </emu-clause>
 
@@ -2131,9 +2135,10 @@
             )
           </h1>
           <dl class="header">
-            <dt>description</dt>
-            <dd>It returns the BigInt value that represents the sum of _x_ and _y_.</dd>
           </dl>
+          <emu-alg>
+            1. Return the BigInt value that represents the sum of _x_ and _y_.
+          </emu-alg>
         </emu-clause>
 
         <emu-clause id="sec-numeric-types-bigint-subtract" type="numeric method">
@@ -2144,9 +2149,10 @@
             )
           </h1>
           <dl class="header">
-            <dt>description</dt>
-            <dd>It returns the BigInt value that represents the difference _x_ minus _y_.</dd>
           </dl>
+          <emu-alg>
+            1. Return the BigInt value that represents the difference _x_ minus _y_.
+          </emu-alg>
         </emu-clause>
 
         <emu-clause id="sec-numeric-types-bigint-leftShift" type="numeric method">
@@ -2202,9 +2208,10 @@
             )
           </h1>
           <dl class="header">
-            <dt>description</dt>
-            <dd>It returns *true* if ℝ(_x_) &lt; ℝ(_y_) and *false* otherwise.</dd>
           </dl>
+          <emu-alg>
+            1. If ℝ(_x_) &lt; ℝ(_y_), return *true*; otherwise return *false*.
+          </emu-alg>
         </emu-clause>
 
         <emu-clause id="sec-numeric-types-bigint-equal" type="numeric method">
@@ -2215,9 +2222,10 @@
             )
           </h1>
           <dl class="header">
-            <dt>description</dt>
-            <dd>It returns *true* if ℝ(_x_) = ℝ(_y_) and *false* otherwise.</dd>
           </dl>
+          <emu-alg>
+            1. If ℝ(_x_) = ℝ(_y_), return *true*; otherwise return *false*.
+          </emu-alg>
         </emu-clause>
 
         <emu-clause id="sec-numeric-types-bigint-sameValue" type="numeric method">


### PR DESCRIPTION
- BigInt::bitwiseNOT
- BigInt::multiply
- BigInt::add
- BigInt::subtract
- BigInt::lessThan
- BigInt::equal

(In most cases, the algorithm just rephrases the description, so there's no need to keep the description.)

Resolves #2522.