### PR TITLE
Editorial: "ECMAScript value" -> "ECMAScript language value"

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -944,7 +944,7 @@
         <li><em>Mathematical values</em>: Arbitrary real numbers, used as the default numeric type.</li>
         <li><em>Extended mathematical values</em>: Mathematical values together with +&infin; and -&infin;.</li>
         <li><em>Numbers</em>: IEEE 754-2019 double-precision floating point values.</li>
-        <li><em>BigInts</em>: ECMAScript values representing arbitrary integers in a one-to-one correspondence.</li>
+        <li><em>BigInts</em>: ECMAScript language values representing arbitrary integers in a one-to-one correspondence.</li>
       </ul>
 
       <p>In the language of this specification, numerical values are distinguished among different numeric kinds using subscript suffixes. The subscript <sub>𝔽</sub> refers to Numbers, and the subscript <sub>ℤ</sub> refers to BigInts. Numeric values without a subscript suffix refer to mathematical values.</p>
@@ -3763,7 +3763,7 @@
       <p>When an algorithm iterates over the elements of a List without specifying an order, the order used is the order of the elements in the List.</p>
       <p>For notational convenience within this specification, a literal syntax can be used to express a new List value. For example, &laquo; 1, 2 &raquo; defines a List value that has two elements each of which is initialized to a specific value. A new empty List can be expressed as &laquo; &raquo;.</p>
       <p>In this specification, the phrase "the <dfn id="list-concatenation">list-concatenation</dfn> of _A_, _B_, ..." (where each argument is a possibly empty List) denotes a new List value whose elements are the concatenation of the elements (in order) of each of the arguments (in order).</p>
-      <p>The <dfn variants="Records">Record</dfn> type is used to describe data aggregations within the algorithms of this specification. A Record type value consists of one or more named fields. The value of each field is either an ECMAScript value or an abstract value represented by a name associated with the Record type. Field names are always enclosed in double brackets, for example [[Value]].</p>
+      <p>The <dfn variants="Records">Record</dfn> type is used to describe data aggregations within the algorithms of this specification. A Record type value consists of one or more named fields. The value of each field is either an ECMAScript language value or an abstract value represented by a name associated with the Record type. Field names are always enclosed in double brackets, for example [[Value]].</p>
       <p>For notational convenience within this specification, an object literal-like syntax can be used to express a Record value. For example, { [[Field1]]: 42, [[Field2]]: *false*, [[Field3]]: ~empty~ } defines a Record value that has three fields, each of which is initialized to a specific value. Field name order is not significant. Any fields that are not explicitly listed are considered to be absent.</p>
       <p>In specification text and algorithms, dot notation may be used to refer to a specific field of a Record value. For example, if R is the record shown in the previous paragraph then R.[[Field2]] is shorthand for &ldquo;the field of R named [[Field2]]&rdquo;.</p>
       <p>Schema for commonly used Record field combinations may be named, and that name may be used as a prefix to a literal Record value to identify the specific kind of aggregations that is being described. For example: PropertyDescriptor { [[Value]]: 42, [[Writable]]: *false*, [[Configurable]]: *true* }.</p>
@@ -19216,7 +19216,7 @@
           <ul>
             <li>It must return a normal completion with a value of a List whose values are all Records with two fields, [[Key]] and [[Value]].</li>
             <li>Each such Record's [[Key]] field must be a property key, i.e., IsPropertyKey must return *true* when applied to it.</li>
-            <li>Each such Record's [[Value]] field must be an ECMAScript value.</li>
+            <li>Each such Record's [[Value]] field must be an ECMAScript language value.</li>
           </ul>
 
           <p>The default implementation of HostGetImportMetaProperties is to return NormalCompletion(&laquo; &raquo;).</p>
@@ -41922,7 +41922,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-json.parse">
       <h1>JSON.parse ( _text_ [ , _reviver_ ] )</h1>
-      <p>The `parse` function parses a JSON text (a JSON-formatted String) and produces an ECMAScript value. The JSON format represents literals, arrays, and objects with a syntax similar to the syntax for ECMAScript literals, Array Initializers, and Object Initializers. After parsing, JSON objects are realized as ECMAScript objects. JSON arrays are realized as ECMAScript Array instances. JSON strings, numbers, booleans, and null are realized as ECMAScript Strings, Numbers, Booleans, and *null*.</p>
+      <p>The `parse` function parses a JSON text (a JSON-formatted String) and produces an ECMAScript language value. The JSON format represents literals, arrays, and objects with a syntax similar to the syntax for ECMAScript literals, Array Initializers, and Object Initializers. After parsing, JSON objects are realized as ECMAScript objects. JSON arrays are realized as ECMAScript Array instances. JSON strings, numbers, booleans, and null are realized as ECMAScript Strings, Numbers, Booleans, and *null*.</p>
       <p>The optional _reviver_ parameter is a function that takes two parameters, _key_ and _value_. It can filter and transform the results. It is called with each of the _key_/_value_ pairs produced by the parse, and its return value is used instead of the original value. If it returns what it received, the structure is not modified. If it returns *undefined* then the property is deleted from the result.</p>
       <emu-alg>
         1. Let _jsonString_ be ? ToString(_text_).
@@ -41997,7 +41997,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-json.stringify">
       <h1>JSON.stringify ( _value_ [ , _replacer_ [ , _space_ ] ] )</h1>
-      <p>The `stringify` function returns a String in UTF-16 encoded JSON format representing an ECMAScript value, or *undefined*. It can take three parameters. The _value_ parameter is an ECMAScript value, which is usually an object or array, although it can also be a String, Boolean, Number or *null*. The optional _replacer_ parameter is either a function that alters the way objects and arrays are stringified, or an array of Strings and Numbers that acts as an inclusion list for selecting the object properties that will be stringified. The optional _space_ parameter is a String or Number that allows the result to have white space injected into it to improve human readability.</p>
+      <p>The `stringify` function returns a String in UTF-16 encoded JSON format representing an ECMAScript language value, or *undefined*. It can take three parameters. The _value_ parameter is an ECMAScript language value, which is usually an object or array, although it can also be a String, Boolean, Number or *null*. The optional _replacer_ parameter is either a function that alters the way objects and arrays are stringified, or an array of Strings and Numbers that acts as an inclusion list for selecting the object properties that will be stringified. The optional _space_ parameter is a String or Number that allows the result to have white space injected into it to improve human readability.</p>
       <p>These are the steps in stringifying an object:</p>
       <emu-alg>
         1. Let _stack_ be a new empty List.


### PR DESCRIPTION
There were 6 occurrences of "ECMAScript value". The term "ECMAScript language value" has 127 occurrences and a `<emu-dfn>`.