### PR TITLE
Editorial: inline infallible CreateDataPropertyOrThrow calls

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -4410,17 +4410,17 @@
           1. Let _obj_ be ! OrdinaryObjectCreate(%Object.prototype%).
           1. Assert: _obj_ is an extensible ordinary object with no own properties.
           1. If _Desc_ has a [[Value]] field, then
-            1. Perform ! CreateDataPropertyOrThrow(_obj_, *"value"*, _Desc_.[[Value]]).
+            1. Perform ! CreateDataProperty(_obj_, *"value"*, _Desc_.[[Value]]).
           1. If _Desc_ has a [[Writable]] field, then
-            1. Perform ! CreateDataPropertyOrThrow(_obj_, *"writable"*, _Desc_.[[Writable]]).
+            1. Perform ! CreateDataProperty(_obj_, *"writable"*, _Desc_.[[Writable]]).
           1. If _Desc_ has a [[Get]] field, then
-            1. Perform ! CreateDataPropertyOrThrow(_obj_, *"get"*, _Desc_.[[Get]]).
+            1. Perform ! CreateDataProperty(_obj_, *"get"*, _Desc_.[[Get]]).
           1. If _Desc_ has a [[Set]] field, then
-            1. Perform ! CreateDataPropertyOrThrow(_obj_, *"set"*, _Desc_.[[Set]]).
+            1. Perform ! CreateDataProperty(_obj_, *"set"*, _Desc_.[[Set]]).
           1. If _Desc_ has an [[Enumerable]] field, then
-            1. Perform ! CreateDataPropertyOrThrow(_obj_, *"enumerable"*, _Desc_.[[Enumerable]]).
+            1. Perform ! CreateDataProperty(_obj_, *"enumerable"*, _Desc_.[[Enumerable]]).
           1. If _Desc_ has a [[Configurable]] field, then
-            1. Perform ! CreateDataPropertyOrThrow(_obj_, *"configurable"*, _Desc_.[[Configurable]]).
+            1. Perform ! CreateDataProperty(_obj_, *"configurable"*, _Desc_.[[Configurable]]).
           1. Return _obj_.
         </emu-alg>
       </emu-clause>
@@ -6605,7 +6605,7 @@
         1. Let _array_ be ! ArrayCreate(0).
         1. Let _n_ be 0.
         1. For each element _e_ of _elements_, do
-          1. Perform ! CreateDataPropertyOrThrow(_array_, ! ToString(𝔽(_n_)), _e_).
+          1. Perform ! CreateDataProperty(_array_, ! ToString(𝔽(_n_)), _e_).
           1. Set _n_ to _n_ + 1.
         1. Return _array_.
       </emu-alg>
@@ -6804,7 +6804,7 @@
             1. Let _desc_ be ? _from_.[[GetOwnProperty]](_nextKey_).
             1. If _desc_ is not *undefined* and _desc_.[[Enumerable]] is *true*, then
               1. Let _propValue_ be ? Get(_from_, _nextKey_).
-              1. Perform ! CreateDataPropertyOrThrow(_target_, _nextKey_, _propValue_).
+              1. Perform ! CreateDataProperty(_target_, _nextKey_, _propValue_).
         1. Return _target_.
       </emu-alg>
       <emu-note>
@@ -7127,8 +7127,8 @@
       </dl>
       <emu-alg>
         1. Let _obj_ be ! OrdinaryObjectCreate(%Object.prototype%).
-        1. Perform ! CreateDataPropertyOrThrow(_obj_, *"value"*, _value_).
-        1. Perform ! CreateDataPropertyOrThrow(_obj_, *"done"*, _done_).
+        1. Perform ! CreateDataProperty(_obj_, *"value"*, _value_).
+        1. Perform ! CreateDataProperty(_obj_, *"done"*, _done_).
         1. Return _obj_.
       </emu-alg>
     </emu-clause>
@@ -9644,7 +9644,7 @@
           1. Let _nextValue_ be IteratorValue(_next_).
           1. If _nextValue_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
           1. ReturnIfAbrupt(_nextValue_).
-          1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_n_)), _nextValue_).
+          1. Perform ! CreateDataProperty(_A_, ! ToString(𝔽(_n_)), _nextValue_).
           1. Set _n_ to _n_ + 1.
       </emu-alg>
       <emu-grammar>BindingRestElement : `...` BindingPattern</emu-grammar>
@@ -9662,7 +9662,7 @@
           1. Let _nextValue_ be IteratorValue(_next_).
           1. If _nextValue_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
           1. ReturnIfAbrupt(_nextValue_).
-          1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_n_)), _nextValue_).
+          1. Perform ! CreateDataProperty(_A_, ! ToString(𝔽(_n_)), _nextValue_).
           1. Set _n_ to _n_ + 1.
       </emu-alg>
       <emu-grammar>FormalParameters : [empty]</emu-grammar>
@@ -14406,7 +14406,7 @@
           1. Let _index_ be 0.
           1. Repeat, while _index_ &lt; _len_,
             1. Let _val_ be _argumentsList_[_index_].
-            1. Perform ! CreateDataPropertyOrThrow(_obj_, ! ToString(𝔽(_index_)), _val_).
+            1. Perform ! CreateDataProperty(_obj_, ! ToString(𝔽(_index_)), _val_).
             1. Set _index_ to _index_ + 1.
           1. Perform ! DefinePropertyOrThrow(_obj_, @@iterator, PropertyDescriptor { [[Value]]: %Array.prototype.values%, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
           1. Perform ! DefinePropertyOrThrow(_obj_, *"callee"*, PropertyDescriptor { [[Get]]: %ThrowTypeError%, [[Set]]: %ThrowTypeError%, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
@@ -14442,7 +14442,7 @@
           1. Let _index_ be 0.
           1. Repeat, while _index_ &lt; _len_,
             1. Let _val_ be _argumentsList_[_index_].
-            1. Perform ! CreateDataPropertyOrThrow(_obj_, ! ToString(𝔽(_index_)), _val_).
+            1. Perform ! CreateDataProperty(_obj_, ! ToString(𝔽(_index_)), _val_).
             1. Set _index_ to _index_ + 1.
           1. Perform ! DefinePropertyOrThrow(_obj_, *"length"*, PropertyDescriptor { [[Value]]: 𝔽(_len_), [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
           1. Let _mappedNames_ be a new empty List.
@@ -18122,7 +18122,7 @@
             1. ReturnIfAbrupt(_nextIndex_).
           1. Let _initResult_ be the result of evaluating |AssignmentExpression|.
           1. Let _initValue_ be ? GetValue(_initResult_).
-          1. Let _created_ be ! CreateDataPropertyOrThrow(_array_, ! ToString(𝔽(_nextIndex_)), _initValue_).
+          1. Let _created_ be ! CreateDataProperty(_array_, ! ToString(𝔽(_nextIndex_)), _initValue_).
           1. Return _nextIndex_ + 1.
         </emu-alg>
         <emu-grammar>ElementList : Elision? SpreadElement</emu-grammar>
@@ -18141,7 +18141,7 @@
             1. ReturnIfAbrupt(_nextIndex_).
           1. Let _initResult_ be the result of evaluating |AssignmentExpression|.
           1. Let _initValue_ be ? GetValue(_initResult_).
-          1. Let _created_ be ! CreateDataPropertyOrThrow(_array_, ! ToString(𝔽(_nextIndex_)), _initValue_).
+          1. Let _created_ be ! CreateDataProperty(_array_, ! ToString(𝔽(_nextIndex_)), _initValue_).
           1. Return _nextIndex_ + 1.
         </emu-alg>
         <emu-grammar>ElementList : ElementList `,` Elision? SpreadElement</emu-grammar>
@@ -18162,7 +18162,7 @@
             1. Let _next_ be ? IteratorStep(_iteratorRecord_).
             1. If _next_ is *false*, return _nextIndex_.
             1. Let _nextValue_ be ? IteratorValue(_next_).
-            1. Perform ! CreateDataPropertyOrThrow(_array_, ! ToString(𝔽(_nextIndex_)), _nextValue_).
+            1. Perform ! CreateDataProperty(_array_, ! ToString(𝔽(_nextIndex_)), _nextValue_).
             1. Set _nextIndex_ to _nextIndex_ + 1.
         </emu-alg>
         <emu-note>
@@ -18379,7 +18379,7 @@
           1. Let _exprValue_ be the result of evaluating |IdentifierReference|.
           1. Let _propValue_ be ? GetValue(_exprValue_).
           1. Assert: _object_ is an ordinary, extensible object with no non-configurable properties.
-          1. Return ! CreateDataPropertyOrThrow(_object_, _propName_, _propValue_).
+          1. Return ! CreateDataProperty(_object_, _propName_, _propValue_).
         </emu-alg>
         <emu-grammar>PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar>
         <emu-alg>
@@ -18401,7 +18401,7 @@
               1. Return ! _object_.[[SetPrototypeOf]](_propValue_).
             1. Return NormalCompletion(~empty~).
           1. Assert: _object_ is an ordinary, extensible object with no non-configurable properties.
-          1. Return ! CreateDataPropertyOrThrow(_object_, _propKey_, _propValue_).
+          1. Return ! CreateDataProperty(_object_, _propKey_, _propValue_).
         </emu-alg>
         <emu-grammar>PropertyDefinition : MethodDefinition</emu-grammar>
         <emu-alg>
@@ -19430,7 +19430,7 @@
             1. Set _importMeta_ to ! OrdinaryObjectCreate(*null*).
             1. Let _importMetaValues_ be ! HostGetImportMetaProperties(_module_).
             1. For each Record { [[Key]], [[Value]] } _p_ of _importMetaValues_, do
-              1. Perform ! CreateDataPropertyOrThrow(_importMeta_, _p_.[[Key]], _p_.[[Value]]).
+              1. Perform ! CreateDataProperty(_importMeta_, _p_.[[Key]], _p_.[[Value]]).
             1. Perform ! HostFinalizeImportMeta(_importMeta_, _module_).
             1. Set _module_.[[ImportMeta]] to _importMeta_.
             1. Return _importMeta_.
@@ -20899,7 +20899,7 @@
               1. Let _nextValue_ be IteratorValue(_next_).
               1. If _nextValue_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
               1. ReturnIfAbrupt(_nextValue_).
-              1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_n_)), _nextValue_).
+              1. Perform ! CreateDataProperty(_A_, ! ToString(𝔽(_n_)), _nextValue_).
               1. Set _n_ to _n_ + 1.
           1. If |DestructuringAssignmentTarget| is neither an |ObjectLiteral| nor an |ArrayLiteral|, then
             1. Return ? PutValue(_lref_, _A_).
@@ -29478,7 +29478,7 @@
           1. Assert: _obj_ is an extensible ordinary object with no own properties.
           1. Let _closure_ be a new Abstract Closure with parameters (_key_, _value_) that captures _obj_ and performs the following steps when called:
             1. Let _propertyKey_ be ? ToPropertyKey(_key_).
-            1. Perform ! CreateDataPropertyOrThrow(_obj_, _propertyKey_, _value_).
+            1. Perform ! CreateDataProperty(_obj_, _propertyKey_, _value_).
             1. Return *undefined*.
           1. Let _adder_ be ! CreateBuiltinFunction(_closure_, 2, *""*, &laquo; &raquo;).
           1. Return ? AddEntriesFromIterable(_obj_, _iterable_, _adder_).
@@ -29509,7 +29509,7 @@
           1. For each element _key_ of _ownKeys_, do
             1. Let _desc_ be ? _obj_.[[GetOwnProperty]](_key_).
             1. Let _descriptor_ be ! FromPropertyDescriptor(_desc_).
-            1. If _descriptor_ is not *undefined*, perform ! CreateDataPropertyOrThrow(_descriptors_, _key_, _descriptor_).
+            1. If _descriptor_ is not *undefined*, perform ! CreateDataProperty(_descriptors_, _key_, _descriptor_).
           1. Return _descriptors_.
         </emu-alg>
       </emu-clause>
@@ -36170,15 +36170,15 @@ THH:mm:ss.sss
             1. Assert: _n_ &lt; 2<sup>32</sup> - 1.
             1. Let _A_ be ! ArrayCreate(_n_ + 1).
             1. Assert: The mathematical value of _A_'s *"length"* property is _n_ + 1.
-            1. Perform ! CreateDataPropertyOrThrow(_A_, *"index"*, 𝔽(_lastIndex_)).
-            1. Perform ! CreateDataPropertyOrThrow(_A_, *"input"*, _S_).
+            1. Perform ! CreateDataProperty(_A_, *"index"*, 𝔽(_lastIndex_)).
+            1. Perform ! CreateDataProperty(_A_, *"input"*, _S_).
             1. Let _matchedSubstr_ be the substring of _S_ from _lastIndex_ to _e_.
-            1. Perform ! CreateDataPropertyOrThrow(_A_, *"0"*, _matchedSubstr_).
+            1. Perform ! CreateDataProperty(_A_, *"0"*, _matchedSubstr_).
             1. If _R_ contains any |GroupName|, then
               1. Let _groups_ be ! OrdinaryObjectCreate(*null*).
             1. Else,
               1. Let _groups_ be *undefined*.
-            1. Perform ! CreateDataPropertyOrThrow(_A_, *"groups"*, _groups_).
+            1. Perform ! CreateDataProperty(_A_, *"groups"*, _groups_).
             1. For each integer _i_ such that _i_ &ge; 1 and _i_ &le; _n_, in ascending order, do
               1. Let _captureI_ be _i_<sup>th</sup> element of _r_'s _captures_ List.
               1. If _captureI_ is *undefined*, let _capturedValue_ be *undefined*.
@@ -36189,10 +36189,10 @@ THH:mm:ss.sss
                 1. Assert: _fullUnicode_ is *false*.
                 1. Assert: _captureI_ is a List of code units.
                 1. Let _capturedValue_ be the String value consisting of the code units of _captureI_.
-              1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_i_)), _capturedValue_).
+              1. Perform ! CreateDataProperty(_A_, ! ToString(𝔽(_i_)), _capturedValue_).
               1. If the _i_<sup>th</sup> capture of _R_ was defined with a |GroupName|, then
                 1. Let _s_ be the CapturingGroupName of the corresponding |RegExpIdentifierName|.
-                1. Perform ! CreateDataPropertyOrThrow(_groups_, _s_, _capturedValue_).
+                1. Perform ! CreateDataProperty(_groups_, _s_, _capturedValue_).
             1. Return _A_.
           </emu-alg>
         </emu-clause>
@@ -36314,7 +36314,7 @@ THH:mm:ss.sss
                 1. Return _A_.
               1. Else,
                 1. Let _matchStr_ be ? ToString(? Get(_result_, *"0"*)).
-                1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_n_)), _matchStr_).
+                1. Perform ! CreateDataProperty(_A_, ! ToString(𝔽(_n_)), _matchStr_).
                 1. If _matchStr_ is the empty String, then
                   1. Let _thisIndex_ be ℝ(? ToLength(? Get(_rx_, *"lastIndex"*))).
                   1. Let _nextIndex_ be AdvanceStringIndex(_S_, _thisIndex_, _fullUnicode_).
@@ -36498,7 +36498,7 @@ THH:mm:ss.sss
           1. If _size_ is 0, then
             1. Let _z_ be ? RegExpExec(_splitter_, _S_).
             1. If _z_ is not *null*, return _A_.
-            1. Perform ! CreateDataPropertyOrThrow(_A_, *"0"*, _S_).
+            1. Perform ! CreateDataProperty(_A_, *"0"*, _S_).
             1. Return _A_.
           1. Let _p_ be 0.
           1. Let _q_ be _p_.
@@ -36512,7 +36512,7 @@ THH:mm:ss.sss
               1. If _e_ = _p_, set _q_ to AdvanceStringIndex(_S_, _q_, _unicodeMatching_).
               1. Else,
                 1. Let _T_ be the substring of _S_ from _p_ to _q_.
-                1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_lengthA_)), _T_).
+                1. Perform ! CreateDataProperty(_A_, ! ToString(𝔽(_lengthA_)), _T_).
                 1. Set _lengthA_ to _lengthA_ + 1.
                 1. If _lengthA_ = _lim_, return _A_.
                 1. Set _p_ to _e_.
@@ -36521,13 +36521,13 @@ THH:mm:ss.sss
                 1. Let _i_ be 1.
                 1. Repeat, while _i_ &le; _numberOfCaptures_,
                   1. Let _nextCapture_ be ? Get(_z_, ! ToString(𝔽(_i_))).
-                  1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_lengthA_)), _nextCapture_).
+                  1. Perform ! CreateDataProperty(_A_, ! ToString(𝔽(_lengthA_)), _nextCapture_).
                   1. Set _i_ to _i_ + 1.
                   1. Set _lengthA_ to _lengthA_ + 1.
                   1. If _lengthA_ = _lim_, return _A_.
                 1. Set _q_ to _p_.
           1. Let _T_ be the substring of _S_ from _p_ to _size_.
-          1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_lengthA_)), _T_).
+          1. Perform ! CreateDataProperty(_A_, ! ToString(𝔽(_lengthA_)), _T_).
           1. Return _A_.
         </emu-alg>
         <p>The value of the *"name"* property of this function is *"[Symbol.split]"*.</p>
@@ -36691,7 +36691,7 @@ THH:mm:ss.sss
             1. Let _len_ be _values_[0].
             1. Let _array_ be ! ArrayCreate(0, _proto_).
             1. If Type(_len_) is not Number, then
-              1. Perform ! CreateDataPropertyOrThrow(_array_, *"0"*, _len_).
+              1. Perform ! CreateDataProperty(_array_, *"0"*, _len_).
               1. Let _intLen_ be *1*<sub>𝔽</sub>.
             1. Else,
               1. Let _intLen_ be ! ToUint32(_len_).
@@ -36705,7 +36705,7 @@ THH:mm:ss.sss
             1. Repeat, while _k_ &lt; _numberOfArgs_,
               1. Let _Pk_ be ! ToString(𝔽(_k_)).
               1. Let _itemK_ be _values_[_k_].
-              1. Perform ! CreateDataPropertyOrThrow(_array_, _Pk_, _itemK_).
+              1. Perform ! CreateDataProperty(_array_, _Pk_, _itemK_).
               1. Set _k_ to _k_ + 1.
             1. Assert: The mathematical value of _array_'s *"length"* property is _numberOfArgs_.
             1. Return _array_.
@@ -37964,17 +37964,17 @@ THH:mm:ss.sss
         <p>The initial value of the @@unscopables data property is an object created by the following steps:</p>
         <emu-alg>
           1. Let _unscopableList_ be ! OrdinaryObjectCreate(*null*).
-          1. Perform ! CreateDataPropertyOrThrow(_unscopableList_, *"at"*, *true*).
-          1. Perform ! CreateDataPropertyOrThrow(_unscopableList_, *"copyWithin"*, *true*).
-          1. Perform ! CreateDataPropertyOrThrow(_unscopableList_, *"entries"*, *true*).
-          1. Perform ! CreateDataPropertyOrThrow(_unscopableList_, *"fill"*, *true*).
-          1. Perform ! CreateDataPropertyOrThrow(_unscopableList_, *"find"*, *true*).
-          1. Perform ! CreateDataPropertyOrThrow(_unscopableList_, *"findIndex"*, *true*).
-          1. Perform ! CreateDataPropertyOrThrow(_unscopableList_, *"flat"*, *true*).
-          1. Perform ! CreateDataPropertyOrThrow(_unscopableList_, *"flatMap"*, *true*).
-          1. Perform ! CreateDataPropertyOrThrow(_unscopableList_, *"includes"*, *true*).
-          1. Perform ! CreateDataPropertyOrThrow(_unscopableList_, *"keys"*, *true*).
-          1. Perform ! CreateDataPropertyOrThrow(_unscopableList_, *"values"*, *true*).
+          1. Perform ! CreateDataProperty(_unscopableList_, *"at"*, *true*).
+          1. Perform ! CreateDataProperty(_unscopableList_, *"copyWithin"*, *true*).
+          1. Perform ! CreateDataProperty(_unscopableList_, *"entries"*, *true*).
+          1. Perform ! CreateDataProperty(_unscopableList_, *"fill"*, *true*).
+          1. Perform ! CreateDataProperty(_unscopableList_, *"find"*, *true*).
+          1. Perform ! CreateDataProperty(_unscopableList_, *"findIndex"*, *true*).
+          1. Perform ! CreateDataProperty(_unscopableList_, *"flat"*, *true*).
+          1. Perform ! CreateDataProperty(_unscopableList_, *"flatMap"*, *true*).
+          1. Perform ! CreateDataProperty(_unscopableList_, *"includes"*, *true*).
+          1. Perform ! CreateDataProperty(_unscopableList_, *"keys"*, *true*).
+          1. Perform ! CreateDataProperty(_unscopableList_, *"values"*, *true*).
           1. Return _unscopableList_.
         </emu-alg>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
@@ -42043,7 +42043,7 @@ THH:mm:ss.sss
         1. If IsCallable(_reviver_) is *true*, then
           1. Let _root_ be ! OrdinaryObjectCreate(%Object.prototype%).
           1. Let _rootName_ be the empty String.
-          1. Perform ! CreateDataPropertyOrThrow(_root_, _rootName_, _unfiltered_).
+          1. Perform ! CreateDataProperty(_root_, _rootName_, _unfiltered_).
           1. Return ? InternalizeJSONProperty(_root_, _rootName_, _reviver_).
         1. Else,
           1. Return _unfiltered_.
@@ -42142,7 +42142,7 @@ THH:mm:ss.sss
         1. Else,
           1. Let _gap_ be the empty String.
         1. Let _wrapper_ be ! OrdinaryObjectCreate(%Object.prototype%).
-        1. Perform ! CreateDataPropertyOrThrow(_wrapper_, the empty String, _value_).
+        1. Perform ! CreateDataProperty(_wrapper_, the empty String, _value_).
         1. Let _state_ be the Record { [[ReplacerFunction]]: _ReplacerFunction_, [[Stack]]: _stack_, [[Indent]]: _indent_, [[Gap]]: _gap_, [[PropertyList]]: _PropertyList_ }.
         1. Return ? SerializeJSONProperty(_state_, the empty String, _wrapper_).
       </emu-alg>
@@ -43854,8 +43854,8 @@ THH:mm:ss.sss
             1. Let _promiseCapability_ be _F_.[[Capability]].
             1. Let _remainingElementsCount_ be _F_.[[RemainingElements]].
             1. Let _obj_ be ! OrdinaryObjectCreate(%Object.prototype%).
-            1. Perform ! CreateDataPropertyOrThrow(_obj_, *"status"*, *"fulfilled"*).
-            1. Perform ! CreateDataPropertyOrThrow(_obj_, *"value"*, _x_).
+            1. Perform ! CreateDataProperty(_obj_, *"status"*, *"fulfilled"*).
+            1. Perform ! CreateDataProperty(_obj_, *"value"*, _x_).
             1. Set _values_[_index_] to _obj_.
             1. Set _remainingElementsCount_.[[Value]] to _remainingElementsCount_.[[Value]] - 1.
             1. If _remainingElementsCount_.[[Value]] is 0, then
@@ -43880,8 +43880,8 @@ THH:mm:ss.sss
             1. Let _promiseCapability_ be _F_.[[Capability]].
             1. Let _remainingElementsCount_ be _F_.[[RemainingElements]].
             1. Let _obj_ be ! OrdinaryObjectCreate(%Object.prototype%).
-            1. Perform ! CreateDataPropertyOrThrow(_obj_, *"status"*, *"rejected"*).
-            1. Perform ! CreateDataPropertyOrThrow(_obj_, *"reason"*, _x_).
+            1. Perform ! CreateDataProperty(_obj_, *"status"*, *"rejected"*).
+            1. Perform ! CreateDataProperty(_obj_, *"reason"*, _x_).
             1. Set _values_[_index_] to _obj_.
             1. Set _remainingElementsCount_.[[Value]] to _remainingElementsCount_.[[Value]] - 1.
             1. If _remainingElementsCount_.[[Value]] is 0, then
@@ -45582,8 +45582,8 @@ THH:mm:ss.sss
           1. Let _revoker_ be ! CreateBuiltinFunction(_revokerClosure_, 0, *""*, &laquo; [[RevocableProxy]] &raquo;).
           1. Set _revoker_.[[RevocableProxy]] to _p_.
           1. Let _result_ be ! OrdinaryObjectCreate(%Object.prototype%).
-          1. Perform ! CreateDataPropertyOrThrow(_result_, *"proxy"*, _p_).
-          1. Perform ! CreateDataPropertyOrThrow(_result_, *"revoke"*, _revoker_).
+          1. Perform ! CreateDataProperty(_result_, *"proxy"*, _p_).
+          1. Perform ! CreateDataProperty(_result_, *"revoke"*, _revoker_).
           1. Return _result_.
         </emu-alg>
       </emu-clause>


### PR DESCRIPTION
There's no reason to call `CreateDataPropertyOrThrow` when it cannot fail (marked with `!`). Instead, call `CreateDataProperty` directly.