### PR TITLE
Meta: Keep old years in gh-pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,9 @@
-name: 'ecma-262'
+name: 'ecma-262 deploy'
 
 on:
   push:
     branches:
-      - $default-branch
+      - master
 
 jobs:
   deploy:

--- a/scripts/auto-deploy.sh
+++ b/scripts/auto-deploy.sh
@@ -8,12 +8,14 @@ declare -r GH_USER_NAME="Bot"
 declare -r COMMIT_MESSAGE="Update gh-pages"
 
 
-cd "$(dirname "$BASH_SOURCE")"/../out
+cd "$(dirname "$BASH_SOURCE")"/..
+git clone --depth 1 --branch gh-pages "https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" gh-pages
+find gh-pages -type f \! \( -path 'gh-pages/2*' -o -path 'gh-pages/.git*' \) -exec rm -rf {} \;
+cp -r out/* gh-pages
 
-git config --global user.email "${GH_USER_EMAIL}"
-git config --global user.name "${GH_USER_NAME}"
-git config --global init.defaultBranch gh-pages
-git init
+cd gh-pages
+git config user.email "${GH_USER_EMAIL}"
+git config user.name "${GH_USER_NAME}"
 git add -A
-git commit --message "${COMMIT_MESSAGE}"
-git push --force "https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" gh-pages
+git commit --allow-empty --message "${COMMIT_MESSAGE}"
+git push origin gh-pages


### PR DESCRIPTION
I updated the [gh-pages branch](https://github.com/tc39/ecma262/tree/gh-pages) with es2016-es2021 subdirectories (including some minor tweaks, which I pushed to the corresponding branches).

This updates the auto-deploy script to preserve those subdirectories.

It also fixes it - #2521 changed the branch name for the workflow to `$default-branch`, which [was a good idea](https://github.blog/changelog/2020-07-22-github-actions-better-support-for-alternative-default-branch-names/), but apparently that syntax [only works in workflow templates](https://github.com/actions/starter-workflows/pull/590#issuecomment-672360634). So we haven't been updating the rendered spec since that PR landed.

Fixes #2529.