### PR TITLE
Editorial: `String.prototype.lastIndexOf`: use explicit algorithm steps

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -33428,9 +33428,12 @@ THH:mm:ss.sss
           1. If _numPos_ is *NaN*, let _pos_ be +&infin;; otherwise, let _pos_ be ! ToIntegerOrInfinity(_numPos_).
           1. Let _len_ be the length of _S_.
           1. Let _start_ be the result of clamping _pos_ between 0 and _len_.
+          1. If _searchStr_ is the empty String, return 𝔽(_start_).
           1. Let _searchLen_ be the length of _searchStr_.
-          1. Let _k_ be the largest possible non-negative integer not larger than _start_ such that _k_ + _searchLen_ &le; _len_, and for all non-negative integers _j_ such that _j_ &lt; _searchLen_, the code unit at index _k_ + _j_ within _S_ is the same as the code unit at index _j_ within _searchStr_; but if there is no such integer, let _k_ be -1.
-          1. Return 𝔽(_k_).
+          1. For each non-negative integer _i_ starting with _start_ such that _i_ &le; _len_ - _searchLen_, in descending order, do
+            1. Let _candidate_ be the substring of _string_ from _i_ to _i_ + _searchLen_.
+            1. If _candidate_ is the same sequence of code units as _searchStr_, return 𝔽(_i_).
+          1. Return *-1*<sub>𝔽</sub>.
         </emu-alg>
         <emu-note>
           <p>The `lastIndexOf` function is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>


### PR DESCRIPTION
See also, https://github.com/tc39/ecma262/pull/2258