### PR TITLE
Editorial: `lastIndexOf`: fix typo from #2536

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -33431,7 +33431,7 @@ THH:mm:ss.sss
           1. If _searchStr_ is the empty String, return 𝔽(_start_).
           1. Let _searchLen_ be the length of _searchStr_.
           1. For each non-negative integer _i_ starting with _start_ such that _i_ &le; _len_ - _searchLen_, in descending order, do
-            1. Let _candidate_ be the substring of _string_ from _i_ to _i_ + _searchLen_.
+            1. Let _candidate_ be the substring of _S_ from _i_ to _i_ + _searchLen_.
             1. If _candidate_ is the same sequence of code units as _searchStr_, return 𝔽(_i_).
           1. Return *-1*<sub>𝔽</sub>.
         </emu-alg>


### PR DESCRIPTION
Thanks to @jmdyck for pointing this out.