### PR TITLE
Editorial: delete stray for-await-of rules in HasCallInTailPosition

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -25134,9 +25134,6 @@
             `for` `(` LeftHandSideExpression `in` Expression `)` Statement
             `for` `(` `var` ForBinding `in` Expression `)` Statement
             `for` `(` ForDeclaration `in` Expression `)` Statement
-            `for` `await` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
-            `for` `await` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
-            `for` `await` `(` ForDeclaration `of` AssignmentExpression `)` Statement
 
           WithStatement : `with` `(` Expression `)` Statement
         </emu-grammar>


### PR DESCRIPTION
Fixes #2279. See that issue for context. Thanks to @rbuckton for raising this again in #2544.

These branches are never invoked, because async functions and top-level async modules are never inspected for tail calls, so they can be removed.