### PR TITLE
Editorial: refer to numeric methods as we do other AOs

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1235,13 +1235,13 @@
 
     <emu-clause id="sec-numeric-types">
       <h1>Numeric Types</h1>
-      <p>ECMAScript has two built-in numeric types: Number and BigInt. In this specification, every numeric type _T_ contains a multiplicative identity value denoted _T_::unit. The specification types also have the following abstract operations, likewise denoted _T_::<i>op</i> for a given operation with specification name <i>op</i>. All argument types are _T_. The "Result" column shows the return type, along with an indication if it is possible for some invocations of the operation to return an abrupt completion.</p>
+      <p>ECMAScript has two built-in numeric types: Number and BigInt. The following abstract operations are defined over these numeric types. The "Result" column shows the return type, along with an indication if it is possible for some invocations of the operation to return an abrupt completion.</p>
       <emu-table id="table-numeric-type-ops" caption="Numeric Type Operations">
         <table>
           <tbody>
           <tr>
             <th>
-              Invocation Synopsis
+              Operation
             </th>
             <th>
               Example source
@@ -1253,173 +1253,273 @@
               Result
             </th>
           </tr>
+
           <tr>
             <td>
-              _T_::unaryMinus(x)
+              Number::unaryMinus
             </td>
-            <td>
+            <td rowspan="2">
               `-x`
             </td>
-            <td>
+            <td rowspan="2">
               <emu-xref href="#sec-unary-minus-operator" title></emu-xref>
             </td>
             <td>
-              _T_
+              Number
             </td>
           </tr>
           <tr>
             <td>
-              _T_::bitwiseNOT(x)
+              BigInt::unaryMinus
             </td>
             <td>
+              BigInt
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              Number::bitwiseNOT
+            </td>
+            <td rowspan="2">
               `~x`
             </td>
-            <td>
+            <td rowspan="2">
               <emu-xref href="#sec-bitwise-not-operator" title></emu-xref>
             </td>
             <td>
-              _T_
+              Number
             </td>
           </tr>
           <tr>
             <td>
-              _T_::exponentiate(x,&nbsp;y)
+              BigInt::bitwiseNOT
             </td>
             <td>
+              BigInt
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              Number::exponentiate
+            </td>
+            <td rowspan="2">
               `x&nbsp;**&nbsp;y`
             </td>
-            <td>
+            <td rowspan="2">
               <emu-xref href="#sec-exp-operator" title></emu-xref>
               and <emu-xref href="#sec-math.pow" title></emu-xref>
             </td>
             <td>
-              _T_, may throw *RangeError*
+              Number
             </td>
           </tr>
           <tr>
             <td>
-              _T_::multiply(x,&nbsp;y)
+              BigInt::exponentiate
             </td>
             <td>
+              BigInt; may throw *RangeError*
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              Number::multiply
+            </td>
+            <td rowspan="2">
               `x&nbsp;*&nbsp;y`
             </td>
-            <td>
+            <td rowspan="2">
               <emu-xref href="#sec-multiplicative-operators" title></emu-xref>
             </td>
             <td>
-              _T_
+              Number
             </td>
           </tr>
           <tr>
             <td>
-              _T_::divide(x,&nbsp;y)
+              BigInt::multiply
             </td>
             <td>
+              BigInt
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              Number::divide
+            </td>
+            <td rowspan="2">
               `x&nbsp;/&nbsp;y`
             </td>
-            <td>
+            <td rowspan="2">
               <emu-xref href="#sec-multiplicative-operators" title></emu-xref>
             </td>
             <td>
-              _T_, may throw *RangeError*
+              Number
             </td>
           </tr>
           <tr>
             <td>
-              _T_::remainder(x,&nbsp;y)
+              BigInt::divide
             </td>
             <td>
+              BigInt; may throw *RangeError*
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              Number::remainder
+            </td>
+            <td rowspan="2">
               `x&nbsp;%&nbsp;y`
             </td>
-            <td>
+            <td rowspan="2">
               <emu-xref href="#sec-multiplicative-operators" title></emu-xref>
             </td>
             <td>
-              _T_, may throw *RangeError*
+              Number
             </td>
           </tr>
           <tr>
             <td>
-              _T_::add(x,&nbsp;y)
+              BigInt::remainder
             </td>
             <td>
+              BigInt; may throw *RangeError*
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              Number::add
+            </td>
+            <td rowspan="2">
               `x ++`<br>`++ x`<br>`x&nbsp;+&nbsp;y`
             </td>
-            <td>
+            <td rowspan="2">
               <emu-xref href="#sec-postfix-increment-operator" title></emu-xref>,
               <emu-xref href="#sec-prefix-increment-operator" title></emu-xref>,
               and <emu-xref href="#sec-addition-operator-plus" title></emu-xref>
             </td>
             <td>
-              _T_
+              Number
             </td>
           </tr>
           <tr>
             <td>
-              _T_::subtract(x,&nbsp;y)
+              BigInt::add
             </td>
             <td>
+              BigInt
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              Number::subtract
+            </td>
+            <td rowspan="2">
               `x --`<br>`-- x`<br>`x&nbsp;-&nbsp;y`
             </td>
-            <td>
+            <td rowspan="2">
               <emu-xref href="#sec-postfix-decrement-operator" title></emu-xref>,
               <emu-xref href="#sec-prefix-decrement-operator" title></emu-xref>,
               and <emu-xref href="#sec-subtraction-operator-minus" title></emu-xref>
             </td>
             <td>
-              _T_
+              Number
             </td>
           </tr>
           <tr>
             <td>
-              _T_::leftShift(x,&nbsp;y)
+              BigInt::subtract
             </td>
             <td>
+              BigInt
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              Number::leftShift
+            </td>
+            <td rowspan="2">
               `x&nbsp;&lt;&lt;&nbsp;y`
             </td>
-            <td>
+            <td rowspan="2">
               <emu-xref href="#sec-left-shift-operator" title></emu-xref>
             </td>
             <td>
-              _T_
+              Number
             </td>
           </tr>
           <tr>
             <td>
-              _T_::signedRightShift(x,&nbsp;y)
+              BigInt::leftShift
             </td>
             <td>
+              BigInt
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              Number::signedRightShift
+            </td>
+            <td rowspan="2">
               `x&nbsp;>>&nbsp;y`
             </td>
-            <td>
+            <td rowspan="2">
               <emu-xref href="#sec-signed-right-shift-operator" title></emu-xref>
             </td>
             <td>
-              _T_
+              Number
             </td>
           </tr>
           <tr>
             <td>
-              _T_::unsignedRightShift(x,&nbsp;y)
+              BigInt::signedRightShift
             </td>
             <td>
+              BigInt
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              Number::unsignedRightShift
+            </td>
+            <td rowspan="2">
               `x&nbsp;>>>&nbsp;y`
             </td>
-            <td>
+            <td rowspan="2">
               <emu-xref href="#sec-unsigned-right-shift-operator" title></emu-xref>
             </td>
             <td>
-              _T_, may throw *TypeError*
+              Number
             </td>
           </tr>
           <tr>
             <td>
-              _T_::lessThan(x,&nbsp;y)
+              BigInt::unsignedRightShift
             </td>
             <td>
+              always throws a *TypeError*
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              Number::lessThan
+            </td>
+            <td rowspan="2">
               `x&nbsp;&lt;&nbsp;y`<br>`x&nbsp;>&nbsp;y`<br>`x&nbsp;&lt;=&nbsp;y`<br>`x&nbsp;>=&nbsp;y`
             </td>
-            <td>
+            <td rowspan="2">
               <emu-xref href="#sec-relational-operators" title></emu-xref>,
               via <emu-xref href="#sec-islessthan" title></emu-xref>
             </td>
@@ -1427,114 +1527,166 @@
               Boolean or *undefined* (for unordered inputs)
             </td>
           </tr>
+
           <tr>
             <td>
-              _T_::equal(x,&nbsp;y)
-            </td>
-            <td>
-              `x&nbsp;==&nbsp;y`<br>`x&nbsp;!=&nbsp;y`<br>`x&nbsp;===&nbsp;y`<br>`x&nbsp;!==&nbsp;y`
-            </td>
-            <td>
-              <emu-xref href="#sec-equality-operators" title></emu-xref>,
-              via <emu-xref href="#sec-isstrictlyequal" title></emu-xref>
+              BigInt::lessThan
             </td>
             <td>
               Boolean
             </td>
           </tr>
+
           <tr>
             <td>
-              _T_::sameValue(x,&nbsp;y)
+              Number::equal
             </td>
+            <td rowspan="2">
+              `x&nbsp;==&nbsp;y`<br>`x&nbsp;!=&nbsp;y`<br>`x&nbsp;===&nbsp;y`<br>`x&nbsp;!==&nbsp;y`
+            </td>
+            <td rowspan="2">
+              <emu-xref href="#sec-equality-operators" title></emu-xref>,
+              via <emu-xref href="#sec-isstrictlyequal" title></emu-xref>
+            </td>
+            <td rowspan="2">
+              Boolean
+            </td>
+          </tr>
+          <tr>
             <td>
+              BigInt::equal
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              Number::sameValue
+            </td>
+            <td rowspan="2">
               `Object.is(x, y)`
             </td>
-            <td>
+            <td rowspan="2">
               Object internal methods,
               via <emu-xref href="#sec-samevalue" title></emu-xref>,
               to test exact value equality
             </td>
-            <td>
+            <td rowspan="2">
               Boolean
             </td>
           </tr>
           <tr>
             <td>
-              _T_::sameValueZero(x,&nbsp;y)
+              BigInt::sameValue
             </td>
+          </tr>
+
+          <tr>
             <td>
+              Number::sameValueZero
+            </td>
+            <td rowspan="2">
               `[x].includes(y)`
             </td>
-            <td>
+            <td rowspan="2">
               Array, Map, and Set methods,
               via <emu-xref href="#sec-samevaluezero" title></emu-xref>,
-              to test value equality ignoring differences between Numbers in the zero cohort (i.e., *-0*<sub>𝔽</sub> and *+0*<sub>𝔽</sub>)
+              to test value equality, ignoring the difference between *+0*<sub>𝔽</sub> and *-0*<sub>𝔽</sub>
             </td>
-            <td>
+            <td rowspan="2">
               Boolean
             </td>
           </tr>
           <tr>
             <td>
-              _T_::bitwiseAND(x,&nbsp;y)
+              BigInt::sameValueZero
             </td>
+          </tr>
+
+          <tr>
             <td>
+              Number::bitwiseAND
+            </td>
+            <td rowspan="2">
               `x&nbsp;&amp;&nbsp;y`
             </td>
-            <td>
+            <td rowspan="6">
               <emu-xref href="#sec-binary-bitwise-operators" title></emu-xref>
             </td>
             <td>
-              _T_
+              Number
             </td>
           </tr>
           <tr>
             <td>
-              _T_::bitwiseXOR(x,&nbsp;y)
+              BigInt::bitwiseAND
             </td>
             <td>
+              BigInt
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              Number::bitwiseXOR
+            </td>
+            <td rowspan="2">
               `x&nbsp;^&nbsp;y`
             </td>
             <td>
-              <emu-xref href="#sec-binary-bitwise-operators" title></emu-xref>
-            </td>
-            <td>
-              _T_
+              Number
             </td>
           </tr>
           <tr>
             <td>
-              _T_::bitwiseOR(x,&nbsp;y)
+              BigInt::bitwiseXOR
             </td>
             <td>
+              BigInt
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              Number::bitwiseOR
+            </td>
+            <td rowspan="2">
               `x&nbsp;|&nbsp;y`
             </td>
             <td>
-              <emu-xref href="#sec-binary-bitwise-operators" title></emu-xref>
-            </td>
-            <td>
-              _T_
+              Number
             </td>
           </tr>
           <tr>
             <td>
-              _T_::toString(x)
+              BigInt::bitwiseOR
             </td>
             <td>
+              BigInt
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              Number::toString
+            </td>
+            <td rowspan="2">
               `String(x)`
             </td>
-            <td>
+            <td rowspan="2">
               Many expressions and built-in functions, via <emu-xref href="#sec-tostring" title></emu-xref>
             </td>
-            <td>
+            <td rowspan="2">
               String
             </td>
-
+          </tr>
+          <tr>
+            <td>
+              BigInt::toString
+            </td>
           </tr>
           </tbody>
         </table>
       </emu-table>
-      <p>The _T_::unit value and _T_::_op_ operations are not a part of the ECMAScript language; they are defined here solely to aid the specification of the semantics of the ECMAScript language. Other abstract operations are defined throughout this specification.</p>
       <p>Because the numeric types are in general not convertible without loss of precision or truncation, the ECMAScript language provides no implicit conversion among these types. Programmers must explicitly call `Number` and `BigInt` functions to convert among types when calling a function which requires another type.</p>
       <emu-note>
         <p>The first and subsequent editions of ECMAScript have provided, for certain operators, implicit numeric conversions that could lose precision or truncate. These legacy implicit conversions are maintained for backward compatibility, but not provided for BigInt in order to minimize opportunity for programmer error, and to leave open the option of generalized <em>value types</em> in a future edition.</p>
@@ -1565,8 +1717,6 @@
         <p>In this specification, the phrase &ldquo;the <dfn id="number-value">Number value</dfn> for _x_&rdquo; where _x_ represents an exact real mathematical quantity (which might even be an irrational number such as &pi;) means a Number value chosen in the following manner. Consider the set of all finite values of the Number type, with *-0*<sub>𝔽</sub> removed and with two additional values added to it that are not representable in the Number type, namely 2<sup>1024</sup> (which is <emu-eqn>+1 &times; 2<sup>53</sup> &times; 2<sup>971</sup></emu-eqn>) and <emu-eqn>-2<sup>1024</sup></emu-eqn> (which is <emu-eqn>-1 &times; 2<sup>53</sup> &times; 2<sup>971</sup></emu-eqn>). Choose the member of this set that is closest in value to _x_. If two values of the set are equally close, then the one with an even significand is chosen; for this purpose, the two extra values 2<sup>1024</sup> and <emu-eqn>-2<sup>1024</sup></emu-eqn> are considered to have even significands. Finally, if 2<sup>1024</sup> was chosen, replace it with *+&infin;*<sub>𝔽</sub>; if <emu-eqn>-2<sup>1024</sup></emu-eqn> was chosen, replace it with *-&infin;*<sub>𝔽</sub>; if *+0*<sub>𝔽</sub> was chosen, replace it with *-0*<sub>𝔽</sub> if and only if _x_ &lt; 0; any other chosen value is used unchanged. The result is the Number value for _x_. (This procedure corresponds exactly to the behaviour of the IEEE 754-2019 roundTiesToEven mode.)</p>
         <p>The Number value for +&infin; is *+&infin;*<sub>𝔽</sub>, and the Number value for -&infin; is *-&infin;*<sub>𝔽</sub>.</p>
         <p>Some ECMAScript operators deal only with integers in specific ranges such as <emu-eqn>-2<sup>31</sup></emu-eqn> through <emu-eqn>2<sup>31</sup> - 1</emu-eqn>, inclusive, or in the range 0 through <emu-eqn>2<sup>16</sup> - 1</emu-eqn>, inclusive. These operators accept any value of the Number type but first convert each such value to an integer value in the expected range. See the descriptions of the numeric conversion operations in <emu-xref href="#sec-type-conversion"></emu-xref>.</p>
-
-        <p>The Number::unit value is *1*<sub>𝔽</sub>.</p>
 
         <emu-clause id="sec-numeric-types-number-unaryMinus" type="numeric method">
           <h1>
@@ -2044,8 +2194,6 @@
       <emu-clause id="sec-ecmascript-language-types-bigint-type">
         <h1>The BigInt Type</h1>
         <p>The BigInt type represents an integer value. The value may be any size and is not limited to a particular bit-width. Generally, where not otherwise noted, operations are designed to return exact mathematically-based answers. For binary operations, BigInts act as two's complement binary strings, with negative numbers treated as having bits set infinitely to the left.</p>
-
-        <p>The BigInt::unit value is *1*<sub>ℤ</sub>.</p>
 
         <emu-clause id="sec-numeric-types-bigint-unaryMinus" type="numeric method">
           <h1>
@@ -5898,8 +6046,10 @@
       </dl>
       <emu-alg>
         1. If Type(_x_) is different from Type(_y_), return *false*.
-        1. If Type(_x_) is Number or BigInt, then
-          1. Return ! Type(_x_)::sameValue(_x_, _y_).
+        1. If Type(_x_) is Number, then
+          1. Return ! Number::sameValue(_x_, _y_).
+        1. If Type(_x_) is BigInt, then
+          1. Return ! BigInt::sameValue(_x_, _y_).
         1. Return ! SameValueNonNumeric(_x_, _y_).
       </emu-alg>
       <emu-note>
@@ -5920,8 +6070,10 @@
       </dl>
       <emu-alg>
         1. If Type(_x_) is different from Type(_y_), return *false*.
-        1. If Type(_x_) is Number or BigInt, then
-          1. Return ! Type(_x_)::sameValueZero(_x_, _y_).
+        1. If Type(_x_) is Number, then
+          1. Return ! Number::sameValueZero(_x_, _y_).
+        1. If Type(_x_) is BigInt, then
+          1. Return ! BigInt::sameValueZero(_x_, _y_).
         1. Return ! SameValueNonNumeric(_x_, _y_).
       </emu-alg>
       <emu-note>
@@ -5993,7 +6145,12 @@
           1. NOTE: Because _px_ and _py_ are primitive values, evaluation order is not important.
           1. Let _nx_ be ? ToNumeric(_px_).
           1. Let _ny_ be ? ToNumeric(_py_).
-          1. If Type(_nx_) is the same as Type(_ny_), return Type(_nx_)::lessThan(_nx_, _ny_).
+          1. If Type(_nx_) is the same as Type(_ny_), then
+            1. If Type(_nx_) is Number, then
+              1. Return Number::lessThan(_nx_, _ny_).
+            1. Else,
+              1. Assert: Type(_nx_) is BigInt.
+              1. Return BigInt::lessThan(_nx_, _ny_).
           1. Assert: Type(_nx_) is BigInt and Type(_ny_) is Number, or Type(_nx_) is Number and Type(_ny_) is BigInt.
           1. If _nx_ or _ny_ is *NaN*, return *undefined*.
           1. If _nx_ is *-&infin;*<sub>𝔽</sub> or _ny_ is *+&infin;*<sub>𝔽</sub>, return *true*.
@@ -6056,8 +6213,10 @@
       </dl>
       <emu-alg>
         1. If Type(_x_) is different from Type(_y_), return *false*.
-        1. If Type(_x_) is Number or BigInt, then
-          1. Return ! Type(_x_)::equal(_x_, _y_).
+        1. If Type(_x_) is Number, then
+          1. Return ! Number::equal(_x_, _y_).
+        1. If Type(_x_) is BigInt, then
+          1. Return ! BigInt::equal(_x_, _y_).
         1. Return ! SameValueNonNumeric(_x_, _y_).
       </emu-alg>
       <emu-note>
@@ -19337,7 +19496,11 @@
         <emu-alg>
           1. Let _lhs_ be the result of evaluating |LeftHandSideExpression|.
           1. Let _oldValue_ be ? ToNumeric(? GetValue(_lhs_)).
-          1. Let _newValue_ be ! Type(_oldValue_)::add(_oldValue_, Type(_oldValue_)::unit).
+          1. If Type(_oldValue_) is Number, then
+            1. Let _newValue_ be ! Number::add(_oldValue_, *1*<sub>𝔽</sub>).
+          1. Else,
+            1. Assert: Type(_oldValue_) is BigInt.
+            1. Let _newValue_ be ! BigInt::add(_oldValue_, *1*<sub>ℤ</sub>).
           1. Perform ? PutValue(_lhs_, _newValue_).
           1. Return _oldValue_.
         </emu-alg>
@@ -19353,7 +19516,11 @@
         <emu-alg>
           1. Let _lhs_ be the result of evaluating |LeftHandSideExpression|.
           1. Let _oldValue_ be ? ToNumeric(? GetValue(_lhs_)).
-          1. Let _newValue_ be ! Type(_oldValue_)::subtract(_oldValue_, Type(_oldValue_)::unit).
+          1. If Type(_oldValue_) is Number, then
+            1. Let _newValue_ be ! Number::subtract(_oldValue_, *1*<sub>𝔽</sub>).
+          1. Else,
+            1. Assert: Type(_oldValue_) is BigInt.
+            1. Let _newValue_ be ! BigInt::subtract(_oldValue_, *1*<sub>ℤ</sub>).
           1. Perform ? PutValue(_lhs_, _newValue_).
           1. Return _oldValue_.
         </emu-alg>
@@ -19369,7 +19536,11 @@
         <emu-alg>
           1. Let _expr_ be the result of evaluating |UnaryExpression|.
           1. Let _oldValue_ be ? ToNumeric(? GetValue(_expr_)).
-          1. Let _newValue_ be ! Type(_oldValue_)::add(_oldValue_, Type(_oldValue_)::unit).
+          1. If Type(_oldValue_) is Number, then
+            1. Let _newValue_ be ! Number::add(_oldValue_, *1*<sub>𝔽</sub>).
+          1. Else,
+            1. Assert: Type(_oldValue_) is BigInt.
+            1. Let _newValue_ be ! BigInt::add(_oldValue_, *1*<sub>ℤ</sub>).
           1. Perform ? PutValue(_expr_, _newValue_).
           1. Return _newValue_.
         </emu-alg>
@@ -19385,7 +19556,11 @@
         <emu-alg>
           1. Let _expr_ be the result of evaluating |UnaryExpression|.
           1. Let _oldValue_ be ? ToNumeric(? GetValue(_expr_)).
-          1. Let _newValue_ be ! Type(_oldValue_)::subtract(_oldValue_, Type(_oldValue_)::unit).
+          1. If Type(_oldValue_) is Number, then
+            1. Let _newValue_ be ! Number::subtract(_oldValue_, *1*<sub>𝔽</sub>).
+          1. Else,
+            1. Assert: Type(_oldValue_) is BigInt.
+            1. Let _newValue_ be ! BigInt::subtract(_oldValue_, *1*<sub>ℤ</sub>).
           1. Perform ? PutValue(_expr_, _newValue_).
           1. Return _newValue_.
         </emu-alg>
@@ -19614,7 +19789,11 @@
           1. Let _expr_ be the result of evaluating |UnaryExpression|.
           1. Let _oldValue_ be ? ToNumeric(? GetValue(_expr_)).
           1. Let _T_ be Type(_oldValue_).
-          1. Return ! _T_::unaryMinus(_oldValue_).
+          1. If Type(_oldValue_) is Number, then
+            1. Return ! Number::unaryMinus(_oldValue_).
+          1. Else,
+            1. Assert: Type(_oldValue_) is BigInt.
+            1. Return ! BigInt::unaryMinus(_oldValue_).
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -19629,7 +19808,11 @@
           1. Let _expr_ be the result of evaluating |UnaryExpression|.
           1. Let _oldValue_ be ? ToNumeric(? GetValue(_expr_)).
           1. Let _T_ be Type(_oldValue_).
-          1. Return ! _T_::bitwiseNOT(_oldValue_).
+          1. If Type(_oldValue_) is Number, then
+            1. Return ! Number::bitwiseNOT(_oldValue_).
+          1. Else,
+            1. Assert: Type(_oldValue_) is BigInt.
+            1. Return ! BigInt::bitwiseNOT(_oldValue_).
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -20299,24 +20482,35 @@
         1. Let _lnum_ be ? ToNumeric(_lval_).
         1. Let _rnum_ be ? ToNumeric(_rval_).
         1. If Type(_lnum_) is different from Type(_rnum_), throw a *TypeError* exception.
-        1. Let _T_ be Type(_lnum_).
-        1. [id="step-applystringornumericbinaryoperator-operations-table"] Let _operation_ be the abstract operation associated with _opText_ in the following table:
+        1. [id="step-applystringornumericbinaryoperator-operations-table"] Let _operation_ be the abstract operation associated with _opText_ and Type(_lnum_) in the following table:
           <figure>
             <table class="lightweight-table">
               <tbody>
-                <tr><th> _opText_       </th><th> _operation_             </th></tr>
-                <tr><td> `**`           </td><td> _T_::exponentiate       </td></tr>
-                <tr><td> `*`            </td><td> _T_::multiply           </td></tr>
-                <tr><td> `/`            </td><td> _T_::divide             </td></tr>
-                <tr><td> `%`            </td><td> _T_::remainder          </td></tr>
-                <tr><td> `+`            </td><td> _T_::add                </td></tr>
-                <tr><td> `-`            </td><td> _T_::subtract           </td></tr>
-                <tr><td> `&lt;&lt;`     </td><td> _T_::leftShift          </td></tr>
-                <tr><td> `&gt;&gt;`     </td><td> _T_::signedRightShift   </td></tr>
-                <tr><td> `&gt;&gt;&gt;` </td><td> _T_::unsignedRightShift </td></tr>
-                <tr><td> `&amp;`        </td><td> _T_::bitwiseAND         </td></tr>
-                <tr><td> `^`            </td><td> _T_::bitwiseXOR         </td></tr>
-                <tr><td> `|`            </td><td> _T_::bitwiseOR          </td></tr>
+                <tr><th> _opText_       </th><th> Type(_lnum_) </th><th> _operation_                </th></tr>
+                <tr><td> `**`           </td><td> Number       </td><td> Number::exponentiate       </td></tr>
+                <tr><td> `**`           </td><td> BigInt       </td><td> BigInt::exponentiate       </td></tr>
+                <tr><td> `*`            </td><td> Number       </td><td> Number::multiply           </td></tr>
+                <tr><td> `*`            </td><td> BigInt       </td><td> BigInt::multiply           </td></tr>
+                <tr><td> `/`            </td><td> Number       </td><td> Number::divide             </td></tr>
+                <tr><td> `/`            </td><td> BigInt       </td><td> BigInt::divide             </td></tr>
+                <tr><td> `%`            </td><td> Number       </td><td> Number::remainder          </td></tr>
+                <tr><td> `%`            </td><td> BigInt       </td><td> BigInt::remainder          </td></tr>
+                <tr><td> `+`            </td><td> Number       </td><td> Number::add                </td></tr>
+                <tr><td> `+`            </td><td> BigInt       </td><td> BigInt::add                </td></tr>
+                <tr><td> `-`            </td><td> Number       </td><td> Number::subtract           </td></tr>
+                <tr><td> `-`            </td><td> BigInt       </td><td> BigInt::subtract           </td></tr>
+                <tr><td> `&lt;&lt;`     </td><td> Number       </td><td> Number::leftShift          </td></tr>
+                <tr><td> `&lt;&lt;`     </td><td> BigInt       </td><td> BigInt::leftShift          </td></tr>
+                <tr><td> `&gt;&gt;`     </td><td> Number       </td><td> Number::signedRightShift   </td></tr>
+                <tr><td> `&gt;&gt;`     </td><td> BigInt       </td><td> BigInt::signedRightShift   </td></tr>
+                <tr><td> `&gt;&gt;&gt;` </td><td> Number       </td><td> Number::unsignedRightShift </td></tr>
+                <tr><td> `&gt;&gt;&gt;` </td><td> BigInt       </td><td> BigInt::unsignedRightShift </td></tr>
+                <tr><td> `&amp;`        </td><td> Number       </td><td> Number::bitwiseAND         </td></tr>
+                <tr><td> `&amp;`        </td><td> BigInt       </td><td> BigInt::bitwiseAND         </td></tr>
+                <tr><td> `^`            </td><td> Number       </td><td> Number::bitwiseXOR         </td></tr>
+                <tr><td> `^`            </td><td> BigInt       </td><td> BigInt::bitwiseXOR         </td></tr>
+                <tr><td> `|`            </td><td> Number       </td><td> Number::bitwiseOR          </td></tr>
+                <tr><td> `|`            </td><td> BigInt       </td><td> BigInt::bitwiseOR          </td></tr>
               </tbody>
             </table>
           </figure>
@@ -41571,8 +41765,11 @@ THH:mm:ss.sss
         1. Let _add_ be a new read-modify-write modification function with parameters (_xBytes_, _yBytes_) that captures _type_ and _isLittleEndian_ and performs the following steps atomically when called:
           1. Let _x_ be RawBytesToNumeric(_type_, _xBytes_, _isLittleEndian_).
           1. Let _y_ be RawBytesToNumeric(_type_, _yBytes_, _isLittleEndian_).
-          1. Let _T_ be Type(_x_).
-          1. Let _sum_ be _T_::add(_x_, _y_).
+          1. If Type(_x_) is Number, then
+            1. Let _sum_ be Number::add(_x_, _y_).
+          1. Else,
+            1. Assert: Type(_x_) is BigInt.
+            1. Let _sum_ be BigInt::add(_x_, _y_).
           1. Let _sumBytes_ be NumericToRawBytes(_type_, _sum_, _isLittleEndian_).
           1. Assert: _sumBytes_, _xBytes_, and _yBytes_ have the same number of elements.
           1. Return _sumBytes_.
@@ -41711,8 +41908,11 @@ THH:mm:ss.sss
         1. Let _subtract_ be a new read-modify-write modification function with parameters (_xBytes_, _yBytes_) that captures _type_ and _isLittleEndian_ and performs the following steps atomically when called:
           1. Let _x_ be RawBytesToNumeric(_type_, _xBytes_, _isLittleEndian_).
           1. Let _y_ be RawBytesToNumeric(_type_, _yBytes_, _isLittleEndian_).
-          1. Let _T_ be Type(_x_).
-          1. Let _difference_ be _T_::subtract(_x_, _y_).
+          1. If Type(_x_) is Number, then
+            1. Let _difference_ be Number::subtract(_x_, _y_).
+          1. Else,
+            1. Assert: Type(_x_) is BigInt.
+            1. Let _difference_ be BigInt::subtract(_x_, _y_).
           1. Let _differenceBytes_ be NumericToRawBytes(_type_, _difference_, _isLittleEndian_).
           1. Assert: _differenceBytes_, _xBytes_, and _yBytes_ have the same number of elements.
           1. Return _differenceBytes_.


### PR DESCRIPTION
This leaves the `::` in the names for now to make the diff a little easier. We can rename the AOs in a follow-up if we think it's worth it.