### PR TITLE
Editorial: remove implicit wrapping/unwrapping of completion records

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://tc39.es/ecma262/#sec-copyright-and-software-license",
       "dependencies": {
-        "ecmarkup": "^9.8.0"
+        "ecmarkup": "^10.0.2"
       },
       "devDependencies": {
         "glob": "^7.1.6",
@@ -27,19 +27,19 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.15.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
+      "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
-      "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
+      "version": "7.16.10",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
+      "integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.15.7",
+        "@babel/helper-validator-identifier": "^7.16.7",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -158,58 +158,6 @@
       "resolved": "https://registry.npmjs.org/@esfx/type-model/-/type-model-1.0.0-pre.23.tgz",
       "integrity": "sha512-jwcSY9pqEmGoDNhfT+0LUmSTyk6zXF/pbgKb7KU7mTfCrWfVCT/ve61cD1CreerDRBSat/s55se0lJXwDSjhuA=="
     },
-    "node_modules/@eslint/eslintrc": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
-      "integrity": "sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==",
-      "dependencies": {
-        "ajv": "^6.12.4",
-        "debug": "^4.1.1",
-        "espree": "^7.3.0",
-        "globals": "^13.9.0",
-        "ignore": "^4.0.6",
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^3.13.1",
-        "minimatch": "^3.0.4",
-        "strip-json-comments": "^3.1.1"
-      },
-      "engines": {
-        "node": "^10.12.0 || >=12.0.0"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@humanwhocodes/config-array": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
-      "integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
-      "dependencies": {
-        "@humanwhocodes/object-schema": "^1.2.0",
-        "debug": "^4.1.1",
-        "minimatch": "^3.0.4"
-      },
-      "engines": {
-        "node": ">=10.10.0"
-      }
-    },
-    "node_modules/@humanwhocodes/object-schema": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA=="
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -242,15 +190,23 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@tootallnate/once": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/abab": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
-      "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4="
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
+      "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q=="
     },
     "node_modules/acorn": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -262,6 +218,7 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.4.tgz",
       "integrity": "sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==",
+      "dev": true,
       "dependencies": {
         "acorn": "^6.0.1",
         "acorn-walk": "^6.0.1"
@@ -271,6 +228,7 @@
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
       "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
+      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -278,39 +236,36 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/acorn-jsx": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "peerDependencies": {
-        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
     "node_modules/acorn-walk": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
       "integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
+      "dev": true,
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/ajv": {
       "version": "6.12.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
       "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
+      "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
-      }
-    },
-    "node_modules/ansi-colors": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/ansi-regex": {
@@ -337,15 +292,25 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "node_modules/array-back": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/array-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
-      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
+      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+      "dev": true
     },
     "node_modules/asn1": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "dev": true,
       "dependencies": {
         "safer-buffer": "~2.1.0"
       }
@@ -354,22 +319,10 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true,
       "engines": {
         "node": ">=0.8"
       }
-    },
-    "node_modules/astral-regex": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/async-limiter": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -380,6 +333,7 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -387,12 +341,14 @@
     "node_modules/aws4": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
-      "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
+      "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
+      "dev": true
     },
     "node_modules/balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -418,6 +374,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
       "dependencies": {
         "tweetnacl": "^0.14.3"
       }
@@ -437,6 +394,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -482,18 +440,11 @@
         "ieee754": "^1.1.13"
       }
     },
-    "node_modules/callsites": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
     },
     "node_modules/chalk": {
       "version": "1.1.3",
@@ -534,46 +485,123 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/command-line-args": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.1.tgz",
+      "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
+      "dependencies": {
+        "array-back": "^3.1.0",
+        "find-replace": "^3.0.0",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/command-line-usage": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.1.tgz",
+      "integrity": "sha512-F59pEuAR9o1SF/bD0dQBDluhpT4jJQNWUHEuVBqpDmCUo6gPjCi+m9fCWnWZVR/oG6cMTUms4h+3NPl74wGXvA==",
+      "dependencies": {
+        "array-back": "^4.0.1",
+        "chalk": "^2.4.2",
+        "table-layout": "^1.0.1",
+        "typical": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/array-back": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
+      "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/typical": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "node_modules/core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
-    "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "node_modules/cssom": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
+      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw=="
+    },
+    "node_modules/cssstyle": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+      "dependencies": {
+        "cssom": "~0.3.6"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cssstyle/node_modules/cssom": {
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
       "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
-    },
-    "node_modules/cssstyle": {
-      "version": "0.2.37",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
-      "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
-      "dependencies": {
-        "cssom": "0.3.x"
-      }
     },
     "node_modules/dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
       "dependencies": {
         "assert-plus": "^1.0.0"
       },
@@ -585,21 +613,18 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
       "integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
+      "dev": true,
       "dependencies": {
         "abab": "^2.0.0",
         "whatwg-mimetype": "^2.2.0",
         "whatwg-url": "^7.0.0"
       }
     },
-    "node_modules/data-urls/node_modules/abab": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",
-      "integrity": "sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg=="
-    },
     "node_modules/data-urls/node_modules/whatwg-url": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
       "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+      "dev": true,
       "dependencies": {
         "lodash.sortby": "^4.7.0",
         "tr46": "^1.0.1",
@@ -622,10 +647,23 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
+      "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ=="
+    },
     "node_modules/dedent-js": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dedent-js/-/dedent-js-1.0.1.tgz",
       "integrity": "sha1-vuX7fJ5yfYXf+iRZDRDsGrElUwU="
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "engines": {
+        "node": ">=4.0.0"
+      }
     },
     "node_modules/deep-is": {
       "version": "0.1.3",
@@ -640,21 +678,11 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/doctrine": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
-      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-      "dependencies": {
-        "esutils": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/domexception": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
       "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+      "dev": true,
       "dependencies": {
         "webidl-conversions": "^4.0.2"
       }
@@ -663,6 +691,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
       "dependencies": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -677,21 +706,23 @@
       }
     },
     "node_modules/ecmarkup": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-9.8.0.tgz",
-      "integrity": "sha512-HKHSRA6DnpvuvRgAjjscasL6feStd4YRNvDNDtY6orIeH7TZ3rNqbFFCmxNefsyqMBnL00s/2EDM8wKOysvqoA==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-10.0.2.tgz",
+      "integrity": "sha512-n7+7oHHA/vKZr/J4KNAFNLfaqOuNohAytwBmY55t+iUcZzoCZod7I3HIG0gSwnOGnET4sWQwv1HF41nbR3MqjA==",
       "dependencies": {
         "chalk": "^1.1.3",
+        "command-line-args": "^5.2.0",
+        "command-line-usage": "^6.1.1",
         "dedent-js": "^1.0.1",
         "ecmarkdown": "^7.0.0",
-        "eslint": "^7.29.0",
+        "eslint-formatter-codeframe": "^7.32.1",
         "fast-glob": "^3.2.7",
-        "grammarkdown": "3.1.2",
+        "grammarkdown": "^3.2.0",
         "highlight.js": "11.0.1",
         "html-escape": "^1.0.2",
         "js-yaml": "^3.13.1",
-        "jsdom": "11.10.0",
-        "nomnom": "^1.8.1",
+        "jsdom": "^19.0.0",
+        "parse5": "^6.0.1",
         "prex": "^0.4.7",
         "promise-debounce": "^1.0.1"
       },
@@ -703,10 +734,19 @@
         "node": ">= 12 || ^11.10.1 || ^10.13 || ^8.10"
       }
     },
-    "node_modules/ecmarkup/node_modules/acorn": {
-      "version": "5.7.4",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
-      "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
+    "node_modules/ecmarkup/node_modules/acorn-globals": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
+      "integrity": "sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==",
+      "dependencies": {
+        "acorn": "^7.1.1",
+        "acorn-walk": "^7.1.1"
+      }
+    },
+    "node_modules/ecmarkup/node_modules/acorn-globals/node_modules/acorn": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -714,43 +754,216 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/ecmarkup/node_modules/jsdom": {
-      "version": "11.10.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.10.0.tgz",
-      "integrity": "sha512-x5No5FpJgBg3j5aBwA8ka6eGuS5IxbC8FOkmyccKvObtFT0bDMict/LOxINZsZGZSfGdNomLZ/qRV9Bpq/GIBA==",
-      "dependencies": {
-        "abab": "^1.0.4",
-        "acorn": "^5.3.0",
-        "acorn-globals": "^4.1.0",
-        "array-equal": "^1.0.0",
-        "cssom": ">= 0.3.2 < 0.4.0",
-        "cssstyle": ">= 0.2.37 < 0.3.0",
-        "data-urls": "^1.0.0",
-        "domexception": "^1.0.0",
-        "escodegen": "^1.9.0",
-        "html-encoding-sniffer": "^1.0.2",
-        "left-pad": "^1.2.0",
-        "nwmatcher": "^1.4.3",
-        "parse5": "4.0.0",
-        "pn": "^1.1.0",
-        "request": "^2.83.0",
-        "request-promise-native": "^1.0.5",
-        "sax": "^1.2.4",
-        "symbol-tree": "^3.2.2",
-        "tough-cookie": "^2.3.3",
-        "w3c-hr-time": "^1.0.1",
-        "webidl-conversions": "^4.0.2",
-        "whatwg-encoding": "^1.0.3",
-        "whatwg-mimetype": "^2.1.0",
-        "whatwg-url": "^6.4.0",
-        "ws": "^4.0.0",
-        "xml-name-validator": "^3.0.0"
+    "node_modules/ecmarkup/node_modules/acorn-walk": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
+      "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
-    "node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    "node_modules/ecmarkup/node_modules/data-urls": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.1.tgz",
+      "integrity": "sha512-Ds554NeT5Gennfoo9KN50Vh6tpgtvYEwraYjejXnyTpu1C7oXKxdFk75REooENHE8ndTVOJuv+BEs4/J/xcozw==",
+      "dependencies": {
+        "abab": "^2.0.3",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ecmarkup/node_modules/domexception": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
+      "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
+      "dependencies": {
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ecmarkup/node_modules/escodegen": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
+      "integrity": "sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/ecmarkup/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/ecmarkup/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/ecmarkup/node_modules/html-encoding-sniffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+      "dependencies": {
+        "whatwg-encoding": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ecmarkup/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ecmarkup/node_modules/jsdom": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-19.0.0.tgz",
+      "integrity": "sha512-RYAyjCbxy/vri/CfnjUWJQQtZ3LKlLnDqj+9XLNnJPgEGeirZs3hllKR20re8LUZ6o1b1X4Jat+Qd26zmP41+A==",
+      "dependencies": {
+        "abab": "^2.0.5",
+        "acorn": "^8.5.0",
+        "acorn-globals": "^6.0.0",
+        "cssom": "^0.5.0",
+        "cssstyle": "^2.3.0",
+        "data-urls": "^3.0.1",
+        "decimal.js": "^10.3.1",
+        "domexception": "^4.0.0",
+        "escodegen": "^2.0.0",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.0",
+        "parse5": "6.0.1",
+        "saxes": "^5.0.1",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.0.0",
+        "w3c-hr-time": "^1.0.2",
+        "w3c-xmlserializer": "^3.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^2.0.0",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^10.0.0",
+        "ws": "^8.2.3",
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ecmarkup/node_modules/saxes": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
+      "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ecmarkup/node_modules/tough-cookie": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
+      "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.1.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ecmarkup/node_modules/w3c-xmlserializer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-3.0.0.tgz",
+      "integrity": "sha512-3WFqGEgSXIyGhOmAFtlicJNMjEps8b1MG31NCA0/vOF9+nKMUW1ckhi9cnNHmf88Rzw5V+dwIwsm2C7X8k9aQg==",
+      "dependencies": {
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ecmarkup/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ecmarkup/node_modules/whatwg-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ecmarkup/node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ecmarkup/node_modules/xml-name-validator": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
+      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
@@ -759,17 +972,6 @@
       "dev": true,
       "dependencies": {
         "once": "^1.4.0"
-      }
-    },
-    "node_modules/enquirer": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
-      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
-      "dependencies": {
-        "ansi-colors": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=8.6"
       }
     },
     "node_modules/escape-html": {
@@ -789,6 +991,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.1.tgz",
       "integrity": "sha512-Bmt7NcRySdIfNPfU2ZoXDrrXsG9ZjvDxcAlMfDUgRBjLOWTuIACXPBFJH7Z+cLb40JeQco5toikyc9t9P8E9SQ==",
+      "dev": true,
       "dependencies": {
         "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
@@ -806,113 +1009,19 @@
         "source-map": "~0.6.1"
       }
     },
-    "node_modules/eslint": {
-      "version": "7.32.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
-      "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
+    "node_modules/eslint-formatter-codeframe": {
+      "version": "7.32.1",
+      "resolved": "https://registry.npmjs.org/eslint-formatter-codeframe/-/eslint-formatter-codeframe-7.32.1.tgz",
+      "integrity": "sha512-DK/3Q3+zVKq/7PdSYiCxPrsDF8H/TRMK5n8Hziwr4IMkMy+XiKSwbpj25AdajS63I/B61Snetq4uVvX9fOLyAg==",
       "dependencies": {
         "@babel/code-frame": "7.12.11",
-        "@eslint/eslintrc": "^0.4.3",
-        "@humanwhocodes/config-array": "^0.5.0",
-        "ajv": "^6.10.0",
-        "chalk": "^4.0.0",
-        "cross-spawn": "^7.0.2",
-        "debug": "^4.0.1",
-        "doctrine": "^3.0.0",
-        "enquirer": "^2.3.5",
-        "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^5.1.1",
-        "eslint-utils": "^2.1.0",
-        "eslint-visitor-keys": "^2.0.0",
-        "espree": "^7.3.1",
-        "esquery": "^1.4.0",
-        "esutils": "^2.0.2",
-        "fast-deep-equal": "^3.1.3",
-        "file-entry-cache": "^6.0.1",
-        "functional-red-black-tree": "^1.0.1",
-        "glob-parent": "^5.1.2",
-        "globals": "^13.6.0",
-        "ignore": "^4.0.6",
-        "import-fresh": "^3.0.0",
-        "imurmurhash": "^0.1.4",
-        "is-glob": "^4.0.0",
-        "js-yaml": "^3.13.1",
-        "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.4.1",
-        "lodash.merge": "^4.6.2",
-        "minimatch": "^3.0.4",
-        "natural-compare": "^1.4.0",
-        "optionator": "^0.9.1",
-        "progress": "^2.0.0",
-        "regexpp": "^3.1.0",
-        "semver": "^7.2.1",
-        "strip-ansi": "^6.0.0",
-        "strip-json-comments": "^3.1.0",
-        "table": "^6.0.9",
-        "text-table": "^0.2.0",
-        "v8-compile-cache": "^2.0.3"
-      },
-      "bin": {
-        "eslint": "bin/eslint.js"
+        "chalk": "^4.0.0"
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint-scope": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/eslint-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
-      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
-      "dependencies": {
-        "eslint-visitor-keys": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      }
-    },
-    "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/eslint-visitor-keys": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/eslint/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/eslint/node_modules/ansi-styles": {
+    "node_modules/eslint-formatter-codeframe/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
@@ -926,7 +1035,7 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/eslint/node_modules/chalk": {
+    "node_modules/eslint-formatter-codeframe/node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
@@ -941,7 +1050,7 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/eslint/node_modules/color-convert": {
+    "node_modules/eslint-formatter-codeframe/node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
@@ -952,28 +1061,12 @@
         "node": ">=7.0.0"
       }
     },
-    "node_modules/eslint/node_modules/color-name": {
+    "node_modules/eslint-formatter-codeframe/node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
-    "node_modules/eslint/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint/node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
-    },
-    "node_modules/eslint/node_modules/has-flag": {
+    "node_modules/eslint-formatter-codeframe/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
@@ -981,54 +1074,7 @@
         "node": ">=8"
       }
     },
-    "node_modules/eslint/node_modules/levn": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
-      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
-      "dependencies": {
-        "prelude-ls": "^1.2.1",
-        "type-check": "~0.4.0"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/eslint/node_modules/optionator": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
-      "dependencies": {
-        "deep-is": "^0.1.3",
-        "fast-levenshtein": "^2.0.6",
-        "levn": "^0.4.1",
-        "prelude-ls": "^1.2.1",
-        "type-check": "^0.4.0",
-        "word-wrap": "^1.2.3"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/eslint/node_modules/prelude-ls": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
-      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/eslint/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/eslint/node_modules/supports-color": {
+    "node_modules/eslint-formatter-codeframe/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
@@ -1037,38 +1083,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/eslint/node_modules/type-check": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
-      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-      "dependencies": {
-        "prelude-ls": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/espree": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
-      "integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
-      "dependencies": {
-        "acorn": "^7.4.0",
-        "acorn-jsx": "^5.3.1",
-        "eslint-visitor-keys": "^1.3.0"
-      },
-      "engines": {
-        "node": "^10.12.0 || >=12.0.0"
-      }
-    },
-    "node_modules/espree/node_modules/eslint-visitor-keys": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/esprima": {
@@ -1083,48 +1097,11 @@
         "node": ">=4"
       }
     },
-    "node_modules/esquery": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
-      "dependencies": {
-        "estraverse": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/esquery/node_modules/estraverse": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/esrecurse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
-      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-      "dependencies": {
-        "estraverse": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/esrecurse/node_modules/estraverse": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
     "node_modules/estraverse": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -1140,12 +1117,14 @@
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
     },
     "node_modules/extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true,
       "engines": [
         "node >=0.6.0"
       ]
@@ -1153,7 +1132,8 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+      "dev": true
     },
     "node_modules/fast-glob": {
       "version": "3.2.7",
@@ -1173,7 +1153,8 @@
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
@@ -1188,17 +1169,6 @@
         "reusify": "^1.0.4"
       }
     },
-    "node_modules/file-entry-cache": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
-      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
-      "dependencies": {
-        "flat-cache": "^3.0.4"
-      },
-      "engines": {
-        "node": "^10.12.0 || >=12.0.0"
-      }
-    },
     "node_modules/fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -1210,27 +1180,22 @@
         "node": ">=8"
       }
     },
-    "node_modules/flat-cache": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
-      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+    "node_modules/find-replace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
+      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
       "dependencies": {
-        "flatted": "^3.1.0",
-        "rimraf": "^3.0.2"
+        "array-back": "^3.0.1"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": ">=4.0.0"
       }
-    },
-    "node_modules/flatted": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
-      "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw=="
     },
     "node_modules/forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -1239,6 +1204,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -1257,17 +1223,14 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-    },
-    "node_modules/functional-red-black-tree": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "node_modules/getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
       "dependencies": {
         "assert-plus": "^1.0.0"
       }
@@ -1276,6 +1239,7 @@
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
       "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -1302,24 +1266,10 @@
         "node": ">= 6"
       }
     },
-    "node_modules/globals": {
-      "version": "13.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz",
-      "integrity": "sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==",
-      "dependencies": {
-        "type-fest": "^0.20.2"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/grammarkdown": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/grammarkdown/-/grammarkdown-3.1.2.tgz",
-      "integrity": "sha512-2WHeSg1sYjeeWMqnt0jEa4FyhofhE8T02a9PhBXvA1+6hLdZ39E753X05LYIdTff+1GYW6UMy+2nLfeQYQZ9Hw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/grammarkdown/-/grammarkdown-3.2.0.tgz",
+      "integrity": "sha512-pEVUvG2Kxv/PwM3Dm3kFEU1/GHRkNcFWmk/zkqN/y0uoQtPaZ+5VaBacMQAaFOIL9WGYjHXtqpkT5YRvySsISQ==",
       "dependencies": {
         "@esfx/async-canceltoken": "^1.0.0-pre.13",
         "@esfx/cancelable": "^1.0.0-pre.13"
@@ -1332,6 +1282,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -1341,6 +1292,7 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
       "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
       "deprecated": "this library is no longer supported",
+      "dev": true,
       "dependencies": {
         "ajv": "^6.5.5",
         "har-schema": "^2.0.0"
@@ -1356,14 +1308,6 @@
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/has-color": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-      "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1388,6 +1332,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
       "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+      "dev": true,
       "dependencies": {
         "whatwg-encoding": "^1.0.1"
       }
@@ -1397,10 +1342,24 @@
       "resolved": "https://registry.npmjs.org/html-escape/-/html-escape-1.0.2.tgz",
       "integrity": "sha1-X6eHwFaAkP4zLtWzz0qk9kZCGnQ="
     },
+    "node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
       "dependencies": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -1411,10 +1370,23 @@
         "npm": ">=1.3.7"
       }
     },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -1442,41 +1414,11 @@
         }
       ]
     },
-    "node_modules/ignore": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/import-fresh": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-      "dependencies": {
-        "parent-module": "^1.0.0",
-        "resolve-from": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/imurmurhash": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-      "engines": {
-        "node": ">=0.8.19"
-      }
-    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -1485,7 +1427,8 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "node_modules/ip-regex": {
       "version": "2.1.0",
@@ -1502,14 +1445,6 @@
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -1531,20 +1466,22 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
+    },
     "node_modules/is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-    },
-    "node_modules/isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
     },
     "node_modules/isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -1566,7 +1503,8 @@
     "node_modules/jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
     },
     "node_modules/jsdom": {
       "version": "15.2.1",
@@ -1613,12 +1551,6 @@
         }
       }
     },
-    "node_modules/jsdom/node_modules/abab": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",
-      "integrity": "sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==",
-      "dev": true
-    },
     "node_modules/jsdom/node_modules/acorn": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
@@ -1635,24 +1567,6 @@
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
       "integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==",
-      "dev": true
-    },
-    "node_modules/jsdom/node_modules/cssstyle": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
-      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
-      "dev": true,
-      "dependencies": {
-        "cssom": "~0.3.6"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jsdom/node_modules/cssstyle/node_modules/cssom": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
       "dev": true
     },
     "node_modules/jsdom/node_modules/parse5": {
@@ -1710,27 +1624,26 @@
     "node_modules/json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-    },
-    "node_modules/json-stable-stringify-without-jsonify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
     },
     "node_modules/jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
       "engines": [
         "node >=0.6.0"
       ],
@@ -1740,12 +1653,6 @@
         "json-schema": "0.2.3",
         "verror": "1.10.0"
       }
-    },
-    "node_modules/left-pad": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
-      "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
-      "deprecated": "use String.prototype.padStart()"
     },
     "node_modules/levn": {
       "version": "0.3.0",
@@ -1762,33 +1669,19 @@
     "node_modules/lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
     },
-    "node_modules/lodash.merge": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
     },
     "node_modules/lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
-    },
-    "node_modules/lodash.truncate": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
-      "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM="
-    },
-    "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+      "dev": true
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -1833,6 +1726,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -1845,68 +1739,16 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
-    "node_modules/natural-compare": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
-    },
-    "node_modules/nomnom": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
-      "integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
-      "deprecated": "Package no longer supported. Contact support@npmjs.com for more info.",
-      "dependencies": {
-        "chalk": "~0.4.0",
-        "underscore": "~1.6.0"
-      }
-    },
-    "node_modules/nomnom/node_modules/ansi-styles": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
-      "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/nomnom/node_modules/chalk": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
-      "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
-      "dependencies": {
-        "ansi-styles": "~1.0.0",
-        "has-color": "~0.1.0",
-        "strip-ansi": "~0.1.0"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/nomnom/node_modules/strip-ansi": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
-      "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
-      "bin": {
-        "strip-ansi": "cli.js"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/nwmatcher": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.4.tgz",
-      "integrity": "sha512-3iuY4N5dhgMpCUrOVnuAdGrgxVqV2cJpM+XNccjR2DKOB1RUP0aA+wGXEiNziG/UKboFyGBIoKOaNlJxx8bciQ=="
-    },
     "node_modules/nwsapi": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
-      "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
-      "dev": true
+      "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ=="
     },
     "node_modules/oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -1915,6 +1757,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -1935,42 +1778,25 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/parent-module": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dependencies": {
-        "callsites": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/parse5": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
-      "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA=="
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/path-key": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
     },
     "node_modules/picomatch": {
       "version": "2.3.0",
@@ -1986,7 +1812,8 @@
     "node_modules/pn": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
-      "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
+      "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
+      "dev": true
     },
     "node_modules/prelude-ls": {
       "version": "1.1.2",
@@ -2003,14 +1830,6 @@
       "dependencies": {
         "@esfx/cancelable": "^1.0.0-pre.13",
         "@esfx/disposable": "^1.0.0-pre.13"
-      }
-    },
-    "node_modules/progress": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/promise-debounce": {
@@ -2035,6 +1854,7 @@
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+      "dev": true,
       "engines": {
         "node": ">=0.6"
       }
@@ -2072,15 +1892,12 @@
         "node": ">= 6"
       }
     },
-    "node_modules/regexpp": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
-      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
+    "node_modules/reduce-flatten": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
+      "integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==",
       "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
+        "node": ">=6"
       }
     },
     "node_modules/request": {
@@ -2088,6 +1905,7 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
       "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
       "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
+      "dev": true,
       "dependencies": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -2118,6 +1936,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.3.tgz",
       "integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
+      "dev": true,
       "dependencies": {
         "lodash": "^4.17.15"
       },
@@ -2133,6 +1952,7 @@
       "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.8.tgz",
       "integrity": "sha512-dapwLGqkHtwL5AEbfenuzjTYg35Jd6KPytsC2/TLkVMz8rm+tNt72MGUWT1RP/aYawMpN6HqbNGBQaRcBtjQMQ==",
       "deprecated": "request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142",
+      "dev": true,
       "dependencies": {
         "request-promise-core": "1.1.3",
         "stealthy-require": "^1.1.1",
@@ -2145,22 +1965,6 @@
         "request": "^2.34"
       }
     },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/resolve-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -2168,20 +1972,6 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/run-parallel": {
@@ -2210,6 +2000,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2230,11 +2021,6 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
-    "node_modules/sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
-    },
     "node_modules/saxes": {
       "version": "3.1.11",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.11.tgz",
@@ -2246,85 +2032,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/shebang-command": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dependencies": {
-        "shebang-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/shebang-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/slice-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
-      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "astral-regex": "^2.0.0",
-        "is-fullwidth-code-point": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-      }
-    },
-    "node_modules/slice-ansi/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/slice-ansi/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/slice-ansi/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/source-map": {
       "version": "0.6.1",
@@ -2344,6 +2051,7 @@
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
       "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "dev": true,
       "dependencies": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -2368,6 +2076,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2381,38 +2090,6 @@
         "safe-buffer": "~5.2.0"
       }
     },
-    "node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
@@ -2422,17 +2099,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/strip-json-comments": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/supports-color": {
@@ -2448,56 +2114,32 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
     },
-    "node_modules/table": {
-      "version": "6.7.5",
-      "resolved": "https://registry.npmjs.org/table/-/table-6.7.5.tgz",
-      "integrity": "sha512-LFNeryOqiQHqCVKzhkymKwt6ozeRhlm8IL1mE8rNUurkir4heF6PzMyRgaTa4tlyPTGGgXuvVOF/OLWiH09Lqw==",
+    "node_modules/table-layout": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-1.0.2.tgz",
+      "integrity": "sha512-qd/R7n5rQTRFi+Zf2sk5XVVd9UQl6ZkduPFC3S7WEGJAmetDTjY3qPN50eSKzwuzEyQKy5TN2TiZdkIjos2L6A==",
       "dependencies": {
-        "ajv": "^8.0.1",
-        "lodash.truncate": "^4.4.2",
-        "slice-ansi": "^4.0.0",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1"
+        "array-back": "^4.0.1",
+        "deep-extend": "~0.6.0",
+        "typical": "^5.2.0",
+        "wordwrapjs": "^4.0.0"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=8.0.0"
       }
     },
-    "node_modules/table/node_modules/ajv": {
-      "version": "8.8.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
-      "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/table/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+    "node_modules/table-layout/node_modules/array-back": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
+      "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
       "engines": {
         "node": ">=8"
       }
     },
-    "node_modules/table/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-    },
-    "node_modules/table/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
+    "node_modules/table-layout/node_modules/typical": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
       "engines": {
         "node": ">=8"
       }
@@ -2517,11 +2159,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/text-table": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
     },
     "node_modules/tiny-json-http": {
       "version": "7.2.0",
@@ -2544,6 +2181,7 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
       "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "dev": true,
       "dependencies": {
         "psl": "^1.1.28",
         "punycode": "^2.1.1"
@@ -2556,6 +2194,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
       "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+      "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -2569,6 +2208,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       },
@@ -2579,7 +2219,8 @@
     "node_modules/tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true
     },
     "node_modules/type-check": {
       "version": "0.3.2",
@@ -2592,26 +2233,27 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+    "node_modules/typical": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=8"
       }
     },
-    "node_modules/underscore": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-      "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
     },
     "node_modules/uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -2627,19 +2269,16 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
       "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "dev": true,
       "bin": {
         "uuid": "bin/uuid"
       }
-    },
-    "node_modules/v8-compile-cache": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
-      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA=="
     },
     "node_modules/verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
       "engines": [
         "node >=0.6.0"
       ],
@@ -2671,12 +2310,14 @@
     "node_modules/webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "dev": true
     },
     "node_modules/whatwg-encoding": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
       "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+      "dev": true,
       "dependencies": {
         "iconv-lite": "0.4.24"
       }
@@ -2684,30 +2325,38 @@
     "node_modules/whatwg-mimetype": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
-      "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g=="
+      "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
+      "dev": true
     },
     "node_modules/whatwg-url": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
-      "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-10.0.0.tgz",
+      "integrity": "sha512-CLxxCmdUby142H5FZzn4D8ikO1cmypvXVQktsgosNy4a4BHrDHeciBBGZhb0bNoR5/MltoCatso+vFjjGx8t0w==",
       "dependencies": {
-        "lodash.sortby": "^4.7.0",
-        "tr46": "^1.0.1",
-        "webidl-conversions": "^4.0.2"
-      }
-    },
-    "node_modules/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
       },
       "engines": {
-        "node": ">= 8"
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-url/node_modules/tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-url/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/word-wrap": {
@@ -2718,40 +2367,62 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wordwrapjs": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-4.0.1.tgz",
+      "integrity": "sha512-kKlNACbvHrkpIw6oPeYDSmdCTu2hdMHoyXLTcUKala++lx5Y+wjJ/e474Jqv5abnVmwxw08DiTuHmw69lJGksA==",
+      "dependencies": {
+        "reduce-flatten": "^2.0.0",
+        "typical": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/wordwrapjs/node_modules/typical": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "node_modules/ws": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
-      "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
-      "dependencies": {
-        "async-limiter": "~1.0.0",
-        "safe-buffer": "~5.1.0"
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
-    },
-    "node_modules/ws/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/xml-name-validator": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
-      "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
+      "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+      "dev": true
     },
     "node_modules/xmlchars": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
-      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "dev": true
-    },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
     }
   },
   "dependencies": {
@@ -2764,16 +2435,16 @@
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.15.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w=="
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
+      "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw=="
     },
     "@babel/highlight": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
-      "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
+      "version": "7.16.10",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
+      "integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
       "requires": {
-        "@babel/helper-validator-identifier": "^7.15.7",
+        "@babel/helper-validator-identifier": "^7.16.7",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -2882,50 +2553,6 @@
       "resolved": "https://registry.npmjs.org/@esfx/type-model/-/type-model-1.0.0-pre.23.tgz",
       "integrity": "sha512-jwcSY9pqEmGoDNhfT+0LUmSTyk6zXF/pbgKb7KU7mTfCrWfVCT/ve61cD1CreerDRBSat/s55se0lJXwDSjhuA=="
     },
-    "@eslint/eslintrc": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
-      "integrity": "sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==",
-      "requires": {
-        "ajv": "^6.12.4",
-        "debug": "^4.1.1",
-        "espree": "^7.3.0",
-        "globals": "^13.9.0",
-        "ignore": "^4.0.6",
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^3.13.1",
-        "minimatch": "^3.0.4",
-        "strip-json-comments": "^3.1.1"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "6.12.6",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        }
-      }
-    },
-    "@humanwhocodes/config-array": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
-      "integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
-      "requires": {
-        "@humanwhocodes/object-schema": "^1.2.0",
-        "debug": "^4.1.1",
-        "minimatch": "^3.0.4"
-      }
-    },
-    "@humanwhocodes/object-schema": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA=="
-    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2949,20 +2576,26 @@
         "fastq": "^1.6.0"
       }
     },
+    "@tootallnate/once": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A=="
+    },
     "abab": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
-      "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4="
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
+      "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q=="
     },
     "acorn": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ=="
     },
     "acorn-globals": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.4.tgz",
       "integrity": "sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==",
+      "dev": true,
       "requires": {
         "acorn": "^6.0.1",
         "acorn-walk": "^6.0.1"
@@ -2971,36 +2604,36 @@
         "acorn": {
           "version": "6.4.1",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
-          "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA=="
+          "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
+          "dev": true
         }
       }
-    },
-    "acorn-jsx": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "requires": {}
     },
     "acorn-walk": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
-      "integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA=="
+      "integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
+      "dev": true
+    },
+    "agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "requires": {
+        "debug": "4"
+      }
     },
     "ajv": {
       "version": "6.12.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
       "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
+      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
       }
-    },
-    "ansi-colors": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA=="
     },
     "ansi-regex": {
       "version": "2.1.1",
@@ -3020,15 +2653,22 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "array-back": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q=="
+    },
     "array-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
-      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
+      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+      "dev": true
     },
     "asn1": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "dev": true,
       "requires": {
         "safer-buffer": "~2.1.0"
       }
@@ -3036,17 +2676,8 @@
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-    },
-    "astral-regex": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ=="
-    },
-    "async-limiter": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
     },
     "asynckit": {
       "version": "0.4.0",
@@ -3056,17 +2687,20 @@
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
     },
     "aws4": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
-      "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
+      "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
+      "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "base64-js": {
       "version": "1.5.1",
@@ -3078,6 +2712,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
       "requires": {
         "tweetnacl": "^0.14.3"
       }
@@ -3097,6 +2732,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -3125,15 +2761,11 @@
         "ieee754": "^1.1.13"
       }
     },
-    "callsites": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
-    },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
     },
     "chalk": {
       "version": "1.1.3",
@@ -3168,43 +2800,103 @@
         "delayed-stream": "~1.0.0"
       }
     },
+    "command-line-args": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.1.tgz",
+      "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
+      "requires": {
+        "array-back": "^3.1.0",
+        "find-replace": "^3.0.0",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^4.0.0"
+      }
+    },
+    "command-line-usage": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.1.tgz",
+      "integrity": "sha512-F59pEuAR9o1SF/bD0dQBDluhpT4jJQNWUHEuVBqpDmCUo6gPjCi+m9fCWnWZVR/oG6cMTUms4h+3NPl74wGXvA==",
+      "requires": {
+        "array-back": "^4.0.1",
+        "chalk": "^2.4.2",
+        "table-layout": "^1.0.1",
+        "typical": "^5.2.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "array-back": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
+          "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg=="
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "typical": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+          "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
+        }
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
-    "cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "requires": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      }
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "cssom": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
+      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw=="
     },
     "cssstyle": {
-      "version": "0.2.37",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
-      "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
       "requires": {
-        "cssom": "0.3.x"
+        "cssom": "~0.3.6"
+      },
+      "dependencies": {
+        "cssom": {
+          "version": "0.3.8",
+          "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+          "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
+        }
       }
     },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -3213,21 +2905,18 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
       "integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
+      "dev": true,
       "requires": {
         "abab": "^2.0.0",
         "whatwg-mimetype": "^2.2.0",
         "whatwg-url": "^7.0.0"
       },
       "dependencies": {
-        "abab": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",
-          "integrity": "sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg=="
-        },
         "whatwg-url": {
           "version": "7.1.0",
           "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
           "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+          "dev": true,
           "requires": {
             "lodash.sortby": "^4.7.0",
             "tr46": "^1.0.1",
@@ -3244,10 +2933,20 @@
         "ms": "2.1.2"
       }
     },
+    "decimal.js": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
+      "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ=="
+    },
     "dedent-js": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dedent-js/-/dedent-js-1.0.1.tgz",
       "integrity": "sha1-vuX7fJ5yfYXf+iRZDRDsGrElUwU="
+    },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
     },
     "deep-is": {
       "version": "0.1.3",
@@ -3259,18 +2958,11 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
-    "doctrine": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
-      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-      "requires": {
-        "esutils": "^2.0.2"
-      }
-    },
     "domexception": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
       "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+      "dev": true,
       "requires": {
         "webidl-conversions": "^4.0.2"
       }
@@ -3279,6 +2971,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -3293,69 +2986,193 @@
       }
     },
     "ecmarkup": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-9.8.0.tgz",
-      "integrity": "sha512-HKHSRA6DnpvuvRgAjjscasL6feStd4YRNvDNDtY6orIeH7TZ3rNqbFFCmxNefsyqMBnL00s/2EDM8wKOysvqoA==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-10.0.2.tgz",
+      "integrity": "sha512-n7+7oHHA/vKZr/J4KNAFNLfaqOuNohAytwBmY55t+iUcZzoCZod7I3HIG0gSwnOGnET4sWQwv1HF41nbR3MqjA==",
       "requires": {
         "chalk": "^1.1.3",
+        "command-line-args": "^5.2.0",
+        "command-line-usage": "^6.1.1",
         "dedent-js": "^1.0.1",
         "ecmarkdown": "^7.0.0",
-        "eslint": "^7.29.0",
+        "eslint-formatter-codeframe": "^7.32.1",
         "fast-glob": "^3.2.7",
-        "grammarkdown": "3.1.2",
+        "grammarkdown": "^3.2.0",
         "highlight.js": "11.0.1",
         "html-escape": "^1.0.2",
         "js-yaml": "^3.13.1",
-        "jsdom": "11.10.0",
-        "nomnom": "^1.8.1",
+        "jsdom": "^19.0.0",
+        "parse5": "^6.0.1",
         "prex": "^0.4.7",
         "promise-debounce": "^1.0.1"
       },
       "dependencies": {
-        "acorn": {
-          "version": "5.7.4",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
-          "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg=="
+        "acorn-globals": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
+          "integrity": "sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==",
+          "requires": {
+            "acorn": "^7.1.1",
+            "acorn-walk": "^7.1.1"
+          },
+          "dependencies": {
+            "acorn": {
+              "version": "7.4.1",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+              "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+            }
+          }
+        },
+        "acorn-walk": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
+          "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA=="
+        },
+        "data-urls": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.1.tgz",
+          "integrity": "sha512-Ds554NeT5Gennfoo9KN50Vh6tpgtvYEwraYjejXnyTpu1C7oXKxdFk75REooENHE8ndTVOJuv+BEs4/J/xcozw==",
+          "requires": {
+            "abab": "^2.0.3",
+            "whatwg-mimetype": "^3.0.0",
+            "whatwg-url": "^10.0.0"
+          }
+        },
+        "domexception": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
+          "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
+          "requires": {
+            "webidl-conversions": "^7.0.0"
+          }
+        },
+        "escodegen": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
+          "integrity": "sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==",
+          "requires": {
+            "esprima": "^4.0.1",
+            "estraverse": "^5.2.0",
+            "esutils": "^2.0.2",
+            "optionator": "^0.8.1",
+            "source-map": "~0.6.1"
+          }
+        },
+        "estraverse": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
+        },
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "html-encoding-sniffer": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+          "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+          "requires": {
+            "whatwg-encoding": "^2.0.0"
+          }
+        },
+        "iconv-lite": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
         },
         "jsdom": {
-          "version": "11.10.0",
-          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.10.0.tgz",
-          "integrity": "sha512-x5No5FpJgBg3j5aBwA8ka6eGuS5IxbC8FOkmyccKvObtFT0bDMict/LOxINZsZGZSfGdNomLZ/qRV9Bpq/GIBA==",
+          "version": "19.0.0",
+          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-19.0.0.tgz",
+          "integrity": "sha512-RYAyjCbxy/vri/CfnjUWJQQtZ3LKlLnDqj+9XLNnJPgEGeirZs3hllKR20re8LUZ6o1b1X4Jat+Qd26zmP41+A==",
           "requires": {
-            "abab": "^1.0.4",
-            "acorn": "^5.3.0",
-            "acorn-globals": "^4.1.0",
-            "array-equal": "^1.0.0",
-            "cssom": ">= 0.3.2 < 0.4.0",
-            "cssstyle": ">= 0.2.37 < 0.3.0",
-            "data-urls": "^1.0.0",
-            "domexception": "^1.0.0",
-            "escodegen": "^1.9.0",
-            "html-encoding-sniffer": "^1.0.2",
-            "left-pad": "^1.2.0",
-            "nwmatcher": "^1.4.3",
-            "parse5": "4.0.0",
-            "pn": "^1.1.0",
-            "request": "^2.83.0",
-            "request-promise-native": "^1.0.5",
-            "sax": "^1.2.4",
-            "symbol-tree": "^3.2.2",
-            "tough-cookie": "^2.3.3",
-            "w3c-hr-time": "^1.0.1",
-            "webidl-conversions": "^4.0.2",
-            "whatwg-encoding": "^1.0.3",
-            "whatwg-mimetype": "^2.1.0",
-            "whatwg-url": "^6.4.0",
-            "ws": "^4.0.0",
-            "xml-name-validator": "^3.0.0"
+            "abab": "^2.0.5",
+            "acorn": "^8.5.0",
+            "acorn-globals": "^6.0.0",
+            "cssom": "^0.5.0",
+            "cssstyle": "^2.3.0",
+            "data-urls": "^3.0.1",
+            "decimal.js": "^10.3.1",
+            "domexception": "^4.0.0",
+            "escodegen": "^2.0.0",
+            "form-data": "^4.0.0",
+            "html-encoding-sniffer": "^3.0.0",
+            "http-proxy-agent": "^5.0.0",
+            "https-proxy-agent": "^5.0.0",
+            "is-potential-custom-element-name": "^1.0.1",
+            "nwsapi": "^2.2.0",
+            "parse5": "6.0.1",
+            "saxes": "^5.0.1",
+            "symbol-tree": "^3.2.4",
+            "tough-cookie": "^4.0.0",
+            "w3c-hr-time": "^1.0.2",
+            "w3c-xmlserializer": "^3.0.0",
+            "webidl-conversions": "^7.0.0",
+            "whatwg-encoding": "^2.0.0",
+            "whatwg-mimetype": "^3.0.0",
+            "whatwg-url": "^10.0.0",
+            "ws": "^8.2.3",
+            "xml-name-validator": "^4.0.0"
           }
+        },
+        "saxes": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
+          "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
+          "requires": {
+            "xmlchars": "^2.2.0"
+          }
+        },
+        "tough-cookie": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
+          "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
+          "requires": {
+            "psl": "^1.1.33",
+            "punycode": "^2.1.1",
+            "universalify": "^0.1.2"
+          }
+        },
+        "w3c-xmlserializer": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-3.0.0.tgz",
+          "integrity": "sha512-3WFqGEgSXIyGhOmAFtlicJNMjEps8b1MG31NCA0/vOF9+nKMUW1ckhi9cnNHmf88Rzw5V+dwIwsm2C7X8k9aQg==",
+          "requires": {
+            "xml-name-validator": "^4.0.0"
+          }
+        },
+        "webidl-conversions": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+          "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="
+        },
+        "whatwg-encoding": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+          "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+          "requires": {
+            "iconv-lite": "0.6.3"
+          }
+        },
+        "whatwg-mimetype": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+          "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="
+        },
+        "xml-name-validator": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
+          "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw=="
         }
       }
-    },
-    "emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -3364,14 +3181,6 @@
       "dev": true,
       "requires": {
         "once": "^1.4.0"
-      }
-    },
-    "enquirer": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
-      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
-      "requires": {
-        "ansi-colors": "^4.1.1"
       }
     },
     "escape-html": {
@@ -3388,6 +3197,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.1.tgz",
       "integrity": "sha512-Bmt7NcRySdIfNPfU2ZoXDrrXsG9ZjvDxcAlMfDUgRBjLOWTuIACXPBFJH7Z+cLb40JeQco5toikyc9t9P8E9SQ==",
+      "dev": true,
       "requires": {
         "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
@@ -3396,58 +3206,15 @@
         "source-map": "~0.6.1"
       }
     },
-    "eslint": {
-      "version": "7.32.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
-      "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
+    "eslint-formatter-codeframe": {
+      "version": "7.32.1",
+      "resolved": "https://registry.npmjs.org/eslint-formatter-codeframe/-/eslint-formatter-codeframe-7.32.1.tgz",
+      "integrity": "sha512-DK/3Q3+zVKq/7PdSYiCxPrsDF8H/TRMK5n8Hziwr4IMkMy+XiKSwbpj25AdajS63I/B61Snetq4uVvX9fOLyAg==",
       "requires": {
         "@babel/code-frame": "7.12.11",
-        "@eslint/eslintrc": "^0.4.3",
-        "@humanwhocodes/config-array": "^0.5.0",
-        "ajv": "^6.10.0",
-        "chalk": "^4.0.0",
-        "cross-spawn": "^7.0.2",
-        "debug": "^4.0.1",
-        "doctrine": "^3.0.0",
-        "enquirer": "^2.3.5",
-        "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^5.1.1",
-        "eslint-utils": "^2.1.0",
-        "eslint-visitor-keys": "^2.0.0",
-        "espree": "^7.3.1",
-        "esquery": "^1.4.0",
-        "esutils": "^2.0.2",
-        "fast-deep-equal": "^3.1.3",
-        "file-entry-cache": "^6.0.1",
-        "functional-red-black-tree": "^1.0.1",
-        "glob-parent": "^5.1.2",
-        "globals": "^13.6.0",
-        "ignore": "^4.0.6",
-        "import-fresh": "^3.0.0",
-        "imurmurhash": "^0.1.4",
-        "is-glob": "^4.0.0",
-        "js-yaml": "^3.13.1",
-        "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.4.1",
-        "lodash.merge": "^4.6.2",
-        "minimatch": "^3.0.4",
-        "natural-compare": "^1.4.0",
-        "optionator": "^0.9.1",
-        "progress": "^2.0.0",
-        "regexpp": "^3.1.0",
-        "semver": "^7.2.1",
-        "strip-ansi": "^6.0.0",
-        "strip-json-comments": "^3.1.0",
-        "table": "^6.0.9",
-        "text-table": "^0.2.0",
-        "v8-compile-cache": "^2.0.3"
+        "chalk": "^4.0.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
-        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -3478,55 +3245,10 @@
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
-        "escape-string-regexp": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
-        },
-        "fast-deep-equal": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
-        },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-        },
-        "levn": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
-          "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
-          "requires": {
-            "prelude-ls": "^1.2.1",
-            "type-check": "~0.4.0"
-          }
-        },
-        "optionator": {
-          "version": "0.9.1",
-          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-          "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
-          "requires": {
-            "deep-is": "^0.1.3",
-            "fast-levenshtein": "^2.0.6",
-            "levn": "^0.4.1",
-            "prelude-ls": "^1.2.1",
-            "type-check": "^0.4.0",
-            "word-wrap": "^1.2.3"
-          }
-        },
-        "prelude-ls": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
-          "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="
-        },
-        "strip-ansi": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-          "requires": {
-            "ansi-regex": "^5.0.1"
-          }
         },
         "supports-color": {
           "version": "7.2.0",
@@ -3535,60 +3257,6 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
-        },
-        "type-check": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
-          "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-          "requires": {
-            "prelude-ls": "^1.2.1"
-          }
-        }
-      }
-    },
-    "eslint-scope": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-      "requires": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^4.1.1"
-      }
-    },
-    "eslint-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
-      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
-      "requires": {
-        "eslint-visitor-keys": "^1.1.0"
-      },
-      "dependencies": {
-        "eslint-visitor-keys": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ=="
-        }
-      }
-    },
-    "eslint-visitor-keys": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw=="
-    },
-    "espree": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
-      "integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
-      "requires": {
-        "acorn": "^7.4.0",
-        "acorn-jsx": "^5.3.1",
-        "eslint-visitor-keys": "^1.3.0"
-      },
-      "dependencies": {
-        "eslint-visitor-keys": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ=="
         }
       }
     },
@@ -3597,40 +3265,11 @@
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
-    "esquery": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
-      "requires": {
-        "estraverse": "^5.1.0"
-      },
-      "dependencies": {
-        "estraverse": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
-        }
-      }
-    },
-    "esrecurse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
-      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-      "requires": {
-        "estraverse": "^5.2.0"
-      },
-      "dependencies": {
-        "estraverse": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
-        }
-      }
-    },
     "estraverse": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true
     },
     "esutils": {
       "version": "2.0.3",
@@ -3640,17 +3279,20 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
     },
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
     },
     "fast-deep-equal": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+      "dev": true
     },
     "fast-glob": {
       "version": "3.2.7",
@@ -3667,7 +3309,8 @@
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -3682,14 +3325,6 @@
         "reusify": "^1.0.4"
       }
     },
-    "file-entry-cache": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
-      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
-      "requires": {
-        "flat-cache": "^3.0.4"
-      }
-    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -3698,29 +3333,25 @@
         "to-regex-range": "^5.0.1"
       }
     },
-    "flat-cache": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
-      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+    "find-replace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
+      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
       "requires": {
-        "flatted": "^3.1.0",
-        "rimraf": "^3.0.2"
+        "array-back": "^3.0.1"
       }
-    },
-    "flatted": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
-      "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw=="
     },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
     },
     "form-data": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -3736,17 +3367,14 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-    },
-    "functional-red-black-tree": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -3755,6 +3383,7 @@
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
       "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -3772,18 +3401,10 @@
         "is-glob": "^4.0.1"
       }
     },
-    "globals": {
-      "version": "13.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz",
-      "integrity": "sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==",
-      "requires": {
-        "type-fest": "^0.20.2"
-      }
-    },
     "grammarkdown": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/grammarkdown/-/grammarkdown-3.1.2.tgz",
-      "integrity": "sha512-2WHeSg1sYjeeWMqnt0jEa4FyhofhE8T02a9PhBXvA1+6hLdZ39E753X05LYIdTff+1GYW6UMy+2nLfeQYQZ9Hw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/grammarkdown/-/grammarkdown-3.2.0.tgz",
+      "integrity": "sha512-pEVUvG2Kxv/PwM3Dm3kFEU1/GHRkNcFWmk/zkqN/y0uoQtPaZ+5VaBacMQAaFOIL9WGYjHXtqpkT5YRvySsISQ==",
       "requires": {
         "@esfx/async-canceltoken": "^1.0.0-pre.13",
         "@esfx/cancelable": "^1.0.0-pre.13"
@@ -3792,12 +3413,14 @@
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
     },
     "har-validator": {
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
       "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "dev": true,
       "requires": {
         "ajv": "^6.5.5",
         "har-schema": "^2.0.0"
@@ -3810,11 +3433,6 @@
       "requires": {
         "ansi-regex": "^2.0.0"
       }
-    },
-    "has-color": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-      "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8="
     },
     "has-flag": {
       "version": "3.0.0",
@@ -3830,6 +3448,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
       "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+      "dev": true,
       "requires": {
         "whatwg-encoding": "^1.0.1"
       }
@@ -3839,20 +3458,41 @@
       "resolved": "https://registry.npmjs.org/html-escape/-/html-escape-1.0.2.tgz",
       "integrity": "sha1-X6eHwFaAkP4zLtWzz0qk9kZCGnQ="
     },
+    "http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "requires": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      }
+    },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
       }
     },
+    "https-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "requires": {
+        "agent-base": "6",
+        "debug": "4"
+      }
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -3863,29 +3503,11 @@
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
       "dev": true
     },
-    "ignore": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
-    },
-    "import-fresh": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-      "requires": {
-        "parent-module": "^1.0.0",
-        "resolve-from": "^4.0.0"
-      }
-    },
-    "imurmurhash": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
-    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -3894,7 +3516,8 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "ip-regex": {
       "version": "2.1.0",
@@ -3906,11 +3529,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
-    },
-    "is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
     },
     "is-glob": {
       "version": "4.0.3",
@@ -3925,20 +3543,22 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
     },
+    "is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
+    },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-    },
-    "isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
     },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -3957,7 +3577,8 @@
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
     },
     "jsdom": {
       "version": "15.2.1",
@@ -3993,12 +3614,6 @@
         "xml-name-validator": "^3.0.0"
       },
       "dependencies": {
-        "abab": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",
-          "integrity": "sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==",
-          "dev": true
-        },
         "acorn": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
@@ -4010,23 +3625,6 @@
           "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
           "integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==",
           "dev": true
-        },
-        "cssstyle": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
-          "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
-          "dev": true,
-          "requires": {
-            "cssom": "~0.3.6"
-          },
-          "dependencies": {
-            "cssom": {
-              "version": "0.3.8",
-              "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-              "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
-              "dev": true
-            }
-          }
         },
         "parse5": {
           "version": "5.1.0",
@@ -4068,38 +3666,32 @@
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
     },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-    },
-    "json-stable-stringify-without-jsonify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
     },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
       }
-    },
-    "left-pad": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
-      "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA=="
     },
     "levn": {
       "version": "0.3.0",
@@ -4113,30 +3705,19 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
     },
-    "lodash.merge": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
     },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
-    },
-    "lodash.truncate": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
-      "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM="
-    },
-    "lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "requires": {
-        "yallist": "^4.0.0"
-      }
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+      "dev": true
     },
     "merge2": {
       "version": "1.4.1",
@@ -4169,6 +3750,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -4178,62 +3760,22 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
-    "natural-compare": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
-    },
-    "nomnom": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
-      "integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
-      "requires": {
-        "chalk": "~0.4.0",
-        "underscore": "~1.6.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
-          "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg="
-        },
-        "chalk": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
-          "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
-          "requires": {
-            "ansi-styles": "~1.0.0",
-            "has-color": "~0.1.0",
-            "strip-ansi": "~0.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
-          "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE="
-        }
-      }
-    },
-    "nwmatcher": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.4.tgz",
-      "integrity": "sha512-3iuY4N5dhgMpCUrOVnuAdGrgxVqV2cJpM+XNccjR2DKOB1RUP0aA+wGXEiNziG/UKboFyGBIoKOaNlJxx8bciQ=="
-    },
     "nwsapi": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
-      "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
-      "dev": true
+      "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ=="
     },
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "dev": true
     },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -4251,33 +3793,22 @@
         "word-wrap": "~1.2.3"
       }
     },
-    "parent-module": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "requires": {
-        "callsites": "^3.0.0"
-      }
-    },
     "parse5": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
-      "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA=="
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
     },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-    },
-    "path-key": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
     },
     "picomatch": {
       "version": "2.3.0",
@@ -4287,7 +3818,8 @@
     "pn": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
-      "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
+      "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
+      "dev": true
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -4302,11 +3834,6 @@
         "@esfx/cancelable": "^1.0.0-pre.13",
         "@esfx/disposable": "^1.0.0-pre.13"
       }
-    },
-    "progress": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
     },
     "promise-debounce": {
       "version": "1.0.1",
@@ -4326,7 +3853,8 @@
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+      "dev": true
     },
     "queue-microtask": {
       "version": "1.2.3",
@@ -4344,15 +3872,16 @@
         "util-deprecate": "^1.0.1"
       }
     },
-    "regexpp": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
-      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg=="
+    "reduce-flatten": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
+      "integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w=="
     },
     "request": {
       "version": "2.88.2",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
       "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -4380,6 +3909,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.3.tgz",
       "integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
+      "dev": true,
       "requires": {
         "lodash": "^4.17.15"
       }
@@ -4388,34 +3918,17 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.8.tgz",
       "integrity": "sha512-dapwLGqkHtwL5AEbfenuzjTYg35Jd6KPytsC2/TLkVMz8rm+tNt72MGUWT1RP/aYawMpN6HqbNGBQaRcBtjQMQ==",
+      "dev": true,
       "requires": {
         "request-promise-core": "1.1.3",
         "stealthy-require": "^1.1.1",
         "tough-cookie": "^2.3.3"
       }
     },
-    "require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
-    },
-    "resolve-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
-    },
     "reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
-    },
-    "rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "requires": {
-        "glob": "^7.1.3"
-      }
     },
     "run-parallel": {
       "version": "1.2.0",
@@ -4428,17 +3941,13 @@
     "safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true
     },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
-    "sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "saxes": {
       "version": "3.1.11",
@@ -4447,60 +3956,6 @@
       "dev": true,
       "requires": {
         "xmlchars": "^2.1.1"
-      }
-    },
-    "semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "requires": {
-        "lru-cache": "^6.0.0"
-      }
-    },
-    "shebang-command": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "requires": {
-        "shebang-regex": "^3.0.0"
-      }
-    },
-    "shebang-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
-    },
-    "slice-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
-      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
-      "requires": {
-        "ansi-styles": "^4.0.0",
-        "astral-regex": "^2.0.0",
-        "is-fullwidth-code-point": "^3.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        }
       }
     },
     "source-map": {
@@ -4518,6 +3973,7 @@
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
       "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "dev": true,
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -4533,7 +3989,8 @@
     "stealthy-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+      "dev": true
     },
     "string_decoder": {
       "version": "1.3.0",
@@ -4544,31 +4001,6 @@
         "safe-buffer": "~5.2.0"
       }
     },
-    "string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "requires": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
-        },
-        "strip-ansi": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-          "requires": {
-            "ansi-regex": "^5.0.1"
-          }
-        }
-      }
-    },
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
@@ -4576,11 +4008,6 @@
       "requires": {
         "ansi-regex": "^2.0.0"
       }
-    },
-    "strip-json-comments": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
     },
     "supports-color": {
       "version": "2.0.0",
@@ -4592,46 +4019,26 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
     },
-    "table": {
-      "version": "6.7.5",
-      "resolved": "https://registry.npmjs.org/table/-/table-6.7.5.tgz",
-      "integrity": "sha512-LFNeryOqiQHqCVKzhkymKwt6ozeRhlm8IL1mE8rNUurkir4heF6PzMyRgaTa4tlyPTGGgXuvVOF/OLWiH09Lqw==",
+    "table-layout": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-1.0.2.tgz",
+      "integrity": "sha512-qd/R7n5rQTRFi+Zf2sk5XVVd9UQl6ZkduPFC3S7WEGJAmetDTjY3qPN50eSKzwuzEyQKy5TN2TiZdkIjos2L6A==",
       "requires": {
-        "ajv": "^8.0.1",
-        "lodash.truncate": "^4.4.2",
-        "slice-ansi": "^4.0.0",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1"
+        "array-back": "^4.0.1",
+        "deep-extend": "~0.6.0",
+        "typical": "^5.2.0",
+        "wordwrapjs": "^4.0.0"
       },
       "dependencies": {
-        "ajv": {
-          "version": "8.8.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
-          "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "json-schema-traverse": "^1.0.0",
-            "require-from-string": "^2.0.2",
-            "uri-js": "^4.2.2"
-          }
+        "array-back": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
+          "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg=="
         },
-        "ansi-regex": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
-        },
-        "json-schema-traverse": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-        },
-        "strip-ansi": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-          "requires": {
-            "ansi-regex": "^5.0.1"
-          }
+        "typical": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+          "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
         }
       }
     },
@@ -4647,11 +4054,6 @@
         "inherits": "^2.0.3",
         "readable-stream": "^3.1.1"
       }
-    },
-    "text-table": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
     },
     "tiny-json-http": {
       "version": "7.2.0",
@@ -4671,6 +4073,7 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
       "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "dev": true,
       "requires": {
         "psl": "^1.1.28",
         "punycode": "^2.1.1"
@@ -4680,6 +4083,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
       "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -4693,6 +4097,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -4700,7 +4105,8 @@
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true
     },
     "type-check": {
       "version": "0.3.2",
@@ -4710,20 +4116,21 @@
         "prelude-ls": "~1.1.2"
       }
     },
-    "type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
+    "typical": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw=="
     },
-    "underscore": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-      "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -4737,17 +4144,14 @@
     "uuid": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-    },
-    "v8-compile-cache": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
-      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA=="
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "dev": true
     },
     "verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
@@ -4776,12 +4180,14 @@
     "webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "dev": true
     },
     "whatwg-encoding": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
       "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+      "dev": true,
       "requires": {
         "iconv-lite": "0.4.24"
       }
@@ -4789,24 +4195,31 @@
     "whatwg-mimetype": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
-      "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g=="
+      "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
+      "dev": true
     },
     "whatwg-url": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
-      "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-10.0.0.tgz",
+      "integrity": "sha512-CLxxCmdUby142H5FZzn4D8ikO1cmypvXVQktsgosNy4a4BHrDHeciBBGZhb0bNoR5/MltoCatso+vFjjGx8t0w==",
       "requires": {
-        "lodash.sortby": "^4.7.0",
-        "tr46": "^1.0.1",
-        "webidl-conversions": "^4.0.2"
-      }
-    },
-    "which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "requires": {
-        "isexe": "^2.0.0"
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+          "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+          "requires": {
+            "punycode": "^2.1.1"
+          }
+        },
+        "webidl-conversions": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+          "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="
+        }
       }
     },
     "word-wrap": {
@@ -4814,42 +4227,44 @@
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
     },
+    "wordwrapjs": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-4.0.1.tgz",
+      "integrity": "sha512-kKlNACbvHrkpIw6oPeYDSmdCTu2hdMHoyXLTcUKala++lx5Y+wjJ/e474Jqv5abnVmwxw08DiTuHmw69lJGksA==",
+      "requires": {
+        "reduce-flatten": "^2.0.0",
+        "typical": "^5.2.0"
+      },
+      "dependencies": {
+        "typical": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+          "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
+        }
+      }
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "ws": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
-      "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
-      "requires": {
-        "async-limiter": "~1.0.0",
-        "safe-buffer": "~5.1.0"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        }
-      }
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+      "requires": {}
     },
     "xml-name-validator": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
-      "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
+      "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+      "dev": true
     },
     "xmlchars": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
-      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "dev": true
-    },
-    "yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "postbuild-spec": "git remote rm travis-origin",
     "build-head": "npm run build-only -- --lint-spec --strict",
     "prebuild-only": "npm run clean && mkdir out && cp -R img out",
-    "build-only": "ecmarkup --no-ecma-262-biblio --verbose spec.html --multipage out",
+    "build-only": "ecmarkup --verbose spec.html --multipage out",
     "build": "npm run build-head",
     "build-for-pdf": "npm run build-head -- --old-toc",
     "build-travis": "npm run build-head && npm run build-spec",
@@ -27,7 +27,7 @@
   "license": "SEE LICENSE IN https://tc39.es/ecma262/#sec-copyright-and-software-license",
   "homepage": "https://tc39.es/ecma262/",
   "dependencies": {
-    "ecmarkup": "^9.8.0"
+    "ecmarkup": "^10.0.2"
   },
   "devDependencies": {
     "glob": "^7.1.6",

--- a/spec.html
+++ b/spec.html
@@ -855,39 +855,32 @@
 
     <emu-clause id="sec-runtime-semantics">
       <h1>Runtime Semantics</h1>
-      <p>Algorithms which specify semantics that must be called at runtime are called <dfn>runtime semantics</dfn>. Runtime semantics are defined by abstract operations or syntax-directed operations. Such algorithms always return a completion record.</p>
+      <p>Algorithms which specify semantics that must be called at runtime are called <dfn>runtime semantics</dfn>. Runtime semantics are defined by abstract operations or syntax-directed operations.</p>
 
-      <emu-clause id="sec-implicit-completion-values">
-        <h1>Implicit Completion Values</h1>
-        <p>The algorithms of this specification often implicitly return Completion Records whose [[Type]] is ~normal~. Unless it is otherwise obvious from the context, an algorithm statement that returns a value that is not a Completion Record, such as:</p>
-        <emu-alg>
-          1. Return *"Infinity"*.
-        </emu-alg>
-        <p>means the same thing as:</p>
-        <emu-alg>
-          1. Return NormalCompletion(*"Infinity"*).
-        </emu-alg>
-        <p>However, if the value expression of a &ldquo;return&rdquo; statement is a Completion Record construction literal, the resulting Completion Record is returned. If the value expression is a call to an abstract operation, the &ldquo;return&rdquo; statement simply returns the Completion Record produced by the abstract operation.</p>
-        <p>The abstract operation Completion(_completionRecord_) is used to emphasize that a previously computed Completion Record is being returned. The Completion abstract operation takes a single argument, _completionRecord_, and performs the following steps:</p>
+      <emu-clause id="sec-completion-ao" type="abstract operation">
+        <h1>
+          Completion (
+            _completionRecord_: a Completion Record,
+          ): a Completion Record
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It is used to emphasize that a Completion Record is being returned.</dd>
+        </dl>
         <emu-alg>
           1. Assert: _completionRecord_ is a Completion Record.
-          1. Return _completionRecord_ as the Completion Record of this abstract operation.
+          1. Return _completionRecord_.
         </emu-alg>
-        <p>A &ldquo;return&rdquo; statement without a value in an algorithm step means the same thing as:</p>
-        <emu-alg>
-          1. Return NormalCompletion(*undefined*).
-        </emu-alg>
-        <p>Any reference to a Completion Record value that is in a context that does not explicitly require a complete Completion Record value is equivalent to an explicit reference to the [[Value]] field of the Completion Record value unless the Completion Record is an abrupt completion.</p>
       </emu-clause>
 
       <emu-clause id="sec-throw-an-exception">
         <h1>Throw an Exception</h1>
         <p>Algorithms steps that say to throw an exception, such as</p>
-        <emu-alg>
+        <emu-alg example>
           1. Throw a *TypeError* exception.
         </emu-alg>
         <p>mean the same things as:</p>
-        <emu-alg>
+        <emu-alg example>
           1. Return ThrowCompletion(a newly created *TypeError* object).
         </emu-alg>
       </emu-clause>
@@ -895,32 +888,32 @@
       <emu-clause id="sec-returnifabrupt" aoid="ReturnIfAbrupt">
         <h1>ReturnIfAbrupt</h1>
         <p>Algorithms steps that say or are otherwise equivalent to:</p>
-        <emu-alg>
+        <emu-alg example>
           1. ReturnIfAbrupt(_argument_).
         </emu-alg>
         <p>mean the same thing as:</p>
-        <emu-alg>
-          1. If _argument_ is an abrupt completion, return _argument_.
+        <emu-alg example>
+          1. If _argument_ is an abrupt completion, return Completion(_argument_).
           1. Else if _argument_ is a Completion Record, set _argument_ to _argument_.[[Value]].
         </emu-alg>
         <p>Algorithms steps that say or are otherwise equivalent to:</p>
-        <emu-alg>
+        <emu-alg example>
           1. ReturnIfAbrupt(AbstractOperation()).
         </emu-alg>
         <p>mean the same thing as:</p>
-        <emu-alg>
+        <emu-alg example>
           1. Let _hygienicTemp_ be AbstractOperation().
-          1. If _hygienicTemp_ is an abrupt completion, return _hygienicTemp_.
+          1. If _hygienicTemp_ is an abrupt completion, return Completion(_hygienicTemp_).
           1. Else if _hygienicTemp_ is a Completion Record, set _hygienicTemp_ to _hygienicTemp_.[[Value]].
         </emu-alg>
         <p>Where _hygienicTemp_ is ephemeral and visible only in the steps pertaining to ReturnIfAbrupt.</p>
         <p>Algorithms steps that say or are otherwise equivalent to:</p>
-        <emu-alg>
+        <emu-alg example>
           1. Let _result_ be AbstractOperation(ReturnIfAbrupt(_argument_)).
         </emu-alg>
         <p>mean the same thing as:</p>
-        <emu-alg>
-          1. If _argument_ is an abrupt completion, return _argument_.
+        <emu-alg example>
+          1. If _argument_ is an abrupt completion, return Completion(_argument_).
           1. If _argument_ is a Completion Record, set _argument_ to _argument_.[[Value]].
           1. Let _result_ be AbstractOperation(_argument_).
         </emu-alg>
@@ -957,6 +950,42 @@
         <p>Syntax-directed operations for runtime semantics make use of this shorthand by placing `!` or `?` before the invocation of the operation:</p>
         <emu-alg example>
           1. Perform ! SyntaxDirectedOperation of |NonTerminal|.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-implicit-normal-completion" oldids="sec-implicit-completion-values">
+        <h1>Implicit Normal Completion</h1>
+        <p>In algorithms within abstract operations which are declared to return a Completion Record, within the Evaluation syntax-directed operation, and within all built-in functions, the returned value is first passed to NormalCompletion, and the result is used instead. This rule does not apply within the Completion algorithm or when the value being returned is clearly marked as a Completion Record in that step; these cases are:</p>
+        <ul>
+          <li>when the result of applying Completion, NormalCompletion, or ThrowCompletion is directly returned</li>
+          <li>when the result of constructing a Completion Record is directly returned</li>
+          <li>when directly returning with the phrase "the result of evaluating"</li>
+        </ul>
+        <p>It is an editorial error if a Completion Record is returned from such an abstract operation through any other means. For example, within these abstract operations,</p>
+        <emu-alg example>
+          1. Return *true*.
+        </emu-alg>
+        <p>means the same things as any of</p>
+        <emu-alg example>
+          1. Return NormalCompletion(*true*).
+        </emu-alg>
+        <p>or</p>
+        <emu-alg example>
+          1. Let _completion_ be NormalCompletion(*true*).
+          1. Return Completion(_completion_).
+        </emu-alg>
+        <p>or</p>
+        <emu-alg example>
+          1. Return Completion Record { [[Type]]: ~normal~, [[Value]]: *true*, [[Target]]: ~empty~ }.
+        </emu-alg>
+        <p>Note that, through the ReturnIfAbrupt expansion, the following example is allowed, as within the expanded steps, the result of applying Completion is returned directly in the abrupt case and the implicit NormalCompletion application occurs after unwrapping in the normal case.</p>
+        <emu-alg example>
+          1. Return ? _completion_.
+        </emu-alg>
+        <p>The following example would be an editorial error because a Completion Record is being returned without being annotated in that step.</p>
+        <emu-alg example>
+          1. Let _completion_ be NormalCompletion(*true*).
+          1. Return _completion_.
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -1056,7 +1085,7 @@
             _string_: a String,
             _searchValue_: a String,
             _fromIndex_: a non-negative integer,
-          )
+          ): an integer
         </h1>
         <dl class="header">
         </dl>
@@ -1335,7 +1364,7 @@
               BigInt::exponentiate
             </td>
             <td>
-              BigInt; may throw *RangeError*
+              either a normal completion containing a BigInt or an abrupt completion
             </td>
           </tr>
 
@@ -1381,7 +1410,7 @@
               BigInt::divide
             </td>
             <td>
-              BigInt; may throw *RangeError*
+              either a normal completion containing a BigInt or an abrupt completion
             </td>
           </tr>
 
@@ -1404,7 +1433,7 @@
               BigInt::remainder
             </td>
             <td>
-              BigInt; may throw *RangeError*
+              either a normal completion containing a BigInt or an abrupt completion
             </td>
           </tr>
 
@@ -1527,7 +1556,7 @@
               BigInt::unsignedRightShift
             </td>
             <td>
-              always throws a *TypeError*
+              a throw completion
             </td>
           </tr>
 
@@ -1746,7 +1775,7 @@
           <h1>
             Number::unaryMinus (
               _x_: a Number,
-            )
+            ): a Number
           </h1>
           <dl class="header">
           </dl>
@@ -1760,7 +1789,7 @@
           <h1>
             Number::bitwiseNOT (
               _x_: a Number,
-            )
+            ): an integral Number
           </h1>
           <dl class="header">
           </dl>
@@ -1775,7 +1804,7 @@
             Number::exponentiate (
               _base_: a Number,
               _exponent_: a Number,
-            )
+            ): a Number
           </h1>
           <dl class="header">
             <dt>description</dt>
@@ -1822,7 +1851,7 @@
             Number::multiply (
               _x_: a Number,
               _y_: a Number,
-            )
+            ): a Number
           </h1>
           <dl class="header">
             <dt>description</dt>
@@ -1850,7 +1879,7 @@
             Number::divide (
               _x_: a Number,
               _y_: a Number,
-            )
+            ): a Number
           </h1>
           <dl class="header">
             <dt>description</dt>
@@ -1883,7 +1912,7 @@
             Number::remainder (
               _n_: a Number,
               _d_: a Number,
-            )
+            ): a Number
           </h1>
           <dl class="header">
             <dt>description</dt>
@@ -1911,7 +1940,7 @@
             Number::add (
               _x_: a Number,
               _y_: a Number,
-            )
+            ): a Number
           </h1>
           <dl class="header">
             <dt>description</dt>
@@ -1937,7 +1966,7 @@
             Number::subtract (
               _x_: a Number,
               _y_: a Number,
-            )
+            ): a Number
           </h1>
           <dl class="header">
             <dt>description</dt>
@@ -1956,7 +1985,7 @@
             Number::leftShift (
               _x_: a Number,
               _y_: a Number,
-            )
+            ): an integral Number
           </h1>
           <dl class="header">
           </dl>
@@ -1973,7 +2002,7 @@
             Number::signedRightShift (
               _x_: a Number,
               _y_: a Number,
-            )
+            ): an integral Number
           </h1>
           <dl class="header">
           </dl>
@@ -1990,7 +2019,7 @@
             Number::unsignedRightShift (
               _x_: a Number,
               _y_: a Number,
-            )
+            ): an integral Number
           </h1>
           <dl class="header">
           </dl>
@@ -2007,7 +2036,7 @@
             Number::lessThan (
               _x_: a Number,
               _y_: a Number,
-            )
+            ): a Boolean or *undefined*
           </h1>
           <dl class="header">
           </dl>
@@ -2031,7 +2060,7 @@
             Number::equal (
               _x_: a Number,
               _y_: a Number,
-            )
+            ): a Boolean
           </h1>
           <dl class="header">
           </dl>
@@ -2050,7 +2079,7 @@
             Number::sameValue (
               _x_: a Number,
               _y_: a Number,
-            )
+            ): a Boolean
           </h1>
           <dl class="header">
           </dl>
@@ -2068,7 +2097,7 @@
             Number::sameValueZero (
               _x_: a Number,
               _y_: a Number,
-            )
+            ): a Boolean
           </h1>
           <dl class="header">
           </dl>
@@ -2087,7 +2116,7 @@
               _op_: `&amp;`, `^`, or `|`,
               _x_: a Number,
               _y_: a Number,
-            )
+            ): an integral Number
           </h1>
           <dl class="header">
           </dl>
@@ -2108,7 +2137,7 @@
             Number::bitwiseAND (
               _x_: a Number,
               _y_: a Number,
-            )
+            ): an integral Number
           </h1>
           <dl class="header">
           </dl>
@@ -2122,7 +2151,7 @@
             Number::bitwiseXOR (
               _x_: a Number,
               _y_: a Number,
-            )
+            ): an integral Number
           </h1>
           <dl class="header">
           </dl>
@@ -2136,7 +2165,7 @@
             Number::bitwiseOR (
               _x_: a Number,
               _y_: a Number,
-            )
+            ): an integral Number
           </h1>
           <dl class="header">
           </dl>
@@ -2149,7 +2178,7 @@
           <h1>
             Number::toString (
               _x_: a Number,
-            )
+            ): a String
           </h1>
           <dl class="header">
             <dt>description</dt>
@@ -2158,7 +2187,7 @@
           <emu-alg>
             1. If _x_ is *NaN*, return the String *"NaN"*.
             1. If _x_ is *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, return the String *"0"*.
-            1. If _x_ &lt; *+0*<sub>𝔽</sub>, return the string-concatenation of *"-"* and ! Number::toString(-_x_).
+            1. If _x_ &lt; *+0*<sub>𝔽</sub>, return the string-concatenation of *"-"* and Number::toString(-_x_).
             1. If _x_ is *+&infin;*<sub>𝔽</sub>, return the String *"Infinity"*.
             1. [id="step-number-tostring-intermediate-values"] Otherwise, let _n_, _k_, and _s_ be integers such that _k_ &ge; 1, 10<sup>_k_ - 1</sup> &le; _s_ &lt; 10<sup>_k_</sup>, 𝔽(_s_ &times; 10<sup>_n_ - _k_</sup>) is _x_, and _k_ is as small as possible. Note that _k_ is the number of digits in the decimal representation of _s_, that _s_ is not divisible by 10, and that the least significant digit of _s_ is not necessarily uniquely determined by these criteria.
             1. If _k_ &le; _n_ &le; 21, return the string-concatenation of:
@@ -2223,7 +2252,7 @@
           <h1>
             BigInt::unaryMinus (
               _x_: a BigInt,
-            )
+            ): a BigInt
           </h1>
           <dl class="header">
           </dl>
@@ -2237,7 +2266,7 @@
           <h1>
             BigInt::bitwiseNOT (
               _x_: a BigInt,
-            )
+            ): a BigInt
           </h1>
           <dl class="header">
             <dt>description</dt>
@@ -2253,7 +2282,7 @@
             BigInt::exponentiate (
               _base_: a BigInt,
               _exponent_: a BigInt,
-            )
+            ): either a normal completion containing a BigInt or an abrupt completion
           </h1>
           <dl class="header">
           </dl>
@@ -2269,7 +2298,7 @@
             BigInt::multiply (
               _x_: a BigInt,
               _y_: a BigInt,
-            )
+            ): a BigInt
           </h1>
           <dl class="header">
           </dl>
@@ -2284,7 +2313,7 @@
             BigInt::divide (
               _x_: a BigInt,
               _y_: a BigInt,
-            )
+            ): either a normal completion containing a BigInt or an abrupt completion
           </h1>
           <dl class="header">
           </dl>
@@ -2300,7 +2329,7 @@
             BigInt::remainder (
               _n_: a BigInt,
               _d_: a BigInt,
-            )
+            ): either a normal completion containing a BigInt or an abrupt completion
           </h1>
           <dl class="header">
           </dl>
@@ -2318,7 +2347,7 @@
             BigInt::add (
               _x_: a BigInt,
               _y_: a BigInt,
-            )
+            ): a BigInt
           </h1>
           <dl class="header">
           </dl>
@@ -2332,7 +2361,7 @@
             BigInt::subtract (
               _x_: a BigInt,
               _y_: a BigInt,
-            )
+            ): a BigInt
           </h1>
           <dl class="header">
           </dl>
@@ -2346,7 +2375,7 @@
             BigInt::leftShift (
               _x_: a BigInt,
               _y_: a BigInt,
-            )
+            ): a BigInt
           </h1>
           <dl class="header">
           </dl>
@@ -2363,7 +2392,7 @@
             BigInt::signedRightShift (
               _x_: a BigInt,
               _y_: a BigInt,
-            )
+            ): a BigInt
           </h1>
           <dl class="header">
           </dl>
@@ -2377,7 +2406,7 @@
             BigInt::unsignedRightShift (
               _x_: a BigInt,
               _y_: a BigInt,
-            )
+            ): a throw completion
           </h1>
           <dl class="header">
           </dl>
@@ -2391,7 +2420,7 @@
             BigInt::lessThan (
               _x_: a BigInt,
               _y_: a BigInt,
-            )
+            ): a Boolean
           </h1>
           <dl class="header">
           </dl>
@@ -2405,7 +2434,7 @@
             BigInt::equal (
               _x_: a BigInt,
               _y_: a BigInt,
-            )
+            ): a Boolean
           </h1>
           <dl class="header">
           </dl>
@@ -2419,7 +2448,7 @@
             BigInt::sameValue (
               _x_: a BigInt,
               _y_: a BigInt,
-            )
+            ): a Boolean
           </h1>
           <dl class="header">
           </dl>
@@ -2433,7 +2462,7 @@
             BigInt::sameValueZero (
               _x_: a BigInt,
               _y_: a BigInt,
-            )
+            ): a Boolean
           </h1>
           <dl class="header">
           </dl>
@@ -2447,7 +2476,7 @@
             BinaryAnd (
               _x_: 0 or 1,
               _y_: 0 or 1,
-            )
+            ): 0 or 1
           </h1>
           <dl class="header">
           </dl>
@@ -2462,7 +2491,7 @@
             BinaryOr (
               _x_: 0 or 1,
               _y_: 0 or 1,
-            )
+            ): 0 or 1
           </h1>
           <dl class="header">
           </dl>
@@ -2477,7 +2506,7 @@
             BinaryXor (
               _x_: 0 or 1,
               _y_: 0 or 1,
-            )
+            ): 0 or 1
           </h1>
           <dl class="header">
           </dl>
@@ -2494,7 +2523,7 @@
               _op_: `&amp;`, `^`, or `|`,
               _x_: a BigInt,
               _y_: a BigInt,
-            )
+            ): a BigInt
           </h1>
           <dl class="header">
           </dl>
@@ -2531,7 +2560,7 @@
             BigInt::bitwiseAND (
               _x_: a BigInt,
               _y_: a BigInt,
-            )
+            ): a BigInt
           </h1>
           <dl class="header">
           </dl>
@@ -2545,7 +2574,7 @@
             BigInt::bitwiseXOR (
               _x_: a BigInt,
               _y_: a BigInt,
-            )
+            ): a BigInt
           </h1>
           <dl class="header">
           </dl>
@@ -2559,7 +2588,7 @@
             BigInt::bitwiseOR (
               _x_: a BigInt,
               _y_: a BigInt,
-            )
+            ): a BigInt
           </h1>
           <dl class="header">
           </dl>
@@ -2572,14 +2601,14 @@
           <h1>
             BigInt::toString (
               _x_: a BigInt,
-            )
+            ): a String
           </h1>
           <dl class="header">
             <dt>description</dt>
             <dd>It converts _x_ to String format.</dd>
           </dl>
           <emu-alg>
-            1. If _x_ &lt; *0*<sub>ℤ</sub>, return the string-concatenation of the String *"-"* and ! BigInt::toString(-_x_).
+            1. If _x_ &lt; *0*<sub>ℤ</sub>, return the string-concatenation of the String *"-"* and BigInt::toString(-_x_).
             1. Return the String value consisting of the code units of the digits of the decimal representation of _x_.
           </emu-alg>
         </emu-clause>
@@ -2597,7 +2626,7 @@
           An <dfn variants="accessor properties">accessor property</dfn> associates a key value with one or two accessor functions, and a set of Boolean attributes. The accessor functions are used to store or retrieve an ECMAScript language value that is associated with the property.
         </li>
       </ul>
-      <p>Properties are identified using key values. A property key value is either an ECMAScript String value or a Symbol value. All String and Symbol values, including the empty String, are valid as property keys. A <dfn id="property-name">property name</dfn> is a property key that is a String value.</p>
+      <p>Properties are identified using key values. A <dfn variants="property keys">property key</dfn> value is either an ECMAScript String value or a Symbol value. All String and Symbol values, including the empty String, are valid as property keys. A <dfn id="property-name">property name</dfn> is a property key that is a String value.</p>
       <p>An <dfn id="integer-index" variants="integer indices">integer index</dfn> is a String-valued property key that is a canonical numeric String (see <emu-xref href="#sec-canonicalnumericindexstring"></emu-xref>) and whose numeric value is either *+0*<sub>𝔽</sub> or a positive integral Number &le; 𝔽(2<sup>53</sup> - 1). An <dfn id="array-index" variants="array indices">array index</dfn> is an integer index whose numeric value _i_ is in the range <emu-eqn>*+0*<sub>𝔽</sub> &le; _i_ &lt; 𝔽(2<sup>32</sup> - 1)</emu-eqn>.</p>
       <p>Property keys are used to access properties and their values. There are two kinds of access for properties: <em>get</em> and <em>set</em>, corresponding to value retrieval and assignment, respectively. The properties accessible via get and set access includes both <em>own properties</em> that are a direct part of an object and <em>inherited properties</em> which are provided by another associated object via a property inheritance relationship. Inherited properties may be either own or inherited properties of the associated object. Each own property of an object must each have a key value that is distinct from the key values of the other own properties of that object.</p>
       <p>All objects are logically collections of properties, but there are multiple forms of objects that differ in their semantics for accessing and manipulating their properties. Please see <emu-xref href="#sec-object-internal-methods-and-internal-slots"></emu-xref> for definitions of the multiple forms of objects.</p>
@@ -2873,7 +2902,7 @@
                 [[OwnPropertyKeys]]
               </td>
               <td>
-                ( ) <b>&rarr;</b> List of propertyKey
+                ( ) <b>&rarr;</b> List of property keys
               </td>
               <td>
                 Return a List whose elements are all of the own property keys for the object.
@@ -2949,7 +2978,7 @@
           <li>[[Type]] = ~throw~, [[Target]] = ~empty~, and [[Value]] = any ECMAScript language value.</li>
         </ul>
         <emu-note>
-          <p>An internal method must not return a completion with [[Type]] = ~continue~, ~break~, or ~return~.</p>
+          <p>An internal method must not return a continue completion, a break completion, or a return completion.</p>
         </emu-note>
         <h2>[[GetPrototypeOf]] ( )</h2>
         <ul>
@@ -3862,7 +3891,7 @@
 
   <emu-clause id="sec-ecmascript-specification-types">
     <h1>ECMAScript Specification Types</h1>
-    <p>A specification type corresponds to meta-values that are used within algorithms to describe the semantics of ECMAScript language constructs and ECMAScript language types. The specification types include Reference, List, Completion, Property Descriptor, Environment Record, Abstract Closure, and Data Block. Specification type values are specification artefacts that do not necessarily correspond to any specific entity within an ECMAScript implementation. Specification type values may be used to describe intermediate results of ECMAScript expression evaluation but such values cannot be stored as properties of objects or values of ECMAScript language variables.</p>
+    <p>A specification type corresponds to meta-values that are used within algorithms to describe the semantics of ECMAScript language constructs and ECMAScript language types. The specification types include Reference, List, Completion Record, Property Descriptor, Environment Record, Abstract Closure, and Data Block. Specification type values are specification artefacts that do not necessarily correspond to any specific entity within an ECMAScript implementation. Specification type values may be used to describe intermediate results of ECMAScript expression evaluation but such values cannot be stored as properties of objects or values of ECMAScript language variables.</p>
 
     <emu-clause id="sec-list-and-record-specification-type">
       <h1>The List and Record Specification Types</h1>
@@ -3909,10 +3938,10 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-completion-record-specification-type" aoid="Completion">
+    <emu-clause id="sec-completion-record-specification-type">
       <h1>The Completion Record Specification Type</h1>
-      <p>The Completion type is a Record used to explain the runtime propagation of values and control flow such as the behaviour of statements (`break`, `continue`, `return` and `throw`) that perform nonlocal transfers of control.</p>
-      <p>Values of the Completion type are Record values whose fields are defined by <emu-xref href="#table-completion-record-fields"></emu-xref>. Such values are referred to as <dfn variants="Completion Record">Completion Records</dfn>.</p>
+      <p>The <dfn variants="Completion Records">Completion Record</dfn> specification type is used to explain the runtime propagation of values and control flow such as the behaviour of statements (`break`, `continue`, `return` and `throw`) that perform nonlocal transfers of control.</p>
+      <p>Completion Records have the fields defined in <emu-xref href="#table-completion-record-fields"></emu-xref>.</p>
       <emu-table id="table-completion-record-fields" caption="Completion Record Fields" oldids="table-8">
         <table>
           <tr>
@@ -3942,7 +3971,7 @@
               [[Value]]
             </td>
             <td>
-              an ECMAScript language value or ~empty~
+              any value except a Completion Record
             </td>
             <td>
               The value that was produced.
@@ -3961,14 +3990,15 @@
           </tr>
         </table>
       </emu-table>
-      <p>The following shorthand terms are sometimes used to refer to completions.</p>
+      <p>The following shorthand terms are sometimes used to refer to Completion Records.</p>
       <ul>
-        <li><dfn variants="normal completions">normal completion</dfn> refers to any completion with a [[Type]] value of ~normal~.</li>
-        <li><dfn variants="break completions">break completion</dfn> refers to any completion with a [[Type]] value of ~break~.</li>
-        <li><dfn variants="continue completions">continue completion</dfn> refers to any completion with a [[Type]] value of ~continue~.</li>
-        <li><dfn variants="return completions">return completion</dfn> refers to any completion with a [[Type]] value of ~return~.</li>
-        <li><dfn variants="throw completions">throw completion</dfn> refers to any completion with a [[Type]] value of ~throw~.</li>
-        <li><dfn variants="abrupt completions">abrupt completion</dfn> refers to any completion with a [[Type]] value other than ~normal~.</li>
+        <li><dfn variants="normal completions">normal completion</dfn> refers to any Completion Record with a [[Type]] value of ~normal~.</li>
+        <li><dfn variants="break completions">break completion</dfn> refers to any Completion Record with a [[Type]] value of ~break~.</li>
+        <li><dfn variants="continue completions">continue completion</dfn> refers to any Completion Record with a [[Type]] value of ~continue~.</li>
+        <li><dfn variants="return completions">return completion</dfn> refers to any Completion Record with a [[Type]] value of ~return~.</li>
+        <li><dfn variants="throw completions">throw completion</dfn> refers to any Completion Record with a [[Type]] value of ~throw~.</li>
+        <li><dfn variants="abrupt completions">abrupt completion</dfn> refers to any Completion Record with a [[Type]] value other than ~normal~.</li>
+        <li>a <dfn variants="normal completions containing">normal completion containing</dfn> some type of value refers to a normal completion that has a value of that type in its [[Value]] field.</li>
       </ul>
       <p>Callable objects that are defined in this specification only return a normal completion or a throw completion. Returning any other kind of completion is considered an editorial error.</p>
       <p>Implementation-defined callable objects must return either a normal completion or a throw completion.</p>
@@ -3978,13 +4008,13 @@
 
         <p>Algorithm steps that say</p>
 
-        <emu-alg>
+        <emu-alg example>
           1. Let _completion_ be Await(_value_).
         </emu-alg>
 
         <p>mean the same thing as:</p>
 
-        <emu-alg>
+        <emu-alg example>
           1. Let _asyncContext_ be the running execution context.
           1. Let _promise_ be ? PromiseResolve(%Promise%, _value_).
           1. Let _fulfilledClosure_ be a new Abstract Closure with parameters (_value_) that captures _asyncContext_ and performs the following steps when called:
@@ -3994,7 +4024,7 @@
             1. <emu-meta effects="user-code">Resume the suspended evaluation of _asyncContext_</emu-meta> using NormalCompletion(_value_) as the result of the operation that suspended it.
             1. Assert: When we reach this step, _asyncContext_ has already been removed from the execution context stack and _prevContext_ is the currently running execution context.
             1. Return *undefined*.
-          1. Let _onFulfilled_ be ! CreateBuiltinFunction(_fulfilledClosure_, 1, *""*, &laquo; &raquo;).
+          1. Let _onFulfilled_ be CreateBuiltinFunction(_fulfilledClosure_, 1, *""*, &laquo; &raquo;).
           1. Let _rejectedClosure_ be a new Abstract Closure with parameters (_reason_) that captures _asyncContext_ and performs the following steps when called:
             1. Let _prevContext_ be the running execution context.
             1. Suspend _prevContext_.
@@ -4002,11 +4032,11 @@
             1. <emu-meta effects="user-code">Resume the suspended evaluation of _asyncContext_</emu-meta> using ThrowCompletion(_reason_) as the result of the operation that suspended it.
             1. Assert: When we reach this step, _asyncContext_ has already been removed from the execution context stack and _prevContext_ is the currently running execution context.
             1. Return *undefined*.
-          1. Let _onRejected_ be ! CreateBuiltinFunction(_rejectedClosure_, 1, *""*, &laquo; &raquo;).
-          1. Perform ! PerformPromiseThen(_promise_, _onFulfilled_, _onRejected_).
+          1. Let _onRejected_ be CreateBuiltinFunction(_rejectedClosure_, 1, *""*, &laquo; &raquo;).
+          1. Perform PerformPromiseThen(_promise_, _onFulfilled_, _onRejected_).
           1. Remove _asyncContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
-          1. Set the code evaluation state of _asyncContext_ such that when evaluation is resumed with a Completion _completion_, the following steps of the algorithm that invoked Await will be performed, with _completion_ available.
-          1. Return.
+          1. Set the code evaluation state of _asyncContext_ such that when evaluation is resumed with a Completion Record _completion_, the following steps of the algorithm that invoked Await will be performed, with _completion_ available.
+          1. Return NormalCompletion(~unused~).
           1. NOTE: This returns to the evaluation of the operation that had most previously resumed evaluation of _asyncContext_.
         </emu-alg>
 
@@ -4015,13 +4045,13 @@
         <emu-note>
           <p>Await can be combined with the `?` and `!` prefixes, so that for example</p>
 
-          <emu-alg>
+          <emu-alg example>
             1. Let _result_ be ? Await(_value_).
           </emu-alg>
 
           <p>means the same thing as:</p>
 
-          <emu-alg>
+          <emu-alg example>
             1. Let _result_ be Await(_value_).
             1. ReturnIfAbrupt(_result_).
           </emu-alg>
@@ -4032,7 +4062,7 @@
         <h1>
           NormalCompletion (
             _value_: unknown,
-          )
+          ): a normal completion
         </h1>
         <dl class="header">
         </dl>
@@ -4045,7 +4075,7 @@
         <h1>
           ThrowCompletion (
             _value_: an ECMAScript language value,
-          )
+          ): a throw completion
         </h1>
         <dl class="header">
         </dl>
@@ -4057,15 +4087,15 @@
       <emu-clause id="sec-updateempty" type="abstract operation">
         <h1>
           UpdateEmpty (
-            _completionRecord_: unknown,
+            _completionRecord_: a Completion Record,
             _value_: unknown,
-          )
+          ): a Completion Record
         </h1>
         <dl class="header">
         </dl>
         <emu-alg>
           1. Assert: If _completionRecord_.[[Type]] is either ~return~ or ~throw~, then _completionRecord_.[[Value]] is not ~empty~.
-          1. If _completionRecord_.[[Value]] is not ~empty~, return Completion(_completionRecord_).
+          1. If _completionRecord_.[[Value]] is not ~empty~, return ? _completionRecord_.
           1. Return Completion Record { [[Type]]: _completionRecord_.[[Type]], [[Value]]: _value_, [[Target]]: _completionRecord_.[[Target]] }.
         </emu-alg>
       </emu-clause>
@@ -4112,7 +4142,7 @@
         <h1>
           IsPropertyReference (
             _V_: a Reference Record,
-          )
+          ): a Boolean
         </h1>
         <dl class="header">
         </dl>
@@ -4126,7 +4156,7 @@
         <h1>
           IsUnresolvableReference (
             _V_: a Reference Record,
-          )
+          ): a Boolean
         </h1>
         <dl class="header">
         </dl>
@@ -4139,7 +4169,7 @@
         <h1>
           IsSuperReference (
             _V_: a Reference Record,
-          )
+          ): a Boolean
         </h1>
         <dl class="header">
         </dl>
@@ -4152,7 +4182,7 @@
         <h1>
           IsPrivateReference (
             _V_: a Reference Record,
-          )
+          ): a Boolean
         </h1>
         <dl class="header">
         </dl>
@@ -4165,7 +4195,7 @@
         <h1>
           GetValue (
             _V_: unknown,
-          )
+          ): either a normal completion containing an ECMAScript language value or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
@@ -4193,7 +4223,7 @@
           PutValue (
             _V_: unknown,
             _W_: unknown,
-          )
+          ): either a normal completion containing ~unused~ or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
@@ -4204,14 +4234,15 @@
           1. If IsUnresolvableReference(_V_) is *true*, then
             1. If _V_.[[Strict]] is *true*, throw a *ReferenceError* exception.
             1. Let _globalObj_ be GetGlobalObject().
-            1. Return ? Set(_globalObj_, _V_.[[ReferencedName]], _W_, *false*).
+            1. Perform ? Set(_globalObj_, _V_.[[ReferencedName]], _W_, *false*).
+            1. Return ~unused~.
           1. If IsPropertyReference(_V_) is *true*, then
             1. [id="step-putvalue-toobject"] Let _baseObj_ be ? ToObject(_V_.[[Base]]).
             1. If IsPrivateReference(_V_) is *true*, then
               1. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
             1. Let _succeeded_ be ? <emu-meta effects="user-code">_baseObj_.[[Set]]</emu-meta>(_V_.[[ReferencedName]], _W_, GetThisValue(_V_)).
             1. If _succeeded_ is *false* and _V_.[[Strict]] is *true*, throw a *TypeError* exception.
-            1. Return.
+            1. Return ~unused~.
           1. Else,
             1. Let _base_ be _V_.[[Base]].
             1. Assert: _base_ is an Environment Record.
@@ -4226,7 +4257,7 @@
         <h1>
           GetThisValue (
             _V_: unknown,
-          )
+          ): an ECMAScript language value
         </h1>
         <dl class="header">
         </dl>
@@ -4241,7 +4272,7 @@
           InitializeReferencedBinding (
             _V_: unknown,
             _W_: unknown,
-          )
+          ): either a normal completion containing ~unused~ or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
@@ -4252,7 +4283,7 @@
           1. Assert: IsUnresolvableReference(_V_) is *false*.
           1. Let _base_ be _V_.[[Base]].
           1. Assert: _base_ is an Environment Record.
-          1. Return _base_.InitializeBinding(_V_.[[ReferencedName]], _W_).
+          1. Return ? _base_.InitializeBinding(_V_.[[ReferencedName]], _W_).
         </emu-alg>
       </emu-clause>
 
@@ -4261,14 +4292,14 @@
           MakePrivateReference (
             _baseValue_: an ECMAScript language value,
             _privateIdentifier_: a String,
-          )
+          ): a Reference Record
         </h1>
         <dl class="header">
         </dl>
         <emu-alg>
           1. Let _privEnv_ be the running execution context's PrivateEnvironment.
           1. Assert: _privEnv_ is not *null*.
-          1. Let _privateName_ be ! ResolvePrivateIdentifier(_privEnv_, _privateIdentifier_).
+          1. Let _privateName_ be ResolvePrivateIdentifier(_privEnv_, _privateIdentifier_).
           1. Return the Reference Record { [[Base]]: _baseValue_, [[ReferencedName]]: _privateName_, [[Strict]]: *true*, [[ThisValue]]: ~empty~ }.
         </emu-alg>
       </emu-clause>
@@ -4284,7 +4315,7 @@
         <h1>
           IsAccessorDescriptor (
             _Desc_: a Property Descriptor or *undefined*,
-          )
+          ): a Boolean
         </h1>
         <dl class="header">
         </dl>
@@ -4300,7 +4331,7 @@
         <h1>
           IsDataDescriptor (
             _Desc_: a Property Descriptor or *undefined*,
-          )
+          ): a Boolean
         </h1>
         <dl class="header">
         </dl>
@@ -4316,7 +4347,7 @@
         <h1>
           IsGenericDescriptor (
             _Desc_: a Property Descriptor or *undefined*,
-          )
+          ): a Boolean
         </h1>
         <dl class="header">
         </dl>
@@ -4332,13 +4363,13 @@
         <h1>
           FromPropertyDescriptor (
             _Desc_: a Property Descriptor or *undefined*,
-          )
+          ): an Object or *undefined*
         </h1>
         <dl class="header">
         </dl>
         <emu-alg>
           1. If _Desc_ is *undefined*, return *undefined*.
-          1. Let _obj_ be ! OrdinaryObjectCreate(%Object.prototype%).
+          1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%).
           1. Assert: _obj_ is an extensible ordinary object with no own properties.
           1. If _Desc_ has a [[Value]] field, then
             1. Perform ! CreateDataPropertyOrThrow(_obj_, *"value"*, _Desc_.[[Value]]).
@@ -4360,7 +4391,7 @@
         <h1>
           ToPropertyDescriptor (
             _Obj_: unknown,
-          )
+          ): either a normal completion containing a Property Descriptor or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
@@ -4369,11 +4400,11 @@
           1. Let _desc_ be a new Property Descriptor that initially has no fields.
           1. Let _hasEnumerable_ be ? HasProperty(_Obj_, *"enumerable"*).
           1. If _hasEnumerable_ is *true*, then
-            1. Let _enumerable_ be ! ToBoolean(? Get(_Obj_, *"enumerable"*)).
+            1. Let _enumerable_ be ToBoolean(? Get(_Obj_, *"enumerable"*)).
             1. Set _desc_.[[Enumerable]] to _enumerable_.
           1. Let _hasConfigurable_ be ? HasProperty(_Obj_, *"configurable"*).
           1. If _hasConfigurable_ is *true*, then
-            1. Let _configurable_ be ! ToBoolean(? Get(_Obj_, *"configurable"*)).
+            1. Let _configurable_ be ToBoolean(? Get(_Obj_, *"configurable"*)).
             1. Set _desc_.[[Configurable]] to _configurable_.
           1. Let _hasValue_ be ? HasProperty(_Obj_, *"value"*).
           1. If _hasValue_ is *true*, then
@@ -4381,7 +4412,7 @@
             1. Set _desc_.[[Value]] to _value_.
           1. Let _hasWritable_ be ? HasProperty(_Obj_, *"writable"*).
           1. If _hasWritable_ is *true*, then
-            1. Let _writable_ be ! ToBoolean(? Get(_Obj_, *"writable"*)).
+            1. Let _writable_ be ToBoolean(? Get(_Obj_, *"writable"*)).
             1. Set _desc_.[[Writable]] to _writable_.
           1. Let _hasGet_ be ? HasProperty(_Obj_, *"get"*).
           1. If _hasGet_ is *true*, then
@@ -4403,7 +4434,7 @@
         <h1>
           CompletePropertyDescriptor (
             _Desc_: a Property Descriptor,
-          )
+          ): ~unused~
         </h1>
         <dl class="header">
         </dl>
@@ -4417,7 +4448,7 @@
             1. If _Desc_ does not have a [[Set]] field, set _Desc_.[[Set]] to _like_.[[Set]].
           1. If _Desc_ does not have an [[Enumerable]] field, set _Desc_.[[Enumerable]] to _like_.[[Enumerable]].
           1. If _Desc_ does not have a [[Configurable]] field, set _Desc_.[[Configurable]] to _like_.[[Configurable]].
-          1. Return _Desc_.
+          1. Return ~unused~.
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -4455,7 +4486,7 @@
         <h1>
           CreateByteDataBlock (
             _size_: a non-negative integer,
-          )
+          ): either a normal completion containing a Data Block or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
@@ -4470,7 +4501,7 @@
         <h1>
           CreateSharedByteDataBlock (
             _size_: a non-negative integer,
-          )
+          ): either a normal completion containing a Shared Data Block or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
@@ -4493,7 +4524,7 @@
             _fromBlock_: a Data Block or a Shared Data Block,
             _fromIndex_: a non-negative integer,
             _count_: a non-negative integer,
-          )
+          ): ~unused~
         </h1>
         <dl class="header">
         </dl>
@@ -4522,7 +4553,7 @@
             1. Set _toIndex_ to _toIndex_ + 1.
             1. Set _fromIndex_ to _fromIndex_ + 1.
             1. Set _count_ to _count_ - 1.
-          1. Return NormalCompletion(~empty~).
+          1. Return ~unused~.
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -4717,7 +4748,7 @@
         ToPrimitive (
           _input_: an ECMAScript language value,
           optional _preferredType_: ~string~ or ~number~,
-        )
+        ): either a normal completion containing an ECMAScript language value or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -4748,7 +4779,7 @@
           OrdinaryToPrimitive (
             _O_: an Object,
             _hint_: ~string~ or ~number~,
-          )
+          ): either a normal completion containing an ECMAScript language value or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
@@ -4771,7 +4802,7 @@
       <h1>
         ToBoolean (
           _argument_: unknown,
-        )
+        ): a Boolean
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -4862,7 +4893,7 @@
       <h1>
         ToNumeric (
           _value_: unknown,
-        )
+        ): either a normal completion containing either a Number or a BigInt, or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -4879,7 +4910,7 @@
       <h1>
         ToNumber (
           _argument_: unknown,
-        )
+        ): either a normal completion containing a Number or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -5026,14 +5057,12 @@
           <h1>
             StringToNumber (
               _str_: a String,
-            )
+            ): a Number
           </h1>
           <dl class="header">
-            <dt>description</dt>
-            <dd>It returns a Number.</dd>
           </dl>
           <emu-alg>
-            1. Let _text_ be ! StringToCodePoints(_str_).
+            1. Let _text_ be StringToCodePoints(_str_).
             1. Let _literal_ be ParseText(_text_, |StringNumericLiteral|).
             1. If _literal_ is a List of errors, return *NaN*.
             1. Return StringNumericValue of _literal_.
@@ -5041,7 +5070,7 @@
         </emu-clause>
 
         <emu-clause id="sec-runtime-semantics-stringnumericvalue" type="sdo" oldids="sec-runtime-semantics-mv-s">
-          <h1>Runtime Semantics: StringNumericValue</h1>
+          <h1>Runtime Semantics: StringNumericValue ( ): a Number</h1>
           <dl class="header">
           </dl>
           <emu-note>
@@ -5100,7 +5129,7 @@
           <h1>
             RoundMVResult (
               _n_: a mathematical value,
-            )
+            ): a Number
           </h1>
           <dl class="header">
             <dt>description</dt>
@@ -5121,7 +5150,7 @@
       <h1>
         ToIntegerOrInfinity (
           _argument_: an ECMAScript language value,
-        )
+        ): either a normal completion containing either an integer, +&infin;, or -&infin;, or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -5142,7 +5171,7 @@
       <h1>
         ToInt32 (
           _argument_: unknown,
-        )
+        ): either a normal completion containing an integral Number or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -5175,7 +5204,7 @@
       <h1>
         ToUint32 (
           _argument_: unknown,
-        )
+        ): either a normal completion containing an integral Number or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -5211,7 +5240,7 @@
       <h1>
         ToInt16 (
           _argument_: unknown,
-        )
+        ): either a normal completion containing an integral Number or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -5230,7 +5259,7 @@
       <h1>
         ToUint16 (
           _argument_: unknown,
-        )
+        ): either a normal completion containing an integral Number or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -5260,7 +5289,7 @@
       <h1>
         ToInt8 (
           _argument_: unknown,
-        )
+        ): either a normal completion containing an integral Number or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -5279,7 +5308,7 @@
       <h1>
         ToUint8 (
           _argument_: unknown,
-        )
+        ): either a normal completion containing an integral Number or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -5298,7 +5327,7 @@
       <h1>
         ToUint8Clamp (
           _argument_: unknown,
-        )
+        ): either a normal completion containing an integral Number or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -5324,7 +5353,7 @@
       <h1>
         ToBigInt (
           _argument_: unknown,
-        )
+        ): either a normal completion containing a BigInt or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -5390,7 +5419,7 @@
             </td>
             <td>
               <emu-alg>
-                1. Let _n_ be ! StringToBigInt(_prim_).
+                1. Let _n_ be StringToBigInt(_prim_).
                 1. If _n_ is *undefined*, throw a *SyntaxError* exception.
                 1. Return _n_.
               </emu-alg>
@@ -5412,14 +5441,12 @@
       <h1>
         StringToBigInt (
           _str_: a String,
-        )
+        ): a BigInt or *undefined*
       </h1>
       <dl class="header">
-        <dt>description</dt>
-        <dd>It returns a BigInt or *undefined*.</dd>
       </dl>
       <emu-alg>
-        1. Let _text_ be ! StringToCodePoints(_str_).
+        1. Let _text_ be StringToCodePoints(_str_).
         1. Let _literal_ be ParseText(_text_, |StringIntegerLiteral|).
         1. If _literal_ is a List of errors, return *undefined*.
         1. Let _mv_ be the MV of _literal_.
@@ -5459,7 +5486,7 @@
       <h1>
         ToBigInt64 (
           _argument_: unknown,
-        )
+        ): either a normal completion containing a BigInt or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -5476,7 +5503,7 @@
       <h1>
         ToBigUint64 (
           _argument_: unknown,
-        )
+        ): either a normal completion containing a BigInt or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -5493,7 +5520,7 @@
       <h1>
         ToString (
           _argument_: unknown,
-        )
+        ): either a normal completion containing a String or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -5539,7 +5566,7 @@
               Number
             </td>
             <td>
-              Return ! Number::toString(_argument_).
+              Return Number::toString(_argument_).
             </td>
           </tr>
           <tr>
@@ -5586,7 +5613,7 @@
       <h1>
         ToObject (
           _argument_: unknown,
-        )
+        ): either a normal completion containing an Object or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -5674,7 +5701,7 @@
       <h1>
         ToPropertyKey (
           _argument_: unknown,
-        )
+        ): either a normal completion containing a property key or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -5692,7 +5719,7 @@
       <h1>
         ToLength (
           _argument_: an ECMAScript language value,
-        )
+        ): either a normal completion containing an integral Number or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -5709,7 +5736,7 @@
       <h1>
         CanonicalNumericIndexString (
           _argument_: a String,
-        )
+        ): a Number or *undefined*
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -5728,7 +5755,7 @@
       <h1>
         ToIndex (
           _value_: an ECMAScript language value,
-        )
+        ): either a normal completion containing a non-negative integer or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -5740,7 +5767,7 @@
         1. Else,
           1. Let _integer_ be ? ToIntegerOrInfinity(_value_).
           1. Let _clamped_ be ! ToLength(𝔽(_integer_)).
-          1. If ! SameValue(𝔽(_integer_), _clamped_) is *false*, throw a *RangeError* exception.
+          1. If SameValue(𝔽(_integer_), _clamped_) is *false*, throw a *RangeError* exception.
           1. Assert: 0 &le; _integer_ &le; 2<sup>53</sup> - 1.
           1. Return _integer_.
       </emu-alg>
@@ -5754,7 +5781,7 @@
       <h1>
         RequireObjectCoercible (
           _argument_: unknown,
-        )
+        ): either a normal completion containing an ECMAScript language value or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -5842,7 +5869,7 @@
       <h1>
         IsArray (
           _argument_: unknown,
-        )
+        ): either a normal completion containing a Boolean or an abrupt completion
       </h1>
       <dl class="header">
       </dl>
@@ -5861,7 +5888,7 @@
       <h1>
         IsCallable (
           _argument_: an ECMAScript language value,
-        )
+        ): a Boolean
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -5878,7 +5905,7 @@
       <h1>
         IsConstructor (
           _argument_: an ECMAScript language value,
-        )
+        ): a Boolean
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -5895,11 +5922,11 @@
       <h1>
         IsExtensible (
           _O_: an Object,
-        )
+        ): either a normal completion containing a Boolean or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It returns a completion record which, if its [[Type]] is ~normal~, has a [[Value]] which is a Boolean. It is used to determine whether additional properties can be added to _O_.</dd>
+        <dd>It is used to determine whether additional properties can be added to _O_.</dd>
       </dl>
       <emu-alg>
         1. Return ? <emu-meta effects="user-code">_O_.[[IsExtensible]]</emu-meta>().
@@ -5910,7 +5937,7 @@
       <h1>
         IsIntegralNumber (
           _argument_: unknown,
-        )
+        ): a Boolean
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -5928,7 +5955,7 @@
       <h1>
         IsPropertyKey (
           _argument_: an ECMAScript language value,
-        )
+        ): a Boolean
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -5945,14 +5972,14 @@
       <h1>
         IsRegExp (
           _argument_: unknown,
-        )
+        ): either a normal completion containing a Boolean or an abrupt completion
       </h1>
       <dl class="header">
       </dl>
       <emu-alg>
         1. If Type(_argument_) is not Object, return *false*.
         1. Let _matcher_ be ? Get(_argument_, @@match).
-        1. If _matcher_ is not *undefined*, return ! ToBoolean(_matcher_).
+        1. If _matcher_ is not *undefined*, return ToBoolean(_matcher_).
         1. If _argument_ has a [[RegExpMatcher]] internal slot, return *true*.
         1. Return *false*.
       </emu-alg>
@@ -5963,14 +5990,14 @@
         IsStringPrefix (
           _p_: a String,
           _q_: a String,
-        )
+        ): a Boolean
       </h1>
       <dl class="header">
         <dt>description</dt>
         <dd>It determines if _p_ is a prefix of _q_.</dd>
       </dl>
       <emu-alg>
-        1. If ! StringIndexOf(_q_, _p_, 0) is 0, return *true*.
+        1. If StringIndexOf(_q_, _p_, 0) is 0, return *true*.
         1. Else, return *false*.
       </emu-alg>
       <emu-note>
@@ -5982,7 +6009,7 @@
       <h1>
         Static Semantics: IsStringWellFormedUnicode (
           _string_: a String,
-        )
+        ): a Boolean
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -5992,7 +6019,7 @@
         1. Let _strLen_ be the number of code units in _string_.
         1. Let _k_ be 0.
         1. Repeat, while _k_ &ne; _strLen_,
-          1. Let _cp_ be ! CodePointAt(_string_, _k_).
+          1. Let _cp_ be CodePointAt(_string_, _k_).
           1. If _cp_.[[IsUnpairedSurrogate]] is *true*, return *false*.
           1. Set _k_ to _k_ + _cp_.[[CodeUnitCount]].
         1. Return *true*.
@@ -6004,19 +6031,19 @@
         SameValue (
           _x_: an ECMAScript language value,
           _y_: an ECMAScript language value,
-        )
+        ): a Boolean
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It returns a completion record whose [[Type]] is ~normal~ and whose [[Value]] is a Boolean indicating whether or not the two arguments are the same value.</dd>
+        <dd>It determines whether or not the two arguments are the same value.</dd>
       </dl>
       <emu-alg>
         1. If Type(_x_) is different from Type(_y_), return *false*.
         1. If Type(_x_) is Number, then
-          1. Return ! Number::sameValue(_x_, _y_).
+          1. Return Number::sameValue(_x_, _y_).
         1. If Type(_x_) is BigInt, then
-          1. Return ! BigInt::sameValue(_x_, _y_).
-        1. Return ! SameValueNonNumeric(_x_, _y_).
+          1. Return BigInt::sameValue(_x_, _y_).
+        1. Return SameValueNonNumeric(_x_, _y_).
       </emu-alg>
       <emu-note>
         <p>This algorithm differs from the IsStrictlyEqual Algorithm by treating all *NaN* values as equivalent and by differentiating *+0*<sub>𝔽</sub> from *-0*<sub>𝔽</sub>.</p>
@@ -6028,19 +6055,19 @@
         SameValueZero (
           _x_: an ECMAScript language value,
           _y_: an ECMAScript language value,
-        )
+        ): a Boolean
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It returns a completion record whose [[Type]] is ~normal~ and whose [[Value]] is a Boolean indicating whether or not the two arguments are the same value (ignoring the difference between *+0*<sub>𝔽</sub> and *-0*<sub>𝔽</sub>).</dd>
+        <dd>It determines whether or not the two arguments are the same value (ignoring the difference between *+0*<sub>𝔽</sub> and *-0*<sub>𝔽</sub>).</dd>
       </dl>
       <emu-alg>
         1. If Type(_x_) is different from Type(_y_), return *false*.
         1. If Type(_x_) is Number, then
-          1. Return ! Number::sameValueZero(_x_, _y_).
+          1. Return Number::sameValueZero(_x_, _y_).
         1. If Type(_x_) is BigInt, then
-          1. Return ! BigInt::sameValueZero(_x_, _y_).
-        1. Return ! SameValueNonNumeric(_x_, _y_).
+          1. Return BigInt::sameValueZero(_x_, _y_).
+        1. Return SameValueNonNumeric(_x_, _y_).
       </emu-alg>
       <emu-note>
         <p>SameValueZero differs from SameValue only in that it treats *+0*<sub>𝔽</sub> and *-0*<sub>𝔽</sub> as equivalent.</p>
@@ -6052,11 +6079,9 @@
         SameValueNonNumeric (
           _x_: an ECMAScript language value, but not a Number or a BigInt,
           _y_: an ECMAScript language value, but not a Number or a BigInt,
-        )
+        ): a Boolean
       </h1>
       <dl class="header">
-        <dt>description</dt>
-        <dd>It returns a completion record whose [[Type]] is ~normal~ and whose [[Value]] is a Boolean.</dd>
       </dl>
       <emu-alg>
         1. Assert: Type(_x_) is the same as Type(_y_).
@@ -6078,7 +6103,7 @@
           _x_: an ECMAScript language value,
           _y_: an ECMAScript language value,
           _LeftFirst_: a Boolean,
-        )
+        ): either a normal completion containing either a Boolean or *undefined*, or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -6101,11 +6126,11 @@
           1. If _m_ &lt; _n_, return *true*. Otherwise, return *false*.
         1. Else,
           1. If Type(_px_) is BigInt and Type(_py_) is String, then
-            1. Let _ny_ be ! StringToBigInt(_py_).
+            1. Let _ny_ be StringToBigInt(_py_).
             1. If _ny_ is *undefined*, return *undefined*.
             1. Return BigInt::lessThan(_px_, _ny_).
           1. If Type(_px_) is String and Type(_py_) is BigInt, then
-            1. Let _nx_ be ! StringToBigInt(_px_).
+            1. Let _nx_ be StringToBigInt(_px_).
             1. If _nx_ is *undefined*, return *undefined*.
             1. Return BigInt::lessThan(_nx_, _py_).
           1. NOTE: Because _px_ and _py_ are primitive values, evaluation order is not important.
@@ -6136,11 +6161,11 @@
         IsLooselyEqual (
           _x_: an ECMAScript language value,
           _y_: an ECMAScript language value,
-        )
+        ): either a normal completion containing a Boolean or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It provides the semantics for the comparison _x_ == _y_, returning *true* or *false*.</dd>
+        <dd>It provides the semantics for the comparison _x_ == _y_.</dd>
       </dl>
       <emu-alg>
         1. If Type(_x_) is the same as Type(_y_), then
@@ -6148,17 +6173,17 @@
         1. If _x_ is *null* and _y_ is *undefined*, return *true*.
         1. If _x_ is *undefined* and _y_ is *null*, return *true*.
         1. [id="step-abstract-equality-comparison-web-compat-insertion-point"] NOTE: This step is replaced in section <emu-xref href="#sec-IsHTMLDDA-internal-slot-aec"></emu-xref>.
-        1. If Type(_x_) is Number and Type(_y_) is String, return IsLooselyEqual(_x_, ! ToNumber(_y_)).
-        1. If Type(_x_) is String and Type(_y_) is Number, return IsLooselyEqual(! ToNumber(_x_), _y_).
+        1. If Type(_x_) is Number and Type(_y_) is String, return ! IsLooselyEqual(_x_, ! ToNumber(_y_)).
+        1. If Type(_x_) is String and Type(_y_) is Number, return ! IsLooselyEqual(! ToNumber(_x_), _y_).
         1. If Type(_x_) is BigInt and Type(_y_) is String, then
-          1. Let _n_ be ! StringToBigInt(_y_).
+          1. Let _n_ be StringToBigInt(_y_).
           1. If _n_ is *undefined*, return *false*.
-          1. Return IsLooselyEqual(_x_, _n_).
-        1. If Type(_x_) is String and Type(_y_) is BigInt, return IsLooselyEqual(_y_, _x_).
-        1. If Type(_x_) is Boolean, return IsLooselyEqual(! ToNumber(_x_), _y_).
-        1. If Type(_y_) is Boolean, return IsLooselyEqual(_x_, ! ToNumber(_y_)).
-        1. If Type(_x_) is either String, Number, BigInt, or Symbol and Type(_y_) is Object, return IsLooselyEqual(_x_, ? ToPrimitive(_y_)).
-        1. If Type(_x_) is Object and Type(_y_) is either String, Number, BigInt, or Symbol, return IsLooselyEqual(? ToPrimitive(_x_), _y_).
+          1. Return ! IsLooselyEqual(_x_, _n_).
+        1. If Type(_x_) is String and Type(_y_) is BigInt, return ! IsLooselyEqual(_y_, _x_).
+        1. If Type(_x_) is Boolean, return ! IsLooselyEqual(! ToNumber(_x_), _y_).
+        1. If Type(_y_) is Boolean, return ! IsLooselyEqual(_x_, ! ToNumber(_y_)).
+        1. If Type(_x_) is either String, Number, BigInt, or Symbol and Type(_y_) is Object, return ! IsLooselyEqual(_x_, ? ToPrimitive(_y_)).
+        1. If Type(_x_) is Object and Type(_y_) is either String, Number, BigInt, or Symbol, return ! IsLooselyEqual(? ToPrimitive(_x_), _y_).
         1. If Type(_x_) is BigInt and Type(_y_) is Number, or if Type(_x_) is Number and Type(_y_) is BigInt, then
           1. If _x_ or _y_ are any of *NaN*, *+&infin;*<sub>𝔽</sub>, or *-&infin;*<sub>𝔽</sub>, return *false*.
           1. If ℝ(_x_) = ℝ(_y_), return *true*; otherwise return *false*.
@@ -6171,19 +6196,19 @@
         IsStrictlyEqual (
           _x_: an ECMAScript language value,
           _y_: an ECMAScript language value,
-        )
+        ): a Boolean
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It provides the semantics for the comparison _x_ === _y_, returning *true* or *false*.</dd>
+        <dd>It provides the semantics for the comparison _x_ === _y_.</dd>
       </dl>
       <emu-alg>
         1. If Type(_x_) is different from Type(_y_), return *false*.
         1. If Type(_x_) is Number, then
-          1. Return ! Number::equal(_x_, _y_).
+          1. Return Number::equal(_x_, _y_).
         1. If Type(_x_) is BigInt, then
-          1. Return ! BigInt::equal(_x_, _y_).
-        1. Return ! SameValueNonNumeric(_x_, _y_).
+          1. Return BigInt::equal(_x_, _y_).
+        1. Return SameValueNonNumeric(_x_, _y_).
       </emu-alg>
       <emu-note>
         <p>This algorithm differs from the SameValue Algorithm in its treatment of signed zeroes and NaNs.</p>
@@ -6198,7 +6223,7 @@
       <h1>
         MakeBasicObject (
           _internalSlotsList_: a List of internal slot names,
-        )
+        ): an Object
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -6224,7 +6249,7 @@
         Get (
           _O_: an Object,
           _P_: a property key,
-        )
+        ): either a normal completion containing an ECMAScript language value or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -6240,7 +6265,7 @@
         GetV (
           _V_: an ECMAScript language value,
           _P_: a property key,
-        )
+        ): either a normal completion containing an ECMAScript language value or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -6259,7 +6284,7 @@
           _P_: a property key,
           _V_: an ECMAScript language value,
           _Throw_: a Boolean,
-        )
+        ): either a normal completion containing ~unused~ or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -6268,7 +6293,7 @@
       <emu-alg>
         1. Let _success_ be ? <emu-meta effects="user-code">_O_.[[Set]]</emu-meta>(_P_, _V_, _O_).
         1. If _success_ is *false* and _Throw_ is *true*, throw a *TypeError* exception.
-        1. Return _success_.
+        1. Return ~unused~.
       </emu-alg>
     </emu-clause>
 
@@ -6278,7 +6303,7 @@
           _O_: an Object,
           _P_: a property key,
           _V_: an ECMAScript language value,
-        )
+        ): either a normal completion containing a Boolean or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -6293,21 +6318,23 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-createmethodproperty" type="abstract operation">
+    <emu-clause id="sec-createmethodpropertyinfallibly" oldids="sec-createmethodproperty" type="abstract operation">
       <h1>
         CreateMethodProperty (
           _O_: an Object,
           _P_: a property key,
           _V_: an ECMAScript language value,
-        )
+        ): ~unused~
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It is used to create a new own property of an object.</dd>
+        <dd>It is used to create a new own property of an ordinary object.</dd>
       </dl>
       <emu-alg>
+        1. Assert: _O_ is an ordinary, extensible object with no non-configurable properties.
         1. Let _newDesc_ be the PropertyDescriptor { [[Value]]: _V_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.
-        1. Return ? <emu-meta effects="user-code">_O_.[[DefineOwnProperty]]</emu-meta>(_P_, _newDesc_).
+        1. Perform ! _O_.[[DefineOwnProperty]](_P_, _newDesc_).
+        1. Return ~unused~.
       </emu-alg>
       <emu-note>
         <p>This abstract operation creates a property whose attributes are set to the same defaults used for built-in methods and methods defined using class declaration syntax. Normally, the property will not already exist. If it does exist and is not configurable or if _O_ is not extensible, [[DefineOwnProperty]] will return *false*.</p>
@@ -6320,7 +6347,7 @@
           _O_: an Object,
           _P_: a property key,
           _V_: an ECMAScript language value,
-        )
+        ): either a normal completion containing a Boolean or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -6336,21 +6363,23 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-createnonenumerabledatapropertyorthrow" type="abstract operation">
+    <emu-clause id="sec-createnonenumerabledatapropertyinfallibly" oldids="sec-createnonenumerabledatapropertyorthrow" type="abstract operation">
       <h1>
         CreateNonEnumerableDataPropertyOrThrow (
           _O_: an Object,
           _P_: a property key,
           _V_: an ECMAScript language value,
-        )
+        ): ~unused~
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It is used to create a new non-enumerable own property of an object. It throws a *TypeError* exception if the requested property update cannot be performed.</dd>
+        <dd>It is used to create a new non-enumerable own property of an ordinary object.</dd>
       </dl>
       <emu-alg>
+        1. Assert: _O_ is an ordinary, extensible object with no non-configurable properties.
         1. Let _newDesc_ be the PropertyDescriptor { [[Value]]: _V_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.
-        1. Return ? DefinePropertyOrThrow(_O_, _P_, _newDesc_).
+        1. Perform ! DefinePropertyOrThrow(_O_, _P_, _newDesc_).
+        1. Return ~unused~.
       </emu-alg>
       <emu-note>
         <p>This abstract operation creates a property whose attributes are set to the same defaults used for properties created by the ECMAScript language assignment operator except it is not enumerable. Normally, the property will not already exist. If it does exist and is not configurable or if _O_ is not extensible, [[DefineOwnProperty]] will return *false* causing this operation to throw a *TypeError* exception.</p>
@@ -6363,7 +6392,7 @@
           _O_: an Object,
           _P_: a property key,
           _desc_: a Property Descriptor,
-        )
+        ): either a normal completion containing ~unused~ or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -6372,7 +6401,7 @@
       <emu-alg>
         1. Let _success_ be ? <emu-meta effects="user-code">_O_.[[DefineOwnProperty]]</emu-meta>(_P_, _desc_).
         1. If _success_ is *false*, throw a *TypeError* exception.
-        1. Return _success_.
+        1. Return ~unused~.
       </emu-alg>
     </emu-clause>
 
@@ -6381,7 +6410,7 @@
         DeletePropertyOrThrow (
           _O_: an Object,
           _P_: a property key,
-        )
+        ): either a normal completion containing ~unused~ or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -6390,7 +6419,7 @@
       <emu-alg>
         1. Let _success_ be ? <emu-meta effects="user-code">_O_.[[Delete]]</emu-meta>(_P_).
         1. If _success_ is *false*, throw a *TypeError* exception.
-        1. Return _success_.
+        1. Return ~unused~.
       </emu-alg>
     </emu-clause>
 
@@ -6399,7 +6428,7 @@
         GetMethod (
           _V_: an ECMAScript language value,
           _P_: a property key,
-        )
+        ): either a normal completion containing either a function object or *undefined*, or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -6418,11 +6447,11 @@
         HasProperty (
           _O_: an Object,
           _P_: a property key,
-        )
+        ): either a normal completion containing a Boolean or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It returns a completion record which, if its [[Type]] is ~normal~, has a [[Value]] which is a Boolean. It is used to determine whether an object has a property with the specified property key. The property may be either an own or inherited.</dd>
+        <dd>It is used to determine whether an object has a property with the specified property key. The property may be either own or inherited.</dd>
       </dl>
       <emu-alg>
         1. Return ? <emu-meta effects="user-code">_O_.[[HasProperty]]</emu-meta>(_P_).
@@ -6434,11 +6463,11 @@
         HasOwnProperty (
           _O_: an Object,
           _P_: a property key,
-        )
+        ): either a normal completion containing a Boolean or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It returns a completion record which, if its [[Type]] is ~normal~, has a [[Value]] which is a Boolean. It is used to determine whether an object has an own property with the specified property key.</dd>
+        <dd>It is used to determine whether an object has an own property with the specified property key.</dd>
       </dl>
       <emu-alg>
         1. Let _desc_ be ? <emu-meta effects="user-code">_O_.[[GetOwnProperty]]</emu-meta>(_P_).
@@ -6453,7 +6482,7 @@
           _F_: an ECMAScript language value,
           _V_: an ECMAScript language value,
           optional _argumentsList_: a List of ECMAScript language values,
-        )
+        ): either a normal completion containing an ECMAScript language value or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -6472,7 +6501,7 @@
           _F_: a constructor,
           optional _argumentsList_: unknown,
           optional _newTarget_: a constructor,
-        )
+        ): either a normal completion containing an Object or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -6493,7 +6522,7 @@
         SetIntegrityLevel (
           _O_: an Object,
           _level_: ~sealed~ or ~frozen~,
-        )
+        ): either a normal completion containing a Boolean or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -6525,7 +6554,7 @@
         TestIntegrityLevel (
           _O_: an Object,
           _level_: ~sealed~ or ~frozen~,
-        )
+        ): either a normal completion containing a Boolean or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -6550,7 +6579,7 @@
       <h1>
         CreateArrayFromList (
           _elements_: a List of ECMAScript language values,
-        )
+        ): an Array
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -6570,16 +6599,16 @@
       <h1>
         LengthOfArrayLike (
           _obj_: an Object,
-        )
+        ): either a normal completion containing a non-negative integer or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It returns the value of the *"length"* property of an array-like object (as a non-negative integer).</dd>
+        <dd>It returns the value of the *"length"* property of an array-like object.</dd>
       </dl>
       <emu-alg>
         1. Return ℝ(? ToLength(? Get(_obj_, *"length"*))).
       </emu-alg>
-      <p>An <dfn variants="array-like objects">array-like object</dfn> is any object for which this operation returns an integer rather than an abrupt completion.</p>
+      <p>An <dfn variants="array-like objects">array-like object</dfn> is any object for which this operation returns a normal completion.</p>
       <emu-note>
         Typically, an array-like object would also have some properties with integer index names. However, that is not a requirement of this definition.
       </emu-note>
@@ -6593,7 +6622,7 @@
         CreateListFromArrayLike (
           _obj_: unknown,
           optional _elementTypes_: a List of names of ECMAScript Language Types,
-        )
+        ): either a normal completion containing a List or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -6621,7 +6650,7 @@
           _V_: an ECMAScript language value,
           _P_: a property key,
           optional _argumentsList_: a List of ECMAScript language values,
-        )
+        ): either a normal completion containing an ECMAScript language value or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -6640,7 +6669,7 @@
         OrdinaryHasInstance (
           _C_: an ECMAScript language value,
           _O_: unknown,
-        )
+        ): either a normal completion containing a Boolean or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -6666,7 +6695,7 @@
         SpeciesConstructor (
           _O_: an Object,
           _defaultConstructor_: a constructor,
-        )
+        ): either a normal completion containing a constructor or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -6688,7 +6717,7 @@
         EnumerableOwnPropertyNames (
           _O_: an Object,
           _kind_: ~key~, ~value~, or ~key+value~,
-        )
+        ): either a normal completion containing a List or an abrupt completion
       </h1>
       <dl class="header">
       </dl>
@@ -6705,7 +6734,7 @@
                 1. If _kind_ is ~value~, append _value_ to _properties_.
                 1. Else,
                   1. Assert: _kind_ is ~key+value~.
-                  1. Let _entry_ be ! CreateArrayFromList(&laquo; _key_, _value_ &raquo;).
+                  1. Let _entry_ be CreateArrayFromList(&laquo; _key_, _value_ &raquo;).
                   1. Append _entry_ to _properties_.
         1. Return _properties_.
       </emu-alg>
@@ -6715,7 +6744,7 @@
       <h1>
         GetFunctionRealm (
           _obj_: a function object,
-        )
+        ): either a normal completion containing a Realm Record or an abrupt completion
       </h1>
       <dl class="header">
       </dl>
@@ -6742,12 +6771,12 @@
           _target_: an Object,
           _source_: an ECMAScript language value,
           _excludedItems_: a List of property keys,
-        )
+        ): either a normal completion containing ~unused~ or an abrupt completion
       </h1>
       <dl class="header">
       </dl>
       <emu-alg>
-        1. If _source_ is *undefined* or *null*, return _target_.
+        1. If _source_ is *undefined* or *null*, return ~unused~.
         1. Let _from_ be ! ToObject(_source_).
         1. Let _keys_ be ? <emu-meta effects="user-code">_from_.[[OwnPropertyKeys]]</emu-meta>().
         1. For each element _nextKey_ of _keys_, do
@@ -6760,7 +6789,7 @@
             1. If _desc_ is not *undefined* and _desc_.[[Enumerable]] is *true*, then
               1. Let _propValue_ be ? Get(_from_, _nextKey_).
               1. Perform ! CreateDataPropertyOrThrow(_target_, _nextKey_, _propValue_).
-        1. Return _target_.
+        1. Return ~unused~.
       </emu-alg>
       <emu-note>
         <p>The target passed in here is always a newly created object which is not directly accessible in case of an error being thrown.</p>
@@ -6772,7 +6801,7 @@
         PrivateElementFind (
           _O_: an Object,
           _P_: a Private Name,
-        )
+        ): a PrivateElement or ~empty~
       </h1>
       <dl class="header">
       </dl>
@@ -6790,14 +6819,15 @@
           _O_: an Object,
           _P_: a Private Name,
           _value_: an ECMAScript language value,
-        )
+        ): either a normal completion containing ~unused~ or an abrupt completion
       </h1>
       <dl class="header">
       </dl>
       <emu-alg>
-        1. Let _entry_ be ! PrivateElementFind(_O_, _P_).
+        1. Let _entry_ be PrivateElementFind(_O_, _P_).
         1. If _entry_ is not ~empty~, throw a *TypeError* exception.
         1. Append PrivateElement { [[Key]]: _P_, [[Kind]]: ~field~, [[Value]]: _value_ } to _O_.[[PrivateElements]].
+        1. Return ~unused~.
       </emu-alg>
     </emu-clause>
 
@@ -6806,17 +6836,20 @@
         PrivateMethodOrAccessorAdd (
           _O_: an Object,
           _method_: a PrivateElement,
-        )
+        ): either a normal completion containing ~unused~ or an abrupt completion
       </h1>
       <dl class="header">
       </dl>
       <emu-alg>
         1. Assert: _method_.[[Kind]] is either ~method~ or ~accessor~.
-        1. Let _entry_ be ! PrivateElementFind(_O_, _method_.[[Key]]).
+        1. Let _entry_ be PrivateElementFind(_O_, _method_.[[Key]]).
         1. If _entry_ is not ~empty~, throw a *TypeError* exception.
         1. Append _method_ to _O_.[[PrivateElements]].
-        1. NOTE: The values for private methods and accessors are shared across instances. This step does not create a new copy of the method or accessor.
+        1. Return ~unused~.
       </emu-alg>
+      <emu-note>
+        <p>The values for private methods and accessors are shared across instances. This operation does not create a new copy of the method or accessor.</p>
+      </emu-note>
     </emu-clause>
 
     <emu-clause id="sec-privateget" type="abstract operation">
@@ -6824,12 +6857,12 @@
         PrivateGet (
           _O_: an Object,
           _P_: a Private Name,
-        )
+        ): either a normal completion containing an ECMAScript language value or an abrupt completion
       </h1>
       <dl class="header">
       </dl>
       <emu-alg>
-        1. Let _entry_ be ! PrivateElementFind(_O_, _P_).
+        1. Let _entry_ be PrivateElementFind(_O_, _P_).
         1. If _entry_ is ~empty~, throw a *TypeError* exception.
         1. If _entry_.[[Kind]] is ~field~ or ~method~, then
           1. Return _entry_.[[Value]].
@@ -6846,12 +6879,12 @@
           _O_: an Object,
           _P_: a Private Name,
           _value_: an ECMAScript language value,
-        )
+        ): either a normal completion containing ~unused~ or an abrupt completion
       </h1>
       <dl class="header">
       </dl>
       <emu-alg>
-        1. Let _entry_ be ! PrivateElementFind(_O_, _P_).
+        1. Let _entry_ be PrivateElementFind(_O_, _P_).
         1. If _entry_ is ~empty~, throw a *TypeError* exception.
         1. If _entry_.[[Kind]] is ~field~, then
           1. Set _entry_.[[Value]] to _value_.
@@ -6862,6 +6895,7 @@
           1. If _entry_.[[Set]] is *undefined*, throw a *TypeError* exception.
           1. Let _setter_ be _entry_.[[Set]].
           1. Perform ? Call(_setter_, _O_, &laquo; _value_ &raquo;).
+        1. Return ~unused~.
       </emu-alg>
     </emu-clause>
 
@@ -6870,7 +6904,7 @@
         DefineField (
           _receiver_: an Object,
           _fieldRecord_: a ClassFieldDefinition Record,
-        )
+        ): either a normal completion containing ~unused~ or an abrupt completion
       </h1>
       <dl class="header">
       </dl>
@@ -6883,8 +6917,9 @@
         1. If _fieldName_ is a Private Name, then
           1. Perform ? PrivateFieldAdd(_receiver_, _fieldName_, _initValue_).
         1. Else,
-          1. Assert: ! IsPropertyKey(_fieldName_) is *true*.
+          1. Assert: IsPropertyKey(_fieldName_) is *true*.
           1. Perform ? CreateDataPropertyOrThrow(_receiver_, _fieldName_, _initValue_).
+        1. Return ~unused~.
       </emu-alg>
     </emu-clause>
 
@@ -6893,7 +6928,7 @@
         InitializeInstanceElements (
           _O_: an Object,
           _constructor_: an ECMAScript function object,
-        )
+        ): either a normal completion containing ~unused~ or an abrupt completion
       </h1>
       <dl class="header">
       </dl>
@@ -6904,6 +6939,7 @@
         1. Let _fields_ be the value of _constructor_.[[Fields]].
         1. For each element _fieldRecord_ of _fields_, do
           1. Perform ? DefineField(_O_, _fieldRecord_).
+        1. Return ~unused~.
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -6972,7 +7008,7 @@
           _obj_: an ECMAScript language value,
           optional _hint_: ~sync~ or ~async~,
           optional _method_: a function object,
-        )
+        ): either a normal completion containing an Iterator Record or an abrupt completion
       </h1>
       <dl class="header">
       </dl>
@@ -6984,7 +7020,7 @@
             1. If _method_ is *undefined*, then
               1. Let _syncMethod_ be ? GetMethod(_obj_, @@iterator).
               1. Let _syncIteratorRecord_ be ? GetIterator(_obj_, ~sync~, _syncMethod_).
-              1. Return ! CreateAsyncFromSyncIterator(_syncIteratorRecord_).
+              1. Return CreateAsyncFromSyncIterator(_syncIteratorRecord_).
           1. Otherwise, set _method_ to ? GetMethod(_obj_, @@iterator).
         1. Let _iterator_ be ? Call(_method_, _obj_).
         1. If Type(_iterator_) is not Object, throw a *TypeError* exception.
@@ -6999,7 +7035,7 @@
         IteratorNext (
           _iteratorRecord_: an Iterator Record,
           optional _value_: an ECMAScript language value,
-        )
+        ): either a normal completion containing an Object or an abrupt completion
       </h1>
       <dl class="header">
       </dl>
@@ -7017,12 +7053,12 @@
       <h1>
         IteratorComplete (
           _iterResult_: an Object,
-        )
+        ): either a normal completion containing a Boolean or an abrupt completion
       </h1>
       <dl class="header">
       </dl>
       <emu-alg>
-        1. Return ! ToBoolean(? Get(_iterResult_, *"done"*)).
+        1. Return ToBoolean(? Get(_iterResult_, *"done"*)).
       </emu-alg>
     </emu-clause>
 
@@ -7030,7 +7066,7 @@
       <h1>
         IteratorValue (
           _iterResult_: an Object,
-        )
+        ): either a normal completion containing an ECMAScript language value or an abrupt completion
       </h1>
       <dl class="header">
       </dl>
@@ -7043,7 +7079,7 @@
       <h1>
         IteratorStep (
           _iteratorRecord_: an Iterator Record,
-        )
+        ): either a normal completion containing either an Object or *false*, or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -7062,7 +7098,7 @@
         IteratorClose (
           _iteratorRecord_: an Iterator Record,
           _completion_: a Completion Record,
-        )
+        ): a Completion Record
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -7071,15 +7107,15 @@
       <emu-alg>
         1. Assert: Type(_iteratorRecord_.[[Iterator]]) is Object.
         1. Let _iterator_ be _iteratorRecord_.[[Iterator]].
-        1. Let _innerResult_ be GetMethod(_iterator_, *"return"*).
+        1. Let _innerResult_ be Completion(GetMethod(_iterator_, *"return"*)).
         1. If _innerResult_.[[Type]] is ~normal~, then
           1. Let _return_ be _innerResult_.[[Value]].
-          1. If _return_ is *undefined*, return Completion(_completion_).
-          1. Set _innerResult_ to Call(_return_, _iterator_).
-        1. If _completion_.[[Type]] is ~throw~, return Completion(_completion_).
-        1. If _innerResult_.[[Type]] is ~throw~, return Completion(_innerResult_).
+          1. If _return_ is *undefined*, return ? _completion_.
+          1. Set _innerResult_ to Completion(Call(_return_, _iterator_)).
+        1. If _completion_.[[Type]] is ~throw~, return ? _completion_.
+        1. If _innerResult_.[[Type]] is ~throw~, return ? _innerResult_.
         1. If Type(_innerResult_.[[Value]]) is not Object, throw a *TypeError* exception.
-        1. Return Completion(_completion_).
+        1. Return ? _completion_.
       </emu-alg>
     </emu-clause>
 
@@ -7101,7 +7137,7 @@
         AsyncIteratorClose (
           _iteratorRecord_: an Iterator Record,
           _completion_: a Completion Record,
-        )
+        ): a Completion Record
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -7110,16 +7146,16 @@
       <emu-alg>
         1. Assert: Type(_iteratorRecord_.[[Iterator]]) is Object.
         1. Let _iterator_ be _iteratorRecord_.[[Iterator]].
-        1. Let _innerResult_ be GetMethod(_iterator_, *"return"*).
+        1. Let _innerResult_ be Completion(GetMethod(_iterator_, *"return"*)).
         1. If _innerResult_.[[Type]] is ~normal~, then
           1. Let _return_ be _innerResult_.[[Value]].
-          1. If _return_ is *undefined*, return Completion(_completion_).
-          1. Set _innerResult_ to Call(_return_, _iterator_).
-          1. If _innerResult_.[[Type]] is ~normal~, set _innerResult_ to Await(_innerResult_.[[Value]]).
-        1. If _completion_.[[Type]] is ~throw~, return Completion(_completion_).
-        1. If _innerResult_.[[Type]] is ~throw~, return Completion(_innerResult_).
+          1. If _return_ is *undefined*, return ? _completion_.
+          1. Set _innerResult_ to Completion(Call(_return_, _iterator_)).
+          1. If _innerResult_.[[Type]] is ~normal~, set _innerResult_ to Completion(Await(_innerResult_.[[Value]])).
+        1. If _completion_.[[Type]] is ~throw~, return ? _completion_.
+        1. If _innerResult_.[[Type]] is ~throw~, return ? _innerResult_.
         1. If Type(_innerResult_.[[Value]]) is not Object, throw a *TypeError* exception.
-        1. Return Completion(_completion_).
+        1. Return ? _completion_.
       </emu-alg>
     </emu-clause>
 
@@ -7128,14 +7164,14 @@
         CreateIterResultObject (
           _value_: an ECMAScript language value,
           _done_: a Boolean,
-        )
+        ): an Object that conforms to the <i>IteratorResult</i> interface
       </h1>
       <dl class="header">
         <dt>description</dt>
         <dd>It creates an object that conforms to the <i>IteratorResult</i> interface.</dd>
       </dl>
       <emu-alg>
-        1. Let _obj_ be ! OrdinaryObjectCreate(%Object.prototype%).
+        1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%).
         1. Perform ! CreateDataPropertyOrThrow(_obj_, *"value"*, _value_).
         1. Perform ! CreateDataPropertyOrThrow(_obj_, *"done"*, _done_).
         1. Return _obj_.
@@ -7146,7 +7182,7 @@
       <h1>
         CreateListIteratorRecord (
           _list_: a List,
-        )
+        ): an Iterator Record
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -7155,9 +7191,9 @@
       <emu-alg>
         1. Let _closure_ be a new Abstract Closure with no parameters that captures _list_ and performs the following steps when called:
           1. For each element _E_ of _list_, do
-            1. Perform ? GeneratorYield(! CreateIterResultObject(_E_, *false*)).
+            1. Perform ? GeneratorYield(CreateIterResultObject(_E_, *false*)).
           1. Return *undefined*.
-        1. Let _iterator_ be ! CreateIteratorFromClosure(_closure_, ~empty~, %IteratorPrototype%).
+        1. Let _iterator_ be CreateIteratorFromClosure(_closure_, ~empty~, %IteratorPrototype%).
         1. Return the Iterator Record { [[Iterator]]: _iterator_, [[NextMethod]]: %GeneratorFunction.prototype.prototype.next%, [[Done]]: *false* }.
       </emu-alg>
       <emu-note>
@@ -7170,7 +7206,7 @@
         IterableToList (
           _items_: an ECMAScript language value,
           optional _method_: a function object,
-        )
+        ): either a normal completion containing a List or an abrupt completion
       </h1>
       <dl class="header">
       </dl>
@@ -7200,7 +7236,7 @@
     <h1>Scope Analysis</h1>
 
     <emu-clause id="sec-static-semantics-boundnames" oldids="sec-identifiers-static-semantics-boundnames,sec-let-and-const-declarations-static-semantics-boundnames,sec-variable-statement-static-semantics-boundnames,sec-destructuring-binding-patterns-static-semantics-boundnames,sec-for-in-and-for-of-statements-static-semantics-boundnames,sec-function-definitions-static-semantics-boundnames,sec-arrow-function-definitions-static-semantics-boundnames,sec-generator-function-definitions-static-semantics-boundnames,sec-async-generator-function-definitions-static-semantics-boundnames,sec-class-definitions-static-semantics-boundnames,sec-async-function-definitions-static-semantics-BoundNames,sec-async-arrow-function-definitions-static-semantics-BoundNames,sec-imports-static-semantics-boundnames,sec-exports-static-semantics-boundnames" type="sdo">
-      <h1>Static Semantics: BoundNames</h1>
+      <h1>Static Semantics: BoundNames ( ): a List of Strings</h1>
       <dl class="header">
       </dl>
       <emu-note id="note-star-default-star">
@@ -7451,7 +7487,7 @@
     </emu-clause>
 
     <emu-clause id="sec-static-semantics-declarationpart" type="sdo">
-      <h1>Static Semantics: DeclarationPart</h1>
+      <h1>Static Semantics: DeclarationPart ( ): a Parse Node</h1>
       <dl class="header">
       </dl>
       <emu-grammar>HoistableDeclaration : FunctionDeclaration</emu-grammar>
@@ -7481,7 +7517,7 @@
     </emu-clause>
 
     <emu-clause id="sec-static-semantics-isconstantdeclaration" oldids="sec-let-and-const-declarations-static-semantics-isconstantdeclaration,sec-function-definitions-static-semantics-isconstantdeclaration,sec-generator-function-definitions-static-semantics-isconstantdeclaration,sec-async-generator-function-definitions-static-semantics-isconstantdeclaration,sec-class-definitions-static-semantics-isconstantdeclaration,sec-async-function-definitions-static-semantics-IsConstantDeclaration,sec-exports-static-semantics-isconstantdeclaration" type="sdo">
-      <h1>Static Semantics: IsConstantDeclaration</h1>
+      <h1>Static Semantics: IsConstantDeclaration ( ): a Boolean</h1>
       <dl class="header">
       </dl>
       <emu-grammar>LexicalDeclaration : LetOrConst BindingList `;`</emu-grammar>
@@ -7539,7 +7575,7 @@
     </emu-clause>
 
     <emu-clause id="sec-static-semantics-lexicallydeclarednames" oldids="sec-block-static-semantics-lexicallydeclarednames,sec-switch-statement-static-semantics-lexicallydeclarednames,sec-labelled-statements-static-semantics-lexicallydeclarednames,sec-function-definitions-static-semantics-lexicallydeclarednames,sec-arrow-function-definitions-static-semantics-lexicallydeclarednames,sec-async-arrow-function-definitions-static-semantics-LexicallyDeclaredNames,sec-scripts-static-semantics-lexicallydeclarednames,sec-module-semantics-static-semantics-lexicallydeclarednames" type="sdo">
-      <h1>Static Semantics: LexicallyDeclaredNames</h1>
+      <h1>Static Semantics: LexicallyDeclaredNames ( ): a List of Strings</h1>
       <dl class="header">
       </dl>
       <emu-grammar>Block : `{` `}`</emu-grammar>
@@ -7667,7 +7703,7 @@
     </emu-clause>
 
     <emu-clause id="sec-static-semantics-lexicallyscopeddeclarations" oldids="sec-block-static-semantics-lexicallyscopeddeclarations,sec-switch-statement-static-semantics-lexicallyscopeddeclarations,sec-labelled-statements-static-semantics-lexicallyscopeddeclarations,sec-function-definitions-static-semantics-lexicallyscopeddeclarations,sec-arrow-function-definitions-static-semantics-lexicallyscopeddeclarations,sec-async-arrow-function-definitions-static-semantics-LexicallyScopedDeclarations,sec-scripts-static-semantics-lexicallyscopeddeclarations,sec-module-semantics-static-semantics-lexicallyscopeddeclarations,sec-exports-static-semantics-lexicallyscopeddeclarations" type="sdo">
-      <h1>Static Semantics: LexicallyScopedDeclarations</h1>
+      <h1>Static Semantics: LexicallyScopedDeclarations ( ): a List of Parse Nodes</h1>
       <dl class="header">
       </dl>
       <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
@@ -7802,7 +7838,7 @@
     </emu-clause>
 
     <emu-clause id="sec-static-semantics-vardeclarednames" oldids="sec-statement-semantics-static-semantics-vardeclarednames,sec-block-static-semantics-vardeclarednames,sec-variable-statement-static-semantics-vardeclarednames,sec-if-statement-static-semantics-vardeclarednames,sec-do-while-statement-static-semantics-vardeclarednames,sec-while-statement-static-semantics-vardeclarednames,sec-for-statement-static-semantics-vardeclarednames,sec-for-in-and-for-of-statements-static-semantics-vardeclarednames,sec-with-statement-static-semantics-vardeclarednames,sec-switch-statement-static-semantics-vardeclarednames,sec-labelled-statements-static-semantics-vardeclarednames,sec-try-statement-static-semantics-vardeclarednames,sec-function-definitions-static-semantics-vardeclarednames,sec-arrow-function-definitions-static-semantics-vardeclarednames,sec-async-arrow-function-definitions-static-semantics-VarDeclaredNames,sec-scripts-static-semantics-vardeclarednames,sec-module-semantics-static-semantics-vardeclarednames" type="sdo">
-      <h1>Static Semantics: VarDeclaredNames</h1>
+      <h1>Static Semantics: VarDeclaredNames ( ): a List of Strings</h1>
       <dl class="header">
       </dl>
       <emu-grammar>
@@ -8014,7 +8050,7 @@
     </emu-clause>
 
     <emu-clause id="sec-static-semantics-varscopeddeclarations" oldids="sec-statement-semantics-static-semantics-varscopeddeclarations,sec-block-static-semantics-varscopeddeclarations,sec-variable-statement-static-semantics-varscopeddeclarations,sec-if-statement-static-semantics-varscopeddeclarations,sec-do-while-statement-static-semantics-varscopeddeclarations,sec-while-statement-static-semantics-varscopeddeclarations,sec-for-statement-static-semantics-varscopeddeclarations,sec-for-in-and-for-of-statements-static-semantics-varscopeddeclarations,sec-with-statement-static-semantics-varscopeddeclarations,sec-switch-statement-static-semantics-varscopeddeclarations,sec-labelled-statements-static-semantics-varscopeddeclarations,sec-try-statement-static-semantics-varscopeddeclarations,sec-function-definitions-static-semantics-varscopeddeclarations,sec-arrow-function-definitions-static-semantics-varscopeddeclarations,sec-async-arrow-function-definitions-static-semantics-VarScopedDeclarations,sec-scripts-static-semantics-varscopeddeclarations,sec-module-semantics-static-semantics-varscopeddeclarations" type="sdo">
-      <h1>Static Semantics: VarScopedDeclarations</h1>
+      <h1>Static Semantics: VarScopedDeclarations ( ): a List of Parse Nodes</h1>
       <dl class="header">
       </dl>
       <emu-grammar>
@@ -8235,7 +8271,7 @@
     </emu-clause>
 
     <emu-clause id="sec-static-semantics-toplevellexicallydeclarednames" oldids="sec-block-static-semantics-toplevellexicallydeclarednames,sec-labelled-statements-static-semantics-toplevellexicallydeclarednames" type="sdo">
-      <h1>Static Semantics: TopLevelLexicallyDeclaredNames</h1>
+      <h1>Static Semantics: TopLevelLexicallyDeclaredNames ( ): a List of Strings</h1>
       <dl class="header">
       </dl>
       <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
@@ -8260,7 +8296,7 @@
     </emu-clause>
 
     <emu-clause id="sec-static-semantics-toplevellexicallyscopeddeclarations" oldids="sec-block-static-semantics-toplevellexicallyscopeddeclarations,sec-labelled-statements-static-semantics-toplevellexicallyscopeddeclarations" type="sdo">
-      <h1>Static Semantics: TopLevelLexicallyScopedDeclarations</h1>
+      <h1>Static Semantics: TopLevelLexicallyScopedDeclarations ( ): a List of Parse Nodes</h1>
       <dl class="header">
       </dl>
       <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
@@ -8282,7 +8318,7 @@
     </emu-clause>
 
     <emu-clause id="sec-static-semantics-toplevelvardeclarednames" oldids="sec-block-static-semantics-toplevelvardeclarednames,sec-labelled-statements-static-semantics-toplevelvardeclarednames" type="sdo">
-      <h1>Static Semantics: TopLevelVarDeclaredNames</h1>
+      <h1>Static Semantics: TopLevelVarDeclaredNames ( ): a List of Strings</h1>
       <dl class="header">
       </dl>
       <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
@@ -8321,7 +8357,7 @@
     </emu-clause>
 
     <emu-clause id="sec-static-semantics-toplevelvarscopeddeclarations" oldids="sec-block-static-semantics-toplevelvarscopeddeclarations,sec-labelled-statements-static-semantics-toplevelvarscopeddeclarations" type="sdo">
-      <h1>Static Semantics: TopLevelVarScopedDeclarations</h1>
+      <h1>Static Semantics: TopLevelVarScopedDeclarations ( ): a List of Parse Nodes</h1>
       <dl class="header">
       </dl>
       <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
@@ -8365,7 +8401,7 @@
       <h1>
         Static Semantics: ContainsDuplicateLabels (
           _labelSet_: unknown,
-        )
+        ): a Boolean
       </h1>
       <dl class="header">
       </dl>
@@ -8537,7 +8573,7 @@
       <h1>
         Static Semantics: ContainsUndefinedBreakTarget (
           _labelSet_: unknown,
-        )
+        ): a Boolean
       </h1>
       <dl class="header">
       </dl>
@@ -8717,7 +8753,7 @@
         Static Semantics: ContainsUndefinedContinueTarget (
           _iterationSet_: unknown,
           _labelSet_: unknown,
-        )
+        ): a Boolean
       </h1>
       <dl class="header">
       </dl>
@@ -8906,7 +8942,7 @@
     <h1>Function Name Inference</h1>
 
     <emu-clause id="sec-static-semantics-hasname" oldids="sec-semantics-static-semantics-hasname,sec-function-definitions-static-semantics-hasname,sec-arrow-function-definitions-static-semantics-hasname,sec-generator-function-definitions-static-semantics-hasname,sec-async-generator-function-definitions-static-semantics-hasname,sec-class-definitions-static-semantics-hasname,sec-async-function-definitions-static-semantics-HasName,sec-async-arrow-function-definitions-static-semantics-HasName" type="sdo">
-      <h1>Static Semantics: HasName</h1>
+      <h1>Static Semantics: HasName ( ): a Boolean</h1>
       <dl class="header">
       </dl>
       <emu-grammar>PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
@@ -8963,7 +8999,7 @@
     </emu-clause>
 
     <emu-clause id="sec-static-semantics-isfunctiondefinition" oldids="sec-semantics-static-semantics-isfunctiondefinition,sec-grouping-operator-static-semantics-isfunctiondefinition,sec-static-semantics-static-semantics-isfunctiondefinition,sec-update-expressions-static-semantics-isfunctiondefinition,sec-unary-operators-static-semantics-isfunctiondefinition,sec-exp-operator-static-semantics-isfunctiondefinition,sec-multiplicative-operators-static-semantics-isfunctiondefinition,sec-additive-operators-static-semantics-isfunctiondefinition,sec-bitwise-shift-operators-static-semantics-isfunctiondefinition,sec-relational-operators-static-semantics-isfunctiondefinition,sec-equality-operators-static-semantics-isfunctiondefinition,sec-binary-bitwise-operators-static-semantics-isfunctiondefinition,sec-binary-logical-operators-static-semantics-isfunctiondefinition,sec-conditional-operator-static-semantics-isfunctiondefinition,sec-assignment-operators-static-semantics-isfunctiondefinition,sec-comma-operator-static-semantics-isfunctiondefinition,sec-function-definitions-static-semantics-isfunctiondefinition,sec-generator-function-definitions-static-semantics-isfunctiondefinition,sec-async-generator-function-definitions-static-semantics-isfunctiondefinition,sec-class-definitions-static-semantics-isfunctiondefinition,sec-async-function-definitions-static-semantics-IsFunctionDefinition" type="sdo">
-      <h1>Static Semantics: IsFunctionDefinition</h1>
+      <h1>Static Semantics: IsFunctionDefinition ( ): a Boolean</h1>
       <dl class="header">
       </dl>
       <emu-grammar>PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
@@ -9107,7 +9143,7 @@
       <h1>
         Static Semantics: IsAnonymousFunctionDefinition (
           _expr_: an |AssignmentExpression| Parse Node or an |Initializer| Parse Node,
-        )
+        ): a Boolean
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -9122,7 +9158,7 @@
     </emu-clause>
 
     <emu-clause id="sec-static-semantics-isidentifierref" oldids="sec-semantics-static-semantics-isidentifierref,sec-static-semantics-static-semantics-isidentifierref" type="sdo">
-      <h1>Static Semantics: IsIdentifierRef</h1>
+      <h1>Static Semantics: IsIdentifierRef ( ): a Boolean</h1>
       <dl class="header">
       </dl>
       <emu-grammar>PrimaryExpression : IdentifierReference</emu-grammar>
@@ -9169,19 +9205,19 @@
       <h1>
         Runtime Semantics: NamedEvaluation (
           _name_: unknown,
-        )
+        ): either a normal completion containing a function object or an abrupt completion
       </h1>
       <dl class="header">
       </dl>
       <emu-grammar>PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
       <emu-alg>
         1. Let _expr_ be the |ParenthesizedExpression| that is covered by |CoverParenthesizedExpressionAndArrowParameterList|.
-        1. Return the result of performing NamedEvaluation of _expr_ with argument _name_.
+        1. Return ? NamedEvaluation of _expr_ with argument _name_.
       </emu-alg>
       <emu-grammar>ParenthesizedExpression : `(` Expression `)`</emu-grammar>
       <emu-alg>
         1. Assert: IsAnonymousFunctionDefinition(|Expression|) is *true*.
-        1. Return the result of performing NamedEvaluation of |Expression| with argument _name_.
+        1. Return ? NamedEvaluation of |Expression| with argument _name_.
       </emu-alg>
       <emu-grammar>FunctionExpression : `function` `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
@@ -9217,8 +9253,7 @@
       </emu-alg>
       <emu-grammar>ClassExpression : `class` ClassTail</emu-grammar>
       <emu-alg>
-        1. Let _value_ be the result of ClassDefinitionEvaluation of |ClassTail| with arguments *undefined* and _name_.
-        1. ReturnIfAbrupt(_value_).
+        1. Let _value_ be ? ClassDefinitionEvaluation of |ClassTail| with arguments *undefined* and _name_.
         1. Set _value_.[[SourceText]] to the source text matched by |ClassExpression|.
         1. Return _value_.
       </emu-alg>
@@ -9232,7 +9267,7 @@
       <h1>
         Static Semantics: Contains (
           _symbol_: unknown,
-        )
+        ): a Boolean
       </h1>
       <dl class="header">
       </dl>
@@ -9368,7 +9403,7 @@
       <h1>
         Static Semantics: ComputedPropertyContains (
           _symbol_: unknown,
-        )
+        ): a Boolean
       </h1>
       <dl class="header">
       </dl>
@@ -9439,7 +9474,7 @@
         Runtime Semantics: InstantiateFunctionObject (
           _env_: unknown,
           _privateEnv_: unknown,
-        )
+        ): a function object
       </h1>
       <dl class="header">
       </dl>
@@ -9449,7 +9484,7 @@
           `function` `(` FormalParameters `)` `{` FunctionBody `}`
       </emu-grammar>
       <emu-alg>
-        1. Return ? InstantiateOrdinaryFunctionObject of |FunctionDeclaration| with arguments _env_ and _privateEnv_.
+        1. Return InstantiateOrdinaryFunctionObject of |FunctionDeclaration| with arguments _env_ and _privateEnv_.
       </emu-alg>
       <emu-grammar>
         GeneratorDeclaration :
@@ -9457,7 +9492,7 @@
           `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`
       </emu-grammar>
       <emu-alg>
-        1. Return ? InstantiateGeneratorFunctionObject of |GeneratorDeclaration| with arguments _env_ and _privateEnv_.
+        1. Return InstantiateGeneratorFunctionObject of |GeneratorDeclaration| with arguments _env_ and _privateEnv_.
       </emu-alg>
       <emu-grammar>
         AsyncGeneratorDeclaration :
@@ -9465,7 +9500,7 @@
           `async` `function` `*` `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
       </emu-grammar>
       <emu-alg>
-        1. Return ? InstantiateAsyncGeneratorFunctionObject of |AsyncGeneratorDeclaration| with arguments _env_ and _privateEnv_.
+        1. Return InstantiateAsyncGeneratorFunctionObject of |AsyncGeneratorDeclaration| with arguments _env_ and _privateEnv_.
       </emu-alg>
       <emu-grammar>
         AsyncFunctionDeclaration :
@@ -9473,7 +9508,7 @@
           `async` `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
       <emu-alg>
-        1. Return ? InstantiateAsyncFunctionObject of |AsyncFunctionDeclaration| with arguments _env_ and _privateEnv_.
+        1. Return InstantiateAsyncFunctionObject of |AsyncFunctionDeclaration| with arguments _env_ and _privateEnv_.
       </emu-alg>
     </emu-clause>
 
@@ -9482,7 +9517,7 @@
         Runtime Semantics: BindingInitialization (
           _value_: unknown,
           _environment_: unknown,
-        )
+        ): either a normal completion containing ~unused~ or an abrupt completion
       </h1>
       <dl class="header">
       </dl>
@@ -9505,18 +9540,18 @@
       <emu-grammar>BindingPattern : ObjectBindingPattern</emu-grammar>
       <emu-alg>
         1. Perform ? RequireObjectCoercible(_value_).
-        1. Return the result of performing BindingInitialization of |ObjectBindingPattern| with arguments _value_ and _environment_.
+        1. Return ? BindingInitialization of |ObjectBindingPattern| with arguments _value_ and _environment_.
       </emu-alg>
       <emu-grammar>BindingPattern : ArrayBindingPattern</emu-grammar>
       <emu-alg>
         1. Let _iteratorRecord_ be ? GetIterator(_value_).
-        1. Let _result_ be IteratorBindingInitialization of |ArrayBindingPattern| with arguments _iteratorRecord_ and _environment_.
+        1. Let _result_ be Completion(IteratorBindingInitialization of |ArrayBindingPattern| with arguments _iteratorRecord_ and _environment_).
         1. If _iteratorRecord_.[[Done]] is *false*, return ? IteratorClose(_iteratorRecord_, _result_).
-        1. Return _result_.
+        1. Return ? _result_.
       </emu-alg>
       <emu-grammar>ObjectBindingPattern : `{` `}`</emu-grammar>
       <emu-alg>
-        1. Return NormalCompletion(~empty~).
+        1. Return ~unused~.
       </emu-alg>
       <emu-grammar>
         ObjectBindingPattern :
@@ -9525,17 +9560,17 @@
       </emu-grammar>
       <emu-alg>
         1. Perform ? PropertyBindingInitialization of |BindingPropertyList| with arguments _value_ and _environment_.
-        1. Return NormalCompletion(~empty~).
+        1. Return ~unused~.
       </emu-alg>
       <emu-grammar>ObjectBindingPattern : `{` BindingRestProperty `}`</emu-grammar>
       <emu-alg>
         1. Let _excludedNames_ be a new empty List.
-        1. Return the result of performing RestBindingInitialization of |BindingRestProperty| with arguments _value_, _environment_, and _excludedNames_.
+        1. Return ? RestBindingInitialization of |BindingRestProperty| with arguments _value_, _environment_, and _excludedNames_.
       </emu-alg>
       <emu-grammar>ObjectBindingPattern : `{` BindingPropertyList `,` BindingRestProperty `}`</emu-grammar>
       <emu-alg>
         1. Let _excludedNames_ be ? PropertyBindingInitialization of |BindingPropertyList| with arguments _value_ and _environment_.
-        1. Return the result of performing RestBindingInitialization of |BindingRestProperty| with arguments _value_, _environment_, and _excludedNames_.
+        1. Return ? RestBindingInitialization of |BindingRestProperty| with arguments _value_, _environment_, and _excludedNames_.
       </emu-alg>
 
       <emu-clause id="sec-initializeboundname" type="abstract operation">
@@ -9544,16 +9579,16 @@
             _name_: a String,
             _value_: unknown,
             _environment_: unknown,
-          )
+          ): either a normal completion containing ~unused~ or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
         <emu-alg>
           1. If _environment_ is not *undefined*, then
-            1. Perform _environment_.InitializeBinding(_name_, _value_).
-            1. Return NormalCompletion(*undefined*).
+            1. Perform ! _environment_.InitializeBinding(_name_, _value_).
+            1. Return ~unused~.
           1. Else,
-            1. Let _lhs_ be ResolveBinding(_name_).
+            1. Let _lhs_ be ? ResolveBinding(_name_).
             1. Return ? PutValue(_lhs_, _value_).
         </emu-alg>
       </emu-clause>
@@ -9564,7 +9599,7 @@
         Runtime Semantics: IteratorBindingInitialization (
           _iteratorRecord_: unknown,
           _environment_: unknown,
-        )
+        ): either a normal completion containing ~unused~ or an abrupt completion
       </h1>
       <dl class="header">
       </dl>
@@ -9573,39 +9608,39 @@
       </emu-note>
       <emu-grammar>ArrayBindingPattern : `[` `]`</emu-grammar>
       <emu-alg>
-        1. Return NormalCompletion(~empty~).
+        1. Return ~unused~.
       </emu-alg>
       <emu-grammar>ArrayBindingPattern : `[` Elision `]`</emu-grammar>
       <emu-alg>
-        1. Return the result of performing IteratorDestructuringAssignmentEvaluation of |Elision| with argument _iteratorRecord_.
+        1. Return ? IteratorDestructuringAssignmentEvaluation of |Elision| with argument _iteratorRecord_.
       </emu-alg>
       <emu-grammar>ArrayBindingPattern : `[` Elision? BindingRestElement `]`</emu-grammar>
       <emu-alg>
         1. If |Elision| is present, then
           1. Perform ? IteratorDestructuringAssignmentEvaluation of |Elision| with argument _iteratorRecord_.
-        1. Return the result of performing IteratorBindingInitialization of |BindingRestElement| with arguments _iteratorRecord_ and _environment_.
+        1. Return ? IteratorBindingInitialization of |BindingRestElement| with arguments _iteratorRecord_ and _environment_.
       </emu-alg>
       <emu-grammar>ArrayBindingPattern : `[` BindingElementList `,` Elision `]`</emu-grammar>
       <emu-alg>
         1. Perform ? IteratorBindingInitialization of |BindingElementList| with arguments _iteratorRecord_ and _environment_.
-        1. Return the result of performing IteratorDestructuringAssignmentEvaluation of |Elision| with argument _iteratorRecord_.
+        1. Return ? IteratorDestructuringAssignmentEvaluation of |Elision| with argument _iteratorRecord_.
       </emu-alg>
       <emu-grammar>ArrayBindingPattern : `[` BindingElementList `,` Elision? BindingRestElement `]`</emu-grammar>
       <emu-alg>
         1. Perform ? IteratorBindingInitialization of |BindingElementList| with arguments _iteratorRecord_ and _environment_.
         1. If |Elision| is present, then
           1. Perform ? IteratorDestructuringAssignmentEvaluation of |Elision| with argument _iteratorRecord_.
-        1. Return the result of performing IteratorBindingInitialization of |BindingRestElement| with arguments _iteratorRecord_ and _environment_.
+        1. Return ? IteratorBindingInitialization of |BindingRestElement| with arguments _iteratorRecord_ and _environment_.
       </emu-alg>
       <emu-grammar>BindingElementList : BindingElementList `,` BindingElisionElement</emu-grammar>
       <emu-alg>
         1. Perform ? IteratorBindingInitialization of |BindingElementList| with arguments _iteratorRecord_ and _environment_.
-        1. Return the result of performing IteratorBindingInitialization of |BindingElisionElement| with arguments _iteratorRecord_ and _environment_.
+        1. Return ? IteratorBindingInitialization of |BindingElisionElement| with arguments _iteratorRecord_ and _environment_.
       </emu-alg>
       <emu-grammar>BindingElisionElement : Elision BindingElement</emu-grammar>
       <emu-alg>
         1. Perform ? IteratorDestructuringAssignmentEvaluation of |Elision| with argument _iteratorRecord_.
-        1. Return the result of performing IteratorBindingInitialization of |BindingElement| with arguments _iteratorRecord_ and _environment_.
+        1. Return ? IteratorBindingInitialization of |BindingElement| with arguments _iteratorRecord_ and _environment_.
       </emu-alg>
       <emu-grammar>SingleNameBinding : BindingIdentifier Initializer?</emu-grammar>
       <emu-alg>
@@ -9613,39 +9648,39 @@
         1. Let _lhs_ be ? ResolveBinding(_bindingId_, _environment_).
         1. Let _v_ be *undefined*.
         1. If _iteratorRecord_.[[Done]] is *false*, then
-          1. Let _next_ be IteratorStep(_iteratorRecord_).
+          1. Let _next_ be Completion(IteratorStep(_iteratorRecord_)).
           1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
           1. ReturnIfAbrupt(_next_).
           1. If _next_ is *false*, set _iteratorRecord_.[[Done]] to *true*.
           1. Else,
-            1. Set _v_ to IteratorValue(_next_).
+            1. Set _v_ to Completion(IteratorValue(_next_)).
             1. If _v_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
             1. ReturnIfAbrupt(_v_).
         1. If |Initializer| is present and _v_ is *undefined*, then
           1. If IsAnonymousFunctionDefinition(|Initializer|) is *true*, then
-            1. Set _v_ to the result of performing NamedEvaluation of |Initializer| with argument _bindingId_.
+            1. Set _v_ to ? NamedEvaluation of |Initializer| with argument _bindingId_.
           1. Else,
             1. Let _defaultValue_ be the result of evaluating |Initializer|.
             1. Set _v_ to ? GetValue(_defaultValue_).
         1. If _environment_ is *undefined*, return ? PutValue(_lhs_, _v_).
-        1. Return InitializeReferencedBinding(_lhs_, _v_).
+        1. Return ? InitializeReferencedBinding(_lhs_, _v_).
       </emu-alg>
       <emu-grammar>BindingElement : BindingPattern Initializer?</emu-grammar>
       <emu-alg>
         1. Let _v_ be *undefined*.
         1. If _iteratorRecord_.[[Done]] is *false*, then
-          1. Let _next_ be IteratorStep(_iteratorRecord_).
+          1. Let _next_ be Completion(IteratorStep(_iteratorRecord_)).
           1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
           1. ReturnIfAbrupt(_next_).
           1. If _next_ is *false*, set _iteratorRecord_.[[Done]] to *true*.
           1. Else,
-            1. Set _v_ to IteratorValue(_next_).
+            1. Set _v_ to Completion(IteratorValue(_next_)).
             1. If _v_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
             1. ReturnIfAbrupt(_v_).
         1. If |Initializer| is present and _v_ is *undefined*, then
           1. Let _defaultValue_ be the result of evaluating |Initializer|.
           1. Set _v_ to ? GetValue(_defaultValue_).
-        1. Return the result of performing BindingInitialization of |BindingPattern| with arguments _v_ and _environment_.
+        1. Return ? BindingInitialization of |BindingPattern| with arguments _v_ and _environment_.
       </emu-alg>
       <emu-grammar>BindingRestElement : `...` BindingIdentifier</emu-grammar>
       <emu-alg>
@@ -9654,14 +9689,14 @@
         1. Let _n_ be 0.
         1. Repeat,
           1. If _iteratorRecord_.[[Done]] is *false*, then
-            1. Let _next_ be IteratorStep(_iteratorRecord_).
+            1. Let _next_ be Completion(IteratorStep(_iteratorRecord_)).
             1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
             1. ReturnIfAbrupt(_next_).
             1. If _next_ is *false*, set _iteratorRecord_.[[Done]] to *true*.
           1. If _iteratorRecord_.[[Done]] is *true*, then
             1. If _environment_ is *undefined*, return ? PutValue(_lhs_, _A_).
-            1. Return InitializeReferencedBinding(_lhs_, _A_).
-          1. Let _nextValue_ be IteratorValue(_next_).
+            1. Return ? InitializeReferencedBinding(_lhs_, _A_).
+          1. Let _nextValue_ be Completion(IteratorValue(_next_)).
           1. If _nextValue_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
           1. ReturnIfAbrupt(_nextValue_).
           1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_n_)), _nextValue_).
@@ -9673,13 +9708,13 @@
         1. Let _n_ be 0.
         1. Repeat,
           1. If _iteratorRecord_.[[Done]] is *false*, then
-            1. Let _next_ be IteratorStep(_iteratorRecord_).
+            1. Let _next_ be Completion(IteratorStep(_iteratorRecord_)).
             1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
             1. ReturnIfAbrupt(_next_).
             1. If _next_ is *false*, set _iteratorRecord_.[[Done]] to *true*.
           1. If _iteratorRecord_.[[Done]] is *true*, then
-            1. Return the result of performing BindingInitialization of |BindingPattern| with arguments _A_ and _environment_.
-          1. Let _nextValue_ be IteratorValue(_next_).
+            1. Return ? BindingInitialization of |BindingPattern| with arguments _A_ and _environment_.
+          1. Let _nextValue_ be Completion(IteratorValue(_next_)).
           1. If _nextValue_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
           1. ReturnIfAbrupt(_nextValue_).
           1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_n_)), _nextValue_).
@@ -9687,36 +9722,36 @@
       </emu-alg>
       <emu-grammar>FormalParameters : [empty]</emu-grammar>
       <emu-alg>
-        1. Return NormalCompletion(~empty~).
+        1. Return ~unused~.
       </emu-alg>
       <emu-grammar>FormalParameters : FormalParameterList `,` FunctionRestParameter</emu-grammar>
       <emu-alg>
         1. Perform ? IteratorBindingInitialization of |FormalParameterList| with arguments _iteratorRecord_ and _environment_.
-        1. Return the result of performing IteratorBindingInitialization of |FunctionRestParameter| with arguments _iteratorRecord_ and _environment_.
+        1. Return ? IteratorBindingInitialization of |FunctionRestParameter| with arguments _iteratorRecord_ and _environment_.
       </emu-alg>
       <emu-grammar>FormalParameterList : FormalParameterList `,` FormalParameter</emu-grammar>
       <emu-alg>
         1. Perform ? IteratorBindingInitialization of |FormalParameterList| with arguments _iteratorRecord_ and _environment_.
-        1. Return the result of performing IteratorBindingInitialization of |FormalParameter| with arguments _iteratorRecord_ and _environment_.
+        1. Return ? IteratorBindingInitialization of |FormalParameter| with arguments _iteratorRecord_ and _environment_.
       </emu-alg>
       <emu-grammar>ArrowParameters : BindingIdentifier</emu-grammar>
       <emu-alg>
         1. Let _v_ be *undefined*.
         1. Assert: _iteratorRecord_.[[Done]] is *false*.
-        1. Let _next_ be IteratorStep(_iteratorRecord_).
+        1. Let _next_ be Completion(IteratorStep(_iteratorRecord_)).
         1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
         1. ReturnIfAbrupt(_next_).
         1. If _next_ is *false*, set _iteratorRecord_.[[Done]] to *true*.
         1. Else,
-          1. Set _v_ to IteratorValue(_next_).
+          1. Set _v_ to Completion(IteratorValue(_next_)).
           1. If _v_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
           1. ReturnIfAbrupt(_v_).
-        1. Return the result of performing BindingInitialization of |BindingIdentifier| with arguments _v_ and _environment_.
+        1. Return ? BindingInitialization of |BindingIdentifier| with arguments _v_ and _environment_.
       </emu-alg>
       <emu-grammar>ArrowParameters : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
       <emu-alg>
         1. Let _formals_ be the |ArrowFormalParameters| that is covered by |CoverParenthesizedExpressionAndArrowParameterList|.
-        1. Return IteratorBindingInitialization of _formals_ with arguments _iteratorRecord_ and _environment_.
+        1. Return ? IteratorBindingInitialization of _formals_ with arguments _iteratorRecord_ and _environment_.
       </emu-alg>
       <emu-grammar>
         AsyncArrowBindingIdentifier : BindingIdentifier
@@ -9724,20 +9759,20 @@
       <emu-alg>
         1. Let _v_ be *undefined*.
         1. Assert: _iteratorRecord_.[[Done]] is *false*.
-        1. Let _next_ be IteratorStep(_iteratorRecord_).
+        1. Let _next_ be Completion(IteratorStep(_iteratorRecord_)).
         1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
         1. ReturnIfAbrupt(_next_).
         1. If _next_ is *false*, set _iteratorRecord_.[[Done]] to *true*.
         1. Else,
-          1. Set _v_ to IteratorValue(_next_).
+          1. Set _v_ to Completion(IteratorValue(_next_)).
           1. If _v_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
           1. ReturnIfAbrupt(_v_).
-        1. Return the result of performing BindingInitialization of |BindingIdentifier| with arguments _v_ and _environment_.
+        1. Return ? BindingInitialization of |BindingIdentifier| with arguments _v_ and _environment_.
       </emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-static-semantics-assignmenttargettype" oldids="sec-identifiers-static-semantics-assignmenttargettype,sec-identifiers-static-semantics-isvalidsimpleassignmenttarget,sec-semantics-static-semantics-assignmenttargettype,sec-semantics-static-semantics-isvalidsimpleassignmenttarget,sec-grouping-operator-static-semantics-assignmenttargettype,sec-grouping-operator-static-semantics-isvalidsimpleassignmenttarget,sec-static-semantics-static-semantics-assignmenttargettype,sec-static-semantics-static-semantics-isvalidsimpleassignmenttarget,sec-update-expressions-static-semantics-assignmenttargettype,sec-update-expressions-static-semantics-isvalidsimpleassignmenttarget,sec-unary-operators-static-semantics-assignmenttargettype,sec-unary-operators-static-semantics-isvalidsimpleassignmenttarget,sec-exp-operator-static-semantics-assignmenttargettype,sec-exp-operator-static-semantics-isvalidsimpleassignmenttarget,sec-multiplicative-operators-static-semantics-assignmenttargettype,sec-multiplicative-operators-static-semantics-isvalidsimpleassignmenttarget,sec-additive-operators-static-semantics-assignmenttargettype,sec-additive-operators-static-semantics-isvalidsimpleassignmenttarget,sec-bitwise-shift-operators-static-semantics-assignmenttargettype,sec-bitwise-shift-operators-static-semantics-isvalidsimpleassignmenttarget,sec-relational-operators-static-semantics-assignmenttargettype,sec-relational-operators-static-semantics-isvalidsimpleassignmenttarget,sec-equality-operators-static-semantics-assignmenttargettype,sec-equality-operators-static-semantics-isvalidsimpleassignmenttarget,sec-binary-bitwise-operators-static-semantics-assignmenttargettype,sec-binary-bitwise-operators-static-semantics-isvalidsimpleassignmenttarget,sec-binary-logical-operators-static-semantics-assignmenttargettype,sec-binary-logical-operators-static-semantics-isvalidsimpleassignmenttarget,sec-conditional-operator-static-semantics-assignmenttargettype,sec-conditional-operator-static-semantics-isvalidsimpleassignmenttarget,sec-assignment-operators-static-semantics-assignmenttargettype,sec-assignment-operators-static-semantics-isvalidsimpleassignmenttarget,sec-comma-operator-static-semantics-assignmenttargettype,sec-comma-operator-static-semantics-isvalidsimpleassignmenttarget" type="sdo">
-      <h1>Static Semantics: AssignmentTargetType</h1>
+      <h1>Static Semantics: AssignmentTargetType ( ): ~simple~ or ~invalid~</h1>
       <dl class="header">
       </dl>
       <emu-grammar>IdentifierReference : Identifier</emu-grammar>
@@ -9895,7 +9930,7 @@
     </emu-clause>
 
     <emu-clause id="sec-static-semantics-propname" oldids="sec-object-initializer-static-semantics-propname,sec-method-definitions-static-semantics-propname,sec-generator-function-definitions-static-semantics-propname,sec-async-generator-function-definitions-static-semantics-propname,sec-class-definitions-static-semantics-propname,sec-async-function-definitions-static-semantics-PropName" type="sdo">
-      <h1>Static Semantics: PropName</h1>
+      <h1>Static Semantics: PropName ( ): a String or ~empty~</h1>
       <dl class="header">
       </dl>
       <emu-grammar>PropertyDefinition : IdentifierReference</emu-grammar>
@@ -10114,7 +10149,7 @@
           <h1>
             HasBinding (
               _N_: a String,
-            )
+            ): a normal completion containing a Boolean
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -10134,7 +10169,7 @@
             CreateMutableBinding (
               _N_: a String,
               _D_: a Boolean,
-            )
+            ): a normal completion containing ~unused~
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -10146,7 +10181,7 @@
           <emu-alg>
             1. Assert: _envRec_ does not already have a binding for _N_.
             1. Create a mutable binding in _envRec_ for _N_ and record that it is uninitialized. If _D_ is *true*, record that the newly created binding may be deleted by a subsequent DeleteBinding call.
-            1. Return NormalCompletion(~empty~).
+            1. Return ~unused~.
           </emu-alg>
         </emu-clause>
 
@@ -10155,7 +10190,7 @@
             CreateImmutableBinding (
               _N_: a String,
               _S_: a Boolean,
-            )
+            ): a normal completion containing ~unused~
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -10167,7 +10202,7 @@
           <emu-alg>
             1. Assert: _envRec_ does not already have a binding for _N_.
             1. Create an immutable binding in _envRec_ for _N_ and record that it is uninitialized. If _S_ is *true*, record that the newly created binding is a strict binding.
-            1. Return NormalCompletion(~empty~).
+            1. Return ~unused~.
           </emu-alg>
         </emu-clause>
 
@@ -10176,7 +10211,7 @@
             InitializeBinding (
               _N_: a String,
               _V_: an ECMAScript language value,
-            )
+            ): a normal completion containing ~unused~
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -10189,7 +10224,7 @@
             1. Assert: _envRec_ must have an uninitialized binding for _N_.
             1. Set the bound value for _N_ in _envRec_ to _V_.
             1. <emu-not-ref>Record</emu-not-ref> that the binding for _N_ in _envRec_ has been initialized.
-            1. Return NormalCompletion(~empty~).
+            1. Return ~unused~.
           </emu-alg>
         </emu-clause>
 
@@ -10199,7 +10234,7 @@
               _N_: a String,
               _V_: an ECMAScript language value,
               _S_: a Boolean,
-            )
+            ): either a normal completion containing ~unused~ or an abrupt completion
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -10212,15 +10247,15 @@
             1. [id="step-setmutablebinding-missing-binding"] If _envRec_ does not have a binding for _N_, then
               1. If _S_ is *true*, throw a *ReferenceError* exception.
               1. Perform _envRec_.CreateMutableBinding(_N_, *true*).
-              1. Perform _envRec_.InitializeBinding(_N_, _V_).
-              1. Return NormalCompletion(~empty~).
+              1. Perform ! _envRec_.InitializeBinding(_N_, _V_).
+              1. Return ~unused~.
             1. If the binding for _N_ in _envRec_ is a strict binding, set _S_ to *true*.
             1. If the binding for _N_ in _envRec_ has not yet been initialized, throw a *ReferenceError* exception.
             1. Else if the binding for _N_ in _envRec_ is a mutable binding, change its bound value to _V_.
             1. Else,
               1. Assert: This is an attempt to change the value of an immutable binding.
               1. If _S_ is *true*, throw a *TypeError* exception.
-            1. Return NormalCompletion(~empty~).
+            1. Return ~unused~.
           </emu-alg>
           <emu-note>
             <p>An example of ECMAScript code that results in a missing binding at step <emu-xref href="#step-setmutablebinding-missing-binding"></emu-xref> is:</p>
@@ -10233,7 +10268,7 @@
             GetBindingValue (
               _N_: a String,
               _S_: a Boolean,
-            )
+            ): either a normal completion containing an ECMAScript language value or an abrupt completion
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -10253,7 +10288,7 @@
           <h1>
             DeleteBinding (
               _N_: a String,
-            )
+            ): a normal completion containing a Boolean
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -10271,7 +10306,7 @@
         </emu-clause>
 
         <emu-clause id="sec-declarative-environment-records-hasthisbinding" type="concrete method">
-          <h1>HasThisBinding ( )</h1>
+          <h1>HasThisBinding ( ): *false*</h1>
           <dl class="header">
             <dt>for</dt>
             <dd>a declarative Environment Record _envRec_</dd>
@@ -10285,7 +10320,7 @@
         </emu-clause>
 
         <emu-clause id="sec-declarative-environment-records-hassuperbinding" type="concrete method">
-          <h1>HasSuperBinding ( )</h1>
+          <h1>HasSuperBinding ( ): *false*</h1>
           <dl class="header">
             <dt>for</dt>
             <dd>a declarative Environment Record _envRec_</dd>
@@ -10299,7 +10334,7 @@
         </emu-clause>
 
         <emu-clause id="sec-declarative-environment-records-withbaseobject" type="concrete method">
-          <h1>WithBaseObject ( )</h1>
+          <h1>WithBaseObject ( ): *undefined*</h1>
           <dl class="header">
             <dt>for</dt>
             <dd>a declarative Environment Record _envRec_</dd>
@@ -10358,7 +10393,7 @@
           <h1>
             HasBinding (
               _N_: a String,
-            )
+            ): either a normal completion containing a Boolean or an abrupt completion
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -10374,7 +10409,7 @@
             1. If _envRec_.[[IsWithEnvironment]] is *false*, return *true*.
             1. Let _unscopables_ be ? Get(_bindingObject_, @@unscopables).
             1. If Type(_unscopables_) is Object, then
-              1. Let _blocked_ be ! ToBoolean(? Get(_unscopables_, _N_)).
+              1. Let _blocked_ be ToBoolean(? Get(_unscopables_, _N_)).
               1. If _blocked_ is *true*, return *false*.
             1. Return *true*.
           </emu-alg>
@@ -10385,7 +10420,7 @@
             CreateMutableBinding (
               _N_: a String,
               _D_: a Boolean,
-            )
+            ): either a normal completion containing ~unused~ or an abrupt completion
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -10396,7 +10431,8 @@
           </dl>
           <emu-alg>
             1. Let _bindingObject_ be _envRec_.[[BindingObject]].
-            1. Return ? DefinePropertyOrThrow(_bindingObject_, _N_, PropertyDescriptor { [[Value]]: *undefined*, [[Writable]]: *true*, [[Enumerable]]: *true*, [[Configurable]]: _D_ }).
+            1. Perform ? DefinePropertyOrThrow(_bindingObject_, _N_, PropertyDescriptor { [[Value]]: *undefined*, [[Writable]]: *true*, [[Enumerable]]: *true*, [[Configurable]]: _D_ }).
+            1. Return ~unused~.
           </emu-alg>
           <emu-note>
             <p>Normally _envRec_ will not have a binding for _N_ but if it does, the semantics of DefinePropertyOrThrow may result in an existing binding being replaced or shadowed or cause an abrupt completion to be returned.</p>
@@ -10413,7 +10449,7 @@
             InitializeBinding (
               _N_: a String,
               _V_: an ECMAScript language value,
-            )
+            ): either a normal completion containing ~unused~ or an abrupt completion
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -10423,7 +10459,8 @@
             <dd>It is used to set the bound value of the current binding of the identifier whose name is the value of the argument _N_ to the value of argument _V_.</dd>
           </dl>
           <emu-alg>
-            1. Return ? <emu-meta effects="user-code">_envRec_.SetMutableBinding</emu-meta>(_N_, _V_, *false*).
+            1. Perform ? <emu-meta effects="user-code">_envRec_.SetMutableBinding</emu-meta>(_N_, _V_, *false*).
+            1. Return ~unused~.
           </emu-alg>
           <emu-note>
             <p>In this specification, all uses of CreateMutableBinding for object Environment Records are immediately followed by a call to InitializeBinding for the same name. Hence, this specification does not explicitly track the initialization state of bindings in object Environment Records.</p>
@@ -10436,7 +10473,7 @@
               _N_: a String,
               _V_: an ECMAScript language value,
               _S_: a Boolean,
-            )
+            ): either a normal completion containing ~unused~ or an abrupt completion
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -10449,7 +10486,8 @@
             1. Let _bindingObject_ be _envRec_.[[BindingObject]].
             1. Let _stillExists_ be ? HasProperty(_bindingObject_, _N_).
             1. If _stillExists_ is *false* and _S_ is *true*, throw a *ReferenceError* exception.
-            1. Return ? Set(_bindingObject_, _N_, _V_, _S_).
+            1. Perform ? Set(_bindingObject_, _N_, _V_, _S_).
+            1. Return ~unused~.
           </emu-alg>
         </emu-clause>
 
@@ -10458,7 +10496,7 @@
             GetBindingValue (
               _N_: a String,
               _S_: a Boolean,
-            )
+            ): either a normal completion containing an ECMAScript language value or an abrupt completion
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -10471,7 +10509,7 @@
             1. Let _bindingObject_ be _envRec_.[[BindingObject]].
             1. Let _value_ be ? HasProperty(_bindingObject_, _N_).
             1. If _value_ is *false*, then
-              1. If _S_ is *false*, return the value *undefined*; otherwise throw a *ReferenceError* exception.
+              1. If _S_ is *false*, return *undefined*; otherwise throw a *ReferenceError* exception.
             1. Return ? Get(_bindingObject_, _N_).
           </emu-alg>
         </emu-clause>
@@ -10480,7 +10518,7 @@
           <h1>
             DeleteBinding (
               _N_: a String,
-            )
+            ): either a normal completion containing a Boolean or an abrupt completion
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -10496,7 +10534,7 @@
         </emu-clause>
 
         <emu-clause id="sec-object-environment-records-hasthisbinding" type="concrete method">
-          <h1>HasThisBinding ( )</h1>
+          <h1>HasThisBinding ( ): *false*</h1>
           <dl class="header">
             <dt>for</dt>
             <dd>an object Environment Record _envRec_</dd>
@@ -10510,7 +10548,7 @@
         </emu-clause>
 
         <emu-clause id="sec-object-environment-records-hassuperbinding" type="concrete method">
-          <h1>HasSuperBinding ( )</h1>
+          <h1>HasSuperBinding ( ): *false*</h1>
           <dl class="header">
             <dt>for</dt>
             <dd>an object Environment Record _envRec_</dd>
@@ -10524,7 +10562,7 @@
         </emu-clause>
 
         <emu-clause id="sec-object-environment-records-withbaseobject" type="concrete method">
-          <h1>WithBaseObject ( )</h1>
+          <h1>WithBaseObject ( ): an Object or *undefined*</h1>
           <dl class="header">
             <dt>for</dt>
             <dd>an object Environment Record _envRec_</dd>
@@ -10642,7 +10680,7 @@
           <h1>
             BindThisValue (
               _V_: an ECMAScript language value,
-            )
+            ): either a normal completion containing an ECMAScript language value or an abrupt completion
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -10658,7 +10696,7 @@
         </emu-clause>
 
         <emu-clause id="sec-function-environment-records-hasthisbinding" type="concrete method">
-          <h1>HasThisBinding ( )</h1>
+          <h1>HasThisBinding ( ): a Boolean</h1>
           <dl class="header">
             <dt>for</dt>
             <dd>a function Environment Record _envRec_</dd>
@@ -10669,7 +10707,7 @@
         </emu-clause>
 
         <emu-clause id="sec-function-environment-records-hassuperbinding" type="concrete method">
-          <h1>HasSuperBinding ( )</h1>
+          <h1>HasSuperBinding ( ): a Boolean</h1>
           <dl class="header">
             <dt>for</dt>
             <dd>a function Environment Record _envRec_</dd>
@@ -10681,7 +10719,7 @@
         </emu-clause>
 
         <emu-clause id="sec-function-environment-records-getthisbinding" type="concrete method">
-          <h1>GetThisBinding ( )</h1>
+          <h1>GetThisBinding ( ): either a normal completion containing an ECMAScript language value or an abrupt completion</h1>
           <dl class="header">
             <dt>for</dt>
             <dd>a function Environment Record _envRec_</dd>
@@ -10694,7 +10732,7 @@
         </emu-clause>
 
         <emu-clause id="sec-getsuperbase" type="concrete method">
-          <h1>GetSuperBase ( )</h1>
+          <h1>GetSuperBase ( ): either a normal completion containing either an Object, *null*, or *undefined*, or an abrupt completion</h1>
           <dl class="header">
             <dt>for</dt>
             <dd>a function Environment Record _envRec_</dd>
@@ -10855,7 +10893,7 @@
           <h1>
             HasBinding (
               _N_: a String,
-            )
+            ): either a normal completion containing a Boolean or an abrupt completion
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -10866,7 +10904,7 @@
           </dl>
           <emu-alg>
             1. Let _DclRec_ be _envRec_.[[DeclarativeRecord]].
-            1. If _DclRec_.HasBinding(_N_) is *true*, return *true*.
+            1. If ! _DclRec_.HasBinding(_N_) is *true*, return *true*.
             1. Let _ObjRec_ be _envRec_.[[ObjectRecord]].
             1. Return ? <emu-meta effects="user-code">_ObjRec_.HasBinding</emu-meta>(_N_).
           </emu-alg>
@@ -10877,7 +10915,7 @@
             CreateMutableBinding (
               _N_: a String,
               _D_: a Boolean,
-            )
+            ): either a normal completion containing ~unused~ or an abrupt completion
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -10888,7 +10926,7 @@
           </dl>
           <emu-alg>
             1. Let _DclRec_ be _envRec_.[[DeclarativeRecord]].
-            1. If _DclRec_.HasBinding(_N_) is *true*, throw a *TypeError* exception.
+            1. If ! _DclRec_.HasBinding(_N_) is *true*, throw a *TypeError* exception.
             1. Return _DclRec_.CreateMutableBinding(_N_, _D_).
           </emu-alg>
         </emu-clause>
@@ -10898,7 +10936,7 @@
             CreateImmutableBinding (
               _N_: a String,
               _S_: a Boolean,
-            )
+            ): either a normal completion containing ~unused~ or an abrupt completion
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -10909,7 +10947,7 @@
           </dl>
           <emu-alg>
             1. Let _DclRec_ be _envRec_.[[DeclarativeRecord]].
-            1. If _DclRec_.HasBinding(_N_) is *true*, throw a *TypeError* exception.
+            1. If ! _DclRec_.HasBinding(_N_) is *true*, throw a *TypeError* exception.
             1. Return _DclRec_.CreateImmutableBinding(_N_, _S_).
           </emu-alg>
         </emu-clause>
@@ -10919,7 +10957,7 @@
             InitializeBinding (
               _N_: a String,
               _V_: an ECMAScript language value,
-            )
+            ): either a normal completion containing ~unused~ or an abrupt completion
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -10930,8 +10968,8 @@
           </dl>
           <emu-alg>
             1. Let _DclRec_ be _envRec_.[[DeclarativeRecord]].
-            1. If _DclRec_.HasBinding(_N_) is *true*, then
-              1. Return _DclRec_.InitializeBinding(_N_, _V_).
+            1. If ! _DclRec_.HasBinding(_N_) is *true*, then
+              1. Return ! _DclRec_.InitializeBinding(_N_, _V_).
             1. Assert: If the binding exists, it must be in the object Environment Record.
             1. Let _ObjRec_ be _envRec_.[[ObjectRecord]].
             1. Return ? <emu-meta effects="user-code">_ObjRec_.InitializeBinding</emu-meta>(_N_, _V_).
@@ -10944,7 +10982,7 @@
               _N_: a String,
               _V_: an ECMAScript language value,
               _S_: a Boolean,
-            )
+            ): either a normal completion containing ~unused~ or an abrupt completion
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -10955,8 +10993,8 @@
           </dl>
           <emu-alg>
             1. Let _DclRec_ be _envRec_.[[DeclarativeRecord]].
-            1. If _DclRec_.HasBinding(_N_) is *true*, then
-              1. Return _DclRec_.SetMutableBinding(_N_, _V_, _S_).
+            1. If ! _DclRec_.HasBinding(_N_) is *true*, then
+              1. Return ! _DclRec_.SetMutableBinding(_N_, _V_, _S_).
             1. Let _ObjRec_ be _envRec_.[[ObjectRecord]].
             1. Return ? <emu-meta effects="user-code">_ObjRec_.SetMutableBinding</emu-meta>(_N_, _V_, _S_).
           </emu-alg>
@@ -10967,7 +11005,7 @@
             GetBindingValue (
               _N_: a String,
               _S_: a Boolean,
-            )
+            ): either a normal completion containing an ECMAScript language value or an abrupt completion
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -10978,7 +11016,7 @@
           </dl>
           <emu-alg>
             1. Let _DclRec_ be _envRec_.[[DeclarativeRecord]].
-            1. If _DclRec_.HasBinding(_N_) is *true*, then
+            1. If ! _DclRec_.HasBinding(_N_) is *true*, then
               1. Return _DclRec_.GetBindingValue(_N_, _S_).
             1. Let _ObjRec_ be _envRec_.[[ObjectRecord]].
             1. Return ? <emu-meta effects="user-code">_ObjRec_.GetBindingValue</emu-meta>(_N_, _S_).
@@ -10989,7 +11027,7 @@
           <h1>
             DeleteBinding (
               _N_: a String,
-            )
+            ): either a normal completion containing a Boolean or an abrupt completion
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -11000,8 +11038,8 @@
           </dl>
           <emu-alg>
             1. Let _DclRec_ be _envRec_.[[DeclarativeRecord]].
-            1. If _DclRec_.HasBinding(_N_) is *true*, then
-              1. Return _DclRec_.DeleteBinding(_N_).
+            1. If ! _DclRec_.HasBinding(_N_) is *true*, then
+              1. Return ! _DclRec_.DeleteBinding(_N_).
             1. Let _ObjRec_ be _envRec_.[[ObjectRecord]].
             1. Let _globalObject_ be _ObjRec_.[[BindingObject]].
             1. Let _existingProp_ be ? HasOwnProperty(_globalObject_, _N_).
@@ -11016,7 +11054,7 @@
         </emu-clause>
 
         <emu-clause id="sec-global-environment-records-hasthisbinding" type="concrete method">
-          <h1>HasThisBinding ( )</h1>
+          <h1>HasThisBinding ( ): *true*</h1>
           <dl class="header">
             <dt>for</dt>
             <dd>a global Environment Record _envRec_</dd>
@@ -11030,7 +11068,7 @@
         </emu-clause>
 
         <emu-clause id="sec-global-environment-records-hassuperbinding" type="concrete method">
-          <h1>HasSuperBinding ( )</h1>
+          <h1>HasSuperBinding ( ): *false*</h1>
           <dl class="header">
             <dt>for</dt>
             <dd>a global Environment Record _envRec_</dd>
@@ -11044,7 +11082,7 @@
         </emu-clause>
 
         <emu-clause id="sec-global-environment-records-withbaseobject" type="concrete method">
-          <h1>WithBaseObject ( )</h1>
+          <h1>WithBaseObject ( ): *undefined*</h1>
           <dl class="header">
             <dt>for</dt>
             <dd>a global Environment Record _envRec_</dd>
@@ -11055,7 +11093,7 @@
         </emu-clause>
 
         <emu-clause id="sec-global-environment-records-getthisbinding" type="concrete method">
-          <h1>GetThisBinding ( )</h1>
+          <h1>GetThisBinding ( ): a normal completion containing an Object</h1>
           <dl class="header">
             <dt>for</dt>
             <dd>a global Environment Record _envRec_</dd>
@@ -11069,7 +11107,7 @@
           <h1>
             HasVarDeclaration (
               _N_: a String,
-            )
+            ): a Boolean
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -11089,7 +11127,7 @@
           <h1>
             HasLexicalDeclaration (
               _N_: a String,
-            )
+            ): a Boolean
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -11100,7 +11138,7 @@
           </dl>
           <emu-alg>
             1. Let _DclRec_ be _envRec_.[[DeclarativeRecord]].
-            1. Return _DclRec_.HasBinding(_N_).
+            1. Return ! _DclRec_.HasBinding(_N_).
           </emu-alg>
         </emu-clause>
 
@@ -11108,7 +11146,7 @@
           <h1>
             HasRestrictedGlobalProperty (
               _N_: a String,
-            )
+            ): either a normal completion containing a Boolean or an abrupt completion
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -11134,7 +11172,7 @@
           <h1>
             CanDeclareGlobalVar (
               _N_: a String,
-            )
+            ): either a normal completion containing a Boolean or an abrupt completion
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -11156,7 +11194,7 @@
           <h1>
             CanDeclareGlobalFunction (
               _N_: a String,
-            )
+            ): either a normal completion containing a Boolean or an abrupt completion
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -11181,7 +11219,7 @@
             CreateGlobalVarBinding (
               _N_: a String,
               _D_: a Boolean,
-            )
+            ): either a normal completion containing ~unused~ or an abrupt completion
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -11201,7 +11239,7 @@
             1. Let _varDeclaredNames_ be _envRec_.[[VarNames]].
             1. If _varDeclaredNames_ does not contain _N_, then
               1. Append _N_ to _varDeclaredNames_.
-            1. Return NormalCompletion(~empty~).
+            1. Return ~unused~.
           </emu-alg>
         </emu-clause>
 
@@ -11211,7 +11249,7 @@
               _N_: a String,
               _V_: an ECMAScript language value,
               _D_: a Boolean,
-            )
+            ): either a normal completion containing ~unused~ or an abrupt completion
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -11233,7 +11271,7 @@
             1. Let _varDeclaredNames_ be _envRec_.[[VarNames]].
             1. If _varDeclaredNames_ does not contain _N_, then
               1. Append _N_ to _varDeclaredNames_.
-            1. Return NormalCompletion(~empty~).
+            1. Return ~unused~.
           </emu-alg>
           <emu-note>
             <p>Global function declarations are always represented as own properties of the global object. If possible, an existing own property is reconfigured to have a standard set of attribute values. Step <emu-xref href="#step-createglobalfunctionbinding-set"></emu-xref> is equivalent to what calling the InitializeBinding concrete method would do and if _globalObject_ is a Proxy will produce the same sequence of Proxy trap calls.</p>
@@ -11280,7 +11318,7 @@
             GetBindingValue (
               _N_: a String,
               _S_: a Boolean,
-            )
+            ): either a normal completion containing an ECMAScript language value or an abrupt completion
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -11314,7 +11352,7 @@
         </emu-clause>
 
         <emu-clause id="sec-module-environment-records-hasthisbinding" type="concrete method">
-          <h1>HasThisBinding ( )</h1>
+          <h1>HasThisBinding ( ): *true*</h1>
           <dl class="header">
             <dt>for</dt>
             <dd>a module Environment Record _envRec_</dd>
@@ -11328,7 +11366,7 @@
         </emu-clause>
 
         <emu-clause id="sec-module-environment-records-getthisbinding" type="concrete method">
-          <h1>GetThisBinding ( )</h1>
+          <h1>GetThisBinding ( ): a normal completion containing *undefined*</h1>
           <dl class="header">
             <dt>for</dt>
             <dd>a module Environment Record _envRec_</dd>
@@ -11344,7 +11382,7 @@
               _N_: a String,
               _M_: a Module Record,
               _N2_: a String,
-            )
+            ): ~unused~
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -11357,7 +11395,7 @@
             1. Assert: _envRec_ does not already have a binding for _N_.
             1. Assert: When _M_.[[Environment]] is instantiated it will have a direct binding for _N2_.
             1. Create an immutable indirect binding in _envRec_ for _N_ that references _M_ and _N2_ as its target binding and record that the binding is initialized.
-            1. Return NormalCompletion(~empty~).
+            1. Return ~unused~.
           </emu-alg>
         </emu-clause>
       </emu-clause>
@@ -11373,7 +11411,7 @@
             _env_: an Environment Record or *null*,
             _name_: a String,
             _strict_: a Boolean,
-          )
+          ): either a normal completion containing a Reference Record or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
@@ -11393,7 +11431,7 @@
         <h1>
           NewDeclarativeEnvironment (
             _E_: an Environment Record,
-          )
+          ): a declarative Environment Record
         </h1>
         <dl class="header">
         </dl>
@@ -11410,7 +11448,7 @@
             _O_: an Object,
             _W_: a Boolean,
             _E_: an Environment Record or *null*,
-          )
+          ): an object Environment Record
         </h1>
         <dl class="header">
         </dl>
@@ -11428,7 +11466,7 @@
           NewFunctionEnvironment (
             _F_: an ECMAScript function,
             _newTarget_: an Object or *undefined*,
-          )
+          ): a function Environment Record
         </h1>
         <dl class="header">
         </dl>
@@ -11448,7 +11486,7 @@
           NewGlobalEnvironment (
             _G_: unknown,
             _thisValue_: unknown,
-          )
+          ): a global Environment Record
         </h1>
         <dl class="header">
         </dl>
@@ -11469,7 +11507,7 @@
         <h1>
           NewModuleEnvironment (
             _E_: an Environment Record,
-          )
+          ): a module Environment Record
         </h1>
         <dl class="header">
         </dl>
@@ -11534,7 +11572,7 @@
         <h1>
           NewPrivateEnvironment (
             _outerPrivEnv_: a PrivateEnvironment Record or *null*,
-          )
+          ): a PrivateEnvironment Record
         </h1>
         <dl class="header">
         </dl>
@@ -11549,7 +11587,7 @@
           ResolvePrivateIdentifier (
             _privEnv_: a PrivateEnvironment Record,
             _identifier_: a String,
-          )
+          ): a Private Name
         </h1>
         <dl class="header">
         </dl>
@@ -11600,7 +11638,7 @@
             [[GlobalObject]]
           </td>
           <td>
-            an Object
+            an Object or *undefined*
           </td>
           <td>
             The global object for this realm
@@ -11644,7 +11682,7 @@
     </emu-table>
 
     <emu-clause id="sec-createrealm" type="abstract operation">
-      <h1>CreateRealm ( )</h1>
+      <h1>CreateRealm ( ): a Realm Record</h1>
       <dl class="header">
       </dl>
       <emu-alg>
@@ -11661,16 +11699,15 @@
       <h1>
         CreateIntrinsics (
           _realmRec_: unknown,
-        )
+        ): ~unused~
       </h1>
       <dl class="header">
       </dl>
       <emu-alg>
-        1. Let _intrinsics_ be a new Record.
-        1. Set _realmRec_.[[Intrinsics]] to _intrinsics_.
-        1. Set fields of _intrinsics_ with the values listed in <emu-xref href="#table-well-known-intrinsic-objects"></emu-xref>. The field names are the names listed in column one of the table. The value of each field is a new object value fully and recursively populated with property values as defined by the specification of each object in clauses <emu-xref href="#sec-global-object"></emu-xref> through <emu-xref href="#sec-reflection"></emu-xref>. All object property values are newly created object values. All values that are built-in function objects are created by performing CreateBuiltinFunction(_steps_, _length_, _name_, _slots_, _realmRec_, _prototype_) where _steps_ is the definition of that function provided by this specification, _name_ is the initial value of the function's `name` property, _length_ is the initial value of the function's `length` property, _slots_ is a list of the names, if any, of the function's specified internal slots, and _prototype_ is the specified value of the function's [[Prototype]] internal slot. The creation of the intrinsics and their properties must be ordered to avoid any dependencies upon objects that have not yet been created.
-        1. Perform AddRestrictedFunctionProperties(_intrinsics_.[[%Function.prototype%]], _realmRec_).
-        1. Return _intrinsics_.
+        1. Set _realmRec_.[[Intrinsics]] to a new Record.
+        1. Set fields of _realmRec_.[[Intrinsics]] with the values listed in <emu-xref href="#table-well-known-intrinsic-objects"></emu-xref>. The field names are the names listed in column one of the table. The value of each field is a new object value fully and recursively populated with property values as defined by the specification of each object in clauses <emu-xref href="#sec-global-object"></emu-xref> through <emu-xref href="#sec-reflection"></emu-xref>. All object property values are newly created object values. All values that are built-in function objects are created by performing CreateBuiltinFunction(_steps_, _length_, _name_, _slots_, _realmRec_, _prototype_) where _steps_ is the definition of that function provided by this specification, _name_ is the initial value of the function's `name` property, _length_ is the initial value of the function's `length` property, _slots_ is a list of the names, if any, of the function's specified internal slots, and _prototype_ is the specified value of the function's [[Prototype]] internal slot. The creation of the intrinsics and their properties must be ordered to avoid any dependencies upon objects that have not yet been created.
+        1. Perform AddRestrictedFunctionProperties(_realmRec_.[[Intrinsics]].[[%Function.prototype%]], _realmRec_).
+        1. Return ~unused~.
       </emu-alg>
     </emu-clause>
 
@@ -11680,20 +11717,20 @@
           _realmRec_: unknown,
           _globalObj_: an Object or *undefined*,
           _thisValue_: unknown,
-        )
+        ): ~unused~
       </h1>
       <dl class="header">
       </dl>
       <emu-alg>
         1. If _globalObj_ is *undefined*, then
           1. Let _intrinsics_ be _realmRec_.[[Intrinsics]].
-          1. Set _globalObj_ to ! OrdinaryObjectCreate(_intrinsics_.[[%Object.prototype%]]).
+          1. Set _globalObj_ to OrdinaryObjectCreate(_intrinsics_.[[%Object.prototype%]]).
         1. Assert: Type(_globalObj_) is Object.
         1. If _thisValue_ is *undefined*, set _thisValue_ to _globalObj_.
         1. Set _realmRec_.[[GlobalObject]] to _globalObj_.
         1. Let _newGlobalEnv_ be NewGlobalEnvironment(_globalObj_, _thisValue_).
         1. Set _realmRec_.[[GlobalEnv]] to _newGlobalEnv_.
-        1. Return _realmRec_.
+        1. Return ~unused~.
       </emu-alg>
     </emu-clause>
 
@@ -11701,7 +11738,7 @@
       <h1>
         SetDefaultGlobalBindings (
           _realmRec_: unknown,
-        )
+        ): either a normal completion containing an Object or an abrupt completion
       </h1>
       <dl class="header">
       </dl>
@@ -11830,7 +11867,7 @@
     <p>An execution context is purely a specification mechanism and need not correspond to any particular artefact of an ECMAScript implementation. It is impossible for ECMAScript code to directly access or observe an execution context.</p>
 
     <emu-clause id="sec-getactivescriptormodule" type="abstract operation">
-      <h1>GetActiveScriptOrModule ( )</h1>
+      <h1>GetActiveScriptOrModule ( ): a Script Record, a Module Record, or *null*</h1>
       <dl class="header">
         <dt>description</dt>
         <dd>It is used to determine the running script or module, based on the running execution context.</dd>
@@ -11848,7 +11885,7 @@
         ResolveBinding (
           _name_: a String,
           optional _env_: an Environment Record or *undefined*,
-        )
+        ): either a normal completion containing a Reference Record or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -11867,7 +11904,7 @@
     </emu-clause>
 
     <emu-clause id="sec-getthisenvironment" type="abstract operation">
-      <h1>GetThisEnvironment ( )</h1>
+      <h1>GetThisEnvironment ( ): an Environment Record</h1>
       <dl class="header">
         <dt>description</dt>
         <dd>It finds the Environment Record that currently supplies the binding of the keyword `this`.</dd>
@@ -11887,7 +11924,7 @@
     </emu-clause>
 
     <emu-clause id="sec-resolvethisbinding" type="abstract operation">
-      <h1>ResolveThisBinding ( )</h1>
+      <h1>ResolveThisBinding ( ): either a normal completion containing an ECMAScript language value or an abrupt completion</h1>
       <dl class="header">
         <dt>description</dt>
         <dd>It determines the binding of the keyword `this` using the LexicalEnvironment of the running execution context.</dd>
@@ -11899,7 +11936,7 @@
     </emu-clause>
 
     <emu-clause id="sec-getnewtarget" type="abstract operation">
-      <h1>GetNewTarget ( )</h1>
+      <h1>GetNewTarget ( ): an Object or *undefined*</h1>
       <dl class="header">
         <dt>description</dt>
         <dd>It determines the NewTarget value using the LexicalEnvironment of the running execution context.</dd>
@@ -11912,7 +11949,7 @@
     </emu-clause>
 
     <emu-clause id="sec-getglobalobject" type="abstract operation">
-      <h1>GetGlobalObject ( )</h1>
+      <h1>GetGlobalObject ( ): an Object</h1>
       <dl class="header">
         <dt>description</dt>
         <dd>It returns the global object used by the currently running execution context.</dd>
@@ -12015,13 +12052,13 @@
       <h1>
         HostMakeJobCallback (
           _callback_: a function object,
-        )
+        ): a JobCallback Record
       </h1>
       <dl class="header">
       </dl>
       <p>An implementation of HostMakeJobCallback must conform to the following requirements:</p>
       <ul>
-        <li>It must complete normally with a JobCallback Record whose [[Callback]] field is _callback_.</li>
+        <li>It must return a JobCallback Record whose [[Callback]] field is _callback_.</li>
       </ul>
       <p>The default implementation of HostMakeJobCallback performs the following steps when called:</p>
       <emu-alg>
@@ -12039,7 +12076,7 @@
           _jobCallback_: a JobCallback Record,
           _V_: an ECMAScript language value,
           _argumentsList_: a List of ECMAScript language values,
-        )
+        ): either a normal completion containing an ECMAScript language value or an abrupt completion
       </h1>
       <dl class="header">
       </dl>
@@ -12063,7 +12100,7 @@
         HostEnqueuePromiseJob (
           _job_: a Job Abstract Closure,
           _realm_: a Realm Record or *null*,
-        )
+        ): ~unused~
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -12084,7 +12121,7 @@
   </emu-clause>
 
   <emu-clause id="sec-initializehostdefinedrealm" type="abstract operation">
-    <h1>InitializeHostDefinedRealm ( )</h1>
+    <h1>InitializeHostDefinedRealm ( ): either a normal completion containing ~unused~ or an abrupt completion</h1>
     <dl class="header">
     </dl>
 
@@ -12100,7 +12137,7 @@
       1. Perform SetRealmGlobalObject(_realm_, _global_, _thisValue_).
       1. Let _globalObj_ be ? SetDefaultGlobalBindings(_realm_).
       1. Create any host-defined global object properties on _globalObj_.
-      1. Return NormalCompletion(~empty~).
+      1. Return ~unused~.
     </emu-alg>
   </emu-clause>
 
@@ -12113,6 +12150,7 @@
       <p>Some web browsers share a single executing thread across multiple unrelated tabs of a browser window, for example.</p>
     </emu-note>
     <p>While an agent's executing thread executes jobs, the agent is the <dfn id="surrounding-agent" variants="surrounding agents">surrounding agent</dfn> for the code in those jobs. The code uses the surrounding agent to access the specification-level execution objects held within the agent: the running execution context, the execution context stack, and the Agent Record's fields.</p>
+    <p>An <dfn variants="agent signifiers">agent signifier</dfn> is a globally-unique opaque value used to identify an Agent.</p>
     <emu-table id="table-agent-record" caption="Agent Record Fields">
       <table>
         <tr>
@@ -12132,7 +12170,7 @@
         </tr>
         <tr>
           <td>[[Signifier]]</td>
-          <td>a globally-unique value</td>
+          <td>an agent signifier</td>
           <td>Uniquely identifies the agent within its agent cluster.</td>
         </tr>
         <tr>
@@ -12180,7 +12218,7 @@
     </emu-note>
 
     <emu-clause id="sec-agentsignifier" type="abstract operation">
-      <h1>AgentSignifier ( )</h1>
+      <h1>AgentSignifier ( ): an agent signifier</h1>
       <dl class="header">
       </dl>
       <emu-alg>
@@ -12190,7 +12228,7 @@
     </emu-clause>
 
     <emu-clause id="sec-agentcansuspend" type="abstract operation">
-      <h1>AgentCanSuspend ( )</h1>
+      <h1>AgentCanSuspend ( ): a Boolean</h1>
       <dl class="header">
       </dl>
       <emu-alg>
@@ -12244,7 +12282,7 @@
       <p>Examples of that type of termination are: operating systems or users terminating agents that are running in separate processes; the embedding itself terminating an agent that is running in-process with the other agents when per-agent resource accounting indicates that the agent is runaway.</p>
     </emu-note>
 
-    <p>Prior to any evaluation of any ECMAScript code by any agent in a cluster, the [[CandidateExecution]] field of the Agent Record for all agents in the cluster is set to the initial candidate execution. The initial candidate execution is an empty candidate execution whose [[EventsRecords]] field is a List containing, for each agent, an Agent Events Record whose [[AgentSignifier]] field is that agent's signifier, and whose [[EventList]] and [[AgentSynchronizesWith]] fields are empty Lists.</p>
+    <p>Prior to any evaluation of any ECMAScript code by any agent in a cluster, the [[CandidateExecution]] field of the Agent Record for all agents in the cluster is set to the initial candidate execution. The initial candidate execution is an empty candidate execution whose [[EventsRecords]] field is a List containing, for each agent, an Agent Events Record whose [[AgentSignifier]] field is that agent's agent signifier, and whose [[EventList]] and [[AgentSynchronizesWith]] fields are empty Lists.</p>
 
     <emu-note>
       <p>All agents in an agent cluster share the same candidate execution in its Agent Record's [[CandidateExecution]] field. The candidate execution is a specification mechanism used by the memory model.</p>
@@ -12348,7 +12386,7 @@
             1. Set _ref_.[[WeakRefTarget]] to ~empty~.
           1. For each FinalizationRegistry _fg_ such that _fg_.[[Cells]] contains a Record _cell_ such that _cell_.[[WeakRefTarget]] is _obj_, do
             1. Set _cell_.[[WeakRefTarget]] to ~empty~.
-            1. Optionally, perform ! HostEnqueueFinalizationRegistryCleanupJob(_fg_).
+            1. Optionally, perform HostEnqueueFinalizationRegistryCleanupJob(_fg_).
           1. For each WeakMap _map_ such that _map_.[[WeakMapData]] contains a Record _r_ such that _r_.[[Key]] is _obj_, do
             1. Set _r_.[[Key]] to ~empty~.
             1. Set _r_.[[Value]] to ~empty~.
@@ -12378,15 +12416,15 @@
         <h1>
           HostEnqueueFinalizationRegistryCleanupJob (
             _finalizationRegistry_: a FinalizationRegistry,
-          )
+          ): ~unused~
         </h1>
         <dl class="header">
         </dl>
         <p>Let _cleanupJob_ be a new Job Abstract Closure with no parameters that captures _finalizationRegistry_ and performs the following steps when called:</p>
         <emu-alg>
-          1. Let _cleanupResult_ be CleanupFinalizationRegistry(_finalizationRegistry_).
+          1. Let _cleanupResult_ be Completion(CleanupFinalizationRegistry(_finalizationRegistry_)).
           1. If _cleanupResult_ is an abrupt completion, perform any host-defined steps for reporting the error.
-          1. Return NormalCompletion(~empty~).
+          1. Return ~unused~.
         </emu-alg>
         <p>An implementation of HostEnqueueFinalizationRegistryCleanupJob schedules _cleanupJob_ to be performed at some future time, if possible. It must also conform to the requirements in <emu-xref href="#sec-jobs"></emu-xref>.</p>
       </emu-clause>
@@ -12394,7 +12432,7 @@
   </emu-clause>
 
   <emu-clause id="sec-clear-kept-objects" type="abstract operation">
-    <h1>ClearKeptObjects ( )</h1>
+    <h1>ClearKeptObjects ( ): ~unused~</h1>
     <dl class="header">
       <dt>description</dt>
       <dd>ECMAScript implementations are expected to call ClearKeptObjects when a synchronous sequence of ECMAScript executions completes.</dd>
@@ -12402,6 +12440,7 @@
     <emu-alg>
       1. Let _agentRecord_ be the surrounding agent's Agent Record.
       1. Set _agentRecord_.[[KeptAlive]] to a new empty List.
+      1. Return ~unused~.
     </emu-alg>
   </emu-clause>
 
@@ -12409,13 +12448,14 @@
     <h1>
       AddToKeptObjects (
         _object_: an Object,
-      )
+      ): ~unused~
     </h1>
     <dl class="header">
     </dl>
     <emu-alg>
       1. Let _agentRecord_ be the surrounding agent's Agent Record.
       1. Append _object_ to _agentRecord_.[[KeptAlive]].
+      1. Return ~unused~.
     </emu-alg>
     <emu-note>
       When the abstract operation AddToKeptObjects is called with a target object reference, it adds the target to a list that will point strongly at the target until ClearKeptObjects is called.
@@ -12426,7 +12466,7 @@
     <h1>
       CleanupFinalizationRegistry (
         _finalizationRegistry_: a FinalizationRegistry,
-      )
+      ): either a normal completion containing ~unused~ or an abrupt completion
     </h1>
     <dl class="header">
     </dl>
@@ -12437,7 +12477,7 @@
         1. Choose any such _cell_.
         1. Remove _cell_ from _finalizationRegistry_.[[Cells]].
         1. Perform ? HostCallJobCallback(_callback_, *undefined*, &laquo; _cell_.[[HeldValue]] &raquo;).
-      1. Return NormalCompletion(~empty~).
+      1. Return ~unused~.
     </emu-alg>
   </emu-clause>
 </emu-clause>
@@ -12453,20 +12493,20 @@
     <p>Each ordinary object internal method delegates to a similarly-named abstract operation. If such an abstract operation depends on another internal method, then the internal method is invoked on _O_ rather than calling the similarly-named abstract operation directly. These semantics ensure that exotic objects have their overridden internal methods invoked when ordinary object internal methods are applied to them.</p>
 
     <emu-clause id="sec-ordinary-object-internal-methods-and-internal-slots-getprototypeof" type="internal method">
-      <h1>[[GetPrototypeOf]] ( )</h1>
+      <h1>[[GetPrototypeOf]] ( ): a normal completion containing either an Object or *null*</h1>
       <dl class="header">
         <dt>for</dt>
         <dd>an ordinary object _O_</dd>
       </dl>
       <emu-alg>
-        1. Return ! OrdinaryGetPrototypeOf(_O_).
+        1. Return OrdinaryGetPrototypeOf(_O_).
       </emu-alg>
 
       <emu-clause id="sec-ordinarygetprototypeof" type="abstract operation">
         <h1>
           OrdinaryGetPrototypeOf (
             _O_: an Object,
-          )
+          ): an Object or *null*
         </h1>
         <dl class="header">
         </dl>
@@ -12480,14 +12520,14 @@
       <h1>
         [[SetPrototypeOf]] (
           _V_: an Object or *null*,
-        )
+        ): a normal completion containing a Boolean
       </h1>
       <dl class="header">
         <dt>for</dt>
         <dd>an ordinary object _O_</dd>
       </dl>
       <emu-alg>
-        1. Return ! OrdinarySetPrototypeOf(_O_, _V_).
+        1. Return OrdinarySetPrototypeOf(_O_, _V_).
       </emu-alg>
 
       <emu-clause id="sec-ordinarysetprototypeof" type="abstract operation">
@@ -12495,7 +12535,7 @@
           OrdinarySetPrototypeOf (
             _O_: an Object,
             _V_: an Object or *null*,
-          )
+          ): a Boolean
         </h1>
         <dl class="header">
         </dl>
@@ -12522,20 +12562,20 @@
     </emu-clause>
 
     <emu-clause id="sec-ordinary-object-internal-methods-and-internal-slots-isextensible" type="internal method">
-      <h1>[[IsExtensible]] ( )</h1>
+      <h1>[[IsExtensible]] ( ): a normal completion containing a Boolean</h1>
       <dl class="header">
         <dt>for</dt>
         <dd>an ordinary object _O_</dd>
       </dl>
       <emu-alg>
-        1. Return ! OrdinaryIsExtensible(_O_).
+        1. Return OrdinaryIsExtensible(_O_).
       </emu-alg>
 
       <emu-clause id="sec-ordinaryisextensible" type="abstract operation">
         <h1>
           OrdinaryIsExtensible (
             _O_: an Object,
-          )
+          ): a Boolean
         </h1>
         <dl class="header">
         </dl>
@@ -12546,20 +12586,20 @@
     </emu-clause>
 
     <emu-clause id="sec-ordinary-object-internal-methods-and-internal-slots-preventextensions" type="internal method">
-      <h1>[[PreventExtensions]] ( )</h1>
+      <h1>[[PreventExtensions]] ( ): a normal completion containing *true*</h1>
       <dl class="header">
         <dt>for</dt>
         <dd>an ordinary object _O_</dd>
       </dl>
       <emu-alg>
-        1. Return ! OrdinaryPreventExtensions(_O_).
+        1. Return OrdinaryPreventExtensions(_O_).
       </emu-alg>
 
       <emu-clause id="sec-ordinarypreventextensions" type="abstract operation">
         <h1>
           OrdinaryPreventExtensions (
             _O_: an Object,
-          )
+          ): *true*
         </h1>
         <dl class="header">
         </dl>
@@ -12574,14 +12614,14 @@
       <h1>
         [[GetOwnProperty]] (
           _P_: a property key,
-        )
+        ): a normal completion containing either a Property Descriptor or *undefined*
       </h1>
       <dl class="header">
         <dt>for</dt>
         <dd>an ordinary object _O_</dd>
       </dl>
       <emu-alg>
-        1. Return ! OrdinaryGetOwnProperty(_O_, _P_).
+        1. Return OrdinaryGetOwnProperty(_O_, _P_).
       </emu-alg>
 
       <emu-clause id="sec-ordinarygetownproperty" type="abstract operation">
@@ -12589,7 +12629,7 @@
           OrdinaryGetOwnProperty (
             _O_: an Object,
             _P_: a property key,
-          )
+          ): a Property Descriptor or *undefined*
         </h1>
         <dl class="header">
         </dl>
@@ -12616,7 +12656,7 @@
         [[DefineOwnProperty]] (
           _P_: a property key,
           _Desc_: a Property Descriptor,
-        )
+        ): either a normal completion containing a Boolean or an abrupt completion
       </h1>
       <dl class="header">
         <dt>for</dt>
@@ -12632,7 +12672,7 @@
             _O_: an Object,
             _P_: a property key,
             _Desc_: a Property Descriptor,
-          )
+          ): either a normal completion containing a Boolean or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
@@ -12649,7 +12689,7 @@
             _Extensible_: a Boolean,
             _Desc_: a Property Descriptor,
             _Current_: a Property Descriptor,
-          )
+          ): a Boolean
         </h1>
         <dl class="header">
         </dl>
@@ -12666,18 +12706,18 @@
             _extensible_: a Boolean,
             _Desc_: a Property Descriptor,
             _current_: a Property Descriptor or *undefined*,
-          )
+          ): a Boolean
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It returns a Boolean value which is *true* if and only if _Desc_ can be applied as the property of an object with specified _extensibility_ and current property _current_ while upholding <emu-xref href="#sec-invariants-of-the-essential-internal-methods">invariants</emu-xref>. When such application is possible and _O_ is not *undefined*, it is performed for the property named _P_ (which is created if necessary).</dd>
+          <dd>It returns *true* if and only if _Desc_ can be applied as the property of an object with specified _extensibility_ and current property _current_ while upholding <emu-xref href="#sec-invariants-of-the-essential-internal-methods">invariants</emu-xref>. When such application is possible and _O_ is not *undefined*, it is performed for the property named _P_ (which is created if necessary).</dd>
         </dl>
         <emu-alg>
-          1. Assert: ! IsPropertyKey(_P_) is *true*.
+          1. Assert: IsPropertyKey(_P_) is *true*.
           1. If _current_ is *undefined*, then
             1. If _extensible_ is *false*, return *false*.
             1. If _O_ is *undefined*, return *true*.
-            1. If ! IsAccessorDescriptor(_Desc_) is *true*, then
+            1. If IsAccessorDescriptor(_Desc_) is *true*, then
               1. Create an own accessor property named _P_ of object _O_ whose [[Get]], [[Set]], [[Enumerable]], and [[Configurable]] attributes are set to the value of the corresponding field in _Desc_ if _Desc_ has that field, or to the attribute's <emu-xref href="#table-object-property-attributes">default value</emu-xref> otherwise.
             1. Else,
               1. Create an own data property named _P_ of object _O_ whose [[Value]], [[Writable]], [[Enumerable]], and [[Configurable]] attributes are set to the value of the corresponding field in _Desc_ if _Desc_ has that field, or to the attribute's <emu-xref href="#table-object-property-attributes">default value</emu-xref> otherwise.
@@ -12686,20 +12726,20 @@
           1. If _Desc_ does not have any fields, return *true*.
           1. If _current_.[[Configurable]] is *false*, then
             1. If _Desc_ has a [[Configurable]] field and _Desc_.[[Configurable]] is *true*, return *false*.
-            1. If _Desc_ has an [[Enumerable]] field and ! SameValue(_Desc_.[[Enumerable]], _current_.[[Enumerable]]) is *false*, return *false*.
-            1. If ! IsGenericDescriptor(_Desc_) is *false* and ! SameValue(IsAccessorDescriptor(_Desc_), IsAccessorDescriptor(_current_)) is *false*, return *false*.
-            1. If ! IsAccessorDescriptor(_Desc_) is *true*, then
-              1. If _Desc_ has a [[Get]] field and ! SameValue(_Desc_.[[Get]], _current_.[[Get]]) is *false*, return *false*.
-              1. If _Desc_ has a [[Set]] field and ! SameValue(_Desc_.[[Set]], _current_.[[Set]]) is *false*, return *false*.
+            1. If _Desc_ has an [[Enumerable]] field and SameValue(_Desc_.[[Enumerable]], _current_.[[Enumerable]]) is *false*, return *false*.
+            1. If IsGenericDescriptor(_Desc_) is *false* and SameValue(IsAccessorDescriptor(_Desc_), IsAccessorDescriptor(_current_)) is *false*, return *false*.
+            1. If IsAccessorDescriptor(_Desc_) is *true*, then
+              1. If _Desc_ has a [[Get]] field and SameValue(_Desc_.[[Get]], _current_.[[Get]]) is *false*, return *false*.
+              1. If _Desc_ has a [[Set]] field and SameValue(_Desc_.[[Set]], _current_.[[Set]]) is *false*, return *false*.
             1. Else if _current_.[[Writable]] is *false*, then
               1. If _Desc_ has a [[Writable]] field and _Desc_.[[Writable]] is *true*, return *false*.
-              1. If _Desc_ has a [[Value]] field and ! SameValue(_Desc_.[[Value]], _current_.[[Value]]) is *false*, return *false*.
+              1. If _Desc_ has a [[Value]] field and SameValue(_Desc_.[[Value]], _current_.[[Value]]) is *false*, return *false*.
           1. If _O_ is not *undefined*, then
-            1. If ! IsDataDescriptor(_current_) is *true* and ! IsAccessorDescriptor(_Desc_) is *true*, then
+            1. If IsDataDescriptor(_current_) is *true* and IsAccessorDescriptor(_Desc_) is *true*, then
               1. If _Desc_ has a [[Configurable]] field, let _configurable_ be _Desc_.[[Configurable]]; else let _configurable_ be _current_.[[Configurable]].
               1. If _Desc_ has a [[Enumerable]] field, let _enumerable_ be _Desc_.[[Enumerable]]; else let _enumerable_ be _current_.[[Enumerable]].
               1. Replace the property named _P_ of object _O_ with an accessor property whose [[Configurable]] and [[Enumerable]] attributes are set to _configurable_ and _enumerable_, respectively, and whose [[Get]] and [[Set]] attributes are set to the value of the corresponding field in _Desc_ if _Desc_ has that field, or to the attribute's <emu-xref href="#table-object-property-attributes">default value</emu-xref> otherwise.
-            1. Else if ! IsAccessorDescriptor(_current_) is *true* and ! IsDataDescriptor(_Desc_) is *true*, then
+            1. Else if IsAccessorDescriptor(_current_) is *true* and IsDataDescriptor(_Desc_) is *true*, then
               1. If _Desc_ has a [[Configurable]] field, let _configurable_ be _Desc_.[[Configurable]]; else let _configurable_ be _current_.[[Configurable]].
               1. If _Desc_ has a [[Enumerable]] field, let _enumerable_ be _Desc_.[[Enumerable]]; else let _enumerable_ be _current_.[[Enumerable]].
               1. Replace the property named _P_ of object _O_ with a data property whose [[Configurable]] and [[Enumerable]] attributes are set to _configurable_ and _enumerable_, respectively, and whose [[Value]] and [[Writable]] attributes are set to the value of the corresponding field in _Desc_ if _Desc_ has that field, or to the attribute's <emu-xref href="#table-object-property-attributes">default value</emu-xref> otherwise.
@@ -12714,7 +12754,7 @@
       <h1>
         [[HasProperty]] (
           _P_: a property key,
-        )
+        ): either a normal completion containing a Boolean or an abrupt completion
       </h1>
       <dl class="header">
         <dt>for</dt>
@@ -12729,7 +12769,7 @@
           OrdinaryHasProperty (
             _O_: an Object,
             _P_: a property key,
-          )
+          ): either a normal completion containing a Boolean or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
@@ -12749,7 +12789,7 @@
         [[Get]] (
           _P_: a property key,
           _Receiver_: an ECMAScript language value,
-        )
+        ): either a normal completion containing an ECMAScript language value or an abrupt completion
       </h1>
       <dl class="header">
         <dt>for</dt>
@@ -12766,7 +12806,7 @@
             _O_: an Object,
             _P_: a property key,
             _Receiver_: an ECMAScript language value,
-          )
+          ): either a normal completion containing an ECMAScript language value or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
@@ -12792,7 +12832,7 @@
           _P_: a property key,
           _V_: an ECMAScript language value,
           _Receiver_: an ECMAScript language value,
-        )
+        ): either a normal completion containing a Boolean or an abrupt completion
       </h1>
       <dl class="header">
         <dt>for</dt>
@@ -12809,14 +12849,14 @@
             _P_: a property key,
             _V_: an ECMAScript language value,
             _Receiver_: an ECMAScript language value,
-          )
+          ): either a normal completion containing a Boolean or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
 
         <emu-alg>
           1. Let _ownDesc_ be ? <emu-meta effects="user-code">_O_.[[GetOwnProperty]]</emu-meta>(_P_).
-          1. Return OrdinarySetWithOwnDescriptor(_O_, _P_, _V_, _Receiver_, _ownDesc_).
+          1. Return ? OrdinarySetWithOwnDescriptor(_O_, _P_, _V_, _Receiver_, _ownDesc_).
         </emu-alg>
       </emu-clause>
 
@@ -12828,7 +12868,7 @@
             _V_: an ECMAScript language value,
             _Receiver_: an ECMAScript language value,
             _ownDesc_: a Property Descriptor or *undefined*,
-          )
+          ): either a normal completion containing a Boolean or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
@@ -12865,7 +12905,7 @@
       <h1>
         [[Delete]] (
           _P_: a property key,
-        )
+        ): either a normal completion containing a Boolean or an abrupt completion
       </h1>
       <dl class="header">
         <dt>for</dt>
@@ -12880,7 +12920,7 @@
           OrdinaryDelete (
             _O_: an Object,
             _P_: a property key,
-          )
+          ): either a normal completion containing a Boolean or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
@@ -12896,20 +12936,20 @@
     </emu-clause>
 
     <emu-clause id="sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys" type="internal method">
-      <h1>[[OwnPropertyKeys]] ( )</h1>
+      <h1>[[OwnPropertyKeys]] ( ): a normal completion containing a List of property keys</h1>
       <dl class="header">
         <dt>for</dt>
         <dd>an ordinary object _O_</dd>
       </dl>
       <emu-alg>
-        1. Return ! OrdinaryOwnPropertyKeys(_O_).
+        1. Return OrdinaryOwnPropertyKeys(_O_).
       </emu-alg>
 
       <emu-clause id="sec-ordinaryownpropertykeys" type="abstract operation">
         <h1>
           OrdinaryOwnPropertyKeys (
             _O_: an Object,
-          )
+          ): a List of property keys
         </h1>
         <dl class="header">
         </dl>
@@ -12932,7 +12972,7 @@
         OrdinaryObjectCreate (
           _proto_: an Object or *null*,
           optional _additionalInternalSlotsList_: a List of names of internal slots,
-        )
+        ): an Object
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -12941,7 +12981,7 @@
       <emu-alg>
         1. Let _internalSlotsList_ be &laquo; [[Prototype]], [[Extensible]] &raquo;.
         1. If _additionalInternalSlotsList_ is present, append each of its elements to _internalSlotsList_.
-        1. Let _O_ be ! MakeBasicObject(_internalSlotsList_).
+        1. Let _O_ be MakeBasicObject(_internalSlotsList_).
         1. Set _O_.[[Prototype]] to _proto_.
         1. Return _O_.
       </emu-alg>
@@ -12957,7 +12997,7 @@
           _constructor_: unknown,
           _intrinsicDefaultProto_: a String,
           optional _internalSlotsList_: a List of names of internal slots,
-        )
+        ): either a normal completion containing an Object or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -12966,7 +13006,7 @@
       <emu-alg>
         1. Assert: _intrinsicDefaultProto_ is this specification's name of an intrinsic object. The corresponding object must be an intrinsic that is intended to be used as the [[Prototype]] value of an object.
         1. Let _proto_ be ? GetPrototypeFromConstructor(_constructor_, _intrinsicDefaultProto_).
-        1. Return ! OrdinaryObjectCreate(_proto_, _internalSlotsList_).
+        1. Return OrdinaryObjectCreate(_proto_, _internalSlotsList_).
       </emu-alg>
     </emu-clause>
 
@@ -12975,7 +13015,7 @@
         GetPrototypeFromConstructor (
           _constructor_: a function object,
           _intrinsicDefaultProto_: a String,
-        )
+        ): either a normal completion containing an Object or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -12999,7 +13039,7 @@
         RequireInternalSlot (
           _O_: unknown,
           _internalSlot_: unknown,
-        )
+        ): either a normal completion containing ~unused~ or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -13008,6 +13048,7 @@
       <emu-alg>
         1. If Type(_O_) is not Object, throw a *TypeError* exception.
         1. If _O_ does not have an _internalSlot_ internal slot, throw a *TypeError* exception.
+        1. Return ~unused~.
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -13203,7 +13244,7 @@
         [[Call]] (
           _thisArgument_: an ECMAScript language value,
           _argumentsList_: a List of ECMAScript language values,
-        )
+        ): either a normal completion containing an ECMAScript language value or an abrupt completion
       </h1>
       <dl class="header">
         <dt>for</dt>
@@ -13219,11 +13260,11 @@
           1. Remove _calleeContext_ from the execution context stack and restore _callerContext_ as the running execution context.
           1. Return ThrowCompletion(_error_).
         1. Perform OrdinaryCallBindThis(_F_, _calleeContext_, _thisArgument_).
-        1. Let _result_ be OrdinaryCallEvaluateBody(_F_, _argumentsList_).
+        1. Let _result_ be Completion(OrdinaryCallEvaluateBody(_F_, _argumentsList_)).
         1. [id="step-call-pop-context-stack"] Remove _calleeContext_ from the execution context stack and restore _callerContext_ as the running execution context.
-        1. If _result_.[[Type]] is ~return~, return NormalCompletion(_result_.[[Value]]).
+        1. If _result_.[[Type]] is ~return~, return _result_.[[Value]].
         1. ReturnIfAbrupt(_result_).
-        1. Return NormalCompletion(*undefined*).
+        1. Return *undefined*.
       </emu-alg>
       <emu-note>
         <p>When _calleeContext_ is removed from the execution context stack in step <emu-xref href="#step-call-pop-context-stack"></emu-xref> it must not be destroyed if it is suspended and retained for later resumption by an accessible Generator.</p>
@@ -13234,7 +13275,7 @@
           PrepareForOrdinaryCall (
             _F_: a function object,
             _newTarget_: an Object or *undefined*,
-          )
+          ): an execution context
         </h1>
         <dl class="header">
         </dl>
@@ -13262,13 +13303,13 @@
             _F_: a function object,
             _calleeContext_: an execution context,
             _thisArgument_: an ECMAScript language value,
-          )
+          ): ~unused~
         </h1>
         <dl class="header">
         </dl>
         <emu-alg>
           1. Let _thisMode_ be _F_.[[ThisMode]].
-          1. If _thisMode_ is ~lexical~, return NormalCompletion(*undefined*).
+          1. If _thisMode_ is ~lexical~, return ~unused~.
           1. Let _calleeRealm_ be _F_.[[Realm]].
           1. Let _localEnv_ be the LexicalEnvironment of _calleeContext_.
           1. If _thisMode_ is ~strict~, let _thisValue_ be _thisArgument_.
@@ -13282,7 +13323,8 @@
               1. NOTE: ToObject produces wrapper objects using _calleeRealm_.
           1. Assert: _localEnv_ is a function Environment Record.
           1. Assert: The next step never returns an abrupt completion because _localEnv_.[[ThisBindingStatus]] is not ~initialized~.
-          1. Return _localEnv_.BindThisValue(_thisValue_).
+          1. Perform ! _localEnv_.BindThisValue(_thisValue_).
+          1. Return ~unused~.
         </emu-alg>
       </emu-clause>
 
@@ -13291,7 +13333,7 @@
           Runtime Semantics: EvaluateBody (
             _functionObject_: unknown,
             _argumentsList_: a List,
-          )
+          ): either a normal completion containing an ECMAScript language value or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
@@ -13333,7 +13375,7 @@
           1. Assert: _argumentsList_ is empty.
           1. Assert: _functionObject_.[[ClassFieldInitializerName]] is not ~empty~.
           1. If IsAnonymousFunctionDefinition(|AssignmentExpression|) is *true*, then
-            1. Let _value_ be NamedEvaluation of |Initializer| with argument _functionObject_.[[ClassFieldInitializerName]].
+            1. Let _value_ be ? NamedEvaluation of |Initializer| with argument _functionObject_.[[ClassFieldInitializerName]].
           1. Else,
             1. Let _rhs_ be the result of evaluating |AssignmentExpression|.
             1. Let _value_ be ? GetValue(_rhs_).
@@ -13356,12 +13398,12 @@
           OrdinaryCallEvaluateBody (
             _F_: a function object,
             _argumentsList_: a List,
-          )
+          ): either a normal completion containing an ECMAScript language value or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
         <emu-alg>
-          1. Return the result of EvaluateBody of the parsed code that is _F_.[[ECMAScriptCode]] with arguments _F_ and _argumentsList_.
+          1. Return ? EvaluateBody of _F_.[[ECMAScriptCode]] with arguments _F_ and _argumentsList_.
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -13371,7 +13413,7 @@
         [[Construct]] (
           _argumentsList_: a List of ECMAScript language values,
           _newTarget_: a constructor,
-        )
+        ): either a normal completion containing an Object or an abrupt completion
       </h1>
       <dl class="header">
         <dt>for</dt>
@@ -13386,19 +13428,21 @@
         1. Assert: _calleeContext_ is now the running execution context.
         1. If _kind_ is ~base~, then
           1. Perform OrdinaryCallBindThis(_F_, _calleeContext_, _thisArgument_).
-          1. Let _initializeResult_ be InitializeInstanceElements(_thisArgument_, _F_).
+          1. Let _initializeResult_ be Completion(InitializeInstanceElements(_thisArgument_, _F_)).
           1. If _initializeResult_ is an abrupt completion, then
             1. Remove _calleeContext_ from the execution context stack and restore _callerContext_ as the running execution context.
-            1. Return Completion(_initializeResult_).
+            1. Return ? _initializeResult_.
         1. Let _constructorEnv_ be the LexicalEnvironment of _calleeContext_.
-        1. Let _result_ be OrdinaryCallEvaluateBody(_F_, _argumentsList_).
+        1. Let _result_ be Completion(OrdinaryCallEvaluateBody(_F_, _argumentsList_)).
         1. Remove _calleeContext_ from the execution context stack and restore _callerContext_ as the running execution context.
         1. If _result_.[[Type]] is ~return~, then
-          1. If Type(_result_.[[Value]]) is Object, return NormalCompletion(_result_.[[Value]]).
-          1. If _kind_ is ~base~, return NormalCompletion(_thisArgument_).
+          1. If Type(_result_.[[Value]]) is Object, return _result_.[[Value]].
+          1. If _kind_ is ~base~, return _thisArgument_.
           1. If _result_.[[Value]] is not *undefined*, throw a *TypeError* exception.
         1. Else, ReturnIfAbrupt(_result_).
-        1. Return ? _constructorEnv_.GetThisBinding().
+        1. Let _thisBinding_ be ? _constructorEnv_.GetThisBinding().
+        1. Assert: Type(_thisBinding_) is Object.
+        1. Return _thisBinding_.
       </emu-alg>
     </emu-clause>
 
@@ -13412,7 +13456,7 @@
           _thisMode_: ~lexical-this~ or ~non-lexical-this~,
           _env_: an Environment Record,
           _privateEnv_: a PrivateEnvironment Record or *null*,
-        )
+        ): a function object
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -13420,7 +13464,7 @@
       </dl>
       <emu-alg>
         1. Let _internalSlotsList_ be the internal slots listed in <emu-xref href="#table-internal-slots-of-ecmascript-function-objects"></emu-xref>.
-        1. Let _F_ be ! OrdinaryObjectCreate(_functionPrototype_, _internalSlotsList_).
+        1. Let _F_ be OrdinaryObjectCreate(_functionPrototype_, _internalSlotsList_).
         1. Set _F_.[[Call]] to the definition specified in <emu-xref href="#sec-ecmascript-function-objects-call-thisargument-argumentslist"></emu-xref>.
         1. Set _F_.[[SourceText]] to _sourceText_.
         1. Set _F_.[[FormalParameters]] to _ParameterList_.
@@ -13440,7 +13484,7 @@
         1. Set _F_.[[PrivateMethods]] to a new empty List.
         1. Set _F_.[[ClassFieldInitializerName]] to ~empty~.
         1. Let _len_ be the ExpectedArgumentCount of _ParameterList_.
-        1. Perform ! SetFunctionLength(_F_, _len_).
+        1. Perform SetFunctionLength(_F_, _len_).
         1. Return _F_.
       </emu-alg>
     </emu-clause>
@@ -13450,7 +13494,7 @@
         AddRestrictedFunctionProperties (
           _F_: a function object,
           _realm_: a Realm Record,
-        )
+        ): ~unused~
       </h1>
       <dl class="header">
       </dl>
@@ -13458,7 +13502,8 @@
         1. Assert: _realm_.[[Intrinsics]].[[%ThrowTypeError%]] exists and has been initialized.
         1. Let _thrower_ be _realm_.[[Intrinsics]].[[%ThrowTypeError%]].
         1. Perform ! DefinePropertyOrThrow(_F_, *"caller"*, PropertyDescriptor { [[Get]]: _thrower_, [[Set]]: _thrower_, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
-        1. Return ! DefinePropertyOrThrow(_F_, *"arguments"*, PropertyDescriptor { [[Get]]: _thrower_, [[Set]]: _thrower_, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
+        1. Perform ! DefinePropertyOrThrow(_F_, *"arguments"*, PropertyDescriptor { [[Get]]: _thrower_, [[Set]]: _thrower_, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
+        1. Return ~unused~.
       </emu-alg>
 
       <emu-clause id="sec-%throwtypeerror%">
@@ -13479,7 +13524,7 @@
           _F_: an ECMAScript function object or a built-in function object,
           optional _writablePrototype_: a Boolean,
           optional _prototype_: an Object,
-        )
+        ): ~unused~
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -13495,10 +13540,10 @@
         1. Set _F_.[[ConstructorKind]] to ~base~.
         1. If _writablePrototype_ is not present, set _writablePrototype_ to *true*.
         1. If _prototype_ is not present, then
-          1. Set _prototype_ to ! OrdinaryObjectCreate(%Object.prototype%).
+          1. Set _prototype_ to OrdinaryObjectCreate(%Object.prototype%).
           1. Perform ! DefinePropertyOrThrow(_prototype_, *"constructor"*, PropertyDescriptor { [[Value]]: _F_, [[Writable]]: _writablePrototype_, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
         1. Perform ! DefinePropertyOrThrow(_F_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: _writablePrototype_, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
-        1. Return NormalCompletion(*undefined*).
+        1. Return ~unused~.
       </emu-alg>
     </emu-clause>
 
@@ -13506,14 +13551,14 @@
       <h1>
         MakeClassConstructor (
           _F_: an ECMAScript function object,
-        )
+        ): ~unused~
       </h1>
       <dl class="header">
       </dl>
       <emu-alg>
         1. Assert: _F_.[[IsClassConstructor]] is *false*.
         1. Set _F_.[[IsClassConstructor]] to *true*.
-        1. Return NormalCompletion(*undefined*).
+        1. Return ~unused~.
       </emu-alg>
     </emu-clause>
 
@@ -13522,7 +13567,7 @@
         MakeMethod (
           _F_: an ECMAScript function object,
           _homeObject_: an Object,
-        )
+        ): ~unused~
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -13530,7 +13575,7 @@
       </dl>
       <emu-alg>
         1. Set _F_.[[HomeObject]] to _homeObject_.
-        1. Return NormalCompletion(*undefined*).
+        1. Return ~unused~.
       </emu-alg>
     </emu-clause>
 
@@ -13541,17 +13586,18 @@
           _key_: a property key or Private Name,
           _closure_: a function object,
           _enumerable_: a Boolean,
-        )
+        ): a PrivateElement or ~unused~
       </h1>
       <dl class="header">
       </dl>
       <emu-alg>
+        1. Assert: _homeObject_ is an ordinary, extensible object with no non-configurable properties.
         1. If _key_ is a Private Name, then
           1. Return PrivateElement { [[Key]]: _key_, [[Kind]]: ~method~, [[Value]]: _closure_ }.
         1. Else,
           1. Let _desc_ be the PropertyDescriptor { [[Value]]: _closure_, [[Writable]]: *true*, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
-          1. Perform ? DefinePropertyOrThrow(_homeObject_, _key_, _desc_).
-          1. Return ~empty~.
+          1. Perform ! DefinePropertyOrThrow(_homeObject_, _key_, _desc_).
+          1. Return ~unused~.
       </emu-alg>
     </emu-clause>
 
@@ -13561,7 +13607,7 @@
           _F_: a function object,
           _name_: a property key or Private Name,
           optional _prefix_: a String,
-        )
+        ): ~unused~
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -13581,7 +13627,8 @@
           1. Set _name_ to the string-concatenation of _prefix_, the code unit 0x0020 (SPACE), and _name_.
           1. If _F_ has an [[InitialName]] internal slot, then
             1. Optionally, set _F_.[[InitialName]] to _name_.
-        1. Return ! DefinePropertyOrThrow(_F_, *"name"*, PropertyDescriptor { [[Value]]: _name_, [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
+        1. Perform ! DefinePropertyOrThrow(_F_, *"name"*, PropertyDescriptor { [[Value]]: _name_, [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
+        1. Return ~unused~.
       </emu-alg>
     </emu-clause>
 
@@ -13590,7 +13637,7 @@
         SetFunctionLength (
           _F_: a function object,
           _length_: a non-negative integer or +&infin;,
-        )
+        ): ~unused~
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -13598,7 +13645,8 @@
       </dl>
       <emu-alg>
         1. Assert: _F_ is an extensible object that does not have a *"length"* own property.
-        1. Return ! DefinePropertyOrThrow(_F_, *"length"*, PropertyDescriptor { [[Value]]: 𝔽(_length_), [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
+        1. Perform ! DefinePropertyOrThrow(_F_, *"length"*, PropertyDescriptor { [[Value]]: 𝔽(_length_), [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
+        1. Return ~unused~.
       </emu-alg>
     </emu-clause>
 
@@ -13607,7 +13655,7 @@
         FunctionDeclarationInstantiation (
           _func_: a function object,
           _argumentsList_: unknown,
-        )
+        ): either a normal completion containing ~unused~ or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -13663,7 +13711,7 @@
           1. Assert: The VariableEnvironment of _calleeContext_ is _calleeEnv_.
           1. Set the LexicalEnvironment of _calleeContext_ to _env_.
         1. For each String _paramName_ of _parameterNames_, do
-          1. Let _alreadyDeclared_ be _env_.HasBinding(_paramName_).
+          1. Let _alreadyDeclared_ be ! _env_.HasBinding(_paramName_).
           1. NOTE: Early errors ensure that duplicate parameter names can only occur in non-strict functions that do not have parameter default values or rest parameters.
           1. If _alreadyDeclared_ is *false*, then
             1. Perform ! _env_.CreateMutableBinding(_paramName_, *false*).
@@ -13679,7 +13727,7 @@
             1. Perform ! _env_.CreateImmutableBinding(*"arguments"*, *false*).
           1. Else,
             1. Perform ! _env_.CreateMutableBinding(*"arguments"*, *false*).
-          1. Call _env_.InitializeBinding(*"arguments"*, _ao_).
+          1. Perform ! _env_.InitializeBinding(*"arguments"*, _ao_).
           1. Let _parameterBindings_ be the list-concatenation of _parameterNames_ and &laquo; *"arguments"* &raquo;.
         1. Else,
           1. Let _parameterBindings_ be _parameterNames_.
@@ -13695,7 +13743,7 @@
             1. If _n_ is not an element of _instantiatedVarNames_, then
               1. Append _n_ to _instantiatedVarNames_.
               1. Perform ! _env_.CreateMutableBinding(_n_, *false*).
-              1. Call _env_.InitializeBinding(_n_, *undefined*).
+              1. Perform ! _env_.InitializeBinding(_n_, *undefined*).
           1. Let _varEnv_ be _env_.
         1. Else,
           1. NOTE: A separate Environment Record is needed to ensure that closures created by expressions in the formal parameter list do not have visibility of declarations in the function body.
@@ -13709,7 +13757,7 @@
               1. If _n_ is not an element of _parameterBindings_ or if _n_ is an element of _functionNames_, let _initialValue_ be *undefined*.
               1. Else,
                 1. Let _initialValue_ be ! _env_.GetBindingValue(_n_, *false*).
-              1. Call _varEnv_.InitializeBinding(_n_, _initialValue_).
+              1. Perform ! _varEnv_.InitializeBinding(_n_, _initialValue_).
               1. NOTE: A var with the same name as a formal parameter initially has the same value as the corresponding initialized parameter.
         1. [id="step-functiondeclarationinstantiation-web-compat-insertion-point"] NOTE: Annex <emu-xref href="#sec-web-compat-functiondeclarationinstantiation"></emu-xref> adds additional steps at this point.
         1. If _strict_ is *false*, then
@@ -13730,7 +13778,7 @@
           1. Let _fn_ be the sole element of the BoundNames of _f_.
           1. Let _fo_ be InstantiateFunctionObject of _f_ with arguments _lexEnv_ and _privateEnv_.
           1. Perform ! _varEnv_.SetMutableBinding(_fn_, _fo_, *false*).
-        1. Return NormalCompletion(~empty~).
+        1. Return ~unused~.
       </emu-alg>
       <emu-note>
         <p><emu-xref href="#sec-block-level-function-declarations-web-legacy-compatibility-semantics"></emu-xref> provides an extension to the above algorithm that is necessary for backwards compatibility with web browser implementations of ECMAScript that predate ECMAScript 2015.</p>
@@ -13754,7 +13802,7 @@
         [[Call]] (
           _thisArgument_: an ECMAScript language value,
           _argumentsList_: a List of ECMAScript language values,
-        )
+        ): either a normal completion containing an ECMAScript language value or an abrupt completion
       </h1>
       <dl class="header">
         <dt>for</dt>
@@ -13772,7 +13820,7 @@
         1. Push _calleeContext_ onto the execution context stack; _calleeContext_ is now the running execution context.
         1. [id="step-call-builtin-function-result"] Let _result_ be the Completion Record that is the result of evaluating _F_ in a manner that conforms to the specification of _F_. _thisArgument_ is the *this* value, _argumentsList_ provides the named parameters, and the NewTarget value is *undefined*.
         1. Remove _calleeContext_ from the execution context stack and restore _callerContext_ as the running execution context.
-        1. Return _result_.
+        1. Return ? _result_.
       </emu-alg>
       <emu-note>
         <p>When _calleeContext_ is removed from the execution context stack it must not be destroyed if it has been suspended and retained by an accessible Generator for later resumption.</p>
@@ -13784,7 +13832,7 @@
         [[Construct]] (
           _argumentsList_: a List of ECMAScript language values,
           _newTarget_: a constructor,
-        )
+        ): either a normal completion containing an Object or an abrupt completion
       </h1>
       <dl class="header">
         <dt>for</dt>
@@ -13808,7 +13856,7 @@
           optional _realm_: a Realm Record,
           optional _prototype_: an Object or *null*,
           optional _prefix_: a String,
-        )
+        ): a function object
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -13824,11 +13872,11 @@
         1. Set _func_.[[Extensible]] to *true*.
         1. Set _func_.[[Realm]] to _realm_.
         1. Set _func_.[[InitialName]] to *null*.
-        1. Perform ! SetFunctionLength(_func_, _length_).
+        1. Perform SetFunctionLength(_func_, _length_).
         1. If _prefix_ is not present, then
-          1. Perform ! SetFunctionName(_func_, _name_).
+          1. Perform SetFunctionName(_func_, _name_).
         1. Else,
-          1. Perform ! SetFunctionName(_func_, _name_, _prefix_).
+          1. Perform SetFunctionName(_func_, _name_, _prefix_).
         1. Return _func_.
       </emu-alg>
       <p>Each built-in function defined in this specification is created by calling the CreateBuiltinFunction abstract operation.</p>
@@ -13900,7 +13948,7 @@
           [[Call]] (
             _thisArgument_: an ECMAScript language value,
             _argumentsList_: a List of ECMAScript language values,
-          )
+          ): either a normal completion containing an ECMAScript language value or an abrupt completion
         </h1>
         <dl class="header">
           <dt>for</dt>
@@ -13920,7 +13968,7 @@
           [[Construct]] (
             _argumentsList_: a List of ECMAScript language values,
             _newTarget_: a constructor,
-          )
+          ): either a normal completion containing an Object or an abrupt completion
         </h1>
         <dl class="header">
           <dt>for</dt>
@@ -13942,7 +13990,7 @@
             _targetFunction_: a function object,
             _boundThis_: an ECMAScript language value,
             _boundArgs_: a List of ECMAScript language values,
-          )
+          ): either a normal completion containing a function object or an abrupt completion
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -13951,7 +13999,7 @@
         <emu-alg>
           1. Let _proto_ be ? <emu-meta effects="user-code">_targetFunction_.[[GetPrototypeOf]]</emu-meta>().
           1. Let _internalSlotsList_ be the list-concatenation of &laquo; [[Prototype]], [[Extensible]] &raquo; and the internal slots listed in <emu-xref href="#table-internal-slots-of-bound-function-exotic-objects"></emu-xref>.
-          1. Let _obj_ be ! MakeBasicObject(_internalSlotsList_).
+          1. Let _obj_ be MakeBasicObject(_internalSlotsList_).
           1. Set _obj_.[[Prototype]] to _proto_.
           1. Set _obj_.[[Call]] as described in <emu-xref href="#sec-bound-function-exotic-objects-call-thisargument-argumentslist"></emu-xref>.
           1. If IsConstructor(_targetFunction_) is *true*, then
@@ -13978,7 +14026,7 @@
           [[DefineOwnProperty]] (
             _P_: a property key,
             _Desc_: a Property Descriptor,
-          )
+          ): either a normal completion containing a Boolean or an abrupt completion
         </h1>
         <dl class="header">
           <dt>for</dt>
@@ -13989,7 +14037,7 @@
             1. Return ? ArraySetLength(_A_, _Desc_).
           1. Else if _P_ is an array index, then
             1. Let _oldLenDesc_ be OrdinaryGetOwnProperty(_A_, *"length"*).
-            1. Assert: ! IsDataDescriptor(_oldLenDesc_) is *true*.
+            1. Assert: IsDataDescriptor(_oldLenDesc_) is *true*.
             1. Assert: _oldLenDesc_.[[Configurable]] is *false*.
             1. Let _oldLen_ be _oldLenDesc_.[[Value]].
             1. Assert: _oldLen_ is a non-negative integral Number.
@@ -13999,10 +14047,10 @@
             1. If _succeeded_ is *false*, return *false*.
             1. If _index_ &ge; _oldLen_, then
               1. Set _oldLenDesc_.[[Value]] to _index_ + *1*<sub>𝔽</sub>.
-              1. Set _succeeded_ to OrdinaryDefineOwnProperty(_A_, *"length"*, _oldLenDesc_).
+              1. Set _succeeded_ to ! OrdinaryDefineOwnProperty(_A_, *"length"*, _oldLenDesc_).
               1. Assert: _succeeded_ is *true*.
             1. Return *true*.
-          1. Return OrdinaryDefineOwnProperty(_A_, _P_, _Desc_).
+          1. Return ? OrdinaryDefineOwnProperty(_A_, _P_, _Desc_).
         </emu-alg>
       </emu-clause>
 
@@ -14011,7 +14059,7 @@
           ArrayCreate (
             _length_: a non-negative integer,
             optional _proto_: unknown,
-          )
+          ): either a normal completion containing an Array exotic object or an abrupt completion
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -14020,7 +14068,7 @@
         <emu-alg>
           1. If _length_ &gt; 2<sup>32</sup> - 1, throw a *RangeError* exception.
           1. If _proto_ is not present, set _proto_ to %Array.prototype%.
-          1. Let _A_ be ! MakeBasicObject(&laquo; [[Prototype]], [[Extensible]] &raquo;).
+          1. Let _A_ be MakeBasicObject(&laquo; [[Prototype]], [[Extensible]] &raquo;).
           1. Set _A_.[[Prototype]] to _proto_.
           1. Set _A_.[[DefineOwnProperty]] as specified in <emu-xref href="#sec-array-exotic-objects-defineownproperty-p-desc"></emu-xref>.
           1. Perform ! OrdinaryDefineOwnProperty(_A_, *"length"*, PropertyDescriptor { [[Value]]: 𝔽(_length_), [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
@@ -14033,7 +14081,7 @@
           ArraySpeciesCreate (
             _originalArray_: unknown,
             _length_: a non-negative integer,
-          )
+          ): either a normal completion containing an Object or an abrupt completion
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -14065,24 +14113,24 @@
           ArraySetLength (
             _A_: an Array,
             _Desc_: a Property Descriptor,
-          )
+          ): either a normal completion containing a Boolean or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
         <emu-alg>
           1. If _Desc_ does not have a [[Value]] field, then
-            1. Return OrdinaryDefineOwnProperty(_A_, *"length"*, _Desc_).
+            1. Return ! OrdinaryDefineOwnProperty(_A_, *"length"*, _Desc_).
           1. Let _newLenDesc_ be a copy of _Desc_.
           1. [id="step-arraysetlength-newlen"] Let _newLen_ be ? ToUint32(_Desc_.[[Value]]).
           1. [id="step-arraysetlength-numberlen"] Let _numberLen_ be ? ToNumber(_Desc_.[[Value]]).
           1. If SameValueZero(_newLen_, _numberLen_) is *false*, throw a *RangeError* exception.
           1. Set _newLenDesc_.[[Value]] to _newLen_.
           1. Let _oldLenDesc_ be OrdinaryGetOwnProperty(_A_, *"length"*).
-          1. Assert: ! IsDataDescriptor(_oldLenDesc_) is *true*.
+          1. Assert: IsDataDescriptor(_oldLenDesc_) is *true*.
           1. Assert: _oldLenDesc_.[[Configurable]] is *false*.
           1. Let _oldLen_ be _oldLenDesc_.[[Value]].
           1. If _newLen_ &ge; _oldLen_, then
-            1. Return OrdinaryDefineOwnProperty(_A_, *"length"*, _newLenDesc_).
+            1. Return ! OrdinaryDefineOwnProperty(_A_, *"length"*, _newLenDesc_).
           1. If _oldLenDesc_.[[Writable]] is *false*, return *false*.
           1. If _newLenDesc_ does not have a [[Writable]] field or _newLenDesc_.[[Writable]] is *true*, let _newWritable_ be *true*.
           1. Else,
@@ -14121,7 +14169,7 @@
         <h1>
           [[GetOwnProperty]] (
             _P_: a property key,
-          )
+          ): a normal completion containing either a Property Descriptor or *undefined*
         </h1>
         <dl class="header">
           <dt>for</dt>
@@ -14130,7 +14178,7 @@
         <emu-alg>
           1. Let _desc_ be OrdinaryGetOwnProperty(_S_, _P_).
           1. If _desc_ is not *undefined*, return _desc_.
-          1. Return ! StringGetOwnProperty(_S_, _P_).
+          1. Return StringGetOwnProperty(_S_, _P_).
         </emu-alg>
       </emu-clause>
 
@@ -14139,23 +14187,23 @@
           [[DefineOwnProperty]] (
             _P_: a property key,
             _Desc_: a Property Descriptor,
-          )
+          ): a normal completion containing a Boolean
         </h1>
         <dl class="header">
           <dt>for</dt>
           <dd>a String exotic object _S_</dd>
         </dl>
         <emu-alg>
-          1. Let _stringDesc_ be ! StringGetOwnProperty(_S_, _P_).
+          1. Let _stringDesc_ be StringGetOwnProperty(_S_, _P_).
           1. If _stringDesc_ is not *undefined*, then
             1. Let _extensible_ be _S_.[[Extensible]].
-            1. Return ! IsCompatiblePropertyDescriptor(_extensible_, _Desc_, _stringDesc_).
+            1. Return IsCompatiblePropertyDescriptor(_extensible_, _Desc_, _stringDesc_).
           1. Return ! OrdinaryDefineOwnProperty(_S_, _P_, _Desc_).
         </emu-alg>
       </emu-clause>
 
       <emu-clause id="sec-string-exotic-objects-ownpropertykeys" type="internal method">
-        <h1>[[OwnPropertyKeys]] ( )</h1>
+        <h1>[[OwnPropertyKeys]] ( ): a normal completion containing a List of property keys</h1>
         <dl class="header">
           <dt>for</dt>
           <dd>a String exotic object _O_</dd>
@@ -14182,14 +14230,14 @@
           StringCreate (
             _value_: a String,
             _prototype_: unknown,
-          )
+          ): a String exotic object
         </h1>
         <dl class="header">
           <dt>description</dt>
           <dd>It is used to specify the creation of new String exotic objects.</dd>
         </dl>
         <emu-alg>
-          1. Let _S_ be ! MakeBasicObject(&laquo; [[Prototype]], [[Extensible]], [[StringData]] &raquo;).
+          1. Let _S_ be MakeBasicObject(&laquo; [[Prototype]], [[Extensible]], [[StringData]] &raquo;).
           1. Set _S_.[[Prototype]] to _prototype_.
           1. Set _S_.[[StringData]] to _value_.
           1. Set _S_.[[GetOwnProperty]] as specified in <emu-xref href="#sec-string-exotic-objects-getownproperty-p"></emu-xref>.
@@ -14206,13 +14254,13 @@
           StringGetOwnProperty (
             _S_: an Object that has a [[StringData]] internal slot,
             _P_: a property key,
-          )
+          ): a Property Descriptor or *undefined*
         </h1>
         <dl class="header">
         </dl>
         <emu-alg>
           1. If Type(_P_) is not String, return *undefined*.
-          1. Let _index_ be ! CanonicalNumericIndexString(_P_).
+          1. Let _index_ be CanonicalNumericIndexString(_P_).
           1. If _index_ is *undefined*, return *undefined*.
           1. If IsIntegralNumber(_index_) is *false*, return *undefined*.
           1. If _index_ is *-0*<sub>𝔽</sub>, return *undefined*.
@@ -14256,7 +14304,7 @@
         <h1>
           [[GetOwnProperty]] (
             _P_: a property key,
-          )
+          ): a normal completion containing either a Property Descriptor or *undefined*
         </h1>
         <dl class="header">
           <dt>for</dt>
@@ -14268,7 +14316,7 @@
           1. Let _map_ be _args_.[[ParameterMap]].
           1. Let _isMapped_ be ! HasOwnProperty(_map_, _P_).
           1. If _isMapped_ is *true*, then
-            1. Set _desc_.[[Value]] to Get(_map_, _P_).
+            1. Set _desc_.[[Value]] to ! Get(_map_, _P_).
           1. Return _desc_.
         </emu-alg>
       </emu-clause>
@@ -14278,7 +14326,7 @@
           [[DefineOwnProperty]] (
             _P_: a property key,
             _Desc_: a Property Descriptor,
-          )
+          ): a normal completion containing a Boolean
         </h1>
         <dl class="header">
           <dt>for</dt>
@@ -14286,23 +14334,23 @@
         </dl>
         <emu-alg>
           1. Let _map_ be _args_.[[ParameterMap]].
-          1. Let _isMapped_ be HasOwnProperty(_map_, _P_).
+          1. Let _isMapped_ be ! HasOwnProperty(_map_, _P_).
           1. Let _newArgDesc_ be _Desc_.
           1. If _isMapped_ is *true* and IsDataDescriptor(_Desc_) is *true*, then
             1. If _Desc_ does not have a [[Value]] field, and _Desc_ has a [[Writable]] field, and _Desc_.[[Writable]] is *false*, then
               1. Set _newArgDesc_ to a copy of _Desc_.
-              1. Set _newArgDesc_.[[Value]] to Get(_map_, _P_).
-          1. Let _allowed_ be ? OrdinaryDefineOwnProperty(_args_, _P_, _newArgDesc_).
+              1. Set _newArgDesc_.[[Value]] to ! Get(_map_, _P_).
+          1. Let _allowed_ be ! OrdinaryDefineOwnProperty(_args_, _P_, _newArgDesc_).
           1. If _allowed_ is *false*, return *false*.
           1. If _isMapped_ is *true*, then
             1. If IsAccessorDescriptor(_Desc_) is *true*, then
-              1. Call <emu-meta effects="user-code">_map_.[[Delete]]</emu-meta>(_P_).
+              1. Perform ! _map_.[[Delete]](_P_).
             1. Else,
               1. If _Desc_ has a [[Value]] field, then
-                1. Let _setStatus_ be Set(_map_, _P_, _Desc_.[[Value]], *false*).
-                1. Assert: _setStatus_ is *true* because formal parameters mapped by argument objects are always writable.
+                1. Assert: The following Set will succeed, since formal parameters mapped by arguments objects are always writable.
+                1. Perform ! Set(_map_, _P_, _Desc_.[[Value]], *false*).
               1. If _Desc_ has a [[Writable]] field and _Desc_.[[Writable]] is *false*, then
-                1. Call <emu-meta effects="user-code">_map_.[[Delete]]</emu-meta>(_P_).
+                1. Perform ! _map_.[[Delete]](_P_).
           1. Return *true*.
         </emu-alg>
       </emu-clause>
@@ -14312,7 +14360,7 @@
           [[Get]] (
             _P_: a property key,
             _Receiver_: an ECMAScript language value,
-          )
+          ): either a normal completion containing an ECMAScript language value or an abrupt completion
         </h1>
         <dl class="header">
           <dt>for</dt>
@@ -14325,7 +14373,7 @@
             1. Return ? OrdinaryGet(_args_, _P_, _Receiver_).
           1. Else,
             1. Assert: _map_ contains a formal parameter mapping for _P_.
-            1. Return Get(_map_, _P_).
+            1. Return ! Get(_map_, _P_).
         </emu-alg>
       </emu-clause>
 
@@ -14335,7 +14383,7 @@
             _P_: a property key,
             _V_: an ECMAScript language value,
             _Receiver_: an ECMAScript language value,
-          )
+          ): either a normal completion containing a Boolean or an abrupt completion
         </h1>
         <dl class="header">
           <dt>for</dt>
@@ -14348,8 +14396,8 @@
             1. Let _map_ be _args_.[[ParameterMap]].
             1. Let _isMapped_ be ! HasOwnProperty(_map_, _P_).
           1. If _isMapped_ is *true*, then
-            1. Let _setStatus_ be Set(_map_, _P_, _V_, *false*).
-            1. Assert: _setStatus_ is *true* because formal parameters mapped by argument objects are always writable.
+            1. Assert: The following Set will succeed, since formal parameters mapped by arguments objects are always writable.
+            1. Perform ! Set(_map_, _P_, _V_, *false*).
           1. Return ? OrdinarySet(_args_, _P_, _V_, _Receiver_).
         </emu-alg>
       </emu-clause>
@@ -14358,7 +14406,7 @@
         <h1>
           [[Delete]] (
             _P_: a property key,
-          )
+          ): either a normal completion containing a Boolean or an abrupt completion
         </h1>
         <dl class="header">
           <dt>for</dt>
@@ -14369,7 +14417,7 @@
           1. Let _isMapped_ be ! HasOwnProperty(_map_, _P_).
           1. Let _result_ be ? OrdinaryDelete(_args_, _P_).
           1. If _result_ is *true* and _isMapped_ is *true*, then
-            1. Call <emu-meta effects="user-code">_map_.[[Delete]]</emu-meta>(_P_).
+            1. Perform ! _map_.[[Delete]](_P_).
           1. Return _result_.
         </emu-alg>
       </emu-clause>
@@ -14378,15 +14426,15 @@
         <h1>
           CreateUnmappedArgumentsObject (
             _argumentsList_: unknown,
-          )
+          ): an arguments exotic object
         </h1>
         <dl class="header">
         </dl>
         <emu-alg>
           1. Let _len_ be the number of elements in _argumentsList_.
-          1. Let _obj_ be ! OrdinaryObjectCreate(%Object.prototype%, &laquo; [[ParameterMap]] &raquo;).
+          1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%, &laquo; [[ParameterMap]] &raquo;).
           1. Set _obj_.[[ParameterMap]] to *undefined*.
-          1. Perform DefinePropertyOrThrow(_obj_, *"length"*, PropertyDescriptor { [[Value]]: 𝔽(_len_), [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
+          1. Perform ! DefinePropertyOrThrow(_obj_, *"length"*, PropertyDescriptor { [[Value]]: 𝔽(_len_), [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
           1. Let _index_ be 0.
           1. Repeat, while _index_ &lt; _len_,
             1. Let _val_ be _argumentsList_[_index_].
@@ -14405,21 +14453,21 @@
             _formals_: a Parse Node,
             _argumentsList_: a List,
             _env_: an Environment Record,
-          )
+          ): an arguments exotic object
         </h1>
         <dl class="header">
         </dl>
         <emu-alg>
           1. Assert: _formals_ does not contain a rest parameter, any binding patterns, or any initializers. It may contain duplicate identifiers.
           1. Let _len_ be the number of elements in _argumentsList_.
-          1. Let _obj_ be ! MakeBasicObject(&laquo; [[Prototype]], [[Extensible]], [[ParameterMap]] &raquo;).
+          1. Let _obj_ be MakeBasicObject(&laquo; [[Prototype]], [[Extensible]], [[ParameterMap]] &raquo;).
           1. Set _obj_.[[GetOwnProperty]] as specified in <emu-xref href="#sec-arguments-exotic-objects-getownproperty-p"></emu-xref>.
           1. Set _obj_.[[DefineOwnProperty]] as specified in <emu-xref href="#sec-arguments-exotic-objects-defineownproperty-p-desc"></emu-xref>.
           1. Set _obj_.[[Get]] as specified in <emu-xref href="#sec-arguments-exotic-objects-get-p-receiver"></emu-xref>.
           1. Set _obj_.[[Set]] as specified in <emu-xref href="#sec-arguments-exotic-objects-set-p-v-receiver"></emu-xref>.
           1. Set _obj_.[[Delete]] as specified in <emu-xref href="#sec-arguments-exotic-objects-delete-p"></emu-xref>.
           1. Set _obj_.[[Prototype]] to %Object.prototype%.
-          1. Let _map_ be ! OrdinaryObjectCreate(*null*).
+          1. Let _map_ be OrdinaryObjectCreate(*null*).
           1. Set _obj_.[[ParameterMap]] to _map_.
           1. Let _parameterNames_ be the BoundNames of _formals_.
           1. Let _numberOfParameters_ be the number of elements in _parameterNames_.
@@ -14438,7 +14486,7 @@
               1. If _index_ &lt; _len_, then
                 1. Let _g_ be MakeArgGetter(_name_, _env_).
                 1. Let _p_ be MakeArgSetter(_name_, _env_).
-                1. Perform <emu-meta effects="user-code">_map_.[[DefineOwnProperty]]</emu-meta>(! ToString(𝔽(_index_)), PropertyDescriptor { [[Set]]: _p_, [[Get]]: _g_, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
+                1. Perform ! _map_.[[DefineOwnProperty]](! ToString(𝔽(_index_)), PropertyDescriptor { [[Set]]: _p_, [[Get]]: _g_, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
             1. Set _index_ to _index_ - 1.
           1. Perform ! DefinePropertyOrThrow(_obj_, @@iterator, PropertyDescriptor { [[Value]]: %Array.prototype.values%, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
           1. Perform ! DefinePropertyOrThrow(_obj_, *"callee"*, PropertyDescriptor { [[Value]]: _func_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
@@ -14450,7 +14498,7 @@
             MakeArgGetter (
               _name_: a String,
               _env_: an Environment Record,
-            )
+            ): a function object
           </h1>
           <dl class="header">
             <dt>description</dt>
@@ -14459,7 +14507,7 @@
           <emu-alg>
             1. Let _getterClosure_ be a new Abstract Closure with no parameters that captures _name_ and _env_ and performs the following steps when called:
               1. Return _env_.GetBindingValue(_name_, *false*).
-            1. Let _getter_ be ! CreateBuiltinFunction(_getterClosure_, 0, *""*, &laquo; &raquo;).
+            1. Let _getter_ be CreateBuiltinFunction(_getterClosure_, 0, *""*, &laquo; &raquo;).
             1. NOTE: _getter_ is never directly accessible to ECMAScript code.
             1. Return _getter_.
           </emu-alg>
@@ -14470,7 +14518,7 @@
             MakeArgSetter (
               _name_: a String,
               _env_: an Environment Record,
-            )
+            ): a function object
           </h1>
           <dl class="header">
             <dt>description</dt>
@@ -14478,8 +14526,8 @@
           </dl>
           <emu-alg>
             1. Let _setterClosure_ be a new Abstract Closure with parameters (_value_) that captures _name_ and _env_ and performs the following steps when called:
-              1. Return _env_.SetMutableBinding(_name_, _value_, *false*).
-            1. Let _setter_ be ! CreateBuiltinFunction(_setterClosure_, 1, *""*, &laquo; &raquo;).
+              1. Return ! _env_.SetMutableBinding(_name_, _value_, *false*).
+            1. Let _setter_ be CreateBuiltinFunction(_setterClosure_, 1, *""*, &laquo; &raquo;).
             1. NOTE: _setter_ is never directly accessible to ECMAScript code.
             1. Return _setter_.
           </emu-alg>
@@ -14497,7 +14545,7 @@
         <h1>
           [[GetOwnProperty]] (
             _P_: a property key,
-          )
+          ): a normal completion containing either a Property Descriptor or *undefined*
         </h1>
         <dl class="header">
           <dt>for</dt>
@@ -14505,9 +14553,9 @@
         </dl>
         <emu-alg>
           1. If Type(_P_) is String, then
-            1. Let _numericIndex_ be ! CanonicalNumericIndexString(_P_).
+            1. Let _numericIndex_ be CanonicalNumericIndexString(_P_).
             1. If _numericIndex_ is not *undefined*, then
-              1. Let _value_ be ! IntegerIndexedElementGet(_O_, _numericIndex_).
+              1. Let _value_ be IntegerIndexedElementGet(_O_, _numericIndex_).
               1. If _value_ is *undefined*, return *undefined*.
               1. Return the PropertyDescriptor { [[Value]]: _value_, [[Writable]]: *true*, [[Enumerable]]: *true*, [[Configurable]]: *true* }.
           1. Return OrdinaryGetOwnProperty(_O_, _P_).
@@ -14518,7 +14566,7 @@
         <h1>
           [[HasProperty]] (
             _P_: a property key,
-          )
+          ): either a normal completion containing a Boolean or an abrupt completion
         </h1>
         <dl class="header">
           <dt>for</dt>
@@ -14526,8 +14574,8 @@
         </dl>
         <emu-alg>
           1. If Type(_P_) is String, then
-            1. Let _numericIndex_ be ! CanonicalNumericIndexString(_P_).
-            1. If _numericIndex_ is not *undefined*, return ! IsValidIntegerIndex(_O_, _numericIndex_).
+            1. Let _numericIndex_ be CanonicalNumericIndexString(_P_).
+            1. If _numericIndex_ is not *undefined*, return IsValidIntegerIndex(_O_, _numericIndex_).
           1. Return ? OrdinaryHasProperty(_O_, _P_).
         </emu-alg>
       </emu-clause>
@@ -14537,7 +14585,7 @@
           [[DefineOwnProperty]] (
             _P_: a property key,
             _Desc_: a Property Descriptor,
-          )
+          ): either a normal completion containing a Boolean or an abrupt completion
         </h1>
         <dl class="header">
           <dt>for</dt>
@@ -14545,12 +14593,12 @@
         </dl>
         <emu-alg>
           1. If Type(_P_) is String, then
-            1. Let _numericIndex_ be ! CanonicalNumericIndexString(_P_).
+            1. Let _numericIndex_ be CanonicalNumericIndexString(_P_).
             1. If _numericIndex_ is not *undefined*, then
-              1. If ! IsValidIntegerIndex(_O_, _numericIndex_) is *false*, return *false*.
+              1. If IsValidIntegerIndex(_O_, _numericIndex_) is *false*, return *false*.
               1. If _Desc_ has a [[Configurable]] field and if _Desc_.[[Configurable]] is *false*, return *false*.
               1. If _Desc_ has an [[Enumerable]] field and if _Desc_.[[Enumerable]] is *false*, return *false*.
-              1. If ! IsAccessorDescriptor(_Desc_) is *true*, return *false*.
+              1. If IsAccessorDescriptor(_Desc_) is *true*, return *false*.
               1. If _Desc_ has a [[Writable]] field and if _Desc_.[[Writable]] is *false*, return *false*.
               1. If _Desc_ has a [[Value]] field, perform ? IntegerIndexedElementSet(_O_, _numericIndex_, _Desc_.[[Value]]).
               1. Return *true*.
@@ -14563,7 +14611,7 @@
           [[Get]] (
             _P_: a property key,
             _Receiver_: an ECMAScript language value,
-          )
+          ): either a normal completion containing an ECMAScript language value or an abrupt completion
         </h1>
         <dl class="header">
           <dt>for</dt>
@@ -14571,9 +14619,9 @@
         </dl>
         <emu-alg>
           1. If Type(_P_) is String, then
-            1. Let _numericIndex_ be ! CanonicalNumericIndexString(_P_).
+            1. Let _numericIndex_ be CanonicalNumericIndexString(_P_).
             1. If _numericIndex_ is not *undefined*, then
-              1. Return ! IntegerIndexedElementGet(_O_, _numericIndex_).
+              1. Return IntegerIndexedElementGet(_O_, _numericIndex_).
           1. Return ? OrdinaryGet(_O_, _P_, _Receiver_).
         </emu-alg>
       </emu-clause>
@@ -14584,7 +14632,7 @@
             _P_: a property key,
             _V_: an ECMAScript language value,
             _Receiver_: an ECMAScript language value,
-          )
+          ): either a normal completion containing a Boolean or an abrupt completion
         </h1>
         <dl class="header">
           <dt>for</dt>
@@ -14592,7 +14640,7 @@
         </dl>
         <emu-alg>
           1. If Type(_P_) is String, then
-            1. Let _numericIndex_ be ! CanonicalNumericIndexString(_P_).
+            1. Let _numericIndex_ be CanonicalNumericIndexString(_P_).
             1. If _numericIndex_ is not *undefined*, then
               1. Perform ? IntegerIndexedElementSet(_O_, _numericIndex_, _V_).
               1. Return *true*.
@@ -14604,7 +14652,7 @@
         <h1>
           [[Delete]] (
             _P_: a property key,
-          )
+          ): a normal completion containing a Boolean
         </h1>
         <dl class="header">
           <dt>for</dt>
@@ -14612,15 +14660,15 @@
         </dl>
         <emu-alg>
           1. If Type(_P_) is String, then
-            1. Let _numericIndex_ be ! CanonicalNumericIndexString(_P_).
+            1. Let _numericIndex_ be CanonicalNumericIndexString(_P_).
             1. If _numericIndex_ is not *undefined*, then
-              1. If ! IsValidIntegerIndex(_O_, _numericIndex_) is *false*, return *true*; else return *false*.
+              1. If IsValidIntegerIndex(_O_, _numericIndex_) is *false*, return *true*; else return *false*.
           1. Return ! OrdinaryDelete(_O_, _P_).
         </emu-alg>
       </emu-clause>
 
       <emu-clause id="sec-integer-indexed-exotic-objects-ownpropertykeys" type="internal method">
-        <h1>[[OwnPropertyKeys]] ( )</h1>
+        <h1>[[OwnPropertyKeys]] ( ): a normal completion containing a List of property keys</h1>
         <dl class="header">
           <dt>for</dt>
           <dd>an Integer-Indexed exotic object _O_</dd>
@@ -14642,7 +14690,7 @@
         <h1>
           IntegerIndexedObjectCreate (
             _prototype_: unknown,
-          )
+          ): an Integer-Indexed exotic object
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -14650,7 +14698,7 @@
         </dl>
         <emu-alg>
           1. Let _internalSlotsList_ be &laquo; [[Prototype]], [[Extensible]], [[ViewedArrayBuffer]], [[TypedArrayName]], [[ContentType]], [[ByteLength]], [[ByteOffset]], [[ArrayLength]] &raquo;.
-          1. Let _A_ be ! MakeBasicObject(_internalSlotsList_).
+          1. Let _A_ be MakeBasicObject(_internalSlotsList_).
           1. Set _A_.[[GetOwnProperty]] as specified in <emu-xref href="#sec-integer-indexed-exotic-objects-getownproperty-p"></emu-xref>.
           1. Set _A_.[[HasProperty]] as specified in <emu-xref href="#sec-integer-indexed-exotic-objects-hasproperty-p"></emu-xref>.
           1. Set _A_.[[DefineOwnProperty]] as specified in <emu-xref href="#sec-integer-indexed-exotic-objects-defineownproperty-p-desc"></emu-xref>.
@@ -14668,13 +14716,13 @@
           IsValidIntegerIndex (
             _O_: an Integer-Indexed exotic object,
             _index_: a Number,
-          )
+          ): a Boolean
         </h1>
         <dl class="header">
         </dl>
         <emu-alg>
           1. If IsDetachedBuffer(_O_.[[ViewedArrayBuffer]]) is *true*, return *false*.
-          1. If ! IsIntegralNumber(_index_) is *false*, return *false*.
+          1. If IsIntegralNumber(_index_) is *false*, return *false*.
           1. If _index_ is *-0*<sub>𝔽</sub>, return *false*.
           1. If ℝ(_index_) &lt; 0 or ℝ(_index_) &ge; _O_.[[ArrayLength]], return *false*.
           1. Return *true*.
@@ -14686,12 +14734,12 @@
           IntegerIndexedElementGet (
             _O_: an Integer-Indexed exotic object,
             _index_: a Number,
-          )
+          ): a Number, a BigInt, or *undefined*
         </h1>
         <dl class="header">
         </dl>
         <emu-alg>
-          1. If ! IsValidIntegerIndex(_O_, _index_) is *false*, return *undefined*.
+          1. If IsValidIntegerIndex(_O_, _index_) is *false*, return *undefined*.
           1. Let _offset_ be _O_.[[ByteOffset]].
           1. Let _arrayTypeName_ be the String value of _O_.[[TypedArrayName]].
           1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _arrayTypeName_.
@@ -14707,21 +14755,21 @@
             _O_: an Integer-Indexed exotic object,
             _index_: a Number,
             _value_: an ECMAScript language value,
-          )
+          ): either a normal completion containing ~unused~ or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
         <emu-alg>
           1. If _O_.[[ContentType]] is ~BigInt~, let _numValue_ be ? ToBigInt(_value_).
           1. Otherwise, let _numValue_ be ? ToNumber(_value_).
-          1. If ! IsValidIntegerIndex(_O_, _index_) is *true*, then
+          1. If IsValidIntegerIndex(_O_, _index_) is *true*, then
             1. Let _offset_ be _O_.[[ByteOffset]].
             1. Let _arrayTypeName_ be the String value of _O_.[[TypedArrayName]].
             1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _arrayTypeName_.
             1. Let _indexedPosition_ be (ℝ(_index_) &times; _elementSize_) + _offset_.
             1. Let _elementType_ be the Element Type value in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _arrayTypeName_.
             1. Perform SetValueInBuffer(_O_.[[ViewedArrayBuffer]], _indexedPosition_, _elementType_, _numValue_, *true*, ~Unordered~).
-          1. Return NormalCompletion(*undefined*).
+          1. Return ~unused~.
         </emu-alg>
         <emu-note>
           <p>This operation always appears to succeed, but it has no effect when attempting to write past the end of a TypedArray or to a TypedArray which is backed by a detached ArrayBuffer.</p>
@@ -14773,7 +14821,7 @@
       </emu-table>
 
       <emu-clause id="sec-module-namespace-exotic-objects-getprototypeof" type="internal method">
-        <h1>[[GetPrototypeOf]] ( )</h1>
+        <h1>[[GetPrototypeOf]] ( ): a normal completion containing *null*</h1>
         <dl class="header">
           <dt>for</dt>
           <dd>a module namespace exotic object</dd>
@@ -14787,19 +14835,19 @@
         <h1>
           [[SetPrototypeOf]] (
             _V_: an Object or *null*,
-          )
+          ): a normal completion containing a Boolean
         </h1>
         <dl class="header">
           <dt>for</dt>
           <dd>a module namespace exotic object _O_</dd>
         </dl>
         <emu-alg>
-          1. Return ? SetImmutablePrototype(_O_, _V_).
+          1. Return ! SetImmutablePrototype(_O_, _V_).
         </emu-alg>
       </emu-clause>
 
       <emu-clause id="sec-module-namespace-exotic-objects-isextensible" type="internal method">
-        <h1>[[IsExtensible]] ( )</h1>
+        <h1>[[IsExtensible]] ( ): a normal completion containing *false*</h1>
         <dl class="header">
           <dt>for</dt>
           <dd>a module namespace exotic object</dd>
@@ -14810,7 +14858,7 @@
       </emu-clause>
 
       <emu-clause id="sec-module-namespace-exotic-objects-preventextensions" type="internal method">
-        <h1>[[PreventExtensions]] ( )</h1>
+        <h1>[[PreventExtensions]] ( ): a normal completion containing *true*</h1>
         <dl class="header">
           <dt>for</dt>
           <dd>a module namespace exotic object</dd>
@@ -14824,7 +14872,7 @@
         <h1>
           [[GetOwnProperty]] (
             _P_: a property key,
-          )
+          ): either a normal completion containing either a Property Descriptor or *undefined*, or an abrupt completion
         </h1>
         <dl class="header">
           <dt>for</dt>
@@ -14844,19 +14892,19 @@
           [[DefineOwnProperty]] (
             _P_: a property key,
             _Desc_: a Property Descriptor,
-          )
+          ): either a normal completion containing a Boolean or an abrupt completion
         </h1>
         <dl class="header">
           <dt>for</dt>
           <dd>a module namespace exotic object _O_</dd>
         </dl>
         <emu-alg>
-          1. If Type(_P_) is Symbol, return OrdinaryDefineOwnProperty(_O_, _P_, _Desc_).
+          1. If Type(_P_) is Symbol, return ! OrdinaryDefineOwnProperty(_O_, _P_, _Desc_).
           1. Let _current_ be ? _O_.[[GetOwnProperty]](_P_).
           1. If _current_ is *undefined*, return *false*.
           1. If _Desc_ has a [[Configurable]] field and _Desc_.[[Configurable]] is *true*, return *false*.
           1. If _Desc_ has an [[Enumerable]] field and _Desc_.[[Enumerable]] is *false*, return *false*.
-          1. If ! IsAccessorDescriptor(_Desc_) is *true*, return *false*.
+          1. If IsAccessorDescriptor(_Desc_) is *true*, return *false*.
           1. If _Desc_ has a [[Writable]] field and _Desc_.[[Writable]] is *false*, return *false*.
           1. If _Desc_ has a [[Value]] field, return SameValue(_Desc_.[[Value]], _current_.[[Value]]).
           1. Return *true*.
@@ -14867,14 +14915,14 @@
         <h1>
           [[HasProperty]] (
             _P_: a property key,
-          )
+          ): a normal completion containing a Boolean
         </h1>
         <dl class="header">
           <dt>for</dt>
           <dd>a module namespace exotic object _O_</dd>
         </dl>
         <emu-alg>
-          1. If Type(_P_) is Symbol, return OrdinaryHasProperty(_O_, _P_).
+          1. If Type(_P_) is Symbol, return ! OrdinaryHasProperty(_O_, _P_).
           1. Let _exports_ be _O_.[[Exports]].
           1. If _P_ is an element of _exports_, return *true*.
           1. Return *false*.
@@ -14886,7 +14934,7 @@
           [[Get]] (
             _P_: a property key,
             _Receiver_: an ECMAScript language value,
-          )
+          ): either a normal completion containing an ECMAScript language value or an abrupt completion
         </h1>
         <dl class="header">
           <dt>for</dt>
@@ -14894,7 +14942,7 @@
         </dl>
         <emu-alg>
           1. If Type(_P_) is Symbol, then
-            1. Return ? OrdinaryGet(_O_, _P_, _Receiver_).
+            1. Return ! OrdinaryGet(_O_, _P_, _Receiver_).
           1. Let _exports_ be _O_.[[Exports]].
           1. If _P_ is not an element of _exports_, return *undefined*.
           1. Let _m_ be _O_.[[Module]].
@@ -14919,7 +14967,7 @@
             _P_: a property key,
             _V_: an ECMAScript language value,
             _Receiver_: an ECMAScript language value,
-          )
+          ): a normal completion containing *false*
         </h1>
         <dl class="header">
           <dt>for</dt>
@@ -14934,7 +14982,7 @@
         <h1>
           [[Delete]] (
             _P_: a property key,
-          )
+          ): a normal completion containing a Boolean
         </h1>
         <dl class="header">
           <dt>for</dt>
@@ -14942,7 +14990,7 @@
         </dl>
         <emu-alg>
           1. If Type(_P_) is Symbol, then
-            1. Return ? OrdinaryDelete(_O_, _P_).
+            1. Return ! OrdinaryDelete(_O_, _P_).
           1. Let _exports_ be _O_.[[Exports]].
           1. If _P_ is an element of _exports_, return *false*.
           1. Return *true*.
@@ -14950,14 +14998,14 @@
       </emu-clause>
 
       <emu-clause id="sec-module-namespace-exotic-objects-ownpropertykeys" type="internal method">
-        <h1>[[OwnPropertyKeys]] ( )</h1>
+        <h1>[[OwnPropertyKeys]] ( ): a normal completion containing a List of property keys</h1>
         <dl class="header">
           <dt>for</dt>
           <dd>a module namespace exotic object _O_</dd>
         </dl>
         <emu-alg>
           1. Let _exports_ be _O_.[[Exports]].
-          1. Let _symbolKeys_ be ! OrdinaryOwnPropertyKeys(_O_).
+          1. Let _symbolKeys_ be OrdinaryOwnPropertyKeys(_O_).
           1. Return the list-concatenation of _exports_ and _symbolKeys_.
         </emu-alg>
       </emu-clause>
@@ -14967,7 +15015,7 @@
           ModuleNamespaceCreate (
             _module_: a Module Record,
             _exports_: a List of Strings,
-          )
+          ): a module namespace exotic object
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -14976,7 +15024,7 @@
         <emu-alg>
           1. Assert: _module_.[[Namespace]] is ~empty~.
           1. Let _internalSlotsList_ be the internal slots listed in <emu-xref href="#table-internal-slots-of-module-namespace-exotic-objects"></emu-xref>.
-          1. Let _M_ be ! MakeBasicObject(_internalSlotsList_).
+          1. Let _M_ be MakeBasicObject(_internalSlotsList_).
           1. Set _M_'s essential internal methods to the definitions specified in <emu-xref href="#sec-module-namespace-exotic-objects"></emu-xref>.
           1. Set _M_.[[Module]] to _module_.
           1. Let _sortedExports_ be a List whose elements are the elements of _exports_ ordered as if an Array of the same values had been sorted using %Array.prototype.sort% using *undefined* as _comparefn_.
@@ -15002,7 +15050,7 @@
         <h1>
           [[SetPrototypeOf]] (
             _V_: an Object or *null*,
-          )
+          ): either a normal completion containing a Boolean or an abrupt completion
         </h1>
         <dl class="header">
           <dt>for</dt>
@@ -15018,7 +15066,7 @@
           SetImmutablePrototype (
             _O_: unknown,
             _V_: an Object or *null*,
-          )
+          ): either a normal completion containing a Boolean or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
@@ -15159,7 +15207,7 @@
     <p>In the following algorithm descriptions, assume _O_ is an ECMAScript Proxy object, _P_ is a property key value, _V_ is any ECMAScript language value and _Desc_ is a Property Descriptor record.</p>
 
     <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-getprototypeof" type="internal method">
-      <h1>[[GetPrototypeOf]] ( )</h1>
+      <h1>[[GetPrototypeOf]] ( ): either a normal completion containing either an Object or *null*, or an abrupt completion</h1>
       <dl class="header">
         <dt>for</dt>
         <dd>a Proxy exotic object _O_</dd>
@@ -15197,7 +15245,7 @@
       <h1>
         [[SetPrototypeOf]] (
           _V_: an Object or *null*,
-        )
+        ): either a normal completion containing a Boolean or an abrupt completion
       </h1>
       <dl class="header">
         <dt>for</dt>
@@ -15211,7 +15259,7 @@
         1. Let _trap_ be ? GetMethod(_handler_, *"setPrototypeOf"*).
         1. If _trap_ is *undefined*, then
           1. Return ? <emu-meta effects="user-code">_target_.[[SetPrototypeOf]]</emu-meta>(_V_).
-        1. Let _booleanTrapResult_ be ! ToBoolean(? Call(_trap_, _handler_, &laquo; _target_, _V_ &raquo;)).
+        1. Let _booleanTrapResult_ be ToBoolean(? Call(_trap_, _handler_, &laquo; _target_, _V_ &raquo;)).
         1. If _booleanTrapResult_ is *false*, return *false*.
         1. Let _extensibleTarget_ be ? IsExtensible(_target_).
         1. If _extensibleTarget_ is *true*, return *true*.
@@ -15233,7 +15281,7 @@
     </emu-clause>
 
     <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-isextensible" type="internal method">
-      <h1>[[IsExtensible]] ( )</h1>
+      <h1>[[IsExtensible]] ( ): either a normal completion containing a Boolean or an abrupt completion</h1>
       <dl class="header">
         <dt>for</dt>
         <dd>a Proxy exotic object _O_</dd>
@@ -15246,7 +15294,7 @@
         1. Let _trap_ be ? GetMethod(_handler_, *"isExtensible"*).
         1. If _trap_ is *undefined*, then
           1. Return ? IsExtensible(_target_).
-        1. Let _booleanTrapResult_ be ! ToBoolean(? Call(_trap_, _handler_, &laquo; _target_ &raquo;)).
+        1. Let _booleanTrapResult_ be ToBoolean(? Call(_trap_, _handler_, &laquo; _target_ &raquo;)).
         1. Let _targetResult_ be ? IsExtensible(_target_).
         1. If SameValue(_booleanTrapResult_, _targetResult_) is *false*, throw a *TypeError* exception.
         1. Return _booleanTrapResult_.
@@ -15265,7 +15313,7 @@
     </emu-clause>
 
     <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-preventextensions" type="internal method">
-      <h1>[[PreventExtensions]] ( )</h1>
+      <h1>[[PreventExtensions]] ( ): either a normal completion containing a Boolean or an abrupt completion</h1>
       <dl class="header">
         <dt>for</dt>
         <dd>a Proxy exotic object _O_</dd>
@@ -15278,7 +15326,7 @@
         1. Let _trap_ be ? GetMethod(_handler_, *"preventExtensions"*).
         1. If _trap_ is *undefined*, then
           1. Return ? <emu-meta effects="user-code">_target_.[[PreventExtensions]]()</emu-meta>.
-        1. Let _booleanTrapResult_ be ! ToBoolean(? Call(_trap_, _handler_, &laquo; _target_ &raquo;)).
+        1. Let _booleanTrapResult_ be ToBoolean(? Call(_trap_, _handler_, &laquo; _target_ &raquo;)).
         1. If _booleanTrapResult_ is *true*, then
           1. Let _extensibleTarget_ be ? IsExtensible(_target_).
           1. If _extensibleTarget_ is *true*, throw a *TypeError* exception.
@@ -15301,7 +15349,7 @@
       <h1>
         [[GetOwnProperty]] (
           _P_: a property key,
-        )
+        ): either a normal completion containing either a Property Descriptor or *undefined*, or an abrupt completion
       </h1>
       <dl class="header">
         <dt>for</dt>
@@ -15326,7 +15374,7 @@
           1. Return *undefined*.
         1. Let _extensibleTarget_ be ? IsExtensible(_target_).
         1. Let _resultDesc_ be ? ToPropertyDescriptor(_trapResultObj_).
-        1. Call CompletePropertyDescriptor(_resultDesc_).
+        1. Perform CompletePropertyDescriptor(_resultDesc_).
         1. Let _valid_ be IsCompatiblePropertyDescriptor(_extensibleTarget_, _resultDesc_, _targetDesc_).
         1. If _valid_ is *false*, throw a *TypeError* exception.
         1. If _resultDesc_.[[Configurable]] is *false*, then
@@ -15367,7 +15415,7 @@
         [[DefineOwnProperty]] (
           _P_: a property key,
           _Desc_: a Property Descriptor,
-        )
+        ): either a normal completion containing a Boolean or an abrupt completion
       </h1>
       <dl class="header">
         <dt>for</dt>
@@ -15382,7 +15430,7 @@
         1. If _trap_ is *undefined*, then
           1. Return ? <emu-meta effects="user-code">_target_.[[DefineOwnProperty]]</emu-meta>(_P_, _Desc_).
         1. Let _descObj_ be FromPropertyDescriptor(_Desc_).
-        1. Let _booleanTrapResult_ be ! ToBoolean(? Call(_trap_, _handler_, &laquo; _target_, _P_, _descObj_ &raquo;)).
+        1. Let _booleanTrapResult_ be ToBoolean(? Call(_trap_, _handler_, &laquo; _target_, _P_, _descObj_ &raquo;)).
         1. If _booleanTrapResult_ is *false*, return *false*.
         1. Let _targetDesc_ be ? <emu-meta effects="user-code">_target_.[[GetOwnProperty]]</emu-meta>(_P_).
         1. Let _extensibleTarget_ be ? IsExtensible(_target_).
@@ -15425,7 +15473,7 @@
       <h1>
         [[HasProperty]] (
           _P_: a property key,
-        )
+        ): either a normal completion containing a Boolean or an abrupt completion
       </h1>
       <dl class="header">
         <dt>for</dt>
@@ -15439,7 +15487,7 @@
         1. Let _trap_ be ? GetMethod(_handler_, *"has"*).
         1. If _trap_ is *undefined*, then
           1. Return ? <emu-meta effects="user-code">_target_.[[HasProperty]]</emu-meta>(_P_).
-        1. Let _booleanTrapResult_ be ! ToBoolean(? Call(_trap_, _handler_, &laquo; _target_, _P_ &raquo;)).
+        1. Let _booleanTrapResult_ be ToBoolean(? Call(_trap_, _handler_, &laquo; _target_, _P_ &raquo;)).
         1. If _booleanTrapResult_ is *false*, then
           1. Let _targetDesc_ be ? <emu-meta effects="user-code">_target_.[[GetOwnProperty]]</emu-meta>(_P_).
           1. If _targetDesc_ is not *undefined*, then
@@ -15469,7 +15517,7 @@
         [[Get]] (
           _P_: a property key,
           _Receiver_: an ECMAScript language value,
-        )
+        ): either a normal completion containing an ECMAScript language value or an abrupt completion
       </h1>
       <dl class="header">
         <dt>for</dt>
@@ -15511,7 +15559,7 @@
           _P_: a property key,
           _V_: an ECMAScript language value,
           _Receiver_: an ECMAScript language value,
-        )
+        ): either a normal completion containing a Boolean or an abrupt completion
       </h1>
       <dl class="header">
         <dt>for</dt>
@@ -15525,7 +15573,7 @@
         1. Let _trap_ be ? GetMethod(_handler_, *"set"*).
         1. If _trap_ is *undefined*, then
           1. Return ? <emu-meta effects="user-code">_target_.[[Set]]</emu-meta>(_P_, _V_, _Receiver_).
-        1. Let _booleanTrapResult_ be ! ToBoolean(? Call(_trap_, _handler_, &laquo; _target_, _P_, _V_, _Receiver_ &raquo;)).
+        1. Let _booleanTrapResult_ be ToBoolean(? Call(_trap_, _handler_, &laquo; _target_, _P_, _V_, _Receiver_ &raquo;)).
         1. If _booleanTrapResult_ is *false*, return *false*.
         1. Let _targetDesc_ be ? <emu-meta effects="user-code">_target_.[[GetOwnProperty]]</emu-meta>(_P_).
         1. If _targetDesc_ is not *undefined* and _targetDesc_.[[Configurable]] is *false*, then
@@ -15555,7 +15603,7 @@
       <h1>
         [[Delete]] (
           _P_: a property key,
-        )
+        ): either a normal completion containing a Boolean or an abrupt completion
       </h1>
       <dl class="header">
         <dt>for</dt>
@@ -15569,7 +15617,7 @@
         1. Let _trap_ be ? GetMethod(_handler_, *"deleteProperty"*).
         1. If _trap_ is *undefined*, then
           1. Return ? <emu-meta effects="user-code">_target_.[[Delete]]</emu-meta>(_P_).
-        1. Let _booleanTrapResult_ be ! ToBoolean(? Call(_trap_, _handler_, &laquo; _target_, _P_ &raquo;)).
+        1. Let _booleanTrapResult_ be ToBoolean(? Call(_trap_, _handler_, &laquo; _target_, _P_ &raquo;)).
         1. If _booleanTrapResult_ is *false*, return *false*.
         1. Let _targetDesc_ be ? <emu-meta effects="user-code">_target_.[[GetOwnProperty]]</emu-meta>(_P_).
         1. If _targetDesc_ is *undefined*, return *true*.
@@ -15595,7 +15643,7 @@
     </emu-clause>
 
     <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-ownpropertykeys" type="internal method">
-      <h1>[[OwnPropertyKeys]] ( )</h1>
+      <h1>[[OwnPropertyKeys]] ( ): either a normal completion containing a List of property keys or an abrupt completion</h1>
       <dl class="header">
         <dt>for</dt>
         <dd>a Proxy exotic object _O_</dd>
@@ -15663,7 +15711,7 @@
         [[Call]] (
           _thisArgument_: an ECMAScript language value,
           _argumentsList_: a List of ECMAScript language values,
-        )
+        ): either a normal completion containing an ECMAScript language value or an abrupt completion
       </h1>
       <dl class="header">
         <dt>for</dt>
@@ -15677,7 +15725,7 @@
         1. Let _trap_ be ? GetMethod(_handler_, *"apply"*).
         1. If _trap_ is *undefined*, then
           1. Return ? Call(_target_, _thisArgument_, _argumentsList_).
-        1. Let _argArray_ be ! CreateArrayFromList(_argumentsList_).
+        1. Let _argArray_ be CreateArrayFromList(_argumentsList_).
         1. Return ? Call(_trap_, _handler_, &laquo; _target_, _thisArgument_, _argArray_ &raquo;).
       </emu-alg>
       <emu-note>
@@ -15690,7 +15738,7 @@
         [[Construct]] (
           _argumentsList_: a List of ECMAScript language values,
           _newTarget_: a constructor,
-        )
+        ): either a normal completion containing an Object or an abrupt completion
       </h1>
       <dl class="header">
         <dt>for</dt>
@@ -15705,7 +15753,7 @@
         1. Let _trap_ be ? GetMethod(_handler_, *"construct"*).
         1. If _trap_ is *undefined*, then
           1. Return ? Construct(_target_, _argumentsList_, _newTarget_).
-        1. Let _argArray_ be ! CreateArrayFromList(_argumentsList_).
+        1. Let _argArray_ be CreateArrayFromList(_argumentsList_).
         1. Let _newObj_ be ? Call(_trap_, _handler_, &laquo; _target_, _argArray_, _newTarget_ &raquo;).
         1. If Type(_newObj_) is not Object, throw a *TypeError* exception.
         1. Return _newObj_.
@@ -15728,7 +15776,7 @@
         ProxyCreate (
           _target_: unknown,
           _handler_: unknown,
-        )
+        ): either a normal completion containing a Proxy exotic object or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -15737,7 +15785,7 @@
       <emu-alg>
         1. If Type(_target_) is not Object, throw a *TypeError* exception.
         1. If Type(_handler_) is not Object, throw a *TypeError* exception.
-        1. Let _P_ be ! MakeBasicObject(&laquo; [[ProxyHandler]], [[ProxyTarget]] &raquo;).
+        1. Let _P_ be MakeBasicObject(&laquo; [[ProxyHandler]], [[ProxyTarget]] &raquo;).
         1. Set _P_'s essential internal methods, except for [[Call]] and [[Construct]], to the definitions specified in <emu-xref href="#sec-proxy-object-internal-methods-and-internal-slots"></emu-xref>.
         1. If IsCallable(_target_) is *true*, then
           1. Set _P_.[[Call]] as specified in <emu-xref href="#sec-proxy-object-internal-methods-and-internal-slots-call-thisargument-argumentslist"></emu-xref>.
@@ -15772,7 +15820,7 @@
       <h1>
         Static Semantics: UTF16EncodeCodePoint (
           _cp_: a Unicode code point,
-        )
+        ): a String
       </h1>
       <dl class="header">
       </dl>
@@ -15789,7 +15837,7 @@
       <h1>
         Static Semantics: CodePointsToString (
           _text_: a sequence of Unicode code points,
-        )
+        ): a String
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -15798,7 +15846,7 @@
       <emu-alg>
         1. Let _result_ be the empty String.
         1. For each code point _cp_ of _text_, do
-          1. Set _result_ to the string-concatenation of _result_ and ! UTF16EncodeCodePoint(_cp_).
+          1. Set _result_ to the string-concatenation of _result_ and UTF16EncodeCodePoint(_cp_).
         1. Return _result_.
       </emu-alg>
     </emu-clause>
@@ -15808,7 +15856,7 @@
         Static Semantics: UTF16SurrogatePairToCodePoint (
           _lead_: a code unit,
           _trail_: a code unit,
-        )
+        ): a code point
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -15826,7 +15874,7 @@
         Static Semantics: CodePointAt (
           _string_: a String,
           _position_: a non-negative integer,
-        )
+        ): a Record with fields [[CodePoint]] (a code point), [[CodeUnitCount]] (a positive integer), and [[IsUnpairedSurrogate]] (a Boolean)
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -15844,7 +15892,7 @@
         1. Let _second_ be the code unit at index _position_ + 1 within _string_.
         1. If _second_ is not a <emu-xref href="#trailing-surrogate"></emu-xref>, then
           1. Return the Record { [[CodePoint]]: _cp_, [[CodeUnitCount]]: 1, [[IsUnpairedSurrogate]]: *true* }.
-        1. Set _cp_ to ! UTF16SurrogatePairToCodePoint(_first_, _second_).
+        1. Set _cp_ to UTF16SurrogatePairToCodePoint(_first_, _second_).
         1. Return the Record { [[CodePoint]]: _cp_, [[CodeUnitCount]]: 2, [[IsUnpairedSurrogate]]: *false* }.
       </emu-alg>
     </emu-clause>
@@ -15853,7 +15901,7 @@
       <h1>
         Static Semantics: StringToCodePoints (
           _string_: a String,
-        )
+        ): a List of code points
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -15864,7 +15912,7 @@
         1. Let _size_ be the length of _string_.
         1. Let _position_ be 0.
         1. Repeat, while _position_ &lt; _size_,
-          1. Let _cp_ be ! CodePointAt(_string_, _position_).
+          1. Let _cp_ be CodePointAt(_string_, _position_).
           1. Append _cp_.[[CodePoint]] to _codePoints_.
           1. Set _position_ to _position_ + _cp_.[[CodeUnitCount]].
         1. Return _codePoints_.
@@ -15876,7 +15924,7 @@
         Static Semantics: ParseText (
           _sourceText_: a sequence of Unicode code points,
           _goalSymbol_: a nonterminal in one of the ECMAScript grammars,
-        )
+        ): a Parse Node or a non-empty List of *SyntaxError* objects
       </h1>
       <dl class="header">
       </dl>
@@ -16389,7 +16437,7 @@
       </emu-clause>
 
       <emu-clause id="sec-identifiercodepoints" type="sdo">
-        <h1>Static Semantics: IdentifierCodePoints</h1>
+        <h1>Static Semantics: IdentifierCodePoints ( ): a List of code points</h1>
         <dl class="header">
         </dl>
         <emu-grammar>IdentifierName :: IdentifierStart</emu-grammar>
@@ -16406,7 +16454,7 @@
       </emu-clause>
 
       <emu-clause id="sec-identifiercodepoint" type="sdo">
-        <h1>Static Semantics: IdentifierCodePoint</h1>
+        <h1>Static Semantics: IdentifierCodePoint ( ): a code point</h1>
         <dl class="header">
         </dl>
         <emu-grammar>IdentifierStart :: IdentifierStartChar</emu-grammar>
@@ -16796,7 +16844,7 @@
       </emu-clause>
 
       <emu-clause id="sec-numericvalue" type="sdo">
-        <h1>Static Semantics: NumericValue</h1>
+        <h1>Static Semantics: NumericValue ( ): a Number or a BigInt</h1>
         <dl class="header">
         </dl>
         <emu-grammar>NumericLiteral :: DecimalLiteral</emu-grammar>
@@ -16948,7 +16996,7 @@
       </emu-clause>
 
       <emu-clause id="sec-static-semantics-sv" oldids="sec-string-literals-static-semantics-stringvalue,sec-additional-syntax-string-literals-static-semantics" type="sdo">
-        <h1>Static Semantics: SV</h1>
+        <h1>Static Semantics: SV ( ): a String</h1>
         <dl class="header">
           <dt>description</dt>
           <dd>
@@ -17272,7 +17320,7 @@
       </emu-note>
 
       <emu-clause id="sec-static-semantics-bodytext" type="sdo">
-        <h1>Static Semantics: BodyText</h1>
+        <h1>Static Semantics: BodyText ( ): source text</h1>
         <dl class="header">
         </dl>
         <emu-grammar>RegularExpressionLiteral :: `/` RegularExpressionBody `/` RegularExpressionFlags</emu-grammar>
@@ -17282,7 +17330,7 @@
       </emu-clause>
 
       <emu-clause id="sec-static-semantics-flagtext" type="sdo">
-        <h1>Static Semantics: FlagText</h1>
+        <h1>Static Semantics: FlagText ( ): source text</h1>
         <dl class="header">
         </dl>
         <emu-grammar>RegularExpressionLiteral :: `/` RegularExpressionBody `/` RegularExpressionFlags</emu-grammar>
@@ -17357,7 +17405,7 @@
       </emu-note>
 
       <emu-clause id="sec-static-semantics-tv" type="sdo" oldids="sec-static-semantics-tv-and-trv">
-        <h1>Static Semantics: TV</h1>
+        <h1>Static Semantics: TV ( ): a String or *undefined*</h1>
         <dl class="header">
           <dt>description</dt>
           <dd>A template literal component is interpreted by TV as a value of the String type. TV is used to construct the indexed components of a template object (colloquially, the template values). In TV, escape sequences are replaced by the UTF-16 code unit(s) of the Unicode code point represented by the escape sequence.</dd>
@@ -17400,7 +17448,7 @@
       </emu-clause>
 
       <emu-clause id="sec-static-semantics-trv" type="sdo">
-        <h1>Static Semantics: TRV</h1>
+        <h1>Static Semantics: TRV ( ): a String</h1>
         <dl class="header">
           <dt>description</dt>
           <dd>A template literal component is interpreted by TRV as a value of the String type. TRV is used to construct the raw components of a template object (colloquially, the template raw values). TRV is similar to TV with the difference being that in TRV, escape sequences are interpreted as they appear in the literal.</dd>
@@ -17869,7 +17917,7 @@
     </emu-clause>
 
     <emu-clause id="sec-static-semantics-stringvalue" oldids="sec-identifiers-static-semantics-stringvalue,sec-identifier-names-static-semantics-stringvalue" type="sdo">
-      <h1>Static Semantics: StringValue</h1>
+      <h1>Static Semantics: StringValue ( ): a String</h1>
       <dl class="header">
       </dl>
       <emu-grammar>
@@ -17879,7 +17927,7 @@
       </emu-grammar>
       <emu-alg>
         1. Let _idTextUnescaped_ be IdentifierCodePoints of |IdentifierName|.
-        1. Return ! CodePointsToString(_idTextUnescaped_).
+        1. Return CodePointsToString(_idTextUnescaped_).
       </emu-alg>
       <emu-grammar>
         IdentifierReference : `yield`
@@ -18062,9 +18110,9 @@
       <emu-clause id="sec-runtime-semantics-arrayaccumulation" oldids="sec-static-semantics-elisionwidth" type="sdo">
         <h1>
           Runtime Semantics: ArrayAccumulation (
-            _array_: unknown,
-            _nextIndex_: unknown,
-          )
+            _array_: an Array,
+            _nextIndex_: an integer,
+          ): either a normal completion containing an integer or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
@@ -18072,18 +18120,17 @@
         <emu-alg>
           1. Let _len_ be _nextIndex_ + 1.
           1. Perform ? Set(_array_, *"length"*, 𝔽(_len_), *true*).
-          1. NOTE: The above Set throws if _len_ exceeds 2<sup>32</sup>-1.
+          1. NOTE: The above step throws if _len_ exceeds 2<sup>32</sup>-1.
           1. Return _len_.
         </emu-alg>
         <emu-grammar>Elision : Elision `,`</emu-grammar>
         <emu-alg>
-          1. Return the result of performing ArrayAccumulation of |Elision| with arguments _array_ and _nextIndex_ + 1.
+          1. Return ? ArrayAccumulation of |Elision| with arguments _array_ and (_nextIndex_ + 1).
         </emu-alg>
         <emu-grammar>ElementList : Elision? AssignmentExpression</emu-grammar>
         <emu-alg>
           1. If |Elision| is present, then
-            1. Set _nextIndex_ to the result of performing ArrayAccumulation of |Elision| with arguments _array_ and _nextIndex_.
-            1. ReturnIfAbrupt(_nextIndex_).
+            1. Set _nextIndex_ to ? ArrayAccumulation of |Elision| with arguments _array_ and _nextIndex_.
           1. Let _initResult_ be the result of evaluating |AssignmentExpression|.
           1. Let _initValue_ be ? GetValue(_initResult_).
           1. Let _created_ be ! CreateDataPropertyOrThrow(_array_, ! ToString(𝔽(_nextIndex_)), _initValue_).
@@ -18092,17 +18139,14 @@
         <emu-grammar>ElementList : Elision? SpreadElement</emu-grammar>
         <emu-alg>
           1. If |Elision| is present, then
-            1. Set _nextIndex_ to the result of performing ArrayAccumulation of |Elision| with arguments _array_ and _nextIndex_.
-            1. ReturnIfAbrupt(_nextIndex_).
-          1. Return the result of performing ArrayAccumulation of |SpreadElement| with arguments _array_ and _nextIndex_.
+            1. Set _nextIndex_ to ? ArrayAccumulation of |Elision| with arguments _array_ and _nextIndex_.
+          1. Return ? ArrayAccumulation of |SpreadElement| with arguments _array_ and _nextIndex_.
         </emu-alg>
         <emu-grammar>ElementList : ElementList `,` Elision? AssignmentExpression</emu-grammar>
         <emu-alg>
-          1. Set _nextIndex_ to the result of performing ArrayAccumulation of |ElementList| with arguments _array_ and _nextIndex_.
-          1. ReturnIfAbrupt(_nextIndex_).
+          1. Set _nextIndex_ to ? ArrayAccumulation of |ElementList| with arguments _array_ and _nextIndex_.
           1. If |Elision| is present, then
-            1. Set _nextIndex_ to the result of performing ArrayAccumulation of |Elision| with arguments _array_ and _nextIndex_.
-            1. ReturnIfAbrupt(_nextIndex_).
+            1. Set _nextIndex_ to ? ArrayAccumulation of |Elision| with arguments _array_ and _nextIndex_.
           1. Let _initResult_ be the result of evaluating |AssignmentExpression|.
           1. Let _initValue_ be ? GetValue(_initResult_).
           1. Let _created_ be ! CreateDataPropertyOrThrow(_array_, ! ToString(𝔽(_nextIndex_)), _initValue_).
@@ -18110,12 +18154,10 @@
         </emu-alg>
         <emu-grammar>ElementList : ElementList `,` Elision? SpreadElement</emu-grammar>
         <emu-alg>
-          1. Set _nextIndex_ to the result of performing ArrayAccumulation of |ElementList| with arguments _array_ and _nextIndex_.
-          1. ReturnIfAbrupt(_nextIndex_).
+          1. Set _nextIndex_ to ? ArrayAccumulation of |ElementList| with arguments _array_ and _nextIndex_.
           1. If |Elision| is present, then
-            1. Set _nextIndex_ to the result of performing ArrayAccumulation of |Elision| with arguments _array_ and _nextIndex_.
-            1. ReturnIfAbrupt(_nextIndex_).
-          1. Return the result of performing ArrayAccumulation of |SpreadElement| with arguments _array_ and _nextIndex_.
+            1. Set _nextIndex_ to ? ArrayAccumulation of |Elision| with arguments _array_ and _nextIndex_.
+          1. Return ? ArrayAccumulation of |SpreadElement| with arguments _array_ and _nextIndex_.
         </emu-alg>
         <emu-grammar>SpreadElement : `...` AssignmentExpression</emu-grammar>
         <emu-alg>
@@ -18140,25 +18182,21 @@
         <emu-alg>
           1. Let _array_ be ! ArrayCreate(0).
           1. If |Elision| is present, then
-            1. Let _len_ be the result of performing ArrayAccumulation of |Elision| with arguments _array_ and 0.
-            1. ReturnIfAbrupt(_len_).
+            1. Perform ? ArrayAccumulation of |Elision| with arguments _array_ and 0.
           1. Return _array_.
         </emu-alg>
         <emu-grammar>ArrayLiteral : `[` ElementList `]`</emu-grammar>
         <emu-alg>
           1. Let _array_ be ! ArrayCreate(0).
-          1. Let _len_ be the result of performing ArrayAccumulation of |ElementList| with arguments _array_ and 0.
-          1. ReturnIfAbrupt(_len_).
+          1. Perform ? ArrayAccumulation of |ElementList| with arguments _array_ and 0.
           1. Return _array_.
         </emu-alg>
         <emu-grammar>ArrayLiteral : `[` ElementList `,` Elision? `]`</emu-grammar>
         <emu-alg>
           1. Let _array_ be ! ArrayCreate(0).
-          1. Let _nextIndex_ be the result of performing ArrayAccumulation of |ElementList| with arguments _array_ and 0.
-          1. ReturnIfAbrupt(_nextIndex_).
+          1. Let _nextIndex_ be ? ArrayAccumulation of |ElementList| with arguments _array_ and 0.
           1. If |Elision| is present, then
-            1. Let _len_ be the result of performing ArrayAccumulation of |Elision| with arguments _array_ and _nextIndex_.
-            1. ReturnIfAbrupt(_len_).
+            1. Perform ? ArrayAccumulation of |Elision| with arguments _array_ and _nextIndex_.
           1. Return _array_.
         </emu-alg>
       </emu-clause>
@@ -18249,7 +18287,7 @@
       </emu-clause>
 
       <emu-clause id="sec-static-semantics-iscomputedpropertykey" type="sdo">
-        <h1>Static Semantics: IsComputedPropertyKey</h1>
+        <h1>Static Semantics: IsComputedPropertyKey ( ): a Boolean</h1>
         <dl class="header">
         </dl>
         <emu-grammar>PropertyName : LiteralPropertyName</emu-grammar>
@@ -18263,7 +18301,7 @@
       </emu-clause>
 
       <emu-clause id="sec-static-semantics-propertynamelist" type="sdo">
-        <h1>Static Semantics: PropertyNameList</h1>
+        <h1>Static Semantics: PropertyNameList ( ): a List of Strings</h1>
         <dl class="header">
         </dl>
         <emu-grammar>PropertyDefinitionList : PropertyDefinition</emu-grammar>
@@ -18285,7 +18323,7 @@
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>ObjectLiteral : `{` `}`</emu-grammar>
         <emu-alg>
-          1. Return ! OrdinaryObjectCreate(%Object.prototype%).
+          1. Return OrdinaryObjectCreate(%Object.prototype%).
         </emu-alg>
         <emu-grammar>
           ObjectLiteral :
@@ -18293,7 +18331,7 @@
             `{` PropertyDefinitionList `,` `}`
         </emu-grammar>
         <emu-alg>
-          1. Let _obj_ be ! OrdinaryObjectCreate(%Object.prototype%).
+          1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%).
           1. Perform ? PropertyDefinitionEvaluation of |PropertyDefinitionList| with argument _obj_.
           1. Return _obj_.
         </emu-alg>
@@ -18322,21 +18360,23 @@
         <h1>
           Runtime Semantics: PropertyDefinitionEvaluation (
             _object_: unknown,
-          )
+          ): either a normal completion containing ~unused~ or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
         <emu-grammar>PropertyDefinitionList : PropertyDefinitionList `,` PropertyDefinition</emu-grammar>
         <emu-alg>
           1. Perform ? PropertyDefinitionEvaluation of |PropertyDefinitionList| with argument _object_.
-          1. Return the result of performing PropertyDefinitionEvaluation of |PropertyDefinition| with argument _object_.
+          1. Perform ? PropertyDefinitionEvaluation of |PropertyDefinition| with argument _object_.
+          1. Return ~unused~.
         </emu-alg>
         <emu-grammar>PropertyDefinition : `...` AssignmentExpression</emu-grammar>
         <emu-alg>
           1. Let _exprValue_ be the result of evaluating |AssignmentExpression|.
           1. Let _fromValue_ be ? GetValue(_exprValue_).
           1. Let _excludedNames_ be a new empty List.
-          1. Return ? CopyDataProperties(_object_, _fromValue_, _excludedNames_).
+          1. Perform ? CopyDataProperties(_object_, _fromValue_, _excludedNames_).
+          1. Return ~unused~.
         </emu-alg>
         <emu-grammar>PropertyDefinition : IdentifierReference</emu-grammar>
         <emu-alg>
@@ -18344,7 +18384,8 @@
           1. Let _exprValue_ be the result of evaluating |IdentifierReference|.
           1. Let _propValue_ be ? GetValue(_exprValue_).
           1. Assert: _object_ is an ordinary, extensible object with no non-configurable properties.
-          1. Return ! CreateDataPropertyOrThrow(_object_, _propName_, _propValue_).
+          1. Perform ! CreateDataPropertyOrThrow(_object_, _propName_, _propValue_).
+          1. Return ~unused~.
         </emu-alg>
         <emu-grammar>PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar>
         <emu-alg>
@@ -18363,14 +18404,16 @@
             1. Let _propValue_ be ? GetValue(_exprValueRef_).
           1. If _isProtoSetter_ is *true*, then
             1. If Type(_propValue_) is either Object or Null, then
-              1. Return ! <emu-meta effects="user-code">_object_.[[SetPrototypeOf]]</emu-meta>(_propValue_).
-            1. Return NormalCompletion(~empty~).
+              1. Perform ! <emu-meta effects="user-code">_object_.[[SetPrototypeOf]]</emu-meta>(_propValue_).
+            1. Return ~unused~.
           1. Assert: _object_ is an ordinary, extensible object with no non-configurable properties.
-          1. Return ! CreateDataPropertyOrThrow(_object_, _propKey_, _propValue_).
+          1. Perform ! CreateDataPropertyOrThrow(_object_, _propKey_, _propValue_).
+          1. Return ~unused~.
         </emu-alg>
         <emu-grammar>PropertyDefinition : MethodDefinition</emu-grammar>
         <emu-alg>
-          1. Return ? MethodDefinitionEvaluation of |MethodDefinition| with arguments _object_ and *true*.
+          1. Perform ? MethodDefinitionEvaluation of |MethodDefinition| with arguments _object_ and *true*.
+          1. Return ~unused~.
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -18403,7 +18446,7 @@
         <h1>
           Static Semantics: IsValidRegularExpressionLiteral (
             _literal_: a |RegularExpressionLiteral| Parse Node,
-          )
+          ): a Boolean
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -18425,9 +18468,9 @@
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>PrimaryExpression : RegularExpressionLiteral</emu-grammar>
         <emu-alg>
-          1. Let _pattern_ be ! CodePointsToString(BodyText of |RegularExpressionLiteral|).
-          1. Let _flags_ be ! CodePointsToString(FlagText of |RegularExpressionLiteral|).
-          1. Return <emu-meta suppress-effects="user-code">RegExpCreate(_pattern_, _flags_)</emu-meta>.
+          1. Let _pattern_ be CodePointsToString(BodyText of |RegularExpressionLiteral|).
+          1. Let _flags_ be CodePointsToString(FlagText of |RegularExpressionLiteral|).
+          1. Return ! RegExpCreate(_pattern_, _flags_).
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -18506,7 +18549,7 @@
         <h1>
           Static Semantics: TemplateStrings (
             _raw_: unknown,
-          )
+          ): a List of Strings
         </h1>
         <dl class="header">
         </dl>
@@ -18567,7 +18610,7 @@
         <h1>
           GetTemplateObject (
             _templateLiteral_: a Parse Node,
-          )
+          ): an Array
         </h1>
         <dl class="header">
         </dl>
@@ -18609,7 +18652,7 @@
       </emu-clause>
 
       <emu-clause id="sec-runtime-semantics-substitutionevaluation" type="sdo">
-        <h1>Runtime Semantics: SubstitutionEvaluation</h1>
+        <h1>Runtime Semantics: SubstitutionEvaluation ( ): either a normal completion containing a List of ECMAScript language values or an abrupt completion</h1>
         <dl class="header">
         </dl>
         <emu-grammar>TemplateSpans : TemplateTail</emu-grammar>
@@ -18618,13 +18661,13 @@
         </emu-alg>
         <emu-grammar>TemplateSpans : TemplateMiddleList TemplateTail</emu-grammar>
         <emu-alg>
-          1. Return the result of SubstitutionEvaluation of |TemplateMiddleList|.
+          1. Return ? SubstitutionEvaluation of |TemplateMiddleList|.
         </emu-alg>
         <emu-grammar>TemplateMiddleList : TemplateMiddle Expression</emu-grammar>
         <emu-alg>
           1. Let _subRef_ be the result of evaluating |Expression|.
           1. Let _sub_ be ? GetValue(_subRef_).
-          1. Return a List whose sole element is _sub_.
+          1. Return &laquo; _sub_ &raquo;.
         </emu-alg>
         <emu-grammar>TemplateMiddleList : TemplateMiddleList TemplateMiddle Expression</emu-grammar>
         <emu-alg>
@@ -18902,14 +18945,14 @@
           1. Let _baseReference_ be the result of evaluating |MemberExpression|.
           1. Let _baseValue_ be ? GetValue(_baseReference_).
           1. If the source text matched by this |MemberExpression| is strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
-          1. Return ! EvaluatePropertyAccessWithIdentifierKey(_baseValue_, |IdentifierName|, _strict_).
+          1. Return EvaluatePropertyAccessWithIdentifierKey(_baseValue_, |IdentifierName|, _strict_).
         </emu-alg>
         <emu-grammar>MemberExpression : MemberExpression `.` PrivateIdentifier</emu-grammar>
         <emu-alg>
           1. Let _baseReference_ be the result of evaluating |MemberExpression|.
           1. Let _baseValue_ be ? GetValue(_baseReference_).
           1. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
-          1. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+          1. Return MakePrivateReference(_baseValue_, _fieldNameString_).
         </emu-alg>
         <emu-grammar>CallExpression : CallExpression `[` Expression `]`</emu-grammar>
         <emu-alg>
@@ -18923,14 +18966,14 @@
           1. Let _baseReference_ be the result of evaluating |CallExpression|.
           1. Let _baseValue_ be ? GetValue(_baseReference_).
           1. If the source text matched by this |CallExpression| is strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
-          1. Return ! EvaluatePropertyAccessWithIdentifierKey(_baseValue_, |IdentifierName|, _strict_).
+          1. Return EvaluatePropertyAccessWithIdentifierKey(_baseValue_, |IdentifierName|, _strict_).
         </emu-alg>
         <emu-grammar>CallExpression : CallExpression `.` PrivateIdentifier</emu-grammar>
         <emu-alg>
           1. Let _baseReference_ be the result of evaluating |CallExpression|.
           1. Let _baseValue_ be ? GetValue(_baseReference_).
           1. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
-          1. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+          1. Return MakePrivateReference(_baseValue_, _fieldNameString_).
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -18941,7 +18984,7 @@
           _baseValue_: an ECMAScript language value,
           _expression_: a Parse Node,
           _strict_: a Boolean,
-        )
+        ): either a normal completion containing a Reference Record or an abrupt completion
       </h1>
       <dl class="header">
       </dl>
@@ -18959,7 +19002,7 @@
           _baseValue_: an ECMAScript language value,
           _identifierName_: an |IdentifierName| Parse Node,
           _strict_: a Boolean,
-        )
+        ): a Reference Record
       </h1>
       <dl class="header">
       </dl>
@@ -18988,7 +19031,7 @@
             EvaluateNew (
               _constructExpr_: a |NewExpression| Parse Node or a |MemberExpression| Parse Node,
               _arguments_: ~empty~ or an |Arguments| Parse Node,
-            )
+            ): either a normal completion containing an ECMAScript language value or an abrupt completion
           </h1>
           <dl class="header">
           </dl>
@@ -19047,7 +19090,7 @@
             _ref_: an ECMAScript language value or a Reference Record,
             _arguments_: a Parse Node,
             _tailPosition_: a Boolean,
-          )
+          ): either a normal completion containing an ECMAScript language value or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
@@ -19065,9 +19108,7 @@
           1. If Type(_func_) is not Object, throw a *TypeError* exception.
           1. If IsCallable(_func_) is *false*, throw a *TypeError* exception.
           1. If _tailPosition_ is *true*, perform PrepareForTailCall().
-          1. Let _result_ be Call(_func_, _thisValue_, _argList_).
-          1. Assert: If _result_ is not an abrupt completion, then Type(_result_) is an ECMAScript language type.
-          1. Return _result_.
+          1. Return ? Call(_func_, _thisValue_, _argList_).
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -19099,7 +19140,7 @@
         <emu-alg>
           1. Let _newTarget_ be GetNewTarget().
           1. Assert: Type(_newTarget_) is Object.
-          1. Let _func_ be ! GetSuperConstructor().
+          1. Let _func_ be GetSuperConstructor().
           1. Let _argList_ be ? ArgumentListEvaluation of |Arguments|.
           1. If IsConstructor(_func_) is *false*, throw a *TypeError* exception.
           1. Let _result_ be ? Construct(_func_, _argList_, _newTarget_).
@@ -19113,7 +19154,7 @@
       </emu-clause>
 
       <emu-clause id="sec-getsuperconstructor" type="abstract operation">
-        <h1>GetSuperConstructor ( )</h1>
+        <h1>GetSuperConstructor ( ): an ECMAScript language value</h1>
         <dl class="header">
         </dl>
         <emu-alg>
@@ -19132,7 +19173,7 @@
             _actualThis_: unknown,
             _propertyKey_: unknown,
             _strict_: unknown,
-          )
+          ): either a normal completion containing a Super Reference Record or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
@@ -19141,7 +19182,6 @@
           1. Assert: _env_.HasSuperBinding() is *true*.
           1. Let _baseValue_ be ? _env_.GetSuperBase().
           1. Return the Reference Record { [[Base]]: _baseValue_, [[ReferencedName]]: _propertyKey_, [[Strict]]: _strict_, [[ThisValue]]: _actualThis_ }.
-          1. NOTE: This returns a Super Reference Record.
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -19153,7 +19193,7 @@
       </emu-note>
 
       <emu-clause id="sec-runtime-semantics-argumentlistevaluation" oldids="sec-template-literals-runtime-semantics-argumentlistevaluation,sec-argument-lists-runtime-semantics-argumentlistevaluation" type="sdo">
-        <h1>Runtime Semantics: ArgumentListEvaluation</h1>
+        <h1>Runtime Semantics: ArgumentListEvaluation ( ): either a normal completion containing a List of ECMAScript language values or an abrupt completion</h1>
         <dl class="header">
         </dl>
         <emu-grammar>Arguments : `(` `)`</emu-grammar>
@@ -19164,7 +19204,7 @@
         <emu-alg>
           1. Let _ref_ be the result of evaluating |AssignmentExpression|.
           1. Let _arg_ be ? GetValue(_ref_).
-          1. Return a List whose sole element is _arg_.
+          1. Return &laquo; _arg_ &raquo;.
         </emu-alg>
         <emu-grammar>ArgumentList : `...` AssignmentExpression</emu-grammar>
         <emu-alg>
@@ -19200,7 +19240,7 @@
         <emu-alg>
           1. Let _templateLiteral_ be this |TemplateLiteral|.
           1. Let _siteObj_ be GetTemplateObject(_templateLiteral_).
-          1. Return a List whose sole element is _siteObj_.
+          1. Return &laquo; _siteObj_ &raquo;.
         </emu-alg>
         <emu-grammar>TemplateLiteral : SubstitutionTemplate</emu-grammar>
         <emu-alg>
@@ -19235,7 +19275,7 @@
           1. Let _baseValue_ be ? GetValue(_baseReference_).
           1. If _baseValue_ is *undefined* or *null*, then
             1. Return *undefined*.
-          1. Return the result of performing ChainEvaluation of |OptionalChain| with arguments _baseValue_ and _baseReference_.
+          1. Return ? ChainEvaluation of |OptionalChain| with arguments _baseValue_ and _baseReference_.
         </emu-alg>
         <emu-grammar>
           OptionalExpression :
@@ -19246,7 +19286,7 @@
           1. Let _baseValue_ be ? GetValue(_baseReference_).
           1. If _baseValue_ is *undefined* or *null*, then
             1. Return *undefined*.
-          1. Return the result of performing ChainEvaluation of |OptionalChain| with arguments _baseValue_ and _baseReference_.
+          1. Return ? ChainEvaluation of |OptionalChain| with arguments _baseValue_ and _baseReference_.
         </emu-alg>
         <emu-grammar>
           OptionalExpression :
@@ -19257,7 +19297,7 @@
           1. Let _baseValue_ be ? GetValue(_baseReference_).
           1. If _baseValue_ is *undefined* or *null*, then
             1. Return *undefined*.
-          1. Return the result of performing ChainEvaluation of |OptionalChain| with arguments _baseValue_ and _baseReference_.
+          1. Return ? ChainEvaluation of |OptionalChain| with arguments _baseValue_ and _baseReference_.
         </emu-alg>
       </emu-clause>
 
@@ -19266,7 +19306,7 @@
           Runtime Semantics: ChainEvaluation (
             _baseValue_: unknown,
             _baseReference_: unknown,
-          )
+          ): either a normal completion containing an ECMAScript language value or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
@@ -19284,12 +19324,12 @@
         <emu-grammar>OptionalChain : `?.` IdentifierName</emu-grammar>
         <emu-alg>
           1. If the source text matched by this |OptionalChain| is strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
-          1. Return ! EvaluatePropertyAccessWithIdentifierKey(_baseValue_, |IdentifierName|, _strict_).
+          1. Return EvaluatePropertyAccessWithIdentifierKey(_baseValue_, |IdentifierName|, _strict_).
         </emu-alg>
         <emu-grammar>OptionalChain : `?.` PrivateIdentifier</emu-grammar>
         <emu-alg>
           1. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
-          1. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+          1. Return MakePrivateReference(_baseValue_, _fieldNameString_).
         </emu-alg>
         <emu-grammar>OptionalChain : OptionalChain Arguments</emu-grammar>
         <emu-alg>
@@ -19314,7 +19354,7 @@
           1. Let _newReference_ be ? ChainEvaluation of _optionalChain_ with arguments _baseValue_ and _baseReference_.
           1. Let _newValue_ be ? GetValue(_newReference_).
           1. If the source text matched by this |OptionalChain| is strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
-          1. Return ! EvaluatePropertyAccessWithIdentifierKey(_newValue_, |IdentifierName|, _strict_).
+          1. Return EvaluatePropertyAccessWithIdentifierKey(_newValue_, |IdentifierName|, _strict_).
         </emu-alg>
         <emu-grammar>OptionalChain : OptionalChain `.` PrivateIdentifier</emu-grammar>
         <emu-alg>
@@ -19322,7 +19362,7 @@
           1. Let _newReference_ be ? ChainEvaluation of _optionalChain_ with arguments _baseValue_ and _baseReference_.
           1. Let _newValue_ be ? GetValue(_newReference_).
           1. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
-          1. Return ! MakePrivateReference(_newValue_, _fieldNameString_).
+          1. Return MakePrivateReference(_newValue_, _fieldNameString_).
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -19335,13 +19375,13 @@
 
         <emu-grammar>ImportCall : `import` `(` AssignmentExpression `)`</emu-grammar>
         <emu-alg>
-          1. Let _referencingScriptOrModule_ be ! GetActiveScriptOrModule().
+          1. Let _referencingScriptOrModule_ be GetActiveScriptOrModule().
           1. Let _argRef_ be the result of evaluating |AssignmentExpression|.
           1. Let _specifier_ be ? GetValue(_argRef_).
           1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
-          1. Let _specifierString_ be ToString(_specifier_).
+          1. Let _specifierString_ be Completion(ToString(_specifier_)).
           1. IfAbruptRejectPromise(_specifierString_, _promiseCapability_).
-          1. Perform ! HostImportModuleDynamically(_referencingScriptOrModule_, _specifierString_, _promiseCapability_).
+          1. Perform HostImportModuleDynamically(_referencingScriptOrModule_, _specifierString_, _promiseCapability_).
           1. Return _promiseCapability_.[[Promise]].
         </emu-alg>
       </emu-clause>
@@ -19386,15 +19426,15 @@
 
         <emu-grammar>ImportMeta : `import` `.` `meta`</emu-grammar>
         <emu-alg>
-          1. Let _module_ be ! GetActiveScriptOrModule().
+          1. Let _module_ be GetActiveScriptOrModule().
           1. Assert: _module_ is a Source Text Module Record.
           1. Let _importMeta_ be _module_.[[ImportMeta]].
           1. If _importMeta_ is ~empty~, then
-            1. Set _importMeta_ to ! OrdinaryObjectCreate(*null*).
-            1. Let _importMetaValues_ be ! HostGetImportMetaProperties(_module_).
+            1. Set _importMeta_ to OrdinaryObjectCreate(*null*).
+            1. Let _importMetaValues_ be HostGetImportMetaProperties(_module_).
             1. For each Record { [[Key]], [[Value]] } _p_ of _importMetaValues_, do
               1. Perform ! CreateDataPropertyOrThrow(_importMeta_, _p_.[[Key]], _p_.[[Value]]).
-            1. Perform ! HostFinalizeImportMeta(_importMeta_, _module_).
+            1. Perform HostFinalizeImportMeta(_importMeta_, _module_).
             1. Set _module_.[[ImportMeta]] to _importMeta_.
             1. Return _importMeta_.
           1. Else,
@@ -19406,7 +19446,7 @@
           <h1>
             HostGetImportMetaProperties (
               _moduleRecord_: a Module Record,
-            )
+            ): a List of Records with fields [[Key]] (a property key) and [[Value]] (an ECMAScript language value)
           </h1>
           <dl class="header">
             <dt>description</dt>
@@ -19415,12 +19455,12 @@
 
           <p>An implementation of HostGetImportMetaProperties must conform to the following requirements:</p>
           <ul>
-            <li>It must return a normal completion with a value of a List whose values are all Records with two fields, [[Key]] and [[Value]].</li>
+            <li>It must return a List whose values are all Records with two fields, [[Key]] and [[Value]].</li>
             <li>Each such Record's [[Key]] field must be a property key, i.e., IsPropertyKey must return *true* when applied to it.</li>
             <li>Each such Record's [[Value]] field must be an ECMAScript language value.</li>
           </ul>
 
-          <p>The default implementation of HostGetImportMetaProperties is to return NormalCompletion(&laquo; &raquo;).</p>
+          <p>The default implementation of HostGetImportMetaProperties is to return a new empty List.</p>
         </emu-clause>
 
         <emu-clause id="sec-hostfinalizeimportmeta" type="host-defined abstract operation">
@@ -19428,7 +19468,7 @@
             HostFinalizeImportMeta (
               _importMeta_: an Object,
               _moduleRecord_: a Module Record,
-            )
+            ): ~unused~
           </h1>
           <dl class="header">
             <dt>description</dt>
@@ -19439,10 +19479,10 @@
 
           <p>An implementation of HostFinalizeImportMeta must conform to the following requirements:</p>
           <ul>
-            <li>It must complete normally (i.e., not return an abrupt completion).</li>
+            <li>It must return ~unused~.</li>
           </ul>
 
-          <p>The default implementation of HostFinalizeImportMeta is to return NormalCompletion(~empty~).</p>
+          <p>The default implementation of HostFinalizeImportMeta is to return ~unused~.</p>
         </emu-clause>
       </emu-clause>
     </emu-clause>
@@ -19495,10 +19535,10 @@
           1. Let _lhs_ be the result of evaluating |LeftHandSideExpression|.
           1. Let _oldValue_ be ? ToNumeric(? GetValue(_lhs_)).
           1. If Type(_oldValue_) is Number, then
-            1. Let _newValue_ be ! Number::add(_oldValue_, *1*<sub>𝔽</sub>).
+            1. Let _newValue_ be Number::add(_oldValue_, *1*<sub>𝔽</sub>).
           1. Else,
             1. Assert: Type(_oldValue_) is BigInt.
-            1. Let _newValue_ be ! BigInt::add(_oldValue_, *1*<sub>ℤ</sub>).
+            1. Let _newValue_ be BigInt::add(_oldValue_, *1*<sub>ℤ</sub>).
           1. Perform ? PutValue(_lhs_, _newValue_).
           1. Return _oldValue_.
         </emu-alg>
@@ -19515,10 +19555,10 @@
           1. Let _lhs_ be the result of evaluating |LeftHandSideExpression|.
           1. Let _oldValue_ be ? ToNumeric(? GetValue(_lhs_)).
           1. If Type(_oldValue_) is Number, then
-            1. Let _newValue_ be ! Number::subtract(_oldValue_, *1*<sub>𝔽</sub>).
+            1. Let _newValue_ be Number::subtract(_oldValue_, *1*<sub>𝔽</sub>).
           1. Else,
             1. Assert: Type(_oldValue_) is BigInt.
-            1. Let _newValue_ be ! BigInt::subtract(_oldValue_, *1*<sub>ℤ</sub>).
+            1. Let _newValue_ be BigInt::subtract(_oldValue_, *1*<sub>ℤ</sub>).
           1. Perform ? PutValue(_lhs_, _newValue_).
           1. Return _oldValue_.
         </emu-alg>
@@ -19535,10 +19575,10 @@
           1. Let _expr_ be the result of evaluating |UnaryExpression|.
           1. Let _oldValue_ be ? ToNumeric(? GetValue(_expr_)).
           1. If Type(_oldValue_) is Number, then
-            1. Let _newValue_ be ! Number::add(_oldValue_, *1*<sub>𝔽</sub>).
+            1. Let _newValue_ be Number::add(_oldValue_, *1*<sub>𝔽</sub>).
           1. Else,
             1. Assert: Type(_oldValue_) is BigInt.
-            1. Let _newValue_ be ! BigInt::add(_oldValue_, *1*<sub>ℤ</sub>).
+            1. Let _newValue_ be BigInt::add(_oldValue_, *1*<sub>ℤ</sub>).
           1. Perform ? PutValue(_expr_, _newValue_).
           1. Return _newValue_.
         </emu-alg>
@@ -19555,10 +19595,10 @@
           1. Let _expr_ be the result of evaluating |UnaryExpression|.
           1. Let _oldValue_ be ? ToNumeric(? GetValue(_expr_)).
           1. If Type(_oldValue_) is Number, then
-            1. Let _newValue_ be ! Number::subtract(_oldValue_, *1*<sub>𝔽</sub>).
+            1. Let _newValue_ be Number::subtract(_oldValue_, *1*<sub>𝔽</sub>).
           1. Else,
             1. Assert: Type(_oldValue_) is BigInt.
-            1. Let _newValue_ be ! BigInt::subtract(_oldValue_, *1*<sub>ℤ</sub>).
+            1. Let _newValue_ be BigInt::subtract(_oldValue_, *1*<sub>ℤ</sub>).
           1. Perform ? PutValue(_expr_, _newValue_).
           1. Return _newValue_.
         </emu-alg>
@@ -19616,7 +19656,7 @@
             1. Assert: _ref_.[[Strict]] is *false*.
             1. Return *true*.
           1. If IsPropertyReference(_ref_) is *true*, then
-            1. Assert: ! IsPrivateReference(_ref_) is *false*.
+            1. Assert: IsPrivateReference(_ref_) is *false*.
             1. If IsSuperReference(_ref_) is *true*, throw a *ReferenceError* exception.
             1. [id="step-delete-operator-toobject"] Let _baseObj_ be ? ToObject(_ref_.[[Base]]).
             1. Let _deleteStatus_ be ? <emu-meta effects="user-code">_baseObj_.[[Delete]]</emu-meta>(_ref_.[[ReferencedName]]).
@@ -19786,10 +19826,10 @@
           1. Let _oldValue_ be ? ToNumeric(? GetValue(_expr_)).
           1. Let _T_ be Type(_oldValue_).
           1. If Type(_oldValue_) is Number, then
-            1. Return ! Number::unaryMinus(_oldValue_).
+            1. Return Number::unaryMinus(_oldValue_).
           1. Else,
             1. Assert: Type(_oldValue_) is BigInt.
-            1. Return ! BigInt::unaryMinus(_oldValue_).
+            1. Return BigInt::unaryMinus(_oldValue_).
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -19805,10 +19845,10 @@
           1. Let _oldValue_ be ? ToNumeric(? GetValue(_expr_)).
           1. Let _T_ be Type(_oldValue_).
           1. If Type(_oldValue_) is Number, then
-            1. Return ! Number::bitwiseNOT(_oldValue_).
+            1. Return Number::bitwiseNOT(_oldValue_).
           1. Else,
             1. Assert: Type(_oldValue_) is BigInt.
-            1. Return ! BigInt::bitwiseNOT(_oldValue_).
+            1. Return BigInt::bitwiseNOT(_oldValue_).
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -19821,7 +19861,7 @@
         <emu-grammar>UnaryExpression : `!` UnaryExpression</emu-grammar>
         <emu-alg>
           1. Let _expr_ be the result of evaluating |UnaryExpression|.
-          1. Let _oldValue_ be ! ToBoolean(? GetValue(_expr_)).
+          1. Let _oldValue_ be ToBoolean(? GetValue(_expr_)).
           1. If _oldValue_ is *true*, return *false*.
           1. Return *true*.
         </emu-alg>
@@ -20060,8 +20100,8 @@
         1. Let _rval_ be ? GetValue(_rref_).
         1. If Type(_rval_) is not Object, throw a *TypeError* exception.
         1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
-        1. Let _privateName_ be ! ResolvePrivateIdentifier(_privateEnv_, _privateIdentifier_).
-        1. If ! PrivateElementFind(_rval_, _privateName_) is not ~empty~, return *true*.
+        1. Let _privateName_ be ResolvePrivateIdentifier(_privateEnv_, _privateIdentifier_).
+        1. If PrivateElementFind(_rval_, _privateName_) is not ~empty~, return *true*.
         1. Return *false*.
       </emu-alg>
     </emu-clause>
@@ -20071,7 +20111,7 @@
         InstanceofOperator (
           _V_: an ECMAScript language value,
           _target_: an ECMAScript language value,
-        )
+        ): either a normal completion containing a Boolean or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -20081,7 +20121,7 @@
         1. If Type(_target_) is not Object, throw a *TypeError* exception.
         1. Let _instOfHandler_ be ? GetMethod(_target_, @@hasInstance).
         1. If _instOfHandler_ is not *undefined*, then
-          1. Return ! ToBoolean(? Call(_instOfHandler_, _target_, &laquo; _V_ &raquo;)).
+          1. Return ToBoolean(? Call(_instOfHandler_, _target_, &laquo; _V_ &raquo;)).
         1. [id="step-instanceof-check-function"] If IsCallable(_target_) is *false*, throw a *TypeError* exception.
         1. [id="step-instanceof-fallback"] Return ? OrdinaryHasInstance(_target_, _V_).
       </emu-alg>
@@ -20114,7 +20154,7 @@
         1. Let _lval_ be ? GetValue(_lref_).
         1. Let _rref_ be the result of evaluating |RelationalExpression|.
         1. Let _rval_ be ? GetValue(_rref_).
-        1. Return IsLooselyEqual(_rval_, _lval_).
+        1. Return ? IsLooselyEqual(_rval_, _lval_).
       </emu-alg>
       <emu-grammar>EqualityExpression : EqualityExpression `!=` RelationalExpression</emu-grammar>
       <emu-alg>
@@ -20139,7 +20179,7 @@
         1. Let _lval_ be ? GetValue(_lref_).
         1. Let _rref_ be the result of evaluating |RelationalExpression|.
         1. Let _rval_ be ? GetValue(_rref_).
-        1. Let _r_ be ! IsStrictlyEqual(_rval_, _lval_).
+        1. Let _r_ be IsStrictlyEqual(_rval_, _lval_).
         1. If _r_ is *true*, return *false*. Otherwise, return *true*.
       </emu-alg>
       <emu-note>
@@ -20251,7 +20291,7 @@
       <emu-alg>
         1. Let _lref_ be the result of evaluating |LogicalANDExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
-        1. Let _lbool_ be ! ToBoolean(_lval_).
+        1. Let _lbool_ be ToBoolean(_lval_).
         1. If _lbool_ is *false*, return _lval_.
         1. Let _rref_ be the result of evaluating |BitwiseORExpression|.
         1. Return ? GetValue(_rref_).
@@ -20260,7 +20300,7 @@
       <emu-alg>
         1. Let _lref_ be the result of evaluating |LogicalORExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
-        1. Let _lbool_ be ! ToBoolean(_lval_).
+        1. Let _lbool_ be ToBoolean(_lval_).
         1. If _lbool_ is *true*, return _lval_.
         1. Let _rref_ be the result of evaluating |LogicalANDExpression|.
         1. Return ? GetValue(_rref_).
@@ -20294,7 +20334,7 @@
       <emu-grammar>ConditionalExpression : ShortCircuitExpression `?` AssignmentExpression `:` AssignmentExpression</emu-grammar>
       <emu-alg>
         1. Let _lref_ be the result of evaluating |ShortCircuitExpression|.
-        1. Let _lval_ be ! ToBoolean(? GetValue(_lref_)).
+        1. Let _lval_ be ToBoolean(? GetValue(_lref_)).
         1. If _lval_ is *true*, then
           1. Let _trueRef_ be the result of evaluating the first |AssignmentExpression|.
           1. Return ? GetValue(_trueRef_).
@@ -20362,7 +20402,7 @@
           1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
           1. ReturnIfAbrupt(_lref_).
           1. If IsAnonymousFunctionDefinition(|AssignmentExpression|) and IsIdentifierRef of |LeftHandSideExpression| are both *true*, then
-            1. Let _rval_ be NamedEvaluation of |AssignmentExpression| with argument _lref_.[[ReferencedName]].
+            1. Let _rval_ be ? NamedEvaluation of |AssignmentExpression| with argument _lref_.[[ReferencedName]].
           1. Else,
             1. Let _rref_ be the result of evaluating |AssignmentExpression|.
             1. Let _rval_ be ? GetValue(_rref_).
@@ -20400,7 +20440,7 @@
               <tr><td> `|=`               </td><td> `|`            </td></tr>
             </table>
           </figure>
-        1. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+        1. Let _r_ be ? ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
         1. [id="step-assignmentexpression-evaluation-compound-putvalue"] Perform ? PutValue(_lref_, _r_).
         1. Return _r_.
       </emu-alg>
@@ -20408,10 +20448,10 @@
       <emu-alg>
         1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
         1. [id="step-assignmentexpression-evaluation-lgcl-and-getvalue"] Let _lval_ be ? GetValue(_lref_).
-        1. Let _lbool_ be ! ToBoolean(_lval_).
+        1. Let _lbool_ be ToBoolean(_lval_).
         1. If _lbool_ is *false*, return _lval_.
         1. If IsAnonymousFunctionDefinition(|AssignmentExpression|) is *true* and IsIdentifierRef of |LeftHandSideExpression| is *true*, then
-          1. Let _rval_ be NamedEvaluation of |AssignmentExpression| with argument _lref_.[[ReferencedName]].
+          1. Let _rval_ be ? NamedEvaluation of |AssignmentExpression| with argument _lref_.[[ReferencedName]].
         1. Else,
           1. Let _rref_ be the result of evaluating |AssignmentExpression|.
           1. Let _rval_ be ? GetValue(_rref_).
@@ -20422,10 +20462,10 @@
       <emu-alg>
         1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
         1. [id="step-assignmentexpression-evaluation-lgcl-or-getvalue"] Let _lval_ be ? GetValue(_lref_).
-        1. Let _lbool_ be ! ToBoolean(_lval_).
+        1. Let _lbool_ be ToBoolean(_lval_).
         1. If _lbool_ is *true*, return _lval_.
         1. If IsAnonymousFunctionDefinition(|AssignmentExpression|) is *true* and IsIdentifierRef of |LeftHandSideExpression| is *true*, then
-          1. Let _rval_ be NamedEvaluation of |AssignmentExpression| with argument _lref_.[[ReferencedName]].
+          1. Let _rval_ be ? NamedEvaluation of |AssignmentExpression| with argument _lref_.[[ReferencedName]].
         1. Else,
           1. Let _rref_ be the result of evaluating |AssignmentExpression|.
           1. Let _rval_ be ? GetValue(_rref_).
@@ -20438,7 +20478,7 @@
         1. [id="step-assignmentexpression-evaluation-lgcl-nullish-getvalue"] Let _lval_ be ? GetValue(_lref_).
         1. If _lval_ is neither *undefined* nor *null*, return _lval_.
         1. If IsAnonymousFunctionDefinition(|AssignmentExpression|) is *true* and IsIdentifierRef of |LeftHandSideExpression| is *true*, then
-          1. Let _rval_ be NamedEvaluation of |AssignmentExpression| with argument _lref_.[[ReferencedName]].
+          1. Let _rval_ be ? NamedEvaluation of |AssignmentExpression| with argument _lref_.[[ReferencedName]].
         1. Else,
           1. Let _rref_ be the result of evaluating |AssignmentExpression|.
           1. Let _rval_ be ? GetValue(_rref_).
@@ -20454,14 +20494,13 @@
       <h1>
         ApplyStringOrNumericBinaryOperator (
           _lval_: an ECMAScript language value,
-          _opText_: a sequence of Unicode code points,
+          _opText_: `**`, `*`, `/`, `%`, `+`, `-`, `&lt;&lt;`, `&gt;&gt;`, `&gt;&gt;&gt;`, `&amp;`, `^`, or `|`,
           _rval_: an ECMAScript language value,
-        )
+        ): either a normal completion containing either a String, a BigInt, or a Number, or an abrupt completion
       </h1>
       <dl class="header">
       </dl>
       <emu-alg>
-        1. Assert: _opText_ is present in the table in step <emu-xref href="#step-applystringornumericbinaryoperator-operations-table"></emu-xref>.
         1. If _opText_ is `+`, then
           1. [id="step-binary-op-toprimitive-lval"] Let _lprim_ be ? ToPrimitive(_lval_).
           1. [id="step-binary-op-toprimitive-rval"] Let _rprim_ be ? ToPrimitive(_rval_).
@@ -20475,19 +20514,21 @@
         1. Let _lnum_ be ? ToNumeric(_lval_).
         1. Let _rnum_ be ? ToNumeric(_rval_).
         1. If Type(_lnum_) is different from Type(_rnum_), throw a *TypeError* exception.
-        1. [id="step-applystringornumericbinaryoperator-operations-table"] Let _operation_ be the abstract operation associated with _opText_ and Type(_lnum_) in the following table:
+        1. If Type(_lnum_) is BigInt, then
+          1. If _opText_ is `**`, return ? BigInt::exponentiate(_lnum_, _rnum_).
+          1. If _opText_ is `/`, return ? BigInt::divide(_lnum_, _rnum_).
+          1. If _opText_ is `%`, return ? BigInt::remainder(_lnum_, _rnum_).
+          1. If _opText_ is `&gt;&gt;&gt;`, return ? BigInt::unsignedRightShift(_lnum_, _rnum_).
+        1. Let _operation_ be the abstract operation associated with _opText_ and Type(_lnum_) in the following table:
           <figure>
             <!-- emu-format ignore -->
             <table class="lightweight-table">
               <tr><th> _opText_       </th><th> Type(_lnum_) </th><th> _operation_                </th></tr>
               <tr><td> `**`           </td><td> Number       </td><td> Number::exponentiate       </td></tr>
-              <tr><td> `**`           </td><td> BigInt       </td><td> BigInt::exponentiate       </td></tr>
               <tr><td> `*`            </td><td> Number       </td><td> Number::multiply           </td></tr>
               <tr><td> `*`            </td><td> BigInt       </td><td> BigInt::multiply           </td></tr>
               <tr><td> `/`            </td><td> Number       </td><td> Number::divide             </td></tr>
-              <tr><td> `/`            </td><td> BigInt       </td><td> BigInt::divide             </td></tr>
               <tr><td> `%`            </td><td> Number       </td><td> Number::remainder          </td></tr>
-              <tr><td> `%`            </td><td> BigInt       </td><td> BigInt::remainder          </td></tr>
               <tr><td> `+`            </td><td> Number       </td><td> Number::add                </td></tr>
               <tr><td> `+`            </td><td> BigInt       </td><td> BigInt::add                </td></tr>
               <tr><td> `-`            </td><td> Number       </td><td> Number::subtract           </td></tr>
@@ -20497,7 +20538,6 @@
               <tr><td> `&gt;&gt;`     </td><td> Number       </td><td> Number::signedRightShift   </td></tr>
               <tr><td> `&gt;&gt;`     </td><td> BigInt       </td><td> BigInt::signedRightShift   </td></tr>
               <tr><td> `&gt;&gt;&gt;` </td><td> Number       </td><td> Number::unsignedRightShift </td></tr>
-              <tr><td> `&gt;&gt;&gt;` </td><td> BigInt       </td><td> BigInt::unsignedRightShift </td></tr>
               <tr><td> `&amp;`        </td><td> Number       </td><td> Number::bitwiseAND         </td></tr>
               <tr><td> `&amp;`        </td><td> BigInt       </td><td> BigInt::bitwiseAND         </td></tr>
               <tr><td> `^`            </td><td> Number       </td><td> Number::bitwiseXOR         </td></tr>
@@ -20506,7 +20546,7 @@
               <tr><td> `|`            </td><td> BigInt       </td><td> BigInt::bitwiseOR          </td></tr>
             </table>
           </figure>
-        1. Return ? _operation_(_lnum_, _rnum_).
+        1. Return _operation_(_lnum_, _rnum_).
       </emu-alg>
       <emu-note>
         <p>No hint is provided in the calls to ToPrimitive in steps <emu-xref href="#step-binary-op-toprimitive-lval"></emu-xref> and <emu-xref href="#step-binary-op-toprimitive-rval"></emu-xref>. All standard objects except Dates handle the absence of a hint as if ~number~ were given; Dates handle the absence of a hint as if ~string~ were given. Exotic objects may handle the absence of a hint in some other manner.</p>
@@ -20522,7 +20562,7 @@
           _leftOperand_: a Parse Node,
           _opText_: a sequence of Unicode code points,
           _rightOperand_: a Parse Node,
-        )
+        ): either a normal completion containing either a String, a BigInt, or a Number, or an abrupt completion
       </h1>
       <dl class="header">
       </dl>
@@ -20620,14 +20660,14 @@
         <h1>
           Runtime Semantics: DestructuringAssignmentEvaluation (
             _value_: unknown,
-          )
+          ): either a normal completion containing ~unused~ or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
         <emu-grammar>ObjectAssignmentPattern : `{` `}`</emu-grammar>
         <emu-alg>
           1. Perform ? RequireObjectCoercible(_value_).
-          1. Return NormalCompletion(~empty~).
+          1. Return ~unused~.
         </emu-alg>
         <emu-grammar>
           ObjectAssignmentPattern :
@@ -20637,17 +20677,17 @@
         <emu-alg>
           1. Perform ? RequireObjectCoercible(_value_).
           1. Perform ? PropertyDestructuringAssignmentEvaluation of |AssignmentPropertyList| with argument _value_.
-          1. Return NormalCompletion(~empty~).
+          1. Return ~unused~.
         </emu-alg>
         <emu-grammar>ArrayAssignmentPattern : `[` `]`</emu-grammar>
         <emu-alg>
           1. Let _iteratorRecord_ be ? GetIterator(_value_).
-          1. Return ? IteratorClose(_iteratorRecord_, NormalCompletion(~empty~)).
+          1. Return ? IteratorClose(_iteratorRecord_, NormalCompletion(~unused~)).
         </emu-alg>
         <emu-grammar>ArrayAssignmentPattern : `[` Elision `]`</emu-grammar>
         <emu-alg>
           1. Let _iteratorRecord_ be ? GetIterator(_value_).
-          1. Let _result_ be IteratorDestructuringAssignmentEvaluation of |Elision| with argument _iteratorRecord_.
+          1. Let _result_ be Completion(IteratorDestructuringAssignmentEvaluation of |Elision| with argument _iteratorRecord_).
           1. If _iteratorRecord_.[[Done]] is *false*, return ? IteratorClose(_iteratorRecord_, _result_).
           1. Return _result_.
         </emu-alg>
@@ -20655,50 +20695,50 @@
         <emu-alg>
           1. Let _iteratorRecord_ be ? GetIterator(_value_).
           1. If |Elision| is present, then
-            1. Let _status_ be IteratorDestructuringAssignmentEvaluation of |Elision| with argument _iteratorRecord_.
+            1. Let _status_ be Completion(IteratorDestructuringAssignmentEvaluation of |Elision| with argument _iteratorRecord_).
             1. If _status_ is an abrupt completion, then
               1. Assert: _iteratorRecord_.[[Done]] is *true*.
-              1. Return Completion(_status_).
-          1. Let _result_ be IteratorDestructuringAssignmentEvaluation of |AssignmentRestElement| with argument _iteratorRecord_.
+              1. Return ? _status_.
+          1. Let _result_ be Completion(IteratorDestructuringAssignmentEvaluation of |AssignmentRestElement| with argument _iteratorRecord_).
           1. If _iteratorRecord_.[[Done]] is *false*, return ? IteratorClose(_iteratorRecord_, _result_).
           1. Return _result_.
         </emu-alg>
         <emu-grammar>ArrayAssignmentPattern : `[` AssignmentElementList `]`</emu-grammar>
         <emu-alg>
           1. Let _iteratorRecord_ be ? GetIterator(_value_).
-          1. Let _result_ be IteratorDestructuringAssignmentEvaluation of |AssignmentElementList| with argument _iteratorRecord_.
+          1. Let _result_ be Completion(IteratorDestructuringAssignmentEvaluation of |AssignmentElementList| with argument _iteratorRecord_).
           1. If _iteratorRecord_.[[Done]] is *false*, return ? IteratorClose(_iteratorRecord_, _result_).
           1. Return _result_.
         </emu-alg>
         <emu-grammar>ArrayAssignmentPattern : `[` AssignmentElementList `,` Elision? AssignmentRestElement? `]`</emu-grammar>
         <emu-alg>
           1. Let _iteratorRecord_ be ? GetIterator(_value_).
-          1. Let _status_ be IteratorDestructuringAssignmentEvaluation of |AssignmentElementList| with argument _iteratorRecord_.
+          1. Let _status_ be Completion(IteratorDestructuringAssignmentEvaluation of |AssignmentElementList| with argument _iteratorRecord_).
           1. If _status_ is an abrupt completion, then
             1. If _iteratorRecord_.[[Done]] is *false*, return ? IteratorClose(_iteratorRecord_, _status_).
-            1. Return Completion(_status_).
+            1. Return ? _status_.
           1. If |Elision| is present, then
-            1. Set _status_ to the result of performing IteratorDestructuringAssignmentEvaluation of |Elision| with argument _iteratorRecord_.
+            1. Set _status_ to Completion(IteratorDestructuringAssignmentEvaluation of |Elision| with argument _iteratorRecord_).
             1. If _status_ is an abrupt completion, then
               1. Assert: _iteratorRecord_.[[Done]] is *true*.
-              1. Return Completion(_status_).
+              1. Return ? _status_.
           1. If |AssignmentRestElement| is present, then
-            1. Set _status_ to the result of performing IteratorDestructuringAssignmentEvaluation of |AssignmentRestElement| with argument _iteratorRecord_.
+            1. Set _status_ to Completion(IteratorDestructuringAssignmentEvaluation of |AssignmentRestElement| with argument _iteratorRecord_).
           1. If _iteratorRecord_.[[Done]] is *false*, return ? IteratorClose(_iteratorRecord_, _status_).
-          1. Return Completion(_status_).
+          1. Return ? _status_.
         </emu-alg>
         <emu-grammar>ObjectAssignmentPattern : `{` AssignmentRestProperty `}`</emu-grammar>
         <emu-alg>
           1. Perform ? RequireObjectCoercible(_value_).
           1. Let _excludedNames_ be a new empty List.
-          1. Return the result of performing RestDestructuringAssignmentEvaluation of |AssignmentRestProperty| with arguments _value_ and _excludedNames_.
+          1. Return ? RestDestructuringAssignmentEvaluation of |AssignmentRestProperty| with arguments _value_ and _excludedNames_.
         </emu-alg>
 
         <emu-grammar>ObjectAssignmentPattern : `{` AssignmentPropertyList `,` AssignmentRestProperty `}`</emu-grammar>
         <emu-alg>
           1. Perform ? RequireObjectCoercible(_value_).
           1. Let _excludedNames_ be ? PropertyDestructuringAssignmentEvaluation of |AssignmentPropertyList| with argument _value_.
-          1. Return the result of performing RestDestructuringAssignmentEvaluation of |AssignmentRestProperty| with arguments _value_ and _excludedNames_.
+          1. Return ? RestDestructuringAssignmentEvaluation of |AssignmentRestProperty| with arguments _value_ and _excludedNames_.
         </emu-alg>
       </emu-clause>
 
@@ -20706,11 +20746,11 @@
         <h1>
           Runtime Semantics: PropertyDestructuringAssignmentEvaluation (
             _value_: unknown,
-          )
+          ): either a normal completion containing a List of property keys or an abrupt completion
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It collects a list of all destructured property names.</dd>
+          <dd>It collects a list of all destructured property keys.</dd>
         </dl>
         <emu-grammar>AssignmentPropertyList : AssignmentPropertyList `,` AssignmentProperty</emu-grammar>
         <emu-alg>
@@ -20726,7 +20766,7 @@
           1. Let _v_ be ? GetV(_value_, _P_).
           1. If |Initializer?| is present and _v_ is *undefined*, then
             1. If IsAnonymousFunctionDefinition(|Initializer|) is *true*, then
-              1. Set _v_ to the result of performing NamedEvaluation of |Initializer| with argument _P_.
+              1. Set _v_ to ? NamedEvaluation of |Initializer| with argument _P_.
             1. Else,
               1. Let _defaultValue_ be the result of evaluating |Initializer|.
               1. Set _v_ to ? GetValue(_defaultValue_).
@@ -20748,7 +20788,7 @@
           Runtime Semantics: RestDestructuringAssignmentEvaluation (
             _value_: unknown,
             _excludedNames_: unknown,
-          )
+          ): either a normal completion containing ~unused~ or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
@@ -20756,9 +20796,9 @@
         <emu-alg>
           1. Let _lref_ be the result of evaluating |DestructuringAssignmentTarget|.
           1. ReturnIfAbrupt(_lref_).
-          1. Let _restObj_ be ! OrdinaryObjectCreate(%Object.prototype%).
+          1. Let _restObj_ be OrdinaryObjectCreate(%Object.prototype%).
           1. Perform ? CopyDataProperties(_restObj_, _value_, _excludedNames_).
-          1. Return PutValue(_lref_, _restObj_).
+          1. Return ? PutValue(_lref_, _restObj_).
         </emu-alg>
       </emu-clause>
 
@@ -20766,46 +20806,46 @@
         <h1>
           Runtime Semantics: IteratorDestructuringAssignmentEvaluation (
             _iteratorRecord_: unknown,
-          )
+          ): either a normal completion containing ~unused~ or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
         <emu-grammar>AssignmentElementList : AssignmentElisionElement</emu-grammar>
         <emu-alg>
-          1. Return the result of performing IteratorDestructuringAssignmentEvaluation of |AssignmentElisionElement| with argument _iteratorRecord_.
+          1. Return ? IteratorDestructuringAssignmentEvaluation of |AssignmentElisionElement| with argument _iteratorRecord_.
         </emu-alg>
         <emu-grammar>AssignmentElementList : AssignmentElementList `,` AssignmentElisionElement</emu-grammar>
         <emu-alg>
           1. Perform ? IteratorDestructuringAssignmentEvaluation of |AssignmentElementList| with argument _iteratorRecord_.
-          1. Return the result of performing IteratorDestructuringAssignmentEvaluation of |AssignmentElisionElement| with argument _iteratorRecord_.
+          1. Return ? IteratorDestructuringAssignmentEvaluation of |AssignmentElisionElement| with argument _iteratorRecord_.
         </emu-alg>
         <emu-grammar>AssignmentElisionElement : AssignmentElement</emu-grammar>
         <emu-alg>
-          1. Return the result of performing IteratorDestructuringAssignmentEvaluation of |AssignmentElement| with argument _iteratorRecord_.
+          1. Return ? IteratorDestructuringAssignmentEvaluation of |AssignmentElement| with argument _iteratorRecord_.
         </emu-alg>
         <emu-grammar>AssignmentElisionElement : Elision AssignmentElement</emu-grammar>
         <emu-alg>
           1. Perform ? IteratorDestructuringAssignmentEvaluation of |Elision| with argument _iteratorRecord_.
-          1. Return the result of performing IteratorDestructuringAssignmentEvaluation of |AssignmentElement| with argument _iteratorRecord_.
+          1. Return ? IteratorDestructuringAssignmentEvaluation of |AssignmentElement| with argument _iteratorRecord_.
         </emu-alg>
         <emu-grammar>Elision : `,`</emu-grammar>
         <emu-alg>
           1. If _iteratorRecord_.[[Done]] is *false*, then
-            1. Let _next_ be IteratorStep(_iteratorRecord_).
+            1. Let _next_ be Completion(IteratorStep(_iteratorRecord_)).
             1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
             1. ReturnIfAbrupt(_next_).
             1. If _next_ is *false*, set _iteratorRecord_.[[Done]] to *true*.
-          1. Return NormalCompletion(~empty~).
+          1. Return ~unused~.
         </emu-alg>
         <emu-grammar>Elision : Elision `,`</emu-grammar>
         <emu-alg>
           1. Perform ? IteratorDestructuringAssignmentEvaluation of |Elision| with argument _iteratorRecord_.
           1. If _iteratorRecord_.[[Done]] is *false*, then
-            1. Let _next_ be IteratorStep(_iteratorRecord_).
+            1. Let _next_ be Completion(IteratorStep(_iteratorRecord_)).
             1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
             1. ReturnIfAbrupt(_next_).
             1. If _next_ is *false*, set _iteratorRecord_.[[Done]] to *true*.
-          1. Return NormalCompletion(~empty~).
+          1. Return ~unused~.
         </emu-alg>
         <emu-grammar>AssignmentElement : DestructuringAssignmentTarget Initializer?</emu-grammar>
         <emu-alg>
@@ -20813,12 +20853,12 @@
             1. Let _lref_ be the result of evaluating |DestructuringAssignmentTarget|.
             1. ReturnIfAbrupt(_lref_).
           1. If _iteratorRecord_.[[Done]] is *false*, then
-            1. Let _next_ be IteratorStep(_iteratorRecord_).
+            1. Let _next_ be Completion(IteratorStep(_iteratorRecord_)).
             1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
             1. ReturnIfAbrupt(_next_).
             1. If _next_ is *false*, set _iteratorRecord_.[[Done]] to *true*.
             1. Else,
-              1. Let _value_ be IteratorValue(_next_).
+              1. Let _value_ be Completion(IteratorValue(_next_)).
               1. If _value_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
               1. ReturnIfAbrupt(_value_).
           1. If _iteratorRecord_.[[Done]] is *true*, let _value_ be *undefined*.
@@ -20831,7 +20871,7 @@
           1. Else, let _v_ be _value_.
           1. If |DestructuringAssignmentTarget| is an |ObjectLiteral| or an |ArrayLiteral|, then
             1. Let _nestedAssignmentPattern_ be the |AssignmentPattern| that is covered by |DestructuringAssignmentTarget|.
-            1. Return the result of performing DestructuringAssignmentEvaluation of _nestedAssignmentPattern_ with argument _v_.
+            1. Return ? DestructuringAssignmentEvaluation of _nestedAssignmentPattern_ with argument _v_.
           1. Return ? PutValue(_lref_, _v_).
         </emu-alg>
         <emu-note>
@@ -20845,12 +20885,12 @@
           1. Let _A_ be ! ArrayCreate(0).
           1. Let _n_ be 0.
           1. Repeat, while _iteratorRecord_.[[Done]] is *false*,
-            1. Let _next_ be IteratorStep(_iteratorRecord_).
+            1. Let _next_ be Completion(IteratorStep(_iteratorRecord_)).
             1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
             1. ReturnIfAbrupt(_next_).
             1. If _next_ is *false*, set _iteratorRecord_.[[Done]] to *true*.
             1. Else,
-              1. Let _nextValue_ be IteratorValue(_next_).
+              1. Let _nextValue_ be Completion(IteratorValue(_next_)).
               1. If _nextValue_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
               1. ReturnIfAbrupt(_nextValue_).
               1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_n_)), _nextValue_).
@@ -20858,7 +20898,7 @@
           1. If |DestructuringAssignmentTarget| is neither an |ObjectLiteral| nor an |ArrayLiteral|, then
             1. Return ? PutValue(_lref_, _A_).
           1. Let _nestedAssignmentPattern_ be the |AssignmentPattern| that is covered by |DestructuringAssignmentTarget|.
-          1. Return the result of performing DestructuringAssignmentEvaluation of _nestedAssignmentPattern_ with argument _A_.
+          1. Return ? DestructuringAssignmentEvaluation of _nestedAssignmentPattern_ with argument _A_.
         </emu-alg>
       </emu-clause>
 
@@ -20867,7 +20907,7 @@
           Runtime Semantics: KeyedDestructuringAssignmentEvaluation (
             _value_: unknown,
             _propertyName_: unknown,
-          )
+          ): either a normal completion containing ~unused~ or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
@@ -20886,7 +20926,7 @@
           1. Else, let _rhsValue_ be _v_.
           1. If |DestructuringAssignmentTarget| is an |ObjectLiteral| or an |ArrayLiteral|, then
             1. Let _assignmentPattern_ be the |AssignmentPattern| that is covered by |DestructuringAssignmentTarget|.
-            1. Return the result of performing DestructuringAssignmentEvaluation of _assignmentPattern_ with argument _rhsValue_.
+            1. Return ? DestructuringAssignmentEvaluation of _assignmentPattern_ with argument _rhsValue_.
           1. Return ? PutValue(_lref_, _rhsValue_).
         </emu-alg>
       </emu-clause>
@@ -20966,7 +21006,7 @@
           AsyncGeneratorDeclaration
       </emu-grammar>
       <emu-alg>
-        1. Return NormalCompletion(~empty~).
+        1. Return ~empty~.
       </emu-alg>
       <emu-grammar>
         HoistableDeclaration : FunctionDeclaration
@@ -20981,7 +21021,7 @@
       </emu-grammar>
       <emu-alg>
         1. Let _newLabelSet_ be a new empty List.
-        1. Return the result of performing LabelledEvaluation of this |BreakableStatement| with argument _newLabelSet_.
+        1. Return ? LabelledEvaluation of this |BreakableStatement| with argument _newLabelSet_.
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -21022,7 +21062,7 @@
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>Block : `{` `}`</emu-grammar>
       <emu-alg>
-        1. Return NormalCompletion(~empty~).
+        1. Return ~empty~.
       </emu-alg>
       <emu-grammar>Block : `{` StatementList `}`</emu-grammar>
       <emu-alg>
@@ -21042,7 +21082,7 @@
         1. Let _sl_ be the result of evaluating |StatementList|.
         1. ReturnIfAbrupt(_sl_).
         1. Let _s_ be the result of evaluating |StatementListItem|.
-        1. Return Completion(UpdateEmpty(_s_, _sl_)).
+        1. Return ? UpdateEmpty(_s_, _sl_).
       </emu-alg>
       <emu-note>
         <p>The value of a |StatementList| is the value of the last value-producing item in the |StatementList|. For example, the following calls to the `eval` function all return the value 1:</p>
@@ -21059,7 +21099,7 @@
         BlockDeclarationInstantiation (
           _code_: a Parse Node,
           _env_: a declarative Environment Record,
-        )
+        ): ~unused~
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -21086,7 +21126,8 @@
           1. If _d_ is a |FunctionDeclaration|, a |GeneratorDeclaration|, an |AsyncFunctionDeclaration|, or an |AsyncGeneratorDeclaration|, then
             1. Let _fn_ be the sole element of the BoundNames of _d_.
             1. Let _fo_ be InstantiateFunctionObject of _d_ with arguments _env_ and _privateEnv_.
-            1. [id="step-blockdeclarationinstantiation-initializebinding"] Perform _env_.InitializeBinding(_fn_, _fo_). NOTE: This step is replaced in section <emu-xref href="#sec-web-compat-blockdeclarationinstantiation"></emu-xref>.
+            1. [id="step-blockdeclarationinstantiation-initializebinding"] Perform ! _env_.InitializeBinding(_fn_, _fo_). NOTE: This step is replaced in section <emu-xref href="#sec-web-compat-blockdeclarationinstantiation"></emu-xref>.
+        1. Return ~unused~.
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -21142,7 +21183,7 @@
         <emu-alg>
           1. Let _next_ be the result of evaluating |BindingList|.
           1. ReturnIfAbrupt(_next_).
-          1. Return NormalCompletion(~empty~).
+          1. Return ~empty~.
         </emu-alg>
         <emu-grammar>BindingList : BindingList `,` LexicalBinding</emu-grammar>
         <emu-alg>
@@ -21152,8 +21193,9 @@
         </emu-alg>
         <emu-grammar>LexicalBinding : BindingIdentifier</emu-grammar>
         <emu-alg>
-          1. Let _lhs_ be ResolveBinding(StringValue of |BindingIdentifier|).
-          1. Return InitializeReferencedBinding(_lhs_, *undefined*).
+          1. Let _lhs_ be Completion(ResolveBinding(StringValue of |BindingIdentifier|)).
+          1. Perform ? InitializeReferencedBinding(_lhs_, *undefined*).
+          1. Return ~empty~.
         </emu-alg>
         <emu-note>
           <p>A static semantics rule ensures that this form of |LexicalBinding| never occurs in a `const` declaration.</p>
@@ -21161,20 +21203,21 @@
         <emu-grammar>LexicalBinding : BindingIdentifier Initializer</emu-grammar>
         <emu-alg>
           1. Let _bindingId_ be StringValue of |BindingIdentifier|.
-          1. Let _lhs_ be ResolveBinding(_bindingId_).
+          1. Let _lhs_ be Completion(ResolveBinding(_bindingId_)).
           1. If IsAnonymousFunctionDefinition(|Initializer|) is *true*, then
-            1. Let _value_ be NamedEvaluation of |Initializer| with argument _bindingId_.
+            1. Let _value_ be ? NamedEvaluation of |Initializer| with argument _bindingId_.
           1. Else,
             1. Let _rhs_ be the result of evaluating |Initializer|.
             1. Let _value_ be ? GetValue(_rhs_).
-          1. Return InitializeReferencedBinding(_lhs_, _value_).
+          1. Perform ? InitializeReferencedBinding(_lhs_, _value_).
+          1. Return ~empty~.
         </emu-alg>
         <emu-grammar>LexicalBinding : BindingPattern Initializer</emu-grammar>
         <emu-alg>
           1. Let _rhs_ be the result of evaluating |Initializer|.
           1. Let _value_ be ? GetValue(_rhs_).
           1. Let _env_ be the running execution context's LexicalEnvironment.
-          1. Return the result of performing BindingInitialization of |BindingPattern| with arguments _value_ and _env_.
+          1. Return ? BindingInitialization of |BindingPattern| with arguments _value_ and _env_.
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -21204,7 +21247,7 @@
         <emu-alg>
           1. Let _next_ be the result of evaluating |VariableDeclarationList|.
           1. ReturnIfAbrupt(_next_).
-          1. Return NormalCompletion(~empty~).
+          1. Return ~empty~.
         </emu-alg>
         <emu-grammar>VariableDeclarationList : VariableDeclarationList `,` VariableDeclaration</emu-grammar>
         <emu-alg>
@@ -21214,18 +21257,19 @@
         </emu-alg>
         <emu-grammar>VariableDeclaration : BindingIdentifier</emu-grammar>
         <emu-alg>
-          1. Return NormalCompletion(~empty~).
+          1. Return ~empty~.
         </emu-alg>
         <emu-grammar>VariableDeclaration : BindingIdentifier Initializer</emu-grammar>
         <emu-alg>
           1. Let _bindingId_ be StringValue of |BindingIdentifier|.
           1. Let _lhs_ be ? ResolveBinding(_bindingId_).
           1. If IsAnonymousFunctionDefinition(|Initializer|) is *true*, then
-            1. Let _value_ be NamedEvaluation of |Initializer| with argument _bindingId_.
+            1. Let _value_ be ? NamedEvaluation of |Initializer| with argument _bindingId_.
           1. Else,
             1. Let _rhs_ be the result of evaluating |Initializer|.
             1. Let _value_ be ? GetValue(_rhs_).
-          1. [id="step-vardecllist-evaluation-putvalue"] Return ? PutValue(_lhs_, _value_).
+          1. [id="step-vardecllist-evaluation-putvalue"] Perform ? PutValue(_lhs_, _value_).
+          1. Return ~empty~.
         </emu-alg>
         <emu-note>
           <p>If a |VariableDeclaration| is nested within a with statement and the |BindingIdentifier| in the |VariableDeclaration| is the same as a property name of the binding object of the with statement's object Environment Record, then step <emu-xref href="#step-vardecllist-evaluation-putvalue"></emu-xref> will assign _value_ to the property instead of assigning to the VariableEnvironment binding of the |Identifier|.</p>
@@ -21234,7 +21278,7 @@
         <emu-alg>
           1. Let _rhs_ be the result of evaluating |Initializer|.
           1. Let _rval_ be ? GetValue(_rhs_).
-          1. Return the result of performing BindingInitialization of |BindingPattern| with arguments _rval_ and *undefined*.
+          1. Return ? BindingInitialization of |BindingPattern| with arguments _rval_ and *undefined*.
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -21293,11 +21337,11 @@
           Runtime Semantics: PropertyBindingInitialization (
             _value_: unknown,
             _environment_: unknown,
-          )
+          ): either a normal completion containing a List of property keys or an abrupt completion
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It collects a list of all bound property names rather than just empty completion.</dd>
+          <dd>It collects a list of all bound property names.</dd>
         </dl>
         <emu-grammar>BindingPropertyList : BindingPropertyList `,` BindingProperty</emu-grammar>
         <emu-alg>
@@ -21310,7 +21354,7 @@
         <emu-alg>
           1. Let _name_ be the string that is the only element of BoundNames of |SingleNameBinding|.
           1. Perform ? KeyedBindingInitialization of |SingleNameBinding| with arguments _value_, _environment_, and _name_.
-          1. Return a List whose sole element is _name_.
+          1. Return &laquo; _name_ &raquo;.
         </emu-alg>
 
         <emu-grammar>BindingProperty : PropertyName `:` BindingElement</emu-grammar>
@@ -21318,7 +21362,7 @@
           1. Let _P_ be the result of evaluating |PropertyName|.
           1. ReturnIfAbrupt(_P_).
           1. Perform ? KeyedBindingInitialization of |BindingElement| with arguments _value_, _environment_, and _P_.
-          1. Return a List whose sole element is _P_.
+          1. Return &laquo; _P_ &raquo;.
         </emu-alg>
       </emu-clause>
 
@@ -21328,17 +21372,17 @@
             _value_: unknown,
             _environment_: unknown,
             _excludedNames_: unknown,
-          )
+          ): either a normal completion containing ~unused~ or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
         <emu-grammar>BindingRestProperty : `...` BindingIdentifier</emu-grammar>
         <emu-alg>
           1. Let _lhs_ be ? ResolveBinding(StringValue of |BindingIdentifier|, _environment_).
-          1. Let _restObj_ be ! OrdinaryObjectCreate(%Object.prototype%).
+          1. Let _restObj_ be OrdinaryObjectCreate(%Object.prototype%).
           1. Perform ? CopyDataProperties(_restObj_, _value_, _excludedNames_).
-          1. If _environment_ is *undefined*, return PutValue(_lhs_, _restObj_).
-          1. Return InitializeReferencedBinding(_lhs_, _restObj_).
+          1. If _environment_ is *undefined*, return ? PutValue(_lhs_, _restObj_).
+          1. Return ? InitializeReferencedBinding(_lhs_, _restObj_).
         </emu-alg>
       </emu-clause>
 
@@ -21348,7 +21392,7 @@
             _value_: unknown,
             _environment_: unknown,
             _propertyName_: unknown,
-          )
+          ): either a normal completion containing ~unused~ or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
@@ -21361,7 +21405,7 @@
           1. If |Initializer| is present and _v_ is *undefined*, then
             1. Let _defaultValue_ be the result of evaluating |Initializer|.
             1. Set _v_ to ? GetValue(_defaultValue_).
-          1. Return the result of performing BindingInitialization of |BindingPattern| with arguments _v_ and _environment_.
+          1. Return ? BindingInitialization of |BindingPattern| with arguments _v_ and _environment_.
         </emu-alg>
         <emu-grammar>SingleNameBinding : BindingIdentifier Initializer?</emu-grammar>
         <emu-alg>
@@ -21370,12 +21414,12 @@
           1. Let _v_ be ? GetV(_value_, _propertyName_).
           1. If |Initializer| is present and _v_ is *undefined*, then
             1. If IsAnonymousFunctionDefinition(|Initializer|) is *true*, then
-              1. Set _v_ to the result of performing NamedEvaluation of |Initializer| with argument _bindingId_.
+              1. Set _v_ to ? NamedEvaluation of |Initializer| with argument _bindingId_.
             1. Else,
               1. Let _defaultValue_ be the result of evaluating |Initializer|.
               1. Set _v_ to ? GetValue(_defaultValue_).
           1. If _environment_ is *undefined*, return ? PutValue(_lhs_, _v_).
-          1. Return InitializeReferencedBinding(_lhs_, _v_).
+          1. Return ? InitializeReferencedBinding(_lhs_, _v_).
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -21393,7 +21437,7 @@
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>EmptyStatement : `;`</emu-grammar>
       <emu-alg>
-        1. Return NormalCompletion(~empty~).
+        1. Return ~empty~.
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -21456,22 +21500,22 @@
       <emu-grammar>IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
       <emu-alg>
         1. Let _exprRef_ be the result of evaluating |Expression|.
-        1. Let _exprValue_ be ! ToBoolean(? GetValue(_exprRef_)).
+        1. Let _exprValue_ be ToBoolean(? GetValue(_exprRef_)).
         1. If _exprValue_ is *true*, then
           1. Let _stmtCompletion_ be the result of evaluating the first |Statement|.
         1. Else,
           1. Let _stmtCompletion_ be the result of evaluating the second |Statement|.
-        1. Return Completion(UpdateEmpty(_stmtCompletion_, *undefined*)).
+        1. Return ? UpdateEmpty(_stmtCompletion_, *undefined*).
       </emu-alg>
       <emu-grammar>IfStatement : `if` `(` Expression `)` Statement</emu-grammar>
       <emu-alg>
         1. Let _exprRef_ be the result of evaluating |Expression|.
-        1. Let _exprValue_ be ! ToBoolean(? GetValue(_exprRef_)).
+        1. Let _exprValue_ be ToBoolean(? GetValue(_exprRef_)).
         1. If _exprValue_ is *false*, then
-          1. Return NormalCompletion(*undefined*).
+          1. Return *undefined*.
         1. Else,
           1. Let _stmtCompletion_ be the result of evaluating |Statement|.
-          1. Return Completion(UpdateEmpty(_stmtCompletion_, *undefined*)).
+          1. Return ? UpdateEmpty(_stmtCompletion_, *undefined*).
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -21495,7 +21539,7 @@
           LoopContinues (
             _completion_: unknown,
             _labelSet_: unknown,
-          )
+          ): a Boolean
         </h1>
         <dl class="header">
         </dl>
@@ -21515,7 +21559,7 @@
         <h1>
           Runtime Semantics: LoopEvaluation (
             _labelSet_: unknown,
-          )
+          ): either a normal completion containing an ECMAScript language value or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
@@ -21563,7 +21607,7 @@
         <h1>
           Runtime Semantics: DoWhileLoopEvaluation (
             _labelSet_: unknown,
-          )
+          ): either a normal completion containing an ECMAScript language value or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
@@ -21572,11 +21616,11 @@
           1. Let _V_ be *undefined*.
           1. Repeat,
             1. Let _stmtResult_ be the result of evaluating |Statement|.
-            1. If LoopContinues(_stmtResult_, _labelSet_) is *false*, return Completion(UpdateEmpty(_stmtResult_, _V_)).
+            1. If LoopContinues(_stmtResult_, _labelSet_) is *false*, return ? UpdateEmpty(_stmtResult_, _V_).
             1. If _stmtResult_.[[Value]] is not ~empty~, set _V_ to _stmtResult_.[[Value]].
             1. Let _exprRef_ be the result of evaluating |Expression|.
             1. Let _exprValue_ be ? GetValue(_exprRef_).
-            1. If ! ToBoolean(_exprValue_) is *false*, return NormalCompletion(_V_).
+            1. If ToBoolean(_exprValue_) is *false*, return _V_.
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -21606,7 +21650,7 @@
         <h1>
           Runtime Semantics: WhileLoopEvaluation (
             _labelSet_: unknown,
-          )
+          ): either a normal completion containing an ECMAScript language value or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
@@ -21616,9 +21660,9 @@
           1. Repeat,
             1. Let _exprRef_ be the result of evaluating |Expression|.
             1. Let _exprValue_ be ? GetValue(_exprRef_).
-            1. If ! ToBoolean(_exprValue_) is *false*, return NormalCompletion(_V_).
+            1. If ToBoolean(_exprValue_) is *false*, return _V_.
             1. Let _stmtResult_ be the result of evaluating |Statement|.
-            1. If LoopContinues(_stmtResult_, _labelSet_) is *false*, return Completion(UpdateEmpty(_stmtResult_, _V_)).
+            1. If LoopContinues(_stmtResult_, _labelSet_) is *false*, return ? UpdateEmpty(_stmtResult_, _V_).
             1. If _stmtResult_.[[Value]] is not ~empty~, set _V_ to _stmtResult_.[[Value]].
         </emu-alg>
       </emu-clause>
@@ -21662,7 +21706,7 @@
         <h1>
           Runtime Semantics: ForLoopEvaluation (
             _labelSet_: unknown,
-          )
+          ): either a normal completion containing an ECMAScript language value or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
@@ -21694,11 +21738,11 @@
           1. Let _forDcl_ be the result of evaluating |LexicalDeclaration|.
           1. If _forDcl_ is an abrupt completion, then
             1. Set the running execution context's LexicalEnvironment to _oldEnv_.
-            1. Return Completion(_forDcl_).
+            1. Return ? _forDcl_.
           1. If _isConst_ is *false*, let _perIterationLets_ be _boundNames_; otherwise let _perIterationLets_ be &laquo; &raquo;.
-          1. Let _bodyResult_ be ForBodyEvaluation(the first |Expression|, the second |Expression|, |Statement|, _perIterationLets_, _labelSet_).
+          1. Let _bodyResult_ be Completion(ForBodyEvaluation(the first |Expression|, the second |Expression|, |Statement|, _perIterationLets_, _labelSet_)).
           1. Set the running execution context's LexicalEnvironment to _oldEnv_.
-          1. Return Completion(_bodyResult_).
+          1. Return ? _bodyResult_.
         </emu-alg>
       </emu-clause>
 
@@ -21710,7 +21754,7 @@
             _stmt_: unknown,
             _perIterationBindings_: unknown,
             _labelSet_: unknown,
-          )
+          ): either a normal completion containing an ECMAScript language value or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
@@ -21721,9 +21765,9 @@
             1. If _test_ is not ~[empty]~, then
               1. Let _testRef_ be the result of evaluating _test_.
               1. Let _testValue_ be ? GetValue(_testRef_).
-              1. If ! ToBoolean(_testValue_) is *false*, return NormalCompletion(_V_).
+              1. If ToBoolean(_testValue_) is *false*, return _V_.
             1. Let _result_ be the result of evaluating _stmt_.
-            1. If LoopContinues(_result_, _labelSet_) is *false*, return Completion(UpdateEmpty(_result_, _V_)).
+            1. If LoopContinues(_result_, _labelSet_) is *false*, return ? UpdateEmpty(_result_, _V_).
             1. If _result_.[[Value]] is not ~empty~, set _V_ to _result_.[[Value]].
             1. Perform ? CreatePerIterationEnvironment(_perIterationBindings_).
             1. If _increment_ is not ~[empty]~, then
@@ -21736,7 +21780,7 @@
         <h1>
           CreatePerIterationEnvironment (
             _perIterationBindings_: unknown,
-          )
+          ): either a normal completion containing ~unused~ or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
@@ -21749,9 +21793,9 @@
             1. For each element _bn_ of _perIterationBindings_, do
               1. Perform ! _thisIterationEnv_.CreateMutableBinding(_bn_, *false*).
               1. Let _lastValue_ be ? _lastIterationEnv_.GetBindingValue(_bn_, *true*).
-              1. Perform _thisIterationEnv_.InitializeBinding(_bn_, _lastValue_).
+              1. Perform ! _thisIterationEnv_.InitializeBinding(_bn_, _lastValue_).
             1. Set the running execution context's LexicalEnvironment to _thisIterationEnv_.
-          1. Return *undefined*.
+          1. Return ~unused~.
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -21842,7 +21886,7 @@
       </emu-clause>
 
       <emu-clause id="sec-static-semantics-isdestructuring" oldids="sec-static-semantics-static-semantics-isdestructuring,sec-for-in-and-for-of-statements-static-semantics-isdestructuring" type="sdo">
-        <h1>Static Semantics: IsDestructuring</h1>
+        <h1>Static Semantics: IsDestructuring ( ): a Boolean</h1>
         <dl class="header">
         </dl>
         <emu-grammar>MemberExpression : PrimaryExpression</emu-grammar>
@@ -21892,7 +21936,7 @@
           Runtime Semantics: ForDeclarationBindingInitialization (
             _value_: unknown,
             _environment_: unknown,
-          )
+          ): either a normal completion containing ~unused~ or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
@@ -21901,7 +21945,7 @@
         </emu-note>
         <emu-grammar>ForDeclaration : LetOrConst ForBinding</emu-grammar>
         <emu-alg>
-          1. Return the result of performing BindingInitialization of |ForBinding| with arguments _value_ and _environment_.
+          1. Return ? BindingInitialization of |ForBinding| with arguments _value_ and _environment_.
         </emu-alg>
       </emu-clause>
 
@@ -21909,7 +21953,7 @@
         <h1>
           Runtime Semantics: ForDeclarationBindingInstantiation (
             _environment_: unknown,
-          )
+          ): ~unused~
         </h1>
         <dl class="header">
         </dl>
@@ -21921,6 +21965,7 @@
               1. Perform ! _environment_.CreateImmutableBinding(_name_, *true*).
             1. Else,
               1. Perform ! _environment_.CreateMutableBinding(_name_, *false*).
+          1. Return ~unused~.
         </emu-alg>
       </emu-clause>
 
@@ -21928,7 +21973,7 @@
         <h1>
           Runtime Semantics: ForInOfLoopEvaluation (
             _labelSet_: unknown,
-          )
+          ): either a normal completion containing an ECMAScript language value or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
@@ -21994,7 +22039,7 @@
             _uninitializedBoundNames_: unknown,
             _expr_: unknown,
             _iterationKind_: ~enumerate~, ~iterate~, or ~async-iterate~,
-          )
+          ): either a normal completion containing an Iterator Record or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
@@ -22013,7 +22058,7 @@
             1. If _exprValue_ is *undefined* or *null*, then
               1. Return Completion Record { [[Type]]: ~break~, [[Value]]: ~empty~, [[Target]]: ~empty~ }.
             1. Let _obj_ be ! ToObject(_exprValue_).
-            1. Let _iterator_ be ? EnumerateObjectProperties(_obj_).
+            1. Let _iterator_ be EnumerateObjectProperties(_obj_).
             1. Let _nextMethod_ be ! GetV(_iterator_, *"next"*).
             1. Return the Iterator Record { [[Iterator]]: _iterator_, [[NextMethod]]: _nextMethod_, [[Done]]: *false* }.
           1. Else,
@@ -22034,7 +22079,7 @@
             _lhsKind_: ~assignment~, ~varBinding~, or ~lexicalBinding~,
             _labelSet_: unknown,
             optional _iteratorKind_: ~sync~ or ~async~,
-          )
+          ): either a normal completion containing an ECMAScript language value or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
@@ -22051,7 +22096,7 @@
             1. If _iteratorKind_ is ~async~, set _nextResult_ to ? Await(_nextResult_).
             1. If Type(_nextResult_) is not Object, throw a *TypeError* exception.
             1. Let _done_ be ? IteratorComplete(_nextResult_).
-            1. If _done_ is *true*, return NormalCompletion(_V_).
+            1. If _done_ is *true*, return _V_.
             1. Let _nextValue_ be ? IteratorValue(_nextResult_).
             1. If _lhsKind_ is either ~assignment~ or ~varBinding~, then
               1. If _destructuring_ is *false*, then
@@ -22070,24 +22115,24 @@
               1. If _lhsRef_ is an abrupt completion, then
                 1. Let _status_ be _lhsRef_.
               1. Else if _lhsKind_ is ~lexicalBinding~, then
-                1. Let _status_ be InitializeReferencedBinding(_lhsRef_, _nextValue_).
+                1. Let _status_ be Completion(InitializeReferencedBinding(_lhsRef_, _nextValue_)).
               1. Else,
-                1. Let _status_ be PutValue(_lhsRef_, _nextValue_).
+                1. Let _status_ be Completion(PutValue(_lhsRef_, _nextValue_)).
             1. Else,
               1. If _lhsKind_ is ~assignment~, then
-                1. Let _status_ be DestructuringAssignmentEvaluation of _assignmentPattern_ with argument _nextValue_.
+                1. Let _status_ be Completion(DestructuringAssignmentEvaluation of _assignmentPattern_ with argument _nextValue_).
               1. Else if _lhsKind_ is ~varBinding~, then
                 1. Assert: _lhs_ is a |ForBinding|.
-                1. Let _status_ be BindingInitialization of _lhs_ with arguments _nextValue_ and *undefined*.
+                1. Let _status_ be Completion(BindingInitialization of _lhs_ with arguments _nextValue_ and *undefined*).
               1. Else,
                 1. Assert: _lhsKind_ is ~lexicalBinding~.
                 1. Assert: _lhs_ is a |ForDeclaration|.
-                1. Let _status_ be ForDeclarationBindingInitialization of _lhs_ with arguments _nextValue_ and _iterationEnv_.
+                1. Let _status_ be Completion(ForDeclarationBindingInitialization of _lhs_ with arguments _nextValue_ and _iterationEnv_).
             1. If _status_ is an abrupt completion, then
               1. Set the running execution context's LexicalEnvironment to _oldEnv_.
               1. If _iteratorKind_ is ~async~, return ? AsyncIteratorClose(_iteratorRecord_, _status_).
               1. If _iterationKind_ is ~enumerate~, then
-                1. Return _status_.
+                1. Return ? _status_.
               1. Else,
                 1. Assert: _iterationKind_ is ~iterate~.
                 1. Return ? IteratorClose(_iteratorRecord_, _status_).
@@ -22095,10 +22140,10 @@
             1. Set the running execution context's LexicalEnvironment to _oldEnv_.
             1. If LoopContinues(_result_, _labelSet_) is *false*, then
               1. If _iterationKind_ is ~enumerate~, then
-                1. Return Completion(UpdateEmpty(_result_, _V_)).
+                1. Return ? UpdateEmpty(_result_, _V_).
               1. Else,
                 1. Assert: _iterationKind_ is ~iterate~.
-                1. Set _status_ to UpdateEmpty(_result_, _V_).
+                1. Set _status_ to Completion(UpdateEmpty(_result_, _V_)).
                 1. If _iteratorKind_ is ~async~, return ? AsyncIteratorClose(_iteratorRecord_, _status_).
                 1. Return ? IteratorClose(_iteratorRecord_, _status_).
             1. If _result_.[[Value]] is not ~empty~, set _V_ to _result_.[[Value]].
@@ -22123,7 +22168,7 @@
         <h1>
           EnumerateObjectProperties (
             _O_: an Object,
-          )
+          ): an Iterator
         </h1>
         <dl class="header">
         </dl>
@@ -22175,14 +22220,14 @@
           <h1>
             CreateForInIterator (
               _object_: an Object,
-            )
+            ): a For-In Iterator
           </h1>
           <dl class="header">
             <dt>description</dt>
             <dd>It is used to create a For-In Iterator object which iterates over the own and inherited enumerable string properties of _object_ in a specific order.</dd>
           </dl>
           <emu-alg>
-            1. Let _iterator_ be ! OrdinaryObjectCreate(%ForInIteratorPrototype%, &laquo; [[Object]], [[ObjectWasVisited]], [[VisitedKeys]], [[RemainingKeys]] &raquo;).
+            1. Let _iterator_ be OrdinaryObjectCreate(%ForInIteratorPrototype%, &laquo; [[Object]], [[ObjectWasVisited]], [[VisitedKeys]], [[RemainingKeys]] &raquo;).
             1. Set _iterator_.[[Object]] to _object_.
             1. Set _iterator_.[[ObjectWasVisited]] to *false*.
             1. Set _iterator_.[[VisitedKeys]] to a new empty List.
@@ -22365,7 +22410,7 @@
         `return` [no LineTerminator here] Expression[+In, ?Yield, ?Await] `;`
     </emu-grammar>
     <emu-note>
-      <p>A `return` statement causes a function to cease execution and, in most cases, returns a value to the caller. If |Expression| is omitted, the return value is *undefined*. Otherwise, the return value is the value of |Expression|. A `return` statement may not actually return a value to the caller depending on surrounding context. For example, in a `try` block, a `return` statement's completion record may be replaced with another completion record during evaluation of the `finally` block.</p>
+      <p>A `return` statement causes a function to cease execution and, in most cases, returns a value to the caller. If |Expression| is omitted, the return value is *undefined*. Otherwise, the return value is the value of |Expression|. A `return` statement may not actually return a value to the caller depending on surrounding context. For example, in a `try` block, a `return` statement's Completion Record may be replaced with another Completion Record during evaluation of the `finally` block.</p>
     </emu-note>
 
     <emu-clause id="sec-return-statement-runtime-semantics-evaluation" type="sdo">
@@ -22378,7 +22423,7 @@
       <emu-alg>
         1. Let _exprRef_ be the result of evaluating |Expression|.
         1. Let _exprValue_ be ? GetValue(_exprRef_).
-        1. If ! GetGeneratorKind() is ~async~, set _exprValue_ to ? Await(_exprValue_).
+        1. If GetGeneratorKind() is ~async~, set _exprValue_ to ? Await(_exprValue_).
         1. Return Completion Record { [[Type]]: ~return~, [[Value]]: _exprValue_, [[Target]]: ~empty~ }.
       </emu-alg>
     </emu-clause>
@@ -22426,7 +22471,7 @@
         1. Set the running execution context's LexicalEnvironment to _newEnv_.
         1. Let _C_ be the result of evaluating |Statement|.
         1. Set the running execution context's LexicalEnvironment to _oldEnv_.
-        1. Return Completion(UpdateEmpty(_C_, *undefined*)).
+        1. Return ? UpdateEmpty(_C_, *undefined*).
       </emu-alg>
       <emu-note>
         <p>No matter how control leaves the embedded |Statement|, whether normally or by some form of abrupt completion or exception, the LexicalEnvironment is always restored to its former state.</p>
@@ -22473,13 +22518,13 @@
       <h1>
         Runtime Semantics: CaseBlockEvaluation (
           _input_: unknown,
-        )
+        ): either a normal completion containing an ECMAScript language value or an abrupt completion
       </h1>
       <dl class="header">
       </dl>
       <emu-grammar>CaseBlock : `{` `}`</emu-grammar>
       <emu-alg>
-        1. Return NormalCompletion(*undefined*).
+        1. Return *undefined*.
       </emu-alg>
       <emu-grammar>CaseBlock : `{` CaseClauses `}`</emu-grammar>
       <emu-alg>
@@ -22492,8 +22537,8 @@
           1. If _found_ is *true*, then
             1. Let _R_ be the result of evaluating _C_.
             1. If _R_.[[Value]] is not ~empty~, set _V_ to _R_.[[Value]].
-            1. If _R_ is an abrupt completion, return Completion(UpdateEmpty(_R_, _V_)).
-        1. Return NormalCompletion(_V_).
+            1. If _R_ is an abrupt completion, return ? UpdateEmpty(_R_, _V_).
+        1. Return _V_.
       </emu-alg>
       <emu-grammar>CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
       <emu-alg>
@@ -22509,7 +22554,7 @@
           1. If _found_ is *true*, then
             1. Let _R_ be the result of evaluating _C_.
             1. If _R_.[[Value]] is not ~empty~, set _V_ to _R_.[[Value]].
-            1. If _R_ is an abrupt completion, return Completion(UpdateEmpty(_R_, _V_)).
+            1. If _R_ is an abrupt completion, return ? UpdateEmpty(_R_, _V_).
         1. Let _foundInB_ be *false*.
         1. If the second |CaseClauses| is present, then
           1. Let _B_ be the List of |CaseClause| items in the second |CaseClauses|, in source text order.
@@ -22522,17 +22567,17 @@
             1. If _foundInB_ is *true*, then
               1. Let _R_ be the result of evaluating |CaseClause| _C_.
               1. If _R_.[[Value]] is not ~empty~, set _V_ to _R_.[[Value]].
-              1. If _R_ is an abrupt completion, return Completion(UpdateEmpty(_R_, _V_)).
-        1. If _foundInB_ is *true*, return NormalCompletion(_V_).
+              1. If _R_ is an abrupt completion, return ? UpdateEmpty(_R_, _V_).
+        1. If _foundInB_ is *true*, return _V_.
         1. Let _R_ be the result of evaluating |DefaultClause|.
         1. If _R_.[[Value]] is not ~empty~, set _V_ to _R_.[[Value]].
-        1. If _R_ is an abrupt completion, return Completion(UpdateEmpty(_R_, _V_)).
+        1. If _R_ is an abrupt completion, return ? UpdateEmpty(_R_, _V_).
         1. NOTE: The following is another complete iteration of the second |CaseClauses|.
         1. For each |CaseClause| _C_ of _B_, do
           1. Let _R_ be the result of evaluating |CaseClause| _C_.
           1. If _R_.[[Value]] is not ~empty~, set _V_ to _R_.[[Value]].
-          1. If _R_ is an abrupt completion, return Completion(UpdateEmpty(_R_, _V_)).
-        1. Return NormalCompletion(_V_).
+          1. If _R_ is an abrupt completion, return ? UpdateEmpty(_R_, _V_).
+        1. Return _V_.
       </emu-alg>
     </emu-clause>
 
@@ -22541,7 +22586,7 @@
         CaseClauseIsSelected (
           _C_: a |CaseClause| Parse Node,
           _input_: an ECMAScript language value,
-        )
+        ): either a normal completion containing a Boolean or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -22568,7 +22613,7 @@
         1. Let _blockEnv_ be NewDeclarativeEnvironment(_oldEnv_).
         1. Perform BlockDeclarationInstantiation(|CaseBlock|, _blockEnv_).
         1. Set the running execution context's LexicalEnvironment to _blockEnv_.
-        1. Let _R_ be CaseBlockEvaluation of |CaseBlock| with argument _switchValue_.
+        1. Let _R_ be Completion(CaseBlockEvaluation of |CaseBlock| with argument _switchValue_).
         1. Set the running execution context's LexicalEnvironment to _oldEnv_.
         1. Return _R_.
       </emu-alg>
@@ -22577,7 +22622,7 @@
       </emu-note>
       <emu-grammar>CaseClause : `case` Expression `:`</emu-grammar>
       <emu-alg>
-        1. Return NormalCompletion(~empty~).
+        1. Return ~empty~.
       </emu-alg>
       <emu-grammar>CaseClause : `case` Expression `:` StatementList</emu-grammar>
       <emu-alg>
@@ -22585,7 +22630,7 @@
       </emu-alg>
       <emu-grammar>DefaultClause : `default` `:`</emu-grammar>
       <emu-alg>
-        1. Return NormalCompletion(~empty~).
+        1. Return ~empty~.
       </emu-alg>
       <emu-grammar>DefaultClause : `default` `:` StatementList</emu-grammar>
       <emu-alg>
@@ -22626,7 +22671,7 @@
       <h1>
         Static Semantics: IsLabelledFunction (
           _stmt_: unknown,
-        )
+        ): a Boolean
       </h1>
       <dl class="header">
       </dl>
@@ -22644,7 +22689,7 @@
       <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
       <emu-alg>
         1. Let _newLabelSet_ be a new empty List.
-        1. Return LabelledEvaluation of this |LabelledStatement| with argument _newLabelSet_.
+        1. Return ? LabelledEvaluation of this |LabelledStatement| with argument _newLabelSet_.
       </emu-alg>
     </emu-clause>
 
@@ -22652,18 +22697,18 @@
       <h1>
         Runtime Semantics: LabelledEvaluation (
           _labelSet_: unknown,
-        )
+        ): either a normal completion containing an ECMAScript language value or an abrupt completion
       </h1>
       <dl class="header">
       </dl>
       <emu-grammar>BreakableStatement : IterationStatement</emu-grammar>
       <emu-alg>
-        1. Let _stmtResult_ be LoopEvaluation of |IterationStatement| with argument _labelSet_.
+        1. Let _stmtResult_ be Completion(LoopEvaluation of |IterationStatement| with argument _labelSet_).
         1. If _stmtResult_.[[Type]] is ~break~, then
           1. If _stmtResult_.[[Target]] is ~empty~, then
             1. If _stmtResult_.[[Value]] is ~empty~, set _stmtResult_ to NormalCompletion(*undefined*).
             1. Else, set _stmtResult_ to NormalCompletion(_stmtResult_.[[Value]]).
-        1. Return Completion(_stmtResult_).
+        1. Return ? _stmtResult_.
       </emu-alg>
       <emu-grammar>BreakableStatement : SwitchStatement</emu-grammar>
       <emu-alg>
@@ -22672,7 +22717,7 @@
           1. If _stmtResult_.[[Target]] is ~empty~, then
             1. If _stmtResult_.[[Value]] is ~empty~, set _stmtResult_ to NormalCompletion(*undefined*).
             1. Else, set _stmtResult_ to NormalCompletion(_stmtResult_.[[Value]]).
-        1. Return Completion(_stmtResult_).
+        1. Return ? _stmtResult_.
       </emu-alg>
       <emu-note>
         <p>A |BreakableStatement| is one that can be exited via an unlabelled |BreakStatement|.</p>
@@ -22681,10 +22726,10 @@
       <emu-alg>
         1. Let _label_ be the StringValue of |LabelIdentifier|.
         1. Let _newLabelSet_ be the list-concatenation of _labelSet_ and &laquo; _label_ &raquo;.
-        1. Let _stmtResult_ be LabelledEvaluation of |LabelledItem| with argument _newLabelSet_.
+        1. Let _stmtResult_ be Completion(LabelledEvaluation of |LabelledItem| with argument _newLabelSet_).
         1. If _stmtResult_.[[Type]] is ~break~ and SameValue(_stmtResult_.[[Target]], _label_) is *true*, then
           1. Set _stmtResult_ to NormalCompletion(_stmtResult_.[[Value]]).
-        1. Return Completion(_stmtResult_).
+        1. Return ? _stmtResult_.
       </emu-alg>
       <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
       <emu-alg>
@@ -22780,7 +22825,7 @@
       <h1>
         Runtime Semantics: CatchClauseEvaluation (
           _thrownValue_: unknown,
-        )
+        ): either a normal completion containing an ECMAScript language value or an abrupt completion
       </h1>
       <dl class="header">
       </dl>
@@ -22791,13 +22836,13 @@
         1. For each element _argName_ of the BoundNames of |CatchParameter|, do
           1. Perform ! _catchEnv_.CreateMutableBinding(_argName_, *false*).
         1. Set the running execution context's LexicalEnvironment to _catchEnv_.
-        1. Let _status_ be BindingInitialization of |CatchParameter| with arguments _thrownValue_ and _catchEnv_.
+        1. Let _status_ be Completion(BindingInitialization of |CatchParameter| with arguments _thrownValue_ and _catchEnv_).
         1. If _status_ is an abrupt completion, then
           1. Set the running execution context's LexicalEnvironment to _oldEnv_.
-          1. Return Completion(_status_).
+          1. Return ? _status_.
         1. Let _B_ be the result of evaluating |Block|.
         1. Set the running execution context's LexicalEnvironment to _oldEnv_.
-        1. Return Completion(_B_).
+        1. Return ? _B_.
       </emu-alg>
       <emu-grammar>Catch : `catch` Block</emu-grammar>
       <emu-alg>
@@ -22813,25 +22858,25 @@
       <emu-grammar>TryStatement : `try` Block Catch</emu-grammar>
       <emu-alg>
         1. Let _B_ be the result of evaluating |Block|.
-        1. If _B_.[[Type]] is ~throw~, let _C_ be CatchClauseEvaluation of |Catch| with argument _B_.[[Value]].
+        1. If _B_.[[Type]] is ~throw~, let _C_ be Completion(CatchClauseEvaluation of |Catch| with argument _B_.[[Value]]).
         1. Else, let _C_ be _B_.
-        1. Return Completion(UpdateEmpty(_C_, *undefined*)).
+        1. Return ? UpdateEmpty(_C_, *undefined*).
       </emu-alg>
       <emu-grammar>TryStatement : `try` Block Finally</emu-grammar>
       <emu-alg>
         1. Let _B_ be the result of evaluating |Block|.
         1. Let _F_ be the result of evaluating |Finally|.
         1. If _F_.[[Type]] is ~normal~, set _F_ to _B_.
-        1. Return Completion(UpdateEmpty(_F_, *undefined*)).
+        1. Return ? UpdateEmpty(_F_, *undefined*).
       </emu-alg>
       <emu-grammar>TryStatement : `try` Block Catch Finally</emu-grammar>
       <emu-alg>
         1. Let _B_ be the result of evaluating |Block|.
-        1. If _B_.[[Type]] is ~throw~, let _C_ be CatchClauseEvaluation of |Catch| with argument _B_.[[Value]].
+        1. If _B_.[[Type]] is ~throw~, let _C_ be Completion(CatchClauseEvaluation of |Catch| with argument _B_.[[Value]]).
         1. Else, let _C_ be _B_.
         1. Let _F_ be the result of evaluating |Finally|.
         1. If _F_.[[Type]] is ~normal~, set _F_ to _C_.
-        1. Return Completion(UpdateEmpty(_F_, *undefined*)).
+        1. Return ? UpdateEmpty(_F_, *undefined*).
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -22853,10 +22898,9 @@
       <emu-alg>
         1. If an implementation-defined debugging facility is available and enabled, then
           1. Perform an implementation-defined debugging action.
-          1. Let _result_ be an implementation-defined Completion value.
+          1. Return a new implementation-defined Completion Record.
         1. Else,
-          1. Let _result_ be NormalCompletion(~empty~).
-        1. Return _result_.
+          1. Return ~empty~.
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -22913,7 +22957,7 @@
     </emu-clause>
 
     <emu-clause id="sec-static-semantics-containsexpression" oldids="sec-destructuring-binding-patterns-static-semantics-containsexpression,sec-function-definitions-static-semantics-containsexpression,sec-arrow-function-definitions-static-semantics-containsexpression,sec-async-arrow-function-definitions-static-semantics-ContainsExpression" type="sdo">
-      <h1>Static Semantics: ContainsExpression</h1>
+      <h1>Static Semantics: ContainsExpression ( ): a Boolean</h1>
       <dl class="header">
       </dl>
       <emu-grammar>
@@ -23020,7 +23064,7 @@
     </emu-clause>
 
     <emu-clause id="sec-static-semantics-issimpleparameterlist" oldids="sec-destructuring-binding-patterns-static-semantics-issimpleparameterlist,sec-function-definitions-static-semantics-issimpleparameterlist,sec-arrow-function-definitions-static-semantics-issimpleparameterlist,sec-async-arrow-function-definitions-static-semantics-IsSimpleParameterList" type="sdo">
-      <h1>Static Semantics: IsSimpleParameterList</h1>
+      <h1>Static Semantics: IsSimpleParameterList ( ): a Boolean</h1>
       <dl class="header">
       </dl>
       <emu-grammar>BindingElement : BindingPattern</emu-grammar>
@@ -23085,7 +23129,7 @@
     </emu-clause>
 
     <emu-clause id="sec-static-semantics-hasinitializer" oldids="sec-destructuring-binding-patterns-static-semantics-hasinitializer,sec-function-definitions-static-semantics-hasinitializer" type="sdo">
-      <h1>Static Semantics: HasInitializer</h1>
+      <h1>Static Semantics: HasInitializer ( ): a Boolean</h1>
       <dl class="header">
       </dl>
       <emu-grammar>BindingElement : BindingPattern</emu-grammar>
@@ -23112,7 +23156,7 @@
     </emu-clause>
 
     <emu-clause id="sec-static-semantics-expectedargumentcount" oldids="sec-function-definitions-static-semantics-expectedargumentcount,sec-arrow-function-definitions-static-semantics-expectedargumentcount,sec-method-definitions-static-semantics-expectedargumentcount,sec-async-arrow-function-definitions-static-semantics-ExpectedArgumentCount" type="sdo">
-      <h1>Static Semantics: ExpectedArgumentCount</h1>
+      <h1>Static Semantics: ExpectedArgumentCount ( ): an integer</h1>
       <dl class="header">
       </dl>
       <emu-grammar>
@@ -23242,7 +23286,7 @@
     </emu-clause>
 
     <emu-clause id="sec-static-semantics-functionbodycontainsusestrict" oldids="sec-function-definitions-static-semantics-containsusestrict" type="sdo">
-      <h1>Static Semantics: FunctionBodyContainsUseStrict</h1>
+      <h1>Static Semantics: FunctionBodyContainsUseStrict ( ): a Boolean</h1>
       <dl class="header">
       </dl>
       <emu-grammar>FunctionBody : FunctionStatementList</emu-grammar>
@@ -23256,7 +23300,7 @@
         Runtime Semantics: EvaluateFunctionBody (
           _functionObject_: unknown,
           _argumentsList_: a List,
-        )
+        ): either a normal completion containing an ECMAScript language value or an abrupt completion
       </h1>
       <dl class="header">
       </dl>
@@ -23272,7 +23316,7 @@
         Runtime Semantics: InstantiateOrdinaryFunctionObject (
           _env_: unknown,
           _privateEnv_: unknown,
-        )
+        ): a function object
       </h1>
       <dl class="header">
       </dl>
@@ -23302,7 +23346,7 @@
       <h1>
         Runtime Semantics: InstantiateOrdinaryFunctionExpression (
           optional _name_: unknown,
-        )
+        ): a function object
       </h1>
       <dl class="header">
       </dl>
@@ -23329,7 +23373,7 @@
         1. Let _closure_ be OrdinaryFunctionCreate(%Function.prototype%, _sourceText_, |FormalParameters|, |FunctionBody|, ~non-lexical-this~, _funcEnv_, _privateEnv_).
         1. Perform SetFunctionName(_closure_, _name_).
         1. Perform MakeConstructor(_closure_).
-        1. Perform _funcEnv_.InitializeBinding(_name_, _closure_).
+        1. Perform ! _funcEnv_.InitializeBinding(_name_, _closure_).
         1. Return _closure_.
       </emu-alg>
       <emu-note>
@@ -23341,14 +23385,14 @@
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>FunctionDeclaration : `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
-        1. Return NormalCompletion(~empty~).
+        1. Return ~empty~.
       </emu-alg>
       <emu-note>
         <p>An alternative semantics is provided in <emu-xref href="#sec-block-level-function-declarations-web-legacy-compatibility-semantics"></emu-xref>.</p>
       </emu-note>
       <emu-grammar>FunctionDeclaration : `function` `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
-        1. Return NormalCompletion(~empty~).
+        1. Return ~empty~.
       </emu-alg>
       <emu-grammar>
         FunctionExpression : `function` BindingIdentifier? `(` FormalParameters `)` `{` FunctionBody `}`
@@ -23361,7 +23405,7 @@
       </emu-note>
       <emu-grammar>FunctionStatementList : [empty]</emu-grammar>
       <emu-alg>
-        1. Return NormalCompletion(*undefined*).
+        1. Return *undefined*.
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -23421,7 +23465,7 @@
     </emu-clause>
 
     <emu-clause id="sec-static-semantics-concisebodycontainsusestrict" oldids="sec-arrow-function-definitions-static-semantics-containsusestrict" type="sdo">
-      <h1>Static Semantics: ConciseBodyContainsUseStrict</h1>
+      <h1>Static Semantics: ConciseBodyContainsUseStrict ( ): a Boolean</h1>
       <dl class="header">
       </dl>
       <emu-grammar>ConciseBody : ExpressionBody</emu-grammar>
@@ -23439,7 +23483,7 @@
         Runtime Semantics: EvaluateConciseBody (
           _functionObject_: unknown,
           _argumentsList_: a List,
-        )
+        ): either a normal completion containing an ECMAScript language value or an abrupt completion
       </h1>
       <dl class="header">
       </dl>
@@ -23454,7 +23498,7 @@
       <h1>
         Runtime Semantics: InstantiateArrowFunctionExpression (
           optional _name_: unknown,
-        )
+        ): a function object
       </h1>
       <dl class="header">
       </dl>
@@ -23530,7 +23574,7 @@
     </emu-clause>
 
     <emu-clause id="sec-static-semantics-hasdirectsuper" oldids="sec-method-definitions-static-semantics-hasdirectsuper,sec-generator-function-definitions-static-semantics-hasdirectsuper,sec-async-generator-function-definitions-static-semantics-hasdirectsuper,sec-async-function-definitions-static-semantics-HasDirectSuper" type="sdo">
-      <h1>Static Semantics: HasDirectSuper</h1>
+      <h1>Static Semantics: HasDirectSuper ( ): a Boolean</h1>
       <dl class="header">
       </dl>
       <emu-grammar>MethodDefinition : ClassElementName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
@@ -23567,7 +23611,7 @@
     </emu-clause>
 
     <emu-clause id="sec-static-semantics-specialmethod" type="sdo">
-      <h1>Static Semantics: SpecialMethod</h1>
+      <h1>Static Semantics: SpecialMethod ( ): a Boolean</h1>
       <dl class="header">
       </dl>
       <emu-grammar>MethodDefinition : ClassElementName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
@@ -23592,7 +23636,7 @@
         Runtime Semantics: DefineMethod (
           _object_: unknown,
           optional _functionPrototype_: unknown,
-        )
+        ): either a normal completion containing a Record with fields [[Key]] (a property key) and [[Closure]] (a function object) or an abrupt completion
       </h1>
       <dl class="header">
       </dl>
@@ -23618,15 +23662,15 @@
         Runtime Semantics: MethodDefinitionEvaluation (
           _object_: unknown,
           _enumerable_: unknown,
-        )
+        ): either a normal completion containing either a PrivateElement or ~unused~, or an abrupt completion
       </h1>
       <dl class="header">
       </dl>
       <emu-grammar>MethodDefinition : ClassElementName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Let _methodDef_ be ? DefineMethod of |MethodDefinition| with argument _object_.
-        1. Perform ! SetFunctionName(_methodDef_.[[Closure]], _methodDef_.[[Key]]).
-        1. Return ? DefineMethodProperty(_object_, _methodDef_.[[Key]], _methodDef_.[[Closure]], _enumerable_).
+        1. Perform SetFunctionName(_methodDef_.[[Closure]], _methodDef_.[[Key]]).
+        1. Return DefineMethodProperty(_object_, _methodDef_.[[Key]], _methodDef_.[[Closure]], _enumerable_).
       </emu-alg>
       <emu-grammar>MethodDefinition : `get` ClassElementName `(` `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
@@ -23644,7 +23688,7 @@
         1. Else,
           1. Let _desc_ be the PropertyDescriptor { [[Get]]: _closure_, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
           1. Perform ? DefinePropertyOrThrow(_object_, _propKey_, _desc_).
-          1. Return ~empty~.
+          1. Return ~unused~.
       </emu-alg>
       <emu-grammar>MethodDefinition : `set` ClassElementName `(` PropertySetParameterList `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
@@ -23661,7 +23705,7 @@
         1. Else,
           1. Let _desc_ be the PropertyDescriptor { [[Set]]: _closure_, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
           1. Perform ? DefinePropertyOrThrow(_object_, _propKey_, _desc_).
-          1. Return ~empty~.
+          1. Return ~unused~.
       </emu-alg>
       <emu-grammar>GeneratorMethod : `*` ClassElementName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
@@ -23673,9 +23717,9 @@
         1. Let _closure_ be OrdinaryFunctionCreate(%GeneratorFunction.prototype%, _sourceText_, |UniqueFormalParameters|, |GeneratorBody|, ~non-lexical-this~, _env_, _privateEnv_).
         1. Perform MakeMethod(_closure_, _object_).
         1. Perform SetFunctionName(_closure_, _propKey_).
-        1. Let _prototype_ be ! OrdinaryObjectCreate(%GeneratorFunction.prototype.prototype%).
+        1. Let _prototype_ be OrdinaryObjectCreate(%GeneratorFunction.prototype.prototype%).
         1. Perform ! DefinePropertyOrThrow(_closure_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
-        1. Return ? DefineMethodProperty(_object_, _propKey_, _closure_, _enumerable_).
+        1. Return DefineMethodProperty(_object_, _propKey_, _closure_, _enumerable_).
       </emu-alg>
       <emu-grammar>
         AsyncGeneratorMethod : `async` `*` ClassElementName `(` UniqueFormalParameters `)` `{` AsyncGeneratorBody `}`
@@ -23686,12 +23730,12 @@
         1. Let _env_ be the running execution context's LexicalEnvironment.
         1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
         1. Let _sourceText_ be the source text matched by |AsyncGeneratorMethod|.
-        1. Let _closure_ be ! OrdinaryFunctionCreate(%AsyncGeneratorFunction.prototype%, _sourceText_, |UniqueFormalParameters|, |AsyncGeneratorBody|, ~non-lexical-this~, _env_, _privateEnv_).
-        1. Perform ! MakeMethod(_closure_, _object_).
-        1. Perform ! SetFunctionName(_closure_, _propKey_).
-        1. Let _prototype_ be ! OrdinaryObjectCreate(%AsyncGeneratorFunction.prototype.prototype%).
+        1. Let _closure_ be OrdinaryFunctionCreate(%AsyncGeneratorFunction.prototype%, _sourceText_, |UniqueFormalParameters|, |AsyncGeneratorBody|, ~non-lexical-this~, _env_, _privateEnv_).
+        1. Perform MakeMethod(_closure_, _object_).
+        1. Perform SetFunctionName(_closure_, _propKey_).
+        1. Let _prototype_ be OrdinaryObjectCreate(%AsyncGeneratorFunction.prototype.prototype%).
         1. Perform ! DefinePropertyOrThrow(_closure_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
-        1. Return ? DefineMethodProperty(_object_, _propKey_, _closure_, _enumerable_).
+        1. Return DefineMethodProperty(_object_, _propKey_, _closure_, _enumerable_).
       </emu-alg>
       <emu-grammar>
         AsyncMethod : `async` ClassElementName `(` UniqueFormalParameters `)` `{` AsyncFunctionBody `}`
@@ -23702,10 +23746,10 @@
         1. Let _env_ be the LexicalEnvironment of the running execution context.
         1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
         1. Let _sourceText_ be the source text matched by |AsyncMethod|.
-        1. Let _closure_ be ! OrdinaryFunctionCreate(%AsyncFunction.prototype%, _sourceText_, |UniqueFormalParameters|, |AsyncFunctionBody|, ~non-lexical-this~, _env_, _privateEnv_).
-        1. Perform ! MakeMethod(_closure_, _object_).
-        1. Perform ! SetFunctionName(_closure_, _propKey_).
-        1. Return ? DefineMethodProperty(_object_, _propKey_, _closure_, _enumerable_).
+        1. Let _closure_ be OrdinaryFunctionCreate(%AsyncFunction.prototype%, _sourceText_, |UniqueFormalParameters|, |AsyncFunctionBody|, ~non-lexical-this~, _env_, _privateEnv_).
+        1. Perform MakeMethod(_closure_, _object_).
+        1. Perform SetFunctionName(_closure_, _propKey_).
+        1. Return DefineMethodProperty(_object_, _propKey_, _closure_, _enumerable_).
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -23803,7 +23847,7 @@
         Runtime Semantics: EvaluateGeneratorBody (
           _functionObject_: unknown,
           _argumentsList_: a List,
-        )
+        ): a throw completion or a return completion
       </h1>
       <dl class="header">
       </dl>
@@ -23822,7 +23866,7 @@
         Runtime Semantics: InstantiateGeneratorFunctionObject (
           _env_: unknown,
           _privateEnv_: unknown,
-        )
+        ): a function object
       </h1>
       <dl class="header">
       </dl>
@@ -23832,8 +23876,8 @@
         1. Let _sourceText_ be the source text matched by |GeneratorDeclaration|.
         1. Let _F_ be OrdinaryFunctionCreate(%GeneratorFunction.prototype%, _sourceText_, |FormalParameters|, |GeneratorBody|, ~non-lexical-this~, _env_, _privateEnv_).
         1. Perform SetFunctionName(_F_, _name_).
-        1. Let _prototype_ be ! OrdinaryObjectCreate(%GeneratorFunction.prototype.prototype%).
-        1. Perform DefinePropertyOrThrow(_F_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
+        1. Let _prototype_ be OrdinaryObjectCreate(%GeneratorFunction.prototype.prototype%).
+        1. Perform ! DefinePropertyOrThrow(_F_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
         1. Return _F_.
       </emu-alg>
       <emu-grammar>GeneratorDeclaration : `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
@@ -23841,8 +23885,8 @@
         1. Let _sourceText_ be the source text matched by |GeneratorDeclaration|.
         1. Let _F_ be OrdinaryFunctionCreate(%GeneratorFunction.prototype%, _sourceText_, |FormalParameters|, |GeneratorBody|, ~non-lexical-this~, _env_, _privateEnv_).
         1. Perform SetFunctionName(_F_, *"default"*).
-        1. Let _prototype_ be ! OrdinaryObjectCreate(%GeneratorFunction.prototype.prototype%).
-        1. Perform DefinePropertyOrThrow(_F_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
+        1. Let _prototype_ be OrdinaryObjectCreate(%GeneratorFunction.prototype.prototype%).
+        1. Perform ! DefinePropertyOrThrow(_F_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
         1. Return _F_.
       </emu-alg>
       <emu-note>
@@ -23854,7 +23898,7 @@
       <h1>
         Runtime Semantics: InstantiateGeneratorFunctionExpression (
           optional _name_: unknown,
-        )
+        ): a function object
       </h1>
       <dl class="header">
       </dl>
@@ -23866,8 +23910,8 @@
         1. Let _sourceText_ be the source text matched by |GeneratorExpression|.
         1. Let _closure_ be OrdinaryFunctionCreate(%GeneratorFunction.prototype%, _sourceText_, |FormalParameters|, |GeneratorBody|, ~non-lexical-this~, _env_, _privateEnv_).
         1. Perform SetFunctionName(_closure_, _name_).
-        1. Let _prototype_ be ! OrdinaryObjectCreate(%GeneratorFunction.prototype.prototype%).
-        1. Perform DefinePropertyOrThrow(_closure_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
+        1. Let _prototype_ be OrdinaryObjectCreate(%GeneratorFunction.prototype.prototype%).
+        1. Perform ! DefinePropertyOrThrow(_closure_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
         1. Return _closure_.
       </emu-alg>
       <emu-grammar>GeneratorExpression : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
@@ -23881,9 +23925,9 @@
         1. Let _sourceText_ be the source text matched by |GeneratorExpression|.
         1. Let _closure_ be OrdinaryFunctionCreate(%GeneratorFunction.prototype%, _sourceText_, |FormalParameters|, |GeneratorBody|, ~non-lexical-this~, _funcEnv_, _privateEnv_).
         1. Perform SetFunctionName(_closure_, _name_).
-        1. Let _prototype_ be ! OrdinaryObjectCreate(%GeneratorFunction.prototype.prototype%).
-        1. Perform DefinePropertyOrThrow(_closure_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
-        1. Perform _funcEnv_.InitializeBinding(_name_, _closure_).
+        1. Let _prototype_ be OrdinaryObjectCreate(%GeneratorFunction.prototype.prototype%).
+        1. Perform ! DefinePropertyOrThrow(_closure_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
+        1. Perform ! _funcEnv_.InitializeBinding(_name_, _closure_).
         1. Return _closure_.
       </emu-alg>
       <emu-note>
@@ -23911,7 +23955,7 @@
       </emu-alg>
       <emu-grammar>YieldExpression : `yield` `*` AssignmentExpression</emu-grammar>
       <emu-alg>
-        1. Let _generatorKind_ be ! GetGeneratorKind().
+        1. Let _generatorKind_ be GetGeneratorKind().
         1. Let _exprRef_ be the result of evaluating |AssignmentExpression|.
         1. Let _value_ be ? GetValue(_exprRef_).
         1. Let _iteratorRecord_ be ? GetIterator(_value_, _generatorKind_).
@@ -23925,8 +23969,8 @@
             1. Let _done_ be ? IteratorComplete(_innerResult_).
             1. If _done_ is *true*, then
               1. Return ? IteratorValue(_innerResult_).
-            1. If _generatorKind_ is ~async~, set _received_ to AsyncGeneratorYield(? IteratorValue(_innerResult_)).
-            1. Else, set _received_ to GeneratorYield(_innerResult_).
+            1. If _generatorKind_ is ~async~, set _received_ to Completion(AsyncGeneratorYield(? IteratorValue(_innerResult_))).
+            1. Else, set _received_ to Completion(GeneratorYield(_innerResult_)).
           1. Else if _received_.[[Type]] is ~throw~, then
             1. Let _throw_ be ? GetMethod(_iterator_, *"throw"*).
             1. If _throw_ is not *undefined*, then
@@ -23937,8 +23981,8 @@
               1. Let _done_ be ? IteratorComplete(_innerResult_).
               1. If _done_ is *true*, then
                 1. Return ? IteratorValue(_innerResult_).
-              1. If _generatorKind_ is ~async~, set _received_ to AsyncGeneratorYield(? IteratorValue(_innerResult_)).
-              1. Else, set _received_ to GeneratorYield(_innerResult_).
+              1. If _generatorKind_ is ~async~, set _received_ to Completion(AsyncGeneratorYield(? IteratorValue(_innerResult_))).
+              1. Else, set _received_ to Completion(GeneratorYield(_innerResult_)).
             1. Else,
               1. NOTE: If _iterator_ does not have a `throw` method, this throw is going to terminate the `yield*` loop. But first we need to give _iterator_ a chance to clean up.
               1. Let _closeCompletion_ be Completion Record { [[Type]]: ~normal~, [[Value]]: ~empty~, [[Target]]: ~empty~ }.
@@ -23951,7 +23995,7 @@
             1. Let _return_ be ? GetMethod(_iterator_, *"return"*).
             1. If _return_ is *undefined*, then
               1. If _generatorKind_ is ~async~, set _received_.[[Value]] to ? Await(_received_.[[Value]]).
-              1. Return Completion(_received_).
+              1. Return ? _received_.
             1. Let _innerReturnResult_ be ? Call(_return_, _iterator_, &laquo; _received_.[[Value]] &raquo;).
             1. If _generatorKind_ is ~async~, set _innerReturnResult_ to ? Await(_innerReturnResult_).
             1. If Type(_innerReturnResult_) is not Object, throw a *TypeError* exception.
@@ -23959,8 +24003,8 @@
             1. If _done_ is *true*, then
               1. Let _value_ be ? IteratorValue(_innerReturnResult_).
               1. Return Completion Record { [[Type]]: ~return~, [[Value]]: _value_, [[Target]]: ~empty~ }.
-            1. If _generatorKind_ is ~async~, set _received_ to AsyncGeneratorYield(? IteratorValue(_innerReturnResult_)).
-            1. Else, set _received_ to GeneratorYield(_innerReturnResult_).
+            1. If _generatorKind_ is ~async~, set _received_ to Completion(AsyncGeneratorYield(? IteratorValue(_innerReturnResult_))).
+            1. Else, set _received_ to Completion(GeneratorYield(_innerReturnResult_)).
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -24026,7 +24070,7 @@
         Runtime Semantics: EvaluateAsyncGeneratorBody (
           _functionObject_: unknown,
           _argumentsList_: a List,
-        )
+        ): a throw completion or a return completion
       </h1>
       <dl class="header">
       </dl>
@@ -24037,7 +24081,7 @@
         1. Perform ? FunctionDeclarationInstantiation(_functionObject_, _argumentsList_).
         1. Let _generator_ be ? OrdinaryCreateFromConstructor(_functionObject_, *"%AsyncGeneratorFunction.prototype.prototype%"*, &laquo; [[AsyncGeneratorState]], [[AsyncGeneratorContext]], [[AsyncGeneratorQueue]], [[GeneratorBrand]] &raquo;).
         1. Set _generator_.[[GeneratorBrand]] to ~empty~.
-        1. Perform ! AsyncGeneratorStart(_generator_, |FunctionBody|).
+        1. Perform AsyncGeneratorStart(_generator_, |FunctionBody|).
         1. Return Completion Record { [[Type]]: ~return~, [[Value]]: _generator_, [[Target]]: ~empty~ }.
       </emu-alg>
     </emu-clause>
@@ -24047,7 +24091,7 @@
         Runtime Semantics: InstantiateAsyncGeneratorFunctionObject (
           _env_: unknown,
           _privateEnv_: unknown,
-        )
+        ): a function object
       </h1>
       <dl class="header">
       </dl>
@@ -24057,9 +24101,9 @@
       <emu-alg>
         1. Let _name_ be StringValue of |BindingIdentifier|.
         1. Let _sourceText_ be the source text matched by |AsyncGeneratorDeclaration|.
-        1. Let _F_ be ! OrdinaryFunctionCreate(%AsyncGeneratorFunction.prototype%, _sourceText_, |FormalParameters|, |AsyncGeneratorBody|, ~non-lexical-this~, _env_, _privateEnv_).
-        1. Perform ! SetFunctionName(_F_, _name_).
-        1. Let _prototype_ be ! OrdinaryObjectCreate(%AsyncGeneratorFunction.prototype.prototype%).
+        1. Let _F_ be OrdinaryFunctionCreate(%AsyncGeneratorFunction.prototype%, _sourceText_, |FormalParameters|, |AsyncGeneratorBody|, ~non-lexical-this~, _env_, _privateEnv_).
+        1. Perform SetFunctionName(_F_, _name_).
+        1. Let _prototype_ be OrdinaryObjectCreate(%AsyncGeneratorFunction.prototype.prototype%).
         1. Perform ! DefinePropertyOrThrow(_F_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
         1. Return _F_.
       </emu-alg>
@@ -24070,8 +24114,8 @@
         1. Let _sourceText_ be the source text matched by |AsyncGeneratorDeclaration|.
         1. Let _F_ be OrdinaryFunctionCreate(%AsyncGeneratorFunction.prototype%, _sourceText_, |FormalParameters|, |AsyncGeneratorBody|, ~non-lexical-this~, _env_, _privateEnv_).
         1. Perform SetFunctionName(_F_, *"default"*).
-        1. Let _prototype_ be ! OrdinaryObjectCreate(%AsyncGeneratorFunction.prototype.prototype%).
-        1. Perform DefinePropertyOrThrow(_F_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
+        1. Let _prototype_ be OrdinaryObjectCreate(%AsyncGeneratorFunction.prototype.prototype%).
+        1. Perform ! DefinePropertyOrThrow(_F_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
         1. Return _F_.
       </emu-alg>
       <emu-note>
@@ -24083,7 +24127,7 @@
       <h1>
         Runtime Semantics: InstantiateAsyncGeneratorFunctionExpression (
           optional _name_: unknown,
-        )
+        ): a function object
       </h1>
       <dl class="header">
       </dl>
@@ -24095,9 +24139,9 @@
         1. Let _env_ be the LexicalEnvironment of the running execution context.
         1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
         1. Let _sourceText_ be the source text matched by |AsyncGeneratorExpression|.
-        1. Let _closure_ be ! OrdinaryFunctionCreate(%AsyncGeneratorFunction.prototype%, _sourceText_, |FormalParameters|, |AsyncGeneratorBody|, ~non-lexical-this~, _env_, _privateEnv_).
+        1. Let _closure_ be OrdinaryFunctionCreate(%AsyncGeneratorFunction.prototype%, _sourceText_, |FormalParameters|, |AsyncGeneratorBody|, ~non-lexical-this~, _env_, _privateEnv_).
         1. Perform SetFunctionName(_closure_, _name_).
-        1. Let _prototype_ be ! OrdinaryObjectCreate(%AsyncGeneratorFunction.prototype.prototype%).
+        1. Let _prototype_ be OrdinaryObjectCreate(%AsyncGeneratorFunction.prototype.prototype%).
         1. Perform ! DefinePropertyOrThrow(_closure_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
         1. Return _closure_.
       </emu-alg>
@@ -24108,13 +24152,13 @@
         1. Assert: _name_ is not present.
         1. Set _name_ to StringValue of |BindingIdentifier|.
         1. Let _outerEnv_ be the running execution context's LexicalEnvironment.
-        1. Let _funcEnv_ be ! NewDeclarativeEnvironment(_outerEnv_).
+        1. Let _funcEnv_ be NewDeclarativeEnvironment(_outerEnv_).
         1. Perform ! _funcEnv_.CreateImmutableBinding(_name_, *false*).
         1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
         1. Let _sourceText_ be the source text matched by |AsyncGeneratorExpression|.
-        1. Let _closure_ be ! OrdinaryFunctionCreate(%AsyncGeneratorFunction.prototype%, _sourceText_, |FormalParameters|, |AsyncGeneratorBody|, ~non-lexical-this~, _funcEnv_, _privateEnv_).
-        1. Perform ! SetFunctionName(_closure_, _name_).
-        1. Let _prototype_ be ! OrdinaryObjectCreate(%AsyncGeneratorFunction.prototype.prototype%).
+        1. Let _closure_ be OrdinaryFunctionCreate(%AsyncGeneratorFunction.prototype%, _sourceText_, |FormalParameters|, |AsyncGeneratorBody|, ~non-lexical-this~, _funcEnv_, _privateEnv_).
+        1. Perform SetFunctionName(_closure_, _name_).
+        1. Let _prototype_ be OrdinaryObjectCreate(%AsyncGeneratorFunction.prototype.prototype%).
         1. Perform ! DefinePropertyOrThrow(_closure_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
         1. Perform ! _funcEnv_.InitializeBinding(_name_, _closure_).
         1. Return _closure_.
@@ -24192,7 +24236,7 @@
       <emu-grammar>ClassTail : ClassHeritage? `{` ClassBody `}`</emu-grammar>
       <ul>
         <li>
-          <p>It is a Syntax Error if |ClassHeritage| is not present and the following algorithm evaluates to *true*:</p>
+          <p>It is a Syntax Error if |ClassHeritage| is not present and the following algorithm returns *true*:</p>
           <emu-alg>
             1. Let _constructor_ be ConstructorMethod of |ClassBody|.
             1. If _constructor_ is ~empty~, return *false*.
@@ -24284,7 +24328,7 @@
     </emu-clause>
 
     <emu-clause id="sec-static-semantics-classelementkind" type="sdo">
-      <h1>Static Semantics: ClassElementKind</h1>
+      <h1>Static Semantics: ClassElementKind ( ): ~ConstructorMethod~, ~NonConstructorMethod~, or ~empty~</h1>
       <dl class="header">
       </dl>
       <emu-grammar>ClassElement : MethodDefinition</emu-grammar>
@@ -24312,7 +24356,7 @@
     </emu-clause>
 
     <emu-clause id="sec-static-semantics-constructormethod" type="sdo">
-      <h1>Static Semantics: ConstructorMethod</h1>
+      <h1>Static Semantics: ConstructorMethod ( ): a |ClassElement| Parse Node or ~empty~</h1>
       <dl class="header">
       </dl>
       <emu-grammar>ClassElementList : ClassElement</emu-grammar>
@@ -24333,7 +24377,7 @@
     </emu-clause>
 
     <emu-clause id="sec-static-semantics-isstatic" type="sdo">
-      <h1>Static Semantics: IsStatic</h1>
+      <h1>Static Semantics: IsStatic ( ): a Boolean</h1>
       <dl class="header">
       </dl>
       <emu-grammar>ClassElement : MethodDefinition</emu-grammar>
@@ -24363,7 +24407,7 @@
     </emu-clause>
 
     <emu-clause id="sec-static-semantics-nonconstructorelements" oldids="sec-static-semantics-nonconstructormethoddefinitions" type="sdo">
-      <h1>Static Semantics: NonConstructorElements</h1>
+      <h1>Static Semantics: NonConstructorElements ( ): a List of |ClassElement| Parse Nodes</h1>
       <dl class="header">
       </dl>
       <emu-grammar>ClassElementList : ClassElement</emu-grammar>
@@ -24382,7 +24426,7 @@
     </emu-clause>
 
     <emu-clause id="sec-static-semantics-prototypepropertynamelist" type="sdo">
-      <h1>Static Semantics: PrototypePropertyNameList</h1>
+      <h1>Static Semantics: PrototypePropertyNameList ( ): a List of property keys</h1>
       <dl class="header">
       </dl>
       <emu-grammar>ClassElementList : ClassElement</emu-grammar>
@@ -24406,7 +24450,7 @@
       <h1>
         Static Semantics: AllPrivateIdentifiersValid (
           _names_: unknown,
-        )
+        ): a Boolean
       </h1>
       <dl class="header">
       </dl>
@@ -24460,7 +24504,7 @@
     </emu-clause>
 
     <emu-clause id="sec-static-semantics-privateboundidentifiers" type="sdo">
-      <h1>Static Semantics: PrivateBoundIdentifiers</h1>
+      <h1>Static Semantics: PrivateBoundIdentifiers ( ): a List of Strings</h1>
       <dl class="header">
       </dl>
       <emu-grammar>
@@ -24519,7 +24563,7 @@
     </emu-clause>
 
     <emu-clause id="sec-static-semantics-containsarguments" type="sdo">
-      <h1>Static Semantics: ContainsArguments</h1>
+      <h1>Static Semantics: ContainsArguments ( ): a Boolean</h1>
       <dl class="header">
       </dl>
 
@@ -24596,7 +24640,7 @@
       <h1>
         Runtime Semantics: ClassFieldDefinitionEvaluation (
           _homeObject_: unknown,
-        )
+        ): either a normal completion containing a ClassFieldDefinition Record or an abrupt completion
       </h1>
       <dl class="header">
       </dl>
@@ -24611,7 +24655,7 @@
           1. Let _env_ be the LexicalEnvironment of the running execution context.
           1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
           1. Let _sourceText_ be the empty sequence of Unicode code points.
-          1. Let _initializer_ be ! OrdinaryFunctionCreate(%Function.prototype%, _sourceText_, _formalParameterList_, |Initializer|, ~non-lexical-this~, _env_, _privateEnv_).
+          1. Let _initializer_ be OrdinaryFunctionCreate(%Function.prototype%, _sourceText_, _formalParameterList_, |Initializer|, ~non-lexical-this~, _env_, _privateEnv_).
           1. Perform MakeMethod(_initializer_, _homeObject_).
           1. Set _initializer_.[[ClassFieldInitializerName]] to _name_.
         1. Else,
@@ -24627,7 +24671,7 @@
       <h1>
         Runtime Semantics: ClassStaticBlockDefinitionEvaluation (
           _homeObject_: unknown,
-        )
+        ): a ClassStaticBlockDefinition Record
       </h1>
       <dl class="header">
       </dl>
@@ -24648,7 +24692,7 @@
       <h1>
         Runtime Semantics: EvaluateClassStaticBlockBody (
           _functionObject_: unknown,
-        )
+        ): either a normal completion containing an ECMAScript language value or an abrupt completion
       </h1>
       <dl class="header">
       </dl>
@@ -24663,7 +24707,7 @@
       <h1>
         Runtime Semantics: ClassElementEvaluation (
           _object_: unknown,
-        )
+        ): either a normal completion containing either a ClassFieldDefinition Record, a ClassStaticBlockDefinition Record, a Private Name, or ~unused~, or an abrupt completion
       </h1>
       <dl class="header">
       </dl>
@@ -24674,7 +24718,7 @@
           `static` FieldDefinition `;`
       </emu-grammar>
       <emu-alg>
-        1. Return ClassFieldDefinitionEvaluation of |FieldDefinition| with argument _object_.
+        1. Return ? ClassFieldDefinitionEvaluation of |FieldDefinition| with argument _object_.
       </emu-alg>
 
       <emu-grammar>
@@ -24683,7 +24727,7 @@
           `static` MethodDefinition
       </emu-grammar>
       <emu-alg>
-        1. Return MethodDefinitionEvaluation of |MethodDefinition| with arguments _object_ and *false*.
+        1. Return ? MethodDefinitionEvaluation of |MethodDefinition| with arguments _object_ and *false*.
       </emu-alg>
 
       <emu-grammar>ClassElement : ClassStaticBlock</emu-grammar>
@@ -24695,7 +24739,7 @@
         ClassElement : `;`
       </emu-grammar>
       <emu-alg>
-        1. Return.
+        1. Return ~unused~.
       </emu-alg>
     </emu-clause>
 
@@ -24704,7 +24748,7 @@
         Runtime Semantics: ClassDefinitionEvaluation (
           _classBinding_: unknown,
           _className_: unknown,
-        )
+        ): either a normal completion containing a function object or an abrupt completion
       </h1>
       <dl class="header">
       </dl>
@@ -24745,7 +24789,7 @@
             1. Let _protoParent_ be ? Get(_superclass_, *"prototype"*).
             1. If Type(_protoParent_) is neither Object nor Null, throw a *TypeError* exception.
             1. Let _constructorParent_ be _superclass_.
-        1. Let _proto_ be ! OrdinaryObjectCreate(_protoParent_).
+        1. Let _proto_ be OrdinaryObjectCreate(_protoParent_).
         1. If |ClassBody?| is not present, let _constructor_ be ~empty~.
         1. Else, let _constructor_ be ConstructorMethod of |ClassBody|.
         1. Set the running execution context's LexicalEnvironment to _classEnv_.
@@ -24765,15 +24809,15 @@
               1. Let _result_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Object.prototype%"*).
             1. Perform ? InitializeInstanceElements(_result_, _F_).
             1. Return _result_.
-          1. Let _F_ be ! CreateBuiltinFunction(_defaultConstructor_, 0, _className_, &laquo; [[ConstructorKind]], [[SourceText]] &raquo;, the current Realm Record, _constructorParent_).
+          1. Let _F_ be CreateBuiltinFunction(_defaultConstructor_, 0, _className_, &laquo; [[ConstructorKind]], [[SourceText]] &raquo;, the current Realm Record, _constructorParent_).
         1. Else,
           1. Let _constructorInfo_ be ! DefineMethod of _constructor_ with arguments _proto_ and _constructorParent_.
           1. Let _F_ be _constructorInfo_.[[Closure]].
-          1. Perform ! MakeClassConstructor(_F_).
-          1. Perform ! SetFunctionName(_F_, _className_).
-        1. Perform ! MakeConstructor(_F_, *false*, _proto_).
+          1. Perform MakeClassConstructor(_F_).
+          1. Perform SetFunctionName(_F_, _className_).
+        1. Perform MakeConstructor(_F_, *false*, _proto_).
         1. If |ClassHeritage?| is present, set _F_.[[ConstructorKind]] to ~derived~.
-        1. Perform ! CreateMethodProperty(_proto_, *"constructor"*, _F_).
+        1. Perform CreateMethodProperty(_proto_, *"constructor"*, _F_).
         1. If |ClassBody?| is not present, let _elements_ be a new empty List.
         1. Else, let _elements_ be NonConstructorElements of |ClassBody|.
         1. Let _instancePrivateMethods_ be a new empty List.
@@ -24782,13 +24826,13 @@
         1. Let _staticElements_ be a new empty List.
         1. For each |ClassElement| _e_ of _elements_, do
           1. If IsStatic of _e_ is *false*, then
-            1. Let _element_ be ClassElementEvaluation of _e_ with argument _proto_.
+            1. Let _element_ be Completion(ClassElementEvaluation of _e_ with argument _proto_).
           1. Else,
-            1. Let _element_ be ClassElementEvaluation of _e_ with argument _F_.
+            1. Let _element_ be Completion(ClassElementEvaluation of _e_ with argument _F_).
           1. If _element_ is an abrupt completion, then
             1. Set the running execution context's LexicalEnvironment to _env_.
             1. Set the running execution context's PrivateEnvironment to _outerPrivateEnvironment_.
-            1. Return Completion(_element_).
+            1. Return ? _element_.
           1. Set _element_ to _element_.[[Value]].
           1. If _element_ is a PrivateElement, then
             1. Assert: _element_.[[Kind]] is either ~method~ or ~accessor~.
@@ -24811,27 +24855,27 @@
             1. Append _element_ to _staticElements_.
         1. Set the running execution context's LexicalEnvironment to _env_.
         1. If _classBinding_ is not *undefined*, then
-          1. Perform _classEnv_.InitializeBinding(_classBinding_, _F_).
+          1. Perform ! _classEnv_.InitializeBinding(_classBinding_, _F_).
         1. Set _F_.[[PrivateMethods]] to _instancePrivateMethods_.
         1. Set _F_.[[Fields]] to _instanceFields_.
         1. For each PrivateElement _method_ of _staticPrivateMethods_, do
           1. Perform ! PrivateMethodOrAccessorAdd(_F_, _method_).
         1. For each element _elementRecord_ of _staticElements_, do
           1. If _elementRecord_ is a ClassFieldDefinition Record, then
-            1. Let _result_ be DefineField(_F_, _elementRecord_).
+            1. Let _result_ be Completion(DefineField(_F_, _elementRecord_)).
           1. Else,
             1. Assert: _elementRecord_ is a ClassStaticBlockDefinition Record.
-            1. Let _result_ be ? Call(_elementRecord_.[[BodyFunction]], _F_).
+            1. Let _result_ be Completion(Call(_elementRecord_.[[BodyFunction]], _F_)).
           1. If _result_ is an abrupt completion, then
             1. Set the running execution context's PrivateEnvironment to _outerPrivateEnvironment_.
-            1. Return _result_.
+            1. Return ? _result_.
         1. Set the running execution context's PrivateEnvironment to _outerPrivateEnvironment_.
         1. Return _F_.
       </emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-runtime-semantics-bindingclassdeclarationevaluation" type="sdo">
-      <h1>Runtime Semantics: BindingClassDeclarationEvaluation</h1>
+      <h1>Runtime Semantics: BindingClassDeclarationEvaluation ( ): either a normal completion containing a function object or an abrupt completion</h1>
       <dl class="header">
       </dl>
       <emu-grammar>ClassDeclaration : `class` BindingIdentifier ClassTail</emu-grammar>
@@ -24859,7 +24903,7 @@
       <emu-grammar>ClassDeclaration : `class` BindingIdentifier ClassTail</emu-grammar>
       <emu-alg>
         1. Perform ? BindingClassDeclarationEvaluation of this |ClassDeclaration|.
-        1. Return NormalCompletion(~empty~).
+        1. Return ~empty~.
       </emu-alg>
       <emu-note>
         <p><emu-grammar>ClassDeclaration : `class` ClassTail</emu-grammar> only occurs as part of an |ExportDeclaration| and is never directly evaluated.</p>
@@ -24888,7 +24932,7 @@
       </emu-alg>
       <emu-grammar>ClassStaticBlockStatementList : [empty]</emu-grammar>
       <emu-alg>
-        1. Return NormalCompletion(*undefined*).
+        1. Return *undefined*.
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -24969,7 +25013,7 @@
         Runtime Semantics: InstantiateAsyncFunctionObject (
           _env_: unknown,
           _privateEnv_: unknown,
-        )
+        ): a function object
       </h1>
       <dl class="header">
       </dl>
@@ -24979,8 +25023,8 @@
       <emu-alg>
         1. Let _name_ be StringValue of |BindingIdentifier|.
         1. Let _sourceText_ be the source text matched by |AsyncFunctionDeclaration|.
-        1. Let _F_ be ! OrdinaryFunctionCreate(%AsyncFunction.prototype%, _sourceText_, |FormalParameters|, |AsyncFunctionBody|, ~non-lexical-this~, _env_, _privateEnv_).
-        1. Perform ! SetFunctionName(_F_, _name_).
+        1. Let _F_ be OrdinaryFunctionCreate(%AsyncFunction.prototype%, _sourceText_, |FormalParameters|, |AsyncFunctionBody|, ~non-lexical-this~, _env_, _privateEnv_).
+        1. Perform SetFunctionName(_F_, _name_).
         1. Return _F_.
       </emu-alg>
       <emu-grammar>
@@ -24988,8 +25032,8 @@
       </emu-grammar>
       <emu-alg>
         1. Let _sourceText_ be the source text matched by |AsyncFunctionDeclaration|.
-        1. Let _F_ be ! OrdinaryFunctionCreate(%AsyncFunction.prototype%, _sourceText_, |FormalParameters|, |AsyncFunctionBody|, ~non-lexical-this~, _env_, _privateEnv_).
-        1. Perform ! SetFunctionName(_F_, *"default"*).
+        1. Let _F_ be OrdinaryFunctionCreate(%AsyncFunction.prototype%, _sourceText_, |FormalParameters|, |AsyncFunctionBody|, ~non-lexical-this~, _env_, _privateEnv_).
+        1. Perform SetFunctionName(_F_, *"default"*).
         1. Return _F_.
       </emu-alg>
     </emu-clause>
@@ -24998,7 +25042,7 @@
       <h1>
         Runtime Semantics: InstantiateAsyncFunctionExpression (
           optional _name_: unknown,
-        )
+        ): a function object
       </h1>
       <dl class="header">
       </dl>
@@ -25010,7 +25054,7 @@
         1. Let _env_ be the LexicalEnvironment of the running execution context.
         1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
         1. Let _sourceText_ be the source text matched by |AsyncFunctionExpression|.
-        1. Let _closure_ be ! OrdinaryFunctionCreate(%AsyncFunction.prototype%, _sourceText_, |FormalParameters|, |AsyncFunctionBody|, ~non-lexical-this~, _env_, _privateEnv_).
+        1. Let _closure_ be OrdinaryFunctionCreate(%AsyncFunction.prototype%, _sourceText_, |FormalParameters|, |AsyncFunctionBody|, ~non-lexical-this~, _env_, _privateEnv_).
         1. Perform SetFunctionName(_closure_, _name_).
         1. Return _closure_.
       </emu-alg>
@@ -25021,12 +25065,12 @@
         1. Assert: _name_ is not present.
         1. Set _name_ to StringValue of |BindingIdentifier|.
         1. Let _outerEnv_ be the LexicalEnvironment of the running execution context.
-        1. Let _funcEnv_ be ! NewDeclarativeEnvironment(_outerEnv_).
+        1. Let _funcEnv_ be NewDeclarativeEnvironment(_outerEnv_).
         1. Perform ! _funcEnv_.CreateImmutableBinding(_name_, *false*).
         1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
         1. Let _sourceText_ be the source text matched by |AsyncFunctionExpression|.
-        1. Let _closure_ be ! OrdinaryFunctionCreate(%AsyncFunction.prototype%, _sourceText_, |FormalParameters|, |AsyncFunctionBody|, ~non-lexical-this~, _funcEnv_, _privateEnv_).
-        1. Perform ! SetFunctionName(_closure_, _name_).
+        1. Let _closure_ be OrdinaryFunctionCreate(%AsyncFunction.prototype%, _sourceText_, |FormalParameters|, |AsyncFunctionBody|, ~non-lexical-this~, _funcEnv_, _privateEnv_).
+        1. Perform SetFunctionName(_closure_, _name_).
         1. Perform ! _funcEnv_.InitializeBinding(_name_, _closure_).
         1. Return _closure_.
       </emu-alg>
@@ -25040,7 +25084,7 @@
         Runtime Semantics: EvaluateAsyncFunctionBody (
           _functionObject_: unknown,
           _argumentsList_: a List,
-        )
+        ): a return completion
       </h1>
       <dl class="header">
       </dl>
@@ -25049,11 +25093,11 @@
       </emu-grammar>
       <emu-alg>
         1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
-        1. Let _declResult_ be FunctionDeclarationInstantiation(_functionObject_, _argumentsList_).
-        1. If _declResult_ is not an abrupt completion, then
-          1. Perform ! AsyncFunctionStart(_promiseCapability_, |FunctionBody|).
-        1. Else,
+        1. Let _declResult_ be Completion(FunctionDeclarationInstantiation(_functionObject_, _argumentsList_)).
+        1. If _declResult_ is an abrupt completion, then
           1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _declResult_.[[Value]] &raquo;).
+        1. Else,
+          1. Perform AsyncFunctionStart(_promiseCapability_, |FunctionBody|).
         1. Return Completion Record { [[Type]]: ~return~, [[Value]]: _promiseCapability_.[[Promise]], [[Target]]: ~empty~ }.
       </emu-alg>
     </emu-clause>
@@ -25129,7 +25173,7 @@
     </emu-clause>
 
     <emu-clause id="sec-static-semantics-asyncconcisebodycontainsusestrict" oldids="sec-async-arrow-function-definitions-static-semantics-containsusestrict" type="sdo">
-      <h1>Static Semantics: AsyncConciseBodyContainsUseStrict</h1>
+      <h1>Static Semantics: AsyncConciseBodyContainsUseStrict ( ): a Boolean</h1>
       <dl class="header">
       </dl>
       <emu-grammar>AsyncConciseBody : ExpressionBody</emu-grammar>
@@ -25147,7 +25191,7 @@
         Runtime Semantics: EvaluateAsyncConciseBody (
           _functionObject_: unknown,
           _argumentsList_: a List,
-        )
+        ): a return completion
       </h1>
       <dl class="header">
       </dl>
@@ -25156,11 +25200,11 @@
       </emu-grammar>
       <emu-alg>
         1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
-        1. Let _declResult_ be FunctionDeclarationInstantiation(_functionObject_, _argumentsList_).
-        1. If _declResult_ is not an abrupt completion, then
-          1. Perform ! AsyncFunctionStart(_promiseCapability_, |ExpressionBody|).
-        1. Else,
+        1. Let _declResult_ be Completion(FunctionDeclarationInstantiation(_functionObject_, _argumentsList_)).
+        1. If _declResult_ is an abrupt completion, then
           1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _declResult_.[[Value]] &raquo;).
+        1. Else,
+          1. Perform AsyncFunctionStart(_promiseCapability_, |ExpressionBody|).
         1. Return Completion Record { [[Type]]: ~return~, [[Value]]: _promiseCapability_.[[Promise]], [[Target]]: ~empty~ }.
       </emu-alg>
     </emu-clause>
@@ -25169,7 +25213,7 @@
       <h1>
         Runtime Semantics: InstantiateAsyncArrowFunctionExpression (
           optional _name_: unknown,
-        )
+        ): a function object
       </h1>
       <dl class="header">
       </dl>
@@ -25182,7 +25226,7 @@
         1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
         1. Let _sourceText_ be the source text matched by |AsyncArrowFunction|.
         1. Let _parameters_ be |AsyncArrowBindingIdentifier|.
-        1. Let _closure_ be ! OrdinaryFunctionCreate(%AsyncFunction.prototype%, _sourceText_, _parameters_, |AsyncConciseBody|, ~lexical-this~, _env_, _privateEnv_).
+        1. Let _closure_ be OrdinaryFunctionCreate(%AsyncFunction.prototype%, _sourceText_, _parameters_, |AsyncConciseBody|, ~lexical-this~, _env_, _privateEnv_).
         1. Perform SetFunctionName(_closure_, _name_).
         1. Return _closure_.
       </emu-alg>
@@ -25196,7 +25240,7 @@
         1. Let _sourceText_ be the source text matched by |AsyncArrowFunction|.
         1. Let _head_ be the |AsyncArrowHead| that is covered by |CoverCallExpressionAndAsyncArrowHead|.
         1. Let _parameters_ be the |ArrowFormalParameters| of _head_.
-        1. Let _closure_ be ! OrdinaryFunctionCreate(%AsyncFunction.prototype%, _sourceText_, _parameters_, |AsyncConciseBody|, ~lexical-this~, _env_, _privateEnv_).
+        1. Let _closure_ be OrdinaryFunctionCreate(%AsyncFunction.prototype%, _sourceText_, _parameters_, |AsyncConciseBody|, ~lexical-this~, _env_, _privateEnv_).
         1. Perform SetFunctionName(_closure_, _name_).
         1. Return _closure_.
       </emu-alg>
@@ -25222,7 +25266,7 @@
       <h1>
         Static Semantics: IsInTailPosition (
           _call_: a Parse Node,
-        )
+        ): a Boolean
       </h1>
       <dl class="header">
       </dl>
@@ -25245,7 +25289,7 @@
       <h1>
         Static Semantics: HasCallInTailPosition (
           _call_: unknown,
-        )
+        ): a Boolean
       </h1>
       <dl class="header">
       </dl>
@@ -25582,12 +25626,13 @@
     </emu-clause>
 
     <emu-clause id="sec-preparefortailcall" type="abstract operation">
-      <h1>PrepareForTailCall ( )</h1>
+      <h1>PrepareForTailCall ( ): ~unused~</h1>
       <dl class="header">
       </dl>
       <emu-alg>
         1. Assert: The current execution context will not subsequently be used for the evaluation of any ECMAScript code or built-in functions. The invocation of Call subsequent to the invocation of this abstract operation will create and push a new execution context before performing any such evaluation.
         1. Discard all resources associated with the current execution context.
+        1. Return ~unused~.
       </emu-alg>
       <p>A tail position call must either release any transient internal resources associated with the currently executing function execution context before invoking the target function or reuse those resources in support of the target function.</p>
       <emu-note>
@@ -25646,7 +25691,7 @@
     </emu-clause>
 
     <emu-clause id="sec-static-semantics-isstrict" type="sdo">
-      <h1>Static Semantics: IsStrict</h1>
+      <h1>Static Semantics: IsStrict ( ): a Boolean</h1>
       <dl class="header">
       </dl>
       <emu-grammar>Script : ScriptBody?</emu-grammar>
@@ -25659,7 +25704,7 @@
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>Script : [empty]</emu-grammar>
       <emu-alg>
-        1. Return NormalCompletion(*undefined*).
+        1. Return *undefined*.
       </emu-alg>
     </emu-clause>
 
@@ -25726,7 +25771,7 @@
           _sourceText_: ECMAScript source text,
           _realm_: unknown,
           _hostDefined_: unknown,
-        )
+        ): a Script Record or a non-empty List of *SyntaxError* objects
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -25747,7 +25792,7 @@
       <h1>
         ScriptEvaluation (
           _scriptRecord_: unknown,
-        )
+        ): either a normal completion containing an ECMAScript language value or an abrupt completion
       </h1>
       <dl class="header">
       </dl>
@@ -25764,7 +25809,7 @@
         1. Suspend the currently running execution context.
         1. Push _scriptContext_ onto the execution context stack; _scriptContext_ is now the running execution context.
         1. Let _script_ be _scriptRecord_.[[ECMAScriptCode]].
-        1. Let _result_ be GlobalDeclarationInstantiation(_script_, _globalEnv_).
+        1. Let _result_ be Completion(GlobalDeclarationInstantiation(_script_, _globalEnv_)).
         1. If _result_.[[Type]] is ~normal~, then
           1. Set _result_ to the result of evaluating _script_.
         1. If _result_.[[Type]] is ~normal~ and _result_.[[Value]] is ~empty~, then
@@ -25772,7 +25817,7 @@
         1. Suspend _scriptContext_ and remove it from the execution context stack.
         1. Assert: The execution context stack is not empty.
         1. Resume the context that is now on the top of the execution context stack as the running execution context.
-        1. Return Completion(_result_).
+        1. Return ? _result_.
       </emu-alg>
     </emu-clause>
 
@@ -25781,7 +25826,7 @@
         GlobalDeclarationInstantiation (
           _script_: a |ScriptBody| Parse Node,
           _env_: a global Environment Record,
-        )
+        ): either a normal completion containing ~unused~ or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -25845,7 +25890,7 @@
           1. Perform ? <emu-meta effects="user-code">_env_.CreateGlobalFunctionBinding</emu-meta>(_fn_, _fo_, *false*).
         1. For each String _vn_ of _declaredVarNames_, do
           1. Perform ? <emu-meta effects="user-code">_env_.CreateGlobalVarBinding</emu-meta>(_vn_, *false*).
-        1. Return NormalCompletion(~empty~).
+        1. Return ~unused~.
       </emu-alg>
       <emu-note>
         <p>Early errors specified in <emu-xref href="#sec-scripts-static-semantics-early-errors"></emu-xref> prevent name conflicts between function/var declarations and let/const/class declarations as well as redeclaration of let/const/class bindings for declaration contained within a single |Script|. However, such conflicts and redeclarations that span more than one |Script| are detected as runtime errors during GlobalDeclarationInstantiation. If any such errors are detected, no bindings are instantiated for the script. However, if the global object is defined using Proxy exotic objects then the runtime tests for conflicting declarations may be unreliable resulting in an abrupt completion and some global declarations not being instantiated. If this occurs, the code for the |Script| is not evaluated.</p>
@@ -25928,8 +25973,8 @@
       <emu-clause id="sec-importedlocalnames" type="abstract operation">
         <h1>
           Static Semantics: ImportedLocalNames (
-            _importEntries_: a List of ImportEntry Records (see <emu-xref href="#table-importentry-record-fields"></emu-xref>),
-          )
+            _importEntries_: a List of ImportEntry Records,
+          ): a List of Strings
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -25944,7 +25989,7 @@
       </emu-clause>
 
       <emu-clause id="sec-static-semantics-modulerequests" oldids="sec-module-semantics-static-semantics-modulerequests,sec-imports-static-semantics-modulerequests,sec-exports-static-semantics-modulerequests" type="sdo">
-        <h1>Static Semantics: ModuleRequests</h1>
+        <h1>Static Semantics: ModuleRequests ( ): a List of Strings</h1>
         <dl class="header">
         </dl>
         <emu-grammar>Module : [empty]</emu-grammar>
@@ -26144,7 +26189,7 @@
                 an abrupt completion or ~empty~
               </td>
               <td>
-                A completion of type ~throw~ representing the exception that occurred during evaluation. *undefined* if no exception occurred or if [[Status]] is not ~evaluated~.
+                A throw completion representing the exception that occurred during evaluation. *undefined* if no exception occurred or if [[Status]] is not ~evaluated~.
               </td>
             </tr>
             <tr>
@@ -26279,7 +26324,7 @@
         </emu-table>
 
         <emu-clause id="sec-moduledeclarationlinking" type="concrete method" oldids="sec-moduledeclarationinstantiation">
-          <h1>Link ( )</h1>
+          <h1>Link ( ): either a normal completion containing ~unused~ or an abrupt completion</h1>
           <dl class="header">
             <dt>for</dt>
             <dd>a Cyclic Module Record _module_</dd>
@@ -26291,16 +26336,16 @@
           <emu-alg>
             1. Assert: _module_.[[Status]] is not ~linking~ or ~evaluating~.
             1. Let _stack_ be a new empty List.
-            1. Let _result_ be InnerModuleLinking(_module_, _stack_, 0).
+            1. Let _result_ be Completion(InnerModuleLinking(_module_, _stack_, 0)).
             1. If _result_ is an abrupt completion, then
               1. For each Cyclic Module Record _m_ of _stack_, do
                 1. Assert: _m_.[[Status]] is ~linking~.
                 1. Set _m_.[[Status]] to ~unlinked~.
               1. Assert: _module_.[[Status]] is ~unlinked~.
-              1. Return _result_.
+              1. Return ? _result_.
             1. Assert: _module_.[[Status]] is ~linked~, ~evaluating-async~, or ~evaluated~.
             1. Assert: _stack_ is empty.
-            1. Return *undefined*.
+            1. Return ~unused~.
           </emu-alg>
 
           <emu-clause id="sec-InnerModuleLinking" type="abstract operation" oldids="sec-innermoduleinstantiation">
@@ -26309,7 +26354,7 @@
                 _module_: a Module Record,
                 _stack_: unknown,
                 _index_: a non-negative integer,
-              )
+              ): either a normal completion containing a non-negative integer or an abrupt completion
             </h1>
             <dl class="header">
               <dt>description</dt>
@@ -26353,7 +26398,7 @@
         </emu-clause>
 
         <emu-clause id="sec-moduleevaluation" type="concrete method">
-          <h1>Evaluate ( )</h1>
+          <h1>Evaluate ( ): a Promise</h1>
           <dl class="header">
             <dt>for</dt>
             <dd>a Cyclic Module Record _module_</dd>
@@ -26371,7 +26416,7 @@
             1. Let _stack_ be a new empty List.
             1. Let _capability_ be ! NewPromiseCapability(%Promise%).
             1. Set _module_.[[TopLevelCapability]] to _capability_.
-            1. Let _result_ be InnerModuleEvaluation(_module_, _stack_, 0).
+            1. Let _result_ be Completion(InnerModuleEvaluation(_module_, _stack_, 0)).
             1. If _result_ is an abrupt completion, then
               1. For each Cyclic Module Record _m_ of _stack_, do
                 1. Assert: _m_.[[Status]] is ~evaluating~.
@@ -26396,7 +26441,7 @@
                 _module_: a Module Record,
                 _stack_: unknown,
                 _index_: a non-negative integer,
-              )
+              ): either a normal completion containing a non-negative integer or an abrupt completion
             </h1>
             <dl class="header">
               <dt>description</dt>
@@ -26412,7 +26457,7 @@
                 1. Return _index_.
               1. If _module_.[[Status]] is ~evaluating-async~ or ~evaluated~, then
                 1. If _module_.[[EvaluationError]] is ~empty~, return _index_.
-                1. Otherwise, return _module_.[[EvaluationError]].
+                1. Otherwise, return ? _module_.[[EvaluationError]].
               1. If _module_.[[Status]] is ~evaluating~, return _index_.
               1. Assert: _module_.[[Status]] is ~linked~.
               1. Set _module_.[[Status]] to ~evaluating~.
@@ -26433,7 +26478,7 @@
                   1. Else,
                     1. Set _requiredModule_ to _requiredModule_.[[CycleRoot]].
                     1. Assert: _requiredModule_.[[Status]] is ~evaluating-async~ or ~evaluated~.
-                    1. If _requiredModule_.[[EvaluationError]] is not ~empty~, return _requiredModule_.[[EvaluationError]].
+                    1. If _requiredModule_.[[EvaluationError]] is not ~empty~, return ? _requiredModule_.[[EvaluationError]].
                   1. If _requiredModule_.[[AsyncEvaluation]] is *true*, then
                     1. Set _module_.[[PendingAsyncDependencies]] to _module_.[[PendingAsyncDependencies]] + 1.
                     1. Append _module_ to _requiredModule_.[[AsyncParentModules]].
@@ -26441,7 +26486,7 @@
                 1. Assert: _module_.[[AsyncEvaluation]] is *false* and was never previously set to *true*.
                 1. Set _module_.[[AsyncEvaluation]] to *true*.
                 1. NOTE: The order in which module records have their [[AsyncEvaluation]] fields transition to *true* is significant. (See <emu-xref href="#sec-async-module-execution-fulfilled"></emu-xref>.)
-                1. If _module_.[[PendingAsyncDependencies]] is 0, perform ! ExecuteAsyncModule(_module_).
+                1. If _module_.[[PendingAsyncDependencies]] is 0, perform ExecuteAsyncModule(_module_).
               1. Otherwise, perform ? <emu-meta effects="user-code">_module_.ExecuteModule()</emu-meta>.
               1. Assert: _module_ occurs exactly once in _stack_.
               1. Assert: _module_.[[DFSAncestorIndex]] &le; _module_.[[DFSIndex]].
@@ -26469,7 +26514,7 @@
             <h1>
               ExecuteAsyncModule (
                 _module_: a Cyclic Module Record,
-              )
+              ): ~unused~
             </h1>
             <dl class="header">
             </dl>
@@ -26479,15 +26524,16 @@
               1. Assert: _module_.[[HasTLA]] is *true*.
               1. Let _capability_ be ! NewPromiseCapability(%Promise%).
               1. Let _fulfilledClosure_ be a new Abstract Closure with no parameters that captures _module_ and performs the following steps when called:
-                1. Perform ! AsyncModuleExecutionFulfilled(_module_).
+                1. Perform AsyncModuleExecutionFulfilled(_module_).
                 1. Return *undefined*.
-              1. Let _onFulfilled_ be ! CreateBuiltinFunction(_fulfilledClosure_, 0, *""*, &laquo; &raquo;).
+              1. Let _onFulfilled_ be CreateBuiltinFunction(_fulfilledClosure_, 0, *""*, &laquo; &raquo;).
               1. Let _rejectedClosure_ be a new Abstract Closure with parameters (_error_) that captures _module_ and performs the following steps when called:
-                1. Perform ! AsyncModuleExecutionRejected(_module_, _error_).
+                1. Perform AsyncModuleExecutionRejected(_module_, _error_).
                 1. Return *undefined*.
-              1. Let _onRejected_ be ! CreateBuiltinFunction(_rejectedClosure_, 0, *""*, &laquo; &raquo;).
-              1. Perform ! PerformPromiseThen(_capability_.[[Promise]], _onFulfilled_, _onRejected_).
+              1. Let _onRejected_ be CreateBuiltinFunction(_rejectedClosure_, 0, *""*, &laquo; &raquo;).
+              1. Perform PerformPromiseThen(_capability_.[[Promise]], _onFulfilled_, _onRejected_).
               1. Perform ! <emu-meta effects="user-code">_module_.ExecuteModule</emu-meta>(_capability_).
+              1. Return ~unused~.
             </emu-alg>
           </emu-clause>
 
@@ -26496,7 +26542,7 @@
               GatherAvailableAncestors (
                 _module_: a Cyclic Module Record,
                 _execList_: a List of Cyclic Module Records,
-              )
+              ): ~unused~
             </h1>
             <dl class="header">
             </dl>
@@ -26510,7 +26556,8 @@
                   1. Set _m_.[[PendingAsyncDependencies]] to _m_.[[PendingAsyncDependencies]] - 1.
                   1. If _m_.[[PendingAsyncDependencies]] = 0, then
                     1. Append _m_ to _execList_.
-                    1. If _m_.[[HasTLA]] is *false*, perform ! GatherAvailableAncestors(_m_, _execList_).
+                    1. If _m_.[[HasTLA]] is *false*, perform GatherAvailableAncestors(_m_, _execList_).
+              1. Return ~unused~.
             </emu-alg>
             <emu-note>
               <p>When an asynchronous execution for a root _module_ is fulfilled, this function determines the list of modules which are able to synchronously execute together on this completion, populating them in _execList_.</p>
@@ -26521,14 +26568,14 @@
             <h1>
               AsyncModuleExecutionFulfilled (
                 _module_: a Cyclic Module Record,
-              )
+              ): ~unused~
             </h1>
             <dl class="header">
             </dl>
             <emu-alg>
               1. If _module_.[[Status]] is ~evaluated~, then
                 1. Assert: _module_.[[EvaluationError]] is not ~empty~.
-                1. Return.
+                1. Return ~unused~.
               1. Assert: _module_.[[Status]] is ~evaluating-async~.
               1. Assert: _module_.[[AsyncEvaluation]] is *true*.
               1. Assert: _module_.[[EvaluationError]] is ~empty~.
@@ -26538,23 +26585,24 @@
                 1. Assert: _module_.[[CycleRoot]] is _module_.
                 1. Perform ! Call(_module_.[[TopLevelCapability]].[[Resolve]], *undefined*, &laquo; *undefined* &raquo;).
               1. Let _execList_ be a new empty List.
-              1. Perform ! GatherAvailableAncestors(_module_, _execList_).
+              1. Perform GatherAvailableAncestors(_module_, _execList_).
               1. Let _sortedExecList_ be a List whose elements are the elements of _execList_, in the order in which they had their [[AsyncEvaluation]] fields set to *true* in InnerModuleEvaluation.
               1. Assert: All elements of _sortedExecList_ have their [[AsyncEvaluation]] field set to *true*, [[PendingAsyncDependencies]] field set to 0, and [[EvaluationError]] field set to ~empty~.
               1. For each Cyclic Module Record _m_ of _sortedExecList_, do
                 1. If _m_.[[Status]] is ~evaluated~, then
                   1. Assert: _m_.[[EvaluationError]] is not ~empty~.
                 1. Else if _m_.[[HasTLA]] is *true*, then
-                  1. Perform ! ExecuteAsyncModule(_m_).
+                  1. Perform ExecuteAsyncModule(_m_).
                 1. Else,
                   1. Let _result_ be <emu-meta effects="user-code">_m_.ExecuteModule()</emu-meta>.
                   1. If _result_ is an abrupt completion, then
-                    1. Perform ! AsyncModuleExecutionRejected(_m_, _result_.[[Value]]).
+                    1. Perform AsyncModuleExecutionRejected(_m_, _result_.[[Value]]).
                   1. Else,
                     1. Set _m_.[[Status]] to ~evaluated~.
                     1. If _m_.[[TopLevelCapability]] is not ~empty~, then
                       1. Assert: _m_.[[CycleRoot]] is _m_.
                       1. Perform ! Call(_m_.[[TopLevelCapability]].[[Resolve]], *undefined*, &laquo; *undefined* &raquo;).
+              1. Return ~unused~.
             </emu-alg>
           </emu-clause>
 
@@ -26563,24 +26611,25 @@
               AsyncModuleExecutionRejected (
                 _module_: a Cyclic Module Record,
                 _error_: an ECMAScript language value,
-              )
+              ): ~unused~
             </h1>
             <dl class="header">
             </dl>
             <emu-alg>
               1. If _module_.[[Status]] is ~evaluated~, then
                 1. Assert: _module_.[[EvaluationError]] is not ~empty~.
-                1. Return.
+                1. Return ~unused~.
               1. Assert: _module_.[[Status]] is ~evaluating-async~.
               1. Assert: _module_.[[AsyncEvaluation]] is *true*.
               1. Assert: _module_.[[EvaluationError]] is ~empty~.
               1. Set _module_.[[EvaluationError]] to ThrowCompletion(_error_).
               1. Set _module_.[[Status]] to ~evaluated~.
               1. For each Cyclic Module Record _m_ of _module_.[[AsyncParentModules]], do
-                1. Perform ! AsyncModuleExecutionRejected(_m_, _error_).
+                1. Perform AsyncModuleExecutionRejected(_m_, _error_).
               1. If _module_.[[TopLevelCapability]] is not ~empty~, then
                 1. Assert: _module_.[[CycleRoot]] is _module_.
                 1. Perform ! Call(_module_.[[TopLevelCapability]].[[Reject]], *undefined*, &laquo; _error_ &raquo;).
+              1. Return ~unused~.
             </emu-alg>
           </emu-clause>
         </emu-clause>
@@ -27479,7 +27528,7 @@
               _sourceText_: ECMAScript source text,
               _realm_: unknown,
               _hostDefined_: unknown,
-            )
+            ): a Source Text Module Record or a non-empty List of *SyntaxError* objects
           </h1>
           <dl class="header">
             <dt>description</dt>
@@ -27524,7 +27573,7 @@
           <h1>
             GetExportedNames (
               optional _exportStarSet_: a List of Source Text Module Records,
-            )
+            ): either a normal completion containing a List of either Strings or *null*, or an abrupt completion
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -27562,7 +27611,7 @@
             ResolveExport (
               _exportName_: a String,
               optional _resolveSet_: a List of Records that have [[Module]] and [[ExportName]] fields,
-            )
+            ): either a normal completion containing either a ResolvedBinding Record, *null*, or ~ambiguous~, or an abrupt completion
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -27594,7 +27643,7 @@
                   1. Return ResolvedBinding Record { [[Module]]: _importedModule_, [[BindingName]]: ~namespace~ }.
                 1. Else,
                   1. Assert: _module_ imports a specific binding for this export.
-                  1. Return _importedModule_.ResolveExport(_e_.[[ImportName]], _resolveSet_).
+                  1. Return ? _importedModule_.ResolveExport(_e_.[[ImportName]], _resolveSet_).
             1. If SameValue(_exportName_, *"default"*) is *true*, then
               1. Assert: A `default` export was not explicitly defined by this module.
               1. Return *null*.
@@ -27617,7 +27666,7 @@
         </emu-clause>
 
         <emu-clause id="sec-source-text-module-record-initialize-environment" type="concrete method">
-          <h1>InitializeEnvironment ( )</h1>
+          <h1>InitializeEnvironment ( ): either a normal completion containing ~unused~ or an abrupt completion</h1>
           <dl class="header">
             <dt>for</dt>
             <dd>a Source Text Module Record _module_</dd>
@@ -27639,16 +27688,16 @@
               1. If _in_.[[ImportName]] is ~namespace-object~, then
                 1. Let _namespace_ be ? GetModuleNamespace(_importedModule_).
                 1. Perform ! _env_.CreateImmutableBinding(_in_.[[LocalName]], *true*).
-                1. Call _env_.InitializeBinding(_in_.[[LocalName]], _namespace_).
+                1. Perform ! _env_.InitializeBinding(_in_.[[LocalName]], _namespace_).
               1. Else,
                 1. Let _resolution_ be ? _importedModule_.ResolveExport(_in_.[[ImportName]]).
                 1. If _resolution_ is *null* or ~ambiguous~, throw a *SyntaxError* exception.
                 1. If _resolution_.[[BindingName]] is ~namespace~, then
                   1. Let _namespace_ be ? GetModuleNamespace(_resolution_.[[Module]]).
                   1. Perform ! _env_.CreateImmutableBinding(_in_.[[LocalName]], *true*).
-                  1. Call _env_.InitializeBinding(_in_.[[LocalName]], _namespace_).
+                  1. Perform ! _env_.InitializeBinding(_in_.[[LocalName]], _namespace_).
                 1. Else,
-                  1. Call _env_.CreateImportBinding(_in_.[[LocalName]], _resolution_.[[Module]], _resolution_.[[BindingName]]).
+                  1. Perform _env_.CreateImportBinding(_in_.[[LocalName]], _resolution_.[[Module]], _resolution_.[[BindingName]]).
             1. Let _moduleContext_ be a new ECMAScript code execution context.
             1. Set the Function of _moduleContext_ to *null*.
             1. Assert: _module_.[[Realm]] is not *undefined*.
@@ -27666,7 +27715,7 @@
               1. For each element _dn_ of the BoundNames of _d_, do
                 1. If _dn_ is not an element of _declaredVarNames_, then
                   1. Perform ! _env_.CreateMutableBinding(_dn_, *false*).
-                  1. Call _env_.InitializeBinding(_dn_, *undefined*).
+                  1. Perform ! _env_.InitializeBinding(_dn_, *undefined*).
                   1. Append _dn_ to _declaredVarNames_.
             1. Let _lexDeclarations_ be the LexicallyScopedDeclarations of _code_.
             1. Let _privateEnv_ be *null*.
@@ -27678,9 +27727,9 @@
                   1. Perform ! _env_.CreateMutableBinding(_dn_, *false*).
                 1. If _d_ is a |FunctionDeclaration|, a |GeneratorDeclaration|, an |AsyncFunctionDeclaration|, or an |AsyncGeneratorDeclaration|, then
                   1. Let _fo_ be InstantiateFunctionObject of _d_ with arguments _env_ and _privateEnv_.
-                  1. Call _env_.InitializeBinding(_dn_, _fo_).
+                  1. Perform ! _env_.InitializeBinding(_dn_, _fo_).
             1. Remove _moduleContext_ from the execution context stack.
-            1. Return NormalCompletion(~empty~).
+            1. Return ~unused~.
           </emu-alg>
         </emu-clause>
 
@@ -27688,7 +27737,7 @@
           <h1>
             ExecuteModule (
               optional _capability_: unknown,
-            )
+            ): either a normal completion containing ~unused~ or an abrupt completion
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -27710,11 +27759,12 @@
               1. Let _result_ be the result of evaluating _module_.[[ECMAScriptCode]].
               1. Suspend _moduleContext_ and remove it from the execution context stack.
               1. Resume the context that is now on the top of the execution context stack as the running execution context.
-              1. Return Completion(_result_).
+              1. If _result_ is an abrupt completion, then
+                1. Return ? _result_.
             1. Else,
               1. Assert: _capability_ is a PromiseCapability Record.
-              1. Perform ! AsyncBlockStart(_capability_, _module_.[[ECMAScriptCode]], _moduleContext_).
-              1. Return NormalCompletion(~empty~).
+              1. Perform AsyncBlockStart(_capability_, _module_.[[ECMAScriptCode]], _moduleContext_).
+            1. Return ~unused~.
           </emu-alg>
         </emu-clause>
       </emu-clause>
@@ -27724,7 +27774,7 @@
           HostResolveImportedModule (
             _referencingScriptOrModule_: a Script Record, a Module Record, or *null*,
             _specifier_: a |ModuleSpecifier| String,
-          )
+          ): either a normal completion containing a Module Record or an abrupt completion
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -27742,7 +27792,7 @@
         <p>An implementation of HostResolveImportedModule must conform to the following requirements:</p>
         <ul>
           <li>
-            If it completes normally, the [[Value]] slot of the completion must contain an instance of a concrete subclass of Module Record.
+            If the returned Completion Record is a normal completion, it must be a normal completion containing an instance of a concrete subclass of Module Record.
           </li>
           <li>
             If a Module Record corresponding to the pair _referencingScriptOrModule_, _specifier_ does not exist or cannot be created, an exception must be thrown.
@@ -27760,7 +27810,7 @@
             _referencingScriptOrModule_: a Script Record, a Module Record, or *null*,
             _specifier_: a |ModuleSpecifier| String,
             _promiseCapability_: a PromiseCapability Record,
-          )
+          ): ~unused~
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -27770,7 +27820,7 @@
 
         <ul>
           <li>
-            It must return NormalCompletion(*undefined*). Success or failure must instead be signaled as discussed below.
+            It must return ~unused~. Success or failure must instead be signaled as discussed below.
           </li>
           <li>
             The host environment must conform to one of the two following sets of requirements:
@@ -27814,7 +27864,7 @@
             _specifier_: unknown,
             _promiseCapability_: a PromiseCapability Record,
             _innerPromise_: unknown,
-          )
+          ): ~unused~
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -27825,18 +27875,19 @@
             1. Assert: _result_ is *undefined*.
             1. Let _moduleRecord_ be ! HostResolveImportedModule(_referencingScriptOrModule_, _specifier_).
             1. Assert: Evaluate has already been invoked on _moduleRecord_ and successfully completed.
-            1. Let _namespace_ be GetModuleNamespace(_moduleRecord_).
+            1. Let _namespace_ be Completion(GetModuleNamespace(_moduleRecord_)).
             1. If _namespace_ is an abrupt completion, then
               1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _namespace_.[[Value]] &raquo;).
             1. Else,
               1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _namespace_.[[Value]] &raquo;).
-            1. Return *undefined*.
-          1. Let _onFulfilled_ be ! CreateBuiltinFunction(_fulfilledClosure_, 0, *""*, &laquo; &raquo;).
+            1. Return ~unused~.
+          1. Let _onFulfilled_ be CreateBuiltinFunction(_fulfilledClosure_, 0, *""*, &laquo; &raquo;).
           1. Let _rejectedClosure_ be a new Abstract Closure with parameters (_error_) that captures _promiseCapability_ and performs the following steps when called:
             1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _error_ &raquo;).
-            1. Return *undefined*.
-          1. Let _onRejected_ be ! CreateBuiltinFunction(_rejectedClosure_, 0, *""*, &laquo; &raquo;).
-          1. Perform ! PerformPromiseThen(_innerPromise_, _onFulfilled_, _onRejected_).
+            1. Return ~unused~.
+          1. Let _onRejected_ be CreateBuiltinFunction(_rejectedClosure_, 0, *""*, &laquo; &raquo;).
+          1. Perform PerformPromiseThen(_innerPromise_, _onFulfilled_, _onRejected_).
+          1. Return ~unused~.
         </emu-alg>
       </emu-clause>
 
@@ -27844,7 +27895,7 @@
         <h1>
           GetModuleNamespace (
             _module_: an instance of a concrete subclass of Module Record,
-          )
+          ): either a normal completion containing either a Module Namespace Object or ~empty~, or an abrupt completion
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -27872,28 +27923,28 @@
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>Module : [empty]</emu-grammar>
         <emu-alg>
-          1. Return NormalCompletion(*undefined*).
+          1. Return *undefined*.
         </emu-alg>
         <emu-grammar>ModuleBody : ModuleItemList</emu-grammar>
         <emu-alg>
           1. Let _result_ be the result of evaluating |ModuleItemList|.
           1. If _result_.[[Type]] is ~normal~ and _result_.[[Value]] is ~empty~, then
-            1. Return NormalCompletion(*undefined*).
-          1. Return Completion(_result_).
+            1. Return *undefined*.
+          1. Return ? _result_.
         </emu-alg>
         <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
         <emu-alg>
           1. Let _sl_ be the result of evaluating |ModuleItemList|.
           1. ReturnIfAbrupt(_sl_).
           1. Let _s_ be the result of evaluating |ModuleItem|.
-          1. Return Completion(UpdateEmpty(_s_, _sl_)).
+          1. Return ? UpdateEmpty(_s_, _sl_).
         </emu-alg>
         <emu-note>
           <p>The value of a |ModuleItemList| is the value of the last value-producing item in the |ModuleItemList|.</p>
         </emu-note>
         <emu-grammar>ModuleItem : ImportDeclaration</emu-grammar>
         <emu-alg>
-          1. Return NormalCompletion(~empty~).
+          1. Return ~empty~.
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -27953,7 +28004,7 @@
       </emu-clause>
 
       <emu-clause id="sec-static-semantics-importentries" oldids="sec-module-semantics-static-semantics-importentries,sec-imports-static-semantics-importentries" type="sdo">
-        <h1>Static Semantics: ImportEntries</h1>
+        <h1>Static Semantics: ImportEntries ( ): a List of ImportEntry Records</h1>
         <dl class="header">
         </dl>
         <emu-grammar>Module : [empty]</emu-grammar>
@@ -27989,7 +28040,7 @@
         <h1>
           Static Semantics: ImportEntriesForModule (
             _module_: unknown,
-          )
+          ): a List of ImportEntry Records
         </h1>
         <dl class="header">
         </dl>
@@ -28092,7 +28143,7 @@
       </emu-clause>
 
       <emu-clause id="sec-static-semantics-exportedbindings" oldids="sec-module-semantics-static-semantics-exportedbindings,sec-exports-static-semantics-exportedbindings" type="sdo">
-        <h1>Static Semantics: ExportedBindings</h1>
+        <h1>Static Semantics: ExportedBindings ( ): a List of Strings</h1>
         <dl class="header">
         </dl>
         <emu-note>
@@ -28161,7 +28212,7 @@
       </emu-clause>
 
       <emu-clause id="sec-static-semantics-exportednames" oldids="sec-module-semantics-static-semantics-exportednames,sec-exports-static-semantics-exportednames" type="sdo">
-        <h1>Static Semantics: ExportedNames</h1>
+        <h1>Static Semantics: ExportedNames ( ): a List of Strings</h1>
         <dl class="header">
         </dl>
         <emu-note>
@@ -28239,7 +28290,7 @@
       </emu-clause>
 
       <emu-clause id="sec-static-semantics-exportentries" oldids="sec-module-semantics-static-semantics-exportentries,sec-exports-static-semantics-exportentries" type="sdo">
-        <h1>Static Semantics: ExportEntries</h1>
+        <h1>Static Semantics: ExportEntries ( ): a List of ExportEntry Records</h1>
         <dl class="header">
         </dl>
         <emu-grammar>Module : [empty]</emu-grammar>
@@ -28311,7 +28362,7 @@
         <h1>
           Static Semantics: ExportEntriesForModule (
             _module_: unknown,
-          )
+          ): a List of ExportEntry Records
         </h1>
         <dl class="header">
         </dl>
@@ -28362,7 +28413,7 @@
       </emu-clause>
 
       <emu-clause id="sec-static-semantics-referencedbindings" type="sdo">
-        <h1>Static Semantics: ReferencedBindings</h1>
+        <h1>Static Semantics: ReferencedBindings ( ): a List of Parse Nodes</h1>
         <dl class="header">
         </dl>
         <emu-grammar>NamedExports : `{` `}`</emu-grammar>
@@ -28397,7 +28448,7 @@
             `export` NamedExports `;`
         </emu-grammar>
         <emu-alg>
-          1. Return NormalCompletion(~empty~).
+          1. Return ~empty~.
         </emu-alg>
         <emu-grammar>ExportDeclaration : `export` VariableStatement</emu-grammar>
         <emu-alg>
@@ -28418,7 +28469,7 @@
           1. If _className_ is *"\*default\*"*, then
             1. Let _env_ be the running execution context's LexicalEnvironment.
             1. Perform ? InitializeBoundName(*"\*default\*"*, _value_, _env_).
-          1. Return NormalCompletion(~empty~).
+          1. Return ~empty~.
         </emu-alg>
         <emu-grammar>ExportDeclaration : `export` `default` AssignmentExpression `;`</emu-grammar>
         <emu-alg>
@@ -28429,7 +28480,7 @@
             1. Let _value_ be ? GetValue(_rhs_).
           1. Let _env_ be the running execution context's LexicalEnvironment.
           1. Perform ? InitializeBoundName(*"\*default\*"*, _value_, _env_).
-          1. Return NormalCompletion(~empty~).
+          1. Return ~empty~.
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -28575,7 +28626,7 @@
             _callerRealm_: unknown,
             _strictCaller_: unknown,
             _direct_: unknown,
-          )
+          ): either a normal completion containing an ECMAScript language value or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
@@ -28589,7 +28640,7 @@
           1. Let _inDerivedConstructor_ be *false*.
           1. Let _inClassFieldInitializer_ be *false*.
           1. If _direct_ is *true*, then
-            1. Let _thisEnvRec_ be ! GetThisEnvironment().
+            1. Let _thisEnvRec_ be GetThisEnvironment().
             1. If _thisEnvRec_ is a function Environment Record, then
               1. Let _F_ be _thisEnvRec_.[[FunctionObject]].
               1. Set _inFunction_ to *true*.
@@ -28598,7 +28649,7 @@
               1. Let _classFieldIntializerName_ be _F_.[[ClassFieldInitializerName]].
               1. If _classFieldIntializerName_ is not ~empty~, set _inClassFieldInitializer_ to *true*.
           1. Perform the following substeps in an implementation-defined order, possibly interleaving parsing and error detection:
-            1. Let _script_ be ParseText(! StringToCodePoints(_x_), |Script|).
+            1. Let _script_ be ParseText(StringToCodePoints(_x_), |Script|).
             1. If _script_ is a List of errors, throw a *SyntaxError* exception.
             1. If _script_ Contains |ScriptBody| is *false*, return *undefined*.
             1. Let _body_ be the |ScriptBody| of _script_.
@@ -28628,14 +28679,14 @@
           1. Set _evalContext_'s LexicalEnvironment to _lexEnv_.
           1. Set _evalContext_'s PrivateEnvironment to _privateEnv_.
           1. Push _evalContext_ onto the execution context stack; _evalContext_ is now the running execution context.
-          1. Let _result_ be EvalDeclarationInstantiation(_body_, _varEnv_, _lexEnv_, _privateEnv_, _strictEval_).
+          1. Let _result_ be Completion(EvalDeclarationInstantiation(_body_, _varEnv_, _lexEnv_, _privateEnv_, _strictEval_)).
           1. If _result_.[[Type]] is ~normal~, then
             1. Set _result_ to the result of evaluating _body_.
           1. If _result_.[[Type]] is ~normal~ and _result_.[[Value]] is ~empty~, then
             1. Set _result_ to NormalCompletion(*undefined*).
           1. Suspend _evalContext_ and remove it from the execution context stack.
           1. Resume the context that is now on the top of the execution context stack as the running execution context.
-          1. Return Completion(_result_).
+          1. Return ? _result_.
         </emu-alg>
         <emu-note>
           <p>The eval code cannot instantiate variable or function bindings in the variable environment of the calling context that invoked the eval if either the code of the calling context or the eval code is strict mode code. Instead such bindings are instantiated in a new VariableEnvironment that is only accessible to the eval code. Bindings introduced by `let`, `const`, or `class` declarations are always instantiated in a new LexicalEnvironment.</p>
@@ -28647,7 +28698,7 @@
           HostEnsureCanCompileStrings (
             _callerRealm_: a Realm Record,
             _calleeRealm_: a Realm Record,
-          )
+          ): either a normal completion containing ~unused~ or an abrupt completion
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -28655,9 +28706,9 @@
         </dl>
         <p>An implementation of HostEnsureCanCompileStrings must conform to the following requirements:</p>
         <ul>
-          <li>It must propagate any throw completion to its callers.</li>
+          <li>If the returned Completion Record is a normal completion, it must be a normal completion containing ~unused~.</li>
         </ul>
-        <p>The default implementation of HostEnsureCanCompileStrings is to return NormalCompletion(~empty~).</p>
+        <p>The default implementation of HostEnsureCanCompileStrings is to return NormalCompletion(~unused~).</p>
       </emu-clause>
 
       <emu-clause id="sec-evaldeclarationinstantiation" type="abstract operation">
@@ -28668,7 +28719,7 @@
             _lexEnv_: unknown,
             _privateEnv_: unknown,
             _strict_: unknown,
-          )
+          ): either a normal completion containing ~unused~ or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
@@ -28692,7 +28743,7 @@
               1. If _thisEnv_ is not an object Environment Record, then
                 1. NOTE: The environment of with statements cannot contain any lexical declaration so it doesn't need to be checked for var/let hoisting conflicts.
                 1. For each element _name_ of _varNames_, do
-                  1. If _thisEnv_.HasBinding(_name_) is *true*, then
+                  1. If ! _thisEnv_.HasBinding(_name_) is *true*, then
                     1. [id="step-evaldeclarationinstantiation-throw-duplicate-binding"] Throw a *SyntaxError* exception.
                     1. NOTE: Annex <emu-xref href="#sec-variablestatements-in-catch-blocks"></emu-xref> defines alternate semantics for the above step.
                   1. NOTE: A direct eval will not hoist var declaration over a like-named lexical declaration.
@@ -28743,10 +28794,10 @@
             1. If _varEnv_ is a global Environment Record, then
               1. Perform ? _varEnv_.CreateGlobalFunctionBinding(_fn_, _fo_, *true*).
             1. Else,
-              1. Let _bindingExists_ be _varEnv_.HasBinding(_fn_).
+              1. Let _bindingExists_ be ! _varEnv_.HasBinding(_fn_).
               1. If _bindingExists_ is *false*, then
-                1. Let _status_ be ! _varEnv_.CreateMutableBinding(_fn_, *true*).
-                1. Assert: _status_ is not an abrupt completion because of validation preceding step <emu-xref href="#step-evaldeclarationinstantiation-post-validation"></emu-xref>.
+                1. NOTE: The following invocation cannot return an abrupt completion because of the validation preceding step <emu-xref href="#step-evaldeclarationinstantiation-post-validation"></emu-xref>.
+                1. Perform ! _varEnv_.CreateMutableBinding(_fn_, *true*).
                 1. Perform ! _varEnv_.InitializeBinding(_fn_, _fo_).
               1. Else,
                 1. Perform ! _varEnv_.SetMutableBinding(_fn_, _fo_, *false*).
@@ -28754,12 +28805,12 @@
             1. If _varEnv_ is a global Environment Record, then
               1. Perform ? _varEnv_.CreateGlobalVarBinding(_vn_, *true*).
             1. Else,
-              1. Let _bindingExists_ be _varEnv_.HasBinding(_vn_).
+              1. Let _bindingExists_ be ! _varEnv_.HasBinding(_vn_).
               1. If _bindingExists_ is *false*, then
-                1. Let _status_ be ! _varEnv_.CreateMutableBinding(_vn_, *true*).
-                1. Assert: _status_ is not an abrupt completion because of validation preceding step <emu-xref href="#step-evaldeclarationinstantiation-post-validation"></emu-xref>.
+                1. NOTE: The following invocation cannot return an abrupt completion because of the validation preceding step <emu-xref href="#step-evaldeclarationinstantiation-post-validation"></emu-xref>.
+                1. Perform ! _varEnv_.CreateMutableBinding(_vn_, *true*).
                 1. Perform ! _varEnv_.InitializeBinding(_vn_, *undefined*).
-          1. Return NormalCompletion(~empty~).
+          1. Return ~unused~.
         </emu-alg>
         <emu-note>
           <p>An alternative version of this algorithm is described in <emu-xref href="#sec-variablestatements-in-catch-blocks"></emu-xref>.</p>
@@ -28799,7 +28850,7 @@
         1. Let _trimmedString_ be ! TrimString(_inputString_, ~start~).
         1. If neither _trimmedString_ nor any prefix of _trimmedString_ satisfies the syntax of a |StrDecimalLiteral| (see <emu-xref href="#sec-tonumber-applied-to-the-string-type"></emu-xref>), return *NaN*.
         1. Let _numberString_ be the longest prefix of _trimmedString_, which might be _trimmedString_ itself, that satisfies the syntax of a |StrDecimalLiteral|.
-        1. Let _parsedNumber_ be ParseText(! StringToCodePoints(_numberString_), |StrDecimalLiteral|).
+        1. Let _parsedNumber_ be ParseText(StringToCodePoints(_numberString_), |StrDecimalLiteral|).
         1. Assert: _parsedNumber_ is a Parse Node.
         1. Return StringNumericValue of _parsedNumber_.
       </emu-alg>
@@ -28902,7 +28953,7 @@
             Encode (
               _string_: a String,
               _unescapedSet_: a String,
-            )
+            ): either a normal completion containing a String or an abrupt completion
           </h1>
           <dl class="header">
             <dt>description</dt>
@@ -28919,7 +28970,7 @@
                 1. Set _k_ to _k_ + 1.
                 1. Set _R_ to the string-concatenation of _R_ and _C_.
               1. Else,
-                1. Let _cp_ be ! CodePointAt(_string_, _k_).
+                1. Let _cp_ be CodePointAt(_string_, _k_).
                 1. If _cp_.[[IsUnpairedSurrogate]] is *true*, throw a *URIError* exception.
                 1. Set _k_ to _k_ + _cp_.[[CodeUnitCount]].
                 1. Let _Octets_ be the List of octets resulting by applying the UTF-8 transformation to _cp_.[[CodePoint]].
@@ -28936,7 +28987,7 @@
             Decode (
               _string_: a String,
               _reservedSet_: a String,
-            )
+            ): either a normal completion containing a String or an abrupt completion
           </h1>
           <dl class="header">
             <dt>description</dt>
@@ -29295,7 +29346,7 @@
         <emu-alg>
           1. If NewTarget is neither *undefined* nor the active function, then
             1. Return ? OrdinaryCreateFromConstructor(NewTarget, *"%Object.prototype%"*).
-          1. If _value_ is *undefined* or *null*, return ! OrdinaryObjectCreate(%Object.prototype%).
+          1. If _value_ is *undefined* or *null*, return OrdinaryObjectCreate(%Object.prototype%).
           1. Return ! ToObject(_value_).
         </emu-alg>
         <p>The *"length"* property of the `Object` function is *1*<sub>𝔽</sub>.</p>
@@ -29336,7 +29387,7 @@
         <p>The `create` function creates a new object with a specified prototype. When the `create` function is called, the following steps are taken:</p>
         <emu-alg>
           1. If Type(_O_) is neither Object nor Null, throw a *TypeError* exception.
-          1. Let _obj_ be ! OrdinaryObjectCreate(_O_).
+          1. Let _obj_ be OrdinaryObjectCreate(_O_).
           1. If _Properties_ is not *undefined*, then
             1. Return ? ObjectDefineProperties(_obj_, _Properties_).
           1. Return _obj_.
@@ -29356,7 +29407,7 @@
             ObjectDefineProperties (
               _O_: an Object,
               _Properties_: unknown,
-            )
+            ): either a normal completion containing an Object or an abrupt completion
           </h1>
           <dl class="header">
           </dl>
@@ -29417,13 +29468,13 @@
         <p>When the `fromEntries` method is called with argument _iterable_, the following steps are taken:</p>
         <emu-alg>
           1. Perform ? RequireObjectCoercible(_iterable_).
-          1. Let _obj_ be ! OrdinaryObjectCreate(%Object.prototype%).
+          1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%).
           1. Assert: _obj_ is an extensible ordinary object with no own properties.
           1. Let _closure_ be a new Abstract Closure with parameters (_key_, _value_) that captures _obj_ and performs the following steps when called:
             1. Let _propertyKey_ be ? ToPropertyKey(_key_).
             1. Perform ! CreateDataPropertyOrThrow(_obj_, _propertyKey_, _value_).
             1. Return *undefined*.
-          1. Let _adder_ be ! CreateBuiltinFunction(_closure_, 2, *""*, &laquo; &raquo;).
+          1. Let _adder_ be CreateBuiltinFunction(_closure_, 2, *""*, &laquo; &raquo;).
           1. Return ? AddEntriesFromIterable(_obj_, _iterable_, _adder_).
         </emu-alg>
         <emu-note>
@@ -29448,10 +29499,10 @@
         <emu-alg>
           1. Let _obj_ be ? ToObject(_O_).
           1. Let _ownKeys_ be ? <emu-meta effects="user-code">_obj_.[[OwnPropertyKeys]]()</emu-meta>.
-          1. Let _descriptors_ be ! OrdinaryObjectCreate(%Object.prototype%).
+          1. Let _descriptors_ be OrdinaryObjectCreate(%Object.prototype%).
           1. For each element _key_ of _ownKeys_, do
             1. Let _desc_ be ? <emu-meta effects="user-code">_obj_.[[GetOwnProperty]]</emu-meta>(_key_).
-            1. Let _descriptor_ be ! FromPropertyDescriptor(_desc_).
+            1. Let _descriptor_ be FromPropertyDescriptor(_desc_).
             1. If _descriptor_ is not *undefined*, perform ! CreateDataPropertyOrThrow(_descriptors_, _key_, _descriptor_).
           1. Return _descriptors_.
         </emu-alg>
@@ -29461,7 +29512,7 @@
         <h1>Object.getOwnPropertyNames ( _O_ )</h1>
         <p>When the `getOwnPropertyNames` function is called, the following steps are taken:</p>
         <emu-alg>
-          1. Return ? GetOwnPropertyKeys(_O_, ~string~).
+          1. Return CreateArrayFromList(? GetOwnPropertyKeys(_O_, ~string~)).
         </emu-alg>
       </emu-clause>
 
@@ -29469,7 +29520,7 @@
         <h1>Object.getOwnPropertySymbols ( _O_ )</h1>
         <p>When the `getOwnPropertySymbols` function is called with argument _O_, the following steps are taken:</p>
         <emu-alg>
-          1. Return ? GetOwnPropertyKeys(_O_, ~symbol~).
+          1. Return CreateArrayFromList(? GetOwnPropertyKeys(_O_, ~symbol~)).
         </emu-alg>
 
         <emu-clause id="sec-getownpropertykeys" type="abstract operation">
@@ -29477,7 +29528,7 @@
             GetOwnPropertyKeys (
               _O_: unknown,
               _type_: ~string~ or ~symbol~,
-            )
+            ): either a normal completion containing a List of property keys or an abrupt completion
           </h1>
           <dl class="header">
           </dl>
@@ -29488,7 +29539,7 @@
             1. For each element _nextKey_ of _keys_, do
               1. If Type(_nextKey_) is Symbol and _type_ is ~symbol~ or Type(_nextKey_) is String and _type_ is ~string~, then
                 1. Append _nextKey_ as the last element of _nameList_.
-            1. Return CreateArrayFromList(_nameList_).
+            1. Return _nameList_.
           </emu-alg>
         </emu-clause>
       </emu-clause>
@@ -29856,7 +29907,7 @@
               _newTarget_: a constructor,
               _kind_: ~normal~, ~generator~, ~async~, or ~asyncGenerator~,
               _args_: a List of ECMAScript language values,
-            )
+            ): either a normal completion containing a function object or an abrupt completion
           </h1>
           <dl class="header">
             <dt>description</dt>
@@ -29911,10 +29962,10 @@
               1. Let _bodyArg_ be _args_[_k_].
             1. Let _bodyString_ be the string-concatenation of 0x000A (LINE FEED), ? ToString(_bodyArg_), and 0x000A (LINE FEED).
             1. Let _sourceString_ be the string-concatenation of _prefix_, *" anonymous("*, _P_, 0x000A (LINE FEED), *") {"*, _bodyString_, and *"}"*.
-            1. Let _sourceText_ be ! StringToCodePoints(_sourceString_).
-            1. Let _parameters_ be ParseText(! StringToCodePoints(_P_), _parameterSym_).
+            1. Let _sourceText_ be StringToCodePoints(_sourceString_).
+            1. Let _parameters_ be ParseText(StringToCodePoints(_P_), _parameterSym_).
             1. If _parameters_ is a List of errors, throw a *SyntaxError* exception.
-            1. Let _body_ be ParseText(! StringToCodePoints(_bodyString_), _bodySym_).
+            1. Let _body_ be ParseText(StringToCodePoints(_bodyString_), _bodySym_).
             1. If _body_ is a List of errors, throw a *SyntaxError* exception.
             1. NOTE: The parameters and body are parsed separately to ensure that each is valid alone. For example, `new Function("/*", "*/ ) {")` is not legal.
             1. NOTE: If this step is reached, _sourceText_ must have the syntax of _exprSym_ (although the reverse implication does not hold). The purpose of the next two steps is to enforce any Early Error rules which apply to _exprSym_ directly.
@@ -29924,14 +29975,14 @@
             1. Let _realmF_ be the current Realm Record.
             1. Let _env_ be _realmF_.[[GlobalEnv]].
             1. Let _privateEnv_ be *null*.
-            1. Let _F_ be ! OrdinaryFunctionCreate(_proto_, _sourceText_, _parameters_, _body_, ~non-lexical-this~, _env_, _privateEnv_).
+            1. Let _F_ be OrdinaryFunctionCreate(_proto_, _sourceText_, _parameters_, _body_, ~non-lexical-this~, _env_, _privateEnv_).
             1. Perform SetFunctionName(_F_, *"anonymous"*).
             1. If _kind_ is ~generator~, then
-              1. Let _prototype_ be ! OrdinaryObjectCreate(%GeneratorFunction.prototype.prototype%).
-              1. Perform DefinePropertyOrThrow(_F_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
+              1. Let _prototype_ be OrdinaryObjectCreate(%GeneratorFunction.prototype.prototype%).
+              1. Perform ! DefinePropertyOrThrow(_F_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
             1. Else if _kind_ is ~asyncGenerator~, then
-              1. Let _prototype_ be ! OrdinaryObjectCreate(%AsyncGeneratorFunction.prototype.prototype%).
-              1. Perform DefinePropertyOrThrow(_F_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
+              1. Let _prototype_ be OrdinaryObjectCreate(%AsyncGeneratorFunction.prototype.prototype%).
+              1. Perform ! DefinePropertyOrThrow(_F_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
             1. Else if _kind_ is ~normal~, perform MakeConstructor(_F_).
             1. NOTE: Functions whose _kind_ is ~async~ are not constructible and do not have a [[Construct]] internal method or a *"prototype"* property.
             1. Return _F_.
@@ -30021,7 +30072,7 @@
                 1. Assert: _targetLenAsInt_ is finite.
                 1. Let _argCount_ be the number of elements in _args_.
                 1. Set _L_ to max(_targetLenAsInt_ - _argCount_, 0).
-          1. Perform ! SetFunctionLength(_F_, _L_).
+          1. Perform SetFunctionLength(_F_, _L_).
           1. Let _targetName_ be ? Get(_Target_, *"name"*).
           1. If Type(_targetName_) is not String, set _targetName_ to the empty String.
           1. Perform SetFunctionName(_F_, _targetName_, *"bound"*).
@@ -30062,8 +30113,8 @@
         <p>When the `toString` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _func_ be the *this* value.
-          1. If Type(_func_) is Object and _func_ has a [[SourceText]] internal slot and _func_.[[SourceText]] is a sequence of Unicode code points and ! HostHasSourceTextAvailable(_func_) is *true*, then
-            1. Return ! CodePointsToString(_func_.[[SourceText]]).
+          1. If Type(_func_) is Object and _func_ has a [[SourceText]] internal slot and _func_.[[SourceText]] is a sequence of Unicode code points and HostHasSourceTextAvailable(_func_) is *true*, then
+            1. Return CodePointsToString(_func_.[[SourceText]]).
           1. If _func_ is a <emu-xref href="#sec-built-in-function-objects">built-in function object</emu-xref>, return an implementation-defined String source code representation of _func_. The representation must have the syntax of a |NativeFunction|. Additionally, if _func_ has an [[InitialName]] internal slot and _func_.[[InitialName]] is a String, the portion of the returned String that would be matched by |NativeFunctionAccessor?| |PropertyName| must be the value of _func_.[[InitialName]].
           1. If Type(_func_) is Object and IsCallable(_func_) is *true*, return an implementation-defined String source code representation of _func_. The representation must have the syntax of a |NativeFunction|.
           1. Throw a *TypeError* exception.
@@ -30133,7 +30184,7 @@
       <h1>
         HostHasSourceTextAvailable (
           _func_: a function object,
-        )
+        ): a Boolean
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -30141,10 +30192,9 @@
       </dl>
       <p>An implementation of HostHasSourceTextAvailable must conform to the following requirements:</p>
       <ul>
-        <li>It must complete normally (i.e. not return an abrupt completion).</li>
-        <li>It must be deterministic with respect to its parameters. Each time it is called with a specific _func_ as its argument, it must return the same completion record.</li>
+        <li>It must be deterministic with respect to its parameters. Each time it is called with a specific _func_ as its argument, it must return the same result.</li>
       </ul>
-      <p>The default implementation of HostHasSourceTextAvailable is to return NormalCompletion(*true*).</p>
+      <p>The default implementation of HostHasSourceTextAvailable is to return *true*.</p>
     </emu-clause>
   </emu-clause>
 
@@ -30166,7 +30216,7 @@
         <h1>Boolean ( _value_ )</h1>
         <p>When `Boolean` is called with argument _value_, the following steps are taken:</p>
         <emu-alg>
-          1. Let _b_ be ! ToBoolean(_value_).
+          1. Let _b_ be ToBoolean(_value_).
           1. If NewTarget is *undefined*, return _b_.
           1. Let _O_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Boolean.prototype%"*, &laquo; [[BooleanData]] &raquo;).
           1. Set _O_.[[BooleanData]] to _b_.
@@ -30468,7 +30518,7 @@
           <h1>
             SymbolDescriptiveString (
               _sym_: a Symbol,
-            )
+            ): a String
           </h1>
           <dl class="header">
           </dl>
@@ -30539,7 +30589,7 @@
           1. Let _O_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%Error.prototype%"*, &laquo; [[ErrorData]] &raquo;).
           1. If _message_ is not *undefined*, then
             1. Let _msg_ be ? ToString(_message_).
-            1. Perform ! CreateNonEnumerableDataPropertyOrThrow(_O_, *"message"*, _msg_).
+            1. Perform CreateNonEnumerableDataPropertyOrThrow(_O_, *"message"*, _msg_).
           1. Perform ? InstallErrorCause(_O_, _options_).
           1. Return _O_.
         </emu-alg>
@@ -30670,7 +30720,7 @@
             1. [id="step-nativerror-ordinarycreatefromconstructor"] Let _O_ be ? OrdinaryCreateFromConstructor(_newTarget_, <code>"%<var>NativeError</var>.prototype%"</code>, &laquo; [[ErrorData]] &raquo;).
             1. If _message_ is not *undefined*, then
               1. Let _msg_ be ? ToString(_message_).
-              1. Perform ! CreateNonEnumerableDataPropertyOrThrow(_O_, *"message"*, _msg_).
+              1. Perform CreateNonEnumerableDataPropertyOrThrow(_O_, *"message"*, _msg_).
             1. Perform ? InstallErrorCause(_O_, _options_).
             1. Return _O_.
           </emu-alg>
@@ -30746,10 +30796,10 @@
             1. Let _O_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%AggregateError.prototype%"*, &laquo; [[ErrorData]] &raquo;).
             1. If _message_ is not *undefined*, then
               1. Let _msg_ be ? ToString(_message_).
-              1. Perform ! CreateNonEnumerableDataPropertyOrThrow(_O_, *"message"*, _msg_).
+              1. Perform CreateNonEnumerableDataPropertyOrThrow(_O_, *"message"*, _msg_).
             1. Perform ? InstallErrorCause(_O_, _options_).
             1. Let _errorsList_ be ? IterableToList(_errors_).
-            1. Perform ! DefinePropertyOrThrow(_O_, *"errors"*, PropertyDescriptor { [[Configurable]]: *true*, [[Enumerable]]: *false*, [[Writable]]: *true*, [[Value]]: ! CreateArrayFromList(_errorsList_) }).
+            1. Perform ! DefinePropertyOrThrow(_O_, *"errors"*, PropertyDescriptor { [[Configurable]]: *true*, [[Enumerable]]: *false*, [[Writable]]: *true*, [[Value]]: CreateArrayFromList(_errorsList_) }).
             1. Return _O_.
           </emu-alg>
         </emu-clause>
@@ -30810,7 +30860,7 @@
           InstallErrorCause (
             _O_: an Object,
             _options_: an ECMAScript language value,
-          )
+          ): either a normal completion containing ~unused~ or an abrupt completion
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -30819,8 +30869,8 @@
         <emu-alg>
           1. If Type(_options_) is Object and ? HasProperty(_options_, *"cause"*) is *true*, then
             1. Let _cause_ be ? Get(_options_, *"cause"*).
-            1. Perform ! CreateNonEnumerableDataPropertyOrThrow(_O_, *"cause"*, _cause_).
-          1. Return NormalCompletion(*undefined*).
+            1. Perform CreateNonEnumerableDataPropertyOrThrow(_O_, *"cause"*, _cause_).
+          1. Return ~unused~.
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -30890,7 +30940,7 @@
         <h1>Number.isInteger ( _number_ )</h1>
         <p>When `Number.isInteger` is called with one argument _number_, the following steps are taken:</p>
         <emu-alg>
-          1. Return ! IsIntegralNumber(_number_).
+          1. Return IsIntegralNumber(_number_).
         </emu-alg>
       </emu-clause>
 
@@ -30911,7 +30961,7 @@
         <h1>Number.isSafeInteger ( _number_ )</h1>
         <p>When `Number.isSafeInteger` is called with one argument _number_, the following steps are taken:</p>
         <emu-alg>
-          1. If ! IsIntegralNumber(_number_) is *true*, then
+          1. If IsIntegralNumber(_number_) is *true*, then
             1. If abs(ℝ(_number_)) &le; 2<sup>53</sup> - 1, return *true*.
           1. Return *false*.
         </emu-alg>
@@ -31016,7 +31066,7 @@
           1. Let _x_ be ? thisNumberValue(*this* value).
           1. Let _f_ be ? ToIntegerOrInfinity(_fractionDigits_).
           1. Assert: If _fractionDigits_ is *undefined*, then _f_ is 0.
-          1. If _x_ is not finite, return ! Number::toString(_x_).
+          1. If _x_ is not finite, return Number::toString(_x_).
           1. If _f_ &lt; 0 or _f_ &gt; 100, throw a *RangeError* exception.
           1. Set _x_ to ℝ(_x_).
           1. Let _s_ be the empty String.
@@ -31069,7 +31119,7 @@
           1. Assert: If _fractionDigits_ is *undefined*, then _f_ is 0.
           1. If _f_ is not finite, throw a *RangeError* exception.
           1. If _f_ &lt; 0 or _f_ &gt; 100, throw a *RangeError* exception.
-          1. If _x_ is not finite, return ! Number::toString(_x_).
+          1. If _x_ is not finite, return Number::toString(_x_).
           1. Set _x_ to ℝ(_x_).
           1. Let _s_ be the empty String.
           1. If _x_ &lt; 0, then
@@ -31114,7 +31164,7 @@
           1. Let _x_ be ? thisNumberValue(*this* value).
           1. If _precision_ is *undefined*, return ! ToString(_x_).
           1. Let _p_ be ? ToIntegerOrInfinity(_precision_).
-          1. If _x_ is not finite, return ! Number::toString(_x_).
+          1. If _x_ is not finite, return Number::toString(_x_).
           1. If _p_ &lt; 1 or _p_ &gt; 100, throw a *RangeError* exception.
           1. Set _x_ to ℝ(_x_).
           1. Let _s_ be the empty String.
@@ -31209,7 +31259,7 @@
           <h1>
             NumberToBigInt (
               _number_: a Number,
-            )
+            ): either a normal completion containing a BigInt or an abrupt completion
           </h1>
           <dl class="header">
           </dl>
@@ -31797,7 +31847,7 @@
         <emu-alg>
           1. Set _base_ to ? ToNumber(_base_).
           1. Set _exponent_ to ? ToNumber(_exponent_).
-          1. Return ! Number::exponentiate(_base_, _exponent_).
+          1. Return Number::exponentiate(_base_, _exponent_).
         </emu-alg>
       </emu-clause>
 
@@ -32027,11 +32077,11 @@
           LocalTZA (
             _t_: a Number,
             _isUTC_: a Boolean,
-          )
+          ): an integral Number
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It returns an integral Number representing the local time zone adjustment, or offset, in milliseconds. The local political rules for standard time and daylight saving time in effect at _t_ should be used to determine the result in the way specified in this section.</dd>
+          <dd>Its return value represents the local time zone adjustment, or offset, in milliseconds. The local political rules for standard time and daylight saving time in effect at _t_ should be used to determine the result in the way specified in this section.</dd>
         </dl>
         <p>When _isUTC_ is true, <emu-eqn>LocalTZA( _t_<sub>UTC</sub>, true )</emu-eqn> should return the offset of the local time zone from UTC measured in milliseconds at time represented by time value <emu-eqn>_t_<sub>UTC</sub></emu-eqn>. When the result is added to <emu-eqn>_t_<sub>UTC</sub></emu-eqn>, it should yield the corresponding Number <emu-eqn>_t_<sub>local</sub></emu-eqn>.</p>
         <p>When _isUTC_ is false, <emu-eqn>LocalTZA( _t_<sub>local</sub>, false )</emu-eqn> should return the offset of the local time zone from UTC measured in milliseconds at local time represented by Number <emu-eqn>_t_<sub>local</sub></emu-eqn>. When the result is subtracted from <emu-eqn>_t_<sub>local</sub></emu-eqn>, it should yield the corresponding time value <emu-eqn>_t_<sub>UTC</sub></emu-eqn>.</p>
@@ -32050,7 +32100,7 @@
         <h1>
           LocalTime (
             _t_: a time value,
-          )
+          ): a Number
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -32069,7 +32119,7 @@
         <h1>
           UTC (
             _t_: a Number,
-          )
+          ): a time value
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -32106,7 +32156,7 @@
             _min_: a Number,
             _sec_: a Number,
             _ms_: a Number,
-          )
+          ): a Number
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -32129,7 +32179,7 @@
             _year_: a Number,
             _month_: a Number,
             _date_: a Number,
-          )
+          ): a Number
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -32153,7 +32203,7 @@
           MakeDate (
             _day_: a Number,
             _time_: a Number,
-          )
+          ): a Number
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -32171,7 +32221,7 @@
         <h1>
           TimeClip (
             _time_: a Number,
-          )
+          ): a Number
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -33029,7 +33079,7 @@ THH:mm:ss.sss
           <h1>
             TimeString (
               _tv_: a Number, but not *NaN*,
-            )
+            ): a String
           </h1>
           <dl class="header">
           </dl>
@@ -33045,7 +33095,7 @@ THH:mm:ss.sss
           <h1>
             DateString (
               _tv_: a Number, but not *NaN*,
-            )
+            ): a String
           </h1>
           <dl class="header">
           </dl>
@@ -33241,7 +33291,7 @@ THH:mm:ss.sss
           <h1>
             TimeZoneString (
               _tv_: a Number, but not *NaN*,
-            )
+            ): a String
           </h1>
           <dl class="header">
           </dl>
@@ -33264,7 +33314,7 @@ THH:mm:ss.sss
           <h1>
             ToDateString (
               _tv_: a Number,
-            )
+            ): a String
           </h1>
           <dl class="header">
           </dl>
@@ -33366,7 +33416,7 @@ THH:mm:ss.sss
             1. If NewTarget is *undefined* and Type(_value_) is Symbol, return SymbolDescriptiveString(_value_).
             1. Let _s_ be ? ToString(_value_).
           1. If NewTarget is *undefined*, return _s_.
-          1. Return ! StringCreate(_s_, ? GetPrototypeFromConstructor(NewTarget, *"%String.prototype%"*)).
+          1. Return StringCreate(_s_, ? GetPrototypeFromConstructor(NewTarget, *"%String.prototype%"*)).
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -33400,9 +33450,9 @@ THH:mm:ss.sss
           1. Let _result_ be the empty String.
           1. For each element _next_ of _codePoints_, do
             1. Let _nextCP_ be ? ToNumber(_next_).
-            1. If ! IsIntegralNumber(_nextCP_) is *false*, throw a *RangeError* exception.
+            1. If IsIntegralNumber(_nextCP_) is *false*, throw a *RangeError* exception.
             1. If ℝ(_nextCP_) &lt; 0 or ℝ(_nextCP_) &gt; 0x10FFFF, throw a *RangeError* exception.
-            1. Set _result_ to the string-concatenation of _result_ and ! UTF16EncodeCodePoint(ℝ(_nextCP_)).
+            1. Set _result_ to the string-concatenation of _result_ and UTF16EncodeCodePoint(ℝ(_nextCP_)).
           1. Assert: If _codePoints_ is empty, then _result_ is the empty String.
           1. Return _result_.
         </emu-alg>
@@ -33532,7 +33582,7 @@ THH:mm:ss.sss
           1. Let _position_ be ? ToIntegerOrInfinity(_pos_).
           1. Let _size_ be the length of _S_.
           1. If _position_ &lt; 0 or _position_ &ge; _size_, return *undefined*.
-          1. Let _cp_ be ! CodePointAt(_S_, _position_).
+          1. Let _cp_ be CodePointAt(_S_, _position_).
           1. Return 𝔽(_cp_.[[CodePoint]]).
         </emu-alg>
         <emu-note>
@@ -33583,7 +33633,7 @@ THH:mm:ss.sss
           1. Let _start_ be _end_ - _searchLength_.
           1. If _start_ &lt; 0, return *false*.
           1. Let _substring_ be the substring of _S_ from _start_ to _end_.
-          1. Return ! SameValueNonNumeric(_substring_, _searchStr_).
+          1. Return SameValueNonNumeric(_substring_, _searchStr_).
         </emu-alg>
         <emu-note>
           <p>Returns *true* if the sequence of code units of _searchString_ converted to a String is the same as the corresponding code units of this object (converted to a String) starting at _endPosition_ - length(this). Otherwise returns *false*.</p>
@@ -33609,7 +33659,7 @@ THH:mm:ss.sss
           1. Assert: If _position_ is *undefined*, then _pos_ is 0.
           1. Let _len_ be the length of _S_.
           1. Let _start_ be the result of clamping _pos_ between 0 and _len_.
-          1. Let _index_ be ! StringIndexOf(_S_, _searchStr_, _start_).
+          1. Let _index_ be StringIndexOf(_S_, _searchStr_, _start_).
           1. If _index_ is not -1, return *true*.
           1. Return *false*.
         </emu-alg>
@@ -33638,7 +33688,7 @@ THH:mm:ss.sss
           1. Assert: If _position_ is *undefined*, then _pos_ is 0.
           1. Let _len_ be the length of _S_.
           1. Let _start_ be the result of clamping _pos_ between 0 and _len_.
-          1. Return 𝔽(! StringIndexOf(_S_, _searchStr_, _start_)).
+          1. Return 𝔽(StringIndexOf(_S_, _searchStr_, _start_)).
         </emu-alg>
         <emu-note>
           <p>The `indexOf` function is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
@@ -33779,7 +33829,7 @@ THH:mm:ss.sss
               _maxLength_: an ECMAScript language value,
               _fillString_: an ECMAScript language value,
               _placement_: ~start~ or ~end~,
-            )
+            ): either a normal completion containing a String or an abrupt completion
           </h1>
           <dl class="header">
           </dl>
@@ -33839,7 +33889,7 @@ THH:mm:ss.sss
           1. If _functionalReplace_ is *false*, then
             1. Set _replaceValue_ to ? ToString(_replaceValue_).
           1. Let _searchLength_ be the length of _searchString_.
-          1. Let _position_ be ! StringIndexOf(_string_, _searchString_, 0).
+          1. Let _position_ be StringIndexOf(_string_, _searchString_, 0).
           1. If _position_ is -1, return _string_.
           1. Let _preceding_ be the substring of _string_ from 0 to _position_.
           1. Let _following_ be the substring of _string_ from _position_ + _searchLength_.
@@ -33864,7 +33914,7 @@ THH:mm:ss.sss
               _captures_: a possibly empty List, each of whose elements is a String or *undefined*,
               _namedCaptures_: an Object or *undefined*,
               _replacementTemplate_: a String,
-            )
+            ): either a normal completion containing a String or an abrupt completion
           </h1>
           <dl class="header">
             <dt>description</dt>
@@ -33958,10 +34008,10 @@ THH:mm:ss.sss
           1. Let _searchLength_ be the length of _searchString_.
           1. Let _advanceBy_ be max(1, _searchLength_).
           1. Let _matchPositions_ be a new empty List.
-          1. Let _position_ be ! StringIndexOf(_string_, _searchString_, 0).
+          1. Let _position_ be StringIndexOf(_string_, _searchString_, 0).
           1. Repeat, while _position_ is not -1,
             1. Append _position_ to the end of _matchPositions_.
-            1. Set _position_ to ! StringIndexOf(_string_, _searchString_, _position_ + _advanceBy_).
+            1. Set _position_ to StringIndexOf(_string_, _searchString_, _position_ + _advanceBy_).
           1. Let _endOfLastMatch_ be 0.
           1. Let _result_ be the empty String.
           1. For each element _p_ of _matchPositions_, do
@@ -34035,27 +34085,27 @@ THH:mm:ss.sss
           1. If _limit_ is *undefined*, let _lim_ be 2<sup>32</sup> - 1; else let _lim_ be ℝ(? ToUint32(_limit_)).
           1. Let _R_ be ? ToString(_separator_).
           1. If _lim_ = 0, then
-            1. Return ! CreateArrayFromList(&laquo; &raquo;).
+            1. Return CreateArrayFromList(&laquo; &raquo;).
           1. If _separator_ is *undefined*, then
-            1. Return ! CreateArrayFromList(&laquo; _S_ &raquo;).
+            1. Return CreateArrayFromList(&laquo; _S_ &raquo;).
           1. Let _separatorLength_ be the length of _R_.
           1. If _separatorLength_ is 0, then
             1. Let _head_ be the substring of _S_ from 0 to _lim_.
             1. Let _codeUnits_ be a List consisting of the sequence of code units that are the elements of _head_.
-            1. Return ! CreateArrayFromList(_codeUnits_).
-          1. If _S_ is the empty String, return ! CreateArrayFromList(&laquo; _S_ &raquo;).
+            1. Return CreateArrayFromList(_codeUnits_).
+          1. If _S_ is the empty String, return CreateArrayFromList(&laquo; _S_ &raquo;).
           1. Let _substrings_ be a new empty List.
           1. Let _i_ be 0.
-          1. Let _j_ be ! StringIndexOf(_S_, _R_, 0).
+          1. Let _j_ be StringIndexOf(_S_, _R_, 0).
           1. Repeat, while _j_ is not -1,
             1. Let _T_ be the substring of _S_ from _i_ to _j_.
             1. Append _T_ as the last element of _substrings_.
-            1. If the number of elements of _substrings_ is _lim_, return ! CreateArrayFromList(_substrings_).
+            1. If the number of elements of _substrings_ is _lim_, return CreateArrayFromList(_substrings_).
             1. Set _i_ to _j_ + _separatorLength_.
-            1. Set _j_ to ! StringIndexOf(_S_, _R_, _i_).
+            1. Set _j_ to StringIndexOf(_S_, _R_, _i_).
           1. Let _T_ be the substring of _S_ from _i_.
           1. Append _T_ to _substrings_.
-          1. Return ! CreateArrayFromList(_substrings_).
+          1. Return CreateArrayFromList(_substrings_).
         </emu-alg>
         <emu-note>
           <p>The value of _separator_ may be an empty String. In this case, _separator_ does not match the empty <emu-not-ref>substring</emu-not-ref> at the beginning or end of the input String, nor does it match the empty <emu-not-ref>substring</emu-not-ref> at the end of the previous separator match. If _separator_ is the empty String, the String is split up into individual code unit elements; the length of the result array equals the length of the String, and each <emu-not-ref>substring</emu-not-ref> contains one code unit.</p>
@@ -34084,7 +34134,7 @@ THH:mm:ss.sss
           1. Let _end_ be _start_ + _searchLength_.
           1. If _end_ &gt; _len_, return *false*.
           1. Let _substring_ be the substring of _S_ from _start_ to _end_.
-          1. Return ! SameValueNonNumeric(_substring_, _searchStr_).
+          1. Return SameValueNonNumeric(_substring_, _searchStr_).
         </emu-alg>
         <emu-note>
           <p>This method returns *true* if the sequence of code units of _searchString_ converted to a String is the same as the corresponding code units of this object (converted to a String) starting at index _position_. Otherwise returns *false*.</p>
@@ -34148,9 +34198,9 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
-          1. Let _sText_ be ! StringToCodePoints(_S_).
+          1. Let _sText_ be StringToCodePoints(_S_).
           1. Let _lowerText_ be the result of toLowercase(_sText_), according to the Unicode Default Case Conversion algorithm.
-          1. Let _L_ be ! CodePointsToString(_lowerText_).
+          1. Let _L_ be CodePointsToString(_lowerText_).
           1. Return _L_.
         </emu-alg>
         <p>The result must be derived according to the locale-insensitive case mappings in the Unicode Character Database (this explicitly includes not only the file <a href="https://unicode.org/Public/UCD/latest/ucd/UnicodeData.txt"><code>UnicodeData.txt</code></a>, but also all locale-insensitive mappings in the file <a href="https://unicode.org/Public/UCD/latest/ucd/SpecialCasing.txt"><code>SpecialCasing.txt</code></a> that accompanies it).</p>
@@ -34199,7 +34249,7 @@ THH:mm:ss.sss
             TrimString (
               _string_: an ECMAScript language value,
               _where_: ~start~, ~end~, or ~start+end~,
-            )
+            ): either a normal completion containing a String or an abrupt completion
           </h1>
           <dl class="header">
             <dt>description</dt>
@@ -34263,13 +34313,13 @@ THH:mm:ss.sss
             1. Let _position_ be 0.
             1. Let _len_ be the length of _s_.
             1. Repeat, while _position_ &lt; _len_,
-              1. Let _cp_ be ! CodePointAt(_s_, _position_).
+              1. Let _cp_ be CodePointAt(_s_, _position_).
               1. Let _nextIndex_ be _position_ + _cp_.[[CodeUnitCount]].
               1. Let _resultString_ be the substring of _s_ from _position_ to _nextIndex_.
               1. Set _position_ to _nextIndex_.
-              1. Perform ? GeneratorYield(! CreateIterResultObject(_resultString_, *false*)).
+              1. Perform ? GeneratorYield(CreateIterResultObject(_resultString_, *false*)).
             1. Return *undefined*.
-          1. Return ! CreateIteratorFromClosure(_closure_, *"%StringIteratorPrototype%"*, %StringIteratorPrototype%).
+          1. Return CreateIteratorFromClosure(_closure_, *"%StringIteratorPrototype%"*, %StringIteratorPrototype%).
         </emu-alg>
         <p>The value of the *"name"* property of this function is *"[Symbol.iterator]"*.</p>
       </emu-clause>
@@ -34623,7 +34673,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-patterns-static-semantics-capturing-group-number" type="sdo">
-        <h1>Static Semantics: CapturingGroupNumber</h1>
+        <h1>Static Semantics: CapturingGroupNumber ( ): a positive integer</h1>
         <dl class="header">
         </dl>
         <emu-note>
@@ -34642,7 +34692,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-patterns-static-semantics-is-character-class" type="sdo">
-        <h1>Static Semantics: IsCharacterClass</h1>
+        <h1>Static Semantics: IsCharacterClass ( ): a Boolean</h1>
         <dl class="header">
         </dl>
         <emu-note>
@@ -34670,7 +34720,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-patterns-static-semantics-character-value" type="sdo">
-        <h1>Static Semantics: CharacterValue</h1>
+        <h1>Static Semantics: CharacterValue ( ): a non-negative integer</h1>
         <dl class="header">
         </dl>
         <emu-note>
@@ -34861,7 +34911,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-static-semantics-sourcetext" type="sdo">
-        <h1>Static Semantics: SourceText</h1>
+        <h1>Static Semantics: SourceText ( ): a List of code points</h1>
         <dl class="header">
         </dl>
         <emu-grammar>
@@ -34875,7 +34925,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-static-semantics-capturinggroupname" oldids="sec-regexp-identifier-names-static-semantics-stringvalue" type="sdo">
-        <h1>Static Semantics: CapturingGroupName</h1>
+        <h1>Static Semantics: CapturingGroupName ( ): a String</h1>
         <dl class="header">
         </dl>
         <emu-grammar>
@@ -34885,12 +34935,12 @@ THH:mm:ss.sss
         </emu-grammar>
         <emu-alg>
           1. Let _idTextUnescaped_ be RegExpIdentifierCodePoints of |RegExpIdentifierName|.
-          1. Return ! CodePointsToString(_idTextUnescaped_).
+          1. Return CodePointsToString(_idTextUnescaped_).
         </emu-alg>
       </emu-clause>
 
       <emu-clause id="sec-regexpidentifiercodepoints" type="sdo">
-        <h1>Static Semantics: RegExpIdentifierCodePoints</h1>
+        <h1>Static Semantics: RegExpIdentifierCodePoints ( ): a List of code points</h1>
         <dl class="header">
         </dl>
         <emu-grammar>RegExpIdentifierName :: RegExpIdentifierStart</emu-grammar>
@@ -34907,7 +34957,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-regexpidentifiercodepoint" type="sdo">
-        <h1>Static Semantics: RegExpIdentifierCodePoint</h1>
+        <h1>Static Semantics: RegExpIdentifierCodePoint ( ): a code point</h1>
         <dl class="header">
         </dl>
         <emu-grammar>RegExpIdentifierStart :: IdentifierStartChar</emu-grammar>
@@ -35000,10 +35050,8 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-compilepattern" type="sdo" oldids="sec-pattern">
-        <h1>Runtime Semantics: CompilePattern</h1>
+        <h1>Runtime Semantics: CompilePattern ( ): an Abstract Closure that takes a String and a non-negative integer and returns a MatchResult</h1>
         <dl class="header">
-          <dt>description</dt>
-          <dd>It returns an Abstract Closure that takes a String and a non-negative integer and returns a MatchResult.</dd>
         </dl>
         <emu-grammar>Pattern :: Disjunction</emu-grammar>
         <emu-alg>
@@ -35011,7 +35059,7 @@ THH:mm:ss.sss
           1. Return a new Abstract Closure with parameters (_str_, _index_) that captures _m_ and performs the following steps when called:
             1. Assert: Type(_str_) is String.
             1. Assert: _index_ is a non-negative integer which is &le; the length of _str_.
-            1. If _Unicode_ is *true*, let _Input_ be ! StringToCodePoints(_str_). Otherwise, let _Input_ be a List whose elements are the code units that are the elements of _str_. _Input_ will be used throughout the algorithms in <emu-xref href="#sec-pattern-semantics"></emu-xref>. Each element of _Input_ is considered to be a character.
+            1. If _Unicode_ is *true*, let _Input_ be StringToCodePoints(_str_). Otherwise, let _Input_ be a List whose elements are the code units that are the elements of _str_. _Input_ will be used throughout the algorithms in <emu-xref href="#sec-pattern-semantics"></emu-xref>. Each element of _Input_ is considered to be a character.
             1. Let _InputLength_ be the number of characters contained in _Input_. This alias will be used throughout the algorithms in <emu-xref href="#sec-pattern-semantics"></emu-xref>.
             1. Let _listIndex_ be the index into _Input_ of the character that was obtained from element _index_ of _str_.
             1. Let _c_ be a new Continuation with parameters (_y_) that captures nothing and performs the following steps when called:
@@ -35030,11 +35078,9 @@ THH:mm:ss.sss
         <h1>
           Runtime Semantics: CompileSubpattern (
             _direction_: ~forward~ or ~backward~,
-          )
+          ): a Matcher
         </h1>
         <dl class="header">
-          <dt>description</dt>
-          <dd>It returns a Matcher.</dd>
         </dl>
         <emu-note>
           <p>This section is amended in <emu-xref href="#sec-compilesubpattern-annexb"></emu-xref>.</p>
@@ -35120,7 +35166,7 @@ THH:mm:ss.sss
           1. Return a new Matcher with parameters (_x_, _c_) that captures _m_, _q_, _parenIndex_, and _parenCount_ and performs the following steps when called:
             1. Assert: _x_ is a State.
             1. Assert: _c_ is a Continuation.
-            1. Return ! RepeatMatcher(_m_, _q_.[[Min]], _q_.[[Max]], _q_.[[Greedy]], _x_, _c_, _parenIndex_, _parenCount_).
+            1. Return RepeatMatcher(_m_, _q_.[[Min]], _q_.[[Max]], _q_.[[Greedy]], _x_, _c_, _parenIndex_, _parenCount_).
         </emu-alg>
 
         <emu-clause id="sec-runtime-semantics-repeatmatcher-abstract-operation" type="abstract operation">
@@ -35134,7 +35180,7 @@ THH:mm:ss.sss
               _c_: a Continuation,
               _parenIndex_: a non-negative integer,
               _parenCount_: a non-negative integer,
-            )
+            ): a MatchResult
           </h1>
           <dl class="header">
           </dl>
@@ -35145,7 +35191,7 @@ THH:mm:ss.sss
               1. [id="step-repeatmatcher-done"] If _min_ = 0 and _y_'s _endIndex_ = _x_'s _endIndex_, return ~failure~.
               1. If _min_ = 0, let _min2_ be 0; otherwise let _min2_ be _min_ - 1.
               1. If _max_ is +&infin;, let _max2_ be +&infin;; otherwise let _max2_ be _max_ - 1.
-              1. Return ! RepeatMatcher(_m_, _min2_, _max2_, _greedy_, _y_, _c_, _parenIndex_, _parenCount_).
+              1. Return RepeatMatcher(_m_, _min2_, _max2_, _greedy_, _y_, _c_, _parenIndex_, _parenCount_).
             1. Let _cap_ be a copy of _x_'s _captures_ List.
             1. [id="step-repeatmatcher-clear-captures"] For each integer _k_ such that _parenIndex_ &lt; _k_ and _k_ &le; _parenIndex_ + _parenCount_, set _cap_[_k_] to *undefined*.
             1. Let _e_ be _x_'s _endIndex_.
@@ -35203,10 +35249,8 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-compileassertion" type="sdo" oldids="sec-assertion">
-        <h1>Runtime Semantics: CompileAssertion</h1>
+        <h1>Runtime Semantics: CompileAssertion ( ): a Matcher</h1>
         <dl class="header">
-          <dt>description</dt>
-          <dd>It returns a Matcher.</dd>
         </dl>
         <emu-note>
           <p>This section is amended in <emu-xref href="#sec-compileassertion-annexb"></emu-xref>.</p>
@@ -35240,8 +35284,8 @@ THH:mm:ss.sss
             1. Assert: _x_ is a State.
             1. Assert: _c_ is a Continuation.
             1. Let _e_ be _x_'s _endIndex_.
-            1. Let _a_ be ! IsWordChar(_e_ - 1).
-            1. Let _b_ be ! IsWordChar(_e_).
+            1. Let _a_ be IsWordChar(_e_ - 1).
+            1. Let _b_ be IsWordChar(_e_).
             1. If _a_ is *true* and _b_ is *false*, or if _a_ is *false* and _b_ is *true*, return _c_(_x_).
             1. Return ~failure~.
         </emu-alg>
@@ -35251,8 +35295,8 @@ THH:mm:ss.sss
             1. Assert: _x_ is a State.
             1. Assert: _c_ is a Continuation.
             1. Let _e_ be _x_'s _endIndex_.
-            1. Let _a_ be ! IsWordChar(_e_ - 1).
-            1. Let _b_ be ! IsWordChar(_e_).
+            1. Let _a_ be IsWordChar(_e_ - 1).
+            1. Let _b_ be IsWordChar(_e_).
             1. If _a_ is *true* and _b_ is *true*, or if _a_ is *false* and _b_ is *false*, return _c_(_x_).
             1. Return ~failure~.
         </emu-alg>
@@ -35321,7 +35365,7 @@ THH:mm:ss.sss
           <h1>
             IsWordChar (
               _e_: an integer,
-            )
+            ): a Boolean
           </h1>
           <dl class="header">
           </dl>
@@ -35335,10 +35379,8 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-compilequantifier" type="sdo" oldids="sec-quantifier">
-        <h1>Runtime Semantics: CompileQuantifier</h1>
+        <h1>Runtime Semantics: CompileQuantifier ( ): a Record with fields [[Min]] (a non-negative integer), [[Max]] (a non-negative integer or +&infin;), and [[Greedy]] (a Boolean)</h1>
         <dl class="header">
-          <dt>description</dt>
-          <dd>It returns a Record with fields [[Min]] (a non-negative integer), [[Max]] (a non-negative integer or +&infin;), and [[Greedy]] (a Boolean).</dd>
         </dl>
         <emu-grammar>Quantifier :: QuantifierPrefix</emu-grammar>
         <emu-alg>
@@ -35353,10 +35395,8 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-compilequantifierprefix" type="sdo">
-        <h1>Runtime Semantics: CompileQuantifierPrefix</h1>
+        <h1>Runtime Semantics: CompileQuantifierPrefix ( ): a Record with fields [[Min]] (a non-negative integer) and [[Max]] (a non-negative integer or +&infin;)</h1>
         <dl class="header">
-          <dt>description</dt>
-          <dd>It returns a Record with fields [[Min]] (a non-negative integer) and [[Max]] (a non-negative integer or +&infin;).</dd>
         </dl>
         <emu-grammar>QuantifierPrefix :: `*`</emu-grammar>
         <emu-alg>
@@ -35392,11 +35432,9 @@ THH:mm:ss.sss
         <h1>
           Runtime Semantics: CompileAtom (
             _direction_: ~forward~ or ~backward~,
-          )
+          ): a Matcher
         </h1>
         <dl class="header">
-          <dt>description</dt>
-          <dd>It returns a Matcher.</dd>
         </dl>
         <emu-note>
           <p>This section is amended in <emu-xref href="#sec-compileatom-annexb"></emu-xref>.</p>
@@ -35407,19 +35445,19 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _ch_ be the character matched by |PatternCharacter|.
           1. Let _A_ be a one-element CharSet containing the character _ch_.
-          1. Return ! CharacterSetMatcher(_A_, *false*, _direction_).
+          1. Return CharacterSetMatcher(_A_, *false*, _direction_).
         </emu-alg>
         <emu-grammar>Atom :: `.`</emu-grammar>
         <emu-alg>
           1. Let _A_ be the CharSet of all characters.
           1. If _DotAll_ is not *true*, then
             1. Remove from _A_ all characters corresponding to a code point on the right-hand side of the |LineTerminator| production.
-          1. Return ! CharacterSetMatcher(_A_, *false*, _direction_).
+          1. Return CharacterSetMatcher(_A_, *false*, _direction_).
         </emu-alg>
         <emu-grammar>Atom :: CharacterClass</emu-grammar>
         <emu-alg>
           1. Let _cc_ be CompileCharacterClass of |CharacterClass|.
-          1. Return ! CharacterSetMatcher(_cc_.[[CharSet]], _cc_.[[Invert]], _direction_).
+          1. Return CharacterSetMatcher(_cc_.[[CharSet]], _cc_.[[Invert]], _direction_).
         </emu-alg>
         <emu-grammar>Atom :: `(` GroupSpecifier Disjunction `)`</emu-grammar>
         <emu-alg>
@@ -35455,7 +35493,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _n_ be the CapturingGroupNumber of |DecimalEscape|.
           1. Assert: _n_ &le; _NcapturingParens_.
-          1. Return ! BackreferenceMatcher(_n_, _direction_).
+          1. Return BackreferenceMatcher(_n_, _direction_).
         </emu-alg>
         <emu-note>
           <p>An escape sequence of the form `\\` followed by a non-zero decimal number _n_ matches the result of the _n_<sup>th</sup> set of capturing parentheses (<emu-xref href="#sec-notation"></emu-xref>). It is an error if the regular expression has fewer than _n_ capturing parentheses. If the regular expression has _n_ or more capturing parentheses but the _n_<sup>th</sup> one is *undefined* because it has not captured anything, then the backreference always succeeds.</p>
@@ -35465,19 +35503,19 @@ THH:mm:ss.sss
           1. Let _cv_ be the CharacterValue of |CharacterEscape|.
           1. Let _ch_ be the character whose character value is _cv_.
           1. Let _A_ be a one-element CharSet containing the character _ch_.
-          1. Return ! CharacterSetMatcher(_A_, *false*, _direction_).
+          1. Return CharacterSetMatcher(_A_, *false*, _direction_).
         </emu-alg>
         <emu-grammar>AtomEscape :: CharacterClassEscape</emu-grammar>
         <emu-alg>
           1. Let _A_ be CompileToCharSet of |CharacterClassEscape|.
-          1. Return ! CharacterSetMatcher(_A_, *false*, _direction_).
+          1. Return CharacterSetMatcher(_A_, *false*, _direction_).
         </emu-alg>
         <emu-grammar>AtomEscape :: `k` GroupName</emu-grammar>
         <emu-alg>
           1. Search the enclosing |Pattern| for an instance of a |GroupSpecifier| containing a |RegExpIdentifierName| which has a CapturingGroupName equal to the CapturingGroupName of the |RegExpIdentifierName| contained in |GroupName|.
           1. Assert: A unique such |GroupSpecifier| is found.
           1. Let _parenIndex_ be the number of left-capturing parentheses in the entire regular expression that occur to the left of the located |GroupSpecifier|. This is the total number of <emu-grammar>Atom :: `(` GroupSpecifier Disjunction `)`</emu-grammar> Parse Nodes prior to or enclosing the located |GroupSpecifier|, including its immediately enclosing |Atom|.
-          1. Return ! BackreferenceMatcher(_parenIndex_, _direction_).
+          1. Return BackreferenceMatcher(_parenIndex_, _direction_).
         </emu-alg>
 
         <emu-clause id="sec-runtime-semantics-charactersetmatcher-abstract-operation" type="abstract operation">
@@ -35486,7 +35524,7 @@ THH:mm:ss.sss
               _A_: a CharSet,
               _invert_: a Boolean,
               _direction_: ~forward~ or ~backward~,
-            )
+            ): a Matcher
           </h1>
           <dl class="header">
           </dl>
@@ -35515,7 +35553,7 @@ THH:mm:ss.sss
             BackreferenceMatcher (
               _n_: a positive integer,
               _direction_: ~forward~ or ~backward~,
-            )
+            ): a Matcher
           </h1>
           <dl class="header">
           </dl>
@@ -35543,7 +35581,7 @@ THH:mm:ss.sss
           <h1>
             Canonicalize (
               _ch_: a character,
-            )
+            ): a character
           </h1>
           <dl class="header">
           </dl>
@@ -35555,7 +35593,7 @@ THH:mm:ss.sss
             1. Assert: _ch_ is a UTF-16 code unit.
             1. Let _cp_ be the code point whose numeric value is that of _ch_.
             1. Let _u_ be the result of toUppercase(&laquo; _cp_ &raquo;), according to the Unicode Default Case Conversion algorithm.
-            1. Let _uStr_ be ! CodePointsToString(_u_).
+            1. Let _uStr_ be CodePointsToString(_u_).
             1. If _uStr_ does not consist of a single code unit, return _ch_.
             1. Let _cu_ be _uStr_'s single code unit element.
             1. If the numeric value of _ch_ &ge; 128 and the numeric value of _cu_ &lt; 128, return _ch_.
@@ -35590,10 +35628,8 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-compilecharacterclass" type="sdo" oldids="sec-characterclass">
-        <h1>Runtime Semantics: CompileCharacterClass</h1>
+        <h1>Runtime Semantics: CompileCharacterClass ( ): a Record with fields [[CharSet]] (a CharSet) and [[Invert]] (a Boolean)</h1>
         <dl class="header">
-          <dt>description</dt>
-          <dd>It returns a Record with fields [[CharSet]] (a CharSet) and [[Invert]] (a Boolean).</dd>
         </dl>
         <emu-grammar>CharacterClass :: `[` ClassRanges `]`</emu-grammar>
         <emu-alg>
@@ -35608,10 +35644,8 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-compiletocharset" type="sdo" oldids="sec-classranges,sec-nonemptyclassranges,sec-nonemptyclassrangesnodash,sec-classatom,sec-classatomnodash,sec-classescape,sec-characterclassescape">
-        <h1>Runtime Semantics: CompileToCharSet</h1>
+        <h1>Runtime Semantics: CompileToCharSet ( ): a CharSet</h1>
         <dl class="header">
-          <dt>description</dt>
-          <dd>It returns a CharSet.</dd>
         </dl>
         <emu-note>
           <p>This section is amended in <emu-xref href="#sec-compiletocharset-annexb"></emu-xref>.</p>
@@ -35635,7 +35669,7 @@ THH:mm:ss.sss
           1. Let _A_ be CompileToCharSet of the first |ClassAtom|.
           1. Let _B_ be CompileToCharSet of the second |ClassAtom|.
           1. Let _C_ be CompileToCharSet of |ClassRanges|.
-          1. Let _D_ be ! CharacterRange(_A_, _B_).
+          1. Let _D_ be CharacterRange(_A_, _B_).
           1. Return the union of _D_ and _C_.
         </emu-alg>
 
@@ -35651,7 +35685,7 @@ THH:mm:ss.sss
           1. Let _A_ be CompileToCharSet of |ClassAtomNoDash|.
           1. Let _B_ be CompileToCharSet of |ClassAtom|.
           1. Let _C_ be CompileToCharSet of |ClassRanges|.
-          1. Let _D_ be ! CharacterRange(_A_, _B_).
+          1. Let _D_ be CharacterRange(_A_, _B_).
           1. Return the union of _D_ and _C_.
         </emu-alg>
         <emu-note>
@@ -35728,18 +35762,18 @@ THH:mm:ss.sss
         <emu-grammar>UnicodePropertyValueExpression :: UnicodePropertyName `=` UnicodePropertyValue</emu-grammar>
         <emu-alg>
           1. Let _ps_ be SourceText of |UnicodePropertyName|.
-          1. Let _p_ be ! UnicodeMatchProperty(_ps_).
+          1. Let _p_ be UnicodeMatchProperty(_ps_).
           1. Assert: _p_ is a Unicode property name or property alias listed in the &ldquo;Property name and aliases&rdquo; column of <emu-xref href="#table-nonbinary-unicode-properties"></emu-xref>.
           1. Let _vs_ be SourceText of |UnicodePropertyValue|.
-          1. Let _v_ be ! UnicodeMatchPropertyValue(_p_, _vs_).
+          1. Let _v_ be UnicodeMatchPropertyValue(_p_, _vs_).
           1. Return the CharSet containing all Unicode code points whose character database definition includes the property _p_ with value _v_.
         </emu-alg>
         <emu-grammar>UnicodePropertyValueExpression :: LoneUnicodePropertyNameOrValue</emu-grammar>
         <emu-alg>
           1. Let _s_ be SourceText of |LoneUnicodePropertyNameOrValue|.
-          1. If ! UnicodeMatchPropertyValue(`General_Category`, _s_) is identical to a List of Unicode code points that is the name of a Unicode general category or general category alias listed in the &ldquo;Property value and aliases&rdquo; column of <emu-xref href="#table-unicode-general-category-values"></emu-xref>, then
+          1. If UnicodeMatchPropertyValue(`General_Category`, _s_) is identical to a List of Unicode code points that is the name of a Unicode general category or general category alias listed in the &ldquo;Property value and aliases&rdquo; column of <emu-xref href="#table-unicode-general-category-values"></emu-xref>, then
             1. Return the CharSet containing all Unicode code points whose character database definition includes the property &ldquo;General_Category&rdquo; with value _s_.
-          1. Let _p_ be ! UnicodeMatchProperty(_s_).
+          1. Let _p_ be UnicodeMatchProperty(_s_).
           1. Assert: _p_ is a binary Unicode property or binary property alias listed in the &ldquo;Property name and aliases&rdquo; column of <emu-xref href="#table-binary-unicode-properties"></emu-xref>.
           1. Return the CharSet containing all Unicode code points whose character database definition includes the property _p_ with value &ldquo;True&rdquo;.
         </emu-alg>
@@ -35749,7 +35783,7 @@ THH:mm:ss.sss
             CharacterRange (
               _A_: a CharSet,
               _B_: a CharSet,
-            )
+            ): a CharSet
           </h1>
           <dl class="header">
           </dl>
@@ -35768,7 +35802,7 @@ THH:mm:ss.sss
           <h1>
             UnicodeMatchProperty (
               _p_: a List of Unicode code points,
-            )
+            ): a Unicode property name
           </h1>
           <dl class="header">
           </dl>
@@ -35793,7 +35827,7 @@ THH:mm:ss.sss
             UnicodeMatchPropertyValue (
               _p_: a List of Unicode code points,
               _v_: a List of Unicode code points,
-            )
+            ): a Unicode property value
           </h1>
           <dl class="header">
           </dl>
@@ -35867,7 +35901,7 @@ THH:mm:ss.sss
           <h1>
             RegExpAlloc (
               _newTarget_: unknown,
-            )
+            ): either a normal completion containing an Object or an abrupt completion
           </h1>
           <dl class="header">
           </dl>
@@ -35884,7 +35918,7 @@ THH:mm:ss.sss
               _obj_: an Object,
               _pattern_: an ECMAScript language value,
               _flags_: an ECMAScript language value,
-            )
+            ): either a normal completion containing an Object or an abrupt completion
           </h1>
           <dl class="header">
           </dl>
@@ -35896,7 +35930,7 @@ THH:mm:ss.sss
             1. If _F_ contains any code unit other than *"g"*, *"i"*, *"m"*, *"s"*, *"u"*, or *"y"* or if it contains the same code unit more than once, throw a *SyntaxError* exception.
             1. If _F_ contains *"u"*, let _u_ be *true*; else let _u_ be *false*.
             1. If _u_ is *true*, then
-              1. Let _patternText_ be ! StringToCodePoints(_P_).
+              1. Let _patternText_ be StringToCodePoints(_P_).
             1. Else,
               1. Let _patternText_ be the result of interpreting each of _P_'s 16-bit elements as a Unicode BMP code point. UTF-16 decoding is not applied to the elements.
             1. Let _parseResult_ be ParsePattern(_patternText_, _u_).
@@ -35916,7 +35950,7 @@ THH:mm:ss.sss
             Static Semantics: ParsePattern (
               _patternText_: a sequence of Unicode code points,
               _u_: a Boolean,
-            )
+            ): a Parse Node or a non-empty List of *SyntaxError* objects
           </h1>
           <dl class="header">
           </dl>
@@ -35936,7 +35970,7 @@ THH:mm:ss.sss
             RegExpCreate (
               _P_: unknown,
               _F_: unknown,
-            )
+            ): either a normal completion containing an Object or an abrupt completion
           </h1>
           <dl class="header">
           </dl>
@@ -35951,7 +35985,7 @@ THH:mm:ss.sss
             EscapeRegExpPattern (
               _P_: unknown,
               _F_: unknown,
-            )
+            ): a String
           </h1>
           <dl class="header">
           </dl>
@@ -36025,7 +36059,7 @@ THH:mm:ss.sss
             RegExpExec (
               _R_: an Object,
               _S_: a String,
-            )
+            ): either a normal completion containing either an Object or *null*, or an abrupt completion
           </h1>
           <dl class="header">
           </dl>
@@ -36048,7 +36082,7 @@ THH:mm:ss.sss
             RegExpBuiltinExec (
               _R_: an initialized RegExp instance,
               _S_: a String,
-            )
+            ): either a normal completion containing either an Array exotic object or *null*, or an abrupt completion
           </h1>
           <dl class="header">
           </dl>
@@ -36091,7 +36125,7 @@ THH:mm:ss.sss
             1. Let _matchedSubstr_ be the substring of _S_ from _lastIndex_ to _e_.
             1. Perform ! CreateDataPropertyOrThrow(_A_, *"0"*, _matchedSubstr_).
             1. If _R_ contains any |GroupName|, then
-              1. Let _groups_ be ! OrdinaryObjectCreate(*null*).
+              1. Let _groups_ be OrdinaryObjectCreate(*null*).
             1. Else,
               1. Let _groups_ be *undefined*.
             1. Perform ! CreateDataPropertyOrThrow(_A_, *"groups"*, _groups_).
@@ -36100,7 +36134,7 @@ THH:mm:ss.sss
               1. If _captureI_ is *undefined*, let _capturedValue_ be *undefined*.
               1. Else if _fullUnicode_ is *true*, then
                 1. Assert: _captureI_ is a List of code points.
-                1. Let _capturedValue_ be ! CodePointsToString(_captureI_).
+                1. Let _capturedValue_ be CodePointsToString(_captureI_).
               1. Else,
                 1. Assert: _fullUnicode_ is *false*.
                 1. Assert: _captureI_ is a List of code units.
@@ -36119,7 +36153,7 @@ THH:mm:ss.sss
               _S_: a String,
               _index_: a non-negative integer,
               _unicode_: a Boolean,
-            )
+            ): an integer
           </h1>
           <dl class="header">
           </dl>
@@ -36128,7 +36162,7 @@ THH:mm:ss.sss
             1. If _unicode_ is *false*, return _index_ + 1.
             1. Let _length_ be the number of code units in _S_.
             1. If _index_ + 1 &ge; _length_, return _index_ + 1.
-            1. Let _cp_ be ! CodePointAt(_S_, _index_).
+            1. Let _cp_ be CodePointAt(_S_, _index_).
             1. Return _index_ + _cp_.[[CodeUnitCount]].
           </emu-alg>
         </emu-clause>
@@ -36148,7 +36182,7 @@ THH:mm:ss.sss
             RegExpHasFlag (
               _R_: an ECMAScript language value,
               _codeUnit_: a code unit,
-            )
+            ): either a normal completion containing either a Boolean or *undefined*, or an abrupt completion
           </h1>
           <dl class="header">
           </dl>
@@ -36171,17 +36205,17 @@ THH:mm:ss.sss
           1. Let _R_ be the *this* value.
           1. If Type(_R_) is not Object, throw a *TypeError* exception.
           1. Let _result_ be the empty String.
-          1. Let _global_ be ! ToBoolean(? Get(_R_, *"global"*)).
+          1. Let _global_ be ToBoolean(? Get(_R_, *"global"*)).
           1. If _global_ is *true*, append the code unit 0x0067 (LATIN SMALL LETTER G) as the last code unit of _result_.
-          1. Let _ignoreCase_ be ! ToBoolean(? Get(_R_, *"ignoreCase"*)).
+          1. Let _ignoreCase_ be ToBoolean(? Get(_R_, *"ignoreCase"*)).
           1. If _ignoreCase_ is *true*, append the code unit 0x0069 (LATIN SMALL LETTER I) as the last code unit of _result_.
-          1. Let _multiline_ be ! ToBoolean(? Get(_R_, *"multiline"*)).
+          1. Let _multiline_ be ToBoolean(? Get(_R_, *"multiline"*)).
           1. If _multiline_ is *true*, append the code unit 0x006D (LATIN SMALL LETTER M) as the last code unit of _result_.
-          1. Let _dotAll_ be ! ToBoolean(? Get(_R_, *"dotAll"*)).
+          1. Let _dotAll_ be ToBoolean(? Get(_R_, *"dotAll"*)).
           1. If _dotAll_ is *true*, append the code unit 0x0073 (LATIN SMALL LETTER S) as the last code unit of _result_.
-          1. Let _unicode_ be ! ToBoolean(? Get(_R_, *"unicode"*)).
+          1. Let _unicode_ be ToBoolean(? Get(_R_, *"unicode"*)).
           1. If _unicode_ is *true*, append the code unit 0x0075 (LATIN SMALL LETTER U) as the last code unit of _result_.
-          1. Let _sticky_ be ! ToBoolean(? Get(_R_, *"sticky"*)).
+          1. Let _sticky_ be ToBoolean(? Get(_R_, *"sticky"*)).
           1. If _sticky_ is *true*, append the code unit 0x0079 (LATIN SMALL LETTER Y) as the last code unit of _result_.
           1. Return _result_.
         </emu-alg>
@@ -36214,12 +36248,12 @@ THH:mm:ss.sss
           1. Let _rx_ be the *this* value.
           1. If Type(_rx_) is not Object, throw a *TypeError* exception.
           1. Let _S_ be ? ToString(_string_).
-          1. Let _global_ be ! ToBoolean(? Get(_rx_, *"global"*)).
+          1. Let _global_ be ToBoolean(? Get(_rx_, *"global"*)).
           1. If _global_ is *false*, then
             1. Return ? RegExpExec(_rx_, _S_).
           1. Else,
             1. Assert: _global_ is *true*.
-            1. Let _fullUnicode_ be ! ToBoolean(? Get(_rx_, *"unicode"*)).
+            1. Let _fullUnicode_ be ToBoolean(? Get(_rx_, *"unicode"*)).
             1. Perform ? Set(_rx_, *"lastIndex"*, *+0*<sub>𝔽</sub>, *true*).
             1. Let _A_ be ! ArrayCreate(0).
             1. Let _n_ be 0.
@@ -36259,7 +36293,7 @@ THH:mm:ss.sss
           1. Else, let _global_ be *false*.
           1. If _flags_ contains *"u"*, let _fullUnicode_ be *true*.
           1. Else, let _fullUnicode_ be *false*.
-          1. Return ! CreateRegExpStringIterator(_matcher_, _S_, _global_, _fullUnicode_).
+          1. Return CreateRegExpStringIterator(_matcher_, _S_, _global_, _fullUnicode_).
         </emu-alg>
         <p>The value of the *"name"* property of this function is *"[Symbol.matchAll]"*.</p>
       </emu-clause>
@@ -36285,9 +36319,9 @@ THH:mm:ss.sss
           1. Let _functionalReplace_ be IsCallable(_replaceValue_).
           1. If _functionalReplace_ is *false*, then
             1. Set _replaceValue_ to ? ToString(_replaceValue_).
-          1. Let _global_ be ! ToBoolean(? Get(_rx_, *"global"*)).
+          1. Let _global_ be ToBoolean(? Get(_rx_, *"global"*)).
           1. If _global_ is *true*, then
-            1. Let _fullUnicode_ be ! ToBoolean(? Get(_rx_, *"unicode"*)).
+            1. Let _fullUnicode_ be ToBoolean(? Get(_rx_, *"unicode"*)).
             1. Perform ? Set(_rx_, *"lastIndex"*, *+0*<sub>𝔽</sub>, *true*).
           1. Let _results_ be a new empty List.
           1. Let _done_ be *false*.
@@ -36526,7 +36560,7 @@ THH:mm:ss.sss
             _S_: a String,
             _global_: a Boolean,
             _fullUnicode_: a Boolean,
-          )
+          ): a Generator
         </h1>
         <dl class="header">
         </dl>
@@ -36536,15 +36570,15 @@ THH:mm:ss.sss
               1. Let _match_ be ? RegExpExec(_R_, _S_).
               1. If _match_ is *null*, return *undefined*.
               1. If _global_ is *false*, then
-                1. Perform ? GeneratorYield(! CreateIterResultObject(_match_, *false*)).
+                1. Perform ? GeneratorYield(CreateIterResultObject(_match_, *false*)).
                 1. Return *undefined*.
               1. Let _matchStr_ be ? ToString(? Get(_match_, *"0"*)).
               1. If _matchStr_ is the empty String, then
                 1. Let _thisIndex_ be ℝ(? ToLength(? Get(_R_, *"lastIndex"*))).
-                1. Let _nextIndex_ be ! AdvanceStringIndex(_S_, _thisIndex_, _fullUnicode_).
+                1. Let _nextIndex_ be AdvanceStringIndex(_S_, _thisIndex_, _fullUnicode_).
                 1. Perform ? Set(_R_, *"lastIndex"*, 𝔽(_nextIndex_), *true*).
-              1. Perform ? GeneratorYield(! CreateIterResultObject(_match_, *false*)).
-          1. Return ! CreateIteratorFromClosure(_closure_, *"%RegExpStringIteratorPrototype%"*, %RegExpStringIteratorPrototype%).
+              1. Perform ? GeneratorYield(CreateIterResultObject(_match_, *false*)).
+          1. Return CreateIteratorFromClosure(_closure_, *"%RegExpStringIteratorPrototype%"*, %RegExpStringIteratorPrototype%).
         </emu-alg>
       </emu-clause>
 
@@ -36666,10 +36700,10 @@ THH:mm:ss.sss
                 1. Return _A_.
               1. Let _nextValue_ be ? IteratorValue(_next_).
               1. If _mapping_ is *true*, then
-                1. Let _mappedValue_ be Call(_mapfn_, _thisArg_, &laquo; _nextValue_, 𝔽(_k_) &raquo;).
+                1. Let _mappedValue_ be Completion(Call(_mapfn_, _thisArg_, &laquo; _nextValue_, 𝔽(_k_) &raquo;)).
                 1. IfAbruptCloseIterator(_mappedValue_, _iteratorRecord_).
               1. Else, let _mappedValue_ be _nextValue_.
-              1. Let _defineStatus_ be CreateDataPropertyOrThrow(_A_, _Pk_, _mappedValue_).
+              1. Let _defineStatus_ be Completion(CreateDataPropertyOrThrow(_A_, _Pk_, _mappedValue_)).
               1. IfAbruptCloseIterator(_defineStatus_, _iteratorRecord_).
               1. Set _k_ to _k_ + 1.
           1. NOTE: _items_ is not an Iterable so assume it is an array-like object.
@@ -36819,14 +36853,14 @@ THH:mm:ss.sss
           <h1>
             IsConcatSpreadable (
               _O_: unknown,
-            )
+            ): either a normal completion containing a Boolean or an abrupt completion
           </h1>
           <dl class="header">
           </dl>
           <emu-alg>
             1. If Type(_O_) is not Object, return *false*.
             1. Let _spreadable_ be ? Get(_O_, @@isConcatSpreadable).
-            1. If _spreadable_ is not *undefined*, return ! ToBoolean(_spreadable_).
+            1. If _spreadable_ is not *undefined*, return ToBoolean(_spreadable_).
             1. Return ? IsArray(_O_).
           </emu-alg>
         </emu-clause>
@@ -36917,7 +36951,7 @@ THH:mm:ss.sss
             1. Let _kPresent_ be ? HasProperty(_O_, _Pk_).
             1. If _kPresent_ is *true*, then
               1. Let _kValue_ be ? Get(_O_, _Pk_).
-              1. Let _testResult_ be ! ToBoolean(? Call(_callbackfn_, _thisArg_, &laquo; _kValue_, 𝔽(_k_), _O_ &raquo;)).
+              1. Let _testResult_ be ToBoolean(? Call(_callbackfn_, _thisArg_, &laquo; _kValue_, 𝔽(_k_), _O_ &raquo;)).
               1. If _testResult_ is *false*, return *false*.
             1. Set _k_ to _k_ + 1.
           1. Return *true*.
@@ -36981,7 +37015,7 @@ THH:mm:ss.sss
             1. Let _kPresent_ be ? HasProperty(_O_, _Pk_).
             1. If _kPresent_ is *true*, then
               1. Let _kValue_ be ? Get(_O_, _Pk_).
-              1. Let _selected_ be ! ToBoolean(? Call(_callbackfn_, _thisArg_, &laquo; _kValue_, 𝔽(_k_), _O_ &raquo;)).
+              1. Let _selected_ be ToBoolean(? Call(_callbackfn_, _thisArg_, &laquo; _kValue_, 𝔽(_k_), _O_ &raquo;)).
               1. If _selected_ is *true*, then
                 1. Perform ? CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_to_)), _kValue_).
                 1. Set _to_ to _to_ + 1.
@@ -37011,7 +37045,7 @@ THH:mm:ss.sss
           1. Repeat, while _k_ &lt; _len_,
             1. Let _Pk_ be ! ToString(𝔽(_k_)).
             1. Let _kValue_ be ? Get(_O_, _Pk_).
-            1. Let _testResult_ be ! ToBoolean(? Call(_predicate_, _thisArg_, &laquo; _kValue_, 𝔽(_k_), _O_ &raquo;)).
+            1. Let _testResult_ be ToBoolean(? Call(_predicate_, _thisArg_, &laquo; _kValue_, 𝔽(_k_), _O_ &raquo;)).
             1. If _testResult_ is *true*, return _kValue_.
             1. Set _k_ to _k_ + 1.
           1. Return *undefined*.
@@ -37039,7 +37073,7 @@ THH:mm:ss.sss
           1. Repeat, while _k_ &lt; _len_,
             1. Let _Pk_ be ! ToString(𝔽(_k_)).
             1. Let _kValue_ be ? Get(_O_, _Pk_).
-            1. Let _testResult_ be ! ToBoolean(? Call(_predicate_, _thisArg_, &laquo; _kValue_, 𝔽(_k_), _O_ &raquo;)).
+            1. Let _testResult_ be ToBoolean(? Call(_predicate_, _thisArg_, &laquo; _kValue_, 𝔽(_k_), _O_ &raquo;)).
             1. If _testResult_ is *true*, return 𝔽(_k_).
             1. Set _k_ to _k_ + 1.
           1. Return *-1*<sub>𝔽</sub>.
@@ -37074,12 +37108,12 @@ THH:mm:ss.sss
               _depth_: a non-negative integer or +&infin;,
               optional _mapperFunction_: unknown,
               optional _thisArg_: unknown,
-            )
+            ): either a normal completion containing a non-negative integer or an abrupt completion
           </h1>
           <dl class="header">
           </dl>
           <emu-alg>
-            1. Assert: If _mapperFunction_ is present, then ! IsCallable(_mapperFunction_) is *true*, _thisArg_ is present, and _depth_ is 1.
+            1. Assert: If _mapperFunction_ is present, then IsCallable(_mapperFunction_) is *true*, _thisArg_ is present, and _depth_ is 1.
             1. Let _targetIndex_ be _start_.
             1. Let _sourceIndex_ be *+0*<sub>𝔽</sub>.
             1. Repeat, while ℝ(_sourceIndex_) &lt; _sourceLen_,
@@ -37113,7 +37147,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _sourceLen_ be ? LengthOfArrayLike(_O_).
-          1. If ! IsCallable(_mapperFunction_) is *false*, throw a *TypeError* exception.
+          1. If IsCallable(_mapperFunction_) is *false*, throw a *TypeError* exception.
           1. Let _A_ be ? ArraySpeciesCreate(_O_, 0).
           1. Perform ? FlattenIntoArray(_A_, _O_, _sourceLen_, 0, 1, _mapperFunction_, _thisArg_).
           1. Return _A_.
@@ -37573,7 +37607,7 @@ THH:mm:ss.sss
             1. Let _kPresent_ be ? HasProperty(_O_, _Pk_).
             1. If _kPresent_ is *true*, then
               1. Let _kValue_ be ? Get(_O_, _Pk_).
-              1. Let _testResult_ be ! ToBoolean(? Call(_callbackfn_, _thisArg_, &laquo; _kValue_, 𝔽(_k_), _O_ &raquo;)).
+              1. Let _testResult_ be ToBoolean(? Call(_callbackfn_, _thisArg_, &laquo; _kValue_, 𝔽(_k_), _O_ &raquo;)).
               1. If _testResult_ is *true*, return *true*.
             1. Set _k_ to _k_ + 1.
           1. Return *false*.
@@ -37670,7 +37704,7 @@ THH:mm:ss.sss
             SortCompare (
               _x_: unknown,
               _y_: unknown,
-            )
+            ): either a normal completion containing a Number or an abrupt completion
           </h1>
           <dl class="header">
             <dt>description</dt>
@@ -37686,9 +37720,9 @@ THH:mm:ss.sss
               1. Return _v_.
             1. [id="step-sortcompare-tostring-x"] Let _xString_ be ? ToString(_x_).
             1. [id="step-sortcompare-tostring-y"] Let _yString_ be ? ToString(_y_).
-            1. Let _xSmaller_ be <emu-meta suppress-effects="user-code">IsLessThan(_xString_, _yString_, *true*)</emu-meta>.
+            1. Let _xSmaller_ be ! IsLessThan(_xString_, _yString_, *true*).
             1. If _xSmaller_ is *true*, return *-1*<sub>𝔽</sub>.
-            1. Let _ySmaller_ be <emu-meta suppress-effects="user-code">IsLessThan(_yString_, _xString_, *true*)</emu-meta>.
+            1. Let _ySmaller_ be ! IsLessThan(_yString_, _xString_, *true*).
             1. If _ySmaller_ is *true*, return *1*<sub>𝔽</sub>.
             1. Return *+0*<sub>𝔽</sub>.
           </emu-alg>
@@ -37873,7 +37907,7 @@ THH:mm:ss.sss
         <h1>Array.prototype [ @@unscopables ]</h1>
         <p>The initial value of the @@unscopables data property is an object created by the following steps:</p>
         <emu-alg>
-          1. Let _unscopableList_ be ! OrdinaryObjectCreate(*null*).
+          1. Let _unscopableList_ be OrdinaryObjectCreate(*null*).
           1. Perform ! CreateDataPropertyOrThrow(_unscopableList_, *"at"*, *true*).
           1. Perform ! CreateDataPropertyOrThrow(_unscopableList_, *"copyWithin"*, *true*).
           1. Perform ! CreateDataPropertyOrThrow(_unscopableList_, *"entries"*, *true*).
@@ -37918,7 +37952,7 @@ THH:mm:ss.sss
           CreateArrayIterator (
             _array_: an Object,
             _kind_: ~key+value~, ~key~, or ~value~,
-          )
+          ): a Generator
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -37934,17 +37968,17 @@ THH:mm:ss.sss
               1. Else,
                 1. Let _len_ be ? LengthOfArrayLike(_array_).
               1. If _index_ &ge; _len_, return *undefined*.
-              1. If _kind_ is ~key~, perform ? GeneratorYield(! CreateIterResultObject(𝔽(_index_), *false*)).
+              1. If _kind_ is ~key~, perform ? GeneratorYield(CreateIterResultObject(𝔽(_index_), *false*)).
               1. Else,
                 1. Let _elementKey_ be ! ToString(𝔽(_index_)).
                 1. Let _elementValue_ be ? Get(_array_, _elementKey_).
-                1. If _kind_ is ~value~, perform ? GeneratorYield(! CreateIterResultObject(_elementValue_, *false*)).
+                1. If _kind_ is ~value~, perform ? GeneratorYield(CreateIterResultObject(_elementValue_, *false*)).
                 1. Else,
                   1. Assert: _kind_ is ~key+value~.
-                  1. Let _result_ be ! CreateArrayFromList(&laquo; 𝔽(_index_), _elementValue_ &raquo;).
-                  1. Perform ? GeneratorYield(! CreateIterResultObject(_result_, *false*)).
+                  1. Let _result_ be CreateArrayFromList(&laquo; 𝔽(_index_), _elementValue_ &raquo;).
+                  1. Perform ? GeneratorYield(CreateIterResultObject(_result_, *false*)).
               1. Set _index_ to _index_ + 1.
-          1. Return ! CreateIteratorFromClosure(_closure_, *"%ArrayIteratorPrototype%"*, %ArrayIteratorPrototype%).
+          1. Return CreateIteratorFromClosure(_closure_, *"%ArrayIteratorPrototype%"*, %ArrayIteratorPrototype%).
         </emu-alg>
       </emu-clause>
 
@@ -38447,7 +38481,7 @@ THH:mm:ss.sss
           1. Repeat, while _k_ &lt; _len_,
             1. Let _Pk_ be ! ToString(𝔽(_k_)).
             1. Let _kValue_ be ! Get(_O_, _Pk_).
-            1. Let _testResult_ be ! ToBoolean(? Call(_callbackfn_, _thisArg_, &laquo; _kValue_, 𝔽(_k_), _O_ &raquo;)).
+            1. Let _testResult_ be ToBoolean(? Call(_callbackfn_, _thisArg_, &laquo; _kValue_, 𝔽(_k_), _O_ &raquo;)).
             1. If _testResult_ is *false*, return *false*.
             1. Set _k_ to _k_ + 1.
           1. Return *true*.
@@ -38497,7 +38531,7 @@ THH:mm:ss.sss
           1. Repeat, while _k_ &lt; _len_,
             1. Let _Pk_ be ! ToString(𝔽(_k_)).
             1. Let _kValue_ be ! Get(_O_, _Pk_).
-            1. Let _selected_ be ! ToBoolean(? Call(_callbackfn_, _thisArg_, &laquo; _kValue_, 𝔽(_k_), _O_ &raquo;)).
+            1. Let _selected_ be ToBoolean(? Call(_callbackfn_, _thisArg_, &laquo; _kValue_, 𝔽(_k_), _O_ &raquo;)).
             1. If _selected_ is *true*, then
               1. Append _kValue_ to the end of _kept_.
               1. Set _captured_ to _captured_ + 1.
@@ -38525,7 +38559,7 @@ THH:mm:ss.sss
           1. Repeat, while _k_ &lt; _len_,
             1. Let _Pk_ be ! ToString(𝔽(_k_)).
             1. Let _kValue_ be ! Get(_O_, _Pk_).
-            1. Let _testResult_ be ! ToBoolean(? Call(_predicate_, _thisArg_, &laquo; _kValue_, 𝔽(_k_), _O_ &raquo;)).
+            1. Let _testResult_ be ToBoolean(? Call(_predicate_, _thisArg_, &laquo; _kValue_, 𝔽(_k_), _O_ &raquo;)).
             1. If _testResult_ is *true*, return _kValue_.
             1. Set _k_ to _k_ + 1.
           1. Return *undefined*.
@@ -38546,7 +38580,7 @@ THH:mm:ss.sss
           1. Repeat, while _k_ &lt; _len_,
             1. Let _Pk_ be ! ToString(𝔽(_k_)).
             1. Let _kValue_ be ! Get(_O_, _Pk_).
-            1. Let _testResult_ be ! ToBoolean(? Call(_predicate_, _thisArg_, &laquo; _kValue_, 𝔽(_k_), _O_ &raquo;)).
+            1. Let _testResult_ be ToBoolean(? Call(_predicate_, _thisArg_, &laquo; _kValue_, 𝔽(_k_), _O_ &raquo;)).
             1. If _testResult_ is *true*, return 𝔽(_k_).
             1. Set _k_ to _k_ + 1.
           1. Return *-1*<sub>𝔽</sub>.
@@ -38833,7 +38867,7 @@ THH:mm:ss.sss
               _target_: a TypedArray,
               _targetOffset_: a non-negative integer or +&infin;,
               _source_: a TypedArray,
-            )
+            ): either a normal completion containing ~unused~ or an abrupt completion
           </h1>
           <dl class="header">
             <dt>description</dt>
@@ -38881,6 +38915,7 @@ THH:mm:ss.sss
                 1. Perform SetValueInBuffer(_targetBuffer_, _targetByteIndex_, _targetType_, _value_, *true*, ~Unordered~).
                 1. Set _srcByteIndex_ to _srcByteIndex_ + _srcElementSize_.
                 1. Set _targetByteIndex_ to _targetByteIndex_ + _targetElementSize_.
+            1. Return ~unused~.
           </emu-alg>
         </emu-clause>
 
@@ -38890,7 +38925,7 @@ THH:mm:ss.sss
               _target_: a TypedArray,
               _targetOffset_: a non-negative integer or +&infin;,
               _source_: an ECMAScript language value, but not a TypedArray,
-            )
+            ): either a normal completion containing ~unused~ or an abrupt completion
           </h1>
           <dl class="header">
             <dt>description</dt>
@@ -38920,6 +38955,7 @@ THH:mm:ss.sss
               1. Perform SetValueInBuffer(_targetBuffer_, _targetByteIndex_, _targetType_, _value_, *true*, ~Unordered~).
               1. Set _k_ to _k_ + 1.
               1. Set _targetByteIndex_ to _targetByteIndex_ + _targetElementSize_.
+            1. Return ~unused~.
           </emu-alg>
         </emu-clause>
       </emu-clause>
@@ -38988,7 +39024,7 @@ THH:mm:ss.sss
           1. Repeat, while _k_ &lt; _len_,
             1. Let _Pk_ be ! ToString(𝔽(_k_)).
             1. Let _kValue_ be ! Get(_O_, _Pk_).
-            1. Let _testResult_ be ! ToBoolean(? Call(_callbackfn_, _thisArg_, &laquo; _kValue_, 𝔽(_k_), _O_ &raquo;)).
+            1. Let _testResult_ be ToBoolean(? Call(_callbackfn_, _thisArg_, &laquo; _kValue_, 𝔽(_k_), _O_ &raquo;)).
             1. If _testResult_ is *true*, return *true*.
             1. Set _k_ to _k_ + 1.
           1. Return *false*.
@@ -39015,7 +39051,7 @@ THH:mm:ss.sss
             TypedArraySortCompare (
               _x_: unknown,
               _y_: unknown,
-            )
+            ): either a normal completion containing a Number or an abrupt completion
           </h1>
           <dl class="header">
             <dt>description</dt>
@@ -39125,7 +39161,7 @@ THH:mm:ss.sss
           TypedArraySpeciesCreate (
             _exemplar_: a TypedArray,
             _argumentList_: unknown,
-          )
+          ): either a normal completion containing a TypedArray or an abrupt completion
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -39146,7 +39182,7 @@ THH:mm:ss.sss
           TypedArrayCreate (
             _constructor_: unknown,
             _argumentList_: unknown,
-          )
+          ): either a normal completion containing a TypedArray or an abrupt completion
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -39165,7 +39201,7 @@ THH:mm:ss.sss
         <h1>
           ValidateTypedArray (
             _O_: unknown,
-          )
+          ): either a normal completion containing ~unused~ or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
@@ -39174,6 +39210,7 @@ THH:mm:ss.sss
           1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
           1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
           1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
+          1. Return ~unused~.
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -39232,7 +39269,7 @@ THH:mm:ss.sss
               _newTarget_: unknown,
               _defaultProto_: unknown,
               optional _length_: a non-negative integer,
-            )
+            ): either a normal completion containing a TypedArray or an abrupt completion
           </h1>
           <dl class="header">
             <dt>description</dt>
@@ -39240,7 +39277,7 @@ THH:mm:ss.sss
           </dl>
           <emu-alg>
             1. Let _proto_ be ? GetPrototypeFromConstructor(_newTarget_, _defaultProto_).
-            1. Let _obj_ be ! IntegerIndexedObjectCreate(_proto_).
+            1. Let _obj_ be IntegerIndexedObjectCreate(_proto_).
             1. Assert: _obj_.[[ViewedArrayBuffer]] is *undefined*.
             1. Set _obj_.[[TypedArrayName]] to _constructorName_.
             1. If _constructorName_ is *"BigInt64Array"* or *"BigUint64Array"*, set _obj_.[[ContentType]] to ~BigInt~.
@@ -39260,7 +39297,7 @@ THH:mm:ss.sss
             InitializeTypedArrayFromTypedArray (
               _O_: a TypedArray,
               _srcArray_: a TypedArray,
-            )
+            ): either a normal completion containing ~unused~ or an abrupt completion
           </h1>
           <dl class="header">
           </dl>
@@ -39299,6 +39336,7 @@ THH:mm:ss.sss
             1. Set _O_.[[ByteLength]] to _byteLength_.
             1. Set _O_.[[ByteOffset]] to 0.
             1. Set _O_.[[ArrayLength]] to _elementLength_.
+            1. Return ~unused~.
           </emu-alg>
         </emu-clause>
 
@@ -39309,7 +39347,7 @@ THH:mm:ss.sss
               _buffer_: an ArrayBuffer or a SharedArrayBuffer,
               _byteOffset_: an ECMAScript language value,
               _length_: an ECMAScript language value,
-            )
+            ): either a normal completion containing ~unused~ or an abrupt completion
           </h1>
           <dl class="header">
           </dl>
@@ -39333,6 +39371,7 @@ THH:mm:ss.sss
             1. Set _O_.[[ByteLength]] to _newByteLength_.
             1. Set _O_.[[ByteOffset]] to _offset_.
             1. Set _O_.[[ArrayLength]] to _newByteLength_ / _elementSize_.
+            1. Return ~unused~.
           </emu-alg>
         </emu-clause>
 
@@ -39341,7 +39380,7 @@ THH:mm:ss.sss
             InitializeTypedArrayFromList (
               _O_: a TypedArray,
               _values_: a List of ECMAScript language values,
-            )
+            ): either a normal completion containing ~unused~ or an abrupt completion
           </h1>
           <dl class="header">
           </dl>
@@ -39355,6 +39394,7 @@ THH:mm:ss.sss
               1. Perform ? Set(_O_, _Pk_, _kValue_, *true*).
               1. Set _k_ to _k_ + 1.
             1. Assert: _values_ is now an empty List.
+            1. Return ~unused~.
           </emu-alg>
         </emu-clause>
 
@@ -39363,7 +39403,7 @@ THH:mm:ss.sss
             InitializeTypedArrayFromArrayLike (
               _O_: a TypedArray,
               _arrayLike_: an Object, but not a TypedArray or an ArrayBuffer,
-            )
+            ): either a normal completion containing ~unused~ or an abrupt completion
           </h1>
           <dl class="header">
           </dl>
@@ -39376,6 +39416,7 @@ THH:mm:ss.sss
               1. Let _kValue_ be ? Get(_arrayLike_, _Pk_).
               1. Perform ? Set(_O_, _Pk_, _kValue_, *true*).
               1. Set _k_ to _k_ + 1.
+            1. Return ~unused~.
           </emu-alg>
         </emu-clause>
 
@@ -39384,7 +39425,7 @@ THH:mm:ss.sss
             AllocateTypedArrayBuffer (
               _O_: a TypedArray,
               _length_: a non-negative integer,
-            )
+            ): either a normal completion containing ~unused~ or an abrupt completion
           </h1>
           <dl class="header">
             <dt>description</dt>
@@ -39400,7 +39441,7 @@ THH:mm:ss.sss
             1. Set _O_.[[ByteLength]] to _byteLength_.
             1. Set _O_.[[ByteOffset]] to 0.
             1. Set _O_.[[ArrayLength]] to _length_.
-            1. Return _O_.
+            1. Return ~unused~.
           </emu-alg>
         </emu-clause>
       </emu-clause>
@@ -39497,7 +39538,7 @@ THH:mm:ss.sss
             _target_: unknown,
             _iterable_: an ECMAScript language value, but not *undefined* or *null*,
             _adder_: a function object,
-          )
+          ): either a normal completion containing an ECMAScript language value or an abrupt completion
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -39513,11 +39554,11 @@ THH:mm:ss.sss
             1. If Type(_nextItem_) is not Object, then
               1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
               1. Return ? IteratorClose(_iteratorRecord_, _error_).
-            1. Let _k_ be Get(_nextItem_, *"0"*).
+            1. Let _k_ be Completion(Get(_nextItem_, *"0"*)).
             1. IfAbruptCloseIterator(_k_, _iteratorRecord_).
-            1. Let _v_ be Get(_nextItem_, *"1"*).
+            1. Let _v_ be Completion(Get(_nextItem_, *"1"*)).
             1. IfAbruptCloseIterator(_v_, _iteratorRecord_).
-            1. Let _status_ be Call(_adder_, _target_, &laquo; _k_, _v_ &raquo;).
+            1. Let _status_ be Completion(Call(_adder_, _target_, &laquo; _k_, _v_ &raquo;)).
             1. IfAbruptCloseIterator(_status_, _iteratorRecord_).
         </emu-alg>
         <emu-note>
@@ -39736,7 +39777,7 @@ THH:mm:ss.sss
           CreateMapIterator (
             _map_: an ECMAScript language value,
             _kind_: ~key+value~, ~key~, or ~value~,
-          )
+          ): either a normal completion containing a Generator or an abrupt completion
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -39756,12 +39797,12 @@ THH:mm:ss.sss
                 1. Else if _kind_ is ~value~, let _result_ be _e_.[[Value]].
                 1. Else,
                   1. Assert: _kind_ is ~key+value~.
-                  1. Let _result_ be ! CreateArrayFromList(&laquo; _e_.[[Key]], _e_.[[Value]] &raquo;).
-                1. Perform ? GeneratorYield(! CreateIterResultObject(_result_, *false*)).
+                  1. Let _result_ be CreateArrayFromList(&laquo; _e_.[[Key]], _e_.[[Value]] &raquo;).
+                1. Perform ? GeneratorYield(CreateIterResultObject(_result_, *false*)).
                 1. NOTE: The number of elements in _entries_ may have changed while execution of this abstract operation was paused by Yield.
                 1. Set _numEntries_ to the number of elements of _entries_.
             1. Return *undefined*.
-          1. Return ! CreateIteratorFromClosure(_closure_, *"%MapIteratorPrototype%"*, %MapIteratorPrototype%).
+          1. Return CreateIteratorFromClosure(_closure_, *"%MapIteratorPrototype%"*, %MapIteratorPrototype%).
         </emu-alg>
       </emu-clause>
 
@@ -39822,7 +39863,7 @@ THH:mm:ss.sss
             1. Let _next_ be ? IteratorStep(_iteratorRecord_).
             1. If _next_ is *false*, return _set_.
             1. Let _nextValue_ be ? IteratorValue(_next_).
-            1. Let _status_ be Call(_adder_, _set_, &laquo; _nextValue_ &raquo;).
+            1. Let _status_ be Completion(Call(_adder_, _set_, &laquo; _nextValue_ &raquo;)).
             1. IfAbruptCloseIterator(_status_, _iteratorRecord_).
         </emu-alg>
       </emu-clause>
@@ -40025,7 +40066,7 @@ THH:mm:ss.sss
           CreateSetIterator (
             _set_: an ECMAScript language value,
             _kind_: ~key+value~ or ~value~,
-          )
+          ): either a normal completion containing a Generator or an abrupt completion
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -40042,15 +40083,15 @@ THH:mm:ss.sss
               1. Set _index_ to _index_ + 1.
               1. If _e_ is not ~empty~, then
                 1. If _kind_ is ~key+value~, then
-                  1. Let _result_ be ! CreateArrayFromList(&laquo; _e_, _e_ &raquo;).
-                  1. Perform ? GeneratorYield(! CreateIterResultObject(_result_, *false*)).
+                  1. Let _result_ be CreateArrayFromList(&laquo; _e_, _e_ &raquo;).
+                  1. Perform ? GeneratorYield(CreateIterResultObject(_result_, *false*)).
                 1. Else,
                   1. Assert: _kind_ is ~value~.
-                  1. Perform ? GeneratorYield(! CreateIterResultObject(_e_, *false*)).
+                  1. Perform ? GeneratorYield(CreateIterResultObject(_e_, *false*)).
                 1. NOTE: The number of elements in _entries_ may have changed while execution of this abstract operation was paused by Yield.
                 1. Set _numEntries_ to the number of elements of _entries_.
             1. Return *undefined*.
-          1. Return ! CreateIteratorFromClosure(_closure_, *"%SetIteratorPrototype%"*, %SetIteratorPrototype%).
+          1. Return CreateIteratorFromClosure(_closure_, *"%SetIteratorPrototype%"*, %SetIteratorPrototype%).
         </emu-alg>
       </emu-clause>
 
@@ -40263,7 +40304,7 @@ THH:mm:ss.sss
             1. Let _next_ be ? IteratorStep(_iteratorRecord_).
             1. If _next_ is *false*, return _set_.
             1. Let _nextValue_ be ? IteratorValue(_next_).
-            1. Let _status_ be Call(_adder_, _set_, &laquo; _nextValue_ &raquo;).
+            1. Let _status_ be Completion(Call(_adder_, _set_, &laquo; _nextValue_ &raquo;)).
             1. IfAbruptCloseIterator(_status_, _iteratorRecord_).
         </emu-alg>
       </emu-clause>
@@ -40393,7 +40434,7 @@ THH:mm:ss.sss
           AllocateArrayBuffer (
             _constructor_: unknown,
             _byteLength_: a non-negative integer,
-          )
+          ): either a normal completion containing an ArrayBuffer or an abrupt completion
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -40412,7 +40453,7 @@ THH:mm:ss.sss
         <h1>
           IsDetachedBuffer (
             _arrayBuffer_: an ArrayBuffer or a SharedArrayBuffer,
-          )
+          ): a Boolean
         </h1>
         <dl class="header">
         </dl>
@@ -40427,7 +40468,7 @@ THH:mm:ss.sss
           DetachArrayBuffer (
             _arrayBuffer_: an ArrayBuffer,
             optional _key_: unknown,
-          )
+          ): either a normal completion containing ~unused~ or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
@@ -40437,7 +40478,7 @@ THH:mm:ss.sss
           1. If SameValue(_arrayBuffer_.[[ArrayBufferDetachKey]], _key_) is *false*, throw a *TypeError* exception.
           1. Set _arrayBuffer_.[[ArrayBufferData]] to *null*.
           1. Set _arrayBuffer_.[[ArrayBufferByteLength]] to 0.
-          1. Return NormalCompletion(*null*).
+          1. Return ~unused~.
         </emu-alg>
         <emu-note>
           <p>Detaching an ArrayBuffer instance disassociates the Data Block used as its backing store from the instance and sets the byte length of the buffer to 0. No operations defined by this specification use the DetachArrayBuffer abstract operation. However, an ECMAScript host or implementation may define such operations.</p>
@@ -40451,7 +40492,7 @@ THH:mm:ss.sss
             _srcByteOffset_: a non-negative integer,
             _srcLength_: a non-negative integer,
             _cloneConstructor_: a constructor,
-          )
+          ): either a normal completion containing an ArrayBuffer or an abrupt completion
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -40471,7 +40512,7 @@ THH:mm:ss.sss
         <h1>
           IsUnsignedElementType (
             _type_: unknown,
-          )
+          ): a Boolean
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -40487,7 +40528,7 @@ THH:mm:ss.sss
         <h1>
           IsUnclampedIntegerElementType (
             _type_: unknown,
-          )
+          ): a Boolean
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -40503,7 +40544,7 @@ THH:mm:ss.sss
         <h1>
           IsBigIntElementType (
             _type_: unknown,
-          )
+          ): a Boolean
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -40520,13 +40561,13 @@ THH:mm:ss.sss
           IsNoTearConfiguration (
             _type_: unknown,
             _order_: unknown,
-          )
+          ): a Boolean
         </h1>
         <dl class="header">
         </dl>
         <emu-alg>
-          1. If ! IsUnclampedIntegerElementType(_type_) is *true*, return *true*.
-          1. If ! IsBigIntElementType(_type_) is *true* and _order_ is not ~Init~ or ~Unordered~, return *true*.
+          1. If IsUnclampedIntegerElementType(_type_) is *true*, return *true*.
+          1. If IsBigIntElementType(_type_) is *true* and _order_ is not ~Init~ or ~Unordered~, return *true*.
           1. Return *false*.
         </emu-alg>
       </emu-clause>
@@ -40537,7 +40578,7 @@ THH:mm:ss.sss
             _type_: a TypedArray element type,
             _rawBytes_: a List,
             _isLittleEndian_: a Boolean,
-          )
+          ): a Number or a BigInt
         </h1>
         <dl class="header">
         </dl>
@@ -40552,11 +40593,11 @@ THH:mm:ss.sss
             1. Let _value_ be the byte elements of _rawBytes_ concatenated and interpreted as a little-endian bit string encoding of an IEEE 754-2019 binary64 value.
             1. If _value_ is an IEEE 754-2019 binary64 NaN value, return the *NaN* Number value.
             1. Return the Number value that corresponds to _value_.
-          1. If ! IsUnsignedElementType(_type_) is *true*, then
+          1. If IsUnsignedElementType(_type_) is *true*, then
             1. Let _intValue_ be the byte elements of _rawBytes_ concatenated and interpreted as a bit string encoding of an unsigned little-endian binary number.
           1. Else,
             1. Let _intValue_ be the byte elements of _rawBytes_ concatenated and interpreted as a bit string encoding of a binary little-endian two's complement number of bit length _elementSize_ &times; 8.
-          1. If ! IsBigIntElementType(_type_) is *true*, return the BigInt value that corresponds to _intValue_.
+          1. If IsBigIntElementType(_type_) is *true*, return the BigInt value that corresponds to _intValue_.
           1. Otherwise, return the Number value that corresponds to _intValue_.
         </emu-alg>
       </emu-clause>
@@ -40570,7 +40611,7 @@ THH:mm:ss.sss
             _isTypedArray_: a Boolean,
             _order_: ~SeqCst~ or ~Unordered~,
             optional _isLittleEndian_: a Boolean,
-          )
+          ): a Number or a BigInt
         </h1>
         <dl class="header">
         </dl>
@@ -40601,7 +40642,7 @@ THH:mm:ss.sss
             _type_: a TypedArray element type,
             _value_: a BigInt or a Number,
             _isLittleEndian_: a Boolean,
-          )
+          ): a List of byte values
         </h1>
         <dl class="header">
         </dl>
@@ -40632,14 +40673,14 @@ THH:mm:ss.sss
             _isTypedArray_: a Boolean,
             _order_: ~SeqCst~, ~Unordered~, or ~Init~,
             optional _isLittleEndian_: a Boolean,
-          )
+          ): ~unused~
         </h1>
         <dl class="header">
         </dl>
         <emu-alg>
           1. Assert: IsDetachedBuffer(_arrayBuffer_) is *false*.
           1. Assert: There are sufficient bytes in _arrayBuffer_ starting at _byteIndex_ to represent a value of _type_.
-          1. Assert: Type(_value_) is BigInt if ! IsBigIntElementType(_type_) is *true*; otherwise, Type(_value_) is Number.
+          1. Assert: Type(_value_) is BigInt if IsBigIntElementType(_type_) is *true*; otherwise, Type(_value_) is Number.
           1. Let _block_ be _arrayBuffer_.[[ArrayBufferData]].
           1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for Element Type _type_.
           1. If _isLittleEndian_ is not present, set _isLittleEndian_ to the value of the [[LittleEndian]] field of the surrounding agent's Agent Record.
@@ -40650,7 +40691,7 @@ THH:mm:ss.sss
             1. If _isTypedArray_ is *true* and IsNoTearConfiguration(_type_, _order_) is *true*, let _noTear_ be *true*; otherwise let _noTear_ be *false*.
             1. Append WriteSharedMemory { [[Order]]: _order_, [[NoTear]]: _noTear_, [[Block]]: _block_, [[ByteIndex]]: _byteIndex_, [[ElementSize]]: _elementSize_, [[Payload]]: _rawBytes_ } to _eventList_.
           1. Else, store the individual bytes of _rawBytes_ into _block_, starting at _block_[_byteIndex_].
-          1. Return NormalCompletion(*undefined*).
+          1. Return ~unused~.
         </emu-alg>
       </emu-clause>
 
@@ -40663,14 +40704,14 @@ THH:mm:ss.sss
             _value_: a Number or a BigInt,
             _op_: a read-modify-write modification function,
             optional _isLittleEndian_: a Boolean,
-          )
+          ): a Number or a BigInt
         </h1>
         <dl class="header">
         </dl>
         <emu-alg>
           1. Assert: IsDetachedBuffer(_arrayBuffer_) is *false*.
           1. Assert: There are sufficient bytes in _arrayBuffer_ starting at _byteIndex_ to represent a value of _type_.
-          1. Assert: Type(_value_) is BigInt if ! IsBigIntElementType(_type_) is *true*; otherwise, Type(_value_) is Number.
+          1. Assert: Type(_value_) is BigInt if IsBigIntElementType(_type_) is *true*; otherwise, Type(_value_) is Number.
           1. Let _block_ be _arrayBuffer_.[[ArrayBufferData]].
           1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for Element Type _type_.
           1. If _isLittleEndian_ is not present, set _isLittleEndian_ to the value of the [[LittleEndian]] field of the surrounding agent's Agent Record.
@@ -40839,7 +40880,7 @@ THH:mm:ss.sss
           AllocateSharedArrayBuffer (
             _constructor_: unknown,
             _byteLength_: a non-negative integer,
-          )
+          ): either a normal completion containing a SharedArrayBuffer or an abrupt completion
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -40858,7 +40899,7 @@ THH:mm:ss.sss
         <h1>
           IsSharedArrayBuffer (
             _obj_: an ArrayBuffer or a SharedArrayBuffer,
-          )
+          ): a Boolean
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -41013,7 +41054,7 @@ THH:mm:ss.sss
             _requestIndex_: unknown,
             _isLittleEndian_: unknown,
             _type_: unknown,
-          )
+          ): either a normal completion containing either a Number or a BigInt, or an abrupt completion
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -41023,7 +41064,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_view_, [[DataView]]).
           1. Assert: _view_ has a [[ViewedArrayBuffer]] internal slot.
           1. Let _getIndex_ be ? ToIndex(_requestIndex_).
-          1. Set _isLittleEndian_ to ! ToBoolean(_isLittleEndian_).
+          1. Set _isLittleEndian_ to ToBoolean(_isLittleEndian_).
           1. Let _buffer_ be _view_.[[ViewedArrayBuffer]].
           1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
           1. Let _viewOffset_ be _view_.[[ByteOffset]].
@@ -41043,7 +41084,7 @@ THH:mm:ss.sss
             _isLittleEndian_: unknown,
             _type_: unknown,
             _value_: unknown,
-          )
+          ): either a normal completion containing *undefined* or an abrupt completion
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -41053,9 +41094,9 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_view_, [[DataView]]).
           1. Assert: _view_ has a [[ViewedArrayBuffer]] internal slot.
           1. Let _getIndex_ be ? ToIndex(_requestIndex_).
-          1. If ! IsBigIntElementType(_type_) is *true*, let _numberValue_ be ? ToBigInt(_value_).
+          1. If IsBigIntElementType(_type_) is *true*, let _numberValue_ be ? ToBigInt(_value_).
           1. Otherwise, let _numberValue_ be ? ToNumber(_value_).
-          1. Set _isLittleEndian_ to ! ToBoolean(_isLittleEndian_).
+          1. Set _isLittleEndian_ to ToBoolean(_isLittleEndian_).
           1. Let _buffer_ be _view_.[[ViewedArrayBuffer]].
           1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
           1. Let _viewOffset_ be _view_.[[ByteOffset]].
@@ -41063,7 +41104,8 @@ THH:mm:ss.sss
           1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for Element Type _type_.
           1. If _getIndex_ + _elementSize_ &gt; _viewSize_, throw a *RangeError* exception.
           1. Let _bufferIndex_ be _getIndex_ + _viewOffset_.
-          1. Return SetValueInBuffer(_buffer_, _bufferIndex_, _type_, _numberValue_, *false*, ~Unordered~, _isLittleEndian_).
+          1. Perform SetValueInBuffer(_buffer_, _bufferIndex_, _type_, _numberValue_, *false*, ~Unordered~, _isLittleEndian_).
+          1. Return *undefined*.
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -41400,7 +41442,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-waiterlist-objects">
       <h1>WaiterList Objects</h1>
-      <p>A <dfn variants="WaiterLists">WaiterList</dfn> is a semantic object that contains an ordered list of those agents that are waiting on a location (_block_, _i_) in shared memory; _block_ is a Shared Data Block and _i_ a byte offset into the memory of _block_. A WaiterList object also optionally contains a Synchronize event denoting the previous leaving of its critical section.</p>
+      <p>A <dfn variants="WaiterLists">WaiterList</dfn> is a semantic object that contains an ordered list of agent signifiers for those agents that are waiting on a location (_block_, _i_) in shared memory; _block_ is a Shared Data Block and _i_ a byte offset into the memory of _block_. A WaiterList object also optionally contains a Synchronize event denoting the previous leaving of its critical section.</p>
       <p>Initially a WaiterList object has an empty list and no Synchronize event.</p>
       <p>The agent cluster has a store of WaiterList objects; the store is indexed by (_block_, _i_). WaiterLists are agent-independent: a lookup in the store of WaiterLists by (_block_, _i_) will result in the same WaiterList object in any agent in the agent cluster.</p>
       <p>Each WaiterList has a <dfn variants="critical sections">critical section</dfn> that controls exclusive access to that WaiterList during evaluation. Only a single agent may enter a WaiterList's critical section at one time. Entering and leaving a WaiterList's critical section is controlled by the abstract operations EnterCriticalSection and LeaveCriticalSection. Operations on a WaiterList&mdash;adding and removing waiting agents, traversing the list of agents, suspending and notifying agents on the list, setting and retrieving the Synchronize event&mdash;may only be performed by agents that have entered the WaiterList's critical section.</p>
@@ -41414,7 +41456,7 @@ THH:mm:ss.sss
           ValidateIntegerTypedArray (
             _typedArray_: unknown,
             optional _waitable_: a Boolean,
-          )
+          ): either a normal completion containing either an ArrayBuffer or a SharedArrayBuffer, or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
@@ -41427,7 +41469,7 @@ THH:mm:ss.sss
           1. If _waitable_ is *true*, then
             1. If _typeName_ is not *"Int32Array"* or *"BigInt64Array"*, throw a *TypeError* exception.
           1. Else,
-            1. If ! IsUnclampedIntegerElementType(_type_) is *false* and ! IsBigIntElementType(_type_) is *false*, throw a *TypeError* exception.
+            1. If IsUnclampedIntegerElementType(_type_) is *false* and IsBigIntElementType(_type_) is *false*, throw a *TypeError* exception.
           1. Return _buffer_.
         </emu-alg>
       </emu-clause>
@@ -41437,7 +41479,7 @@ THH:mm:ss.sss
           ValidateAtomicAccess (
             _typedArray_: a TypedArray,
             _requestIndex_: unknown,
-          )
+          ): either a normal completion containing an integer or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
@@ -41458,7 +41500,7 @@ THH:mm:ss.sss
           GetWaiterList (
             _block_: a Shared Data Block,
             _i_: a non-negative integer that is evenly divisble by 4,
-          )
+          ): a WaiterList
         </h1>
         <dl class="header">
         </dl>
@@ -41472,7 +41514,7 @@ THH:mm:ss.sss
         <h1>
           EnterCriticalSection (
             _WL_: a WaiterList,
-          )
+          ): ~unused~
         </h1>
         <dl class="header">
         </dl>
@@ -41488,6 +41530,7 @@ THH:mm:ss.sss
             1. Append _enterEvent_ to _entererEventList_.
             1. Let _leaveEvent_ be the Synchronize event in _WL_.
             1. Append (_leaveEvent_, _enterEvent_) to _eventsRecord_.[[AgentSynchronizesWith]].
+          1. Return ~unused~.
         </emu-alg>
         <p>EnterCriticalSection has <dfn>contention</dfn> when an agent attempting to enter the critical section must wait for another agent to leave it. When there is no contention, FIFO order of EnterCriticalSection calls is observable. When there is contention, an implementation may choose an arbitrary order but may not cause an agent to wait indefinitely.</p>
       </emu-clause>
@@ -41496,7 +41539,7 @@ THH:mm:ss.sss
         <h1>
           LeaveCriticalSection (
             _WL_: a WaiterList,
-          )
+          ): ~unused~
         </h1>
         <dl class="header">
         </dl>
@@ -41509,6 +41552,7 @@ THH:mm:ss.sss
           1. Append _leaveEvent_ to _leaverEventList_.
           1. Set the Synchronize event in _WL_ to _leaveEvent_.
           1. Leave the critical section for _WL_.
+          1. Return ~unused~.
         </emu-alg>
       </emu-clause>
 
@@ -41517,7 +41561,7 @@ THH:mm:ss.sss
           AddWaiter (
             _WL_: a WaiterList,
             _W_: an agent signifier,
-          )
+          ): ~unused~
         </h1>
         <dl class="header">
         </dl>
@@ -41525,6 +41569,7 @@ THH:mm:ss.sss
           1. Assert: The calling agent is in the critical section for _WL_.
           1. Assert: _W_ is not on the list of waiters in any WaiterList.
           1. Add _W_ to the end of the list of waiters in _WL_.
+          1. Return ~unused~.
         </emu-alg>
       </emu-clause>
 
@@ -41533,7 +41578,7 @@ THH:mm:ss.sss
           RemoveWaiter (
             _WL_: a WaiterList,
             _W_: an agent signifier,
-          )
+          ): ~unused~
         </h1>
         <dl class="header">
         </dl>
@@ -41541,6 +41586,7 @@ THH:mm:ss.sss
           1. Assert: The calling agent is in the critical section for _WL_.
           1. Assert: _W_ is on the list of waiters in _WL_.
           1. Remove _W_ from the list of waiters in _WL_.
+          1. Return ~unused~.
         </emu-alg>
       </emu-clause>
 
@@ -41549,7 +41595,7 @@ THH:mm:ss.sss
           RemoveWaiters (
             _WL_: a WaiterList,
             _c_: a non-negative integer or +&infin;,
-          )
+          ): a List of agent signifiers
         </h1>
         <dl class="header">
         </dl>
@@ -41572,7 +41618,7 @@ THH:mm:ss.sss
             _WL_: a WaiterList,
             _W_: an agent signifier,
             _timeout_: a non-negative integer,
-          )
+          ): a Boolean
         </h1>
         <dl class="header">
         </dl>
@@ -41593,13 +41639,14 @@ THH:mm:ss.sss
           NotifyWaiter (
             _WL_: a WaiterList,
             _W_: an agent signifier,
-          )
+          ): ~unused~
         </h1>
         <dl class="header">
         </dl>
         <emu-alg>
           1. Assert: The calling agent is in the critical section for _WL_.
           1. Notify the agent _W_.
+          1. Return ~unused~.
         </emu-alg>
         <emu-note>
           <p>The embedding may delay notifying _W_, e.g. for resource management reasons, but _W_ must eventually be notified in order to guarantee forward progress.</p>
@@ -41613,7 +41660,7 @@ THH:mm:ss.sss
             _index_: unknown,
             _value_: unknown,
             _op_: a read-modify-write modification function,
-          )
+          ): either a normal completion containing either a Number or a BigInt, or an abrupt completion
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -41638,7 +41685,7 @@ THH:mm:ss.sss
             _op_: `&amp;`, `^`, or `|`,
             _xBytes_: a List of byte values,
             _yBytes_: a List of byte values,
-          )
+          ): a List of byte values
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -41664,7 +41711,7 @@ THH:mm:ss.sss
           ByteListEqual (
             _xBytes_: a List of byte values,
             _yBytes_: a List of byte values,
-          )
+          ): a Boolean
         </h1>
         <dl class="header">
         </dl>
@@ -41863,7 +41910,7 @@ THH:mm:ss.sss
         1. Let _WL_ be GetWaiterList(_block_, _indexedPosition_).
         1. Perform EnterCriticalSection(_WL_).
         1. Let _elementType_ be the Element Type value in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _arrayTypeName_.
-        1. Let _w_ be ! GetValueFromBuffer(_buffer_, _indexedPosition_, _elementType_, *true*, ~SeqCst~).
+        1. Let _w_ be GetValueFromBuffer(_buffer_, _indexedPosition_, _elementType_, *true*, ~SeqCst~).
         1. If _v_ &ne; _w_, then
           1. Perform LeaveCriticalSection(_WL_).
           1. Return the String *"not-equal"*.
@@ -41943,9 +41990,9 @@ THH:mm:ss.sss
       <p>The optional _reviver_ parameter is a function that takes two parameters, _key_ and _value_. It can filter and transform the results. It is called with each of the _key_/_value_ pairs produced by the parse, and its return value is used instead of the original value. If it returns what it received, the structure is not modified. If it returns *undefined* then the property is deleted from the result.</p>
       <emu-alg>
         1. Let _jsonString_ be ? ToString(_text_).
-        1. [id="step-json-parse-validate"] Parse ! StringToCodePoints(_jsonString_) as a JSON text as specified in ECMA-404. Throw a *SyntaxError* exception if it is not a valid JSON text as defined in that specification.
+        1. [id="step-json-parse-validate"] Parse StringToCodePoints(_jsonString_) as a JSON text as specified in ECMA-404. Throw a *SyntaxError* exception if it is not a valid JSON text as defined in that specification.
         1. Let _scriptString_ be the string-concatenation of *"("*, _jsonString_, and *");"*.
-        1. [id="step-json-parse-parse"] Let _script_ be ParseText(! StringToCodePoints(_scriptString_), |Script|).
+        1. [id="step-json-parse-parse"] Let _script_ be ParseText(StringToCodePoints(_scriptString_), |Script|).
         1. NOTE: The early error rules defined in <emu-xref href="#sec-object-initializer-static-semantics-early-errors"></emu-xref> have special handling for the above invocation of ParseText.
         1. Assert: _script_ is a Parse Node.
         1. [id="step-json-parse-eval"] Let _completion_ be the result of <emu-meta suppress-effects="user-code">evaluating _script_</emu-meta>.
@@ -41953,7 +42000,7 @@ THH:mm:ss.sss
         1. Let _unfiltered_ be _completion_.[[Value]].
         1. [id="step-json-parse-assert-type"] Assert: _unfiltered_ is either a String, Number, Boolean, Null, or an Object that is defined by either an |ArrayLiteral| or an |ObjectLiteral|.
         1. If IsCallable(_reviver_) is *true*, then
-          1. Let _root_ be ! OrdinaryObjectCreate(%Object.prototype%).
+          1. Let _root_ be OrdinaryObjectCreate(%Object.prototype%).
           1. Let _rootName_ be the empty String.
           1. Perform ! CreateDataPropertyOrThrow(_root_, _rootName_, _unfiltered_).
           1. Return ? InternalizeJSONProperty(_root_, _rootName_, _reviver_).
@@ -41972,7 +42019,7 @@ THH:mm:ss.sss
             _holder_: an Object,
             _name_: a String,
             _reviver_: a function object,
-          )
+          ): either a normal completion containing an ECMAScript language value or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
@@ -42053,7 +42100,7 @@ THH:mm:ss.sss
           1. If the length of _space_ is 10 or less, let _gap_ be _space_; otherwise let _gap_ be the substring of _space_ from 0 to 10.
         1. Else,
           1. Let _gap_ be the empty String.
-        1. Let _wrapper_ be ! OrdinaryObjectCreate(%Object.prototype%).
+        1. Let _wrapper_ be OrdinaryObjectCreate(%Object.prototype%).
         1. Perform ! CreateDataPropertyOrThrow(_wrapper_, the empty String, _value_).
         1. Let _state_ be the Record { [[ReplacerFunction]]: _ReplacerFunction_, [[Stack]]: _stack_, [[Indent]]: _indent_, [[Gap]]: _gap_, [[PropertyList]]: _PropertyList_ }.
         1. Return ? SerializeJSONProperty(_state_, the empty String, _wrapper_).
@@ -42103,7 +42150,7 @@ THH:mm:ss.sss
             _state_: unknown,
             _key_: unknown,
             _holder_: unknown,
-          )
+          ): either a normal completion containing either *undefined* or a String, or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
@@ -42143,8 +42190,8 @@ THH:mm:ss.sss
       <emu-clause id="sec-quotejsonstring" type="abstract operation">
         <h1>
           QuoteJSONString (
-            _value_: unknown,
-          )
+            _value_: a String,
+          ): a String
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -42152,14 +42199,14 @@ THH:mm:ss.sss
         </dl>
         <emu-alg>
           1. Let _product_ be the String value consisting solely of the code unit 0x0022 (QUOTATION MARK).
-          1. For each code point _C_ of ! StringToCodePoints(_value_), do
+          1. For each code point _C_ of StringToCodePoints(_value_), do
             1. If _C_ is listed in the &ldquo;Code Point&rdquo; column of <emu-xref href="#table-json-single-character-escapes"></emu-xref>, then
               1. Set _product_ to the string-concatenation of _product_ and the escape sequence for _C_ as specified in the &ldquo;Escape Sequence&rdquo; column of the corresponding row.
             1. Else if _C_ has a numeric value less than 0x0020 (SPACE), or if _C_ has the same numeric value as a <emu-xref href="#leading-surrogate"></emu-xref> or <emu-xref href="#trailing-surrogate"></emu-xref>, then
               1. Let _unit_ be the code unit whose numeric value is that of _C_.
               1. Set _product_ to the string-concatenation of _product_ and UnicodeEscape(_unit_).
             1. Else,
-              1. Set _product_ to the string-concatenation of _product_ and ! UTF16EncodeCodePoint(_C_).
+              1. Set _product_ to the string-concatenation of _product_ and UTF16EncodeCodePoint(_C_).
           1. Set _product_ to the string-concatenation of _product_ and the code unit 0x0022 (QUOTATION MARK).
           1. Return _product_.
         </emu-alg>
@@ -42261,7 +42308,7 @@ THH:mm:ss.sss
         <h1>
           UnicodeEscape (
             _C_: a code unit,
-          )
+          ): a String
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -42281,8 +42328,8 @@ THH:mm:ss.sss
         <h1>
           SerializeJSONObject (
             _state_: unknown,
-            _value_: unknown,
-          )
+            _value_: an Object,
+          ): either a normal completion containing a String or an abrupt completion
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -42327,8 +42374,8 @@ THH:mm:ss.sss
         <h1>
           SerializeJSONArray (
             _state_: unknown,
-            _value_: unknown,
-          )
+            _value_: an ECMAScript language value,
+          ): either a normal completion containing a String or an abrupt completion
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -42410,7 +42457,7 @@ THH:mm:ss.sss
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
           1. If Type(_target_) is not Object, throw a *TypeError* exception.
           1. Let _weakRef_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%WeakRef.prototype%"*, &laquo; [[WeakRefTarget]] &raquo;).
-          1. Perform ! AddToKeptObjects(_target_).
+          1. Perform AddToKeptObjects(_target_).
           1. Set _weakRef_.[[WeakRefTarget]] to _target_.
           1. Return _weakRef_.
         </emu-alg>
@@ -42460,7 +42507,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _weakRef_ be the *this* value.
           1. Perform ? RequireInternalSlot(_weakRef_, [[WeakRefTarget]]).
-          1. Return ! WeakRefDeref(_weakRef_).
+          1. Return WeakRefDeref(_weakRef_).
         </emu-alg>
 
         <emu-note>
@@ -42495,14 +42542,14 @@ THH:mm:ss.sss
         <h1>
           WeakRefDeref (
             _weakRef_: a WeakRef,
-          )
+          ): an ECMAScript language value
         </h1>
         <dl class="header">
         </dl>
         <emu-alg>
           1. Let _target_ be _weakRef_.[[WeakRefTarget]].
           1. If _target_ is not ~empty~, then
-            1. Perform ! AddToKeptObjects(_target_).
+            1. Perform AddToKeptObjects(_target_).
             1. Return _target_.
           1. Return *undefined*.
         </emu-alg>
@@ -42929,14 +42976,14 @@ THH:mm:ss.sss
         <h1>
           CreateAsyncFromSyncIterator (
             _syncIteratorRecord_: unknown,
-          )
+          ): an Iterator Record
         </h1>
         <dl class="header">
           <dt>description</dt>
           <dd>It is used to create an async Iterator Record from a synchronous Iterator Record.</dd>
         </dl>
         <emu-alg>
-          1. Let _asyncIterator_ be ! OrdinaryObjectCreate(%AsyncFromSyncIteratorPrototype%, &laquo; [[SyncIteratorRecord]] &raquo;).
+          1. Let _asyncIterator_ be OrdinaryObjectCreate(%AsyncFromSyncIteratorPrototype%, &laquo; [[SyncIteratorRecord]] &raquo;).
           1. Set _asyncIterator_.[[SyncIteratorRecord]] to _syncIteratorRecord_.
           1. Let _nextMethod_ be ! Get(_asyncIterator_, *"next"*).
           1. Let _iteratorRecord_ be the Iterator Record { [[Iterator]]: _asyncIterator_, [[NextMethod]]: _nextMethod_, [[Done]]: *false* }.
@@ -42962,11 +43009,11 @@ THH:mm:ss.sss
             1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
             1. Let _syncIteratorRecord_ be _O_.[[SyncIteratorRecord]].
             1. If _value_ is present, then
-              1. Let _result_ be IteratorNext(_syncIteratorRecord_, _value_).
+              1. Let _result_ be Completion(IteratorNext(_syncIteratorRecord_, _value_)).
             1. Else,
-              1. Let _result_ be IteratorNext(_syncIteratorRecord_).
+              1. Let _result_ be Completion(IteratorNext(_syncIteratorRecord_)).
             1. IfAbruptRejectPromise(_result_, _promiseCapability_).
-            1. Return ! AsyncFromSyncIteratorContinuation(_result_, _promiseCapability_).
+            1. Return AsyncFromSyncIteratorContinuation(_result_, _promiseCapability_).
           </emu-alg>
         </emu-clause>
 
@@ -42978,21 +43025,21 @@ THH:mm:ss.sss
             1. Assert: _O_ is an Object that has a [[SyncIteratorRecord]] internal slot.
             1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
             1. Let _syncIterator_ be _O_.[[SyncIteratorRecord]].[[Iterator]].
-            1. Let _return_ be GetMethod(_syncIterator_, *"return"*).
+            1. Let _return_ be Completion(GetMethod(_syncIterator_, *"return"*)).
             1. IfAbruptRejectPromise(_return_, _promiseCapability_).
             1. If _return_ is *undefined*, then
-              1. Let _iterResult_ be ! CreateIterResultObject(_value_, *true*).
+              1. Let _iterResult_ be CreateIterResultObject(_value_, *true*).
               1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _iterResult_ &raquo;).
               1. Return _promiseCapability_.[[Promise]].
             1. If _value_ is present, then
-              1. Let _result_ be Call(_return_, _syncIterator_, &laquo; _value_ &raquo;).
+              1. Let _result_ be Completion(Call(_return_, _syncIterator_, &laquo; _value_ &raquo;)).
             1. Else,
-              1. Let _result_ be Call(_return_, _syncIterator_).
+              1. Let _result_ be Completion(Call(_return_, _syncIterator_)).
             1. IfAbruptRejectPromise(_result_, _promiseCapability_).
             1. If Type(_result_) is not Object, then
               1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; a newly created *TypeError* object &raquo;).
               1. Return _promiseCapability_.[[Promise]].
-            1. Return ! AsyncFromSyncIteratorContinuation(_result_, _promiseCapability_).
+            1. Return AsyncFromSyncIteratorContinuation(_result_, _promiseCapability_).
           </emu-alg>
         </emu-clause>
 
@@ -43005,20 +43052,20 @@ THH:mm:ss.sss
             1. Assert: _O_ is an Object that has a [[SyncIteratorRecord]] internal slot.
             1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
             1. Let _syncIterator_ be _O_.[[SyncIteratorRecord]].[[Iterator]].
-            1. Let _throw_ be GetMethod(_syncIterator_, *"throw"*).
+            1. Let _throw_ be Completion(GetMethod(_syncIterator_, *"throw"*)).
             1. IfAbruptRejectPromise(_throw_, _promiseCapability_).
             1. If _throw_ is *undefined*, then
               1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _value_ &raquo;).
               1. Return _promiseCapability_.[[Promise]].
             1. If _value_ is present, then
-              1. Let _result_ be Call(_throw_, _syncIterator_, &laquo; _value_ &raquo;).
+              1. Let _result_ be Completion(Call(_throw_, _syncIterator_, &laquo; _value_ &raquo;)).
             1. Else,
-              1. Let _result_ be Call(_throw_, _syncIterator_).
+              1. Let _result_ be Completion(Call(_throw_, _syncIterator_)).
             1. IfAbruptRejectPromise(_result_, _promiseCapability_).
             1. If Type(_result_) is not Object, then
               1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; a newly created *TypeError* object &raquo;).
               1. Return _promiseCapability_.[[Promise]].
-            1. Return ! AsyncFromSyncIteratorContinuation(_result_, _promiseCapability_).
+            1. Return AsyncFromSyncIteratorContinuation(_result_, _promiseCapability_).
           </emu-alg>
         </emu-clause>
       </emu-clause>
@@ -43054,24 +43101,25 @@ THH:mm:ss.sss
         <h1>
           AsyncFromSyncIteratorContinuation (
             _result_: unknown,
-            _promiseCapability_: a PromiseCapability Record,
-          )
+            _promiseCapability_: a PromiseCapability Record for an intrinsic %Promise%,
+          ): a Promise
         </h1>
         <dl class="header">
         </dl>
 
         <emu-alg>
-          1. Let _done_ be IteratorComplete(_result_).
+          1. NOTE: Because _promiseCapability_ is derived from the intrinsic %Promise%, the calls to _promiseCapability_.[[Reject]] entailed by the use IfAbruptRejectPromise below are guaranteed not to throw.
+          1. Let _done_ be Completion(IteratorComplete(_result_)).
           1. IfAbruptRejectPromise(_done_, _promiseCapability_).
-          1. Let _value_ be IteratorValue(_result_).
+          1. Let _value_ be Completion(IteratorValue(_result_)).
           1. IfAbruptRejectPromise(_value_, _promiseCapability_).
-          1. Let _valueWrapper_ be PromiseResolve(%Promise%, _value_).
+          1. Let _valueWrapper_ be Completion(PromiseResolve(%Promise%, _value_)).
           1. IfAbruptRejectPromise(_valueWrapper_, _promiseCapability_).
           1. Let _unwrap_ be a new Abstract Closure with parameters (_value_) that captures _done_ and performs the following steps when called:
-            1. Return ! CreateIterResultObject(_value_, _done_).
-          1. Let _onFulfilled_ be ! CreateBuiltinFunction(_unwrap_, 1, *""*, &laquo; &raquo;).
+            1. Return CreateIterResultObject(_value_, _done_).
+          1. Let _onFulfilled_ be CreateBuiltinFunction(_unwrap_, 1, *""*, &laquo; &raquo;).
           1. NOTE: _onFulfilled_ is used when processing the *"value"* property of an IteratorResult object in order to wait for its value if it is a promise and re-package the result in a new "unwrapped" IteratorResult object.
-          1. Perform ! PerformPromiseThen(_valueWrapper_, _onFulfilled_, *undefined*, _promiseCapability_).
+          1. Perform PerformPromiseThen(_valueWrapper_, _onFulfilled_, *undefined*, _promiseCapability_).
           1. Return _promiseCapability_.[[Promise]].
         </emu-alg>
       </emu-clause>
@@ -43226,7 +43274,7 @@ THH:mm:ss.sss
         <h1>
           CreateResolvingFunctions (
             _promise_: unknown,
-          )
+          ): a Record with fields [[Resolve]] (a function object) and [[Reject]] (a function object)
         </h1>
         <dl class="header">
         </dl>
@@ -43234,12 +43282,12 @@ THH:mm:ss.sss
           1. Let _alreadyResolved_ be the Record { [[Value]]: *false* }.
           1. Let _stepsResolve_ be the algorithm steps defined in <emu-xref href="#sec-promise-resolve-functions" title></emu-xref>.
           1. Let _lengthResolve_ be the number of non-optional parameters of the function definition in <emu-xref href="#sec-promise-resolve-functions" title></emu-xref>.
-          1. Let _resolve_ be ! CreateBuiltinFunction(_stepsResolve_, _lengthResolve_, *""*, &laquo; [[Promise]], [[AlreadyResolved]] &raquo;).
+          1. Let _resolve_ be CreateBuiltinFunction(_stepsResolve_, _lengthResolve_, *""*, &laquo; [[Promise]], [[AlreadyResolved]] &raquo;).
           1. Set _resolve_.[[Promise]] to _promise_.
           1. Set _resolve_.[[AlreadyResolved]] to _alreadyResolved_.
           1. Let _stepsReject_ be the algorithm steps defined in <emu-xref href="#sec-promise-reject-functions" title></emu-xref>.
           1. Let _lengthReject_ be the number of non-optional parameters of the function definition in <emu-xref href="#sec-promise-reject-functions" title></emu-xref>.
-          1. Let _reject_ be ! CreateBuiltinFunction(_stepsReject_, _lengthReject_, *""*, &laquo; [[Promise]], [[AlreadyResolved]] &raquo;).
+          1. Let _reject_ be CreateBuiltinFunction(_stepsReject_, _lengthReject_, *""*, &laquo; [[Promise]], [[AlreadyResolved]] &raquo;).
           1. Set _reject_.[[Promise]] to _promise_.
           1. Set _reject_.[[AlreadyResolved]] to _alreadyResolved_.
           1. Return the Record { [[Resolve]]: _resolve_, [[Reject]]: _reject_ }.
@@ -43256,7 +43304,8 @@ THH:mm:ss.sss
             1. Let _alreadyResolved_ be _F_.[[AlreadyResolved]].
             1. If _alreadyResolved_.[[Value]] is *true*, return *undefined*.
             1. Set _alreadyResolved_.[[Value]] to *true*.
-            1. Return RejectPromise(_promise_, _reason_).
+            1. Perform RejectPromise(_promise_, _reason_).
+            1. Return *undefined*.
           </emu-alg>
           <p>The *"length"* property of a promise reject function is *1*<sub>𝔽</sub>.</p>
         </emu-clause>
@@ -43274,15 +43323,19 @@ THH:mm:ss.sss
             1. Set _alreadyResolved_.[[Value]] to *true*.
             1. If SameValue(_resolution_, _promise_) is *true*, then
               1. Let _selfResolutionError_ be a newly created *TypeError* object.
-              1. Return RejectPromise(_promise_, _selfResolutionError_).
+              1. Perform RejectPromise(_promise_, _selfResolutionError_).
+              1. Return *undefined*.
             1. If Type(_resolution_) is not Object, then
-              1. Return FulfillPromise(_promise_, _resolution_).
-            1. Let _then_ be Get(_resolution_, *"then"*).
+              1. Perform FulfillPromise(_promise_, _resolution_).
+              1. Return *undefined*.
+            1. Let _then_ be Completion(Get(_resolution_, *"then"*)).
             1. If _then_ is an abrupt completion, then
-              1. Return RejectPromise(_promise_, _then_.[[Value]]).
+              1. Perform RejectPromise(_promise_, _then_.[[Value]]).
+              1. Return *undefined*.
             1. Let _thenAction_ be _then_.[[Value]].
             1. If IsCallable(_thenAction_) is *false*, then
-              1. Return FulfillPromise(_promise_, _resolution_).
+              1. Perform FulfillPromise(_promise_, _resolution_).
+              1. Return *undefined*.
             1. Let _thenJobCallback_ be HostMakeJobCallback(_thenAction_).
             1. Let _job_ be NewPromiseResolveThenableJob(_promise_, _resolution_, _thenJobCallback_).
             1. Perform HostEnqueuePromiseJob(_job_.[[Job]], _job_.[[Realm]]).
@@ -43297,7 +43350,7 @@ THH:mm:ss.sss
           FulfillPromise (
             _promise_: unknown,
             _value_: unknown,
-          )
+          ): ~unused~
         </h1>
         <dl class="header">
         </dl>
@@ -43308,7 +43361,8 @@ THH:mm:ss.sss
           1. Set _promise_.[[PromiseFulfillReactions]] to *undefined*.
           1. Set _promise_.[[PromiseRejectReactions]] to *undefined*.
           1. Set _promise_.[[PromiseState]] to ~fulfilled~.
-          1. Return TriggerPromiseReactions(_reactions_, _value_).
+          1. Perform TriggerPromiseReactions(_reactions_, _value_).
+          1. Return ~unused~.
         </emu-alg>
       </emu-clause>
 
@@ -43316,7 +43370,7 @@ THH:mm:ss.sss
         <h1>
           NewPromiseCapability (
             _C_: unknown,
-          )
+          ): either a normal completion containing a PromiseCapability Record or an abrupt completion
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -43332,7 +43386,7 @@ THH:mm:ss.sss
             1. Set _promiseCapability_.[[Resolve]] to _resolve_.
             1. Set _promiseCapability_.[[Reject]] to _reject_.
             1. Return *undefined*.
-          1. Let _executor_ be ! CreateBuiltinFunction(_executorClosure_, 2, *""*, &laquo; &raquo;).
+          1. Let _executor_ be CreateBuiltinFunction(_executorClosure_, 2, *""*, &laquo; &raquo;).
           1. Let _promise_ be ? Construct(_C_, &laquo; _executor_ &raquo;).
           1. If IsCallable(_promiseCapability_.[[Resolve]]) is *false*, throw a *TypeError* exception.
           1. If IsCallable(_promiseCapability_.[[Reject]]) is *false*, throw a *TypeError* exception.
@@ -43348,7 +43402,7 @@ THH:mm:ss.sss
         <h1>
           IsPromise (
             _x_: unknown,
-          )
+          ): a Boolean
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -43366,7 +43420,7 @@ THH:mm:ss.sss
           RejectPromise (
             _promise_: unknown,
             _reason_: unknown,
-          )
+          ): ~unused~
         </h1>
         <dl class="header">
         </dl>
@@ -43378,7 +43432,8 @@ THH:mm:ss.sss
           1. Set _promise_.[[PromiseRejectReactions]] to *undefined*.
           1. Set _promise_.[[PromiseState]] to ~rejected~.
           1. If _promise_.[[PromiseIsHandled]] is *false*, perform HostPromiseRejectionTracker(_promise_, *"reject"*).
-          1. Return TriggerPromiseReactions(_reactions_, _reason_).
+          1. Perform TriggerPromiseReactions(_reactions_, _reason_).
+          1. Return ~unused~.
         </emu-alg>
       </emu-clause>
 
@@ -43387,7 +43442,7 @@ THH:mm:ss.sss
           TriggerPromiseReactions (
             _reactions_: a List of PromiseReaction Records,
             _argument_: unknown,
-          )
+          ): ~unused~
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -43397,7 +43452,7 @@ THH:mm:ss.sss
           1. For each element _reaction_ of _reactions_, do
             1. Let _job_ be NewPromiseReactionJob(_reaction_, _argument_).
             1. Perform HostEnqueuePromiseJob(_job_.[[Job]], _job_.[[Realm]]).
-          1. Return *undefined*.
+          1. Return ~unused~.
         </emu-alg>
       </emu-clause>
 
@@ -43406,7 +43461,7 @@ THH:mm:ss.sss
           HostPromiseRejectionTracker (
             _promise_: a Promise,
             _operation_: *"reject"* or *"handle"*,
-          )
+          ): ~unused~
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -43416,7 +43471,7 @@ THH:mm:ss.sss
         <ul>
           <li>It must complete normally (i.e. not return an abrupt completion).</li>
         </ul>
-        <p>The default implementation of HostPromiseRejectionTracker is to return NormalCompletion(~empty~).</p>
+        <p>The default implementation of HostPromiseRejectionTracker is to return ~unused~.</p>
 
         <emu-note>
           <p>HostPromiseRejectionTracker is called in two scenarios:</p>
@@ -43443,7 +43498,7 @@ THH:mm:ss.sss
           NewPromiseReactionJob (
             _reaction_: a PromiseReaction Record,
             _argument_: unknown,
-          )
+          ): a Record with fields [[Job]] (a Job Abstract Closure) and [[Realm]] (a Realm Record or *null*)
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -43459,19 +43514,18 @@ THH:mm:ss.sss
               1. Else,
                 1. Assert: _type_ is ~Reject~.
                 1. Let _handlerResult_ be ThrowCompletion(_argument_).
-            1. Else, let _handlerResult_ be HostCallJobCallback(_handler_, *undefined*, &laquo; _argument_ &raquo;).
+            1. Else, let _handlerResult_ be Completion(HostCallJobCallback(_handler_, *undefined*, &laquo; _argument_ &raquo;)).
             1. If _promiseCapability_ is *undefined*, then
               1. Assert: _handlerResult_ is not an abrupt completion.
-              1. Return NormalCompletion(~empty~).
+              1. Return ~empty~.
             1. Assert: _promiseCapability_ is a PromiseCapability Record.
             1. If _handlerResult_ is an abrupt completion, then
-              1. Let _status_ be Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _handlerResult_.[[Value]] &raquo;).
+              1. Return ? Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _handlerResult_.[[Value]] &raquo;).
             1. Else,
-              1. Let _status_ be Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _handlerResult_.[[Value]] &raquo;).
-            1. Return Completion(_status_).
+              1. Return ? Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _handlerResult_.[[Value]] &raquo;).
           1. Let _handlerRealm_ be *null*.
           1. If _reaction_.[[Handler]] is not ~empty~, then
-            1. Let _getHandlerRealmResult_ be GetFunctionRealm(_reaction_.[[Handler]].[[Callback]]).
+            1. Let _getHandlerRealmResult_ be Completion(GetFunctionRealm(_reaction_.[[Handler]].[[Callback]])).
             1. If _getHandlerRealmResult_ is a normal completion, set _handlerRealm_ to _getHandlerRealmResult_.[[Value]].
             1. Else, set _handlerRealm_ to the current Realm Record.
             1. NOTE: _handlerRealm_ is never *null* unless the handler is *undefined*. When the handler is a revoked Proxy and no ECMAScript code runs, _handlerRealm_ is used to create error objects.
@@ -43485,19 +43539,18 @@ THH:mm:ss.sss
             _promiseToResolve_: unknown,
             _thenable_: unknown,
             _then_: unknown,
-          )
+          ): a Record with fields [[Job]] (a Job Abstract Closure) and [[Realm]] (a Realm Record)
         </h1>
         <dl class="header">
         </dl>
         <emu-alg>
           1. Let _job_ be a new Job Abstract Closure with no parameters that captures _promiseToResolve_, _thenable_, and _then_ and performs the following steps when called:
             1. Let _resolvingFunctions_ be CreateResolvingFunctions(_promiseToResolve_).
-            1. Let _thenCallResult_ be HostCallJobCallback(_then_, _thenable_, &laquo; _resolvingFunctions_.[[Resolve]], _resolvingFunctions_.[[Reject]] &raquo;).
+            1. Let _thenCallResult_ be Completion(HostCallJobCallback(_then_, _thenable_, &laquo; _resolvingFunctions_.[[Resolve]], _resolvingFunctions_.[[Reject]] &raquo;)).
             1. If _thenCallResult_ is an abrupt completion, then
-              1. Let _status_ be Call(_resolvingFunctions_.[[Reject]], *undefined*, &laquo; _thenCallResult_.[[Value]] &raquo;).
-              1. Return Completion(_status_).
-            1. Return Completion(_thenCallResult_).
-          1. Let _getThenRealmResult_ be GetFunctionRealm(_then_.[[Callback]]).
+              1. Return ? Call(_resolvingFunctions_.[[Reject]], *undefined*, &laquo; _thenCallResult_.[[Value]] &raquo;).
+            1. Return ? _thenCallResult_.
+          1. Let _getThenRealmResult_ be Completion(GetFunctionRealm(_then_.[[Callback]])).
           1. If _getThenRealmResult_ is a normal completion, let _thenRealm_ be _getThenRealmResult_.[[Value]].
           1. Else, let _thenRealm_ be the current Realm Record.
           1. NOTE: _thenRealm_ is never *null*. When _then_.[[Callback]] is a revoked Proxy and no code runs, _thenRealm_ is used to create error objects.
@@ -43532,7 +43585,7 @@ THH:mm:ss.sss
           1. Set _promise_.[[PromiseRejectReactions]] to a new empty List.
           1. Set _promise_.[[PromiseIsHandled]] to *false*.
           1. Let _resolvingFunctions_ be CreateResolvingFunctions(_promise_).
-          1. Let _completion_ be Call(_executor_, *undefined*, &laquo; _resolvingFunctions_.[[Resolve]], _resolvingFunctions_.[[Reject]] &raquo;).
+          1. Let _completion_ be Completion(Call(_executor_, *undefined*, &laquo; _resolvingFunctions_.[[Resolve]], _resolvingFunctions_.[[Reject]] &raquo;)).
           1. If _completion_ is an abrupt completion, then
             1. Perform ? Call(_resolvingFunctions_.[[Reject]], *undefined*, &laquo; _completion_.[[Value]] &raquo;).
           1. Return _promise_.
@@ -43560,15 +43613,15 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _C_ be the *this* value.
           1. Let _promiseCapability_ be ? NewPromiseCapability(_C_).
-          1. Let _promiseResolve_ be GetPromiseResolve(_C_).
+          1. Let _promiseResolve_ be Completion(GetPromiseResolve(_C_)).
           1. IfAbruptRejectPromise(_promiseResolve_, _promiseCapability_).
-          1. Let _iteratorRecord_ be GetIterator(_iterable_).
+          1. Let _iteratorRecord_ be Completion(GetIterator(_iterable_)).
           1. IfAbruptRejectPromise(_iteratorRecord_, _promiseCapability_).
-          1. Let _result_ be PerformPromiseAll(_iteratorRecord_, _C_, _promiseCapability_, _promiseResolve_).
+          1. Let _result_ be Completion(PerformPromiseAll(_iteratorRecord_, _C_, _promiseCapability_, _promiseResolve_)).
           1. If _result_ is an abrupt completion, then
-            1. If _iteratorRecord_.[[Done]] is *false*, set _result_ to IteratorClose(_iteratorRecord_, _result_).
+            1. If _iteratorRecord_.[[Done]] is *false*, set _result_ to Completion(IteratorClose(_iteratorRecord_, _result_)).
             1. IfAbruptRejectPromise(_result_, _promiseCapability_).
-          1. Return Completion(_result_).
+          1. Return ? _result_.
         </emu-alg>
         <emu-note>
           <p>The `all` function requires its *this* value to be a constructor function that supports the parameter conventions of the Promise constructor.</p>
@@ -43578,7 +43631,7 @@ THH:mm:ss.sss
           <h1>
             GetPromiseResolve (
               _promiseConstructor_: a constructor,
-            )
+            ): either a normal completion containing a function object or an abrupt completion
           </h1>
           <dl class="header">
           </dl>
@@ -43596,7 +43649,7 @@ THH:mm:ss.sss
               _constructor_: a constructor,
               _resultCapability_: a PromiseCapability Record,
               _promiseResolve_: a function object,
-            )
+            ): either a normal completion containing an ECMAScript language value or an abrupt completion
           </h1>
           <dl class="header">
           </dl>
@@ -43605,24 +43658,24 @@ THH:mm:ss.sss
             1. Let _remainingElementsCount_ be the Record { [[Value]]: 1 }.
             1. Let _index_ be 0.
             1. Repeat,
-              1. Let _next_ be IteratorStep(_iteratorRecord_).
+              1. Let _next_ be Completion(IteratorStep(_iteratorRecord_)).
               1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
               1. ReturnIfAbrupt(_next_).
               1. If _next_ is *false*, then
                 1. Set _iteratorRecord_.[[Done]] to *true*.
                 1. Set _remainingElementsCount_.[[Value]] to _remainingElementsCount_.[[Value]] - 1.
                 1. If _remainingElementsCount_.[[Value]] is 0, then
-                  1. Let _valuesArray_ be ! CreateArrayFromList(_values_).
+                  1. Let _valuesArray_ be CreateArrayFromList(_values_).
                   1. Perform ? Call(_resultCapability_.[[Resolve]], *undefined*, &laquo; _valuesArray_ &raquo;).
                 1. Return _resultCapability_.[[Promise]].
-              1. Let _nextValue_ be IteratorValue(_next_).
+              1. Let _nextValue_ be Completion(IteratorValue(_next_)).
               1. If _nextValue_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
               1. ReturnIfAbrupt(_nextValue_).
               1. Append *undefined* to _values_.
               1. Let _nextPromise_ be ? Call(_promiseResolve_, _constructor_, &laquo; _nextValue_ &raquo;).
               1. Let _steps_ be the algorithm steps defined in <emu-xref href="#sec-promise.all-resolve-element-functions" title></emu-xref>.
               1. Let _length_ be the number of non-optional parameters of the function definition in <emu-xref href="#sec-promise.all-resolve-element-functions" title></emu-xref>.
-              1. Let _onFulfilled_ be ! CreateBuiltinFunction(_steps_, _length_, *""*, &laquo; [[AlreadyCalled]], [[Index]], [[Values]], [[Capability]], [[RemainingElements]] &raquo;).
+              1. Let _onFulfilled_ be CreateBuiltinFunction(_steps_, _length_, *""*, &laquo; [[AlreadyCalled]], [[Index]], [[Values]], [[Capability]], [[RemainingElements]] &raquo;).
               1. Set _onFulfilled_.[[AlreadyCalled]] to *false*.
               1. Set _onFulfilled_.[[Index]] to _index_.
               1. Set _onFulfilled_.[[Values]] to _values_.
@@ -43649,7 +43702,7 @@ THH:mm:ss.sss
             1. Set _values_[_index_] to _x_.
             1. Set _remainingElementsCount_.[[Value]] to _remainingElementsCount_.[[Value]] - 1.
             1. If _remainingElementsCount_.[[Value]] is 0, then
-              1. Let _valuesArray_ be ! CreateArrayFromList(_values_).
+              1. Let _valuesArray_ be CreateArrayFromList(_values_).
               1. Return ? Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _valuesArray_ &raquo;).
             1. Return *undefined*.
           </emu-alg>
@@ -43663,15 +43716,15 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _C_ be the *this* value.
           1. Let _promiseCapability_ be ? NewPromiseCapability(_C_).
-          1. Let _promiseResolve_ be GetPromiseResolve(_C_).
+          1. Let _promiseResolve_ be Completion(GetPromiseResolve(_C_)).
           1. IfAbruptRejectPromise(_promiseResolve_, _promiseCapability_).
-          1. Let _iteratorRecord_ be GetIterator(_iterable_).
+          1. Let _iteratorRecord_ be Completion(GetIterator(_iterable_)).
           1. IfAbruptRejectPromise(_iteratorRecord_, _promiseCapability_).
-          1. Let _result_ be PerformPromiseAllSettled(_iteratorRecord_, _C_, _promiseCapability_, _promiseResolve_).
+          1. Let _result_ be Completion(PerformPromiseAllSettled(_iteratorRecord_, _C_, _promiseCapability_, _promiseResolve_)).
           1. If _result_ is an abrupt completion, then
-            1. If _iteratorRecord_.[[Done]] is *false*, set _result_ to IteratorClose(_iteratorRecord_, _result_).
+            1. If _iteratorRecord_.[[Done]] is *false*, set _result_ to Completion(IteratorClose(_iteratorRecord_, _result_)).
             1. IfAbruptRejectPromise(_result_, _promiseCapability_).
-          1. Return Completion(_result_).
+          1. Return ? _result_.
         </emu-alg>
         <emu-note>
           <p>The `allSettled` function requires its *this* value to be a constructor function that supports the parameter conventions of the Promise constructor.</p>
@@ -43684,7 +43737,7 @@ THH:mm:ss.sss
               _constructor_: a constructor,
               _resultCapability_: a PromiseCapability Record,
               _promiseResolve_: a function object,
-            )
+            ): either a normal completion containing an ECMAScript language value or an abrupt completion
           </h1>
           <dl class="header">
           </dl>
@@ -43693,24 +43746,24 @@ THH:mm:ss.sss
             1. Let _remainingElementsCount_ be the Record { [[Value]]: 1 }.
             1. Let _index_ be 0.
             1. Repeat,
-              1. Let _next_ be IteratorStep(_iteratorRecord_).
+              1. Let _next_ be Completion(IteratorStep(_iteratorRecord_)).
               1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
               1. ReturnIfAbrupt(_next_).
               1. If _next_ is *false*, then
                 1. Set _iteratorRecord_.[[Done]] to *true*.
                 1. Set _remainingElementsCount_.[[Value]] to _remainingElementsCount_.[[Value]] - 1.
                 1. If _remainingElementsCount_.[[Value]] is 0, then
-                  1. Let _valuesArray_ be ! CreateArrayFromList(_values_).
+                  1. Let _valuesArray_ be CreateArrayFromList(_values_).
                   1. Perform ? Call(_resultCapability_.[[Resolve]], *undefined*, &laquo; _valuesArray_ &raquo;).
                 1. Return _resultCapability_.[[Promise]].
-              1. Let _nextValue_ be IteratorValue(_next_).
+              1. Let _nextValue_ be Completion(IteratorValue(_next_)).
               1. If _nextValue_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
               1. ReturnIfAbrupt(_nextValue_).
               1. Append *undefined* to _values_.
               1. Let _nextPromise_ be ? Call(_promiseResolve_, _constructor_, &laquo; _nextValue_ &raquo;).
               1. Let _stepsFulfilled_ be the algorithm steps defined in <emu-xref href="#sec-promise.allsettled-resolve-element-functions" title></emu-xref>.
               1. Let _lengthFulfilled_ be the number of non-optional parameters of the function definition in <emu-xref href="#sec-promise.allsettled-resolve-element-functions" title></emu-xref>.
-              1. Let _onFulfilled_ be ! CreateBuiltinFunction(_stepsFulfilled_, _lengthFulfilled_, *""*, &laquo; [[AlreadyCalled]], [[Index]], [[Values]], [[Capability]], [[RemainingElements]] &raquo;).
+              1. Let _onFulfilled_ be CreateBuiltinFunction(_stepsFulfilled_, _lengthFulfilled_, *""*, &laquo; [[AlreadyCalled]], [[Index]], [[Values]], [[Capability]], [[RemainingElements]] &raquo;).
               1. Let _alreadyCalled_ be the Record { [[Value]]: *false* }.
               1. Set _onFulfilled_.[[AlreadyCalled]] to _alreadyCalled_.
               1. Set _onFulfilled_.[[Index]] to _index_.
@@ -43719,7 +43772,7 @@ THH:mm:ss.sss
               1. Set _onFulfilled_.[[RemainingElements]] to _remainingElementsCount_.
               1. Let _stepsRejected_ be the algorithm steps defined in <emu-xref href="#sec-promise.allsettled-reject-element-functions" title></emu-xref>.
               1. Let _lengthRejected_ be the number of non-optional parameters of the function definition in <emu-xref href="#sec-promise.allsettled-reject-element-functions" title></emu-xref>.
-              1. Let _onRejected_ be ! CreateBuiltinFunction(_stepsRejected_, _lengthRejected_, *""*, &laquo; [[AlreadyCalled]], [[Index]], [[Values]], [[Capability]], [[RemainingElements]] &raquo;).
+              1. Let _onRejected_ be CreateBuiltinFunction(_stepsRejected_, _lengthRejected_, *""*, &laquo; [[AlreadyCalled]], [[Index]], [[Values]], [[Capability]], [[RemainingElements]] &raquo;).
               1. Set _onRejected_.[[AlreadyCalled]] to _alreadyCalled_.
               1. Set _onRejected_.[[Index]] to _index_.
               1. Set _onRejected_.[[Values]] to _values_.
@@ -43744,13 +43797,13 @@ THH:mm:ss.sss
             1. Let _values_ be _F_.[[Values]].
             1. Let _promiseCapability_ be _F_.[[Capability]].
             1. Let _remainingElementsCount_ be _F_.[[RemainingElements]].
-            1. Let _obj_ be ! OrdinaryObjectCreate(%Object.prototype%).
+            1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%).
             1. Perform ! CreateDataPropertyOrThrow(_obj_, *"status"*, *"fulfilled"*).
             1. Perform ! CreateDataPropertyOrThrow(_obj_, *"value"*, _x_).
             1. Set _values_[_index_] to _obj_.
             1. Set _remainingElementsCount_.[[Value]] to _remainingElementsCount_.[[Value]] - 1.
             1. If _remainingElementsCount_.[[Value]] is 0, then
-              1. Let _valuesArray_ be ! CreateArrayFromList(_values_).
+              1. Let _valuesArray_ be CreateArrayFromList(_values_).
               1. Return ? Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _valuesArray_ &raquo;).
             1. Return *undefined*.
           </emu-alg>
@@ -43770,13 +43823,13 @@ THH:mm:ss.sss
             1. Let _values_ be _F_.[[Values]].
             1. Let _promiseCapability_ be _F_.[[Capability]].
             1. Let _remainingElementsCount_ be _F_.[[RemainingElements]].
-            1. Let _obj_ be ! OrdinaryObjectCreate(%Object.prototype%).
+            1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%).
             1. Perform ! CreateDataPropertyOrThrow(_obj_, *"status"*, *"rejected"*).
             1. Perform ! CreateDataPropertyOrThrow(_obj_, *"reason"*, _x_).
             1. Set _values_[_index_] to _obj_.
             1. Set _remainingElementsCount_.[[Value]] to _remainingElementsCount_.[[Value]] - 1.
             1. If _remainingElementsCount_.[[Value]] is 0, then
-              1. Let _valuesArray_ be ! CreateArrayFromList(_values_).
+              1. Let _valuesArray_ be CreateArrayFromList(_values_).
               1. Return ? Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _valuesArray_ &raquo;).
             1. Return *undefined*.
           </emu-alg>
@@ -43790,15 +43843,15 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _C_ be the *this* value.
           1. Let _promiseCapability_ be ? NewPromiseCapability(_C_).
-          1. Let _promiseResolve_ be GetPromiseResolve(_C_).
+          1. Let _promiseResolve_ be Completion(GetPromiseResolve(_C_)).
           1. IfAbruptRejectPromise(_promiseResolve_, _promiseCapability_).
-          1. Let _iteratorRecord_ be GetIterator(_iterable_).
+          1. Let _iteratorRecord_ be Completion(GetIterator(_iterable_)).
           1. IfAbruptRejectPromise(_iteratorRecord_, _promiseCapability_).
-          1. Let _result_ be PerformPromiseAny(_iteratorRecord_, _C_, _promiseCapability_, _promiseResolve_).
+          1. Let _result_ be Completion(PerformPromiseAny(_iteratorRecord_, _C_, _promiseCapability_, _promiseResolve_)).
           1. If _result_ is an abrupt completion, then
-            1. If _iteratorRecord_.[[Done]] is *false*, set _result_ to IteratorClose(_iteratorRecord_, _result_).
+            1. If _iteratorRecord_.[[Done]] is *false*, set _result_ to Completion(IteratorClose(_iteratorRecord_, _result_)).
             1. IfAbruptRejectPromise(_result_, _promiseCapability_).
-          1. Return Completion(_result_).
+          1. Return ? _result_.
         </emu-alg>
         <emu-note>
           <p>The `any` function requires its *this* value to be a constructor function that supports the parameter conventions of the `Promise` constructor.</p>
@@ -43811,7 +43864,7 @@ THH:mm:ss.sss
               _constructor_: a constructor,
               _resultCapability_: a PromiseCapability Record,
               _promiseResolve_: a function object,
-            )
+            ): either a normal completion containing an ECMAScript language value or an abrupt completion
           </h1>
           <dl class="header">
           </dl>
@@ -43820,7 +43873,7 @@ THH:mm:ss.sss
             1. Let _remainingElementsCount_ be the Record { [[Value]]: 1 }.
             1. Let _index_ be 0.
             1. Repeat,
-              1. Let _next_ be IteratorStep(_iteratorRecord_).
+              1. Let _next_ be Completion(IteratorStep(_iteratorRecord_)).
               1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
               1. ReturnIfAbrupt(_next_).
               1. If _next_ is *false*, then
@@ -43828,17 +43881,17 @@ THH:mm:ss.sss
                 1. Set _remainingElementsCount_.[[Value]] to _remainingElementsCount_.[[Value]] - 1.
                 1. If _remainingElementsCount_.[[Value]] is 0, then
                   1. Let _error_ be a newly created *AggregateError* object.
-                  1. Perform ! DefinePropertyOrThrow(_error_, *"errors"*, PropertyDescriptor { [[Configurable]]: *true*, [[Enumerable]]: *false*, [[Writable]]: *true*, [[Value]]: ! CreateArrayFromList(_errors_) }).
+                  1. Perform ! DefinePropertyOrThrow(_error_, *"errors"*, PropertyDescriptor { [[Configurable]]: *true*, [[Enumerable]]: *false*, [[Writable]]: *true*, [[Value]]: CreateArrayFromList(_errors_) }).
                   1. Return ThrowCompletion(_error_).
                 1. Return _resultCapability_.[[Promise]].
-              1. Let _nextValue_ be IteratorValue(_next_).
+              1. Let _nextValue_ be Completion(IteratorValue(_next_)).
               1. If _nextValue_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
               1. ReturnIfAbrupt(_nextValue_).
               1. Append *undefined* to _errors_.
               1. Let _nextPromise_ be ? Call(_promiseResolve_, _constructor_, &laquo; _nextValue_ &raquo;).
               1. Let _stepsRejected_ be the algorithm steps defined in <emu-xref href="#sec-promise.any-reject-element-functions" title></emu-xref>.
               1. Let _lengthRejected_ be the number of non-optional parameters of the function definition in <emu-xref href="#sec-promise.any-reject-element-functions" title></emu-xref>.
-              1. Let _onRejected_ be ! CreateBuiltinFunction(_stepsRejected_, _lengthRejected_, *""*, &laquo; [[AlreadyCalled]], [[Index]], [[Errors]], [[Capability]], [[RemainingElements]] &raquo;).
+              1. Let _onRejected_ be CreateBuiltinFunction(_stepsRejected_, _lengthRejected_, *""*, &laquo; [[AlreadyCalled]], [[Index]], [[Errors]], [[Capability]], [[RemainingElements]] &raquo;).
               1. Set _onRejected_.[[AlreadyCalled]] to *false*.
               1. Set _onRejected_.[[Index]] to _index_.
               1. Set _onRejected_.[[Errors]] to _errors_.
@@ -43866,7 +43919,7 @@ THH:mm:ss.sss
             1. Set _remainingElementsCount_.[[Value]] to _remainingElementsCount_.[[Value]] - 1.
             1. If _remainingElementsCount_.[[Value]] is 0, then
               1. Let _error_ be a newly created *AggregateError* object.
-              1. Perform ! DefinePropertyOrThrow(_error_, *"errors"*, PropertyDescriptor { [[Configurable]]: *true*, [[Enumerable]]: *false*, [[Writable]]: *true*, [[Value]]: ! CreateArrayFromList(_errors_) }).
+              1. Perform ! DefinePropertyOrThrow(_error_, *"errors"*, PropertyDescriptor { [[Configurable]]: *true*, [[Enumerable]]: *false*, [[Writable]]: *true*, [[Value]]: CreateArrayFromList(_errors_) }).
               1. Return ? Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _error_ &raquo;).
             1. Return *undefined*.
           </emu-alg>
@@ -43886,15 +43939,15 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _C_ be the *this* value.
           1. Let _promiseCapability_ be ? NewPromiseCapability(_C_).
-          1. Let _promiseResolve_ be GetPromiseResolve(_C_).
+          1. Let _promiseResolve_ be Completion(GetPromiseResolve(_C_)).
           1. IfAbruptRejectPromise(_promiseResolve_, _promiseCapability_).
-          1. Let _iteratorRecord_ be GetIterator(_iterable_).
+          1. Let _iteratorRecord_ be Completion(GetIterator(_iterable_)).
           1. IfAbruptRejectPromise(_iteratorRecord_, _promiseCapability_).
-          1. Let _result_ be PerformPromiseRace(_iteratorRecord_, _C_, _promiseCapability_, _promiseResolve_).
+          1. Let _result_ be Completion(PerformPromiseRace(_iteratorRecord_, _C_, _promiseCapability_, _promiseResolve_)).
           1. If _result_ is an abrupt completion, then
-            1. If _iteratorRecord_.[[Done]] is *false*, set _result_ to IteratorClose(_iteratorRecord_, _result_).
+            1. If _iteratorRecord_.[[Done]] is *false*, set _result_ to Completion(IteratorClose(_iteratorRecord_, _result_)).
             1. IfAbruptRejectPromise(_result_, _promiseCapability_).
-          1. Return Completion(_result_).
+          1. Return ? _result_.
         </emu-alg>
         <emu-note>
           <p>If the _iterable_ argument is empty or if none of the promises in _iterable_ ever settle then the pending promise returned by this method will never be settled.</p>
@@ -43910,19 +43963,19 @@ THH:mm:ss.sss
               _constructor_: a constructor,
               _resultCapability_: a PromiseCapability Record,
               _promiseResolve_: a function object,
-            )
+            ): either a normal completion containing an ECMAScript language value or an abrupt completion
           </h1>
           <dl class="header">
           </dl>
           <emu-alg>
             1. Repeat,
-              1. Let _next_ be IteratorStep(_iteratorRecord_).
+              1. Let _next_ be Completion(IteratorStep(_iteratorRecord_)).
               1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
               1. ReturnIfAbrupt(_next_).
               1. If _next_ is *false*, then
                 1. Set _iteratorRecord_.[[Done]] to *true*.
                 1. Return _resultCapability_.[[Promise]].
-              1. Let _nextValue_ be IteratorValue(_next_).
+              1. Let _nextValue_ be Completion(IteratorValue(_next_)).
               1. If _nextValue_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
               1. ReturnIfAbrupt(_nextValue_).
               1. Let _nextPromise_ be ? Call(_promiseResolve_, _constructor_, &laquo; _nextValue_ &raquo;).
@@ -43962,7 +44015,7 @@ THH:mm:ss.sss
             PromiseResolve (
               _C_: a constructor,
               _x_: an ECMAScript language value,
-            )
+            ): either a normal completion containing an ECMAScript language value or an abrupt completion
           </h1>
           <dl class="header">
             <dt>description</dt>
@@ -44033,17 +44086,17 @@ THH:mm:ss.sss
               1. Let _promise_ be ? PromiseResolve(_C_, _result_).
               1. Let _returnValue_ be a new Abstract Closure with no parameters that captures _value_ and performs the following steps when called:
                 1. Return _value_.
-              1. Let _valueThunk_ be ! CreateBuiltinFunction(_returnValue_, 0, *""*, &laquo; &raquo;).
+              1. Let _valueThunk_ be CreateBuiltinFunction(_returnValue_, 0, *""*, &laquo; &raquo;).
               1. Return ? Invoke(_promise_, *"then"*, &laquo; _valueThunk_ &raquo;).
-            1. Let _thenFinally_ be ! CreateBuiltinFunction(_thenFinallyClosure_, 1, *""*, &laquo; &raquo;).
+            1. Let _thenFinally_ be CreateBuiltinFunction(_thenFinallyClosure_, 1, *""*, &laquo; &raquo;).
             1. Let _catchFinallyClosure_ be a new Abstract Closure with parameters (_reason_) that captures _onFinally_ and _C_ and performs the following steps when called:
               1. Let _result_ be ? Call(_onFinally_, *undefined*).
               1. Let _promise_ be ? PromiseResolve(_C_, _result_).
               1. Let _throwReason_ be a new Abstract Closure with no parameters that captures _reason_ and performs the following steps when called:
                 1. Return ThrowCompletion(_reason_).
-              1. Let _thrower_ be ! CreateBuiltinFunction(_throwReason_, 0, *""*, &laquo; &raquo;).
+              1. Let _thrower_ be CreateBuiltinFunction(_throwReason_, 0, *""*, &laquo; &raquo;).
               1. Return ? Invoke(_promise_, *"then"*, &laquo; _thrower_ &raquo;).
-            1. Let _catchFinally_ be ! CreateBuiltinFunction(_catchFinallyClosure_, 1, *""*, &laquo; &raquo;).
+            1. Let _catchFinally_ be CreateBuiltinFunction(_catchFinallyClosure_, 1, *""*, &laquo; &raquo;).
           1. Return ? Invoke(_promise_, *"then"*, &laquo; _thenFinally_, _catchFinally_ &raquo;).
         </emu-alg>
       </emu-clause>
@@ -44066,7 +44119,7 @@ THH:mm:ss.sss
               _onFulfilled_: unknown,
               _onRejected_: unknown,
               optional _resultCapability_: a PromiseCapability Record,
-            )
+            ): an ECMAScript language value
           </h1>
           <dl class="header">
             <dt>description</dt>
@@ -44494,7 +44547,7 @@ THH:mm:ss.sss
           GeneratorStart (
             _generator_: unknown,
             _generatorBody_: a |FunctionBody| Parse Node or an Abstract Closure with no parameters,
-          )
+          ): ~unused~
         </h1>
         <dl class="header">
         </dl>
@@ -44516,11 +44569,11 @@ THH:mm:ss.sss
             1. Else if _result_.[[Type]] is ~return~, let _resultValue_ be _result_.[[Value]].
             1. Else,
               1. Assert: _result_.[[Type]] is ~throw~.
-              1. Return Completion(_result_).
+              1. Return ? _result_.
             1. Return CreateIterResultObject(_resultValue_, *true*).
           1. Set _generator_.[[GeneratorContext]] to _genContext_.
           1. Set _generator_.[[GeneratorState]] to ~suspendedStart~.
-          1. Return NormalCompletion(*undefined*).
+          1. Return ~unused~.
         </emu-alg>
       </emu-clause>
 
@@ -44529,7 +44582,7 @@ THH:mm:ss.sss
           GeneratorValidate (
             _generator_: unknown,
             _generatorBrand_: unknown,
-          )
+          ): either a normal completion containing either ~suspendedStart~, ~suspendedYield~, or ~completed~, or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
@@ -44550,7 +44603,7 @@ THH:mm:ss.sss
             _generator_: unknown,
             _value_: unknown,
             _generatorBrand_: unknown,
-          )
+          ): either a normal completion containing an ECMAScript language value or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
@@ -44565,7 +44618,7 @@ THH:mm:ss.sss
           1. Push _genContext_ onto the execution context stack; _genContext_ is now the running execution context.
           1. <emu-meta effects="user-code">Resume the suspended evaluation of _genContext_</emu-meta> using NormalCompletion(_value_) as the result of the operation that suspended it. Let _result_ be the value returned by the resumed computation.
           1. Assert: When we return here, _genContext_ has already been removed from the execution context stack and _methodContext_ is the currently running execution context.
-          1. Return Completion(_result_).
+          1. Return ? _result_.
         </emu-alg>
       </emu-clause>
 
@@ -44573,9 +44626,9 @@ THH:mm:ss.sss
         <h1>
           GeneratorResumeAbrupt (
             _generator_: unknown,
-            _abruptCompletion_: a Completion Record whose [[Type]] is ~return~ or ~throw~,
+            _abruptCompletion_: a return completion or a throw completion,
             _generatorBrand_: unknown,
-          )
+          ): either a normal completion containing an ECMAScript language value or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
@@ -44588,21 +44641,21 @@ THH:mm:ss.sss
           1. If _state_ is ~completed~, then
             1. If _abruptCompletion_.[[Type]] is ~return~, then
               1. Return CreateIterResultObject(_abruptCompletion_.[[Value]], *true*).
-            1. Return Completion(_abruptCompletion_).
+            1. Return ? _abruptCompletion_.
           1. Assert: _state_ is ~suspendedYield~.
           1. Let _genContext_ be _generator_.[[GeneratorContext]].
           1. Let _methodContext_ be the running execution context.
           1. Suspend _methodContext_.
           1. Set _generator_.[[GeneratorState]] to ~executing~.
           1. Push _genContext_ onto the execution context stack; _genContext_ is now the running execution context.
-          1. <emu-meta effects="user-code">Resume the suspended evaluation of _genContext_</emu-meta> using _abruptCompletion_ as the result of the operation that suspended it. Let _result_ be the completion record returned by the resumed computation.
+          1. <emu-meta effects="user-code">Resume the suspended evaluation of _genContext_</emu-meta> using _abruptCompletion_ as the result of the operation that suspended it. Let _result_ be the Completion Record returned by the resumed computation.
           1. Assert: When we return here, _genContext_ has already been removed from the execution context stack and _methodContext_ is the currently running execution context.
-          1. Return Completion(_result_).
+          1. Return ? _result_.
         </emu-alg>
       </emu-clause>
 
       <emu-clause id="sec-getgeneratorkind" type="abstract operation">
-        <h1>GetGeneratorKind ( )</h1>
+        <h1>GetGeneratorKind ( ): ~non-generator~, ~sync~, or ~async~</h1>
         <dl class="header">
         </dl>
         <emu-alg>
@@ -44618,7 +44671,7 @@ THH:mm:ss.sss
         <h1>
           GeneratorYield (
             _iterNextObj_: an Object that conforms to the <i>IteratorResult</i> interface,
-          )
+          ): either a normal completion containing an ECMAScript language value or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
@@ -44629,10 +44682,10 @@ THH:mm:ss.sss
           1. Assert: GetGeneratorKind() is ~sync~.
           1. Set _generator_.[[GeneratorState]] to ~suspendedYield~.
           1. Remove _genContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
-          1. Set the code evaluation state of _genContext_ such that when evaluation is resumed with a Completion _resumptionValue_ the following steps will be performed:
+          1. Set the code evaluation state of _genContext_ such that when evaluation is resumed with a Completion Record _resumptionValue_ the following steps will be performed:
             1. Return _resumptionValue_.
             1. NOTE: This returns to the evaluation of the |YieldExpression| that originally called this abstract operation.
-          1. Return NormalCompletion(_iterNextObj_).
+          1. Return _iterNextObj_.
           1. NOTE: This returns to the evaluation of the operation that had most previously resumed evaluation of _genContext_.
         </emu-alg>
       </emu-clause>
@@ -44641,14 +44694,14 @@ THH:mm:ss.sss
         <h1>
           Yield (
             _value_: an ECMAScript language value,
-          )
+          ): either a normal completion containing an ECMAScript language value or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
         <emu-alg>
-          1. Let _generatorKind_ be ! GetGeneratorKind().
+          1. Let _generatorKind_ be GetGeneratorKind().
           1. If _generatorKind_ is ~async~, return ? AsyncGeneratorYield(_value_).
-          1. Otherwise, return ? GeneratorYield(! CreateIterResultObject(_value_, *false*)).
+          1. Otherwise, return ? GeneratorYield(CreateIterResultObject(_value_, *false*)).
         </emu-alg>
       </emu-clause>
 
@@ -44658,14 +44711,14 @@ THH:mm:ss.sss
             _closure_: an Abstract Closure with no parameters,
             _generatorBrand_: unknown,
             _generatorPrototype_: an Object,
-          )
+          ): a Generator
         </h1>
         <dl class="header">
         </dl>
         <emu-alg>
           1. NOTE: _closure_ can contain uses of the Yield shorthand to yield an IteratorResult object.
           1. Let _internalSlotsList_ be &laquo; [[GeneratorState]], [[GeneratorContext]], [[GeneratorBrand]] &raquo;.
-          1. Let _generator_ be ! OrdinaryObjectCreate(_generatorPrototype_, _internalSlotsList_).
+          1. Let _generator_ be OrdinaryObjectCreate(_generatorPrototype_, _internalSlotsList_).
           1. Set _generator_.[[GeneratorBrand]] to _generatorBrand_.
           1. Set _generator_.[[GeneratorState]] to *undefined*.
           1. Let _callerContext_ be the running execution context.
@@ -44675,7 +44728,7 @@ THH:mm:ss.sss
           1. Set the ScriptOrModule of _calleeContext_ to _callerContext_'s ScriptOrModule.
           1. If _callerContext_ is not already suspended, suspend _callerContext_.
           1. Push _calleeContext_ onto the execution context stack; _calleeContext_ is now the running execution context.
-          1. Perform ! GeneratorStart(_generator_, _closure_).
+          1. Perform GeneratorStart(_generator_, _closure_).
           1. Remove _calleeContext_ from the execution context stack and restore _callerContext_ as the running execution context.
           1. Return _generator_.
         </emu-alg>
@@ -44711,17 +44764,17 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _generator_ be the *this* value.
           1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
-          1. Let _result_ be AsyncGeneratorValidate(_generator_, ~empty~).
+          1. Let _result_ be Completion(AsyncGeneratorValidate(_generator_, ~empty~)).
           1. IfAbruptRejectPromise(_result_, _promiseCapability_).
           1. Let _state_ be _generator_.[[AsyncGeneratorState]].
           1. If _state_ is ~completed~, then
-            1. Let _iteratorResult_ be ! CreateIterResultObject(*undefined*, *true*).
+            1. Let _iteratorResult_ be CreateIterResultObject(*undefined*, *true*).
             1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _iteratorResult_ &raquo;).
             1. Return _promiseCapability_.[[Promise]].
           1. Let _completion_ be NormalCompletion(_value_).
-          1. Perform ! AsyncGeneratorEnqueue(_generator_, _completion_, _promiseCapability_).
+          1. Perform AsyncGeneratorEnqueue(_generator_, _completion_, _promiseCapability_).
           1. If _state_ is either ~suspendedStart~ or ~suspendedYield~, then
-            1. Perform ! AsyncGeneratorResume(_generator_, _completion_).
+            1. Perform AsyncGeneratorResume(_generator_, _completion_).
           1. Else,
             1. Assert: _state_ is either ~executing~ or ~awaiting-return~.
           1. Return _promiseCapability_.[[Promise]].
@@ -44733,16 +44786,16 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _generator_ be the *this* value.
           1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
-          1. Let _result_ be AsyncGeneratorValidate(_generator_, ~empty~).
+          1. Let _result_ be Completion(AsyncGeneratorValidate(_generator_, ~empty~)).
           1. IfAbruptRejectPromise(_result_, _promiseCapability_).
           1. Let _completion_ be Completion Record { [[Type]]: ~return~, [[Value]]: _value_, [[Target]]: ~empty~ }.
-          1. Perform ! AsyncGeneratorEnqueue(_generator_, _completion_, _promiseCapability_).
+          1. Perform AsyncGeneratorEnqueue(_generator_, _completion_, _promiseCapability_).
           1. Let _state_ be _generator_.[[AsyncGeneratorState]].
           1. If _state_ is either ~suspendedStart~ or ~completed~, then
             1. Set _generator_.[[AsyncGeneratorState]] to ~awaiting-return~.
             1. Perform ! AsyncGeneratorAwaitReturn(_generator_).
           1. Else if _state_ is ~suspendedYield~, then
-            1. Perform ! AsyncGeneratorResume(_generator_, _completion_).
+            1. Perform AsyncGeneratorResume(_generator_, _completion_).
           1. Else,
             1. Assert: _state_ is either ~executing~ or ~awaiting-return~.
           1. Return _promiseCapability_.[[Promise]].
@@ -44754,7 +44807,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _generator_ be the *this* value.
           1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
-          1. Let _result_ be AsyncGeneratorValidate(_generator_, ~empty~).
+          1. Let _result_ be Completion(AsyncGeneratorValidate(_generator_, ~empty~)).
           1. IfAbruptRejectPromise(_result_, _promiseCapability_).
           1. Let _state_ be _generator_.[[AsyncGeneratorState]].
           1. If _state_ is ~suspendedStart~, then
@@ -44764,9 +44817,9 @@ THH:mm:ss.sss
             1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _exception_ &raquo;).
             1. Return _promiseCapability_.[[Promise]].
           1. Let _completion_ be ThrowCompletion(_exception_).
-          1. Perform ! AsyncGeneratorEnqueue(_generator_, _completion_, _promiseCapability_).
+          1. Perform AsyncGeneratorEnqueue(_generator_, _completion_, _promiseCapability_).
           1. If _state_ is ~suspendedYield~, then
-            1. Perform ! AsyncGeneratorResume(_generator_, _completion_).
+            1. Perform AsyncGeneratorResume(_generator_, _completion_).
           1. Else,
             1. Assert: _state_ is either ~executing~ or ~awaiting-return~.
           1. Return _promiseCapability_.[[Promise]].
@@ -44826,7 +44879,7 @@ THH:mm:ss.sss
             <tr>
               <td>[[Completion]]</td>
               <td>a Completion Record</td>
-              <td>The completion which should be used to resume the async generator.</td>
+              <td>The Completion Record which should be used to resume the async generator.</td>
             </tr>
             <tr>
               <td>[[Capability]]</td>
@@ -44842,7 +44895,7 @@ THH:mm:ss.sss
           AsyncGeneratorStart (
             _generator_: an AsyncGenerator,
             _generatorBody_: a |FunctionBody| Parse Node or an Abstract Closure with no parameters,
-          )
+          ): ~unused~
         </h1>
         <dl class="header">
         </dl>
@@ -44855,19 +44908,19 @@ THH:mm:ss.sss
               1. Let _result_ be the result of evaluating _generatorBody_.
             1. Else,
               1. Assert: _generatorBody_ is an Abstract Closure with no parameters.
-              1. Let _result_ be _generatorBody_().
+              1. Let _result_ be Completion(_generatorBody_()).
             1. Assert: If we return here, the async generator either threw an exception or performed either an implicit or explicit return.
             1. Remove _genContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
             1. Set _generator_.[[AsyncGeneratorState]] to ~completed~.
             1. If _result_.[[Type]] is ~normal~, set _result_ to NormalCompletion(*undefined*).
             1. If _result_.[[Type]] is ~return~, set _result_ to NormalCompletion(_result_.[[Value]]).
-            1. Perform ! AsyncGeneratorCompleteStep(_generator_, _result_, *true*).
-            1. Perform ! AsyncGeneratorDrainQueue(_generator_).
+            1. Perform AsyncGeneratorCompleteStep(_generator_, _result_, *true*).
+            1. Perform AsyncGeneratorDrainQueue(_generator_).
             1. Return *undefined*.
           1. Set _generator_.[[AsyncGeneratorContext]] to _genContext_.
           1. Set _generator_.[[AsyncGeneratorState]] to ~suspendedStart~.
           1. Set _generator_.[[AsyncGeneratorQueue]] to a new empty List.
-          1. Return *undefined*.
+          1. Return ~unused~.
         </emu-alg>
       </emu-clause>
 
@@ -44876,7 +44929,7 @@ THH:mm:ss.sss
           AsyncGeneratorValidate (
             _generator_: unknown,
             _generatorBrand_: unknown,
-          )
+          ): either a normal completion containing ~unused~ or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
@@ -44885,6 +44938,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_generator_, [[AsyncGeneratorState]]).
           1. Perform ? RequireInternalSlot(_generator_, [[AsyncGeneratorQueue]]).
           1. If _generator_.[[GeneratorBrand]] is not the same value as _generatorBrand_, throw a *TypeError* exception.
+          1. Return ~unused~.
         </emu-alg>
       </emu-clause>
 
@@ -44894,13 +44948,14 @@ THH:mm:ss.sss
             _generator_: an AsyncGenerator,
             _completion_: a Completion Record,
             _promiseCapability_: a PromiseCapability Record,
-          )
+          ): ~unused~
         </h1>
         <dl class="header">
         </dl>
         <emu-alg>
           1. Let _request_ be AsyncGeneratorRequest { [[Completion]]: _completion_, [[Capability]]: _promiseCapability_ }.
           1. Append _request_ to the end of _generator_.[[AsyncGeneratorQueue]].
+          1. Return ~unused~.
         </emu-alg>
       </emu-clause>
 
@@ -44911,7 +44966,7 @@ THH:mm:ss.sss
             _completion_: a Completion Record,
             _done_: a Boolean,
             optional _realm_: a Realm Record,
-          )
+          ): ~unused~
         </h1>
         <dl class="header">
         </dl>
@@ -44929,11 +44984,12 @@ THH:mm:ss.sss
             1. If _realm_ is present, then
               1. Let _oldRealm_ be the running execution context's Realm.
               1. Set the running execution context's Realm to _realm_.
-              1. Let _iteratorResult_ be ! CreateIterResultObject(_value_, _done_).
+              1. Let _iteratorResult_ be CreateIterResultObject(_value_, _done_).
               1. Set the running execution context's Realm to _oldRealm_.
             1. Else,
-              1. Let _iteratorResult_ be ! CreateIterResultObject(_value_, _done_).
+              1. Let _iteratorResult_ be CreateIterResultObject(_value_, _done_).
             1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _iteratorResult_ &raquo;).
+          1. Return ~unused~.
         </emu-alg>
       </emu-clause>
 
@@ -44942,7 +44998,7 @@ THH:mm:ss.sss
           AsyncGeneratorResume (
             _generator_: an AsyncGenerator,
             _completion_: a Completion Record,
-          )
+          ): ~unused~
         </h1>
         <dl class="header">
         </dl>
@@ -44953,9 +45009,10 @@ THH:mm:ss.sss
           1. Suspend _callerContext_.
           1. Set _generator_.[[AsyncGeneratorState]] to ~executing~.
           1. Push _genContext_ onto the execution context stack; _genContext_ is now the running execution context.
-          1. <emu-meta effects="user-code">Resume the suspended evaluation of _genContext_</emu-meta> using _completion_ as the result of the operation that suspended it. Let _result_ be the completion record returned by the resumed computation.
+          1. <emu-meta effects="user-code">Resume the suspended evaluation of _genContext_</emu-meta> using _completion_ as the result of the operation that suspended it. Let _result_ be the Completion Record returned by the resumed computation.
           1. Assert: _result_ is never an abrupt completion.
           1. Assert: When we return here, _genContext_ has already been removed from the execution context stack and _callerContext_ is the currently running execution context.
+          1. Return ~unused~.
         </emu-alg>
       </emu-clause>
 
@@ -44963,14 +45020,14 @@ THH:mm:ss.sss
         <h1>
           AsyncGeneratorUnwrapYieldResumption (
             _resumptionValue_: a Completion Record,
-          )
+          ): either a normal completion containing an ECMAScript language value or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
         <emu-alg>
-          1. If _resumptionValue_.[[Type]] is not ~return~, return Completion(_resumptionValue_).
-          1. Let _awaited_ be Await(_resumptionValue_.[[Value]]).
-          1. If _awaited_.[[Type]] is ~throw~, return Completion(_awaited_).
+          1. If _resumptionValue_.[[Type]] is not ~return~, return ? _resumptionValue_.
+          1. Let _awaited_ be Completion(Await(_resumptionValue_.[[Value]])).
+          1. If _awaited_.[[Type]] is ~throw~, return ? _awaited_.
           1. Assert: _awaited_.[[Type]] is ~normal~.
           1. Return Completion Record { [[Type]]: ~return~, [[Value]]: _awaited_.[[Value]], [[Target]]: ~empty~ }.
         </emu-alg>
@@ -44980,7 +45037,7 @@ THH:mm:ss.sss
         <h1>
           AsyncGeneratorYield (
             _value_: unknown,
-          )
+          ): either a normal completion containing an ECMAScript language value or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
@@ -44994,18 +45051,18 @@ THH:mm:ss.sss
           1. Assert: The execution context stack has at least two elements.
           1. Let _previousContext_ be the second to top element of the execution context stack.
           1. Let _previousRealm_ be _previousContext_'s Realm.
-          1. Perform ! AsyncGeneratorCompleteStep(_generator_, _completion_, *false*, _previousRealm_).
+          1. Perform AsyncGeneratorCompleteStep(_generator_, _completion_, *false*, _previousRealm_).
           1. Let _queue_ be _generator_.[[AsyncGeneratorQueue]].
           1. If _queue_ is not empty, then
             1. NOTE: Execution continues without suspending the generator.
             1. Let _toYield_ be the first element of _queue_.
-            1. Let _resumptionValue_ be _toYield_.[[Completion]].
-            1. Return AsyncGeneratorUnwrapYieldResumption(_resumptionValue_).
+            1. Let _resumptionValue_ be Completion(_toYield_.[[Completion]]).
+            1. Return ? AsyncGeneratorUnwrapYieldResumption(_resumptionValue_).
           1. Else,
             1. Set _generator_.[[AsyncGeneratorState]] to ~suspendedYield~.
             1. Remove _genContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
-            1. Set the code evaluation state of _genContext_ such that when evaluation is resumed with a Completion _resumptionValue_ the following steps will be performed:
-              1. Return AsyncGeneratorUnwrapYieldResumption(_resumptionValue_).
+            1. Set the code evaluation state of _genContext_ such that when evaluation is resumed with a Completion Record _resumptionValue_ the following steps will be performed:
+              1. Return ? AsyncGeneratorUnwrapYieldResumption(_resumptionValue_).
               1. NOTE: When the above step returns, it returns to the evaluation of the |YieldExpression| production that originally called this abstract operation.
             1. Return *undefined*.
             1. NOTE: This returns to the evaluation of the operation that had most previously resumed evaluation of _genContext_.
@@ -45016,7 +45073,7 @@ THH:mm:ss.sss
         <h1>
           AsyncGeneratorAwaitReturn (
             _generator_: an AsyncGenerator,
-          )
+          ): either a normal completion containing ~unused~ or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
@@ -45024,24 +45081,25 @@ THH:mm:ss.sss
           1. Let _queue_ be _generator_.[[AsyncGeneratorQueue]].
           1. Assert: _queue_ is not empty.
           1. Let _next_ be the first element of _queue_.
-          1. Let _completion_ be _next_.[[Completion]].
+          1. Let _completion_ be Completion(_next_.[[Completion]]).
           1. Assert: _completion_.[[Type]] is ~return~.
           1. Let _promise_ be ? PromiseResolve(%Promise%, _completion_.[[Value]]).
           1. Let _fulfilledClosure_ be a new Abstract Closure with parameters (_value_) that captures _generator_ and performs the following steps when called:
             1. Set _generator_.[[AsyncGeneratorState]] to ~completed~.
             1. Let _result_ be NormalCompletion(_value_).
-            1. Perform ! AsyncGeneratorCompleteStep(_generator_, _result_, *true*).
-            1. Perform ! AsyncGeneratorDrainQueue(_generator_).
+            1. Perform AsyncGeneratorCompleteStep(_generator_, _result_, *true*).
+            1. Perform AsyncGeneratorDrainQueue(_generator_).
             1. Return *undefined*.
-          1. Let _onFulfilled_ be ! CreateBuiltinFunction(_fulfilledClosure_, 1, *""*, &laquo; &raquo;).
+          1. Let _onFulfilled_ be CreateBuiltinFunction(_fulfilledClosure_, 1, *""*, &laquo; &raquo;).
           1. Let _rejectedClosure_ be a new Abstract Closure with parameters (_reason_) that captures _generator_ and performs the following steps when called:
             1. Set _generator_.[[AsyncGeneratorState]] to ~completed~.
             1. Let _result_ be ThrowCompletion(_reason_).
-            1. Perform ! AsyncGeneratorCompleteStep(_generator_, _result_, *true*).
-            1. Perform ! AsyncGeneratorDrainQueue(_generator_).
+            1. Perform AsyncGeneratorCompleteStep(_generator_, _result_, *true*).
+            1. Perform AsyncGeneratorDrainQueue(_generator_).
             1. Return *undefined*.
-          1. Let _onRejected_ be ! CreateBuiltinFunction(_rejectedClosure_, 1, *""*, &laquo; &raquo;).
-          1. Perform ! PerformPromiseThen(_promise_, _onFulfilled_, _onRejected_).
+          1. Let _onRejected_ be CreateBuiltinFunction(_rejectedClosure_, 1, *""*, &laquo; &raquo;).
+          1. Perform PerformPromiseThen(_promise_, _onFulfilled_, _onRejected_).
+          1. Return ~unused~.
         </emu-alg>
       </emu-clause>
 
@@ -45049,20 +45107,20 @@ THH:mm:ss.sss
         <h1>
           AsyncGeneratorDrainQueue (
             _generator_: an AsyncGenerator,
-          )
+          ): ~unused~
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It drains the generator's AsyncGeneratorQueue until it encounters an AsyncGeneratorRequest which holds a completion whose type is ~return~.</dd>
+          <dd>It drains the generator's AsyncGeneratorQueue until it encounters an AsyncGeneratorRequest which holds a return completion.</dd>
         </dl>
         <emu-alg>
           1. Assert: _generator_.[[AsyncGeneratorState]] is ~completed~.
           1. Let _queue_ be _generator_.[[AsyncGeneratorQueue]].
-          1. If _queue_ is empty, return.
+          1. If _queue_ is empty, return ~unused~.
           1. Let _done_ be *false*.
           1. Repeat, while _done_ is *false*,
             1. Let _next_ be the first element of _queue_.
-            1. Let _completion_ be _next_.[[Completion]].
+            1. Let _completion_ be Completion(_next_.[[Completion]]).
             1. If _completion_.[[Type]] is ~return~, then
               1. Set _generator_.[[AsyncGeneratorState]] to ~awaiting-return~.
               1. Perform ! AsyncGeneratorAwaitReturn(_generator_).
@@ -45070,8 +45128,9 @@ THH:mm:ss.sss
             1. Else,
               1. If _completion_.[[Type]] is ~normal~, then
                 1. Set _completion_ to NormalCompletion(*undefined*).
-              1. Perform ! AsyncGeneratorCompleteStep(_generator_, _completion_, *true*).
+              1. Perform AsyncGeneratorCompleteStep(_generator_, _completion_, *true*).
               1. If _queue_ is empty, set _done_ to *true*.
+          1. Return ~unused~.
         </emu-alg>
       </emu-clause>
 
@@ -45081,14 +45140,14 @@ THH:mm:ss.sss
             _closure_: an Abstract Closure with no parameters,
             _generatorBrand_: unknown,
             _generatorPrototype_: an Object,
-          )
+          ): an AsyncGenerator
         </h1>
         <dl class="header">
         </dl>
         <emu-alg>
           1. NOTE: _closure_ can contain uses of the Await shorthand and uses of the Yield shorthand to yield an IteratorResult object.
           1. Let _internalSlotsList_ be &laquo; [[AsyncGeneratorState]], [[AsyncGeneratorContext]], [[AsyncGeneratorQueue]], [[GeneratorBrand]] &raquo;.
-          1. Let _generator_ be ! OrdinaryObjectCreate(_generatorPrototype_, _internalSlotsList_).
+          1. Let _generator_ be OrdinaryObjectCreate(_generatorPrototype_, _internalSlotsList_).
           1. Set _generator_.[[GeneratorBrand]] to _generatorBrand_.
           1. Set _generator_.[[AsyncGeneratorState]] to *undefined*.
           1. Let _callerContext_ be the running execution context.
@@ -45098,7 +45157,7 @@ THH:mm:ss.sss
           1. Set the ScriptOrModule of _calleeContext_ to _callerContext_'s ScriptOrModule.
           1. If _callerContext_ is not already suspended, suspend _callerContext_.
           1. Push _calleeContext_ onto the execution context stack; _calleeContext_ is now the running execution context.
-          1. Perform ! AsyncGeneratorStart(_generator_, _closure_).
+          1. Perform AsyncGeneratorStart(_generator_, _closure_).
           1. Remove _calleeContext_ from the execution context stack and restore _callerContext_ as the running execution context.
           1. Return _generator_.
         </emu-alg>
@@ -45129,7 +45188,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _C_ be the active function object.
           1. Let _args_ be the _argumentsList_ that was passed to this function by [[Call]] or [[Construct]].
-          1. Return CreateDynamicFunction(_C_, NewTarget, ~async~, _args_).
+          1. Return ? CreateDynamicFunction(_C_, NewTarget, ~async~, _args_).
         </emu-alg>
 
         <emu-note>See NOTE for <emu-xref href="#sec-function-p1-p2-pn-body"></emu-xref>.</emu-note>
@@ -45212,7 +45271,7 @@ THH:mm:ss.sss
           AsyncFunctionStart (
             _promiseCapability_: a PromiseCapability Record,
             _asyncFunctionBody_: unknown,
-          )
+          ): ~unused~
         </h1>
         <dl class="header">
         </dl>
@@ -45220,7 +45279,8 @@ THH:mm:ss.sss
           1. Let _runningContext_ be the running execution context.
           1. Let _asyncContext_ be a copy of _runningContext_.
           1. NOTE: Copying the execution state is required for AsyncBlockStart to resume its execution. It is ill-defined to resume a currently executing context.
-          1. Perform ! AsyncBlockStart(_promiseCapability_, _asyncFunctionBody_, _asyncContext_).
+          1. Perform AsyncBlockStart(_promiseCapability_, _asyncFunctionBody_, _asyncContext_).
+          1. Return ~unused~.
         </emu-alg>
       </emu-clause>
 
@@ -45230,7 +45290,7 @@ THH:mm:ss.sss
             _promiseCapability_: a PromiseCapability Record,
             _asyncBody_: a Parse Node,
             _asyncContext_: an execution context,
-          )
+          ): ~unused~
         </h1>
         <dl class="header">
         </dl>
@@ -45248,12 +45308,12 @@ THH:mm:ss.sss
             1. Else,
               1. Assert: _result_.[[Type]] is ~throw~.
               1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _result_.[[Value]] &raquo;).
-            1. [id="step-asyncblockstart-return-undefined"] Return.
+            1. [id="step-asyncblockstart-return-undefined"] Return ~unused~.
           1. Push _asyncContext_ onto the execution context stack; _asyncContext_ is now the running execution context.
           1. <emu-meta effects="user-code">Resume the suspended evaluation of _asyncContext_</emu-meta>. Let _result_ be the value returned by the resumed computation.
           1. Assert: When we return here, _asyncContext_ has already been removed from the execution context stack and _runningContext_ is the currently running execution context.
-          1. Assert: _result_ is a normal completion with a value of *undefined*. The possible sources of completion values are Await or, if the async function doesn't await anything, step <emu-xref href="#step-asyncblockstart-return-undefined"></emu-xref> above.
-          1. Return.
+          1. Assert: _result_ is a normal completion with a value of ~unused~. The possible sources of completion values are Await or, if the async function doesn't await anything, step <emu-xref href="#step-asyncblockstart-return-undefined"></emu-xref> above.
+          1. Return ~unused~.
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -45465,9 +45525,9 @@ THH:mm:ss.sss
             1. Set _p_.[[ProxyTarget]] to *null*.
             1. Set _p_.[[ProxyHandler]] to *null*.
             1. Return *undefined*.
-          1. Let _revoker_ be ! CreateBuiltinFunction(_revokerClosure_, 0, *""*, &laquo; [[RevocableProxy]] &raquo;).
+          1. Let _revoker_ be CreateBuiltinFunction(_revokerClosure_, 0, *""*, &laquo; [[RevocableProxy]] &raquo;).
           1. Set _revoker_.[[RevocableProxy]] to _p_.
-          1. Let _result_ be ! OrdinaryObjectCreate(%Object.prototype%).
+          1. Let _result_ be OrdinaryObjectCreate(%Object.prototype%).
           1. Perform ! CreateDataPropertyOrThrow(_result_, *"proxy"*, _p_).
           1. Perform ! CreateDataPropertyOrThrow(_result_, *"revoke"*, _revoker_).
           1. Return _result_.
@@ -45647,7 +45707,7 @@ THH:mm:ss.sss
         </tr>
         <tr>
           <td>[[AgentSignifier]]</td>
-          <td>a value that admits equality testing</td>
+          <td>an agent signifier</td>
           <td>The agent whose evaluation resulted in this ordering.</td>
         </tr>
         <tr>
@@ -45751,7 +45811,7 @@ THH:mm:ss.sss
       <h1>
         EventSet (
           _execution_: a candidate execution,
-        )
+        ): a Set of events
       </h1>
       <dl class="header">
       </dl>
@@ -45768,7 +45828,7 @@ THH:mm:ss.sss
       <h1>
         SharedDataBlockEventSet (
           _execution_: a candidate execution,
-        )
+        ): a Set of events
       </h1>
       <dl class="header">
       </dl>
@@ -45784,7 +45844,7 @@ THH:mm:ss.sss
       <h1>
         HostEventSet (
           _execution_: a candidate execution,
-        )
+        ): a Set of events
       </h1>
       <dl class="header">
       </dl>
@@ -45801,8 +45861,8 @@ THH:mm:ss.sss
         ComposeWriteEventBytes (
           _execution_: a candidate execution,
           _byteIndex_: a non-negative integer,
-          _Ws_: a List of WriteSharedMemory or ReadModifyWriteSharedMemory events,
-        )
+          _Ws_: a List of either WriteSharedMemory or ReadModifyWriteSharedMemory events,
+        ): a List of byte values
       </h1>
       <dl class="header">
       </dl>
@@ -45836,7 +45896,7 @@ THH:mm:ss.sss
         ValueOfReadEvent (
           _execution_: a candidate execution,
           _R_: a ReadSharedMemory or ReadModifyWriteSharedMemory event,
-        )
+        ): a List of byte values
       </h1>
       <dl class="header">
       </dl>
@@ -46813,13 +46873,13 @@ THH:mm:ss.sss
         <emu-grammar>ExtendedAtom :: `\` [lookahead == `c`]</emu-grammar>
         <emu-alg>
           1. Let _A_ be the CharSet containing the single character `\\` U+005C (REVERSE SOLIDUS).
-          1. Return ! CharacterSetMatcher(_A_, *false*, _direction_).
+          1. Return CharacterSetMatcher(_A_, *false*, _direction_).
         </emu-alg>
         <emu-grammar>ExtendedAtom :: ExtendedPatternCharacter</emu-grammar>
         <emu-alg>
           1. Let _ch_ be the character represented by |ExtendedPatternCharacter|.
           1. Let _A_ be a one-element CharSet containing the character _ch_.
-          1. Return ! CharacterSetMatcher(_A_, *false*, _direction_).
+          1. Return CharacterSetMatcher(_A_, *false*, _direction_).
         </emu-alg>
       </emu-annex>
 
@@ -46833,7 +46893,7 @@ THH:mm:ss.sss
           1. Let _A_ be CompileToCharSet of the first |ClassAtom|.
           1. Let _B_ be CompileToCharSet of the second |ClassAtom|.
           1. Let _C_ be CompileToCharSet of |ClassRanges|.
-          1. Let _D_ be ! CharacterRangeOrUnion(_A_, _B_).
+          1. Let _D_ be CharacterRangeOrUnion(_A_, _B_).
           1. Return the union of _D_ and _C_.
         </emu-alg>
         <emu-grammar>NonemptyClassRangesNoDash :: ClassAtomNoDash `-` ClassAtom ClassRanges</emu-grammar>
@@ -46841,7 +46901,7 @@ THH:mm:ss.sss
           1. Let _A_ be CompileToCharSet of |ClassAtomNoDash|.
           1. Let _B_ be CompileToCharSet of |ClassAtom|.
           1. Let _C_ be CompileToCharSet of |ClassRanges|.
-          1. Let _D_ be ! CharacterRangeOrUnion(_A_, _B_).
+          1. Let _D_ be CharacterRangeOrUnion(_A_, _B_).
           1. Return the union of _D_ and _C_.
         </emu-alg>
 
@@ -46864,7 +46924,7 @@ THH:mm:ss.sss
             CharacterRangeOrUnion (
               _A_: a CharSet,
               _B_: a CharSet,
-            )
+            ): a CharSet
           </h1>
           <dl class="header">
           </dl>
@@ -46873,7 +46933,7 @@ THH:mm:ss.sss
               1. If _A_ does not contain exactly one character or _B_ does not contain exactly one character, then
                 1. Let _C_ be the CharSet containing the single character `-` U+002D (HYPHEN-MINUS).
                 1. Return the union of CharSets _A_, _B_ and _C_.
-            1. Return ! CharacterRange(_A_, _B_).
+            1. Return CharacterRange(_A_, _B_).
           </emu-alg>
         </emu-annex>
       </emu-annex>
@@ -47030,7 +47090,7 @@ THH:mm:ss.sss
               _tag_: a String,
               _attribute_: a String,
               _value_: unknown,
-            )
+            ): either a normal completion containing a String or an abrupt completion
           </h1>
           <dl class="header">
           </dl>
@@ -47343,14 +47403,14 @@ THH:mm:ss.sss
                 1. NOTE: A var binding for _F_ is only instantiated here if it is neither a VarDeclaredName, the name of a formal parameter, or another |FunctionDeclaration|.
                 1. If _initializedBindings_ does not contain _F_ and _F_ is not *"arguments"*, then
                   1. Perform ! _varEnv_.CreateMutableBinding(_F_, *false*).
-                  1. Perform _varEnv_.InitializeBinding(_F_, *undefined*).
+                  1. Perform ! _varEnv_.InitializeBinding(_F_, *undefined*).
                   1. Append _F_ to _instantiatedVarNames_.
                 1. When the |FunctionDeclaration| _f_ is evaluated, perform the following steps in place of the |FunctionDeclaration| Evaluation algorithm provided in <emu-xref href="#sec-function-definitions-runtime-semantics-evaluation"></emu-xref>:
                   1. Let _fenv_ be the running execution context's VariableEnvironment.
                   1. Let _benv_ be the running execution context's LexicalEnvironment.
                   1. Let _fobj_ be ! _benv_.GetBindingValue(_F_, *false*).
                   1. Perform ! _fenv_.SetMutableBinding(_F_, _fobj_, *false*).
-                  1. Return NormalCompletion(~empty~).
+                  1. Return ~unused~.
         </emu-alg>
       </emu-annex>
 
@@ -47376,7 +47436,7 @@ THH:mm:ss.sss
                       1. Let _benv_ be the running execution context's LexicalEnvironment.
                       1. Let _fobj_ be ! _benv_.GetBindingValue(_F_, *false*).
                       1. Perform ? <emu-meta effects="user-code">_genv_.SetMutableBinding</emu-meta>(_F_, _fobj_, *false*).
-                      1. Return NormalCompletion(~empty~).
+                      1. Return ~unused~.
         </emu-alg>
       </emu-annex>
 
@@ -47394,7 +47454,7 @@ THH:mm:ss.sss
                 1. Assert: The following loop will terminate.
                 1. Repeat, while _thisEnv_ is not the same as _varEnv_,
                   1. If _thisEnv_ is not an object Environment Record, then
-                    1. If _thisEnv_.HasBinding(_F_) is *true*, then
+                    1. If ! _thisEnv_.HasBinding(_F_) is *true*, then
                       1. [id="step-evaldeclarationinstantiation-web-compat-bindingexists"] Let _bindingExists_ be *true*.
                   1. Set _thisEnv_ to _thisEnv_.[[OuterEnv]].
                 1. If _bindingExists_ is *false* and _varEnv_ is a global Environment Record, then
@@ -47409,7 +47469,7 @@ THH:mm:ss.sss
                     1. If _varEnv_ is a global Environment Record, then
                       1. Perform ? _varEnv_.CreateGlobalVarBinding(_F_, *true*).
                     1. Else,
-                      1. Let _bindingExists_ be _varEnv_.HasBinding(_F_).
+                      1. Let _bindingExists_ be ! _varEnv_.HasBinding(_F_).
                       1. If _bindingExists_ is *false*, then
                         1. Perform ! _varEnv_.CreateMutableBinding(_F_, *true*).
                         1. Perform ! _varEnv_.InitializeBinding(_F_, *undefined*).
@@ -47419,7 +47479,7 @@ THH:mm:ss.sss
                     1. Let _benv_ be the running execution context's LexicalEnvironment.
                     1. Let _fobj_ be ! _benv_.GetBindingValue(_F_, *false*).
                     1. Perform ? <emu-meta effects="user-code">_genv_.SetMutableBinding</emu-meta>(_F_, _fobj_, *false*).
-                    1. Return NormalCompletion(~empty~).
+                    1. Return ~unused~.
         </emu-alg>
       </emu-annex>
 
@@ -47455,16 +47515,16 @@ THH:mm:ss.sss
         <h1>Changes to BlockDeclarationInstantiation</h1>
         <p>During BlockDeclarationInstantiation the following steps are performed in place of step <emu-xref href="#step-blockdeclarationinstantiation-createmutablebinding"></emu-xref>:</p>
         <emu-alg replaces-step="step-blockdeclarationinstantiation-createmutablebinding">
-          1. If _env_.HasBinding(_dn_) is *false*, then
+          1. If ! _env_.HasBinding(_dn_) is *false*, then
             1. Perform ! _env_.CreateMutableBinding(_dn_, *false*).
         </emu-alg>
         <p>During BlockDeclarationInstantiation the following steps are performed in place of step <emu-xref href="#step-blockdeclarationinstantiation-initializebinding"></emu-xref>:</p>
         <emu-alg replaces-step="step-blockdeclarationinstantiation-initializebinding">
           1. If the binding for _fn_ in _env_ is an uninitialized binding, then
-            1. Perform _env_.InitializeBinding(_fn_, _fo_).
+            1. Perform ! _env_.InitializeBinding(_fn_, _fo_).
           1. Else,
             1. Assert: _d_ is a |FunctionDeclaration|.
-            1. Perform _env_.SetMutableBinding(_fn_, _fo_, *false*).
+            1. Perform ! _env_.SetMutableBinding(_fn_, _fo_, *false*).
         </emu-alg>
       </emu-annex>
     </emu-annex>
@@ -47564,7 +47624,7 @@ THH:mm:ss.sss
         1. Let _bindingId_ be StringValue of |BindingIdentifier|.
         1. Let _lhs_ be ? ResolveBinding(_bindingId_).
         1. If IsAnonymousFunctionDefinition(|Initializer|) is *true*, then
-          1. Let _value_ be NamedEvaluation of |Initializer| with argument _bindingId_.
+          1. Let _value_ be ? NamedEvaluation of |Initializer| with argument _bindingId_.
         1. Else,
           1. Let _rhs_ be the result of evaluating |Initializer|.
           1. Let _value_ be ? GetValue(_rhs_).
@@ -47768,9 +47828,9 @@ THH:mm:ss.sss
   <p><emu-xref href="#sec-iteration-statements"></emu-xref>: In ECMAScript 2015, if the `(` token of a for statement is immediately followed by the token sequence `let [` then the `let` is treated as the start of a |LexicalDeclaration|. In previous editions such a token sequence would be the start of an |Expression|.</p>
   <p><emu-xref href="#sec-iteration-statements"></emu-xref>: In ECMAScript 2015, if the ( token of a for-in statement is immediately followed by the token sequence `let [` then the `let` is treated as the start of a |ForDeclaration|. In previous editions such a token sequence would be the start of an |LeftHandSideExpression|.</p>
   <p><emu-xref href="#sec-iteration-statements"></emu-xref>: Prior to ECMAScript 2015, an initialization expression could appear as part of the |VariableDeclaration| that precedes the `in` keyword. In ECMAScript 2015, the |ForBinding| in that same position does not allow the occurrence of such an initializer. In ECMAScript 2017, such an initializer is permitted only in non-strict code.</p>
-  <p><emu-xref href="#sec-iteration-statements"></emu-xref>: In ECMAScript 2015, the completion value of an |IterationStatement| is never the value ~empty~. If the |Statement| part of an |IterationStatement| is not evaluated or if the final evaluation of the |Statement| part produces a completion whose value is ~empty~, the completion value of the |IterationStatement| is *undefined*.</p>
-  <p><emu-xref href="#sec-with-statement-runtime-semantics-evaluation"></emu-xref>: In ECMAScript 2015, the normal completion value of a |WithStatement| is never the value ~empty~. If evaluation of the |Statement| part of a |WithStatement| produces a normal completion whose value is ~empty~, the completion value of the |WithStatement| is *undefined*.</p>
-  <p><emu-xref href="#sec-switch-statement-runtime-semantics-evaluation"></emu-xref>: In ECMAScript 2015, the completion value of a |SwitchStatement| is never the value ~empty~. If the |CaseBlock| part of a |SwitchStatement| produces a completion whose value is ~empty~, the completion value of the |SwitchStatement| is *undefined*.</p>
+  <p><emu-xref href="#sec-iteration-statements"></emu-xref>: In ECMAScript 2015, the result of evaluating an |IterationStatement| is never a normal completion whose [[Value]] is ~empty~. If the |Statement| part of an |IterationStatement| is not evaluated or if the final evaluation of the |Statement| part produces a normal completion whose [[Value]] is ~empty~, the result of evaluating the |IterationStatement| is a normal completion whose [[Value]] is *undefined*.</p>
+  <p><emu-xref href="#sec-with-statement-runtime-semantics-evaluation"></emu-xref>: In ECMAScript 2015, the result of evaluating a |WithStatement| is never a normal completion whose [[Value]] is ~empty~. If evaluation of the |Statement| part of a |WithStatement| produces a normal completion whose [[Value]] is ~empty~, the result of evaluating the |WithStatement| is a normal completion whose [[Value]] is *undefined*.</p>
+  <p><emu-xref href="#sec-switch-statement-runtime-semantics-evaluation"></emu-xref>: In ECMAScript 2015, the result of evaluating a |SwitchStatement| is never a normal completion whose [[Value]] is ~empty~. If evaluation of the |CaseBlock| part of a |SwitchStatement| produces a normal completion whose [[Value]] is ~empty~, the result of evaluating the |SwitchStatement| is a normal completion whose [[Value]] is *undefined*.</p>
   <p><emu-xref href="#sec-try-statement"></emu-xref>: In ECMAScript 2015, it is an early error for a |Catch| clause to contain a `var` declaration for the same |Identifier| that appears as the |Catch| clause parameter. In previous editions, such a variable declaration would be instantiated in the enclosing variable environment but the declaration's |Initializer| value would be assigned to the |Catch| parameter.</p>
   <p><emu-xref href="#sec-try-statement"></emu-xref>, <emu-xref href="#sec-evaldeclarationinstantiation"></emu-xref>: In ECMAScript 2015, a runtime *SyntaxError* is thrown if a |Catch| clause evaluates a non-strict direct `eval` whose eval code includes a `var` or `FunctionDeclaration` declaration that binds the same |Identifier| that appears as the |Catch| clause parameter.</p>
   <p><emu-xref href="#sec-try-statement-runtime-semantics-evaluation"></emu-xref>: In ECMAScript 2015, the completion value of a |TryStatement| is never the value ~empty~. If the |Block| part of a |TryStatement| evaluates to a normal completion whose value is ~empty~, the completion value of the |TryStatement| is *undefined*. If the |Block| part of a |TryStatement| evaluates to a throw completion and it has a |Catch| part that evaluates to a normal completion whose value is ~empty~, the completion value of the |TryStatement| is *undefined* if there is no |Finally| clause or if its |Finally| clause evaluates to an ~empty~ normal completion.</p>


### PR DESCRIPTION
Ready for review. Based on #2546. Fixes #1796. Fixes #497. Fixes #496. Closes #1916. Fixes #253. Fixes #1572. Closes #486. Closes #2612. Fixes #2645.

1. [x] remove the provision for implicit wrapping in normal completion
1. [x] remove the provision for treating normal completions as their [[Value]]
1. [x] annotate return types
1. [x] make sure every AO has a return type specified; figure out what to do with any remaining explicit "unknown" returns
1. [x] see if we can replace any `~empty~` returns with `~unused~`
1. [x] make sure all internal methods with the same name have matching return types
1. [x] make sure all concrete methods with the same name have matching return types
1. [x] call sites for AOs that return completion records should use `?`/`!`/`Completion()`; call sites for AOs that do not return completion records should not use `!`/`?`/`Completion()`
1. [x] make sure that each AO that doesn't return a completion record also doesn't contain a step that uses `ReturnIfAbrupt`/`?`/`throw`
1. [x] make sure that each AO that does return a completion record might plausibly return an abrupt completion, i.e. it uses `?` or `throw` or `ReturnIfAbrupt` or returns a completion explicitly
1. [x] make sure that all AOs that return `~unused~` are always invoked using "Perform". if it's a completion record that normally contains `~unused~`, make sure only its `[[Type]]` is relied upon.
1. [x] If an AO is only ever invoked using "Perform", it should return `~unused~` or a completion record that normally contains `~unused~`
1. [x] find any AOs that return completion records but are always called using `!` and make them not return completion records
1. [x] add notational convention for wrapping of returns in `NormalCompletion` in AOs that return completion records; except `Completion` or `ThrowCompletion` or `NormalCompletion`
1. [x] replace `return Completion(X)` with  `return ? X` in AOs that return a completion record
1. [x] make sure that all uses of `Completion()` are on the call of an AO that returns a completion, field accesses, or some other opaque source
1. [x] go through each AO that returns a completion record with unknown normal type and see if we can further refine it
1. [x] make sure we're not returning `Completion(...)` or `Completion Record { ... }` or `NormalCompletion(...)` or `ThrowCompletion(...)` in algorithms that don't return completion records
1. [x] check as many of the above as possible in ecmarkup and bump ecmarkup
1. [x] go through effect suppressions and make sure they are still valid and necessary
1. [x] go through issues mentioned in #2548 and make sure they are addressed here
1. [ ] add visual indicator to AO headers when the AO returns a completion record
1. [x] explain what "a Completion Record normally containing an X" means; maybe think of better phrasing?