### PR TITLE
Editorial: Can-call-user-code annotation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -485,9 +485,9 @@
       }
     },
     "debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
       "requires": {
         "ms": "2.1.2"
       }
@@ -533,21 +533,21 @@
       }
     },
     "ecmarkdown": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/ecmarkdown/-/ecmarkdown-6.0.2.tgz",
-      "integrity": "sha512-I5ASKhWOFShuvmb1BOr8TTsULSw9Qo6mvFGup9eEyYoAZGHeN/0mbtmrUe7ZOAwx7/On0i8AsSOObEu6MqPTMg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ecmarkdown/-/ecmarkdown-7.0.0.tgz",
+      "integrity": "sha512-hJxPALjSOpSMMcFjSzwzJBk8EWOu20mYlTfV7BnVTh9er0FEaT2eSx16y36YxqQfdFxPUsa0CSH4fLf0qUclKw==",
       "requires": {
         "escape-html": "^1.0.1"
       }
     },
     "ecmarkup": {
-      "version": "9.6.3",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-9.6.3.tgz",
-      "integrity": "sha512-YLskqCc1m6oX7NdmG0LXJTMjt2nlAYqX4MQn1YdRu+TLTO7CtIBWreHyslSWNMyg39auUbGgcXCltFlBGpqCXw==",
+      "version": "9.7.1",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-9.7.1.tgz",
+      "integrity": "sha512-C7tbTrp5OFGB/4E2vaaJGfRK2bK+Ihp2MoI0f6sujpxSdNHiJP5ZYmYp3EbzQwKOmcxr/FtaMoPp7/fRpD0Q5Q==",
       "requires": {
         "chalk": "^1.1.3",
         "dedent-js": "^1.0.1",
-        "ecmarkdown": "^6.0.2",
+        "ecmarkdown": "^7.0.0",
         "eslint": "^7.29.0",
         "fast-glob": "^3.2.7",
         "grammarkdown": "3.1.2",
@@ -1840,9 +1840,9 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
     },
     "table": {
-      "version": "6.7.3",
-      "resolved": "https://registry.npmjs.org/table/-/table-6.7.3.tgz",
-      "integrity": "sha512-5DkIxeA7XERBqMwJq0aHZOdMadBx4e6eDoFRuyT5VR82J0Ycg2DwM6GfA/EQAhJ+toRTaS1lIdSQCqgrmhPnlw==",
+      "version": "6.7.5",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.7.5.tgz",
+      "integrity": "sha512-LFNeryOqiQHqCVKzhkymKwt6ozeRhlm8IL1mE8rNUurkir4heF6PzMyRgaTa4tlyPTGGgXuvVOF/OLWiH09Lqw==",
       "requires": {
         "ajv": "^8.0.1",
         "lodash.truncate": "^4.4.2",
@@ -1852,9 +1852,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "8.8.1",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.1.tgz",
-          "integrity": "sha512-6CiMNDrzv0ZR916u2T+iRunnD60uWmNn8SkdB44/6stVORUg0aAkWO7PkOhpCmjmW8f2I/G/xnowD66fxGyQJg==",
+          "version": "8.8.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
+          "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "license": "SEE LICENSE IN https://tc39.es/ecma262/#sec-copyright-and-software-license",
   "homepage": "https://tc39.es/ecma262/",
   "dependencies": {
-    "ecmarkup": "9.6.3"
+    "ecmarkup": "^9.7.1"
   },
   "devDependencies": {
     "glob": "^7.1.6",

--- a/spec.html
+++ b/spec.html
@@ -4047,7 +4047,7 @@
             1. Let _prevContext_ be the running execution context.
             1. Suspend _prevContext_.
             1. Push _asyncContext_ onto the execution context stack; _asyncContext_ is now the running execution context.
-            1. Resume the suspended evaluation of _asyncContext_ using NormalCompletion(_value_) as the result of the operation that suspended it.
+            1. <emu-meta effects="user-code">Resume the suspended evaluation of _asyncContext_</emu-meta> using NormalCompletion(_value_) as the result of the operation that suspended it.
             1. Assert: When we reach this step, _asyncContext_ has already been removed from the execution context stack and _prevContext_ is the currently running execution context.
             1. Return *undefined*.
           1. Let _onFulfilled_ be ! CreateBuiltinFunction(_fulfilledClosure_, 1, *""*, &laquo; &raquo;).
@@ -4055,7 +4055,7 @@
             1. Let _prevContext_ be the running execution context.
             1. Suspend _prevContext_.
             1. Push _asyncContext_ onto the execution context stack; _asyncContext_ is now the running execution context.
-            1. Resume the suspended evaluation of _asyncContext_ using ThrowCompletion(_reason_) as the result of the operation that suspended it.
+            1. <emu-meta effects="user-code">Resume the suspended evaluation of _asyncContext_</emu-meta> using ThrowCompletion(_reason_) as the result of the operation that suspended it.
             1. Assert: When we reach this step, _asyncContext_ has already been removed from the execution context stack and _prevContext_ is the currently running execution context.
             1. Return *undefined*.
           1. Let _onRejected_ be ! CreateBuiltinFunction(_rejectedClosure_, 1, *""*, &laquo; &raquo;).
@@ -4246,11 +4246,11 @@
             1. [id="step-getvalue-toobject"] Let _baseObj_ be ? ToObject(_V_.[[Base]]).
             1. If IsPrivateReference(_V_) is *true*, then
               1. Return ? PrivateGet(_baseObj_, _V_.[[ReferencedName]]).
-            1. Return ? _baseObj_.[[Get]](_V_.[[ReferencedName]], GetThisValue(_V_)).
+            1. Return ? <emu-meta effects="user-code">_baseObj_.[[Get]]</emu-meta>(_V_.[[ReferencedName]], GetThisValue(_V_)).
           1. Else,
             1. Let _base_ be _V_.[[Base]].
             1. Assert: _base_ is an Environment Record.
-            1. Return ? _base_.GetBindingValue(_V_.[[ReferencedName]], _V_.[[Strict]]) (see <emu-xref href="#sec-environment-records"></emu-xref>).
+            1. Return ? <emu-meta effects="user-code">_base_.GetBindingValue</emu-meta>(_V_.[[ReferencedName]], _V_.[[Strict]]) (see <emu-xref href="#sec-environment-records"></emu-xref>).
         </emu-alg>
         <emu-note>
           <p>The object that may be created in step <emu-xref href="#step-getvalue-toobject"></emu-xref> is not accessible outside of the above abstract operation and the ordinary object [[Get]] internal method. An implementation might choose to avoid the actual creation of the object.</p>
@@ -4278,13 +4278,13 @@
             1. [id="step-putvalue-toobject"] Let _baseObj_ be ? ToObject(_V_.[[Base]]).
             1. If IsPrivateReference(_V_) is *true*, then
               1. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
-            1. Let _succeeded_ be ? _baseObj_.[[Set]](_V_.[[ReferencedName]], _W_, GetThisValue(_V_)).
+            1. Let _succeeded_ be ? <emu-meta effects="user-code">_baseObj_.[[Set]]</emu-meta>(_V_.[[ReferencedName]], _W_, GetThisValue(_V_)).
             1. If _succeeded_ is *false* and _V_.[[Strict]] is *true*, throw a *TypeError* exception.
             1. Return.
           1. Else,
             1. Let _base_ be _V_.[[Base]].
             1. Assert: _base_ is an Environment Record.
-            1. Return ? _base_.SetMutableBinding(_V_.[[ReferencedName]], _W_, _V_.[[Strict]]) (see <emu-xref href="#sec-environment-records"></emu-xref>).
+            1. Return ? <emu-meta effects="user-code">_base_.SetMutableBinding</emu-meta>(_V_.[[ReferencedName]], _W_, _V_.[[Strict]]) (see <emu-xref href="#sec-environment-records"></emu-xref>).
         </emu-alg>
         <emu-note>
           <p>The object that may be created in step <emu-xref href="#step-putvalue-toobject"></emu-xref> is not accessible outside of the above abstract operation and the ordinary object [[Set]] internal method. An implementation might choose to avoid the actual creation of that object.</p>
@@ -5968,7 +5968,7 @@
         <dd>It returns a completion record which, if its [[Type]] is ~normal~, has a [[Value]] which is a Boolean. It is used to determine whether additional properties can be added to _O_.</dd>
       </dl>
       <emu-alg>
-        1. Return ? _O_.[[IsExtensible]]().
+        1. Return ? <emu-meta effects="user-code">_O_.[[IsExtensible]]</emu-meta>().
       </emu-alg>
     </emu-clause>
 
@@ -6297,7 +6297,7 @@
         <dd>It is used to retrieve the value of a specific property of an object.</dd>
       </dl>
       <emu-alg>
-        1. Return ? _O_.[[Get]](_P_, _O_).
+        1. Return ? <emu-meta effects="user-code">_O_.[[Get]]</emu-meta>(_P_, _O_).
       </emu-alg>
     </emu-clause>
 
@@ -6314,7 +6314,7 @@
       </dl>
       <emu-alg>
         1. Let _O_ be ? ToObject(_V_).
-        1. Return ? _O_.[[Get]](_P_, _V_).
+        1. Return ? <emu-meta effects="user-code">_O_.[[Get]]</emu-meta>(_P_, _V_).
       </emu-alg>
     </emu-clause>
 
@@ -6332,7 +6332,7 @@
         <dd>It is used to set the value of a specific property of an object. _V_ is the new value for the property.</dd>
       </dl>
       <emu-alg>
-        1. Let _success_ be ? _O_.[[Set]](_P_, _V_, _O_).
+        1. Let _success_ be ? <emu-meta effects="user-code">_O_.[[Set]]</emu-meta>(_P_, _V_, _O_).
         1. If _success_ is *false* and _Throw_ is *true*, throw a *TypeError* exception.
         1. Return _success_.
       </emu-alg>
@@ -6352,7 +6352,7 @@
       </dl>
       <emu-alg>
         1. Let _newDesc_ be the PropertyDescriptor { [[Value]]: _V_, [[Writable]]: *true*, [[Enumerable]]: *true*, [[Configurable]]: *true* }.
-        1. Return ? _O_.[[DefineOwnProperty]](_P_, _newDesc_).
+        1. Return ? <emu-meta effects="user-code">_O_.[[DefineOwnProperty]]</emu-meta>(_P_, _newDesc_).
       </emu-alg>
       <emu-note>
         <p>This abstract operation creates a property whose attributes are set to the same defaults used for properties created by the ECMAScript language assignment operator. Normally, the property will not already exist. If it does exist and is not configurable or if _O_ is not extensible, [[DefineOwnProperty]] will return *false*.</p>
@@ -6373,7 +6373,7 @@
       </dl>
       <emu-alg>
         1. Let _newDesc_ be the PropertyDescriptor { [[Value]]: _V_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.
-        1. Return ? _O_.[[DefineOwnProperty]](_P_, _newDesc_).
+        1. Return ? <emu-meta effects="user-code">_O_.[[DefineOwnProperty]]</emu-meta>(_P_, _newDesc_).
       </emu-alg>
       <emu-note>
         <p>This abstract operation creates a property whose attributes are set to the same defaults used for built-in methods and methods defined using class declaration syntax. Normally, the property will not already exist. If it does exist and is not configurable or if _O_ is not extensible, [[DefineOwnProperty]] will return *false*.</p>
@@ -6436,7 +6436,7 @@
         <dd>It is used to call the [[DefineOwnProperty]] internal method of an object in a manner that will throw a *TypeError* exception if the requested property update cannot be performed.</dd>
       </dl>
       <emu-alg>
-        1. Let _success_ be ? _O_.[[DefineOwnProperty]](_P_, _desc_).
+        1. Let _success_ be ? <emu-meta effects="user-code">_O_.[[DefineOwnProperty]]</emu-meta>(_P_, _desc_).
         1. If _success_ is *false*, throw a *TypeError* exception.
         1. Return _success_.
       </emu-alg>
@@ -6454,7 +6454,7 @@
         <dd>It is used to remove a specific own property of an object. It throws an exception if the property is not configurable.</dd>
       </dl>
       <emu-alg>
-        1. Let _success_ be ? _O_.[[Delete]](_P_).
+        1. Let _success_ be ? <emu-meta effects="user-code">_O_.[[Delete]]</emu-meta>(_P_).
         1. If _success_ is *false*, throw a *TypeError* exception.
         1. Return _success_.
       </emu-alg>
@@ -6491,7 +6491,7 @@
         <dd>It returns a completion record which, if its [[Type]] is ~normal~, has a [[Value]] which is a Boolean. It is used to determine whether an object has a property with the specified property key. The property may be either an own or inherited.</dd>
       </dl>
       <emu-alg>
-        1. Return ? _O_.[[HasProperty]](_P_).
+        1. Return ? <emu-meta effects="user-code">_O_.[[HasProperty]]</emu-meta>(_P_).
       </emu-alg>
     </emu-clause>
 
@@ -6507,7 +6507,7 @@
         <dd>It returns a completion record which, if its [[Type]] is ~normal~, has a [[Value]] which is a Boolean. It is used to determine whether an object has an own property with the specified property key.</dd>
       </dl>
       <emu-alg>
-        1. Let _desc_ be ? _O_.[[GetOwnProperty]](_P_).
+        1. Let _desc_ be ? <emu-meta effects="user-code">_O_.[[GetOwnProperty]]</emu-meta>(_P_).
         1. If _desc_ is *undefined*, return *false*.
         1. Return *true*.
       </emu-alg>
@@ -6528,7 +6528,7 @@
       <emu-alg>
         1. If _argumentsList_ is not present, set _argumentsList_ to a new empty List.
         1. If IsCallable(_F_) is *false*, throw a *TypeError* exception.
-        1. Return ? _F_.[[Call]](_V_, _argumentsList_).
+        1. Return ? <emu-meta effects="user-code">_F_.[[Call]]</emu-meta>(_V_, _argumentsList_).
       </emu-alg>
     </emu-clause>
 
@@ -6547,7 +6547,7 @@
       <emu-alg>
         1. If _newTarget_ is not present, set _newTarget_ to _F_.
         1. If _argumentsList_ is not present, set _argumentsList_ to a new empty List.
-        1. Return ? _F_.[[Construct]](_argumentsList_, _newTarget_).
+        1. Return ? <emu-meta effects="user-code">_F_.[[Construct]]</emu-meta>(_argumentsList_, _newTarget_).
       </emu-alg>
       <emu-note>
         <p>If _newTarget_ is not present, this operation is equivalent to: `new F(...argumentsList)`</p>
@@ -6575,7 +6575,7 @@
         1. Else,
           1. Assert: _level_ is ~frozen~.
           1. For each element _k_ of _keys_, do
-            1. Let _currentDesc_ be ? _O_.[[GetOwnProperty]](_k_).
+            1. Let _currentDesc_ be ? <emu-meta effects="user-code">_O_.[[GetOwnProperty]]</emu-meta>(_k_).
             1. If _currentDesc_ is not *undefined*, then
               1. If IsAccessorDescriptor(_currentDesc_) is *true*, then
                 1. Let _desc_ be the PropertyDescriptor { [[Configurable]]: *false* }.
@@ -6603,7 +6603,7 @@
         1. NOTE: If the object is extensible, none of its properties are examined.
         1. Let _keys_ be ? _O_.[[OwnPropertyKeys]]().
         1. For each element _k_ of _keys_, do
-          1. Let _currentDesc_ be ? _O_.[[GetOwnProperty]](_k_).
+          1. Let _currentDesc_ be ? <emu-meta effects="user-code">_O_.[[GetOwnProperty]]</emu-meta>(_k_).
           1. If _currentDesc_ is not *undefined*, then
             1. If _currentDesc_.[[Configurable]] is *true*, return *false*.
             1. If _level_ is ~frozen~ and IsDataDescriptor(_currentDesc_) is *true*, then
@@ -6721,7 +6721,7 @@
         1. Let _P_ be ? Get(_C_, *"prototype"*).
         1. If Type(_P_) is not Object, throw a *TypeError* exception.
         1. Repeat,
-          1. Set _O_ to ? _O_.[[GetPrototypeOf]]().
+          1. Set _O_ to ? <emu-meta effects="user-code">_O_.[[GetPrototypeOf]]</emu-meta>().
           1. If _O_ is *null*, return *false*.
           1. If SameValue(_P_, _O_) is *true*, return *true*.
       </emu-alg>
@@ -6759,11 +6759,11 @@
       <dl class="header">
       </dl>
       <emu-alg>
-        1. Let _ownKeys_ be ? _O_.[[OwnPropertyKeys]]().
+        1. Let _ownKeys_ be ? <emu-meta effects="user-code">_O_.[[OwnPropertyKeys]]</emu-meta>().
         1. Let _properties_ be a new empty List.
         1. For each element _key_ of _ownKeys_, do
           1. If Type(_key_) is String, then
-            1. Let _desc_ be ? _O_.[[GetOwnProperty]](_key_).
+            1. Let _desc_ be ? <emu-meta effects="user-code">_O_.[[GetOwnProperty]]</emu-meta>(_key_).
             1. If _desc_ is not *undefined* and _desc_.[[Enumerable]] is *true*, then
               1. If _kind_ is ~key~, append _key_ to _properties_.
               1. Else,
@@ -6815,14 +6815,14 @@
       <emu-alg>
         1. If _source_ is *undefined* or *null*, return _target_.
         1. Let _from_ be ! ToObject(_source_).
-        1. Let _keys_ be ? _from_.[[OwnPropertyKeys]]().
+        1. Let _keys_ be ? <emu-meta effects="user-code">_from_.[[OwnPropertyKeys]]</emu-meta>().
         1. For each element _nextKey_ of _keys_, do
           1. Let _excluded_ be *false*.
           1. For each element _e_ of _excludedItems_, do
             1. If SameValue(_e_, _nextKey_) is *true*, then
               1. Set _excluded_ to *true*.
           1. If _excluded_ is *false*, then
-            1. Let _desc_ be ? _from_.[[GetOwnProperty]](_nextKey_).
+            1. Let _desc_ be ? <emu-meta effects="user-code">_from_.[[GetOwnProperty]]</emu-meta>(_nextKey_).
             1. If _desc_ is not *undefined* and _desc_.[[Enumerable]] is *true*, then
               1. Let _propValue_ be ? Get(_from_, _nextKey_).
               1. Perform ! CreateDataPropertyOrThrow(_target_, _nextKey_, _propValue_).
@@ -7167,7 +7167,7 @@
       <emu-alg>
         1. Let _closure_ be a new Abstract Closure with no parameters that captures _list_ and performs the following steps when called:
           1. For each element _E_ of _list_, do
-            1. Perform ? Yield(_E_).
+            1. Perform ? GeneratorYield(! CreateIterResultObject(_E_, *false*)).
           1. Return *undefined*.
         1. Let _iterator_ be ! CreateIteratorFromClosure(_closure_, ~empty~, %IteratorPrototype%).
         1. Return Record { [[Iterator]]: _iterator_, [[NextMethod]]: %GeneratorFunction.prototype.prototype.next%, [[Done]]: *false* }.
@@ -10435,7 +10435,7 @@
             <dd>It is used to set the bound value of the current binding of the identifier whose name is the value of the argument _N_ to the value of argument _V_.</dd>
           </dl>
           <emu-alg>
-            1. Return ? _envRec_.SetMutableBinding(_N_, _V_, *false*).
+            1. Return ? <emu-meta effects="user-code">_envRec_.SetMutableBinding</emu-meta>(_N_, _V_, *false*).
           </emu-alg>
           <emu-note>
             <p>In this specification, all uses of CreateMutableBinding for object Environment Records are immediately followed by a call to InitializeBinding for the same name. Hence, this specification does not explicitly track the initialization state of bindings in object Environment Records.</p>
@@ -10503,7 +10503,7 @@
           </dl>
           <emu-alg>
             1. Let _bindingObject_ be _envRec_.[[BindingObject]].
-            1. Return ? _bindingObject_.[[Delete]](_N_).
+            1. Return ? <emu-meta effects="user-code">_bindingObject_.[[Delete]]</emu-meta>(_N_).
           </emu-alg>
         </emu-clause>
 
@@ -10715,7 +10715,7 @@
             1. Let _home_ be _envRec_.[[FunctionObject]].[[HomeObject]].
             1. If _home_ is *undefined*, return *undefined*.
             1. Assert: Type(_home_) is Object.
-            1. Return ? _home_.[[GetPrototypeOf]]().
+            1. Return ? <emu-meta effects="user-code">_home_.[[GetPrototypeOf]]</emu-meta>().
           </emu-alg>
         </emu-clause>
       </emu-clause>
@@ -10880,7 +10880,7 @@
             1. Let _DclRec_ be _envRec_.[[DeclarativeRecord]].
             1. If _DclRec_.HasBinding(_N_) is *true*, return *true*.
             1. Let _ObjRec_ be _envRec_.[[ObjectRecord]].
-            1. Return ? _ObjRec_.HasBinding(_N_).
+            1. Return ? <emu-meta effects="user-code">_ObjRec_.HasBinding</emu-meta>(_N_).
           </emu-alg>
         </emu-clause>
 
@@ -10946,7 +10946,7 @@
               1. Return _DclRec_.InitializeBinding(_N_, _V_).
             1. Assert: If the binding exists, it must be in the object Environment Record.
             1. Let _ObjRec_ be _envRec_.[[ObjectRecord]].
-            1. Return ? _ObjRec_.InitializeBinding(_N_, _V_).
+            1. Return ? <emu-meta effects="user-code">_ObjRec_.InitializeBinding</emu-meta>(_N_, _V_).
           </emu-alg>
         </emu-clause>
 
@@ -10970,7 +10970,7 @@
             1. If _DclRec_.HasBinding(_N_) is *true*, then
               1. Return _DclRec_.SetMutableBinding(_N_, _V_, _S_).
             1. Let _ObjRec_ be _envRec_.[[ObjectRecord]].
-            1. Return ? _ObjRec_.SetMutableBinding(_N_, _V_, _S_).
+            1. Return ? <emu-meta effects="user-code">_ObjRec_.SetMutableBinding</emu-meta>(_N_, _V_, _S_).
           </emu-alg>
         </emu-clause>
 
@@ -10993,7 +10993,7 @@
             1. If _DclRec_.HasBinding(_N_) is *true*, then
               1. Return _DclRec_.GetBindingValue(_N_, _S_).
             1. Let _ObjRec_ be _envRec_.[[ObjectRecord]].
-            1. Return ? _ObjRec_.GetBindingValue(_N_, _S_).
+            1. Return ? <emu-meta effects="user-code">_ObjRec_.GetBindingValue</emu-meta>(_N_, _S_).
           </emu-alg>
         </emu-clause>
 
@@ -11018,7 +11018,7 @@
             1. Let _globalObject_ be _ObjRec_.[[BindingObject]].
             1. Let _existingProp_ be ? HasOwnProperty(_globalObject_, _N_).
             1. If _existingProp_ is *true*, then
-              1. Let _status_ be ? _ObjRec_.DeleteBinding(_N_).
+              1. Let _status_ be ? <emu-meta effects="user-code">_ObjRec_.DeleteBinding</emu-meta>(_N_).
               1. If _status_ is *true*, then
                 1. Let _varNames_ be _envRec_.[[VarNames]].
                 1. If _N_ is an element of _varNames_, remove that element from the _varNames_.
@@ -11132,7 +11132,7 @@
           <emu-alg>
             1. Let _ObjRec_ be _envRec_.[[ObjectRecord]].
             1. Let _globalObject_ be _ObjRec_.[[BindingObject]].
-            1. Let _existingProp_ be ? _globalObject_.[[GetOwnProperty]](_N_).
+            1. Let _existingProp_ be ? <emu-meta effects="user-code">_globalObject_.[[GetOwnProperty]]</emu-meta>(_N_).
             1. If _existingProp_ is *undefined*, return *false*.
             1. If _existingProp_.[[Configurable]] is *true*, return *false*.
             1. Return *true*.
@@ -11180,7 +11180,7 @@
           <emu-alg>
             1. Let _ObjRec_ be _envRec_.[[ObjectRecord]].
             1. Let _globalObject_ be _ObjRec_.[[BindingObject]].
-            1. Let _existingProp_ be ? _globalObject_.[[GetOwnProperty]](_N_).
+            1. Let _existingProp_ be ? <emu-meta effects="user-code">_globalObject_.[[GetOwnProperty]]</emu-meta>(_N_).
             1. If _existingProp_ is *undefined*, return ? IsExtensible(_globalObject_).
             1. If _existingProp_.[[Configurable]] is *true*, return *true*.
             1. If IsDataDescriptor(_existingProp_) is *true* and _existingProp_ has attribute values { [[Writable]]: *true*, [[Enumerable]]: *true* }, return *true*.
@@ -11208,8 +11208,8 @@
             1. Let _hasProperty_ be ? HasOwnProperty(_globalObject_, _N_).
             1. Let _extensible_ be ? IsExtensible(_globalObject_).
             1. If _hasProperty_ is *false* and _extensible_ is *true*, then
-              1. Perform ? _ObjRec_.CreateMutableBinding(_N_, _D_).
-              1. Perform ? _ObjRec_.InitializeBinding(_N_, *undefined*).
+              1. Perform ? <emu-meta effects="user-code">_ObjRec_.CreateMutableBinding</emu-meta>(_N_, _D_).
+              1. Perform ? <emu-meta effects="user-code">_ObjRec_.InitializeBinding</emu-meta>(_N_, *undefined*).
             1. Let _varDeclaredNames_ be _envRec_.[[VarNames]].
             1. If _varDeclaredNames_ does not contain _N_, then
               1. Append _N_ to _varDeclaredNames_.
@@ -11235,7 +11235,7 @@
           <emu-alg>
             1. Let _ObjRec_ be _envRec_.[[ObjectRecord]].
             1. Let _globalObject_ be _ObjRec_.[[BindingObject]].
-            1. Let _existingProp_ be ? _globalObject_.[[GetOwnProperty]](_N_).
+            1. Let _existingProp_ be ? <emu-meta effects="user-code">_globalObject_.[[GetOwnProperty]]</emu-meta>(_N_).
             1. If _existingProp_ is *undefined* or _existingProp_.[[Configurable]] is *true*, then
               1. Let _desc_ be the PropertyDescriptor { [[Value]]: _V_, [[Writable]]: *true*, [[Enumerable]]: *true*, [[Configurable]]: _D_ }.
             1. Else,
@@ -11308,7 +11308,7 @@
               1. Let _M_ and _N2_ be the indirection values provided when this binding for _N_ was created.
               1. Let _targetEnv_ be _M_.[[Environment]].
               1. If _targetEnv_ is ~empty~, throw a *ReferenceError* exception.
-              1. Return ? _targetEnv_.GetBindingValue(_N2_, *true*).
+              1. Return ? <emu-meta effects="user-code">_targetEnv_.GetBindingValue</emu-meta>(_N2_, *true*).
             1. If the binding for _N_ in _envRec_ is an uninitialized binding, throw a *ReferenceError* exception.
             1. Return the value currently bound to _N_ in _envRec_.
           </emu-alg>
@@ -11392,7 +11392,7 @@
         <emu-alg>
           1. If _env_ is the value *null*, then
             1. Return the Reference Record { [[Base]]: ~unresolvable~, [[ReferencedName]]: _name_, [[Strict]]: _strict_, [[ThisValue]]: ~empty~ }.
-          1. Let _exists_ be ? _env_.HasBinding(_name_).
+          1. Let _exists_ be ? <emu-meta effects="user-code">_env_.HasBinding</emu-meta>(_name_).
           1. If _exists_ is *true*, then
             1. Return the Reference Record { [[Base]]: _env_, [[ReferencedName]]: _name_, [[Strict]]: _strict_, [[ThisValue]]: ~empty~ }.
           1. Else,
@@ -12649,7 +12649,7 @@
         <dl class="header">
         </dl>
         <emu-alg>
-          1. Let _current_ be ? _O_.[[GetOwnProperty]](_P_).
+          1. Let _current_ be ? <emu-meta effects="user-code">_O_.[[GetOwnProperty]]</emu-meta>(_P_).
           1. Let _extensible_ be ? IsExtensible(_O_).
           1. Return ValidateAndApplyPropertyDescriptor(_O_, _P_, _extensible_, _Desc_, _current_).
         </emu-alg>
@@ -12751,11 +12751,11 @@
         <dl class="header">
         </dl>
         <emu-alg>
-          1. Let _hasOwn_ be ? _O_.[[GetOwnProperty]](_P_).
+          1. Let _hasOwn_ be ? <emu-meta effects="user-code">_O_.[[GetOwnProperty]]</emu-meta>(_P_).
           1. If _hasOwn_ is not *undefined*, return *true*.
-          1. Let _parent_ be ? _O_.[[GetPrototypeOf]]().
+          1. Let _parent_ be ? <emu-meta effects="user-code">_O_.[[GetPrototypeOf]]</emu-meta>().
           1. If _parent_ is not *null*, then
-            1. Return ? _parent_.[[HasProperty]](_P_).
+            1. Return ? <emu-meta effects="user-code">_parent_.[[HasProperty]]</emu-meta>(_P_).
           1. Return *false*.
         </emu-alg>
       </emu-clause>
@@ -12789,11 +12789,11 @@
         </dl>
 
         <emu-alg>
-          1. Let _desc_ be ? _O_.[[GetOwnProperty]](_P_).
+          1. Let _desc_ be ? <emu-meta effects="user-code">_O_.[[GetOwnProperty]]</emu-meta>(_P_).
           1. If _desc_ is *undefined*, then
-            1. Let _parent_ be ? _O_.[[GetPrototypeOf]]().
+            1. Let _parent_ be ? <emu-meta effects="user-code">_O_.[[GetPrototypeOf]]</emu-meta>().
             1. If _parent_ is *null*, return *undefined*.
-            1. Return ? _parent_.[[Get]](_P_, _Receiver_).
+            1. Return ? <emu-meta effects="user-code">_parent_.[[Get]]</emu-meta>(_P_, _Receiver_).
           1. If IsDataDescriptor(_desc_) is *true*, return _desc_.[[Value]].
           1. Assert: IsAccessorDescriptor(_desc_) is *true*.
           1. Let _getter_ be _desc_.[[Get]].
@@ -12832,7 +12832,7 @@
         </dl>
 
         <emu-alg>
-          1. Let _ownDesc_ be ? _O_.[[GetOwnProperty]](_P_).
+          1. Let _ownDesc_ be ? <emu-meta effects="user-code">_O_.[[GetOwnProperty]]</emu-meta>(_P_).
           1. Return OrdinarySetWithOwnDescriptor(_O_, _P_, _V_, _Receiver_, _ownDesc_).
         </emu-alg>
       </emu-clause>
@@ -12852,20 +12852,20 @@
 
         <emu-alg>
           1. If _ownDesc_ is *undefined*, then
-            1. Let _parent_ be ? _O_.[[GetPrototypeOf]]().
+            1. Let _parent_ be ? <emu-meta effects="user-code">_O_.[[GetPrototypeOf]]</emu-meta>().
             1. If _parent_ is not *null*, then
-              1. Return ? _parent_.[[Set]](_P_, _V_, _Receiver_).
+              1. Return ? <emu-meta effects="user-code">_parent_.[[Set]]</emu-meta>(_P_, _V_, _Receiver_).
             1. Else,
               1. Set _ownDesc_ to the PropertyDescriptor { [[Value]]: *undefined*, [[Writable]]: *true*, [[Enumerable]]: *true*, [[Configurable]]: *true* }.
           1. If IsDataDescriptor(_ownDesc_) is *true*, then
             1. If _ownDesc_.[[Writable]] is *false*, return *false*.
             1. If Type(_Receiver_) is not Object, return *false*.
-            1. Let _existingDescriptor_ be ? _Receiver_.[[GetOwnProperty]](_P_).
+            1. Let _existingDescriptor_ be ? <emu-meta effects="user-code">_Receiver_.[[GetOwnProperty]]</emu-meta>(_P_).
             1. If _existingDescriptor_ is not *undefined*, then
               1. If IsAccessorDescriptor(_existingDescriptor_) is *true*, return *false*.
               1. If _existingDescriptor_.[[Writable]] is *false*, return *false*.
               1. Let _valueDesc_ be the PropertyDescriptor { [[Value]]: _V_ }.
-              1. Return ? _Receiver_.[[DefineOwnProperty]](_P_, _valueDesc_).
+              1. Return ? <emu-meta effects="user-code">_Receiver_.[[DefineOwnProperty]]</emu-meta>(_P_, _valueDesc_).
             1. Else,
               1. Assert: _Receiver_ does not currently have a property _P_.
               1. Return ? CreateDataProperty(_Receiver_, _P_, _V_).
@@ -12902,7 +12902,7 @@
         <dl class="header">
         </dl>
         <emu-alg>
-          1. Let _desc_ be ? _O_.[[GetOwnProperty]](_P_).
+          1. Let _desc_ be ? <emu-meta effects="user-code">_O_.[[GetOwnProperty]]</emu-meta>(_P_).
           1. If _desc_ is *undefined*, return *true*.
           1. If _desc_.[[Configurable]] is *true*, then
             1. Remove the own property with name _P_ from _O_.
@@ -13966,7 +13966,7 @@
           <dd>It is used to specify the creation of new bound function exotic objects.</dd>
         </dl>
         <emu-alg>
-          1. Let _proto_ be ? _targetFunction_.[[GetPrototypeOf]]().
+          1. Let _proto_ be ? <emu-meta effects="user-code">_targetFunction_.[[GetPrototypeOf]]</emu-meta>().
           1. Let _internalSlotsList_ be the internal slots listed in <emu-xref href="#table-internal-slots-of-bound-function-exotic-objects"></emu-xref>, plus [[Prototype]] and [[Extensible]].
           1. Let _obj_ be ! MakeBasicObject(_internalSlotsList_).
           1. Set _obj_.[[Prototype]] to _proto_.
@@ -14313,13 +14313,13 @@
           1. If _allowed_ is *false*, return *false*.
           1. If _isMapped_ is *true*, then
             1. If IsAccessorDescriptor(_Desc_) is *true*, then
-              1. Call _map_.[[Delete]](_P_).
+              1. Call <emu-meta effects="user-code">_map_.[[Delete]]</emu-meta>(_P_).
             1. Else,
               1. If _Desc_.[[Value]] is present, then
                 1. Let _setStatus_ be Set(_map_, _P_, _Desc_.[[Value]], *false*).
                 1. Assert: _setStatus_ is *true* because formal parameters mapped by argument objects are always writable.
               1. If _Desc_.[[Writable]] is present and its value is *false*, then
-                1. Call _map_.[[Delete]](_P_).
+                1. Call <emu-meta effects="user-code">_map_.[[Delete]]</emu-meta>(_P_).
           1. Return *true*.
         </emu-alg>
       </emu-clause>
@@ -14386,7 +14386,7 @@
           1. Let _isMapped_ be ! HasOwnProperty(_map_, _P_).
           1. Let _result_ be ? OrdinaryDelete(_args_, _P_).
           1. If _result_ is *true* and _isMapped_ is *true*, then
-            1. Call _map_.[[Delete]](_P_).
+            1. Call <emu-meta effects="user-code">_map_.[[Delete]]</emu-meta>(_P_).
           1. Return _result_.
         </emu-alg>
       </emu-clause>
@@ -14455,7 +14455,7 @@
               1. If _index_ &lt; _len_, then
                 1. Let _g_ be MakeArgGetter(_name_, _env_).
                 1. Let _p_ be MakeArgSetter(_name_, _env_).
-                1. Perform _map_.[[DefineOwnProperty]](! ToString(𝔽(_index_)), PropertyDescriptor { [[Set]]: _p_, [[Get]]: _g_, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
+                1. Perform <emu-meta effects="user-code">_map_.[[DefineOwnProperty]]</emu-meta>(! ToString(𝔽(_index_)), PropertyDescriptor { [[Set]]: _p_, [[Get]]: _g_, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
             1. Set _index_ to _index_ - 1.
           1. Perform ! DefinePropertyOrThrow(_obj_, @@iterator, PropertyDescriptor { [[Value]]: %Array.prototype.values%, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
           1. Perform ! DefinePropertyOrThrow(_obj_, *"callee"*, PropertyDescriptor { [[Value]]: _func_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
@@ -14632,7 +14632,7 @@
             1. Let _numericIndex_ be ! CanonicalNumericIndexString(_P_).
             1. If _numericIndex_ is not *undefined*, then
               1. If ! IsValidIntegerIndex(_O_, _numericIndex_) is *false*, return *true*; else return *false*.
-          1. Return ? OrdinaryDelete(_O_, _P_).
+          1. Return ! OrdinaryDelete(_O_, _P_).
         </emu-alg>
       </emu-clause>
 
@@ -15040,7 +15040,7 @@
         <dl class="header">
         </dl>
         <emu-alg>
-          1. Let _current_ be ? _O_.[[GetPrototypeOf]]().
+          1. Let _current_ be ? <emu-meta effects="user-code">_O_.[[GetPrototypeOf]]</emu-meta>().
           1. If SameValue(_V_, _current_) is *true*, return *true*.
           1. Return *false*.
         </emu-alg>
@@ -15188,12 +15188,12 @@
         1. Let _target_ be _O_.[[ProxyTarget]].
         1. Let _trap_ be ? GetMethod(_handler_, *"getPrototypeOf"*).
         1. If _trap_ is *undefined*, then
-          1. Return ? _target_.[[GetPrototypeOf]]().
+          1. Return ? <emu-meta effects="user-code">_target_.[[GetPrototypeOf]]</emu-meta>().
         1. Let _handlerProto_ be ? Call(_trap_, _handler_, &laquo; _target_ &raquo;).
         1. If Type(_handlerProto_) is neither Object nor Null, throw a *TypeError* exception.
         1. Let _extensibleTarget_ be ? IsExtensible(_target_).
         1. If _extensibleTarget_ is *true*, return _handlerProto_.
-        1. Let _targetProto_ be ? _target_.[[GetPrototypeOf]]().
+        1. Let _targetProto_ be ? <emu-meta effects="user-code">_target_.[[GetPrototypeOf]]</emu-meta>().
         1. If SameValue(_handlerProto_, _targetProto_) is *false*, throw a *TypeError* exception.
         1. Return _handlerProto_.
       </emu-alg>
@@ -15227,12 +15227,12 @@
         1. Let _target_ be _O_.[[ProxyTarget]].
         1. Let _trap_ be ? GetMethod(_handler_, *"setPrototypeOf"*).
         1. If _trap_ is *undefined*, then
-          1. Return ? _target_.[[SetPrototypeOf]](_V_).
+          1. Return ? <emu-meta effects="user-code">_target_.[[SetPrototypeOf]]</emu-meta>(_V_).
         1. Let _booleanTrapResult_ be ! ToBoolean(? Call(_trap_, _handler_, &laquo; _target_, _V_ &raquo;)).
         1. If _booleanTrapResult_ is *false*, return *false*.
         1. Let _extensibleTarget_ be ? IsExtensible(_target_).
         1. If _extensibleTarget_ is *true*, return *true*.
-        1. Let _targetProto_ be ? _target_.[[GetPrototypeOf]]().
+        1. Let _targetProto_ be ? <emu-meta effects="user-code">_target_.[[GetPrototypeOf]]</emu-meta>().
         1. If SameValue(_V_, _targetProto_) is *false*, throw a *TypeError* exception.
         1. Return *true*.
       </emu-alg>
@@ -15294,7 +15294,7 @@
         1. Let _target_ be _O_.[[ProxyTarget]].
         1. Let _trap_ be ? GetMethod(_handler_, *"preventExtensions"*).
         1. If _trap_ is *undefined*, then
-          1. Return ? _target_.[[PreventExtensions]]().
+          1. Return ? <emu-meta effects="user-code">_target_.[[PreventExtensions]]()</emu-meta>.
         1. Let _booleanTrapResult_ be ! ToBoolean(? Call(_trap_, _handler_, &laquo; _target_ &raquo;)).
         1. If _booleanTrapResult_ is *true*, then
           1. Let _extensibleTarget_ be ? IsExtensible(_target_).
@@ -15331,10 +15331,10 @@
         1. Let _target_ be _O_.[[ProxyTarget]].
         1. Let _trap_ be ? GetMethod(_handler_, *"getOwnPropertyDescriptor"*).
         1. If _trap_ is *undefined*, then
-          1. Return ? _target_.[[GetOwnProperty]](_P_).
+          1. Return ? <emu-meta effects="user-code">_target_.[[GetOwnProperty]]</emu-meta>(_P_).
         1. Let _trapResultObj_ be ? Call(_trap_, _handler_, &laquo; _target_, _P_ &raquo;).
         1. If Type(_trapResultObj_) is neither Object nor Undefined, throw a *TypeError* exception.
-        1. Let _targetDesc_ be ? _target_.[[GetOwnProperty]](_P_).
+        1. Let _targetDesc_ be ? <emu-meta effects="user-code">_target_.[[GetOwnProperty]]</emu-meta>(_P_).
         1. If _trapResultObj_ is *undefined*, then
           1. If _targetDesc_ is *undefined*, return *undefined*.
           1. If _targetDesc_.[[Configurable]] is *false*, throw a *TypeError* exception.
@@ -15396,11 +15396,11 @@
         1. Let _target_ be _O_.[[ProxyTarget]].
         1. Let _trap_ be ? GetMethod(_handler_, *"defineProperty"*).
         1. If _trap_ is *undefined*, then
-          1. Return ? _target_.[[DefineOwnProperty]](_P_, _Desc_).
+          1. Return ? <emu-meta effects="user-code">_target_.[[DefineOwnProperty]]</emu-meta>(_P_, _Desc_).
         1. Let _descObj_ be FromPropertyDescriptor(_Desc_).
         1. Let _booleanTrapResult_ be ! ToBoolean(? Call(_trap_, _handler_, &laquo; _target_, _P_, _descObj_ &raquo;)).
         1. If _booleanTrapResult_ is *false*, return *false*.
-        1. Let _targetDesc_ be ? _target_.[[GetOwnProperty]](_P_).
+        1. Let _targetDesc_ be ? <emu-meta effects="user-code">_target_.[[GetOwnProperty]]</emu-meta>(_P_).
         1. Let _extensibleTarget_ be ? IsExtensible(_target_).
         1. If _Desc_ has a [[Configurable]] field and if _Desc_.[[Configurable]] is *false*, then
           1. Let _settingConfigFalse_ be *true*.
@@ -15454,10 +15454,10 @@
         1. Let _target_ be _O_.[[ProxyTarget]].
         1. Let _trap_ be ? GetMethod(_handler_, *"has"*).
         1. If _trap_ is *undefined*, then
-          1. Return ? _target_.[[HasProperty]](_P_).
+          1. Return ? <emu-meta effects="user-code">_target_.[[HasProperty]]</emu-meta>(_P_).
         1. Let _booleanTrapResult_ be ! ToBoolean(? Call(_trap_, _handler_, &laquo; _target_, _P_ &raquo;)).
         1. If _booleanTrapResult_ is *false*, then
-          1. Let _targetDesc_ be ? _target_.[[GetOwnProperty]](_P_).
+          1. Let _targetDesc_ be ? <emu-meta effects="user-code">_target_.[[GetOwnProperty]]</emu-meta>(_P_).
           1. If _targetDesc_ is not *undefined*, then
             1. If _targetDesc_.[[Configurable]] is *false*, throw a *TypeError* exception.
             1. Let _extensibleTarget_ be ? IsExtensible(_target_).
@@ -15498,9 +15498,9 @@
         1. Let _target_ be _O_.[[ProxyTarget]].
         1. Let _trap_ be ? GetMethod(_handler_, *"get"*).
         1. If _trap_ is *undefined*, then
-          1. Return ? _target_.[[Get]](_P_, _Receiver_).
+          1. Return ? <emu-meta effects="user-code">_target_.[[Get]]</emu-meta>(_P_, _Receiver_).
         1. Let _trapResult_ be ? Call(_trap_, _handler_, &laquo; _target_, _P_, _Receiver_ &raquo;).
-        1. Let _targetDesc_ be ? _target_.[[GetOwnProperty]](_P_).
+        1. Let _targetDesc_ be ? <emu-meta effects="user-code">_target_.[[GetOwnProperty]]</emu-meta>(_P_).
         1. If _targetDesc_ is not *undefined* and _targetDesc_.[[Configurable]] is *false*, then
           1. If IsDataDescriptor(_targetDesc_) is *true* and _targetDesc_.[[Writable]] is *false*, then
             1. If SameValue(_trapResult_, _targetDesc_.[[Value]]) is *false*, throw a *TypeError* exception.
@@ -15540,10 +15540,10 @@
         1. Let _target_ be _O_.[[ProxyTarget]].
         1. Let _trap_ be ? GetMethod(_handler_, *"set"*).
         1. If _trap_ is *undefined*, then
-          1. Return ? _target_.[[Set]](_P_, _V_, _Receiver_).
+          1. Return ? <emu-meta effects="user-code">_target_.[[Set]]</emu-meta>(_P_, _V_, _Receiver_).
         1. Let _booleanTrapResult_ be ! ToBoolean(? Call(_trap_, _handler_, &laquo; _target_, _P_, _V_, _Receiver_ &raquo;)).
         1. If _booleanTrapResult_ is *false*, return *false*.
-        1. Let _targetDesc_ be ? _target_.[[GetOwnProperty]](_P_).
+        1. Let _targetDesc_ be ? <emu-meta effects="user-code">_target_.[[GetOwnProperty]]</emu-meta>(_P_).
         1. If _targetDesc_ is not *undefined* and _targetDesc_.[[Configurable]] is *false*, then
           1. If IsDataDescriptor(_targetDesc_) is *true* and _targetDesc_.[[Writable]] is *false*, then
             1. If SameValue(_V_, _targetDesc_.[[Value]]) is *false*, throw a *TypeError* exception.
@@ -15584,10 +15584,10 @@
         1. Let _target_ be _O_.[[ProxyTarget]].
         1. Let _trap_ be ? GetMethod(_handler_, *"deleteProperty"*).
         1. If _trap_ is *undefined*, then
-          1. Return ? _target_.[[Delete]](_P_).
+          1. Return ? <emu-meta effects="user-code">_target_.[[Delete]]</emu-meta>(_P_).
         1. Let _booleanTrapResult_ be ! ToBoolean(? Call(_trap_, _handler_, &laquo; _target_, _P_ &raquo;)).
         1. If _booleanTrapResult_ is *false*, return *false*.
-        1. Let _targetDesc_ be ? _target_.[[GetOwnProperty]](_P_).
+        1. Let _targetDesc_ be ? <emu-meta effects="user-code">_target_.[[GetOwnProperty]]</emu-meta>(_P_).
         1. If _targetDesc_ is *undefined*, return *true*.
         1. If _targetDesc_.[[Configurable]] is *false*, throw a *TypeError* exception.
         1. Let _extensibleTarget_ be ? IsExtensible(_target_).
@@ -15623,18 +15623,18 @@
         1. Let _target_ be _O_.[[ProxyTarget]].
         1. Let _trap_ be ? GetMethod(_handler_, *"ownKeys"*).
         1. If _trap_ is *undefined*, then
-          1. Return ? _target_.[[OwnPropertyKeys]]().
+          1. Return ? <emu-meta effects="user-code">_target_.[[OwnPropertyKeys]]()</emu-meta>.
         1. Let _trapResultArray_ be ? Call(_trap_, _handler_, &laquo; _target_ &raquo;).
         1. Let _trapResult_ be ? CreateListFromArrayLike(_trapResultArray_, &laquo; String, Symbol &raquo;).
         1. If _trapResult_ contains any duplicate entries, throw a *TypeError* exception.
         1. Let _extensibleTarget_ be ? IsExtensible(_target_).
-        1. Let _targetKeys_ be ? _target_.[[OwnPropertyKeys]]().
+        1. Let _targetKeys_ be ? <emu-meta effects="user-code">_target_.[[OwnPropertyKeys]]()</emu-meta>.
         1. Assert: _targetKeys_ is a List of property keys.
         1. Assert: _targetKeys_ contains no duplicate entries.
         1. Let _targetConfigurableKeys_ be a new empty List.
         1. Let _targetNonconfigurableKeys_ be a new empty List.
         1. For each element _key_ of _targetKeys_, do
-          1. Let _desc_ be ? _target_.[[GetOwnProperty]](_key_).
+          1. Let _desc_ be ? <emu-meta effects="user-code">_target_.[[GetOwnProperty]]</emu-meta>(_key_).
           1. If _desc_ is not *undefined* and _desc_.[[Configurable]] is *false*, then
             1. Append _key_ as an element of _targetNonconfigurableKeys_.
           1. Else,
@@ -18379,7 +18379,7 @@
             1. Let _propValue_ be ? GetValue(_exprValueRef_).
           1. If _isProtoSetter_ is *true*, then
             1. If Type(_propValue_) is either Object or Null, then
-              1. Return ! _object_.[[SetPrototypeOf]](_propValue_).
+              1. Return ! <emu-meta effects="user-code">_object_.[[SetPrototypeOf]]</emu-meta>(_propValue_).
             1. Return NormalCompletion(~empty~).
           1. Assert: _object_ is an ordinary, extensible object with no non-configurable properties.
           1. Return ! CreateDataPropertyOrThrow(_object_, _propKey_, _propValue_).
@@ -18443,7 +18443,7 @@
         <emu-alg>
           1. Let _pattern_ be ! CodePointsToString(BodyText of |RegularExpressionLiteral|).
           1. Let _flags_ be ! CodePointsToString(FlagText of |RegularExpressionLiteral|).
-          1. Return RegExpCreate(_pattern_, _flags_).
+          1. Return <emu-meta suppress-effects="user-code">RegExpCreate(_pattern_, _flags_)</emu-meta>.
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -19638,13 +19638,13 @@
             1. Assert: ! IsPrivateReference(_ref_) is *false*.
             1. If IsSuperReference(_ref_) is *true*, throw a *ReferenceError* exception.
             1. [id="step-delete-operator-toobject"] Let _baseObj_ be ? ToObject(_ref_.[[Base]]).
-            1. Let _deleteStatus_ be ? _baseObj_.[[Delete]](_ref_.[[ReferencedName]]).
+            1. Let _deleteStatus_ be ? <emu-meta effects="user-code">_baseObj_.[[Delete]]</emu-meta>(_ref_.[[ReferencedName]]).
             1. If _deleteStatus_ is *false* and _ref_.[[Strict]] is *true*, throw a *TypeError* exception.
             1. Return _deleteStatus_.
           1. Else,
             1. Let _base_ be _ref_.[[Base]].
             1. Assert: _base_ is an Environment Record.
-            1. Return ? _base_.DeleteBinding(_ref_.[[ReferencedName]]).
+            1. Return ? <emu-meta effects="user-code">_base_.DeleteBinding</emu-meta>(_ref_.[[ReferencedName]]).
         </emu-alg>
         <emu-note>
           <p>When a `delete` operator occurs within strict mode code, a *SyntaxError* exception is thrown if its |UnaryExpression| is a direct reference to a variable, function argument, or function name. In addition, if a `delete` operator occurs within strict mode code and the property to be deleted has the attribute { [[Configurable]]: *false* } (or otherwise cannot be deleted), a *TypeError* exception is thrown.</p>
@@ -22241,7 +22241,7 @@
               1. Let _remaining_ be _O_.[[RemainingKeys]].
               1. Repeat,
                 1. If _O_.[[ObjectWasVisited]] is *false*, then
-                  1. Let _keys_ be ? _object_.[[OwnPropertyKeys]]().
+                  1. Let _keys_ be ? <emu-meta effects="user-code">_object_.[[OwnPropertyKeys]]()</emu-meta>.
                   1. For each element _key_ of _keys_, do
                     1. If Type(_key_) is String, then
                       1. Append _key_ to _remaining_.
@@ -22250,11 +22250,11 @@
                   1. Let _r_ be the first element of _remaining_.
                   1. Remove the first element from _remaining_.
                   1. If there does not exist an element _v_ of _visited_ such that SameValue(_r_, _v_) is *true*, then
-                    1. Let _desc_ be ? _object_.[[GetOwnProperty]](_r_).
+                    1. Let _desc_ be ? <emu-meta effects="user-code">_object_.[[GetOwnProperty]]</emu-meta>(_r_).
                     1. If _desc_ is not *undefined*, then
                       1. Append _r_ to _visited_.
                       1. If _desc_.[[Enumerable]] is *true*, return CreateIterResultObject(_r_, *false*).
-                1. Set _object_ to ? _object_.[[GetPrototypeOf]]().
+                1. Set _object_ to ? <emu-meta effects="user-code">_object_.[[GetPrototypeOf]]()</emu-meta>.
                 1. Set _O_.[[Object]] to _object_.
                 1. Set _O_.[[ObjectWasVisited]] to *false*.
                 1. If _object_ is *null*, return CreateIterResultObject(*undefined*, *true*).
@@ -25868,15 +25868,15 @@
           1. NOTE: Lexically declared names are only instantiated here but not initialized.
           1. For each element _dn_ of the BoundNames of _d_, do
             1. If IsConstantDeclaration of _d_ is *true*, then
-              1. Perform ? _env_.CreateImmutableBinding(_dn_, *true*).
+              1. Perform ? <emu-meta effects="user-code">_env_.CreateImmutableBinding</emu-meta>(_dn_, *true*).
             1. Else,
-              1. Perform ? _env_.CreateMutableBinding(_dn_, *false*).
+              1. Perform ? <emu-meta effects="user-code">_env_.CreateMutableBinding</emu-meta>(_dn_, *false*).
         1. For each Parse Node _f_ of _functionsToInitialize_, do
           1. Let _fn_ be the sole element of the BoundNames of _f_.
           1. Let _fo_ be InstantiateFunctionObject of _f_ with arguments _env_ and _privateEnv_.
-          1. Perform ? _env_.CreateGlobalFunctionBinding(_fn_, _fo_, *false*).
+          1. Perform ? <emu-meta effects="user-code">_env_.CreateGlobalFunctionBinding</emu-meta>(_fn_, _fo_, *false*).
         1. For each String _vn_ of _declaredVarNames_, do
-          1. Perform ? _env_.CreateGlobalVarBinding(_vn_, *false*).
+          1. Perform ? <emu-meta effects="user-code">_env_.CreateGlobalVarBinding</emu-meta>(_vn_, *false*).
         1. Return NormalCompletion(~empty~).
       </emu-alg>
       <emu-note>
@@ -26474,7 +26474,7 @@
                 1. Set _module_.[[AsyncEvaluation]] to *true*.
                 1. NOTE: The order in which module records have their [[AsyncEvaluation]] fields transition to *true* is significant. (See <emu-xref href="#sec-async-module-execution-fulfilled"></emu-xref>.)
                 1. If _module_.[[PendingAsyncDependencies]] is 0, perform ! ExecuteAsyncModule(_module_).
-              1. Otherwise, perform ? _module_.ExecuteModule().
+              1. Otherwise, perform ? <emu-meta effects="user-code">_module_.ExecuteModule()</emu-meta>.
               1. Assert: _module_ occurs exactly once in _stack_.
               1. Assert: _module_.[[DFSAncestorIndex]] &le; _module_.[[DFSIndex]].
               1. If _module_.[[DFSAncestorIndex]] = _module_.[[DFSIndex]], then
@@ -26519,7 +26519,7 @@
                 1. Return *undefined*.
               1. Let _onRejected_ be ! CreateBuiltinFunction(_rejectedClosure_, 0, *""*, &laquo; &raquo;).
               1. Perform ! PerformPromiseThen(_capability_.[[Promise]], _onFulfilled_, _onRejected_).
-              1. Perform ! _module_.ExecuteModule(_capability_).
+              1. Perform ! <emu-meta effects="user-code">_module_.ExecuteModule</emu-meta>(_capability_).
             </emu-alg>
           </emu-clause>
 
@@ -26579,7 +26579,7 @@
                 1. Else if _m_.[[HasTLA]] is *true*, then
                   1. Perform ! ExecuteAsyncModule(_m_).
                 1. Else,
-                  1. Let _result_ be _m_.ExecuteModule().
+                  1. Let _result_ be <emu-meta effects="user-code">_m_.ExecuteModule()</emu-meta>.
                   1. If _result_ is an abrupt completion, then
                     1. Perform ! AsyncModuleExecutionRejected(_m_, _result_.[[Value]]).
                   1. Else,
@@ -29352,9 +29352,9 @@
           1. For each element _nextSource_ of _sources_, do
             1. If _nextSource_ is neither *undefined* nor *null*, then
               1. Let _from_ be ! ToObject(_nextSource_).
-              1. Let _keys_ be ? _from_.[[OwnPropertyKeys]]().
+              1. Let _keys_ be ? <emu-meta effects="user-code">_from_.[[OwnPropertyKeys]]()</emu-meta>.
               1. For each element _nextKey_ of _keys_, do
-                1. Let _desc_ be ? _from_.[[GetOwnProperty]](_nextKey_).
+                1. Let _desc_ be ? <emu-meta effects="user-code">_from_.[[GetOwnProperty]]</emu-meta>(_nextKey_).
                 1. If _desc_ is not *undefined* and _desc_.[[Enumerable]] is *true*, then
                   1. Let _propValue_ be ? Get(_from_, _nextKey_).
                   1. Perform ? Set(_to_, _nextKey_, _propValue_, *true*).
@@ -29394,10 +29394,10 @@
           </dl>
           <emu-alg>
             1. Let _props_ be ? ToObject(_Properties_).
-            1. Let _keys_ be ? _props_.[[OwnPropertyKeys]]().
+            1. Let _keys_ be ? <emu-meta effects="user-code">_props_.[[OwnPropertyKeys]]()</emu-meta>.
             1. Let _descriptors_ be a new empty List.
             1. For each element _nextKey_ of _keys_, do
-              1. Let _propDesc_ be ? _props_.[[GetOwnProperty]](_nextKey_).
+              1. Let _propDesc_ be ? <emu-meta effects="user-code">_props_.[[GetOwnProperty]]</emu-meta>(_nextKey_).
               1. If _propDesc_ is not *undefined* and _propDesc_.[[Enumerable]] is *true*, then
                 1. Let _descObj_ be ? Get(_props_, _nextKey_).
                 1. Let _desc_ be ? ToPropertyDescriptor(_descObj_).
@@ -29469,7 +29469,7 @@
         <emu-alg>
           1. Let _obj_ be ? ToObject(_O_).
           1. Let _key_ be ? ToPropertyKey(_P_).
-          1. Let _desc_ be ? _obj_.[[GetOwnProperty]](_key_).
+          1. Let _desc_ be ? <emu-meta effects="user-code">_obj_.[[GetOwnProperty]]</emu-meta>(_key_).
           1. Return FromPropertyDescriptor(_desc_).
         </emu-alg>
       </emu-clause>
@@ -29479,10 +29479,10 @@
         <p>When the `getOwnPropertyDescriptors` function is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _obj_ be ? ToObject(_O_).
-          1. Let _ownKeys_ be ? _obj_.[[OwnPropertyKeys]]().
+          1. Let _ownKeys_ be ? <emu-meta effects="user-code">_obj_.[[OwnPropertyKeys]]()</emu-meta>.
           1. Let _descriptors_ be ! OrdinaryObjectCreate(%Object.prototype%).
           1. For each element _key_ of _ownKeys_, do
-            1. Let _desc_ be ? _obj_.[[GetOwnProperty]](_key_).
+            1. Let _desc_ be ? <emu-meta effects="user-code">_obj_.[[GetOwnProperty]]</emu-meta>(_key_).
             1. Let _descriptor_ be ! FromPropertyDescriptor(_desc_).
             1. If _descriptor_ is not *undefined*, perform ! CreateDataPropertyOrThrow(_descriptors_, _key_, _descriptor_).
           1. Return _descriptors_.
@@ -29515,7 +29515,7 @@
           </dl>
           <emu-alg>
             1. Let _obj_ be ? ToObject(_O_).
-            1. Let _keys_ be ? _obj_.[[OwnPropertyKeys]]().
+            1. Let _keys_ be ? <emu-meta effects="user-code">_obj_.[[OwnPropertyKeys]]()</emu-meta>.
             1. Let _nameList_ be a new empty List.
             1. For each element _nextKey_ of _keys_, do
               1. If Type(_nextKey_) is Symbol and _type_ is ~symbol~ or Type(_nextKey_) is String and _type_ is ~string~, then
@@ -29530,7 +29530,7 @@
         <p>When the `getPrototypeOf` function is called with argument _O_, the following steps are taken:</p>
         <emu-alg>
           1. Let _obj_ be ? ToObject(_O_).
-          1. Return ? _obj_.[[GetPrototypeOf]]().
+          1. Return ? <emu-meta effects="user-code">_obj_.[[GetPrototypeOf]]()</emu-meta>.
         </emu-alg>
       </emu-clause>
 
@@ -29594,7 +29594,7 @@
         <p>When the `preventExtensions` function is called, the following steps are taken:</p>
         <emu-alg>
           1. If Type(_O_) is not Object, return _O_.
-          1. Let _status_ be ? _O_.[[PreventExtensions]]().
+          1. Let _status_ be ? <emu-meta effects="user-code">_O_.[[PreventExtensions]]()</emu-meta>.
           1. If _status_ is *false*, throw a *TypeError* exception.
           1. Return _O_.
         </emu-alg>
@@ -29624,7 +29624,7 @@
           1. Set _O_ to ? RequireObjectCoercible(_O_).
           1. If Type(_proto_) is neither Object nor Null, throw a *TypeError* exception.
           1. If Type(_O_) is not Object, return _O_.
-          1. Let _status_ be ? _O_.[[SetPrototypeOf]](_proto_).
+          1. Let _status_ be ? <emu-meta effects="user-code">_O_.[[SetPrototypeOf]]</emu-meta>(_proto_).
           1. If _status_ is *false*, throw a *TypeError* exception.
           1. Return _O_.
         </emu-alg>
@@ -29676,7 +29676,7 @@
           1. [id="step-isprototypeof-check-object"] If Type(_V_) is not Object, return *false*.
           1. [id="step-isprototypeof-toobject"] Let _O_ be ? ToObject(*this* value).
           1. Repeat,
-            1. Set _V_ to ? _V_.[[GetPrototypeOf]]().
+            1. Set _V_ to ? <emu-meta effects="user-code">_V_.[[GetPrototypeOf]]()</emu-meta>.
             1. If _V_ is *null*, return *false*.
             1. If SameValue(_O_, _V_) is *true*, return *true*.
         </emu-alg>
@@ -29691,7 +29691,7 @@
         <emu-alg>
           1. [id="step-propertyisenumerable-topropertykey"] Let _P_ be ? ToPropertyKey(_V_).
           1. [id="step-propertyisenumerable-toobject"] Let _O_ be ? ToObject(*this* value).
-          1. Let _desc_ be ? _O_.[[GetOwnProperty]](_P_).
+          1. Let _desc_ be ? <emu-meta effects="user-code">_O_.[[GetOwnProperty]]</emu-meta>(_P_).
           1. If _desc_ is *undefined*, return *false*.
           1. Return _desc_.[[Enumerable]].
         </emu-alg>
@@ -29763,7 +29763,7 @@
           <p>The value of the [[Get]] attribute is a built-in function that requires no arguments. It performs the following steps when called:</p>
           <emu-alg>
             1. Let _O_ be ? ToObject(*this* value).
-            1. Return ? _O_.[[GetPrototypeOf]]().
+            1. Return ? <emu-meta effects="user-code">_O_.[[GetPrototypeOf]]()</emu-meta>.
           </emu-alg>
         </emu-clause>
 
@@ -29774,7 +29774,7 @@
             1. Let _O_ be ? RequireObjectCoercible(*this* value).
             1. If Type(_proto_) is neither Object nor Null, return *undefined*.
             1. If Type(_O_) is not Object, return *undefined*.
-            1. Let _status_ be ? _O_.[[SetPrototypeOf]](_proto_).
+            1. Let _status_ be ? <emu-meta effects="user-code">_O_.[[SetPrototypeOf]]</emu-meta>(_proto_).
             1. If _status_ is *false*, throw a *TypeError* exception.
             1. Return *undefined*.
           </emu-alg>
@@ -29817,11 +29817,11 @@
             1. Let _O_ be ? ToObject(*this* value).
             1. Let _key_ be ? ToPropertyKey(_P_).
             1. Repeat,
-              1. Let _desc_ be ? _O_.[[GetOwnProperty]](_key_).
+              1. Let _desc_ be ? <emu-meta effects="user-code">_O_.[[GetOwnProperty]]</emu-meta>(_key_).
               1. If _desc_ is not *undefined*, then
                 1. If IsAccessorDescriptor(_desc_) is *true*, return _desc_.[[Get]].
                 1. Return *undefined*.
-              1. Set _O_ to ? _O_.[[GetPrototypeOf]]().
+              1. Set _O_ to ? <emu-meta effects="user-code">_O_.[[GetPrototypeOf]]()</emu-meta>.
               1. If _O_ is *null*, return *undefined*.
           </emu-alg>
         </emu-clause>
@@ -29833,11 +29833,11 @@
             1. Let _O_ be ? ToObject(*this* value).
             1. Let _key_ be ? ToPropertyKey(_P_).
             1. Repeat,
-              1. Let _desc_ be ? _O_.[[GetOwnProperty]](_key_).
+              1. Let _desc_ be ? <emu-meta effects="user-code">_O_.[[GetOwnProperty]]</emu-meta>(_key_).
               1. If _desc_ is not *undefined*, then
                 1. If IsAccessorDescriptor(_desc_) is *true*, return _desc_.[[Set]].
                 1. Return *undefined*.
-              1. Set _O_ to ? _O_.[[GetPrototypeOf]]().
+              1. Set _O_ to ? <emu-meta effects="user-code">_O_.[[GetPrototypeOf]]()</emu-meta>.
               1. If _O_ is *null*, return *undefined*.
           </emu-alg>
         </emu-clause>
@@ -34274,7 +34274,7 @@ THH:mm:ss.sss
               1. Let _nextIndex_ be _position_ + _cp_.[[CodeUnitCount]].
               1. Let _resultString_ be the substring of _s_ from _position_ to _nextIndex_.
               1. Set _position_ to _nextIndex_.
-              1. Perform ? Yield(_resultString_).
+              1. Perform ? GeneratorYield(! CreateIterResultObject(_resultString_, *false*)).
             1. Return *undefined*.
           1. Return ! CreateIteratorFromClosure(_closure_, *"%StringIteratorPrototype%"*, %StringIteratorPrototype%).
         </emu-alg>
@@ -34311,7 +34311,7 @@ THH:mm:ss.sss
         <emu-clause id="sec-%stringiteratorprototype%.next">
           <h1>%StringIteratorPrototype%.next ( )</h1>
           <emu-alg>
-            1. Return ? GeneratorResume(*this* value, ~empty~, *"%StringIteratorPrototype%"*).
+            1. Return ? <emu-meta suppress-effects="user-code">GeneratorResume(*this* value, ~empty~, *"%StringIteratorPrototype%"*)</emu-meta>.
           </emu-alg>
         </emu-clause>
 
@@ -35949,7 +35949,7 @@ THH:mm:ss.sss
           <dl class="header">
           </dl>
           <emu-alg>
-            1. Let _obj_ be ? RegExpAlloc(%RegExp%).
+            1. Let _obj_ be ! RegExpAlloc(%RegExp%).
             1. Return ? RegExpInitialize(_obj_, _P_, _F_).
           </emu-alg>
         </emu-clause>
@@ -36544,14 +36544,14 @@ THH:mm:ss.sss
               1. Let _match_ be ? RegExpExec(_R_, _S_).
               1. If _match_ is *null*, return *undefined*.
               1. If _global_ is *false*, then
-                1. Perform ? Yield(_match_).
+                1. Perform ? GeneratorYield(! CreateIterResultObject(_match_, *false*)).
                 1. Return *undefined*.
               1. Let _matchStr_ be ? ToString(? Get(_match_, *"0"*)).
               1. If _matchStr_ is the empty String, then
                 1. Let _thisIndex_ be ℝ(? ToLength(? Get(_R_, *"lastIndex"*))).
                 1. Let _nextIndex_ be ! AdvanceStringIndex(_S_, _thisIndex_, _fullUnicode_).
                 1. Perform ? Set(_R_, *"lastIndex"*, 𝔽(_nextIndex_), *true*).
-              1. Perform ? Yield(_match_).
+              1. Perform ? GeneratorYield(! CreateIterResultObject(_match_, *false*)).
           1. Return ! CreateIteratorFromClosure(_closure_, *"%RegExpStringIteratorPrototype%"*, %RegExpStringIteratorPrototype%).
         </emu-alg>
       </emu-clause>
@@ -37694,9 +37694,9 @@ THH:mm:ss.sss
               1. Return _v_.
             1. [id="step-sortcompare-tostring-x"] Let _xString_ be ? ToString(_x_).
             1. [id="step-sortcompare-tostring-y"] Let _yString_ be ? ToString(_y_).
-            1. Let _xSmaller_ be IsLessThan(_xString_, _yString_, *true*).
+            1. Let _xSmaller_ be <emu-meta suppress-effects="user-code">IsLessThan(_xString_, _yString_, *true*)</emu-meta>.
             1. If _xSmaller_ is *true*, return *-1*<sub>𝔽</sub>.
-            1. Let _ySmaller_ be IsLessThan(_yString_, _xString_, *true*).
+            1. Let _ySmaller_ be <emu-meta suppress-effects="user-code">IsLessThan(_yString_, _xString_, *true*)</emu-meta>.
             1. If _ySmaller_ is *true*, return *1*<sub>𝔽</sub>.
             1. Return *+0*<sub>𝔽</sub>.
           </emu-alg>
@@ -37942,14 +37942,15 @@ THH:mm:ss.sss
               1. Else,
                 1. Let _len_ be ? LengthOfArrayLike(_array_).
               1. If _index_ &ge; _len_, return *undefined*.
-              1. If _kind_ is ~key~, perform ? Yield(𝔽(_index_)).
+              1. If _kind_ is ~key~, perform ? GeneratorYield(! CreateIterResultObject(𝔽(_index_), *false*)).
               1. Else,
                 1. Let _elementKey_ be ! ToString(𝔽(_index_)).
                 1. Let _elementValue_ be ? Get(_array_, _elementKey_).
-                1. If _kind_ is ~value~, perform ? Yield(_elementValue_).
+                1. If _kind_ is ~value~, perform ? GeneratorYield(! CreateIterResultObject(_elementValue_, *false*)).
                 1. Else,
                   1. Assert: _kind_ is ~key+value~.
-                  1. Perform ? Yield(! CreateArrayFromList(&laquo; 𝔽(_index_), _elementValue_ &raquo;)).
+                  1. Let _result_ be ! CreateArrayFromList(&laquo; 𝔽(_index_), _elementValue_ &raquo;).
+                  1. Perform ? GeneratorYield(! CreateIterResultObject(_result_, *false*)).
               1. Set _index_ to _index_ + 1.
           1. Return ! CreateIteratorFromClosure(_closure_, *"%ArrayIteratorPrototype%"*, %ArrayIteratorPrototype%).
         </emu-alg>
@@ -39402,7 +39403,7 @@ THH:mm:ss.sss
             1. Let _constructorName_ be the String value of _O_.[[TypedArrayName]].
             1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for _constructorName_.
             1. Let _byteLength_ be _elementSize_ &times; _length_.
-            1. Let _data_ be ? AllocateArrayBuffer(%ArrayBuffer%, _byteLength_).
+            1. Let _data_ be ? <emu-meta suppress-effects="user-code">AllocateArrayBuffer(%ArrayBuffer%, _byteLength_)</emu-meta>.
             1. Set _O_.[[ViewedArrayBuffer]] to _data_.
             1. Set _O_.[[ByteLength]] to _byteLength_.
             1. Set _O_.[[ByteOffset]] to 0.
@@ -39764,7 +39765,7 @@ THH:mm:ss.sss
                 1. Else,
                   1. Assert: _kind_ is ~key+value~.
                   1. Let _result_ be ! CreateArrayFromList(&laquo; _e_.[[Key]], _e_.[[Value]] &raquo;).
-                1. Perform ? Yield(_result_).
+                1. Perform ? GeneratorYield(! CreateIterResultObject(_result_, *false*)).
                 1. NOTE: The number of elements in _entries_ may have changed while execution of this abstract operation was paused by Yield.
                 1. Set _numEntries_ to the number of elements of _entries_.
             1. Return *undefined*.
@@ -39785,7 +39786,7 @@ THH:mm:ss.sss
         <emu-clause id="sec-%mapiteratorprototype%.next">
           <h1>%MapIteratorPrototype%.next ( )</h1>
           <emu-alg>
-            1. Return ? GeneratorResume(*this* value, ~empty~, *"%MapIteratorPrototype%"*).
+            1. Return ? <emu-meta suppress-effects="user-code">GeneratorResume(*this* value, ~empty~, *"%MapIteratorPrototype%"*)</emu-meta>.
           </emu-alg>
         </emu-clause>
 
@@ -40049,10 +40050,11 @@ THH:mm:ss.sss
               1. Set _index_ to _index_ + 1.
               1. If _e_ is not ~empty~, then
                 1. If _kind_ is ~key+value~, then
-                  1. Perform ? Yield(! CreateArrayFromList(&laquo; _e_, _e_ &raquo;)).
+                  1. Let _result_ be ! CreateArrayFromList(&laquo; _e_, _e_ &raquo;).
+                  1. Perform ? GeneratorYield(! CreateIterResultObject(_result_, *false*)).
                 1. Else,
                   1. Assert: _kind_ is ~value~.
-                  1. Perform ? Yield(_e_).
+                  1. Perform ? GeneratorYield(! CreateIterResultObject(_e_, *false*)).
                 1. NOTE: The number of elements in _entries_ may have changed while execution of this abstract operation was paused by Yield.
                 1. Set _numEntries_ to the number of elements of _entries_.
             1. Return *undefined*.
@@ -40073,7 +40075,7 @@ THH:mm:ss.sss
         <emu-clause id="sec-%setiteratorprototype%.next">
           <h1>%SetIteratorPrototype%.next ( )</h1>
           <emu-alg>
-            1. Return ? GeneratorResume(*this* value, ~empty~, *"%SetIteratorPrototype%"*).
+            1. Return ? <emu-meta suppress-effects="user-code">GeneratorResume(*this* value, ~empty~, *"%SetIteratorPrototype%"*)</emu-meta>.
           </emu-alg>
         </emu-clause>
 
@@ -41954,7 +41956,7 @@ THH:mm:ss.sss
         1. [id="step-json-parse-parse"] Let _script_ be ParseText(! StringToCodePoints(_scriptString_), |Script|).
         1. NOTE: The early error rules defined in <emu-xref href="#sec-object-initializer-static-semantics-early-errors"></emu-xref> have special handling for the above invocation of ParseText.
         1. Assert: _script_ is a Parse Node.
-        1. [id="step-json-parse-eval"] Let _completion_ be the result of evaluating _script_.
+        1. [id="step-json-parse-eval"] Let _completion_ be the result of <emu-meta suppress-effects="user-code">evaluating _script_</emu-meta>.
         1. NOTE: The PropertyDefinitionEvaluation semantics defined in <emu-xref href="#sec-runtime-semantics-propertydefinitionevaluation"></emu-xref> have special handling for the above evaluation.
         1. Let _unfiltered_ be _completion_.[[Value]].
         1. [id="step-json-parse-assert-type"] Assert: _unfiltered_ is either a String, Number, Boolean, Null, or an Object that is defined by either an |ArrayLiteral| or an |ObjectLiteral|.
@@ -41997,7 +41999,7 @@ THH:mm:ss.sss
                 1. Let _prop_ be ! ToString(𝔽(_I_)).
                 1. Let _newElement_ be ? InternalizeJSONProperty(_val_, _prop_, _reviver_).
                 1. If _newElement_ is *undefined*, then
-                  1. Perform ? _val_.[[Delete]](_prop_).
+                  1. Perform ? <emu-meta effects="user-code">_val_.[[Delete]]</emu-meta>(_prop_).
                 1. Else,
                   1. Perform ? CreateDataProperty(_val_, _prop_, _newElement_).
                 1. Set _I_ to _I_ + 1.
@@ -42006,7 +42008,7 @@ THH:mm:ss.sss
               1. For each String _P_ of _keys_, do
                 1. Let _newElement_ be ? InternalizeJSONProperty(_val_, _P_, _reviver_).
                 1. If _newElement_ is *undefined*, then
-                  1. Perform ? _val_.[[Delete]](_P_).
+                  1. Perform ? <emu-meta effects="user-code">_val_.[[Delete]]</emu-meta>(_P_).
                 1. Else,
                   1. Perform ? CreateDataProperty(_val_, _P_, _newElement_).
           1. Return ? Call(_reviver_, _holder_, &laquo; _name_, _val_ &raquo;).
@@ -44508,7 +44510,7 @@ THH:mm:ss.sss
           1. Assert: The value of _generator_.[[GeneratorState]] is *undefined*.
           1. Let _genContext_ be the running execution context.
           1. Set the Generator component of _genContext_ to _generator_.
-          1. Set the code evaluation state of _genContext_ such that when evaluation is resumed for that execution context the following steps will be performed:
+          1. [fence-effects="user-code"] Set the code evaluation state of _genContext_ such that when evaluation is resumed for that execution context the following steps will be performed:
             1. If _generatorBody_ is a Parse Node, then
               1. Let _result_ be the result of evaluating _generatorBody_.
             1. Else,
@@ -44569,7 +44571,7 @@ THH:mm:ss.sss
           1. Suspend _methodContext_.
           1. Set _generator_.[[GeneratorState]] to ~executing~.
           1. Push _genContext_ onto the execution context stack; _genContext_ is now the running execution context.
-          1. Resume the suspended evaluation of _genContext_ using NormalCompletion(_value_) as the result of the operation that suspended it. Let _result_ be the value returned by the resumed computation.
+          1. <emu-meta effects="user-code">Resume the suspended evaluation of _genContext_</emu-meta> using NormalCompletion(_value_) as the result of the operation that suspended it. Let _result_ be the value returned by the resumed computation.
           1. Assert: When we return here, _genContext_ has already been removed from the execution context stack and _methodContext_ is the currently running execution context.
           1. Return Completion(_result_).
         </emu-alg>
@@ -44601,7 +44603,7 @@ THH:mm:ss.sss
           1. Suspend _methodContext_.
           1. Set _generator_.[[GeneratorState]] to ~executing~.
           1. Push _genContext_ onto the execution context stack; _genContext_ is now the running execution context.
-          1. Resume the suspended evaluation of _genContext_ using _abruptCompletion_ as the result of the operation that suspended it. Let _result_ be the completion record returned by the resumed computation.
+          1. <emu-meta effects="user-code">Resume the suspended evaluation of _genContext_</emu-meta> using _abruptCompletion_ as the result of the operation that suspended it. Let _result_ be the completion record returned by the resumed computation.
           1. Assert: When we return here, _genContext_ has already been removed from the execution context stack and _methodContext_ is the currently running execution context.
           1. Return Completion(_result_).
         </emu-alg>
@@ -44856,7 +44858,7 @@ THH:mm:ss.sss
           1. Assert: _generator_.[[AsyncGeneratorState]] is *undefined*.
           1. Let _genContext_ be the running execution context.
           1. Set the Generator component of _genContext_ to _generator_.
-          1. Set the code evaluation state of _genContext_ such that when evaluation is resumed for that execution context the following steps will be performed:
+          1. [fence-effects="user-code"] Set the code evaluation state of _genContext_ such that when evaluation is resumed for that execution context the following steps will be performed:
             1. If _generatorBody_ is a Parse Node, then
               1. Let _result_ be the result of evaluating _generatorBody_.
             1. Else,
@@ -44959,7 +44961,7 @@ THH:mm:ss.sss
           1. Suspend _callerContext_.
           1. Set _generator_.[[AsyncGeneratorState]] to ~executing~.
           1. Push _genContext_ onto the execution context stack; _genContext_ is now the running execution context.
-          1. Resume the suspended evaluation of _genContext_ using _completion_ as the result of the operation that suspended it. Let _result_ be the completion record returned by the resumed computation.
+          1. <emu-meta effects="user-code">Resume the suspended evaluation of _genContext_</emu-meta> using _completion_ as the result of the operation that suspended it. Let _result_ be the completion record returned by the resumed computation.
           1. Assert: _result_ is never an abrupt completion.
           1. Assert: When we return here, _genContext_ has already been removed from the execution context stack and _callerContext_ is the currently running execution context.
         </emu-alg>
@@ -45243,7 +45245,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Assert: _promiseCapability_ is a PromiseCapability Record.
           1. Let _runningContext_ be the running execution context.
-          1. Set the code evaluation state of _asyncContext_ such that when evaluation is resumed for that execution context the following steps will be performed:
+          1. [fence-effects="user-code"] Set the code evaluation state of _asyncContext_ such that when evaluation is resumed for that execution context the following steps will be performed:
             1. Let _result_ be the result of evaluating _asyncBody_.
             1. Assert: If we return here, the async function either threw an exception or performed an implicit or explicit return; all awaiting is done.
             1. Remove _asyncContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
@@ -45256,7 +45258,7 @@ THH:mm:ss.sss
               1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _result_.[[Value]] &raquo;).
             1. [id="step-asyncblockstart-return-undefined"] Return.
           1. Push _asyncContext_ onto the execution context stack; _asyncContext_ is now the running execution context.
-          1. Resume the suspended evaluation of _asyncContext_. Let _result_ be the value returned by the resumed computation.
+          1. <emu-meta effects="user-code">Resume the suspended evaluation of _asyncContext_</emu-meta>. Let _result_ be the value returned by the resumed computation.
           1. Assert: When we return here, _asyncContext_ has already been removed from the execution context stack and _runningContext_ is the currently running execution context.
           1. Assert: _result_ is a normal completion with a value of *undefined*. The possible sources of completion values are Await or, if the async function doesn't await anything, step <emu-xref href="#step-asyncblockstart-return-undefined"></emu-xref> above.
           1. Return.
@@ -45312,7 +45314,7 @@ THH:mm:ss.sss
         1. If Type(_target_) is not Object, throw a *TypeError* exception.
         1. Let _key_ be ? ToPropertyKey(_propertyKey_).
         1. Let _desc_ be ? ToPropertyDescriptor(_attributes_).
-        1. Return ? _target_.[[DefineOwnProperty]](_key_, _desc_).
+        1. Return ? <emu-meta effects="user-code">_target_.[[DefineOwnProperty]]</emu-meta>(_key_, _desc_).
       </emu-alg>
     </emu-clause>
 
@@ -45322,7 +45324,7 @@ THH:mm:ss.sss
       <emu-alg>
         1. If Type(_target_) is not Object, throw a *TypeError* exception.
         1. Let _key_ be ? ToPropertyKey(_propertyKey_).
-        1. Return ? _target_.[[Delete]](_key_).
+        1. Return ? <emu-meta effects="user-code">_target_.[[Delete]]</emu-meta>(_key_).
       </emu-alg>
     </emu-clause>
 
@@ -45334,7 +45336,7 @@ THH:mm:ss.sss
         1. Let _key_ be ? ToPropertyKey(_propertyKey_).
         1. If _receiver_ is not present, then
           1. Set _receiver_ to _target_.
-        1. Return ? _target_.[[Get]](_key_, _receiver_).
+        1. Return ? <emu-meta effects="user-code">_target_.[[Get]]</emu-meta>(_key_, _receiver_).
       </emu-alg>
     </emu-clause>
 
@@ -45344,7 +45346,7 @@ THH:mm:ss.sss
       <emu-alg>
         1. If Type(_target_) is not Object, throw a *TypeError* exception.
         1. Let _key_ be ? ToPropertyKey(_propertyKey_).
-        1. Let _desc_ be ? _target_.[[GetOwnProperty]](_key_).
+        1. Let _desc_ be ? <emu-meta effects="user-code">_target_.[[GetOwnProperty]]</emu-meta>(_key_).
         1. Return FromPropertyDescriptor(_desc_).
       </emu-alg>
     </emu-clause>
@@ -45354,7 +45356,7 @@ THH:mm:ss.sss
       <p>When the `getPrototypeOf` function is called with argument _target_, the following steps are taken:</p>
       <emu-alg>
         1. If Type(_target_) is not Object, throw a *TypeError* exception.
-        1. Return ? _target_.[[GetPrototypeOf]]().
+        1. Return ? <emu-meta effects="user-code">_target_.[[GetPrototypeOf]]()</emu-meta>.
       </emu-alg>
     </emu-clause>
 
@@ -45364,7 +45366,7 @@ THH:mm:ss.sss
       <emu-alg>
         1. If Type(_target_) is not Object, throw a *TypeError* exception.
         1. Let _key_ be ? ToPropertyKey(_propertyKey_).
-        1. Return ? _target_.[[HasProperty]](_key_).
+        1. Return ? <emu-meta effects="user-code">_target_.[[HasProperty]]</emu-meta>(_key_).
       </emu-alg>
     </emu-clause>
 
@@ -45373,7 +45375,7 @@ THH:mm:ss.sss
       <p>When the `isExtensible` function is called with argument _target_, the following steps are taken:</p>
       <emu-alg>
         1. If Type(_target_) is not Object, throw a *TypeError* exception.
-        1. Return ? _target_.[[IsExtensible]]().
+        1. Return ? <emu-meta effects="user-code">_target_.[[IsExtensible]]()</emu-meta>.
       </emu-alg>
     </emu-clause>
 
@@ -45382,7 +45384,7 @@ THH:mm:ss.sss
       <p>When the `ownKeys` function is called with argument _target_, the following steps are taken:</p>
       <emu-alg>
         1. If Type(_target_) is not Object, throw a *TypeError* exception.
-        1. Let _keys_ be ? _target_.[[OwnPropertyKeys]]().
+        1. Let _keys_ be ? <emu-meta effects="user-code">_target_.[[OwnPropertyKeys]]()</emu-meta>.
         1. Return CreateArrayFromList(_keys_).
       </emu-alg>
     </emu-clause>
@@ -45392,7 +45394,7 @@ THH:mm:ss.sss
       <p>When the `preventExtensions` function is called with argument _target_, the following steps are taken:</p>
       <emu-alg>
         1. If Type(_target_) is not Object, throw a *TypeError* exception.
-        1. Return ? _target_.[[PreventExtensions]]().
+        1. Return ? <emu-meta effects="user-code">_target_.[[PreventExtensions]]()</emu-meta>.
       </emu-alg>
     </emu-clause>
 
@@ -45404,7 +45406,7 @@ THH:mm:ss.sss
         1. Let _key_ be ? ToPropertyKey(_propertyKey_).
         1. If _receiver_ is not present, then
           1. Set _receiver_ to _target_.
-        1. Return ? _target_.[[Set]](_key_, _V_, _receiver_).
+        1. Return ? <emu-meta effects="user-code">_target_.[[Set]]</emu-meta>(_key_, _V_, _receiver_).
       </emu-alg>
     </emu-clause>
 
@@ -45414,7 +45416,7 @@ THH:mm:ss.sss
       <emu-alg>
         1. If Type(_target_) is not Object, throw a *TypeError* exception.
         1. If Type(_proto_) is not Object and _proto_ is not *null*, throw a *TypeError* exception.
-        1. Return ? _target_.[[SetPrototypeOf]](_proto_).
+        1. Return ? <emu-meta effects="user-code">_target_.[[SetPrototypeOf]]</emu-meta>(_proto_).
       </emu-alg>
     </emu-clause>
 
@@ -47381,7 +47383,7 @@ THH:mm:ss.sss
                       1. Let _genv_ be the running execution context's VariableEnvironment.
                       1. Let _benv_ be the running execution context's LexicalEnvironment.
                       1. Let _fobj_ be ! _benv_.GetBindingValue(_F_, *false*).
-                      1. Perform ? _genv_.SetMutableBinding(_F_, _fobj_, *false*).
+                      1. Perform ? <emu-meta effects="user-code">_genv_.SetMutableBinding</emu-meta>(_F_, _fobj_, *false*).
                       1. Return NormalCompletion(~empty~).
         </emu-alg>
       </emu-annex>
@@ -47424,7 +47426,7 @@ THH:mm:ss.sss
                     1. Let _genv_ be the running execution context's VariableEnvironment.
                     1. Let _benv_ be the running execution context's LexicalEnvironment.
                     1. Let _fobj_ be ! _benv_.GetBindingValue(_F_, *false*).
-                    1. Perform ? _genv_.SetMutableBinding(_F_, _fobj_, *false*).
+                    1. Perform ? <emu-meta effects="user-code">_genv_.SetMutableBinding</emu-meta>(_F_, _fobj_, *false*).
                     1. Return NormalCompletion(~empty~).
         </emu-alg>
       </emu-annex>


### PR DESCRIPTION
This PR adds an annotation to call sites of AOs and SDOs that can call user code, possibly transitively.

Ecmarkup starts with a set of "roots" that can call user code, and propagates the effect to all reachable AO and SDO invocations.

For spec authors:
- Roots and false negatives can be manually tagged with `<emu-meta effects="user-code">root cause</emu-meta>`.
- Most invocations of internal methods (e.g. [[Get]]) are roots.
- The phrase "the result of evaluating" is automatically considered a root.
- False positives can be manually suppressed with `<emu-meta suppress-effects="user-code">suppressed</emu-meta>`.
- Steps can be manually fenced with `1. [fence-effects="user-code"] Step`, which fences any child step effects from propagating.
- Some spec constructs in algorithm steps are like nested functions and should fence effects from propagating. Abstract Closures are automatic fences.