### PR TITLE
Editorial: Define StringToBigInt with an algorithm + grammar

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -5471,7 +5471,7 @@
               <td>
                 <emu-alg>
                   1. Let _n_ be ! StringToBigInt(_prim_).
-                  1. If _n_ is *NaN*, throw a *SyntaxError* exception.
+                  1. If _n_ is *undefined*, throw a *SyntaxError* exception.
                   1. Return _n_.
                 </emu-alg>
               </td>
@@ -5497,12 +5497,12 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It returns a BigInt or *NaN*.</dd>
+        <dd>It returns a BigInt or *undefined*.</dd>
       </dl>
       <emu-alg>
         1. Let _text_ be ! StringToCodePoints(_str_).
         1. Let _literal_ be ParseText(_text_, |StringIntegerLiteral|).
-        1. If _literal_ is a List of errors, return *NaN*.
+        1. If _literal_ is a List of errors, return *undefined*.
         1. Let _mv_ be the MV of _literal_.
         1. Assert: _mv_ is an integer.
         1. Return ℤ(_mv_).
@@ -6168,11 +6168,11 @@
         1. Else,
           1. If Type(_px_) is BigInt and Type(_py_) is String, then
             1. Let _ny_ be ! StringToBigInt(_py_).
-            1. If _ny_ is *NaN*, return *undefined*.
+            1. If _ny_ is *undefined*, return *undefined*.
             1. Return BigInt::lessThan(_px_, _ny_).
           1. If Type(_px_) is String and Type(_py_) is BigInt, then
             1. Let _nx_ be ! StringToBigInt(_px_).
-            1. If _nx_ is *NaN*, return *undefined*.
+            1. If _nx_ is *undefined*, return *undefined*.
             1. Return BigInt::lessThan(_nx_, _py_).
           1. NOTE: Because _px_ and _py_ are primitive values, evaluation order is not important.
           1. Let _nx_ be ? ToNumeric(_px_).
@@ -6218,7 +6218,7 @@
         1. If Type(_x_) is String and Type(_y_) is Number, return IsLooselyEqual(! ToNumber(_x_), _y_).
         1. If Type(_x_) is BigInt and Type(_y_) is String, then
           1. Let _n_ be ! StringToBigInt(_y_).
-          1. If _n_ is *NaN*, return *false*.
+          1. If _n_ is *undefined*, return *false*.
           1. Return IsLooselyEqual(_x_, _n_).
         1. If Type(_x_) is String and Type(_y_) is BigInt, return IsLooselyEqual(_y_, _x_).
         1. If Type(_x_) is Boolean, return IsLooselyEqual(! ToNumber(_x_), _y_).


### PR DESCRIPTION
Formerly, it was defined by describing changes to the StringToNumber operation + grammar.

As @michaelficarra pointed out recently in Matrix, it's weird that StringToBigInt() returns `*NaN*` (a *Number* value) in the case of a parse error. It might make more sense to return `*undefined*` or `~error~` or something. (The specific value isn't user-visible -- it gets mapped to a `SyntaxError`, `*undefined*`, or `*false*`, depending on context.) What might make the most sense is to throw a `SyntaxError`, though that would involve slightly larger changes at call-points. Let me know if you'd like this changed, and I can add a commit.