### PR TITLE
Editorial: Fix parameter type in InnerModuleLinking

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -26248,7 +26248,7 @@
           <emu-clause id="sec-InnerModuleLinking" type="abstract operation" oldids="sec-innermoduleinstantiation">
             <h1>
               InnerModuleLinking (
-                _module_: a Cyclic Module Record,
+                _module_: a Module Record,
                 _stack_: unknown,
                 _index_: a non-negative integer,
               )


### PR DESCRIPTION
Fixes 3 places where the given parameter type is too restrictive.