### PR TITLE
Editorial: Use spec enums for direction instead of 1 and -1

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -35082,7 +35082,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-compilesubpattern" type="sdo" oldids="sec-disjunction,sec-alternative,sec-term">
         <h1>
           Runtime Semantics: CompileSubpattern (
-            _direction_: 1 or -1,
+            _direction_: ~forward~ or ~backward~,
           )
         </h1>
         <dl class="header">
@@ -35129,7 +35129,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _m1_ be CompileSubpattern of |Alternative| with argument _direction_.
           1. Let _m2_ be CompileSubpattern of |Term| with argument _direction_.
-          1. If _direction_ = 1, then
+          1. If _direction_ is ~forward~, then
             1. Return a new Matcher with parameters (_x_, _c_) that captures _m1_ and _m2_ and performs the following steps when called:
               1. Assert: _x_ is a State.
               1. Assert: _c_ is a Continuation.
@@ -35138,7 +35138,7 @@ THH:mm:ss.sss
                 1. Return _m2_(_y_, _c_).
               1. Return _m1_(_x_, _d_).
           1. Else,
-            1. Assert: _direction_ is -1.
+            1. Assert: _direction_ is ~backward~.
             1. Return a new Matcher with parameters (_x_, _c_) that captures _m1_ and _m2_ and performs the following steps when called:
               1. Assert: _x_ is a State.
               1. Assert: _c_ is a Continuation.
@@ -35148,7 +35148,7 @@ THH:mm:ss.sss
               1. Return _m2_(_x_, _d_).
         </emu-alg>
         <emu-note>
-          <p>Consecutive |Term|s try to simultaneously match consecutive portions of _Input_. When _direction_ = 1, if the left |Alternative|, the right |Term|, and the sequel of the regular expression all have choice points, all choices in the sequel are tried before moving on to the next choice in the right |Term|, and all choices in the right |Term| are tried before moving on to the next choice in the left |Alternative|. When _direction_ = -1, the evaluation order of |Alternative| and |Term| are reversed.</p>
+          <p>Consecutive |Term|s try to simultaneously match consecutive portions of _Input_. When _direction_ is ~forward~, if the left |Alternative|, the right |Term|, and the sequel of the regular expression all have choice points, all choices in the sequel are tried before moving on to the next choice in the right |Term|, and all choices in the right |Term| are tried before moving on to the next choice in the left |Alternative|. When _direction_ is ~backward~, the evaluation order of |Alternative| and |Term| are reversed.</p>
         </emu-note>
 
         <!-- Term -->
@@ -35444,7 +35444,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-compileatom" type="sdo" oldids="sec-atom,sec-atomescape,sec-characterescape,sec-decimalescape">
         <h1>
           Runtime Semantics: CompileAtom (
-            _direction_: 1 or -1,
+            _direction_: ~forward~ or ~backward~,
           )
         </h1>
         <dl class="header">
@@ -35486,11 +35486,11 @@ THH:mm:ss.sss
               1. Let _cap_ be a copy of _y_'s _captures_ List.
               1. Let _xe_ be _x_'s _endIndex_.
               1. Let _ye_ be _y_'s _endIndex_.
-              1. If _direction_ = 1, then
+              1. If _direction_ is ~forward~, then
                 1. Assert: _xe_ &le; _ye_.
                 1. Let _s_ be a List whose elements are the characters of _Input_ at indices _xe_ (inclusive) through _ye_ (exclusive).
               1. Else,
-                1. Assert: _direction_ is -1.
+                1. Assert: _direction_ is ~backward~.
                 1. Assert: _ye_ &le; _xe_.
                 1. Let _s_ be a List whose elements are the characters of _Input_ at indices _ye_ (inclusive) through _xe_ (exclusive).
               1. Set _cap_[_parenIndex_ + 1] to _s_.
@@ -35538,7 +35538,7 @@ THH:mm:ss.sss
             CharacterSetMatcher (
               _A_: a CharSet,
               _invert_: a Boolean,
-              _direction_: 1 or -1,
+              _direction_: ~forward~ or ~backward~,
             )
           </h1>
           <dl class="header">
@@ -35548,7 +35548,8 @@ THH:mm:ss.sss
               1. Assert: _x_ is a State.
               1. Assert: _c_ is a Continuation.
               1. Let _e_ be _x_'s _endIndex_.
-              1. Let _f_ be _e_ + _direction_.
+              1. If _direction_ is ~forward~, let _f_ be _e_ + 1.
+              1. Else, let _f_ be _e_ - 1.
               1. If _f_ &lt; 0 or _f_ &gt; _InputLength_, return ~failure~.
               1. Let _index_ be min(_e_, _f_).
               1. Let _ch_ be the character _Input_[_index_].
@@ -35566,7 +35567,7 @@ THH:mm:ss.sss
           <h1>
             BackreferenceMatcher (
               _n_: a positive integer,
-              _direction_: 1 or -1,
+              _direction_: ~forward~ or ~backward~,
             )
           </h1>
           <dl class="header">
@@ -35581,7 +35582,8 @@ THH:mm:ss.sss
               1. If _s_ is *undefined*, return _c_(_x_).
               1. Let _e_ be _x_'s _endIndex_.
               1. Let _len_ be the number of elements in _s_.
-              1. Let _f_ be _e_ + _direction_ &times; _len_.
+              1. If _direction_ is ~forward~, let _f_ be _e_ + _len_.
+              1. Else, let _f_ be _e_ - _len_.
               1. If _f_ &lt; 0 or _f_ &gt; _InputLength_, return ~failure~.
               1. Let _g_ be min(_e_, _f_).
               1. If there exists an integer _i_ between 0 (inclusive) and _len_ (exclusive) such that Canonicalize(_s_[_i_]) is not the same character value as Canonicalize(_Input_[_g_ + _i_]), return ~failure~.


### PR DESCRIPTION
Followup to #2531 as suggested in https://github.com/tc39/ecma262/pull/2531#pullrequestreview-785113737.