### PR TITLE
Editorial: Remove <SP> and <NBSP> as the ones already included by <USP>

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -16204,28 +16204,6 @@
         </tr>
         <tr>
           <td>
-            `U+0020`
-          </td>
-          <td>
-            SPACE
-          </td>
-          <td>
-            &lt;SP&gt;
-          </td>
-        </tr>
-        <tr>
-          <td>
-            `U+00A0`
-          </td>
-          <td>
-            NO-BREAK SPACE
-          </td>
-          <td>
-            &lt;NBSP&gt;
-          </td>
-        </tr>
-        <tr>
-          <td>
             `U+FEFF`
           </td>
           <td>
@@ -16237,10 +16215,10 @@
         </tr>
         <tr>
           <td>
-            Other category &ldquo;Zs&rdquo;
+            Category &ldquo;Zs&rdquo;
           </td>
           <td>
-            Any other Unicode &ldquo;Space_Separator&rdquo; code point
+            Any Unicode &ldquo;Space_Separator&rdquo; code point
           </td>
           <td>
             &lt;USP&gt;
@@ -16249,7 +16227,9 @@
         </tbody>
       </table>
     </emu-table>
-    <p>ECMAScript implementations must recognize as |WhiteSpace| code points listed in the &ldquo;Space_Separator&rdquo; (&ldquo;Zs&rdquo;) category.</p>
+    <emu-note>
+      <p>U+0020 (SPACE) and U+00A0 (NO-BREAK SPACE) code points are part of &lt;USP&gt;.</p>
+    </emu-note>
     <emu-note>
       <p>Other than for the code points listed in <emu-xref href="#table-white-space-code-points"></emu-xref>, ECMAScript |WhiteSpace| intentionally excludes all code points that have the Unicode &ldquo;White_Space&rdquo; property but which are not classified in category &ldquo;Space_Separator&rdquo; (&ldquo;Zs&rdquo;).</p>
     </emu-note>
@@ -16259,8 +16239,6 @@
         &lt;TAB&gt;
         &lt;VT&gt;
         &lt;FF&gt;
-        &lt;SP&gt;
-        &lt;NBSP&gt;
         &lt;ZWNBSP&gt;
         &lt;USP&gt;
     </emu-grammar>


### PR DESCRIPTION
- [Table 39](https://tc39.es/ecma262/#table-white-space-code-points) explicitly lists \<SP> and \<NBSP> to be later used as a right-hand side of `WhiteSpace`. However, they are already implicitly included there by neighbour \<USP> because of their `Zs` category and need no repetition (see <https://www.unicode.org/Public/UCD/latest/ucd/UnicodeData.txt>).

  *This repetition is minor, but deduplication need to be done manually or by a generator while creation of a parser. A simple removal of explicit \<SP> and \<NBSP> allows to avoid such a step.*

  Also I added a note explaining where space and NBSP characters have gone:

  > U+0020 (SPACE) and U+00A0 (NO-BREAK SPACE) code points are part of \<USP>.

   but I can remove it if a reader would not care about where the grammar introduces spaces.

- In addition, with another commit I removed a line that just repeats the grammar (unconditional inclusion of \<USP\> as a right-hand side of `WhiteSpace`) just before the relevant declaration:

  > ECMAScript implementations must recognize as *WhiteSpace* code points listed in the “Space_Separator” (“Zs”) category.