### PR TITLE
Editorial: document forbidden extension

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -28521,6 +28521,9 @@
         If an implementation extends any function object with an own property named *"caller"* the value of that property, as observed using [[Get]] or [[GetOwnProperty]], must not be a strict function object. If it is an accessor property, the function that is the value of the property's [[Get]] attribute must never return a strict function when called.
       </li>
       <li>
+        An implementation must not throw a TypeError from a built-in function based simply on the presence of an argument which that function has not been specified to allow.
+      </li>
+      <li>
         Neither mapped nor unmapped arguments objects may be created with an own property named *"caller"*.
       </li>
       <li>


### PR DESCRIPTION
This restriction has previously been documented in the section titled "ECMAScript Standard Built-in Objects". Include it in the section designed to summarize all such restrictions.

---

I tried to match the original language. That said, the original language might be a little confusing out of context. Maybe this would be better:

> - An implementation must not throw a TypeError from a built-in function based simply on the presence of an argument which is not defined by this specification.