### PR TITLE
Editorial: Fix false claim in notes for find/findIndex

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -37083,7 +37083,7 @@ THH:mm:ss.sss
           <p>If a _thisArg_ parameter is provided, it will be used as the *this* value for each invocation of _predicate_. If it is not provided, *undefined* is used instead.</p>
           <p>_predicate_ is called with three arguments: the value of the element, the index of the element, and the object being traversed.</p>
           <p>`find` does not directly mutate the object on which it is called but the object may be mutated by the calls to _predicate_.</p>
-          <p>The range of elements processed by `find` is set before the first call to _predicate_. Elements that are appended to the array after the call to `find` begins will not be visited by _predicate_. If existing elements of the array are changed, their value as passed to _predicate_ will be the value at the time that `find` visits them; elements that are deleted after the call to `find` begins and before being visited are not visited.</p>
+          <p>The range of elements processed by `find` is set before the first call to _predicate_. Elements that are appended to the array after the call to `find` begins will not be visited by _predicate_. If existing elements of the array are changed, their value as passed to _predicate_ will be the value at the time that `find` visits them; elements that are deleted after the call to `find` begins and before being visited are still visited and are either looked up from the prototype or are *undefined*.</p>
         </emu-note>
         <p>When the `find` method is called, the following steps are taken:</p>
         <emu-alg>
@@ -37111,7 +37111,7 @@ THH:mm:ss.sss
           <p>If a _thisArg_ parameter is provided, it will be used as the *this* value for each invocation of _predicate_. If it is not provided, *undefined* is used instead.</p>
           <p>_predicate_ is called with three arguments: the value of the element, the index of the element, and the object being traversed.</p>
           <p>`findIndex` does not directly mutate the object on which it is called but the object may be mutated by the calls to _predicate_.</p>
-          <p>The range of elements processed by `findIndex` is set before the first call to _predicate_. Elements that are appended to the array after the call to `findIndex` begins will not be visited by _predicate_. If existing elements of the array are changed, their value as passed to _predicate_ will be the value at the time that `findIndex` visits them; elements that are deleted after the call to `findIndex` begins and before being visited are not visited.</p>
+          <p>The range of elements processed by `findIndex` is set before the first call to _predicate_. Elements that are appended to the array after the call to `findIndex` begins will not be visited by _predicate_. If existing elements of the array are changed, their value as passed to _predicate_ will be the value at the time that `findIndex` visits them; elements that are deleted after the call to `findIndex` begins and before being visited are still visited and are either looked up from the prototype or are *undefined*.</p>
         </emu-note>
         <p>When the `findIndex` method is called, the following steps are taken:</p>
         <emu-alg>


### PR DESCRIPTION
This text was presumably copied from `map` or a similar older method, but these two more modern methods do an unconditional [[Get]] rather than gating on [[HasProperty]].