### PR TITLE
Markup: auto-format

### DIFF
--- a/.github/workflows/enforce-format.yml
+++ b/.github/workflows/enforce-format.yml
@@ -1,0 +1,17 @@
+name: 'enforce format'
+
+on: [pull_request]
+
+jobs:
+  build:
+    name: 'enforce format'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ljharb/actions/node/install@56f291b2a0d9e3bce72634356ae949b1e054b9f8
+        name: 'nvm install lts/* && npm ci'
+        with:
+          node-version: lts/*
+          use-npm-ci: true
+      - run: 'if ! $(npm bin)/emu-format --check spec.html; then echo "You need to run `npm run format`"; exit 1; fi'

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,11 +18,11 @@
       "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w=="
     },
     "@babel/highlight": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-      "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
+      "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
       "requires": {
-        "@babel/helper-validator-identifier": "^7.14.5",
+        "@babel/helper-validator-identifier": "^7.15.7",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -56,52 +56,52 @@
       }
     },
     "@esfx/async-canceltoken": {
-      "version": "1.0.0-pre.19",
-      "resolved": "https://registry.npmjs.org/@esfx/async-canceltoken/-/async-canceltoken-1.0.0-pre.19.tgz",
-      "integrity": "sha512-t8Gc0PpasyZkRuMLx6epjoTT4gvB+wICjjsGJwAViAresPG//zNfoOOk61+e9Bg1izEizrYxknQw0on4NwlKHA==",
+      "version": "1.0.0-pre.30",
+      "resolved": "https://registry.npmjs.org/@esfx/async-canceltoken/-/async-canceltoken-1.0.0-pre.30.tgz",
+      "integrity": "sha512-4he0W+ZKH4OO4RvGfmATIibO5JzGLQqwm4Dp3X15bWnguDTmmOFt3Qt169Doij/gXxn2aPpZvxUaYIEebi8Xig==",
       "requires": {
-        "@esfx/cancelable": "^1.0.0-pre.19",
-        "@esfx/collections-linkedlist": "^1.0.0-pre.19",
-        "@esfx/disposable": "^1.0.0-pre.19",
-        "@esfx/internal-guards": "^1.0.0-pre.19",
+        "@esfx/cancelable": "^1.0.0-pre.30",
+        "@esfx/collections-linkedlist": "^1.0.0-pre.24",
+        "@esfx/disposable": "^1.0.0-pre.30",
+        "@esfx/internal-guards": "^1.0.0-pre.23",
         "@esfx/internal-tag": "^1.0.0-pre.19",
         "tslib": "^2.1.0"
       }
     },
     "@esfx/cancelable": {
-      "version": "1.0.0-pre.19",
-      "resolved": "https://registry.npmjs.org/@esfx/cancelable/-/cancelable-1.0.0-pre.19.tgz",
-      "integrity": "sha512-O+p582k+UsiPsikCTBoF0lE0hNrL7ZWXyp17FFiGBxWuq4zqC41qx3rSh+P8+64x8EHGJxkCc1uIhe688hXbjw==",
+      "version": "1.0.0-pre.30",
+      "resolved": "https://registry.npmjs.org/@esfx/cancelable/-/cancelable-1.0.0-pre.30.tgz",
+      "integrity": "sha512-fo0+/D3tEcSOHdZ8HiCR7qOKl5Tkk6Nw6QJNNXSQ0ejlpP3HU4S2i0rb/tjHQ1EkUcWZfB3g2jzfL0ioQSEgGg==",
       "requires": {
-        "@esfx/disposable": "^1.0.0-pre.19",
-        "@esfx/internal-deprecate": "^1.0.0-pre.19",
-        "@esfx/internal-guards": "^1.0.0-pre.19",
+        "@esfx/disposable": "^1.0.0-pre.30",
+        "@esfx/internal-deprecate": "^1.0.0-pre.24",
+        "@esfx/internal-guards": "^1.0.0-pre.23",
         "@esfx/internal-tag": "^1.0.0-pre.19"
       }
     },
     "@esfx/collection-core": {
-      "version": "1.0.0-pre.19",
-      "resolved": "https://registry.npmjs.org/@esfx/collection-core/-/collection-core-1.0.0-pre.19.tgz",
-      "integrity": "sha512-MxhE3HB+l4YbExcmau8osoa3ec6t/qNwIjxWgn4IopYYNpNCl7lu2pY+WTnCpCeRskqGF3faW7nzREsmIapQKA==",
+      "version": "1.0.0-pre.24",
+      "resolved": "https://registry.npmjs.org/@esfx/collection-core/-/collection-core-1.0.0-pre.24.tgz",
+      "integrity": "sha512-OIgMS91JmjSoRWD7u/DfnDzo8vDggeTeUPRi1p5WhyboY0+IwmetEqgeHZb8bpka/SsmtYX5qxqEjeqNXqh+pA==",
       "requires": {
-        "@esfx/internal-deprecate": "^1.0.0-pre.19",
-        "@esfx/internal-guards": "^1.0.0-pre.19"
+        "@esfx/internal-deprecate": "^1.0.0-pre.24",
+        "@esfx/internal-guards": "^1.0.0-pre.23"
       }
     },
     "@esfx/collections-linkedlist": {
-      "version": "1.0.0-pre.19",
-      "resolved": "https://registry.npmjs.org/@esfx/collections-linkedlist/-/collections-linkedlist-1.0.0-pre.19.tgz",
-      "integrity": "sha512-NrH1jyf+BsHe1qYH7rwZoZqTMu404ws85qW/XN3j7qeZeZye3ZvXJN3XyVRCyQMVH6iN9vFbco+kGRz6diiJog==",
+      "version": "1.0.0-pre.24",
+      "resolved": "https://registry.npmjs.org/@esfx/collections-linkedlist/-/collections-linkedlist-1.0.0-pre.24.tgz",
+      "integrity": "sha512-Maya8jXH0xvzyfeSH88/j2b5gavO/mluslgIC2Ttdz8rh6+3o8/pVYriceH/Jinn4pgTEzDhO6Rn/aruZG0+Ug==",
       "requires": {
-        "@esfx/collection-core": "^1.0.0-pre.19",
+        "@esfx/collection-core": "^1.0.0-pre.24",
         "@esfx/equatable": "^1.0.0-pre.19",
-        "@esfx/internal-guards": "^1.0.0-pre.19"
+        "@esfx/internal-guards": "^1.0.0-pre.23"
       }
     },
     "@esfx/disposable": {
-      "version": "1.0.0-pre.19",
-      "resolved": "https://registry.npmjs.org/@esfx/disposable/-/disposable-1.0.0-pre.19.tgz",
-      "integrity": "sha512-xNrDOKBzx49yXfQuAbWv5IN7dL1qL7DhLxmh9U6oC4uN0mLdlUHByMpyKonkHG98rEF43Q1xwuOAgEJd7C4eyw=="
+      "version": "1.0.0-pre.30",
+      "resolved": "https://registry.npmjs.org/@esfx/disposable/-/disposable-1.0.0-pre.30.tgz",
+      "integrity": "sha512-njBGIQO+HW+lMqqMjURC+MWn+55ufulgebPLXzlxbwVSz5hZkoCsv6n9sIBQbnvg/PYQmWK5Dk6gDSmFfihTUg=="
     },
     "@esfx/equatable": {
       "version": "1.0.0-pre.19",
@@ -109,16 +109,16 @@
       "integrity": "sha512-+f6Xm6GOigyGx7t0D0IyG9Z0AuYDhNWjwV49vs5uNG/+0VQAOSYjmnpSzTZRYcYwxW52DmWJWFYNY8bvCDD2ag=="
     },
     "@esfx/internal-deprecate": {
-      "version": "1.0.0-pre.19",
-      "resolved": "https://registry.npmjs.org/@esfx/internal-deprecate/-/internal-deprecate-1.0.0-pre.19.tgz",
-      "integrity": "sha512-vXsdTxRzEaVlXUSahWYsK+hyoqoEOjaKvWXzDuq7Vgu2YsWAvZOCgVrWdhABbAZqasqdjm5MqEVLRdTVskjzug=="
+      "version": "1.0.0-pre.24",
+      "resolved": "https://registry.npmjs.org/@esfx/internal-deprecate/-/internal-deprecate-1.0.0-pre.24.tgz",
+      "integrity": "sha512-TSU5k04+nuVQdyfYhaVXxyskdiwYQHgwN20J3cbyRrm/YFi2dOoFSLFvkMNh7LNOPGWSOg6pfAm3kd23ISR3Ow=="
     },
     "@esfx/internal-guards": {
-      "version": "1.0.0-pre.19",
-      "resolved": "https://registry.npmjs.org/@esfx/internal-guards/-/internal-guards-1.0.0-pre.19.tgz",
-      "integrity": "sha512-vXEn4RAuuQBx6Nr6VVt2ssEzD9cLahRCcGgK2L7ZPmpqh2daYeViHkqKgQD0ouMXFc5m+OQ9/W1xQ6diSz6inQ==",
+      "version": "1.0.0-pre.23",
+      "resolved": "https://registry.npmjs.org/@esfx/internal-guards/-/internal-guards-1.0.0-pre.23.tgz",
+      "integrity": "sha512-y2svuwRERA2eKF1T/Stq+O8kPjicFQcUTob5je3L6iloOHnOD0sX6aQLvheWmTXXS7hAnjlyMeSN/ec84BRyHg==",
       "requires": {
-        "@esfx/type-model": "^1.0.0-pre.19"
+        "@esfx/type-model": "^1.0.0-pre.23"
       }
     },
     "@esfx/internal-tag": {
@@ -127,9 +127,9 @@
       "integrity": "sha512-/v1D5LfvBnbvHzL22Vh6yobrOTVCBhsW/l9M+/GRA51eqCN27yTmWGaYUSd1QXp2vxHwNr0sfckVoNtTzeaIqQ=="
     },
     "@esfx/type-model": {
-      "version": "1.0.0-pre.19",
-      "resolved": "https://registry.npmjs.org/@esfx/type-model/-/type-model-1.0.0-pre.19.tgz",
-      "integrity": "sha512-YPKEdFEHSMn9GCByQN6y6fGZpN4WY8A0D+R4KcwLqAZ3591ID7smitEGSH8ynAJfklmx1N7gMwYVLqysp1L1lg=="
+      "version": "1.0.0-pre.23",
+      "resolved": "https://registry.npmjs.org/@esfx/type-model/-/type-model-1.0.0-pre.23.tgz",
+      "integrity": "sha512-jwcSY9pqEmGoDNhfT+0LUmSTyk6zXF/pbgKb7KU7mTfCrWfVCT/ve61cD1CreerDRBSat/s55se0lJXwDSjhuA=="
     },
     "@eslint/eslintrc": {
       "version": "0.4.3",
@@ -171,9 +171,32 @@
       }
     },
     "@humanwhocodes/object-schema": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
-      "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA=="
+    },
+    "@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "requires": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      }
     },
     "abab": {
       "version": "1.0.4",
@@ -327,6 +350,14 @@
         "concat-map": "0.0.1"
       }
     },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
     "browser-process-hrtime": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
@@ -461,6 +492,11 @@
         "ms": "2.1.2"
       }
     },
+    "dedent-js": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dedent-js/-/dedent-js-1.0.1.tgz",
+      "integrity": "sha1-vuX7fJ5yfYXf+iRZDRDsGrElUwU="
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -497,21 +533,23 @@
       }
     },
     "ecmarkdown": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/ecmarkdown/-/ecmarkdown-6.0.0.tgz",
-      "integrity": "sha512-zy4Qd/1K7LxCkzarnyGdXrXYH2iUzIysQAs+JLu7PcR2OAFzH2D0dgpRYdGJzJ49oHmxxSjx9NnAgFJINwWLOA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/ecmarkdown/-/ecmarkdown-6.0.2.tgz",
+      "integrity": "sha512-I5ASKhWOFShuvmb1BOr8TTsULSw9Qo6mvFGup9eEyYoAZGHeN/0mbtmrUe7ZOAwx7/On0i8AsSOObEu6MqPTMg==",
       "requires": {
         "escape-html": "^1.0.1"
       }
     },
     "ecmarkup": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-9.2.0.tgz",
-      "integrity": "sha512-bWAJJsKlXmenaG8B2TJtDodIXVoANg3pq7a4ZG14/CyxTx4f6c/0ZiFlI/M0rp9/goD6y0Y/G0CRB3tWggJ17w==",
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-9.6.1.tgz",
+      "integrity": "sha512-E0jC7Is8oluC5nlaJXpOHbiaHFibrhtHkRqWxbYLIBsnUQdZTn7rB22hDAWIWDqR7u7q3Vio5as8wURp+B6keA==",
       "requires": {
         "chalk": "^1.1.3",
-        "ecmarkdown": "^6.0.0",
+        "dedent-js": "^1.0.1",
+        "ecmarkdown": "^6.0.2",
         "eslint": "^7.29.0",
+        "fast-glob": "^3.2.7",
         "grammarkdown": "^3.1.1",
         "highlight.js": "11.0.1",
         "html-escape": "^1.0.2",
@@ -731,11 +769,11 @@
           "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="
         },
         "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
           "requires": {
-            "ansi-regex": "^5.0.0"
+            "ansi-regex": "^5.0.1"
           }
         },
         "supports-color": {
@@ -816,9 +854,9 @@
       },
       "dependencies": {
         "estraverse": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
-          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ=="
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
         }
       }
     },
@@ -831,9 +869,9 @@
       },
       "dependencies": {
         "estraverse": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
-          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ=="
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
         }
       }
     },
@@ -862,6 +900,18 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
       "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
     },
+    "fast-glob": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
+      "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+      "requires": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      }
+    },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -872,12 +922,28 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
+    "fastq": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
+      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+      "requires": {
+        "reusify": "^1.0.4"
+      }
+    },
     "file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
       "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
       "requires": {
         "flat-cache": "^3.0.4"
+      }
+    },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "requires": {
+        "to-regex-range": "^5.0.1"
       }
     },
     "flat-cache": {
@@ -890,9 +956,9 @@
       }
     },
     "flatted": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
-      "integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA=="
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
+      "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw=="
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -955,9 +1021,9 @@
       }
     },
     "globals": {
-      "version": "13.11.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.11.0.tgz",
-      "integrity": "sha512-08/xrJ7wQjK9kkkRoI3OFUBbLx4f+6x3SGwcPvQ0QH6goFDrOU2oyAWrmh3dJezu65buo+HBMzAMQy6rovVC3g==",
+      "version": "13.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz",
+      "integrity": "sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==",
       "requires": {
         "type-fest": "^0.20.2"
       }
@@ -1095,12 +1161,17 @@
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
     },
     "is-glob": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "requires": {
         "is-extglob": "^2.1.1"
       }
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -1291,11 +1362,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
-    "lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
-    },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -1317,6 +1383,20 @@
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "requires": {
         "yallist": "^4.0.0"
+      }
+    },
+    "merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
+    },
+    "micromatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+      "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+      "requires": {
+        "braces": "^3.0.1",
+        "picomatch": "^2.2.3"
       }
     },
     "mime-db": {
@@ -1446,6 +1526,11 @@
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
+    "picomatch": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw=="
+    },
     "pn": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
@@ -1489,6 +1574,11 @@
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+    },
+    "queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
     },
     "readable-stream": {
       "version": "3.6.0",
@@ -1561,12 +1651,25 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
     },
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
+    },
     "rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "requires": {
         "glob": "^7.1.3"
+      }
+    },
+    "run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "requires": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "safe-buffer": {
@@ -1680,13 +1783,13 @@
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
     "string-width": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.0"
+        "strip-ansi": "^6.0.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -1695,11 +1798,11 @@
           "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
         },
         "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
           "requires": {
-            "ansi-regex": "^5.0.0"
+            "ansi-regex": "^5.0.1"
           }
         }
       }
@@ -1737,22 +1840,21 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
     },
     "table": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/table/-/table-6.7.1.tgz",
-      "integrity": "sha512-ZGum47Yi6KOOFDE8m223td53ath2enHcYLgOCjGr5ngu8bdIARQk6mN/wRMv4yMRcHnCSnHbCEha4sobQx5yWg==",
+      "version": "6.7.3",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.7.3.tgz",
+      "integrity": "sha512-5DkIxeA7XERBqMwJq0aHZOdMadBx4e6eDoFRuyT5VR82J0Ycg2DwM6GfA/EQAhJ+toRTaS1lIdSQCqgrmhPnlw==",
       "requires": {
         "ajv": "^8.0.1",
-        "lodash.clonedeep": "^4.5.0",
         "lodash.truncate": "^4.4.2",
         "slice-ansi": "^4.0.0",
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0"
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
       },
       "dependencies": {
         "ajv": {
-          "version": "8.6.3",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.3.tgz",
-          "integrity": "sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==",
+          "version": "8.7.1",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.7.1.tgz",
+          "integrity": "sha512-gPpOObTO1QjbnN1sVMjJcp1TF9nggMfO4MBR5uQl6ZVTOaEPq5i4oq/6R9q2alMMPB3eg53wFv1RuJBLuxf3Hw==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -1771,11 +1873,11 @@
           "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
         },
         "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
           "requires": {
-            "ansi-regex": "^5.0.0"
+            "ansi-regex": "^5.0.1"
           }
         }
       }
@@ -1803,6 +1905,14 @@
       "resolved": "https://registry.npmjs.org/tiny-json-http/-/tiny-json-http-7.2.0.tgz",
       "integrity": "sha512-blMwK3w6R+9/ZCMAlrAw4/yOmym6SNaF8LNHqjVnugtDAWNK/+HxK9AgEy8ynagRniMIiWhUcVst16Qumf66QQ==",
       "dev": true
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "requires": {
+        "is-number": "^7.0.0"
+      }
     },
     "tough-cookie": {
       "version": "2.5.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "prebuild-snapshot": "npm run clean",
     "build-snapshot": "npm run build-head && node scripts/insert_snapshot_warning.js",
     "clean": "rm -rf out",
+    "format": "emu-format --write spec.html",
     "test": "exit 0",
     "watch": "npm run build-only -- --lint-spec --watch",
     "check-commit": "node scripts/check-commit"
@@ -26,7 +27,7 @@
   "license": "SEE LICENSE IN https://tc39.es/ecma262/#sec-copyright-and-software-license",
   "homepage": "https://tc39.es/ecma262/",
   "dependencies": {
-    "ecmarkup": "9.2.0"
+    "ecmarkup": "9.6.1"
   },
   "devDependencies": {
     "glob": "^7.1.6",

--- a/spec.html
+++ b/spec.html
@@ -16520,6 +16520,7 @@
       <p>The term <dfn variants="conditional keywords">conditional keyword</dfn>, or <dfn variants="contextual keywords">contextual keyword</dfn>, is sometimes used to refer to the keywords that fall in the last three categories, and thus can be used as identifiers in some contexts and as keywords in others.</p>
       <h2>Syntax</h2>
       <emu-grammar type="definition">
+        // emu-format ignore
         ReservedWord :: one of
           `await`
           `break`
@@ -16561,6 +16562,7 @@
       OptionalChainingPunctuator ::
         `?.` [lookahead &notin; DecimalDigit]
 
+      // emu-format ignore
       OtherPunctuator :: one of
         `{` `(` `)` `[` `]`
         `.` `...` `;` `,`
@@ -16717,6 +16719,7 @@
           HexDigits[?Sep] HexDigit
           [+Sep] HexDigits[+Sep] NumericLiteralSeparator HexDigit
 
+        // emu-format ignore
         HexDigit :: one of
           `0` `1` `2` `3` `4` `5` `6` `7` `8` `9` `a` `b` `c` `d` `e` `f` `A` `B` `C` `D` `E` `F`
       </emu-grammar>
@@ -20385,6 +20388,7 @@
         LeftHandSideExpression[?Yield, ?Await] `||=` AssignmentExpression[?In, ?Yield, ?Await]
         LeftHandSideExpression[?Yield, ?Await] `??=` AssignmentExpression[?In, ?Yield, ?Await]
 
+      // emu-format ignore
       AssignmentOperator : one of
         `*=` `/=` `%=` `+=` `-=` `&lt;&lt;=` `&gt;&gt;=` `&gt;&gt;&gt;=` `&amp;=` `^=` `|=` `**=`
     </emu-grammar>
@@ -20450,6 +20454,7 @@
         1. Let _assignmentOpText_ be the source text matched by |AssignmentOperator|.
         1. Let _opText_ be the sequence of Unicode code points associated with _assignmentOpText_ in the following table:
           <figure>
+            <!-- emu-format ignore -->
             <table class="lightweight-table">
               <tr><th> _assignmentOpText_ </th><th> _opText_       </th></tr>
               <tr><td> `**=`              </td><td> `**`           </td></tr>
@@ -20543,6 +20548,7 @@
         1. If Type(_lnum_) is different from Type(_rnum_), throw a *TypeError* exception.
         1. [id="step-applystringornumericbinaryoperator-operations-table"] Let _operation_ be the abstract operation associated with _opText_ and Type(_lnum_) in the following table:
           <figure>
+            <!-- emu-format ignore -->
             <table class="lightweight-table">
               <tr><th> _opText_       </th><th> Type(_lnum_) </th><th> _operation_                </th></tr>
               <tr><td> `**`           </td><td> Number       </td><td> Number::exponentiate       </td></tr>
@@ -28970,6 +28976,7 @@
             uriUnescaped
             uriEscaped
 
+          // emu-format ignore
           uriReserved ::: one of
             `;` `/` `?` `:` `@` `&amp;` `=` `+` `$` `,`
 
@@ -28981,6 +28988,7 @@
           uriEscaped :::
             `%` HexDigit HexDigit
 
+          // emu-format ignore
           uriAlpha ::: one of
             `a` `b` `c` `d` `e` `f` `g` `h` `i` `j` `k` `l` `m` `n` `o` `p` `q` `r` `s` `t` `u` `v` `w` `x` `y` `z`
             `A` `B` `C` `D` `E` `F` `G` `H` `I` `J` `K` `L` `M` `N` `O` `P` `Q` `R` `S` `T` `U` `V` `W` `X` `Y` `Z`
@@ -34546,6 +34554,7 @@ THH:mm:ss.sss
         ControlEscape :: one of
           `f` `n` `r` `t` `v`
 
+        // emu-format ignore
         ControlLetter :: one of
           `a` `b` `c` `d` `e` `f` `g` `h` `i` `j` `k` `l` `m` `n` `o` `p` `q` `r` `s` `t` `u` `v` `w` `x` `y` `z`
           `A` `B` `C` `D` `E` `F` `G` `H` `I` `J` `K` `L` `M` `N` `O` `P` `Q` `R` `S` `T` `U` `V` `W` `X` `Y` `Z`

--- a/spec.html
+++ b/spec.html
@@ -4136,44 +4136,44 @@
       <emu-table id="table-reference-record-fields" caption="Reference Record Fields">
         <table>
           <tbody>
-            <tr>
-              <th>Field Name</th>
-              <th>Value</th>
-              <th>Meaning</th>
-            </tr>
-            <tr>
-              <td oldids="sec-getbase,ao-getbase">[[Base]]</td>
-              <td>
-                One of:
-                <ul>
-                  <li>
-                    any ECMAScript language value,
-                  </li>
-                  <li>
-                    an Environment Record, or
-                  </li>
-                  <li>
-                    ~unresolvable~.
-                  </li>
-                </ul>
-              </td>
-              <td>The value or Environment Record which holds the binding. A [[Base]] of ~unresolvable~ indicates that the binding could not be resolved.</td>
-            </tr>
-            <tr>
-              <td oldids="sec-getreferencedname,ao-getreferencedname">[[ReferencedName]]</td>
-              <td>String, Symbol, or Private Name</td>
-              <td>The name of the binding. Always a String if [[Base]] value is an Environment Record.</td>
-            </tr>
-            <tr>
-              <td oldids="sec-isstrictreference,ao-isstrictreference">[[Strict]]</td>
-              <td>Boolean</td>
-              <td>*true* if the Reference Record originated in strict mode code, *false* otherwise.</td>
-            </tr>
-            <tr>
-              <td>[[ThisValue]]</td>
-              <td>any ECMAScript language value or ~empty~</td>
-              <td>If not ~empty~, the Reference Record represents a property binding that was expressed using the `super` keyword; it is called a <dfn id="super-reference-record" oldids="super-reference" variants="Super Reference Records">Super Reference Record</dfn> and its [[Base]] value will never be an Environment Record. In that case, the [[ThisValue]] field holds the *this* value at the time the Reference Record was created.</td>
-            </tr>
+          <tr>
+            <th>Field Name</th>
+            <th>Value</th>
+            <th>Meaning</th>
+          </tr>
+          <tr>
+            <td oldids="sec-getbase,ao-getbase">[[Base]]</td>
+            <td>
+              One of:
+              <ul>
+                <li>
+                  any ECMAScript language value,
+                </li>
+                <li>
+                  an Environment Record, or
+                </li>
+                <li>
+                  ~unresolvable~.
+                </li>
+              </ul>
+            </td>
+            <td>The value or Environment Record which holds the binding. A [[Base]] of ~unresolvable~ indicates that the binding could not be resolved.</td>
+          </tr>
+          <tr>
+            <td oldids="sec-getreferencedname,ao-getreferencedname">[[ReferencedName]]</td>
+            <td>String, Symbol, or Private Name</td>
+            <td>The name of the binding. Always a String if [[Base]] value is an Environment Record.</td>
+          </tr>
+          <tr>
+            <td oldids="sec-isstrictreference,ao-isstrictreference">[[Strict]]</td>
+            <td>Boolean</td>
+            <td>*true* if the Reference Record originated in strict mode code, *false* otherwise.</td>
+          </tr>
+          <tr>
+            <td>[[ThisValue]]</td>
+            <td>any ECMAScript language value or ~empty~</td>
+            <td>If not ~empty~, the Reference Record represents a property binding that was expressed using the `super` keyword; it is called a <dfn id="super-reference-record" oldids="super-reference" variants="Super Reference Records">Super Reference Record</dfn> and its [[Base]] value will never be an Environment Record. In that case, the [[ThisValue]] field holds the *this* value at the time the Reference Record was created.</td>
+          </tr>
           </tbody>
         </table>
       </emu-table>
@@ -5416,74 +5416,74 @@
       <emu-table id="table-tobigint" caption="BigInt Conversions">
         <table>
           <tbody>
-            <tr>
-              <th>
-                Argument Type
-              </th>
-              <th>
-                Result
-              </th>
-            </tr>
-            <tr>
-              <td>
-                Undefined
-              </td>
-              <td>
-                Throw a *TypeError* exception.
-              </td>
-            </tr>
-            <tr>
-              <td>
-                Null
-              </td>
-              <td>
-                Throw a *TypeError* exception.
-              </td>
-            </tr>
-            <tr>
-              <td>
-                Boolean
-              </td>
-              <td>
-                Return `1n` if _prim_ is *true* and `0n` if _prim_ is *false*.
-              </td>
-            </tr>
-            <tr>
-              <td>
-                BigInt
-              </td>
-              <td>
-                Return _prim_.
-              </td>
-            </tr>
-            <tr>
-              <td>
-                Number
-              </td>
-              <td>
-                Throw a *TypeError* exception.
-              </td>
-            </tr>
-            <tr>
-              <td>
-                String
-              </td>
-              <td>
-                <emu-alg>
-                  1. Let _n_ be ! StringToBigInt(_prim_).
-                  1. If _n_ is *undefined*, throw a *SyntaxError* exception.
-                  1. Return _n_.
-                </emu-alg>
-              </td>
-            </tr>
-            <tr>
-              <td>
-                Symbol
-              </td>
-              <td>
-                Throw a *TypeError* exception.
-              </td>
-            </tr>
+          <tr>
+            <th>
+              Argument Type
+            </th>
+            <th>
+              Result
+            </th>
+          </tr>
+          <tr>
+            <td>
+              Undefined
+            </td>
+            <td>
+              Throw a *TypeError* exception.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Null
+            </td>
+            <td>
+              Throw a *TypeError* exception.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Boolean
+            </td>
+            <td>
+              Return `1n` if _prim_ is *true* and `0n` if _prim_ is *false*.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              BigInt
+            </td>
+            <td>
+              Return _prim_.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Number
+            </td>
+            <td>
+              Throw a *TypeError* exception.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              String
+            </td>
+            <td>
+              <emu-alg>
+                1. Let _n_ be ! StringToBigInt(_prim_).
+                1. If _n_ is *undefined*, throw a *SyntaxError* exception.
+                1. Return _n_.
+              </emu-alg>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Symbol
+            </td>
+            <td>
+              Throw a *TypeError* exception.
+            </td>
+          </tr>
           </tbody>
         </table>
       </emu-table>
@@ -12021,39 +12021,39 @@
       <emu-table id="table-jobcallback-records" caption="JobCallback Record Fields">
         <table>
           <tbody>
-            <tr>
-              <th>
-                Field Name
-              </th>
-              <th>
-                Value
-              </th>
-              <th>
-                Meaning
-              </th>
-            </tr>
-            <tr>
-              <td>
-                [[Callback]]
-              </td>
-              <td>
-                A function object
-              </td>
-              <td>
-                The function to invoke when the Job is invoked.
-              </td>
-            </tr>
-            <tr>
-              <td>
-                [[HostDefined]]
-              </td>
-              <td>
-                Any, default value is ~empty~.
-              </td>
-              <td>
-                Field reserved for use by hosts.
-              </td>
-            </tr>
+          <tr>
+            <th>
+              Field Name
+            </th>
+            <th>
+              Value
+            </th>
+            <th>
+              Meaning
+            </th>
+          </tr>
+          <tr>
+            <td>
+              [[Callback]]
+            </td>
+            <td>
+              A function object
+            </td>
+            <td>
+              The function to invoke when the Job is invoked.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[HostDefined]]
+            </td>
+            <td>
+              Any, default value is ~empty~.
+            </td>
+            <td>
+              Field reserved for use by hosts.
+            </td>
+          </tr>
           </tbody>
         </table>
       </emu-table>
@@ -12164,51 +12164,51 @@
     <emu-table id="table-agent-record" caption="Agent Record Fields">
       <table>
         <tbody>
-          <tr>
-            <th>Field Name</th>
-            <th>Value</th>
-            <th>Meaning</th>
-          </tr>
-          <tr>
-            <td>[[LittleEndian]]</td>
-            <td>Boolean</td>
-            <td>The default value computed for the <em>isLittleEndian</em> parameter when it is needed by the algorithms GetValueFromBuffer and SetValueInBuffer. The choice is implementation-defined and should be the alternative that is most efficient for the implementation. Once the value has been observed it cannot change.</td>
-          </tr>
-          <tr>
-            <td>[[CanBlock]]</td>
-            <td>Boolean</td>
-            <td>Determines whether the agent can block or not.</td>
-          </tr>
-          <tr>
-            <td>[[Signifier]]</td>
-            <td>Any globally-unique value</td>
-            <td>Uniquely identifies the agent within its agent cluster.</td>
-          </tr>
-          <tr>
-            <td>[[IsLockFree1]]</td>
-            <td>Boolean</td>
-            <td>*true* if atomic operations on one-<emu-not-ref>byte values</emu-not-ref> are lock-free, *false* otherwise.</td>
-          </tr>
-          <tr>
-            <td>[[IsLockFree2]]</td>
-            <td>Boolean</td>
-            <td>*true* if atomic operations on two-<emu-not-ref>byte values</emu-not-ref> are lock-free, *false* otherwise.</td>
-          </tr>
-          <tr>
-            <td>[[IsLockFree8]]</td>
-            <td>Boolean</td>
-            <td>*true* if atomic operations on eight-<emu-not-ref>byte values</emu-not-ref> are lock-free, *false* otherwise.</td>
-          </tr>
-          <tr>
-            <td>[[CandidateExecution]]</td>
-            <td>A candidate execution Record</td>
-            <td>See the memory model.</td>
-          </tr>
-          <tr>
-            <td>[[KeptAlive]]</td>
-            <td>List of objects</td>
-            <td>Initially a new empty List, representing the list of objects to be kept alive until the end of the current Job</td>
-          </tr>
+        <tr>
+          <th>Field Name</th>
+          <th>Value</th>
+          <th>Meaning</th>
+        </tr>
+        <tr>
+          <td>[[LittleEndian]]</td>
+          <td>Boolean</td>
+          <td>The default value computed for the <em>isLittleEndian</em> parameter when it is needed by the algorithms GetValueFromBuffer and SetValueInBuffer. The choice is implementation-defined and should be the alternative that is most efficient for the implementation. Once the value has been observed it cannot change.</td>
+        </tr>
+        <tr>
+          <td>[[CanBlock]]</td>
+          <td>Boolean</td>
+          <td>Determines whether the agent can block or not.</td>
+        </tr>
+        <tr>
+          <td>[[Signifier]]</td>
+          <td>Any globally-unique value</td>
+          <td>Uniquely identifies the agent within its agent cluster.</td>
+        </tr>
+        <tr>
+          <td>[[IsLockFree1]]</td>
+          <td>Boolean</td>
+          <td>*true* if atomic operations on one-<emu-not-ref>byte values</emu-not-ref> are lock-free, *false* otherwise.</td>
+        </tr>
+        <tr>
+          <td>[[IsLockFree2]]</td>
+          <td>Boolean</td>
+          <td>*true* if atomic operations on two-<emu-not-ref>byte values</emu-not-ref> are lock-free, *false* otherwise.</td>
+        </tr>
+        <tr>
+          <td>[[IsLockFree8]]</td>
+          <td>Boolean</td>
+          <td>*true* if atomic operations on eight-<emu-not-ref>byte values</emu-not-ref> are lock-free, *false* otherwise.</td>
+        </tr>
+        <tr>
+          <td>[[CandidateExecution]]</td>
+          <td>A candidate execution Record</td>
+          <td>See the memory model.</td>
+        </tr>
+        <tr>
+          <td>[[KeptAlive]]</td>
+          <td>List of objects</td>
+          <td>Initially a new empty List, representing the list of objects to be kept alive until the end of the current Job</td>
+        </tr>
         </tbody>
       </table>
     </emu-table>
@@ -20451,21 +20451,19 @@
         1. Let _opText_ be the sequence of Unicode code points associated with _assignmentOpText_ in the following table:
           <figure>
             <table class="lightweight-table">
-              <tbody>
-                <tr><th> _assignmentOpText_ </th><th> _opText_       </th></tr>
-                <tr><td> `**=`              </td><td> `**`           </td></tr>
-                <tr><td> `*=`               </td><td> `*`            </td></tr>
-                <tr><td> `/=`               </td><td> `/`            </td></tr>
-                <tr><td> `%=`               </td><td> `%`            </td></tr>
-                <tr><td> `+=`               </td><td> `+`            </td></tr>
-                <tr><td> `-=`               </td><td> `-`            </td></tr>
-                <tr><td> `&lt;&lt;=`        </td><td> `&lt;&lt;`     </td></tr>
-                <tr><td> `&gt;&gt;=`        </td><td> `&gt;&gt;`     </td></tr>
-                <tr><td> `&gt;&gt;&gt;=`    </td><td> `&gt;&gt;&gt;` </td></tr>
-                <tr><td> `&amp;=`           </td><td> `&amp;`        </td></tr>
-                <tr><td> `^=`               </td><td> `^`            </td></tr>
-                <tr><td> `|=`               </td><td> `|`            </td></tr>
-              </tbody>
+              <tr><th> _assignmentOpText_ </th><th> _opText_       </th></tr>
+              <tr><td> `**=`              </td><td> `**`           </td></tr>
+              <tr><td> `*=`               </td><td> `*`            </td></tr>
+              <tr><td> `/=`               </td><td> `/`            </td></tr>
+              <tr><td> `%=`               </td><td> `%`            </td></tr>
+              <tr><td> `+=`               </td><td> `+`            </td></tr>
+              <tr><td> `-=`               </td><td> `-`            </td></tr>
+              <tr><td> `&lt;&lt;=`        </td><td> `&lt;&lt;`     </td></tr>
+              <tr><td> `&gt;&gt;=`        </td><td> `&gt;&gt;`     </td></tr>
+              <tr><td> `&gt;&gt;&gt;=`    </td><td> `&gt;&gt;&gt;` </td></tr>
+              <tr><td> `&amp;=`           </td><td> `&amp;`        </td></tr>
+              <tr><td> `^=`               </td><td> `^`            </td></tr>
+              <tr><td> `|=`               </td><td> `|`            </td></tr>
             </table>
           </figure>
         1. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
@@ -20546,33 +20544,31 @@
         1. [id="step-applystringornumericbinaryoperator-operations-table"] Let _operation_ be the abstract operation associated with _opText_ and Type(_lnum_) in the following table:
           <figure>
             <table class="lightweight-table">
-              <tbody>
-                <tr><th> _opText_       </th><th> Type(_lnum_) </th><th> _operation_                </th></tr>
-                <tr><td> `**`           </td><td> Number       </td><td> Number::exponentiate       </td></tr>
-                <tr><td> `**`           </td><td> BigInt       </td><td> BigInt::exponentiate       </td></tr>
-                <tr><td> `*`            </td><td> Number       </td><td> Number::multiply           </td></tr>
-                <tr><td> `*`            </td><td> BigInt       </td><td> BigInt::multiply           </td></tr>
-                <tr><td> `/`            </td><td> Number       </td><td> Number::divide             </td></tr>
-                <tr><td> `/`            </td><td> BigInt       </td><td> BigInt::divide             </td></tr>
-                <tr><td> `%`            </td><td> Number       </td><td> Number::remainder          </td></tr>
-                <tr><td> `%`            </td><td> BigInt       </td><td> BigInt::remainder          </td></tr>
-                <tr><td> `+`            </td><td> Number       </td><td> Number::add                </td></tr>
-                <tr><td> `+`            </td><td> BigInt       </td><td> BigInt::add                </td></tr>
-                <tr><td> `-`            </td><td> Number       </td><td> Number::subtract           </td></tr>
-                <tr><td> `-`            </td><td> BigInt       </td><td> BigInt::subtract           </td></tr>
-                <tr><td> `&lt;&lt;`     </td><td> Number       </td><td> Number::leftShift          </td></tr>
-                <tr><td> `&lt;&lt;`     </td><td> BigInt       </td><td> BigInt::leftShift          </td></tr>
-                <tr><td> `&gt;&gt;`     </td><td> Number       </td><td> Number::signedRightShift   </td></tr>
-                <tr><td> `&gt;&gt;`     </td><td> BigInt       </td><td> BigInt::signedRightShift   </td></tr>
-                <tr><td> `&gt;&gt;&gt;` </td><td> Number       </td><td> Number::unsignedRightShift </td></tr>
-                <tr><td> `&gt;&gt;&gt;` </td><td> BigInt       </td><td> BigInt::unsignedRightShift </td></tr>
-                <tr><td> `&amp;`        </td><td> Number       </td><td> Number::bitwiseAND         </td></tr>
-                <tr><td> `&amp;`        </td><td> BigInt       </td><td> BigInt::bitwiseAND         </td></tr>
-                <tr><td> `^`            </td><td> Number       </td><td> Number::bitwiseXOR         </td></tr>
-                <tr><td> `^`            </td><td> BigInt       </td><td> BigInt::bitwiseXOR         </td></tr>
-                <tr><td> `|`            </td><td> Number       </td><td> Number::bitwiseOR          </td></tr>
-                <tr><td> `|`            </td><td> BigInt       </td><td> BigInt::bitwiseOR          </td></tr>
-              </tbody>
+              <tr><th> _opText_       </th><th> Type(_lnum_) </th><th> _operation_                </th></tr>
+              <tr><td> `**`           </td><td> Number       </td><td> Number::exponentiate       </td></tr>
+              <tr><td> `**`           </td><td> BigInt       </td><td> BigInt::exponentiate       </td></tr>
+              <tr><td> `*`            </td><td> Number       </td><td> Number::multiply           </td></tr>
+              <tr><td> `*`            </td><td> BigInt       </td><td> BigInt::multiply           </td></tr>
+              <tr><td> `/`            </td><td> Number       </td><td> Number::divide             </td></tr>
+              <tr><td> `/`            </td><td> BigInt       </td><td> BigInt::divide             </td></tr>
+              <tr><td> `%`            </td><td> Number       </td><td> Number::remainder          </td></tr>
+              <tr><td> `%`            </td><td> BigInt       </td><td> BigInt::remainder          </td></tr>
+              <tr><td> `+`            </td><td> Number       </td><td> Number::add                </td></tr>
+              <tr><td> `+`            </td><td> BigInt       </td><td> BigInt::add                </td></tr>
+              <tr><td> `-`            </td><td> Number       </td><td> Number::subtract           </td></tr>
+              <tr><td> `-`            </td><td> BigInt       </td><td> BigInt::subtract           </td></tr>
+              <tr><td> `&lt;&lt;`     </td><td> Number       </td><td> Number::leftShift          </td></tr>
+              <tr><td> `&lt;&lt;`     </td><td> BigInt       </td><td> BigInt::leftShift          </td></tr>
+              <tr><td> `&gt;&gt;`     </td><td> Number       </td><td> Number::signedRightShift   </td></tr>
+              <tr><td> `&gt;&gt;`     </td><td> BigInt       </td><td> BigInt::signedRightShift   </td></tr>
+              <tr><td> `&gt;&gt;&gt;` </td><td> Number       </td><td> Number::unsignedRightShift </td></tr>
+              <tr><td> `&gt;&gt;&gt;` </td><td> BigInt       </td><td> BigInt::unsignedRightShift </td></tr>
+              <tr><td> `&amp;`        </td><td> Number       </td><td> Number::bitwiseAND         </td></tr>
+              <tr><td> `&amp;`        </td><td> BigInt       </td><td> BigInt::bitwiseAND         </td></tr>
+              <tr><td> `^`            </td><td> Number       </td><td> Number::bitwiseXOR         </td></tr>
+              <tr><td> `^`            </td><td> BigInt       </td><td> BigInt::bitwiseXOR         </td></tr>
+              <tr><td> `|`            </td><td> Number       </td><td> Number::bitwiseOR          </td></tr>
+              <tr><td> `|`            </td><td> BigInt       </td><td> BigInt::bitwiseOR          </td></tr>
             </table>
           </figure>
         1. Return ? _operation_(_lnum_, _rnum_).
@@ -26186,138 +26182,138 @@
         <emu-table id="table-cyclic-module-fields" caption="Additional Fields of Cyclic Module Records">
           <table>
             <tbody>
-              <tr>
-                <th>
-                  Field Name
-                </th>
-                <th>
-                  Value Type
-                </th>
-                <th>
-                  Meaning
-                </th>
-              </tr>
-              <tr>
-                <td>
-                  [[Status]]
-                </td>
-                <td>
-                  ~unlinked~ | ~linking~ | ~linked~ | ~evaluating~ | ~evaluating-async~ | ~evaluated~
-                </td>
-                <td>
-                  Initially ~unlinked~. Transitions to ~linking~, ~linked~, ~evaluating~, possibly ~evaluating-async~, ~evaluated~ (in that order) as the module progresses throughout its lifecycle. ~evaluating-async~ indicates this module is queued to execute on completion of its asynchronous dependencies or it is a module whose [[HasTLA]] field is *true* that has been executed and is pending top-level completion.
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  [[EvaluationError]]
-                </td>
-                <td>
-                  An abrupt completion | ~empty~
-                </td>
-                <td>
-                  A completion of type ~throw~ representing the exception that occurred during evaluation. *undefined* if no exception occurred or if [[Status]] is not ~evaluated~.
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  [[DFSIndex]]
-                </td>
-                <td>
-                  Integer | ~empty~
-                </td>
-                <td>
-                  Auxiliary field used during Link and Evaluate only. If [[Status]] is ~linking~ or ~evaluating~, this non-negative number records the point at which the module was first visited during the depth-first traversal of the dependency graph.
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  [[DFSAncestorIndex]]
-                </td>
-                <td>
-                  Integer | ~empty~
-                </td>
-                <td>
-                  Auxiliary field used during Link and Evaluate only. If [[Status]] is ~linking~ or ~evaluating~, this is either the module's own [[DFSIndex]] or that of an "earlier" module in the same strongly connected component.
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  [[RequestedModules]]
-                </td>
-                <td>
-                  List of String
-                </td>
-                <td>
-                  A List of all the |ModuleSpecifier| strings used by the module represented by this record to request the importation of a module. The List is source code occurrence ordered.
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  [[CycleRoot]]
-                </td>
-                <td>
-                  Cyclic Module Record | ~empty~
-                </td>
-                <td>
-                  The first visited module of the cycle, the root DFS ancestor of the strongly connected component. For a module not in a cycle this would be the module itself. Once Evaluate has completed, a module's [[DFSAncestorIndex]] is equal to the [[DFSIndex]] of its [[CycleRoot]].
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  [[HasTLA]]
-                </td>
-                <td>
-                  Boolean
-                </td>
-                <td>
-                  Whether this module is individually asynchronous (for example, if it's a Source Text Module Record containing a top-level await). Having an asynchronous dependency does not mean this field is *true*. This field must not change after the module is parsed.
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  [[AsyncEvaluation]]
-                </td>
-                <td>
-                  Boolean
-                </td>
-                <td>
-                  Whether this module is either itself asynchronous or has an asynchronous dependency. Note: The order in which this field is set is used to order queued executions, see <emu-xref href="#sec-async-module-execution-fulfilled"></emu-xref>.
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  [[TopLevelCapability]]
-                </td>
-                <td>
-                  PromiseCapability Record | ~empty~
-                </td>
-                <td>
-                  If this module is the [[CycleRoot]] of some cycle, and Evaluate() was called on some module in that cycle, this field contains the PromiseCapability Record for that entire evaluation. It is used to settle the Promise object that is returned from the Evaluate() abstract method. This field will be ~empty~ for any dependencies of that module, unless a top-level Evaluate() has been initiated for some of those dependencies.
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  [[AsyncParentModules]]
-                </td>
-                <td>
-                  List of Cyclic Module Records
-                </td>
-                <td>
-                  If this module or a dependency has [[HasTLA]] *true*, and execution is in progress, this tracks the parent importers of this module for the top-level execution job. These parent modules will not start executing before this module has successfully completed execution.
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  [[PendingAsyncDependencies]]
-                </td>
-                <td>
-                  Integer | ~empty~
-                </td>
-                <td>
-                  If this module has any asynchronous dependencies, this tracks the number of asynchronous dependency modules remaining to execute for this module. A module with asynchronous dependencies will be executed when this field reaches 0 and there are no execution errors.
-                </td>
-              </tr>
+            <tr>
+              <th>
+                Field Name
+              </th>
+              <th>
+                Value Type
+              </th>
+              <th>
+                Meaning
+              </th>
+            </tr>
+            <tr>
+              <td>
+                [[Status]]
+              </td>
+              <td>
+                ~unlinked~ | ~linking~ | ~linked~ | ~evaluating~ | ~evaluating-async~ | ~evaluated~
+              </td>
+              <td>
+                Initially ~unlinked~. Transitions to ~linking~, ~linked~, ~evaluating~, possibly ~evaluating-async~, ~evaluated~ (in that order) as the module progresses throughout its lifecycle. ~evaluating-async~ indicates this module is queued to execute on completion of its asynchronous dependencies or it is a module whose [[HasTLA]] field is *true* that has been executed and is pending top-level completion.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                [[EvaluationError]]
+              </td>
+              <td>
+                An abrupt completion | ~empty~
+              </td>
+              <td>
+                A completion of type ~throw~ representing the exception that occurred during evaluation. *undefined* if no exception occurred or if [[Status]] is not ~evaluated~.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                [[DFSIndex]]
+              </td>
+              <td>
+                Integer | ~empty~
+              </td>
+              <td>
+                Auxiliary field used during Link and Evaluate only. If [[Status]] is ~linking~ or ~evaluating~, this non-negative number records the point at which the module was first visited during the depth-first traversal of the dependency graph.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                [[DFSAncestorIndex]]
+              </td>
+              <td>
+                Integer | ~empty~
+              </td>
+              <td>
+                Auxiliary field used during Link and Evaluate only. If [[Status]] is ~linking~ or ~evaluating~, this is either the module's own [[DFSIndex]] or that of an "earlier" module in the same strongly connected component.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                [[RequestedModules]]
+              </td>
+              <td>
+                List of String
+              </td>
+              <td>
+                A List of all the |ModuleSpecifier| strings used by the module represented by this record to request the importation of a module. The List is source code occurrence ordered.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                [[CycleRoot]]
+              </td>
+              <td>
+                Cyclic Module Record | ~empty~
+              </td>
+              <td>
+                The first visited module of the cycle, the root DFS ancestor of the strongly connected component. For a module not in a cycle this would be the module itself. Once Evaluate has completed, a module's [[DFSAncestorIndex]] is equal to the [[DFSIndex]] of its [[CycleRoot]].
+              </td>
+            </tr>
+            <tr>
+              <td>
+                [[HasTLA]]
+              </td>
+              <td>
+                Boolean
+              </td>
+              <td>
+                Whether this module is individually asynchronous (for example, if it's a Source Text Module Record containing a top-level await). Having an asynchronous dependency does not mean this field is *true*. This field must not change after the module is parsed.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                [[AsyncEvaluation]]
+              </td>
+              <td>
+                Boolean
+              </td>
+              <td>
+                Whether this module is either itself asynchronous or has an asynchronous dependency. Note: The order in which this field is set is used to order queued executions, see <emu-xref href="#sec-async-module-execution-fulfilled"></emu-xref>.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                [[TopLevelCapability]]
+              </td>
+              <td>
+                PromiseCapability Record | ~empty~
+              </td>
+              <td>
+                If this module is the [[CycleRoot]] of some cycle, and Evaluate() was called on some module in that cycle, this field contains the PromiseCapability Record for that entire evaluation. It is used to settle the Promise object that is returned from the Evaluate() abstract method. This field will be ~empty~ for any dependencies of that module, unless a top-level Evaluate() has been initiated for some of those dependencies.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                [[AsyncParentModules]]
+              </td>
+              <td>
+                List of Cyclic Module Records
+              </td>
+              <td>
+                If this module or a dependency has [[HasTLA]] *true*, and execution is in progress, this tracks the parent importers of this module for the top-level execution job. These parent modules will not start executing before this module has successfully completed execution.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                [[PendingAsyncDependencies]]
+              </td>
+              <td>
+                Integer | ~empty~
+              </td>
+              <td>
+                If this module has any asynchronous dependencies, this tracks the number of asynchronous dependency modules remaining to execute for this module. A module with asynchronous dependencies will be executed when this field reaches 0 and there are no execution errors.
+              </td>
+            </tr>
             </tbody>
           </table>
         </emu-table>
@@ -26325,30 +26321,30 @@
         <emu-table id="table-cyclic-module-methods" caption="Additional Abstract Methods of Cyclic Module Records">
           <table>
             <tbody>
-              <tr>
-                <th>
-                  Method
-                </th>
-                <th>
-                  Purpose
-                </th>
-              </tr>
-              <tr>
-                <td>
-                  InitializeEnvironment()
-                </td>
-                <td>
-                  Initialize the Environment Record of the module, including resolving all imported bindings, and create the module's execution context.
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  ExecuteModule( [ _promiseCapability_ ] )
-                </td>
-                <td>
-                  Evaluate the module's code within its execution context. If this module has *true* in [[HasTLA]], then a PromiseCapability Record is passed as an argument, and the method is expected to resolve or reject the given capability. In this case, the method must not throw an exception, but instead reject the PromiseCapability Record if necessary.
-                </td>
-              </tr>
+            <tr>
+              <th>
+                Method
+              </th>
+              <th>
+                Purpose
+              </th>
+            </tr>
+            <tr>
+              <td>
+                InitializeEnvironment()
+              </td>
+              <td>
+                Initialize the Environment Record of the module, including resolving all imported bindings, and create the module's execution context.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                ExecuteModule( [ _promiseCapability_ ] )
+              </td>
+              <td>
+                Evaluate the module's code within its execution context. If this module has *true* in [[HasTLA]], then a PromiseCapability Record is passed as an argument, and the method is expected to resolve or reject the given capability. In this case, the method must not throw an exception, but instead reject the PromiseCapability Record if necessary.
+              </td>
+            </tr>
             </tbody>
           </table>
         </emu-table>
@@ -26722,51 +26718,51 @@
                 </tr>
               </thead>
               <tbody>
-                <tr>
-                  <th>_A_</th>
-                  <td>0</td>
-                  <td>0</td>
-                  <td>~evaluating-async~</td>
-                  <td>*true*</td>
-                  <td>&laquo; &raquo;</td>
-                  <td>2 (_B_ and _C_)</td>
-                </tr>
-                <tr>
-                  <th>_B_</th>
-                  <td>1</td>
-                  <td>0</td>
-                  <td>~evaluating-async~</td>
-                  <td>*true*</td>
-                  <td>&laquo; _A_ &raquo;</td>
-                  <td>1 (_D_)</td>
-                </tr>
-                <tr>
-                  <th>_C_</th>
-                  <td>2</td>
-                  <td>0</td>
-                  <td>~evaluating-async~</td>
-                  <td>*true*</td>
-                  <td>&laquo; _A_ &raquo;</td>
-                  <td>2 (_D_ and _E_)</td>
-                </tr>
-                <tr>
-                  <th>_D_</th>
-                  <td>3</td>
-                  <td>0</td>
-                  <td>~evaluating-async~</td>
-                  <td>*true*</td>
-                  <td>&laquo; _B_, _C_ &raquo;</td>
-                  <td>0</td>
-                </tr>
-                <tr>
-                  <th>_E_</th>
-                  <td>4</td>
-                  <td>4</td>
-                  <td>~evaluating-async~</td>
-                  <td>*true*</td>
-                  <td>&laquo; _C_ &raquo;</td>
-                  <td>0</td>
-                </tr>
+              <tr>
+                <th>_A_</th>
+                <td>0</td>
+                <td>0</td>
+                <td>~evaluating-async~</td>
+                <td>*true*</td>
+                <td>&laquo; &raquo;</td>
+                <td>2 (_B_ and _C_)</td>
+              </tr>
+              <tr>
+                <th>_B_</th>
+                <td>1</td>
+                <td>0</td>
+                <td>~evaluating-async~</td>
+                <td>*true*</td>
+                <td>&laquo; _A_ &raquo;</td>
+                <td>1 (_D_)</td>
+              </tr>
+              <tr>
+                <th>_C_</th>
+                <td>2</td>
+                <td>0</td>
+                <td>~evaluating-async~</td>
+                <td>*true*</td>
+                <td>&laquo; _A_ &raquo;</td>
+                <td>2 (_D_ and _E_)</td>
+              </tr>
+              <tr>
+                <th>_D_</th>
+                <td>3</td>
+                <td>0</td>
+                <td>~evaluating-async~</td>
+                <td>*true*</td>
+                <td>&laquo; _B_, _C_ &raquo;</td>
+                <td>0</td>
+              </tr>
+              <tr>
+                <th>_E_</th>
+                <td>4</td>
+                <td>4</td>
+                <td>~evaluating-async~</td>
+                <td>*true*</td>
+                <td>&laquo; _C_ &raquo;</td>
+                <td>0</td>
+              </tr>
               </tbody>
             </table>
           </emu-table>
@@ -26787,24 +26783,24 @@
                 </tr>
               </thead>
               <tbody>
-                <tr>
-                  <th>_C_</th>
-                  <td>2</td>
-                  <td>0</td>
-                  <td>~evaluating-async~</td>
-                  <td>*true*</td>
-                  <td>&laquo; _A_ &raquo;</td>
-                  <td>1 (_D_)</td>
-                </tr>
-                <tr>
-                  <th>_E_</th>
-                  <td>4</td>
-                  <td>4</td>
-                  <td>~evaluated~</td>
-                  <td>*true*</td>
-                  <td>&laquo; _C_ &raquo;</td>
-                  <td>0</td>
-                </tr>
+              <tr>
+                <th>_C_</th>
+                <td>2</td>
+                <td>0</td>
+                <td>~evaluating-async~</td>
+                <td>*true*</td>
+                <td>&laquo; _A_ &raquo;</td>
+                <td>1 (_D_)</td>
+              </tr>
+              <tr>
+                <th>_E_</th>
+                <td>4</td>
+                <td>4</td>
+                <td>~evaluated~</td>
+                <td>*true*</td>
+                <td>&laquo; _C_ &raquo;</td>
+                <td>0</td>
+              </tr>
               </tbody>
             </table>
           </emu-table>
@@ -26825,33 +26821,33 @@
                 </tr>
               </thead>
               <tbody>
-                <tr>
-                  <th>_B_</th>
-                  <td>1</td>
-                  <td>0</td>
-                  <td>~evaluating-async~</td>
-                  <td>*true*</td>
-                  <td>&laquo; _A_ &raquo;</td>
-                  <td>0</td>
-                </tr>
-                <tr>
-                  <th>_C_</th>
-                  <td>2</td>
-                  <td>0</td>
-                  <td>~evaluating-async~</td>
-                  <td>*true*</td>
-                  <td>&laquo; _A_ &raquo;</td>
-                  <td>0</td>
-                </tr>
-                <tr>
-                  <th>_D_</th>
-                  <td>3</td>
-                  <td>0</td>
-                  <td>~evaluated~</td>
-                  <td>*true*</td>
-                  <td>&laquo; _B_, _C_ &raquo;</td>
-                  <td>0</td>
-                </tr>
+              <tr>
+                <th>_B_</th>
+                <td>1</td>
+                <td>0</td>
+                <td>~evaluating-async~</td>
+                <td>*true*</td>
+                <td>&laquo; _A_ &raquo;</td>
+                <td>0</td>
+              </tr>
+              <tr>
+                <th>_C_</th>
+                <td>2</td>
+                <td>0</td>
+                <td>~evaluating-async~</td>
+                <td>*true*</td>
+                <td>&laquo; _A_ &raquo;</td>
+                <td>0</td>
+              </tr>
+              <tr>
+                <th>_D_</th>
+                <td>3</td>
+                <td>0</td>
+                <td>~evaluated~</td>
+                <td>*true*</td>
+                <td>&laquo; _B_, _C_ &raquo;</td>
+                <td>0</td>
+              </tr>
               </tbody>
             </table>
           </emu-table>
@@ -26872,24 +26868,24 @@
                 </tr>
               </thead>
               <tbody>
-                <tr>
-                  <th>_A_</th>
-                  <td>0</td>
-                  <td>0</td>
-                  <td>~evaluating-async~</td>
-                  <td>*true*</td>
-                  <td>&laquo; &raquo;</td>
-                  <td>1 (_B_)</td>
-                </tr>
-                <tr>
-                  <th>_C_</th>
-                  <td>2</td>
-                  <td>0</td>
-                  <td>~evaluated~</td>
-                  <td>*true*</td>
-                  <td>&laquo; _A_ &raquo;</td>
-                  <td>0</td>
-                </tr>
+              <tr>
+                <th>_A_</th>
+                <td>0</td>
+                <td>0</td>
+                <td>~evaluating-async~</td>
+                <td>*true*</td>
+                <td>&laquo; &raquo;</td>
+                <td>1 (_B_)</td>
+              </tr>
+              <tr>
+                <th>_C_</th>
+                <td>2</td>
+                <td>0</td>
+                <td>~evaluated~</td>
+                <td>*true*</td>
+                <td>&laquo; _A_ &raquo;</td>
+                <td>0</td>
+              </tr>
               </tbody>
             </table>
           </emu-table>
@@ -26910,24 +26906,24 @@
                 </tr>
               </thead>
               <tbody>
-                <tr>
-                  <th>_A_</th>
-                  <td>0</td>
-                  <td>0</td>
-                  <td>~evaluating-async~</td>
-                  <td>*true*</td>
-                  <td>&laquo; &raquo;</td>
-                  <td>0</td>
-                </tr>
-                <tr>
-                  <th>_B_</th>
-                  <td>1</td>
-                  <td>0</td>
-                  <td>~evaluated~</td>
-                  <td>*true*</td>
-                  <td>&laquo; _A_ &raquo;</td>
-                  <td>0</td>
-                </tr>
+              <tr>
+                <th>_A_</th>
+                <td>0</td>
+                <td>0</td>
+                <td>~evaluating-async~</td>
+                <td>*true*</td>
+                <td>&laquo; &raquo;</td>
+                <td>0</td>
+              </tr>
+              <tr>
+                <th>_B_</th>
+                <td>1</td>
+                <td>0</td>
+                <td>~evaluated~</td>
+                <td>*true*</td>
+                <td>&laquo; _A_ &raquo;</td>
+                <td>0</td>
+              </tr>
               </tbody>
             </table>
           </emu-table>
@@ -26948,15 +26944,15 @@
                 </tr>
               </thead>
               <tbody>
-                <tr>
-                  <th>_A_</th>
-                  <td>0</td>
-                  <td>0</td>
-                  <td>~evaluated~</td>
-                  <td>*true*</td>
-                  <td>&laquo; &raquo;</td>
-                  <td>0</td>
-                </tr>
+              <tr>
+                <th>_A_</th>
+                <td>0</td>
+                <td>0</td>
+                <td>~evaluated~</td>
+                <td>*true*</td>
+                <td>&laquo; &raquo;</td>
+                <td>0</td>
+              </tr>
               </tbody>
             </table>
           </emu-table>
@@ -26978,26 +26974,26 @@
                 </tr>
               </thead>
               <tbody>
-                <tr>
-                  <th>_A_</th>
-                  <td>0</td>
-                  <td>0</td>
-                  <td>~evaluated~</td>
-                  <td>*true*</td>
-                  <td>&laquo; &raquo;</td>
-                  <td>1 (_B_)</td>
-                  <td>~empty~</td>
-                </tr>
-                <tr>
-                  <th>_C_</th>
-                  <td>2</td>
-                  <td>1</td>
-                  <td>~evaluated~</td>
-                  <td>*true*</td>
-                  <td>&laquo; _A_ &raquo;</td>
-                  <th>0</th>
-                  <td>_C_'s evaluation error</td>
-                </tr>
+              <tr>
+                <th>_A_</th>
+                <td>0</td>
+                <td>0</td>
+                <td>~evaluated~</td>
+                <td>*true*</td>
+                <td>&laquo; &raquo;</td>
+                <td>1 (_B_)</td>
+                <td>~empty~</td>
+              </tr>
+              <tr>
+                <th>_C_</th>
+                <td>2</td>
+                <td>1</td>
+                <td>~evaluated~</td>
+                <td>*true*</td>
+                <td>&laquo; _A_ &raquo;</td>
+                <th>0</th>
+                <td>_C_'s evaluation error</td>
+              </tr>
               </tbody>
             </table>
           </emu-table>
@@ -27019,16 +27015,16 @@
                 </tr>
               </thead>
               <tbody>
-                <tr>
-                  <th>_A_</th>
-                  <td>0</td>
-                  <td>0</td>
-                  <td>~evaluated~</td>
-                  <td>*true*</td>
-                  <td>&laquo; &raquo;</td>
-                  <td>0</td>
-                  <td>_C_'s Evaluation Error</td>
-                </tr>
+              <tr>
+                <th>_A_</th>
+                <td>0</td>
+                <td>0</td>
+                <td>~evaluated~</td>
+                <td>*true*</td>
+                <td>&laquo; &raquo;</td>
+                <td>0</td>
+                <td>_C_'s Evaluation Error</td>
+              </tr>
               </tbody>
             </table>
           </emu-table>
@@ -27050,26 +27046,26 @@
                 </tr>
               </thead>
               <tbody>
-                <tr>
-                  <th>_A_</th>
-                  <td>0</td>
-                  <td>0</td>
-                  <td>~evaluated~</td>
-                  <td>*true*</td>
-                  <td>&laquo; &raquo;</td>
-                  <td>0</td>
-                  <td>_C_'s Evaluation Error</td>
-                </tr>
-                <tr>
-                  <th>_B_</th>
-                  <td>1</td>
-                  <td>0</td>
-                  <td>~evaluated~</td>
-                  <td>*true*</td>
-                  <td>&laquo; _A_ &raquo;</td>
-                  <td>0</td>
-                  <td>~empty~</td>
-                </tr>
+              <tr>
+                <th>_A_</th>
+                <td>0</td>
+                <td>0</td>
+                <td>~evaluated~</td>
+                <td>*true*</td>
+                <td>&laquo; &raquo;</td>
+                <td>0</td>
+                <td>_C_'s Evaluation Error</td>
+              </tr>
+              <tr>
+                <th>_B_</th>
+                <td>1</td>
+                <td>0</td>
+                <td>~evaluated~</td>
+                <td>*true*</td>
+                <td>&laquo; _A_ &raquo;</td>
+                <td>0</td>
+                <td>~empty~</td>
+              </tr>
               </tbody>
             </table>
           </emu-table>
@@ -32415,34 +32411,34 @@ THH:mm:ss.sss
             <figure>
               <table class="lightweight-table">
                 <tbody>
-                  <tr>
-                    <td>-271821-04-20T00:00:00Z</td>
-                    <td>271822 B.C.</td>
-                  </tr>
-                  <tr>
-                    <td>-000001-01-01T00:00:00Z</td>
-                    <td>2 B.C.</td>
-                  </tr>
-                  <tr>
-                    <td>+000000-01-01T00:00:00Z</td>
-                    <td>1 B.C.</td>
-                  </tr>
-                  <tr>
-                    <td>+000001-01-01T00:00:00Z</td>
-                    <td>1 A.D.</td>
-                  </tr>
-                  <tr>
-                    <td>+001970-01-01T00:00:00Z</td>
-                    <td>1970 A.D.</td>
-                  </tr>
-                  <tr>
-                    <td>+002009-12-15T00:00:00Z</td>
-                    <td>2009 A.D.</td>
-                  </tr>
-                  <tr>
-                    <td>+275760-09-13T00:00:00Z</td>
-                    <td>275760 A.D.</td>
-                  </tr>
+                <tr>
+                  <td>-271821-04-20T00:00:00Z</td>
+                  <td>271822 B.C.</td>
+                </tr>
+                <tr>
+                  <td>-000001-01-01T00:00:00Z</td>
+                  <td>2 B.C.</td>
+                </tr>
+                <tr>
+                  <td>+000000-01-01T00:00:00Z</td>
+                  <td>1 B.C.</td>
+                </tr>
+                <tr>
+                  <td>+000001-01-01T00:00:00Z</td>
+                  <td>1 A.D.</td>
+                </tr>
+                <tr>
+                  <td>+001970-01-01T00:00:00Z</td>
+                  <td>1970 A.D.</td>
+                </tr>
+                <tr>
+                  <td>+002009-12-15T00:00:00Z</td>
+                  <td>2009 A.D.</td>
+                </tr>
+                <tr>
+                  <td>+275760-09-13T00:00:00Z</td>
+                  <td>275760 A.D.</td>
+                </tr>
                 </tbody>
               </table>
             </figure>
@@ -45689,36 +45685,36 @@ THH:mm:ss.sss
     <emu-table id="table-readsharedmemory-fields" caption="ReadSharedMemory Event Fields">
       <table>
         <tbody>
-          <tr>
-            <th>Field Name</th>
-            <th>Value</th>
-            <th>Meaning</th>
-          </tr>
-          <tr>
-            <td>[[Order]]</td>
-            <td>~SeqCst~ | ~Unordered~</td>
-            <td>The weakest ordering guaranteed by the memory model for the event.</td>
-          </tr>
-          <tr>
-            <td>[[NoTear]]</td>
-            <td>A Boolean</td>
-            <td>Whether this event is allowed to read from multiple write events on equal range as this event.</td>
-          </tr>
-          <tr>
-            <td>[[Block]]</td>
-            <td>A Shared Data Block</td>
-            <td>The block the event operates on.</td>
-          </tr>
-          <tr>
-            <td>[[ByteIndex]]</td>
-            <td>A non-negative integer</td>
-            <td>The byte address of the read in [[Block]].</td>
-          </tr>
-          <tr>
-            <td>[[ElementSize]]</td>
-            <td>A non-negative integer</td>
-            <td>The size of the read.</td>
-          </tr>
+        <tr>
+          <th>Field Name</th>
+          <th>Value</th>
+          <th>Meaning</th>
+        </tr>
+        <tr>
+          <td>[[Order]]</td>
+          <td>~SeqCst~ | ~Unordered~</td>
+          <td>The weakest ordering guaranteed by the memory model for the event.</td>
+        </tr>
+        <tr>
+          <td>[[NoTear]]</td>
+          <td>A Boolean</td>
+          <td>Whether this event is allowed to read from multiple write events on equal range as this event.</td>
+        </tr>
+        <tr>
+          <td>[[Block]]</td>
+          <td>A Shared Data Block</td>
+          <td>The block the event operates on.</td>
+        </tr>
+        <tr>
+          <td>[[ByteIndex]]</td>
+          <td>A non-negative integer</td>
+          <td>The byte address of the read in [[Block]].</td>
+        </tr>
+        <tr>
+          <td>[[ElementSize]]</td>
+          <td>A non-negative integer</td>
+          <td>The size of the read.</td>
+        </tr>
         </tbody>
       </table>
     </emu-table>
@@ -45726,41 +45722,41 @@ THH:mm:ss.sss
     <emu-table id="table-writesharedmemory-fields" caption="WriteSharedMemory Event Fields">
       <table>
         <tbody>
-          <tr>
-            <th>Field Name</th>
-            <th>Value</th>
-            <th>Meaning</th>
-          </tr>
-          <tr>
-            <td>[[Order]]</td>
-            <td>~SeqCst~ | ~Unordered~ | ~Init~</td>
-            <td>The weakest ordering guaranteed by the memory model for the event.</td>
-          </tr>
-          <tr>
-            <td>[[NoTear]]</td>
-            <td>A Boolean</td>
-            <td>Whether this event is allowed to be read from multiple read events with equal range as this event.</td>
-          </tr>
-          <tr>
-            <td>[[Block]]</td>
-            <td>A Shared Data Block</td>
-            <td>The block the event operates on.</td>
-          </tr>
-          <tr>
-            <td>[[ByteIndex]]</td>
-            <td>A non-negative integer</td>
-            <td>The byte address of the write in [[Block]].</td>
-          </tr>
-          <tr>
-            <td>[[ElementSize]]</td>
-            <td>A non-negative integer</td>
-            <td>The size of the write.</td>
-          </tr>
-          <tr>
-            <td>[[Payload]]</td>
-            <td>A List</td>
-            <td>The List of byte values to be read by other events.</td>
-          </tr>
+        <tr>
+          <th>Field Name</th>
+          <th>Value</th>
+          <th>Meaning</th>
+        </tr>
+        <tr>
+          <td>[[Order]]</td>
+          <td>~SeqCst~ | ~Unordered~ | ~Init~</td>
+          <td>The weakest ordering guaranteed by the memory model for the event.</td>
+        </tr>
+        <tr>
+          <td>[[NoTear]]</td>
+          <td>A Boolean</td>
+          <td>Whether this event is allowed to be read from multiple read events with equal range as this event.</td>
+        </tr>
+        <tr>
+          <td>[[Block]]</td>
+          <td>A Shared Data Block</td>
+          <td>The block the event operates on.</td>
+        </tr>
+        <tr>
+          <td>[[ByteIndex]]</td>
+          <td>A non-negative integer</td>
+          <td>The byte address of the write in [[Block]].</td>
+        </tr>
+        <tr>
+          <td>[[ElementSize]]</td>
+          <td>A non-negative integer</td>
+          <td>The size of the write.</td>
+        </tr>
+        <tr>
+          <td>[[Payload]]</td>
+          <td>A List</td>
+          <td>The List of byte values to be read by other events.</td>
+        </tr>
         </tbody>
       </table>
     </emu-table>
@@ -45768,46 +45764,46 @@ THH:mm:ss.sss
     <emu-table id="table-rmwsharedmemory-fields" caption="ReadModifyWriteSharedMemory Event Fields">
       <table>
         <tbody>
-          <tr>
-            <th>Field Name</th>
-            <th>Value</th>
-            <th>Meaning</th>
-          </tr>
-          <tr>
-            <td>[[Order]]</td>
-            <td>~SeqCst~</td>
-            <td>Read-modify-write events are always sequentially consistent.</td>
-          </tr>
-          <tr>
-            <td>[[NoTear]]</td>
-            <td>*true*</td>
-            <td>Read-modify-write events cannot tear.</td>
-          </tr>
-          <tr>
-            <td>[[Block]]</td>
-            <td>A Shared Data Block</td>
-            <td>The block the event operates on.</td>
-          </tr>
-          <tr>
-            <td>[[ByteIndex]]</td>
-            <td>A non-negative integer</td>
-            <td>The byte address of the read-modify-write in [[Block]].</td>
-          </tr>
-          <tr>
-            <td>[[ElementSize]]</td>
-            <td>A non-negative integer</td>
-            <td>The size of the read-modify-write.</td>
-          </tr>
-          <tr>
-            <td>[[Payload]]</td>
-            <td>A List</td>
-            <td>The List of byte values to be passed to [[ModifyOp]].</td>
-          </tr>
-          <tr>
-            <td>[[ModifyOp]]</td>
-            <td>A read-modify-write modification function</td>
-            <td>An abstract closure that returns a modified List of byte values from a read List of byte values and [[Payload]].</td>
-          </tr>
+        <tr>
+          <th>Field Name</th>
+          <th>Value</th>
+          <th>Meaning</th>
+        </tr>
+        <tr>
+          <td>[[Order]]</td>
+          <td>~SeqCst~</td>
+          <td>Read-modify-write events are always sequentially consistent.</td>
+        </tr>
+        <tr>
+          <td>[[NoTear]]</td>
+          <td>*true*</td>
+          <td>Read-modify-write events cannot tear.</td>
+        </tr>
+        <tr>
+          <td>[[Block]]</td>
+          <td>A Shared Data Block</td>
+          <td>The block the event operates on.</td>
+        </tr>
+        <tr>
+          <td>[[ByteIndex]]</td>
+          <td>A non-negative integer</td>
+          <td>The byte address of the read-modify-write in [[Block]].</td>
+        </tr>
+        <tr>
+          <td>[[ElementSize]]</td>
+          <td>A non-negative integer</td>
+          <td>The size of the read-modify-write.</td>
+        </tr>
+        <tr>
+          <td>[[Payload]]</td>
+          <td>A List</td>
+          <td>The List of byte values to be passed to [[ModifyOp]].</td>
+        </tr>
+        <tr>
+          <td>[[ModifyOp]]</td>
+          <td>A read-modify-write modification function</td>
+          <td>An abstract closure that returns a modified List of byte values from a read List of byte values and [[Payload]].</td>
+        </tr>
         </tbody>
       </table>
     </emu-table>
@@ -45828,26 +45824,26 @@ THH:mm:ss.sss
     <emu-table id="table-agent-events-records" caption="Agent Events Record Fields">
       <table>
         <tbody>
-          <tr>
-            <th>Field Name</th>
-            <th>Value</th>
-            <th>Meaning</th>
-          </tr>
-          <tr>
-            <td>[[AgentSignifier]]</td>
-            <td>A value that admits equality testing</td>
-            <td>The agent whose evaluation resulted in this ordering.</td>
-          </tr>
-          <tr>
-            <td>[[EventList]]</td>
-            <td>A List of events</td>
-            <td>Events are appended to the list during evaluation.</td>
-          </tr>
-          <tr>
-            <td>[[AgentSynchronizesWith]]</td>
-            <td>A List of pairs of Synchronize events</td>
-            <td>Synchronize relationships introduced by the operational semantics.</td>
-          </tr>
+        <tr>
+          <th>Field Name</th>
+          <th>Value</th>
+          <th>Meaning</th>
+        </tr>
+        <tr>
+          <td>[[AgentSignifier]]</td>
+          <td>A value that admits equality testing</td>
+          <td>The agent whose evaluation resulted in this ordering.</td>
+        </tr>
+        <tr>
+          <td>[[EventList]]</td>
+          <td>A List of events</td>
+          <td>Events are appended to the list during evaluation.</td>
+        </tr>
+        <tr>
+          <td>[[AgentSynchronizesWith]]</td>
+          <td>A List of pairs of Synchronize events</td>
+          <td>Synchronize relationships introduced by the operational semantics.</td>
+        </tr>
         </tbody>
       </table>
     </emu-table>
@@ -45859,21 +45855,21 @@ THH:mm:ss.sss
     <emu-table id="table-chosen-value-records" caption="Chosen Value Record Fields">
       <table>
         <tbody>
-          <tr>
-            <th>Field Name</th>
-            <th>Value</th>
-            <th>Meaning</th>
-          </tr>
-          <tr>
-            <td>[[Event]]</td>
-            <td>A Shared Data Block event</td>
-            <td>The ReadSharedMemory or ReadModifyWriteSharedMemory event that was introduced for this chosen value.</td>
-          </tr>
-          <tr>
-            <td>[[ChosenValue]]</td>
-            <td>A List of byte values</td>
-            <td>The bytes that were nondeterministically chosen during evaluation.</td>
-          </tr>
+        <tr>
+          <th>Field Name</th>
+          <th>Value</th>
+          <th>Meaning</th>
+        </tr>
+        <tr>
+          <td>[[Event]]</td>
+          <td>A Shared Data Block event</td>
+          <td>The ReadSharedMemory or ReadModifyWriteSharedMemory event that was introduced for this chosen value.</td>
+        </tr>
+        <tr>
+          <td>[[ChosenValue]]</td>
+          <td>A List of byte values</td>
+          <td>The bytes that were nondeterministically chosen during evaluation.</td>
+        </tr>
         </tbody>
       </table>
     </emu-table>
@@ -45885,51 +45881,51 @@ THH:mm:ss.sss
     <emu-table id="table-candidate-execution-records" caption="Candidate Execution Record Fields">
       <table>
         <tbody>
-          <tr>
-            <th>Field Name</th>
-            <th>Value</th>
-            <th>Meaning</th>
-          </tr>
-          <tr>
-            <td>[[EventsRecords]]</td>
-            <td>A List of Agent Events Records.</td>
-            <td>Maps an agent to Lists of events appended during the evaluation.</td>
-          </tr>
-          <tr>
-            <td>[[ChosenValues]]</td>
-            <td>A List of Chosen Value Records.</td>
-            <td>Maps ReadSharedMemory or ReadModifyWriteSharedMemory events to the List of byte values chosen during the evaluation.</td>
-          </tr>
-          <tr>
-            <td>[[AgentOrder]]</td>
-            <td>An agent-order Relation.</td>
-            <td>Defined below.</td>
-          </tr>
-          <tr>
-            <td>[[ReadsBytesFrom]]</td>
-            <td>A reads-bytes-from mathematical function.</td>
-            <td>Defined below.</td>
-          </tr>
-          <tr>
-            <td>[[ReadsFrom]]</td>
-            <td>A reads-from Relation.</td>
-            <td>Defined below.</td>
-          </tr>
-          <tr>
-            <td>[[HostSynchronizesWith]]</td>
-            <td>A host-synchronizes-with Relation.</td>
-            <td>Defined below.</td>
-          </tr>
-          <tr>
-            <td>[[SynchronizesWith]]</td>
-            <td>A synchronizes-with Relation.</td>
-            <td>Defined below.</td>
-          </tr>
-          <tr>
-            <td>[[HappensBefore]]</td>
-            <td>A happens-before Relation.</td>
-            <td>Defined below.</td>
-          </tr>
+        <tr>
+          <th>Field Name</th>
+          <th>Value</th>
+          <th>Meaning</th>
+        </tr>
+        <tr>
+          <td>[[EventsRecords]]</td>
+          <td>A List of Agent Events Records.</td>
+          <td>Maps an agent to Lists of events appended during the evaluation.</td>
+        </tr>
+        <tr>
+          <td>[[ChosenValues]]</td>
+          <td>A List of Chosen Value Records.</td>
+          <td>Maps ReadSharedMemory or ReadModifyWriteSharedMemory events to the List of byte values chosen during the evaluation.</td>
+        </tr>
+        <tr>
+          <td>[[AgentOrder]]</td>
+          <td>An agent-order Relation.</td>
+          <td>Defined below.</td>
+        </tr>
+        <tr>
+          <td>[[ReadsBytesFrom]]</td>
+          <td>A reads-bytes-from mathematical function.</td>
+          <td>Defined below.</td>
+        </tr>
+        <tr>
+          <td>[[ReadsFrom]]</td>
+          <td>A reads-from Relation.</td>
+          <td>Defined below.</td>
+        </tr>
+        <tr>
+          <td>[[HostSynchronizesWith]]</td>
+          <td>A host-synchronizes-with Relation.</td>
+          <td>Defined below.</td>
+        </tr>
+        <tr>
+          <td>[[SynchronizesWith]]</td>
+          <td>A synchronizes-with Relation.</td>
+          <td>Defined below.</td>
+        </tr>
+        <tr>
+          <td>[[HappensBefore]]</td>
+          <td>A happens-before Relation.</td>
+          <td>Defined below.</td>
+        </tr>
         </tbody>
       </table>
     </emu-table>
@@ -47794,22 +47790,22 @@ THH:mm:ss.sss
           </emu-caption>
           <table>
             <tbody>
-              <tr>
-                <th>
-                  Type of _val_
-                </th>
-                <th>
-                  Result
-                </th>
-              </tr>
-              <tr>
-                <td>
-                  Object (has an [[IsHTMLDDA]] internal slot)
-                </td>
-                <td>
-                  *"undefined"*
-                </td>
-              </tr>
+            <tr>
+              <th>
+                Type of _val_
+              </th>
+              <th>
+                Result
+              </th>
+            </tr>
+            <tr>
+              <td>
+                Object (has an [[IsHTMLDDA]] internal slot)
+              </td>
+              <td>
+                *"undefined"*
+              </td>
+            </tr>
             </tbody>
           </table>
         </emu-table>

--- a/spec.html
+++ b/spec.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en-GB-oxendict">
-<head>
 <meta charset="utf-8">
 <link rel="icon" href="img/favicon.ico">
 <style>
@@ -52,8 +51,6 @@
   }
 
 </style>
-</head>
-<body>
 <pre class="metadata">
   title: ECMAScript&reg; 2022 Language&nbsp;Specification
   shortname: ECMA-262
@@ -64,7 +61,7 @@
 <div id="metadata-block">
   <h1>About this Specification</h1>
   <p>The document at <a href="https://tc39.es/ecma262/">https://tc39.es/ecma262/</a> is the most accurate and up-to-date ECMAScript specification. It contains the content of the most recent yearly snapshot plus any <a href="https://github.com/tc39/proposals/blob/HEAD/finished-proposals.md">finished proposals</a> (those that have reached Stage&nbsp;4 in the <a href="https://tc39.es/process-document/">proposal process</a> and thus are implemented in several implementations and will be in the next practical revision) since that snapshot was taken.</p>
-  <p>This document is available as <a href="">a single page</a> and as <a href="multipage/">multiple pages</a>.</p>
+  <p>This document is available as <a href>a single page</a> and as <a href="multipage/">multiple pages</a>.</p>
   <h1>Contributing to this Specification</h1>
   <p>This specification is developed on GitHub with the help of the ECMAScript community. There are a number of ways to contribute to the development of this specification:</p>
   <ul>
@@ -91,6 +88,7 @@
   </ul>
   <p>Refer to the <emu-xref href="#sec-colophon">colophon</emu-xref> for more information on how this document is created.</p>
 </div>
+
 <emu-intro id="sec-intro">
   <h1>Introduction</h1>
   <p>This Ecma Standard defines the ECMAScript 2022 Language. It is the thirteenth edition of the ECMAScript Language Specification. Since publication of the first edition in 1997, ECMAScript has grown to be one of the world's most widely used general-purpose programming languages. It is best known as the language embedded in web browsers but has also been widely adopted for server and embedded applications.</p>
@@ -138,15 +136,18 @@
   <p>A conforming implementation of ECMAScript must not implement any extension that is listed as a Forbidden Extension in subclause <emu-xref href="#sec-forbidden-extensions"></emu-xref>.</p>
   <p>A conforming implementation of ECMAScript must not redefine any facilities that are not implementation-defined, implementation-approximated, or host-defined.</p>
   <p>A conforming implementation of ECMAScript may choose to implement or not implement <dfn>Normative Optional</dfn> subclauses. If any Normative Optional behaviour is implemented, all of the behaviour in the containing Normative Optional clause must be implemented. A Normative Optional clause is denoted in this specification with the words "Normative Optional" in a coloured box, as shown below.</p>
+
   <emu-clause id="sec-conformance-normative-optional" oldids="sec-conformance.normative-optional" example normative-optional>
     <h1>Example Normative Optional Clause Heading</h1>
     <p>Example clause contents.</p>
   </emu-clause>
   <p>A conforming implementation of ECMAScript must implement <dfn>Legacy</dfn> subclauses, unless they are also marked as Normative Optional. All of the language features and behaviours specified within Legacy subclauses have one or more undesirable characteristics. However, their continued usage in existing applications prevents their removal from this specification. These features are not considered part of the core ECMAScript language. Programmers should not use or assume the existence of these features and behaviours when writing new ECMAScript code.</p>
+
   <emu-clause id="sec-conformance-legacy" example legacy>
     <h1>Example Legacy Clause Heading</h1>
     <p>Example clause contents.</p>
   </emu-clause>
+
   <emu-clause id="sec-conformance-legacy-normative-optional" example legacy normative-optional>
     <h1>Example Legacy Normative Optional Clause Heading</h1>
     <p>Example clause contents.</p>
@@ -157,12 +158,14 @@
   <h1>Normative References</h1>
   <p>The following referenced documents are indispensable for the application of this document. For dated references, only the edition cited applies. For undated references, the latest edition of the referenced document (including any amendments) applies.</p>
   <p>ISO/IEC 10646 <i>Information Technology &mdash; Universal Multiple-Octet Coded Character Set (UCS) plus Amendment 1:2005, Amendment 2:2006, Amendment 3:2008, and Amendment 4:2008</i>, plus additional amendments and corrigenda, or successor</p>
-  <p>ECMA-402, <i>ECMAScript 2015 Internationalization API Specification</i>.
-    <br>
-    <a href="https://ecma-international.org/publications/standards/Ecma-402.htm">https://ecma-international.org/publications/standards/Ecma-402.htm</a></p>
-  <p>ECMA-404, <i>The JSON Data Interchange Format</i>.
-    <br>
-    <a href="https://ecma-international.org/publications/standards/Ecma-404.htm">https://ecma-international.org/publications/standards/Ecma-404.htm</a></p>
+  <p>
+    ECMA-402, <i>ECMAScript 2015 Internationalization API Specification</i>.<br>
+    <a href="https://ecma-international.org/publications/standards/Ecma-402.htm">https://ecma-international.org/publications/standards/Ecma-402.htm</a>
+  </p>
+  <p>
+    ECMA-404, <i>The JSON Data Interchange Format</i>.<br>
+    <a href="https://ecma-international.org/publications/standards/Ecma-404.htm">https://ecma-international.org/publications/standards/Ecma-404.htm</a>
+  </p>
 </emu-clause>
 
 <emu-clause id="sec-overview">
@@ -765,7 +768,7 @@
       <p>the definition:</p>
       <emu-grammar type="definition" example>
         LookaheadExample ::
-          `n` [lookahead &notin; {`1`, `3`, `5`, `7`, `9`}] DecimalDigits
+          `n` [lookahead &notin; { `1`, `3`, `5`, `7`, `9` }] DecimalDigits
           DecimalDigit [lookahead &notin; DecimalDigit]
       </emu-grammar>
       <p>matches either the letter `n` followed by one or more decimal digits the first of which is even, or a decimal digit not followed by another decimal digit.</p>
@@ -843,6 +846,7 @@
     <emu-clause id="sec-runtime-semantics">
       <h1>Runtime Semantics</h1>
       <p>Algorithms which specify semantics that must be called at runtime are called <dfn>runtime semantics</dfn>. Runtime semantics are defined by abstract operations or syntax-directed operations. Such algorithms always return a completion record.</p>
+
       <emu-clause id="sec-implicit-completion-values">
         <h1>Implicit Completion Values</h1>
         <p>The algorithms of this specification often implicitly return Completion Records whose [[Type]] is ~normal~. Unless it is otherwise obvious from the context, an algorithm statement that returns a value that is not a Completion Record, such as:</p>
@@ -911,6 +915,7 @@
           1. Let _result_ be AbstractOperation(_argument_).
         </emu-alg>
       </emu-clause>
+
       <emu-clause id="sec-returnifabrupt-shorthands">
         <h1>ReturnIfAbrupt Shorthands</h1>
         <p>Invocations of abstract operations and syntax-directed operations that are prefixed by `?` indicate that ReturnIfAbrupt should be applied to the resulting Completion Record. For example, the step:</p>
@@ -945,12 +950,14 @@
         </emu-alg>
       </emu-clause>
     </emu-clause>
+
     <emu-clause id="sec-static-semantic-rules">
       <h1>Static Semantics</h1>
       <p>Context-free grammars are not sufficiently powerful to express all the rules that define whether a stream of input elements form a valid ECMAScript |Script| or |Module| that may be evaluated. In some situations additional rules are needed that may be expressed using either ECMAScript algorithm conventions or prose requirements. Such rules are always associated with a production of a grammar and are called the <dfn>static semantics</dfn> of the production.</p>
       <p>Static Semantic Rules have names and typically are defined using an algorithm. Named Static Semantic Rules are associated with grammar productions and a production that has multiple alternative definitions will typically have for each alternative a distinct algorithm for each applicable named static semantic rule.</p>
       <p>A special kind of static semantic rule is an <dfn id="early-error-rule">Early Error Rule</dfn>. Early error rules define early error conditions (see clause <emu-xref href="#sec-error-handling-and-language-extensions"></emu-xref>) that are associated with specific grammar productions. Evaluation of most early error rules are not explicitly invoked within the algorithms of this specification. A conforming implementation must, prior to the first evaluation of a |Script| or |Module|, validate all of the early error rules of the productions used to parse that |Script| or |Module|. If any of the early error rules are violated the |Script| or |Module| is invalid and cannot be evaluated.</p>
     </emu-clause>
+
     <emu-clause id="sec-mathematical-operations">
       <h1>Mathematical Operations</h1>
       <p>This specification makes reference to these kinds of numeric values:</p>
@@ -978,6 +985,7 @@
         <p><emu-eqn>floor(_x_) = _x_ - (_x_ modulo 1)</emu-eqn>.</p>
       </emu-note>
     </emu-clause>
+
     <emu-clause id="sec-value-notation">
       <h1>Value Notation</h1>
       <p>In this specification, ECMAScript language values are displayed in *bold*. Examples include *null*, *true*, or *"hello"*. These are distinguished from longer ECMAScript code sequences such as `Function.prototype.apply` or `let n = 42;`.</p>
@@ -1072,7 +1080,6 @@
         <p>Within this specification a well-known symbol is referred to by using a notation of the form @@name, where &ldquo;name&rdquo; is one of the values listed in <emu-xref href="#table-well-known-symbols"></emu-xref>.</p>
         <emu-table id="table-well-known-symbols" caption="Well-known Symbols" oldids="table-1">
           <table>
-            <tbody>
             <tr>
               <th>
                 Specification Name
@@ -1227,7 +1234,6 @@
                 An object valued property whose own and inherited property names are property names that are excluded from the `with` environment bindings of the associated object.
               </td>
             </tr>
-            </tbody>
           </table>
         </emu-table>
       </emu-clause>
@@ -1238,7 +1244,6 @@
       <p>ECMAScript has two built-in numeric types: Number and BigInt. The following abstract operations are defined over these numeric types. The "Result" column shows the return type, along with an indication if it is possible for some invocations of the operation to return an abrupt completion.</p>
       <emu-table id="table-numeric-type-ops" caption="Numeric Type Operations">
         <table>
-          <tbody>
           <tr>
             <th>
               Operation
@@ -1398,7 +1403,9 @@
               Number::add
             </td>
             <td rowspan="2">
-              `x ++`<br>`++ x`<br>`x&nbsp;+&nbsp;y`
+              `x ++`<br>
+              `++ x`<br>
+              `x&nbsp;+&nbsp;y`
             </td>
             <td rowspan="2">
               <emu-xref href="#sec-postfix-increment-operator" title></emu-xref>,
@@ -1423,7 +1430,9 @@
               Number::subtract
             </td>
             <td rowspan="2">
-              `x --`<br>`-- x`<br>`x&nbsp;-&nbsp;y`
+              `x --`<br>
+              `-- x`<br>
+              `x&nbsp;-&nbsp;y`
             </td>
             <td rowspan="2">
               <emu-xref href="#sec-postfix-decrement-operator" title></emu-xref>,
@@ -1517,7 +1526,10 @@
               Number::lessThan
             </td>
             <td rowspan="2">
-              `x&nbsp;&lt;&nbsp;y`<br>`x&nbsp;>&nbsp;y`<br>`x&nbsp;&lt;=&nbsp;y`<br>`x&nbsp;>=&nbsp;y`
+              `x&nbsp;&lt;&nbsp;y`<br>
+              `x&nbsp;>&nbsp;y`<br>
+              `x&nbsp;&lt;=&nbsp;y`<br>
+              `x&nbsp;>=&nbsp;y`
             </td>
             <td rowspan="2">
               <emu-xref href="#sec-relational-operators" title></emu-xref>,
@@ -1542,7 +1554,10 @@
               Number::equal
             </td>
             <td rowspan="2">
-              `x&nbsp;==&nbsp;y`<br>`x&nbsp;!=&nbsp;y`<br>`x&nbsp;===&nbsp;y`<br>`x&nbsp;!==&nbsp;y`
+              `x&nbsp;==&nbsp;y`<br>
+              `x&nbsp;!=&nbsp;y`<br>
+              `x&nbsp;===&nbsp;y`<br>
+              `x&nbsp;!==&nbsp;y`
             </td>
             <td rowspan="2">
               <emu-xref href="#sec-equality-operators" title></emu-xref>,
@@ -1684,7 +1699,6 @@
               BigInt::toString
             </td>
           </tr>
-          </tbody>
         </table>
       </emu-table>
       <p>Because the numeric types are in general not convertible without loss of precision or truncation, the ECMAScript language provides no implicit conversion among these types. Programmers must explicitly call `Number` and `BigInt` functions to convert among types when calling a function which requires another type.</p>
@@ -2180,13 +2194,12 @@
           </emu-note>
           <emu-note>
             <p>Implementers of ECMAScript may find useful the paper and code written by David M. Gay for binary-to-decimal conversion of floating-point numbers:</p>
-            <p>Gay, David M. Correctly Rounded Binary-Decimal and Decimal-Binary Conversions. Numerical Analysis, Manuscript 90-10. AT&amp;T Bell Laboratories (Murray Hill, New Jersey). 30 November 1990. Available as
-              <br>
-              <a href="http://ampl.com/REFS/abstracts.html#rounding">http://ampl.com/REFS/abstracts.html#rounding</a>. Associated code available as
-              <br>
-              <a href="http://netlib.sandia.gov/fp/dtoa.c">http://netlib.sandia.gov/fp/dtoa.c</a> and as
-              <br>
-              <a href="http://netlib.sandia.gov/fp/g_fmt.c">http://netlib.sandia.gov/fp/g_fmt.c</a> and may also be found at the various `netlib` mirror sites.</p>
+            <p>
+              Gay, David M. Correctly Rounded Binary-Decimal and Decimal-Binary Conversions. Numerical Analysis, Manuscript 90-10. AT&amp;T Bell Laboratories (Murray Hill, New Jersey). 30 November 1990. Available as<br>
+              <a href="http://ampl.com/REFS/abstracts.html#rounding">http://ampl.com/REFS/abstracts.html#rounding</a>. Associated code available as<br>
+              <a href="http://netlib.sandia.gov/fp/dtoa.c">http://netlib.sandia.gov/fp/dtoa.c</a> and as<br>
+              <a href="http://netlib.sandia.gov/fp/g_fmt.c">http://netlib.sandia.gov/fp/g_fmt.c</a> and may also be found at the various `netlib` mirror sites.
+            </p>
           </emu-note>
         </emu-clause>
       </emu-clause>
@@ -2583,7 +2596,6 @@
         <p>Attributes are used in this specification to define and explain the state of Object properties. A data property associates a key value with the attributes listed in <emu-xref href="#table-data-property-attributes"></emu-xref>.</p>
         <emu-table id="table-data-property-attributes" caption="Attributes of a Data Property" oldids="table-2">
           <table>
-            <tbody>
             <tr>
               <th>
                 Attribute Name
@@ -2639,13 +2651,11 @@
                 If *false*, attempts to delete the property, change the property to be an accessor property, or change its attributes (other than [[Value]], or changing [[Writable]] to *false*) will fail.
               </td>
             </tr>
-            </tbody>
           </table>
         </emu-table>
         <p>An accessor property associates a key value with the attributes listed in <emu-xref href="#table-accessor-property-attributes"></emu-xref>.</p>
         <emu-table id="table-accessor-property-attributes" caption="Attributes of an Accessor Property" oldids="table-3">
           <table>
-            <tbody>
             <tr>
               <th>
                 Attribute Name
@@ -2701,13 +2711,11 @@
                 If *false*, attempts to delete the property, change the property to be a data property, or change its attributes will fail.
               </td>
             </tr>
-            </tbody>
           </table>
         </emu-table>
         <p>If the initial values of a property's attributes are not explicitly specified by this specification, the default value defined in <emu-xref href="#table-default-attribute-values"></emu-xref> is used.</p>
         <emu-table id="table-default-attribute-values" caption="Default Attribute Values" oldids="table-4">
           <table>
-            <tbody>
             <tr>
               <th>
                 Attribute Name
@@ -2764,7 +2772,6 @@
                 *false*
               </td>
             </tr>
-            </tbody>
           </table>
         </emu-table>
       </emu-clause>
@@ -2796,7 +2803,6 @@
         <p>An internal method implicitly returns a Completion Record, either a normal completion that wraps a value of the return type shown in its invocation pattern, or a throw completion.</p>
         <emu-table id="table-essential-internal-methods" caption="Essential Internal Methods" oldids="table-5">
           <table>
-            <tbody>
             <tr>
               <th>
                 Internal Method
@@ -2929,13 +2935,11 @@
                 Return a List whose elements are all of the own property keys for the object.
               </td>
             </tr>
-            </tbody>
           </table>
         </emu-table>
         <p><emu-xref href="#table-additional-essential-internal-methods-of-function-objects"></emu-xref> summarizes additional essential internal methods that are supported by objects that may be called as functions. A <dfn id="function-object" variants="function objects">function object</dfn> is an object that supports the [[Call]] internal method. A <dfn id="constructor" variants="constructors">constructor</dfn> is an object that supports the [[Construct]] internal method. Every object that supports [[Construct]] must support [[Call]]; that is, every constructor must be a function object. Therefore, a constructor may also be referred to as a <em>constructor function</em> or <em>constructor function object</em>.</p>
         <emu-table id="table-additional-essential-internal-methods-of-function-objects" caption="Additional Essential Internal Methods of Function Objects" oldids="table-6">
           <table>
-            <tbody>
             <tr>
               <th>
                 Internal Method
@@ -2969,7 +2973,6 @@
                 Creates an object. Invoked via the `new` operator or a `super` call. The first argument to the internal method is a List whose elements are the arguments of the constructor invocation or the `super` call. The second argument is the object to which the `new` operator was initially applied. Objects that implement this internal method are called <em>constructors</em>. A function object is not necessarily a constructor and such non-constructor function objects do not have a [[Construct]] internal method.
               </td>
             </tr>
-            </tbody>
           </table>
         </emu-table>
         <p>The semantics of the essential internal methods for ordinary objects and standard exotic objects are specified in clause <emu-xref href="#sec-ordinary-and-exotic-objects-behaviours"></emu-xref>. If any specified use of an internal method of an exotic object is not supported by an implementation, that usage must throw a *TypeError* exception when attempted.</p>
@@ -3170,7 +3173,6 @@
         <p>Within this specification a reference such as %name% means the intrinsic object, associated with the current realm, corresponding to the name. A reference such as %name.a.b% means, as if the "b" property of the "a" property of the intrinsic object %name% was accessed prior to any ECMAScript code being evaluated. Determination of the current realm and its intrinsics is described in <emu-xref href="#sec-execution-contexts"></emu-xref>. The well-known intrinsics are listed in <emu-xref href="#table-well-known-intrinsic-objects"></emu-xref>.</p>
         <emu-table id="table-well-known-intrinsic-objects" caption="Well-Known Intrinsic Objects" oldids="table-7">
           <table>
-            <tbody>
             <tr>
               <th>
                 Intrinsic Name
@@ -3905,7 +3907,6 @@
                 The WeakSet constructor (<emu-xref href="#sec-weakset-constructor"></emu-xref>)
               </td>
             </tr>
-            </tbody>
           </table>
         </emu-table>
         <emu-note>
@@ -3970,7 +3971,6 @@
       <p>Values of the Completion type are Record values whose fields are defined by <emu-xref href="#table-completion-record-fields"></emu-xref>. Such values are referred to as <dfn variants="Completion Record">Completion Records</dfn>.</p>
       <emu-table id="table-completion-record-fields" caption="Completion Record Fields" oldids="table-8">
         <table>
-          <tbody>
           <tr>
             <th>
               Field Name
@@ -4015,7 +4015,6 @@
               The target label for directed control transfers.
             </td>
           </tr>
-          </tbody>
         </table>
       </emu-table>
       <p>The following shorthand terms are sometimes used to refer to completions.</p>
@@ -4135,7 +4134,6 @@
 
       <emu-table id="table-reference-record-fields" caption="Reference Record Fields">
         <table>
-          <tbody>
           <tr>
             <th>Field Name</th>
             <th>Value</th>
@@ -4174,7 +4172,6 @@
             <td>any ECMAScript language value or ~empty~</td>
             <td>If not ~empty~, the Reference Record represents a property binding that was expressed using the `super` keyword; it is called a <dfn id="super-reference-record" oldids="super-reference" variants="Super Reference Records">Super Reference Record</dfn> and its [[Base]] value will never be an Environment Record. In that case, the [[ThisValue]] field holds the *this* value at the time the Reference Record was created.</td>
           </tr>
-          </tbody>
         </table>
       </emu-table>
 
@@ -4602,7 +4599,6 @@
       <p>Values of the PrivateElement type are Record values whose fields are defined by <emu-xref href="#table-privateelement-fields"></emu-xref>. Such values are referred to as <dfn variants="PrivateElement">PrivateElements</dfn>.</p>
       <emu-table id="table-privateelement-fields" caption="PrivateElement Fields">
         <table>
-          <tbody>
           <tr>
             <th>
               Field Name
@@ -4687,7 +4683,6 @@
               The setter for a private accessor.
             </td>
           </tr>
-          </tbody>
         </table>
       </emu-table>
     </emu-clause>
@@ -4698,7 +4693,6 @@
       <p>Values of the ClassFieldDefinition type are Record values whose fields are defined by <emu-xref href="#table-classfielddefinition-fields"></emu-xref>. Such values are referred to as <dfn variants="ClassFieldDefinition Record">ClassFieldDefinition Records</dfn>.</p>
       <emu-table id="table-classfielddefinition-fields" caption="ClassFieldDefinition Record Fields">
         <table>
-          <tbody>
           <tr>
             <th>
               Field Name
@@ -4732,7 +4726,6 @@
               The initializer of the field, if any.
             </td>
           </tr>
-          </tbody>
         </table>
       </emu-table>
     </emu-clause>
@@ -4748,7 +4741,6 @@
       <p>ClassStaticBlockDefinition Records have the fields listed in <emu-xref href="#table-classstaticblockdefinition-record-fields"></emu-xref>.</p>
       <emu-table id="table-classstaticblockdefinition-record-fields" caption="ClassStaticBlockDefinition Record Fields">
         <table>
-          <tbody>
           <tr>
             <th>
               Field Name
@@ -4771,7 +4763,6 @@
               The function object to be called during static initialization of a class.
             </td>
           </tr>
-          </tbody>
         </table>
       </emu-table>
     </emu-clause>
@@ -4854,7 +4845,6 @@
       </dl>
       <emu-table id="table-toboolean-conversions" caption="ToBoolean Conversions" oldids="table-10">
         <table>
-          <tbody>
           <tr>
             <th>
               Argument Type
@@ -4930,7 +4920,6 @@
               </emu-note>
             </td>
           </tr>
-          </tbody>
         </table>
       </emu-table>
     </emu-clause>
@@ -4964,7 +4953,6 @@
       </dl>
       <emu-table id="table-tonumber-conversions" caption="ToNumber Conversions" oldids="table-11">
         <table>
-          <tbody>
           <tr>
             <th>
               Argument Type
@@ -5041,7 +5029,6 @@
               </emu-alg>
             </td>
           </tr>
-          </tbody>
         </table>
       </emu-table>
 
@@ -5415,7 +5402,6 @@
       </emu-alg>
       <emu-table id="table-tobigint" caption="BigInt Conversions">
         <table>
-          <tbody>
           <tr>
             <th>
               Argument Type
@@ -5484,7 +5470,6 @@
               Throw a *TypeError* exception.
             </td>
           </tr>
-          </tbody>
         </table>
       </emu-table>
     </emu-clause>
@@ -5582,7 +5567,6 @@
       </dl>
       <emu-table id="table-tostring-conversions" caption="ToString Conversions" oldids="table-12">
         <table>
-          <tbody>
           <tr>
             <th>
               Argument Type
@@ -5660,7 +5644,6 @@
               </emu-alg>
             </td>
           </tr>
-          </tbody>
         </table>
       </emu-table>
     </emu-clause>
@@ -5677,7 +5660,6 @@
       </dl>
       <emu-table id="table-toobject-conversions" caption="ToObject Conversions" oldids="table-13">
         <table>
-          <tbody>
           <tr>
             <th>
               Argument Type
@@ -5750,7 +5732,6 @@
               Return _argument_.
             </td>
           </tr>
-          </tbody>
         </table>
       </emu-table>
     </emu-clause>
@@ -5847,7 +5828,6 @@
       </dl>
       <emu-table id="table-requireobjectcoercible-results" caption="RequireObjectCoercible Results" oldids="table-14">
         <table>
-          <tbody>
           <tr>
             <th>
               Argument Type
@@ -5920,7 +5900,6 @@
               Return _argument_.
             </td>
           </tr>
-          </tbody>
         </table>
       </emu-table>
     </emu-clause>
@@ -8413,9 +8392,11 @@
           ThrowStatement
           DebuggerStatement
 
-        Block : `{` `}`
+        Block :
+          `{` `}`
 
-        StatementListItem : Declaration
+        StatementListItem :
+          Declaration
       </emu-grammar>
       <emu-alg>
         1. Return *false*.
@@ -8582,9 +8563,11 @@
           ThrowStatement
           DebuggerStatement
 
-        Block : `{` `}`
+        Block :
+          `{` `}`
 
-        StatementListItem : Declaration
+        StatementListItem :
+          Declaration
       </emu-grammar>
       <emu-alg>
         1. Return *false*.
@@ -8760,9 +8743,11 @@
           ThrowStatement
           DebuggerStatement
 
-        Block : `{` `}`
+        Block :
+          `{` `}`
 
-        StatementListItem : Declaration
+        StatementListItem :
+          Declaration
       </emu-grammar>
       <emu-alg>
         1. Return *false*.
@@ -8931,6 +8916,7 @@
 
   <emu-clause id="sec-syntax-directed-operations-function-name-inference">
     <h1>Function Name Inference</h1>
+
     <emu-clause id="sec-static-semantics-hasname" oldids="sec-semantics-static-semantics-hasname,sec-function-definitions-static-semantics-hasname,sec-arrow-function-definitions-static-semantics-hasname,sec-generator-function-definitions-static-semantics-hasname,sec-async-generator-function-definitions-static-semantics-hasname,sec-class-definitions-static-semantics-hasname,sec-async-function-definitions-static-semantics-HasName,sec-async-arrow-function-definitions-static-semantics-HasName" type="sdo">
       <h1>Static Semantics: HasName</h1>
       <dl class="header">
@@ -8961,7 +8947,8 @@
           `async` AsyncArrowBindingIdentifier `=>` AsyncConciseBody
           CoverCallExpressionAndAsyncArrowHead `=>` AsyncConciseBody
 
-        ClassExpression : `class` ClassTail
+        ClassExpression :
+          `class` ClassTail
       </emu-grammar>
       <emu-alg>
         1. Return *false*.
@@ -8979,7 +8966,8 @@
         AsyncFunctionExpression :
           `async` `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
 
-        ClassExpression : `class` BindingIdentifier ClassTail
+        ClassExpression :
+          `class` BindingIdentifier ClassTail
       </emu-grammar>
       <emu-alg>
         1. Return *true*.
@@ -9119,7 +9107,8 @@
         AsyncFunctionExpression :
           `async` `function` BindingIdentifier? `(` FormalParameters `)` `{` AsyncFunctionBody `}`
 
-        ClassExpression : `class` BindingIdentifier? ClassTail
+        ClassExpression :
+          `class` BindingIdentifier? ClassTail
       </emu-grammar>
       <emu-alg>
         1. Return *true*.
@@ -9560,6 +9549,7 @@
         1. Let _excludedNames_ be ? PropertyBindingInitialization of |BindingPropertyList| with arguments _value_ and _environment_.
         1. Return the result of performing RestBindingInitialization of |BindingRestProperty| with arguments _value_, _environment_, and _excludedNames_.
       </emu-alg>
+
       <emu-clause id="sec-initializeboundname" type="abstract operation">
         <h1>
           InitializeBoundName (
@@ -10036,7 +10026,6 @@
       <p>The Environment Record abstract class includes the abstract specification methods defined in <emu-xref href="#table-abstract-methods-of-environment-records"></emu-xref>. These abstract methods have distinct concrete algorithms for each of the concrete subclasses.</p>
       <emu-table id="table-abstract-methods-of-environment-records" caption="Abstract Methods of Environment Records" oldids="table-15">
         <table>
-          <tbody>
           <tr>
             <th>
               Method
@@ -10125,7 +10114,6 @@
               If this Environment Record is associated with a `with` statement, return the with object. Otherwise, return *undefined*.
             </td>
           </tr>
-          </tbody>
         </table>
       </emu-table>
 
@@ -10341,7 +10329,6 @@
         <p>Object Environment Records have the additional state fields listed in <emu-xref href="#table-additional-fields-of-object-environment-records"></emu-xref>.</p>
         <emu-table id="table-additional-fields-of-object-environment-records" caption="Additional Fields of Object Environment Records">
           <table>
-            <tbody>
             <tr>
               <th>
                 Field Name
@@ -10375,7 +10362,6 @@
                 Indicates whether this Environment Record is created for a `with` statement.
               </td>
             </tr>
-            </tbody>
           </table>
         </emu-table>
         <p>The behaviour of the concrete specification methods for object Environment Records is defined by the following algorithms.</p>
@@ -10568,7 +10554,6 @@
         <p>Function Environment Records have the additional state fields listed in <emu-xref href="#table-additional-fields-of-function-environment-records"></emu-xref>.</p>
         <emu-table id="table-additional-fields-of-function-environment-records" caption="Additional Fields of Function Environment Records" oldids="table-16">
           <table>
-            <tbody>
             <tr>
               <th>
                 Field Name
@@ -10624,13 +10609,11 @@
                 If this Environment Record was created by the [[Construct]] internal method, [[NewTarget]] is the value of the [[Construct]] _newTarget_ parameter. Otherwise, its value is *undefined*.
               </td>
             </tr>
-            </tbody>
           </table>
         </emu-table>
         <p>Function Environment Records support all of the declarative Environment Record methods listed in <emu-xref href="#table-abstract-methods-of-environment-records"></emu-xref> and share the same specifications for all of those methods except for HasThisBinding and HasSuperBinding. In addition, function Environment Records support the methods listed in <emu-xref href="#table-additional-methods-of-function-environment-records"></emu-xref>:</p>
         <emu-table id="table-additional-methods-of-function-environment-records" caption="Additional Methods of Function Environment Records" oldids="table-17">
           <table>
-            <tbody>
             <tr>
               <th>
                 Method
@@ -10663,7 +10646,6 @@
                 Return the object that is the base for `super` property accesses bound in this Environment Record. The value *undefined* indicates that `super` property accesses will produce runtime errors.
               </td>
             </tr>
-            </tbody>
           </table>
         </emu-table>
         <p>The behaviour of the additional concrete specification methods for function Environment Records is defined by the following algorithms:</p>
@@ -10746,7 +10728,6 @@
         <p>Global Environment Records have the additional fields listed in <emu-xref href="#table-additional-fields-of-global-environment-records"></emu-xref> and the additional methods listed in <emu-xref href="#table-additional-methods-of-global-environment-records"></emu-xref>.</p>
         <emu-table id="table-additional-fields-of-global-environment-records" caption="Additional Fields of Global Environment Records" oldids="table-18">
           <table>
-            <tbody>
             <tr>
               <th>
                 Field Name
@@ -10802,12 +10783,10 @@
                 The string names bound by |FunctionDeclaration|, |GeneratorDeclaration|, |AsyncFunctionDeclaration|, |AsyncGeneratorDeclaration|, and |VariableDeclaration| declarations in global code for the associated realm.
               </td>
             </tr>
-            </tbody>
           </table>
         </emu-table>
         <emu-table id="table-additional-methods-of-global-environment-records" caption="Additional Methods of Global Environment Records" oldids="table-19">
           <table>
-            <tbody>
             <tr>
               <th>
                 Method
@@ -10880,7 +10859,6 @@
                 Create and initialize a global `function` binding in the [[ObjectRecord]] component of a global Environment Record. The binding will be a mutable binding. The corresponding global object property will have attribute values appropriate for a `function`. The String value _N_ is the bound name. _V_ is the initialization value. If the Boolean argument _D_ is *true* the binding may be deleted. Logically equivalent to CreateMutableBinding followed by a SetMutableBinding but it allows function declarations to receive special treatment.
               </td>
             </tr>
-            </tbody>
           </table>
         </emu-table>
         <p>The behaviour of the concrete specification methods for global Environment Records is defined by the following algorithms.</p>
@@ -11281,7 +11259,6 @@
         <p>Module Environment Records support all of the declarative Environment Record methods listed in <emu-xref href="#table-abstract-methods-of-environment-records"></emu-xref> and share the same specifications for all of those methods except for GetBindingValue, DeleteBinding, HasThisBinding and GetThisBinding. In addition, module Environment Records support the methods listed in <emu-xref href="#table-additional-methods-of-module-environment-records"></emu-xref>:</p>
         <emu-table id="table-additional-methods-of-module-environment-records" caption="Additional Methods of Module Environment Records" oldids="table-20">
           <table>
-            <tbody>
             <tr>
               <th>
                 Method
@@ -11306,7 +11283,6 @@
                 Return the value of this Environment Record's `this` binding.
               </td>
             </tr>
-            </tbody>
           </table>
         </emu-table>
         <p>The behaviour of the additional concrete specification methods for module Environment Records are defined by the following algorithms:</p>
@@ -11525,19 +11501,18 @@
     <emu-table id="table-privateenvironment-records" caption="PrivateEnvironment Record Fields">
       <table>
         <thead>
-        <tr>
-          <th>
-            Field Name
-          </th>
-          <th>
-            Value Type
-          </th>
-          <th>
-            Meaning
-          </th>
-        </tr>
+          <tr>
+            <th>
+              Field Name
+            </th>
+            <th>
+              Value Type
+            </th>
+            <th>
+              Meaning
+            </th>
+          </tr>
         </thead>
-        <tbody>
         <tr>
           <td>
             [[OuterPrivateEnvironment]]
@@ -11560,7 +11535,6 @@
             The Private Names declared by this class.
           </td>
         </tr>
-        </tbody>
       </table>
     </emu-table>
 
@@ -11611,7 +11585,6 @@
     <p>A realm is represented in this specification as a <dfn id="realm-record" variants="Realm Records">Realm Record</dfn> with the fields specified in <emu-xref href="#table-realm-record-fields"></emu-xref>:</p>
     <emu-table id="table-realm-record-fields" caption="Realm Record Fields" oldids="table-21">
       <table>
-        <tbody>
         <tr>
           <th>
             Field Name
@@ -11679,7 +11652,6 @@
             Field reserved for use by hosts that need to associate additional information with a Realm Record.
           </td>
         </tr>
-        </tbody>
       </table>
     </emu-table>
 
@@ -11763,7 +11735,6 @@
     <p>An execution context contains whatever implementation specific state is necessary to track the execution progress of its associated code. Each execution context has at least the state components listed in <emu-xref href="#table-state-components-for-all-execution-contexts"></emu-xref>.</p>
     <emu-table id="table-state-components-for-all-execution-contexts" caption="State Components for All Execution Contexts" oldids="table-22">
       <table>
-        <tbody>
         <tr>
           <th>
             Component
@@ -11804,7 +11775,6 @@
             The Module Record or Script Record from which associated code originates. If there is no originating script or module, as is the case for the original execution context created in InitializeHostDefinedRealm, the value is *null*.
           </td>
         </tr>
-        </tbody>
       </table>
     </emu-table>
     <p>Evaluation of code by the running execution context may be suspended at various points defined within this specification. Once the running execution context has been suspended a different execution context may become the running execution context and commence evaluating its code. At some later time a suspended execution context may again become the running execution context and continue evaluating its code at the point where it had previously been suspended. Transition of the running execution context status among execution contexts usually occurs in stack-like last-in/first-out manner. However, some ECMAScript features require non-LIFO transitions of the running execution context.</p>
@@ -11812,7 +11782,6 @@
     <p>Execution contexts for ECMAScript code have the additional state components listed in <emu-xref href="#table-additional-state-components-for-ecmascript-code-execution-contexts"></emu-xref>.</p>
     <emu-table id="table-additional-state-components-for-ecmascript-code-execution-contexts" caption="Additional State Components for ECMAScript Code Execution Contexts" oldids="table-23">
       <table>
-        <tbody>
         <tr>
           <th>
             Component
@@ -11845,14 +11814,12 @@
             Identifies the PrivateEnvironment Record that holds Private Names created by |ClassElement|s in the nearest containing class. *null* if there is no containing class.
           </td>
         </tr>
-        </tbody>
       </table>
     </emu-table>
     <p>The LexicalEnvironment and VariableEnvironment components of an execution context are always Environment Records.</p>
     <p>Execution contexts representing the evaluation of Generators have the additional state components listed in <emu-xref href="#table-additional-state-components-for-generator-execution-contexts"></emu-xref>.</p>
     <emu-table id="table-additional-state-components-for-generator-execution-contexts" caption="Additional State Components for Generator Execution Contexts" oldids="table-24">
       <table>
-        <tbody>
         <tr>
           <th>
             Component
@@ -11869,7 +11836,6 @@
             The Generator that this execution context is evaluating.
           </td>
         </tr>
-        </tbody>
       </table>
     </emu-table>
     <p>In most situations only the running execution context (the top of the execution context stack) is directly manipulated by algorithms within this specification. Hence when the terms &ldquo;LexicalEnvironment&rdquo;, and &ldquo;VariableEnvironment&rdquo; are used without qualification they are in reference to those components of the running execution context.</p>
@@ -12020,7 +11986,6 @@
       <p>JobCallback Records have the fields listed in <emu-xref href="#table-jobcallback-records"></emu-xref>.</p>
       <emu-table id="table-jobcallback-records" caption="JobCallback Record Fields">
         <table>
-          <tbody>
           <tr>
             <th>
               Field Name
@@ -12054,7 +12019,6 @@
               Field reserved for use by hosts.
             </td>
           </tr>
-          </tbody>
         </table>
       </emu-table>
     </emu-clause>
@@ -12163,7 +12127,6 @@
     <p>While an agent's executing thread executes jobs, the agent is the <dfn id="surrounding-agent" variants="surrounding agents">surrounding agent</dfn> for the code in those jobs. The code uses the surrounding agent to access the specification-level execution objects held within the agent: the running execution context, the execution context stack, and the Agent Record's fields.</p>
     <emu-table id="table-agent-record" caption="Agent Record Fields">
       <table>
-        <tbody>
         <tr>
           <th>Field Name</th>
           <th>Value</th>
@@ -12209,7 +12172,6 @@
           <td>List of objects</td>
           <td>Initially a new empty List, representing the list of objects to be kept alive until the end of the current Job</td>
         </tr>
-        </tbody>
       </table>
     </emu-table>
 
@@ -12324,6 +12286,7 @@
 
   <emu-clause id="sec-weakref-processing-model">
     <h1>Processing Model of WeakRef and FinalizationRegistry Objects</h1>
+
     <emu-clause id="sec-weakref-invariants">
       <h1>Objectives</h1>
 
@@ -13072,7 +13035,6 @@
     <p>In addition to [[Extensible]] and [[Prototype]], ECMAScript function objects also have the internal slots listed in <emu-xref href="#table-internal-slots-of-ecmascript-function-objects"></emu-xref>.</p>
     <emu-table id="table-internal-slots-of-ecmascript-function-objects" caption="Internal Slots of ECMAScript Function Objects" oldids="table-27">
       <table>
-        <tbody>
         <tr>
           <th>
             Internal Slot
@@ -13249,7 +13211,6 @@
             Indicates whether the function is a class constructor. (If *true*, invoking the function's [[Call]] will immediately throw a *TypeError* exception.)
           </td>
         </tr>
-        </tbody>
       </table>
     </emu-table>
     <p>All ECMAScript function objects have the [[Call]] internal method defined here. ECMAScript functions that are also constructors in addition have the [[Construct]] internal method.</p>
@@ -13904,7 +13865,6 @@
       <p>Bound function exotic objects do not have the internal slots of ECMAScript function objects listed in <emu-xref href="#table-internal-slots-of-ecmascript-function-objects"></emu-xref>. Instead they have the internal slots listed in <emu-xref href="#table-internal-slots-of-bound-function-exotic-objects"></emu-xref>, in addition to [[Prototype]] and [[Extensible]].</p>
       <emu-table id="table-internal-slots-of-bound-function-exotic-objects" caption="Internal Slots of Bound Function Exotic Objects" oldids="table-28">
         <table>
-          <tbody>
           <tr>
             <th>
               Internal Slot
@@ -13949,7 +13909,6 @@
               A list of values whose elements are used as the first arguments to any call to the wrapped function.
             </td>
           </tr>
-          </tbody>
         </table>
       </emu-table>
 
@@ -14794,7 +14753,6 @@
       <p>Module namespace exotic objects have the internal slots defined in <emu-xref href="#table-internal-slots-of-module-namespace-exotic-objects"></emu-xref>.</p>
       <emu-table id="table-internal-slots-of-module-namespace-exotic-objects" caption="Internal Slots of Module Namespace Exotic Objects" oldids="table-29">
         <table>
-          <tbody>
           <tr>
             <th>
               Internal Slot
@@ -14828,7 +14786,6 @@
               A List whose elements are the String values of the exported names exposed as own properties of this object. The list is ordered as if an Array of those String values had been sorted using %Array.prototype.sort% using *undefined* as _comparefn_.
             </td>
           </tr>
-          </tbody>
         </table>
       </emu-table>
 
@@ -15099,7 +15056,6 @@
 
     <emu-table id="table-proxy-handler-methods" caption="Proxy Handler Methods" oldids="table-30">
       <table>
-        <tbody>
         <tr>
           <th>
             Internal Method
@@ -15212,7 +15168,6 @@
             `construct`
           </td>
         </tr>
-        </tbody>
       </table>
     </emu-table>
     <p>When a handler method is called to provide the implementation of a Proxy object internal method, the handler method is passed the proxy's target object as a parameter. A proxy's handler object does not necessarily have a method corresponding to every essential internal method. Invoking an internal method on the proxy results in the invocation of the corresponding internal method on the proxy's target object if the handler object does not have a method corresponding to the internal trap.</p>
@@ -16089,7 +16044,6 @@
     <p>The special treatment of certain format-control characters outside of comments, string literals, and regular expression literals is summarized in <emu-xref href="#table-format-control-code-point-usage"></emu-xref>.</p>
     <emu-table id="table-format-control-code-point-usage" caption="Format-Control Code Point Usage" oldids="table-31">
       <table>
-        <tbody>
         <tr>
           <th>
             Code Point
@@ -16146,7 +16100,6 @@
             |WhiteSpace|
           </td>
         </tr>
-        </tbody>
       </table>
     </emu-table>
   </emu-clause>
@@ -16157,7 +16110,6 @@
     <p>The ECMAScript white space code points are listed in <emu-xref href="#table-white-space-code-points"></emu-xref>.</p>
     <emu-table id="table-white-space-code-points" caption="White Space Code Points" oldids="table-32">
       <table>
-        <tbody>
         <tr>
           <th>
             Code Point
@@ -16224,7 +16176,6 @@
             &lt;USP&gt;
           </td>
         </tr>
-        </tbody>
       </table>
     </emu-table>
     <emu-note>
@@ -16252,7 +16203,6 @@
     <p>The ECMAScript line terminator code points are listed in <emu-xref href="#table-line-terminator-code-points"></emu-xref>.</p>
     <emu-table id="table-line-terminator-code-points" caption="Line Terminator Code Points" oldids="table-33">
       <table>
-        <tbody>
         <tr>
           <th>
             Code Point
@@ -16308,7 +16258,6 @@
             &lt;PS&gt;
           </td>
         </tr>
-        </tbody>
       </table>
     </emu-table>
     <p>Only the Unicode code points in <emu-xref href="#table-line-terminator-code-points"></emu-xref> are treated as line terminators. Other new line or line breaking Unicode code points are not treated as line terminators but are treated as white space if they meet the requirements listed in <emu-xref href="#table-white-space-code-points"></emu-xref>. The sequence &lt;CR&gt;&lt;LF&gt; is commonly used as a line terminator. It should be considered a single |SourceCharacter| for the purpose of reporting line numbers.</p>
@@ -16962,7 +16911,7 @@
           `u`
 
         LegacyOctalEscapeSequence ::
-          `0` [lookahead &isin; {`8`, `9`}]
+          `0` [lookahead &isin; { `8`, `9` }]
           NonZeroOctalDigit [lookahead &notin; OctalDigit]
           ZeroToThree OctalDigit [lookahead &notin; OctalDigit]
           FourToSeven OctalDigit
@@ -16998,9 +16947,9 @@
       <emu-clause id="sec-string-literals-early-errors">
         <h1>Static Semantics: Early Errors</h1>
         <emu-grammar>
-          EscapeSequence :: LegacyOctalEscapeSequence
-
-          EscapeSequence :: NonOctalDecimalEscapeSequence
+          EscapeSequence ::
+            LegacyOctalEscapeSequence
+            NonOctalDecimalEscapeSequence
         </emu-grammar>
         <ul>
           <li>It is a Syntax Error if the source code matching this production is strict mode code.</li>
@@ -17068,7 +17017,6 @@
         </ul>
         <emu-table id="table-string-single-character-escape-sequences" caption="String Single Character Escape Sequences" oldids="table-34">
           <table>
-            <tbody>
             <tr>
               <th>
                 Escape Sequence
@@ -17209,7 +17157,6 @@
                 `\\`
               </td>
             </tr>
-            </tbody>
           </table>
         </emu-table>
         <ul>
@@ -17416,7 +17363,7 @@
           `u` `{` CodePoint [lookahead &notin; HexDigit] [lookahead != `}`]
 
         NotCodePoint ::
-          HexDigits[~Sep] [> but only if MV of |HexDigits| &gt; 0x10FFFF]
+          HexDigits[~Sep] [> but only if MV of |HexDigits| > 0x10FFFF]
 
         CodePoint ::
           HexDigits[~Sep] [> but only if MV of |HexDigits| &le; 0x10FFFF]
@@ -17778,6 +17725,7 @@
       <pre><code class="javascript">a = b + c(d + e).print()</code></pre>
       <p>In the circumstance that an assignment statement must begin with a left parenthesis, it is a good idea for the programmer to provide an explicit semicolon at the end of the preceding statement rather than to rely on automatic semicolon insertion.</p>
     </emu-clause>
+
     <emu-clause id="sec-interesting-cases-of-automatic-semicolon-insertion">
       <h1>Interesting Cases of Automatic Semicolon Insertion</h1>
       <em>This section is non-normative.</em>
@@ -17786,6 +17734,7 @@
       <p>As new syntactic features are added to ECMAScript, additional grammar productions could be added that cause lines relying on automatic semicolon insertion preceding them to change grammar productions when parsed.</p>
 
       <p>For the purposes of this section, a case of automatic semicolon insertion is considered interesting if it is a place where a semicolon may or may not be inserted, depending on the source text which precedes it. The rest of this section describes a number of interesting cases of automatic semicolon insertion in this version of ECMAScript.</p>
+
       <emu-clause id="sec-asi-interesting-cases-in-statement-lists">
         <h1>Interesting Cases of Automatic Semicolon Insertion in Statement Lists</h1>
         <p>In a |StatementList|, many |StatementListItem|s end in semicolons, which may be omitted using automatic semicolon insertion. As a consequence of the rules above, at the end of a line ending an expression, a semicolon is required if the following line begins with any of the following:</p>
@@ -17797,12 +17746,14 @@
           <li><strong>A RegExp literal</strong>. Without a semicolon, the two lines together may be parsed instead as the `/` |MultiplicativeOperator|, for example if the RegExp has flags.</li>
         </ul>
       </emu-clause>
+
       <emu-clause id="sec-asi-cases-with-no-lineterminator-here">
         <h1>Cases of Automatic Semicolon Insertion and &ldquo;[no |LineTerminator| here]&rdquo;</h1>
         <em>This section is non-normative.</em>
         <p>ECMAScript contains grammar productions which include &ldquo;[no |LineTerminator| here]&rdquo;. These productions are sometimes a means to have optional operands in the grammar. Introducing a |LineTerminator| in these locations would change the grammar production of a source text by using the grammar production without the optional operand.</p>
 
         <p>The rest of this section describes a number of productions using &ldquo;[no |LineTerminator| here]&rdquo; in this version of ECMAScript.</p>
+
         <emu-clause id="sec-no-lineterminator-here-automatic-semicolon-insertion-list">
           <h1>List of Grammar Productions with Optional Operands and &ldquo;[no |LineTerminator| here]&rdquo;</h1>
           <ul>
@@ -18037,11 +17988,11 @@
         `(` Expression[+In, ?Yield, ?Await] `,` `...` BindingPattern[?Yield, ?Await] `)`
     </emu-grammar>
     <h2>Supplemental Syntax</h2>
-    <p>When processing an instance of the production
-      <br>
-      <emu-grammar>PrimaryExpression[Yield, Await] : CoverParenthesizedExpressionAndArrowParameterList[?Yield, ?Await]</emu-grammar>
-      <br>
-      the interpretation of |CoverParenthesizedExpressionAndArrowParameterList| is refined using the following grammar:</p>
+    <p>
+      When processing an instance of the production<br>
+      <emu-grammar>PrimaryExpression[Yield, Await] : CoverParenthesizedExpressionAndArrowParameterList[?Yield, ?Await]</emu-grammar><br>
+      the interpretation of |CoverParenthesizedExpressionAndArrowParameterList| is refined using the following grammar:
+    </p>
     <emu-grammar type="definition">
       ParenthesizedExpression[Yield, Await] :
         `(` Expression[+In, ?Yield, ?Await] `)`
@@ -18299,9 +18250,9 @@
           <p>This production exists so that |ObjectLiteral| can serve as a cover grammar for |ObjectAssignmentPattern|. It cannot occur in an actual object initializer.</p>
         </emu-note>
         <emu-grammar>
-          ObjectLiteral : `{` PropertyDefinitionList `}`
-
-          ObjectLiteral : `{` PropertyDefinitionList `,` `}`
+          ObjectLiteral :
+            `{` PropertyDefinitionList `}`
+            `{` PropertyDefinitionList `,` `}`
         </emu-grammar>
         <ul>
           <li>
@@ -18382,6 +18333,7 @@
           1. Return ? ToPropertyKey(_propName_).
         </emu-alg>
       </emu-clause>
+
       <emu-clause id="sec-runtime-semantics-propertydefinitionevaluation" oldids="sec-object-initializer-runtime-semantics-propertydefinitionevaluation" type="sdo">
         <h1>
           Runtime Semantics: PropertyDefinitionEvaluation (
@@ -18872,11 +18824,11 @@
         OptionalExpression[?Yield, ?Await]
     </emu-grammar>
     <h2>Supplemental Syntax</h2>
-    <p>When processing an instance of the production
-      <br>
-      <emu-grammar>CallExpression : CoverCallExpressionAndAsyncArrowHead</emu-grammar>
-      <br>
-      the interpretation of |CoverCallExpressionAndAsyncArrowHead| is refined using the following grammar:</p>
+    <p>
+      When processing an instance of the production<br>
+      <emu-grammar>CallExpression : CoverCallExpressionAndAsyncArrowHead</emu-grammar><br>
+      the interpretation of |CoverCallExpressionAndAsyncArrowHead| is refined using the following grammar:
+    </p>
     <emu-grammar type="definition">
       CallMemberExpression[Yield, Await] :
         MemberExpression[?Yield, ?Await] Arguments[?Yield, ?Await]
@@ -18928,14 +18880,12 @@
       <emu-note>
         <p>Properties are accessed by name, using either the dot notation:</p>
         <div class="rhs">
-          |MemberExpression| `.` |IdentifierName|
-          <br>
+          |MemberExpression| `.` |IdentifierName|<br>
           |CallExpression| `.` |IdentifierName|
         </div>
         <p>or the bracket notation:</p>
         <div class="rhs">
-          |MemberExpression| `[` |Expression| `]`
-          <br>
+          |MemberExpression| `[` |Expression| `]`<br>
           |CallExpression| `[` |Expression| `]`
         </div>
         <p>The dot notation is explained by the following syntactic conversion:</p>
@@ -19021,6 +18971,7 @@
         1. Return the Reference Record { [[Base]]: _baseValue_, [[ReferencedName]]: _propertyKey_, [[Strict]]: _strict_, [[ThisValue]]: ~empty~ }.
       </emu-alg>
     </emu-clause>
+
     <emu-clause id="sec-evaluate-property-access-with-identifier-key" type="abstract operation" oldids="sec-evaluate-identifier-key-property-access">
       <h1>
         EvaluatePropertyAccessWithIdentifierKey (
@@ -19291,6 +19242,7 @@
     <emu-clause id="sec-optional-chains">
       <h1>Optional Chains</h1>
       <emu-note>An optional chain is a chain of one or more property accesses and function calls, the first of which begins with the token `?.`.</emu-note>
+
       <emu-clause id="sec-optional-chaining-evaluation">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>
@@ -19327,6 +19279,7 @@
           1. Return the result of performing ChainEvaluation of |OptionalChain| with arguments _baseValue_ and _baseReference_.
         </emu-alg>
       </emu-clause>
+
       <emu-clause id="sec-optional-chaining-chain-evaluation" type="sdo">
         <h1>
           Runtime Semantics: ChainEvaluation (
@@ -19659,11 +19612,11 @@
             It is a Syntax Error if the |UnaryExpression| is contained in strict mode code and the derived |UnaryExpression| is <emu-grammar>PrimaryExpression : IdentifierReference</emu-grammar>, <emu-grammar>MemberExpression : MemberExpression `.` PrivateIdentifier</emu-grammar>, <emu-grammar>CallExpression : CallExpression `.` PrivateIdentifier</emu-grammar>, <emu-grammar>OptionalChain : `?.` PrivateIdentifier</emu-grammar>, or <emu-grammar>OptionalChain : OptionalChain `.` PrivateIdentifier</emu-grammar>.
           </li>
           <li>
-            <p>It is a Syntax Error if the derived |UnaryExpression| is
-              <br>
-              <emu-grammar>PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
-              <br>
-              and |CoverParenthesizedExpressionAndArrowParameterList| ultimately derives a phrase that, if used in place of |UnaryExpression|, would produce a Syntax Error according to these rules. This rule is recursively applied.</p>
+            <p>
+              It is a Syntax Error if the derived |UnaryExpression| is<br>
+              <emu-grammar>PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar><br>
+              and |CoverParenthesizedExpressionAndArrowParameterList| ultimately derives a phrase that, if used in place of |UnaryExpression|, would produce a Syntax Error according to these rules. This rule is recursively applied.
+            </p>
           </li>
         </ul>
         <emu-note>
@@ -19734,7 +19687,6 @@
         </emu-alg>
         <emu-table id="table-typeof-operator-results" caption="typeof Operator Results" oldids="table-35">
           <table>
-            <tbody>
             <tr>
               <th>
                 Type of _val_
@@ -19815,7 +19767,6 @@
                 *"function"*
               </td>
             </tr>
-            </tbody>
           </table>
         </emu-table>
         <emu-note>
@@ -20609,11 +20560,11 @@
     <emu-clause id="sec-destructuring-assignment">
       <h1>Destructuring Assignment</h1>
       <h2>Supplemental Syntax</h2>
-      <p>In certain circumstances when processing an instance of the production
-        <br>
-        <emu-grammar>AssignmentExpression : LeftHandSideExpression `=` AssignmentExpression</emu-grammar>
-        <br>
-        the interpretation of |LeftHandSideExpression| is refined using the following grammar:</p>
+      <p>
+        In certain circumstances when processing an instance of the production<br>
+        <emu-grammar>AssignmentExpression : LeftHandSideExpression `=` AssignmentExpression</emu-grammar><br>
+        the interpretation of |LeftHandSideExpression| is refined using the following grammar:
+      </p>
       <emu-grammar type="definition">
         AssignmentPattern[Yield, Await] :
           ObjectAssignmentPattern[?Yield, ?Await]
@@ -20798,7 +20749,7 @@
           1. Let _P_ be StringValue of |IdentifierReference|.
           1. Let _lref_ be ? ResolveBinding(_P_).
           1. Let _v_ be ? GetV(_value_, _P_).
-          1. If |Initializer_opt| is present and _v_ is *undefined*, then
+          1. If |Initializer?| is present and _v_ is *undefined*, then
             1. If IsAnonymousFunctionDefinition(|Initializer|) is *true*, then
               1. Set _v_ to the result of performing NamedEvaluation for |Initializer| with argument _P_.
             1. Else,
@@ -21477,7 +21428,7 @@
     <h2>Syntax</h2>
     <emu-grammar type="definition">
       ExpressionStatement[Yield, Await] :
-        [lookahead &notin; {`{`, `function`, `async` [no |LineTerminator| here] `function`, `class`, `let` `[`}] Expression[+In, ?Yield, ?Await] `;`
+        [lookahead &notin; { `{`, `function`, `async` [no LineTerminator here] `function`, `class`, `let` `[` }] Expression[+In, ?Yield, ?Await] `;`
     </emu-grammar>
     <emu-note>
       <p>An |ExpressionStatement| cannot start with a U+007B (LEFT CURLY BRACKET) because that might make it ambiguous with a |Block|. An |ExpressionStatement| cannot start with the `function` or `class` keywords because that would make it ambiguous with a |FunctionDeclaration|, a |GeneratorDeclaration|, or a |ClassDeclaration|. An |ExpressionStatement| cannot start with `async function` because that would make it ambiguous with an |AsyncFunctionDeclaration| or a |AsyncGeneratorDeclaration|. An |ExpressionStatement| cannot start with the two token sequence `let [` because that would make it ambiguous with a `let` |LexicalDeclaration| whose first |LexicalBinding| was an |ArrayBindingPattern|.</p>
@@ -21838,7 +21789,7 @@
           `for` `(` [lookahead != `let` `[`] LeftHandSideExpression[?Yield, ?Await] `in` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
           `for` `(` `var` ForBinding[?Yield, ?Await] `in` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
           `for` `(` ForDeclaration[?Yield, ?Await] `in` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
-          `for` `(` [lookahead &notin; {`let`, `async` `of`}] LeftHandSideExpression[?Yield, ?Await] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
+          `for` `(` [lookahead &notin; { `let`, `async` `of` }] LeftHandSideExpression[?Yield, ?Await] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
           `for` `(` `var` ForBinding[?Yield, ?Await] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
           `for` `(` ForDeclaration[?Yield, ?Await] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
           [+Await] `for` `await` `(` [lookahead != `let`] LeftHandSideExpression[?Yield, ?Await] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
@@ -22316,7 +22267,6 @@
           <p>For-In Iterator instances are ordinary objects that inherit properties from the %ForInIteratorPrototype% intrinsic object. For-In Iterator instances are initially created with the internal slots listed in <emu-xref href="#table-for-in-iterator-instance-slots"></emu-xref>.</p>
           <emu-table id="table-for-in-iterator-instance-slots" caption="Internal Slots of For-In Iterator Instances">
             <table>
-              <tbody>
               <tr>
                 <th>
                   Internal Slot
@@ -22357,7 +22307,6 @@
                   A list of String values remaining to be emitted for the current object, before iterating the properties of its prototype (if its prototype is not *null*).
                 </td>
               </tr>
-              </tbody>
             </table>
           </emu-table>
         </emu-clause>
@@ -22971,6 +22920,7 @@
       FormalParameter[Yield, Await] :
         BindingElement[?Yield, ?Await]
     </emu-grammar>
+
     <emu-clause id="sec-parameter-lists-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
       <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar>
@@ -23463,11 +23413,11 @@
         AssignmentExpression[?In, ~Yield, ?Await]
     </emu-grammar>
     <h2>Supplemental Syntax</h2>
-    <p>When processing an instance of the production
-      <br>
-      <emu-grammar>ArrowParameters[Yield, Await] : CoverParenthesizedExpressionAndArrowParameterList[?Yield, ?Await]</emu-grammar>
-      <br>
-      the interpretation of |CoverParenthesizedExpressionAndArrowParameterList| is refined using the following grammar:</p>
+    <p>
+      When processing an instance of the production<br>
+      <emu-grammar>ArrowParameters[Yield, Await] : CoverParenthesizedExpressionAndArrowParameterList[?Yield, ?Await]</emu-grammar><br>
+      the interpretation of |CoverParenthesizedExpressionAndArrowParameterList| is refined using the following grammar:
+    </p>
     <emu-grammar type="definition">
       ArrowFormalParameters[Yield, Await] :
         `(` UniqueFormalParameters[?Yield, ?Await] `)`
@@ -24559,11 +24509,12 @@
       </emu-alg>
 
       <emu-grammar>
-        ClassElementName : PropertyName
+        ClassElementName :
+          PropertyName
 
-        ClassElement : ClassStaticBlock
-
-        ClassElement : `;`
+        ClassElement :
+          ClassStaticBlock
+          `;`
       </emu-grammar>
       <emu-alg>
         1. Return a new empty List.
@@ -24686,7 +24637,7 @@
       <emu-alg>
         1. Let _name_ be the result of evaluating |ClassElementName|.
         1. ReturnIfAbrupt(_name_).
-        1. If |Initializer_opt| is present, then
+        1. If |Initializer?| is present, then
           1. Let _formalParameterList_ be an instance of the production <emu-grammar>FormalParameters : [empty]</emu-grammar>.
           1. Let _scope_ be the LexicalEnvironment of the running execution context.
           1. Let _privateScope_ be the running execution context's PrivateEnvironment.
@@ -24749,18 +24700,18 @@
       </dl>
 
       <emu-grammar>
-        ClassElement : FieldDefinition `;`
-
-        ClassElement : `static` FieldDefinition `;`
+        ClassElement :
+          FieldDefinition `;`
+          `static` FieldDefinition `;`
       </emu-grammar>
       <emu-alg>
         1. Return ClassFieldDefinitionEvaluation of |FieldDefinition| with argument _object_.
       </emu-alg>
 
       <emu-grammar>
-        ClassElement : MethodDefinition
-
-        ClassElement : `static` MethodDefinition
+        ClassElement :
+          MethodDefinition
+          `static` MethodDefinition
       </emu-grammar>
       <emu-alg>
         1. Return MethodDefinitionEvaluation of |MethodDefinition| with arguments _object_ and *false*.
@@ -24801,14 +24752,14 @@
           1. Perform _classScope_.CreateImmutableBinding(_classBinding_, *true*).
         1. Let _outerPrivateEnvironment_ be the running execution context's PrivateEnvironment.
         1. Let _classPrivateEnvironment_ be NewPrivateEnvironment(_outerPrivateEnvironment_).
-        1. If |ClassBody_opt| is present, then
-          1. For each String _dn_ of the PrivateBoundIdentifiers of |ClassBody_opt|, do
+        1. If |ClassBody?| is present, then
+          1. For each String _dn_ of the PrivateBoundIdentifiers of |ClassBody?|, do
             1. If _classPrivateEnvironment_.[[Names]] contains a Private Name whose [[Description]] is _dn_, then
               1. Assert: This is only possible for getter/setter pairs.
             1. Else,
               1. Let _name_ be a new Private Name whose [[Description]] value is _dn_.
               1. Append _name_ to _classPrivateEnvironment_.[[Names]].
-        1. If |ClassHeritage_opt| is not present, then
+        1. If |ClassHeritage?| is not present, then
           1. Let _protoParent_ be %Object.prototype%.
           1. Let _constructorParent_ be %Function.prototype%.
         1. Else,
@@ -24826,7 +24777,7 @@
             1. If Type(_protoParent_) is neither Object nor Null, throw a *TypeError* exception.
             1. Let _constructorParent_ be _superclass_.
         1. Let _proto_ be ! OrdinaryObjectCreate(_protoParent_).
-        1. If |ClassBody_opt| is not present, let _constructor_ be ~empty~.
+        1. If |ClassBody?| is not present, let _constructor_ be ~empty~.
         1. Else, let _constructor_ be ConstructorMethod of |ClassBody|.
         1. Set the running execution context's LexicalEnvironment to _classScope_.
         1. Set the running execution context's PrivateEnvironment to _classPrivateEnvironment_.
@@ -24852,9 +24803,9 @@
           1. Perform ! MakeClassConstructor(_F_).
           1. Perform ! SetFunctionName(_F_, _className_).
         1. Perform ! MakeConstructor(_F_, *false*, _proto_).
-        1. If |ClassHeritage_opt| is present, set _F_.[[ConstructorKind]] to ~derived~.
+        1. If |ClassHeritage?| is present, set _F_.[[ConstructorKind]] to ~derived~.
         1. Perform ! CreateMethodProperty(_proto_, *"constructor"*, _F_).
-        1. If |ClassBody_opt| is not present, let _elements_ be a new empty List.
+        1. If |ClassBody?| is not present, let _elements_ be a new empty List.
         1. Else, let _elements_ be NonConstructorElements of |ClassBody|.
         1. Let _instancePrivateMethods_ be a new empty List.
         1. Let _staticPrivateMethods_ be a new empty List.
@@ -25177,11 +25128,11 @@
         MemberExpression[?Yield, ?Await] Arguments[?Yield, ?Await]
     </emu-grammar>
     <h2>Supplemental Syntax</h2>
-    <p>When processing an instance of the production
-      <br>
-      <emu-grammar>AsyncArrowFunction : CoverCallExpressionAndAsyncArrowHead `=>` AsyncConciseBody</emu-grammar>
-      <br>
-      the interpretation of |CoverCallExpressionAndAsyncArrowHead| is refined using the following grammar:</p>
+    <p>
+      When processing an instance of the production<br>
+      <emu-grammar>AsyncArrowFunction : CoverCallExpressionAndAsyncArrowHead `=>` AsyncConciseBody</emu-grammar><br>
+      the interpretation of |CoverCallExpressionAndAsyncArrowHead| is refined using the following grammar:
+    </p>
 
     <emu-grammar type="definition">
       AsyncArrowHead :
@@ -25343,9 +25294,11 @@
           1. Return HasCallInTailPosition of |StatementListItem| with argument _call_.
         </emu-alg>
         <emu-grammar>
-          FunctionStatementList : [empty]
+          FunctionStatementList :
+            [empty]
 
-          StatementListItem : Declaration
+          StatementListItem :
+            Declaration
 
           Statement :
             VariableStatement
@@ -25356,18 +25309,22 @@
             ThrowStatement
             DebuggerStatement
 
-          Block : `{` `}`
+          Block :
+            `{` `}`
 
-          ReturnStatement : `return` `;`
+          ReturnStatement :
+            `return` `;`
 
-          LabelledItem : FunctionDeclaration
+          LabelledItem :
+            FunctionDeclaration
 
           ForInOfStatement :
             `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
             `for` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
             `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement
 
-          CaseBlock : `{` `}`
+          CaseBlock :
+            `{` `}`
         </emu-grammar>
         <emu-alg>
           1. Return *false*.
@@ -25379,11 +25336,14 @@
           1. Return HasCallInTailPosition of the second |Statement| with argument _call_.
         </emu-alg>
         <emu-grammar>
-          IfStatement : `if` `(` Expression `)` Statement
+          IfStatement :
+            `if` `(` Expression `)` Statement
 
-          DoWhileStatement : `do` Statement `while` `(` Expression `)` `;`
+          DoWhileStatement :
+            `do` Statement `while` `(` Expression `)` `;`
 
-          WhileStatement : `while` `(` Expression `)` Statement
+          WhileStatement :
+            `while` `(` Expression `)` Statement
 
           ForStatement :
             `for` `(` Expression? `;` Expression? `;` Expression? `)` Statement
@@ -25395,7 +25355,8 @@
             `for` `(` `var` ForBinding `in` Expression `)` Statement
             `for` `(` ForDeclaration `in` Expression `)` Statement
 
-          WithStatement : `with` `(` Expression `)` Statement
+          WithStatement :
+            `with` `(` Expression `)` Statement
         </emu-grammar>
         <emu-alg>
           1. Return HasCallInTailPosition of |Statement| with argument _call_.
@@ -25445,9 +25406,9 @@
           1. Return HasCallInTailPosition of |Catch| with argument _call_.
         </emu-alg>
         <emu-grammar>
-          TryStatement : `try` Block Finally
-
-          TryStatement : `try` Block Catch Finally
+          TryStatement :
+            `try` Block Finally
+            `try` Block Catch Finally
         </emu-grammar>
         <emu-alg>
           1. Return HasCallInTailPosition of |Finally| with argument _call_.
@@ -25474,11 +25435,14 @@
             LeftHandSideExpression `||=` AssignmentExpression
             LeftHandSideExpression `??=` AssignmentExpression
 
-          BitwiseANDExpression : BitwiseANDExpression `&amp;` EqualityExpression
+          BitwiseANDExpression :
+            BitwiseANDExpression `&amp;` EqualityExpression
 
-          BitwiseXORExpression : BitwiseXORExpression `^` BitwiseANDExpression
+          BitwiseXORExpression :
+            BitwiseXORExpression `^` BitwiseANDExpression
 
-          BitwiseORExpression : BitwiseORExpression `|` BitwiseXORExpression
+          BitwiseORExpression :
+            BitwiseORExpression `|` BitwiseXORExpression
 
           EqualityExpression :
             EqualityExpression `==` RelationalExpression
@@ -25532,7 +25496,8 @@
             CallExpression `.` IdentifierName
             CallExpression `.` PrivateIdentifier
 
-          NewExpression : `new` NewExpression
+          NewExpression :
+            `new` NewExpression
 
           MemberExpression :
             MemberExpression `[` Expression `]`
@@ -25738,19 +25703,18 @@
       <emu-table id="table-script-records" caption="Script Record Fields">
         <table>
           <thead>
-          <tr>
-            <th>
-              Field Name
-            </th>
-            <th>
-              Value Type
-            </th>
-            <th>
-              Meaning
-            </th>
-          </tr>
+            <tr>
+              <th>
+                Field Name
+              </th>
+              <th>
+                Value Type
+              </th>
+              <th>
+                Meaning
+              </th>
+            </tr>
           </thead>
-          <tbody>
           <tr>
             <td>
               [[Realm]]
@@ -25784,7 +25748,6 @@
               Field reserved for use by host environments that need to associate additional information with a script.
             </td>
           </tr>
-          </tbody>
         </table>
       </emu-table>
     </emu-clause>
@@ -26071,19 +26034,18 @@
         <emu-table id="table-module-record-fields" caption="Module Record Fields" oldids="table-36">
           <table>
             <thead>
-            <tr>
-              <th>
-                Field Name
-              </th>
-              <th>
-                Value Type
-              </th>
-              <th>
-                Meaning
-              </th>
-            </tr>
+              <tr>
+                <th>
+                  Field Name
+                </th>
+                <th>
+                  Value Type
+                </th>
+                <th>
+                  Meaning
+                </th>
+              </tr>
             </thead>
-            <tbody>
             <tr>
               <td>
                 [[Realm]]
@@ -26128,12 +26090,10 @@
                 Field reserved for use by host environments that need to associate additional information with a module.
               </td>
             </tr>
-            </tbody>
           </table>
         </emu-table>
         <emu-table id="table-abstract-methods-of-module-records" caption="Abstract Methods of Module Records" oldids="table-37">
           <table>
-            <tbody>
             <tr>
               <th>
                 Method
@@ -26176,7 +26136,6 @@
                 <p>Link must have completed successfully prior to invoking this method.</p>
               </td>
             </tr>
-            </tbody>
           </table>
         </emu-table>
       </emu-clause>
@@ -26187,7 +26146,6 @@
         <p>In addition to the fields defined in <emu-xref href="#table-module-record-fields"></emu-xref> Cyclic Module Records have the additional fields listed in <emu-xref href="#table-cyclic-module-fields"></emu-xref></p>
         <emu-table id="table-cyclic-module-fields" caption="Additional Fields of Cyclic Module Records">
           <table>
-            <tbody>
             <tr>
               <th>
                 Field Name
@@ -26320,13 +26278,11 @@
                 If this module has any asynchronous dependencies, this tracks the number of asynchronous dependency modules remaining to execute for this module. A module with asynchronous dependencies will be executed when this field reaches 0 and there are no execution errors.
               </td>
             </tr>
-            </tbody>
           </table>
         </emu-table>
         <p>In addition to the methods defined in <emu-xref href="#table-abstract-methods-of-module-records"></emu-xref> Cyclic Module Records have the additional methods listed in <emu-xref href="#table-cyclic-module-methods"></emu-xref></p>
         <emu-table id="table-cyclic-module-methods" caption="Additional Abstract Methods of Cyclic Module Records">
           <table>
-            <tbody>
             <tr>
               <th>
                 Method
@@ -26351,7 +26307,6 @@
                 Evaluate the module's code within its execution context. If this module has *true* in [[HasTLA]], then a PromiseCapability Record is passed as an argument, and the method is expected to resolve or reject the given capability. In this case, the method must not throw an exception, but instead reject the PromiseCapability Record if necessary.
               </td>
             </tr>
-            </tbody>
           </table>
         </emu-table>
 
@@ -26723,7 +26678,6 @@
                   <th>[[PendingAsyncDependencies]]</th>
                 </tr>
               </thead>
-              <tbody>
               <tr>
                 <th>_A_</th>
                 <td>0</td>
@@ -26769,7 +26723,6 @@
                 <td>&laquo; _C_ &raquo;</td>
                 <td>0</td>
               </tr>
-              </tbody>
             </table>
           </emu-table>
 
@@ -26788,7 +26741,6 @@
                   <th>[[PendingAsyncDependencies]]</th>
                 </tr>
               </thead>
-              <tbody>
               <tr>
                 <th>_C_</th>
                 <td>2</td>
@@ -26807,7 +26759,6 @@
                 <td>&laquo; _C_ &raquo;</td>
                 <td>0</td>
               </tr>
-              </tbody>
             </table>
           </emu-table>
 
@@ -26826,7 +26777,6 @@
                   <th>[[PendingAsyncDependencies]]</th>
                 </tr>
               </thead>
-              <tbody>
               <tr>
                 <th>_B_</th>
                 <td>1</td>
@@ -26854,7 +26804,6 @@
                 <td>&laquo; _B_, _C_ &raquo;</td>
                 <td>0</td>
               </tr>
-              </tbody>
             </table>
           </emu-table>
 
@@ -26873,7 +26822,6 @@
                   <th>[[PendingAsyncDependencies]]</th>
                 </tr>
               </thead>
-              <tbody>
               <tr>
                 <th>_A_</th>
                 <td>0</td>
@@ -26892,7 +26840,6 @@
                 <td>&laquo; _A_ &raquo;</td>
                 <td>0</td>
               </tr>
-              </tbody>
             </table>
           </emu-table>
 
@@ -26911,7 +26858,6 @@
                   <th>[[PendingAsyncDependencies]]</th>
                 </tr>
               </thead>
-              <tbody>
               <tr>
                 <th>_A_</th>
                 <td>0</td>
@@ -26930,7 +26876,6 @@
                 <td>&laquo; _A_ &raquo;</td>
                 <td>0</td>
               </tr>
-              </tbody>
             </table>
           </emu-table>
 
@@ -26949,7 +26894,6 @@
                   <th>[[PendingAsyncDependencies]]</th>
                 </tr>
               </thead>
-              <tbody>
               <tr>
                 <th>_A_</th>
                 <td>0</td>
@@ -26959,7 +26903,6 @@
                 <td>&laquo; &raquo;</td>
                 <td>0</td>
               </tr>
-              </tbody>
             </table>
           </emu-table>
 
@@ -26979,7 +26922,6 @@
                   <th>[[EvaluationError]]</th>
                 </tr>
               </thead>
-              <tbody>
               <tr>
                 <th>_A_</th>
                 <td>0</td>
@@ -27000,7 +26942,6 @@
                 <th>0</th>
                 <td>_C_'s evaluation error</td>
               </tr>
-              </tbody>
             </table>
           </emu-table>
 
@@ -27020,7 +26961,6 @@
                   <th>[[EvaluationError]]</th>
                 </tr>
               </thead>
-              <tbody>
               <tr>
                 <th>_A_</th>
                 <td>0</td>
@@ -27031,7 +26971,6 @@
                 <td>0</td>
                 <td>_C_'s Evaluation Error</td>
               </tr>
-              </tbody>
             </table>
           </emu-table>
 
@@ -27051,7 +26990,6 @@
                   <th>[[EvaluationError]]</th>
                 </tr>
               </thead>
-              <tbody>
               <tr>
                 <th>_A_</th>
                 <td>0</td>
@@ -27072,7 +27010,6 @@
                 <td>0</td>
                 <td>~empty~</td>
               </tr>
-              </tbody>
             </table>
           </emu-table>
         </emu-clause>
@@ -27088,7 +27025,6 @@
         <p>In addition to the fields defined in <emu-xref href="#table-cyclic-module-fields"></emu-xref>, Source Text Module Records have the additional fields listed in <emu-xref href="#table-additional-fields-of-source-text-module-records"></emu-xref>. Each of these fields is initially set in ParseModule.</p>
         <emu-table id="table-additional-fields-of-source-text-module-records" caption="Additional Fields of Source Text Module Records" oldids="table-38">
           <table>
-            <tbody>
             <tr>
               <th>
                 Field Name
@@ -27177,13 +27113,11 @@
                 A List of ExportEntry records derived from the code of this module that correspond to `export *` declarations that occur within the module, not including `export * as namespace` declarations.
               </td>
             </tr>
-            </tbody>
           </table>
         </emu-table>
         <p>An <dfn id="importentry-record" variants="ImportEntry Records">ImportEntry Record</dfn> is a Record that digests information about a single declarative import. Each ImportEntry Record has the fields defined in <emu-xref href="#table-importentry-record-fields"></emu-xref>:</p>
         <emu-table id="table-importentry-record-fields" caption="ImportEntry Record Fields" oldids="table-39">
           <table>
-            <tbody>
             <tr>
               <th>
                 Field Name
@@ -27228,14 +27162,12 @@
                 The name that is used to locally access the imported value from within the importing module.
               </td>
             </tr>
-            </tbody>
           </table>
         </emu-table>
         <emu-note class="module-overflow-note">
           <p><emu-xref href="#table-import-forms-mapping-to-importentry-records"></emu-xref> gives examples of ImportEntry records fields used to represent the syntactic import forms:</p>
           <emu-table id="table-import-forms-mapping-to-importentry-records" caption="Import Forms Mappings to ImportEntry Records" informative oldids="table-40">
             <table>
-              <tbody>
               <tr>
                 <th>
                   Import Statement Form
@@ -27314,14 +27246,12 @@
                   An ImportEntry Record is not created.
                 </td>
               </tr>
-              </tbody>
             </table>
           </emu-table>
         </emu-note>
         <p>An <dfn id="exportentry-record" variants="ExportEntry Records">ExportEntry Record</dfn> is a Record that digests information about a single declarative export. Each ExportEntry Record has the fields defined in <emu-xref href="#table-exportentry-records"></emu-xref>:</p>
         <emu-table id="table-exportentry-records" caption="ExportEntry Record Fields" oldids="table-41">
           <table>
-            <tbody>
             <tr>
               <th>
                 Field Name
@@ -27377,14 +27307,12 @@
                 The name that is used to locally access the exported value from within the importing module. *null* if the exported value is not locally accessible from within the module.
               </td>
             </tr>
-            </tbody>
           </table>
         </emu-table>
         <emu-note class="module-overflow-note">
           <p><emu-xref href="#table-export-forms-mapping-to-exportentry-records"></emu-xref> gives examples of the ExportEntry record fields used to represent the syntactic export forms:</p>
           <emu-table id="table-export-forms-mapping-to-exportentry-records" caption="Export Forms Mappings to ExportEntry Records" informative oldids="table-42">
             <table>
-              <tbody>
               <tr>
                 <th>
                   Export Statement Form
@@ -27572,7 +27500,6 @@
                   *null*
                 </td>
               </tr>
-              </tbody>
             </table>
           </emu-table>
         </emu-note>
@@ -28159,7 +28086,7 @@
           `export` Declaration[~Yield, +Await]
           `export` `default` HoistableDeclaration[~Yield, +Await, +Default]
           `export` `default` ClassDeclaration[~Yield, +Await, +Default]
-          `export` `default` [lookahead &notin; {`function`, `async` [no |LineTerminator| here] `function`, `class`}] AssignmentExpression[+In, ~Yield, +Await] `;`
+          `export` `default` [lookahead &notin; { `function`, `async` [no LineTerminator here] `function`, `class` }] AssignmentExpression[+In, ~Yield, +Await] `;`
 
         ExportFromClause :
           `*`
@@ -30399,7 +30326,6 @@
         <p>The GlobalSymbolRegistry is a List that is globally available. It is shared by all realms. Prior to the evaluation of any ECMAScript code it is initialized as a new empty List. Elements of the GlobalSymbolRegistry are Records with the structure defined in <emu-xref href="#table-globalsymbolregistry-record-fields"></emu-xref>.</p>
         <emu-table id="table-globalsymbolregistry-record-fields" caption="GlobalSymbolRegistry Record Fields" oldids="table-44">
           <table>
-            <tbody>
             <tr>
               <th>
                 Field Name
@@ -30433,7 +30359,6 @@
                 A symbol that can be retrieved from any realm.
               </td>
             </tr>
-            </tbody>
           </table>
         </emu-table>
       </emu-clause>
@@ -31200,9 +31125,10 @@
         </emu-alg>
         <emu-note>
           <p>The output of `toFixed` may be more precise than `toString` for some values because toString only prints enough significant digits to distinguish the number from adjacent Number values. For example,</p>
-          <p>`(1000000000000000128).toString()` returns *"1000000000000000100"*, while
-            <br>
-            `(1000000000000000128).toFixed(0)` returns *"1000000000000000128"*.</p>
+          <p>
+            `(1000000000000000128).toString()` returns *"1000000000000000100"*, while<br>
+            `(1000000000000000128).toFixed(0)` returns *"1000000000000000128"*.
+          </p>
         </emu-note>
       </emu-clause>
 
@@ -31290,6 +31216,7 @@
 
   <emu-clause id="sec-bigint-objects">
     <h1>BigInt Objects</h1>
+
     <emu-clause id="sec-bigint-constructor">
       <h1>The BigInt Constructor</h1>
       <p>The BigInt constructor:</p>
@@ -32056,11 +31983,12 @@
       <emu-clause id="sec-year-number">
         <h1>Year Number</h1>
         <p>ECMAScript uses a proleptic Gregorian calendar to map a day number to a year number and to determine the month and date within that year. In this calendar, leap years are precisely those which are (divisible by 4) and ((not divisible by 100) or (divisible by 400)). The number of days in year number _y_ is therefore defined by</p>
-        <emu-eqn id="eqn-DaysInYear" aoid="DaysInYear">DaysInYear(_y_)
-          = *365*<sub>𝔽</sub> if (ℝ(_y_) modulo 4) &ne; 0
-          = *366*<sub>𝔽</sub> if (ℝ(_y_) modulo 4) = 0 and (ℝ(_y_) modulo 100) &ne; 0
-          = *365*<sub>𝔽</sub> if (ℝ(_y_) modulo 100) = 0 and (ℝ(_y_) modulo 400) &ne; 0
-          = *366*<sub>𝔽</sub> if (ℝ(_y_) modulo 400) = 0
+        <emu-eqn id="eqn-DaysInYear" aoid="DaysInYear">
+          DaysInYear(_y_)
+            = *365*<sub>𝔽</sub> if (ℝ(_y_) modulo 4) &ne; 0
+            = *366*<sub>𝔽</sub> if (ℝ(_y_) modulo 4) = 0 and (ℝ(_y_) modulo 100) &ne; 0
+            = *365*<sub>𝔽</sub> if (ℝ(_y_) modulo 100) = 0 and (ℝ(_y_) modulo 400) &ne; 0
+            = *366*<sub>𝔽</sub> if (ℝ(_y_) modulo 400) = 0
         </emu-eqn>
         <p>All non-leap years have 365 days with the usual number of days per month and leap years have an extra day in February. The day number of the first day of year _y_ is given by:</p>
         <emu-eqn id="eqn-DaysFromYear" aoid="DayFromYear">DayFromYear(_y_) = 𝔽(365 &times; (ℝ(_y_) - 1970) + floor((ℝ(_y_) - 1969) / 4) - floor((ℝ(_y_) - 1901) / 100) + floor((ℝ(_y_) - 1601) / 400))</emu-eqn>
@@ -32069,28 +31997,30 @@
         <p>A time value determines a year by:</p>
         <emu-eqn id="eqn-YearFromTime" aoid="YearFromTime">YearFromTime(_t_) = the largest integral Number _y_ (closest to +&infin;) such that TimeFromYear(_y_) &le; _t_</emu-eqn>
         <p>The leap-year function is *1*<sub>𝔽</sub> for a time within a leap year and otherwise is *+0*<sub>𝔽</sub>:</p>
-        <emu-eqn id="eqn-InLeapYear" aoid="InLeapYear">InLeapYear(_t_)
-          = *+0*<sub>𝔽</sub> if DaysInYear(YearFromTime(_t_)) = *365*<sub>𝔽</sub>
-          = *1*<sub>𝔽</sub> if DaysInYear(YearFromTime(_t_)) = *366*<sub>𝔽</sub>
+        <emu-eqn id="eqn-InLeapYear" aoid="InLeapYear">
+          InLeapYear(_t_)
+            = *+0*<sub>𝔽</sub> if DaysInYear(YearFromTime(_t_)) = *365*<sub>𝔽</sub>
+            = *1*<sub>𝔽</sub> if DaysInYear(YearFromTime(_t_)) = *366*<sub>𝔽</sub>
         </emu-eqn>
       </emu-clause>
 
       <emu-clause id="sec-month-number">
         <h1>Month Number</h1>
         <p>Months are identified by an integral Number in the range *+0*<sub>𝔽</sub> to *11*<sub>𝔽</sub>, inclusive. The mapping MonthFromTime(_t_) from a time value _t_ to a month number is defined by:</p>
-        <emu-eqn id="eqn-MonthFromTime" aoid="MonthFromTime">MonthFromTime(_t_)
-          = *+0*<sub>𝔽</sub> if *+0*<sub>𝔽</sub> &le; DayWithinYear(_t_) &lt; *31*<sub>𝔽</sub>
-          = *1*<sub>𝔽</sub> if *31*<sub>𝔽</sub> &le; DayWithinYear(_t_) &lt; *59*<sub>𝔽</sub> + InLeapYear(_t_)
-          = *2*<sub>𝔽</sub> if *59*<sub>𝔽</sub> + InLeapYear(_t_) &le; DayWithinYear(_t_) &lt; *90*<sub>𝔽</sub> + InLeapYear(_t_)
-          = *3*<sub>𝔽</sub> if *90*<sub>𝔽</sub> + InLeapYear(_t_) &le; DayWithinYear(_t_) &lt; *120*<sub>𝔽</sub> + InLeapYear(_t_)
-          = *4*<sub>𝔽</sub> if *120*<sub>𝔽</sub> + InLeapYear(_t_) &le; DayWithinYear(_t_) &lt; *151*<sub>𝔽</sub> + InLeapYear(_t_)
-          = *5*<sub>𝔽</sub> if *151*<sub>𝔽</sub> + InLeapYear(_t_) &le; DayWithinYear(_t_) &lt; *181*<sub>𝔽</sub> + InLeapYear(_t_)
-          = *6*<sub>𝔽</sub> if *181*<sub>𝔽</sub> + InLeapYear(_t_) &le; DayWithinYear(_t_) &lt; *212*<sub>𝔽</sub> + InLeapYear(_t_)
-          = *7*<sub>𝔽</sub> if *212*<sub>𝔽</sub> + InLeapYear(_t_) &le; DayWithinYear(_t_) &lt; *243*<sub>𝔽</sub> + InLeapYear(_t_)
-          = *8*<sub>𝔽</sub> if *243*<sub>𝔽</sub> + InLeapYear(_t_) &le; DayWithinYear(_t_) &lt; *273*<sub>𝔽</sub> + InLeapYear(_t_)
-          = *9*<sub>𝔽</sub> if *273*<sub>𝔽</sub> + InLeapYear(_t_) &le; DayWithinYear(_t_) &lt; *304*<sub>𝔽</sub> + InLeapYear(_t_)
-          = *10*<sub>𝔽</sub> if *304*<sub>𝔽</sub> + InLeapYear(_t_) &le; DayWithinYear(_t_) &lt; *334*<sub>𝔽</sub> + InLeapYear(_t_)
-          = *11*<sub>𝔽</sub> if *334*<sub>𝔽</sub> + InLeapYear(_t_) &le; DayWithinYear(_t_) &lt; *365*<sub>𝔽</sub> + InLeapYear(_t_)
+        <emu-eqn id="eqn-MonthFromTime" aoid="MonthFromTime">
+          MonthFromTime(_t_)
+            = *+0*<sub>𝔽</sub> if *+0*<sub>𝔽</sub> &le; DayWithinYear(_t_) &lt; *31*<sub>𝔽</sub>
+            = *1*<sub>𝔽</sub> if *31*<sub>𝔽</sub> &le; DayWithinYear(_t_) &lt; *59*<sub>𝔽</sub> + InLeapYear(_t_)
+            = *2*<sub>𝔽</sub> if *59*<sub>𝔽</sub> + InLeapYear(_t_) &le; DayWithinYear(_t_) &lt; *90*<sub>𝔽</sub> + InLeapYear(_t_)
+            = *3*<sub>𝔽</sub> if *90*<sub>𝔽</sub> + InLeapYear(_t_) &le; DayWithinYear(_t_) &lt; *120*<sub>𝔽</sub> + InLeapYear(_t_)
+            = *4*<sub>𝔽</sub> if *120*<sub>𝔽</sub> + InLeapYear(_t_) &le; DayWithinYear(_t_) &lt; *151*<sub>𝔽</sub> + InLeapYear(_t_)
+            = *5*<sub>𝔽</sub> if *151*<sub>𝔽</sub> + InLeapYear(_t_) &le; DayWithinYear(_t_) &lt; *181*<sub>𝔽</sub> + InLeapYear(_t_)
+            = *6*<sub>𝔽</sub> if *181*<sub>𝔽</sub> + InLeapYear(_t_) &le; DayWithinYear(_t_) &lt; *212*<sub>𝔽</sub> + InLeapYear(_t_)
+            = *7*<sub>𝔽</sub> if *212*<sub>𝔽</sub> + InLeapYear(_t_) &le; DayWithinYear(_t_) &lt; *243*<sub>𝔽</sub> + InLeapYear(_t_)
+            = *8*<sub>𝔽</sub> if *243*<sub>𝔽</sub> + InLeapYear(_t_) &le; DayWithinYear(_t_) &lt; *273*<sub>𝔽</sub> + InLeapYear(_t_)
+            = *9*<sub>𝔽</sub> if *273*<sub>𝔽</sub> + InLeapYear(_t_) &le; DayWithinYear(_t_) &lt; *304*<sub>𝔽</sub> + InLeapYear(_t_)
+            = *10*<sub>𝔽</sub> if *304*<sub>𝔽</sub> + InLeapYear(_t_) &le; DayWithinYear(_t_) &lt; *334*<sub>𝔽</sub> + InLeapYear(_t_)
+            = *11*<sub>𝔽</sub> if *334*<sub>𝔽</sub> + InLeapYear(_t_) &le; DayWithinYear(_t_) &lt; *365*<sub>𝔽</sub> + InLeapYear(_t_)
         </emu-eqn>
         <p>where</p>
         <emu-eqn id="eqn-DayWithinYear" aoid="DayWithinYear">DayWithinYear(_t_) = Day(_t_) - DayFromYear(YearFromTime(_t_))</emu-eqn>
@@ -32100,19 +32030,20 @@
       <emu-clause id="sec-date-number">
         <h1>Date Number</h1>
         <p>A date number is identified by an integral Number in the range *1*<sub>𝔽</sub> through *31*<sub>𝔽</sub>, inclusive. The mapping DateFromTime(_t_) from a time value _t_ to a date number is defined by:</p>
-        <emu-eqn aoid="DateFromTime">DateFromTime(_t_)
-          = DayWithinYear(_t_) + *1*<sub>𝔽</sub> if MonthFromTime(_t_) = *+0*<sub>𝔽</sub>
-          = DayWithinYear(_t_) - *30*<sub>𝔽</sub> if MonthFromTime(_t_) = *1*<sub>𝔽</sub>
-          = DayWithinYear(_t_) - *58*<sub>𝔽</sub> - InLeapYear(_t_) if MonthFromTime(_t_) = *2*<sub>𝔽</sub>
-          = DayWithinYear(_t_) - *89*<sub>𝔽</sub> - InLeapYear(_t_) if MonthFromTime(_t_) = *3*<sub>𝔽</sub>
-          = DayWithinYear(_t_) - *119*<sub>𝔽</sub> - InLeapYear(_t_) if MonthFromTime(_t_) = *4*<sub>𝔽</sub>
-          = DayWithinYear(_t_) - *150*<sub>𝔽</sub> - InLeapYear(_t_) if MonthFromTime(_t_) = *5*<sub>𝔽</sub>
-          = DayWithinYear(_t_) - *180*<sub>𝔽</sub> - InLeapYear(_t_) if MonthFromTime(_t_) = *6*<sub>𝔽</sub>
-          = DayWithinYear(_t_) - *211*<sub>𝔽</sub> - InLeapYear(_t_) if MonthFromTime(_t_) = *7*<sub>𝔽</sub>
-          = DayWithinYear(_t_) - *242*<sub>𝔽</sub> - InLeapYear(_t_) if MonthFromTime(_t_) = *8*<sub>𝔽</sub>
-          = DayWithinYear(_t_) - *272*<sub>𝔽</sub> - InLeapYear(_t_) if MonthFromTime(_t_) = *9*<sub>𝔽</sub>
-          = DayWithinYear(_t_) - *303*<sub>𝔽</sub> - InLeapYear(_t_) if MonthFromTime(_t_) = *10*<sub>𝔽</sub>
-          = DayWithinYear(_t_) - *333*<sub>𝔽</sub> - InLeapYear(_t_) if MonthFromTime(_t_) = *11*<sub>𝔽</sub>
+        <emu-eqn aoid="DateFromTime">
+          DateFromTime(_t_)
+            = DayWithinYear(_t_) + *1*<sub>𝔽</sub> if MonthFromTime(_t_) = *+0*<sub>𝔽</sub>
+            = DayWithinYear(_t_) - *30*<sub>𝔽</sub> if MonthFromTime(_t_) = *1*<sub>𝔽</sub>
+            = DayWithinYear(_t_) - *58*<sub>𝔽</sub> - InLeapYear(_t_) if MonthFromTime(_t_) = *2*<sub>𝔽</sub>
+            = DayWithinYear(_t_) - *89*<sub>𝔽</sub> - InLeapYear(_t_) if MonthFromTime(_t_) = *3*<sub>𝔽</sub>
+            = DayWithinYear(_t_) - *119*<sub>𝔽</sub> - InLeapYear(_t_) if MonthFromTime(_t_) = *4*<sub>𝔽</sub>
+            = DayWithinYear(_t_) - *150*<sub>𝔽</sub> - InLeapYear(_t_) if MonthFromTime(_t_) = *5*<sub>𝔽</sub>
+            = DayWithinYear(_t_) - *180*<sub>𝔽</sub> - InLeapYear(_t_) if MonthFromTime(_t_) = *6*<sub>𝔽</sub>
+            = DayWithinYear(_t_) - *211*<sub>𝔽</sub> - InLeapYear(_t_) if MonthFromTime(_t_) = *7*<sub>𝔽</sub>
+            = DayWithinYear(_t_) - *242*<sub>𝔽</sub> - InLeapYear(_t_) if MonthFromTime(_t_) = *8*<sub>𝔽</sub>
+            = DayWithinYear(_t_) - *272*<sub>𝔽</sub> - InLeapYear(_t_) if MonthFromTime(_t_) = *9*<sub>𝔽</sub>
+            = DayWithinYear(_t_) - *303*<sub>𝔽</sub> - InLeapYear(_t_) if MonthFromTime(_t_) = *10*<sub>𝔽</sub>
+            = DayWithinYear(_t_) - *333*<sub>𝔽</sub> - InLeapYear(_t_) if MonthFromTime(_t_) = *11*<sub>𝔽</sub>
         </emu-eqn>
       </emu-clause>
 
@@ -32291,7 +32222,6 @@
         <p>Where the elements are as follows:</p>
         <figure>
           <table class="lightweight-table">
-            <tbody>
             <tr>
               <td>
                 `YYYY`
@@ -32388,7 +32318,6 @@
                 is the UTC offset representation specified as *"Z"* (for UTC with no offset) or an offset of either *"+"* or *"-"* followed by a time expression `HH:mm` (indicating local time ahead of or behind UTC, respectively)
               </td>
             </tr>
-            </tbody>
           </table>
         </figure>
         <p>This format includes date-only forms:</p>
@@ -32418,7 +32347,6 @@ THH:mm:ss.sss
             <p>Examples of date-time values with expanded years:</p>
             <figure>
               <table class="lightweight-table">
-                <tbody>
                 <tr>
                   <td>-271821-04-20T00:00:00Z</td>
                   <td>271822 B.C.</td>
@@ -32447,7 +32375,6 @@ THH:mm:ss.sss
                   <td>+275760-09-13T00:00:00Z</td>
                   <td>275760 A.D.</td>
                 </tr>
-                </tbody>
               </table>
             </figure>
           </emu-note>
@@ -33142,7 +33069,6 @@ THH:mm:ss.sss
           </emu-alg>
           <emu-table id="sec-todatestring-day-names" caption="Names of days of the week">
             <table>
-              <tbody>
               <tr>
                 <th>
                   Number
@@ -33207,12 +33133,10 @@ THH:mm:ss.sss
                   *"Sat"*
                 </td>
               </tr>
-              </tbody>
             </table>
           </emu-table>
           <emu-table id="sec-todatestring-month-names" caption="Names of months of the year">
             <table>
-              <tbody>
               <tr>
                 <th>
                   Number
@@ -33317,7 +33241,6 @@ THH:mm:ss.sss
                   *"Dec"*
                 </td>
               </tr>
-              </tbody>
             </table>
           </emu-table>
         </emu-clause>
@@ -33963,7 +33886,6 @@ THH:mm:ss.sss
           </emu-alg>
           <emu-table id="table-replacement-text-symbol-substitutions" caption="Replacement Text Symbol Substitutions" oldids="table-45">
             <table>
-              <tbody>
               <tr>
                 <th>
                   Code units
@@ -34021,15 +33943,12 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  0x0024, N
-                  <br>
-                  Where
-                  <br>
+                  0x0024, N<br>
+                  Where<br>
                   0x0031 &le; N &le; 0x0039
                 </td>
                 <td>
-                  `$n` where
-                  <br>
+                  `$n` where<br>
                   `n` is one of `1 2 3 4 5 6 7 8 9` and `$n` is not followed by a decimal digit
                 </td>
                 <td>
@@ -34038,15 +33957,12 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  0x0024, N, N
-                  <br>
-                  Where
-                  <br>
+                  0x0024, N, N<br>
+                  Where<br>
                   0x0030 &le; N &le; 0x0039
                 </td>
                 <td>
-                  `$nn` where
-                  <br>
+                  `$nn` where<br>
                   `n` is one of `0 1 2 3 4 5 6 7 8 9`
                 </td>
                 <td>
@@ -34086,7 +34002,6 @@ THH:mm:ss.sss
                   `$`
                 </td>
               </tr>
-              </tbody>
             </table>
           </emu-table>
         </emu-clause>
@@ -34805,15 +34720,16 @@ THH:mm:ss.sss
           <p>This section is amended in <emu-xref href="#sec-patterns-static-semantics-is-character-class-annexb"></emu-xref>.</p>
         </emu-note>
         <emu-grammar>
-          ClassAtom :: `-`
+          ClassAtom ::
+            `-`
 
-          ClassAtomNoDash :: SourceCharacter but not one of `\` or `]` or `-`
+          ClassAtomNoDash ::
+            SourceCharacter but not one of `\` or `]` or `-`
 
-          ClassEscape :: `b`
-
-          ClassEscape :: `-`
-
-          ClassEscape :: CharacterEscape
+          ClassEscape ::
+            `b`
+            `-`
+            CharacterEscape
         </emu-grammar>
         <emu-alg>
           1. Return *false*.
@@ -34862,7 +34778,6 @@ THH:mm:ss.sss
         </emu-alg>
         <emu-table id="table-controlescape-code-point-values" caption="ControlEscape Code Point Values" oldids="table-47">
           <table>
-            <tbody>
             <tr>
               <th>
                 ControlEscape
@@ -34965,7 +34880,6 @@ THH:mm:ss.sss
                 &lt;CR&gt;
               </td>
             </tr>
-            </tbody>
           </table>
         </emu-table>
         <emu-grammar>CharacterEscape :: `c` ControlLetter</emu-grammar>
@@ -35835,11 +35749,10 @@ THH:mm:ss.sss
 
         <!-- ClassEscape -->
         <emu-grammar>
-          ClassEscape :: `b`
-
-          ClassEscape :: `-`
-
-          ClassEscape :: CharacterEscape
+          ClassEscape ::
+            `b`
+            `-`
+            CharacterEscape
         </emu-grammar>
         <emu-alg>
           1. Let _cv_ be the CharacterValue of this |ClassEscape|.
@@ -38140,7 +38053,6 @@ THH:mm:ss.sss
     <p>A _TypedArray_ presents an array-like view of an underlying binary data buffer (<emu-xref href="#sec-arraybuffer-objects"></emu-xref>). A <dfn variants="TypedArray element types">TypedArray element type</dfn> is the underlying binary scalar data type that all elements of a _TypedArray_ instance have. There is a distinct _TypedArray_ constructor, listed in <emu-xref href="#table-the-typedarray-constructors"></emu-xref>, for each of the supported element types. Each constructor in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> has a corresponding distinct prototype object.</p>
     <emu-table id="table-the-typedarray-constructors" caption="The TypedArray Constructors" oldids="table-49">
       <table>
-        <tbody>
         <tr>
           <th>
             Constructor Name and Intrinsic
@@ -38160,8 +38072,7 @@ THH:mm:ss.sss
         </tr>
         <tr>
           <td>
-            Int8Array
-            <br>
+            Int8Array<br>
             <dfn>%Int8Array%</dfn>
           </td>
           <td>
@@ -38179,8 +38090,7 @@ THH:mm:ss.sss
         </tr>
         <tr>
           <td>
-            Uint8Array
-            <br>
+            Uint8Array<br>
             <dfn>%Uint8Array%</dfn>
           </td>
           <td>
@@ -38198,8 +38108,7 @@ THH:mm:ss.sss
         </tr>
         <tr>
           <td>
-            Uint8ClampedArray
-            <br>
+            Uint8ClampedArray<br>
             <dfn>%Uint8ClampedArray%</dfn>
           </td>
           <td>
@@ -38217,8 +38126,7 @@ THH:mm:ss.sss
         </tr>
         <tr>
           <td>
-            Int16Array
-            <br>
+            Int16Array<br>
             <dfn>%Int16Array%</dfn>
           </td>
           <td>
@@ -38236,8 +38144,7 @@ THH:mm:ss.sss
         </tr>
         <tr>
           <td>
-            Uint16Array
-            <br>
+            Uint16Array<br>
             <dfn>%Uint16Array%</dfn>
           </td>
           <td>
@@ -38255,8 +38162,7 @@ THH:mm:ss.sss
         </tr>
         <tr>
           <td>
-            Int32Array
-            <br>
+            Int32Array<br>
             <dfn>%Int32Array%</dfn>
           </td>
           <td>
@@ -38274,8 +38180,7 @@ THH:mm:ss.sss
         </tr>
         <tr>
           <td>
-            Uint32Array
-            <br>
+            Uint32Array<br>
             <dfn>%Uint32Array%</dfn>
           </td>
           <td>
@@ -38293,8 +38198,7 @@ THH:mm:ss.sss
         </tr>
         <tr>
           <td>
-            BigInt64Array
-            <br>
+            BigInt64Array<br>
             <dfn>%BigInt64Array%</dfn>
           </td>
           <td>
@@ -38312,8 +38216,7 @@ THH:mm:ss.sss
         </tr>
         <tr>
           <td>
-            BigUint64Array
-            <br>
+            BigUint64Array<br>
             <dfn>%BigUint64Array%</dfn>
           </td>
           <td>
@@ -38331,8 +38234,7 @@ THH:mm:ss.sss
         </tr>
         <tr>
           <td>
-            Float32Array
-            <br>
+            Float32Array<br>
             <dfn>%Float32Array%</dfn>
           </td>
           <td>
@@ -38349,8 +38251,7 @@ THH:mm:ss.sss
         </tr>
         <tr>
           <td>
-            Float64Array
-            <br>
+            Float64Array<br>
             <dfn>%Float64Array%</dfn>
           </td>
           <td>
@@ -38365,7 +38266,6 @@ THH:mm:ss.sss
             64-bit IEEE floating point
           </td>
         </tr>
-        </tbody>
       </table>
     </emu-table>
     <p>In the definitions below, references to _TypedArray_ should be replaced with the appropriate constructor name from the above table.</p>
@@ -41943,6 +41843,7 @@ THH:mm:ss.sss
         <p>Regardless of the value of `Atomics.isLockFree`, all atomic operations are guaranteed to be atomic. For example, they will never have a visible operation take place in the middle of the operation (e.g., "tearing").</p>
       </emu-note>
     </emu-clause>
+
     <emu-clause id="sec-atomics.load" oldids="sec-atomicload">
       <h1>Atomics.load ( _typedArray_, _index_ )</h1>
       <p>The following steps are taken:</p>
@@ -42325,7 +42226,6 @@ THH:mm:ss.sss
         </emu-alg>
         <emu-table id="table-json-single-character-escapes" caption="JSON Single Character Escape Sequences">
           <table>
-            <tbody>
             <tr>
               <th>
                 Code Point
@@ -42414,7 +42314,6 @@ THH:mm:ss.sss
                 `\\\\`
               </td>
             </tr>
-            </tbody>
           </table>
         </emu-table>
       </emu-clause>
@@ -42652,6 +42551,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-weakref-abstract-operations">
       <h1>WeakRef Abstract Operations</h1>
+
       <emu-clause id="sec-weakrefderef" type="abstract operation">
         <h1>
           WeakRefDeref (
@@ -42820,7 +42720,6 @@ THH:mm:ss.sss
         <p>The <i>Iterable</i> interface includes the property described in <emu-xref href="#table-iterable-interface-required-properties"></emu-xref>:</p>
         <emu-table id="table-iterable-interface-required-properties" caption="<i>Iterable</i> Interface Required Properties" oldids="table-52">
           <table>
-            <tbody>
             <tr>
               <th>
                 Property
@@ -42843,7 +42742,6 @@ THH:mm:ss.sss
                 The returned object must conform to the <i>Iterator</i> interface.
               </td>
             </tr>
-            </tbody>
           </table>
         </emu-table>
       </emu-clause>
@@ -42853,7 +42751,6 @@ THH:mm:ss.sss
         <p>An object that implements the <i>Iterator</i> interface must include the property in <emu-xref href="#table-iterator-interface-required-properties"></emu-xref>. Such objects may also implement the properties in <emu-xref href="#table-iterator-interface-optional-properties"></emu-xref>.</p>
         <emu-table id="table-iterator-interface-required-properties" caption="<i>Iterator</i> Interface Required Properties" oldids="table-53">
           <table>
-            <tbody>
             <tr>
               <th>
                 Property
@@ -42876,7 +42773,6 @@ THH:mm:ss.sss
                 The returned object must conform to the <i>IteratorResult</i> interface. If a previous call to the `next` method of an <i>Iterator</i> has returned an <i>IteratorResult</i> object whose *"done"* property is *true*, then all subsequent calls to the `next` method of that object should also return an <i>IteratorResult</i> object whose *"done"* property is *true*. However, this requirement is not enforced.
               </td>
             </tr>
-            </tbody>
           </table>
         </emu-table>
         <emu-note>
@@ -42884,7 +42780,6 @@ THH:mm:ss.sss
         </emu-note>
         <emu-table id="table-iterator-interface-optional-properties" caption="<i>Iterator</i> Interface Optional Properties" oldids="table-54">
           <table>
-            <tbody>
             <tr>
               <th>
                 Property
@@ -42918,7 +42813,6 @@ THH:mm:ss.sss
                 The returned object must conform to the <i>IteratorResult</i> interface. Invoking this method notifies the <i>Iterator</i> object that the caller has detected an error condition. The argument may be used to identify the error condition and typically will be an exception object. A typical response is to `throw` the value passed as the argument. If the method does not `throw`, the returned <i>IteratorResult</i> object will typically have a *"done"* property whose value is *true*.
               </td>
             </tr>
-            </tbody>
           </table>
         </emu-table>
         <emu-note>
@@ -42931,7 +42825,6 @@ THH:mm:ss.sss
         <p>The <i>AsyncIterable</i> interface includes the properties described in <emu-xref href="#table-async-iterable"></emu-xref>:</p>
         <emu-table id="table-async-iterable" caption="<i>AsyncIterable</i> Interface Required Properties">
           <table>
-            <tbody>
             <tr>
               <th>Property</th>
               <th>Value</th>
@@ -42942,7 +42835,6 @@ THH:mm:ss.sss
               <td>A function that returns an <i>AsyncIterator</i> object.</td>
               <td>The returned object must conform to the <i>AsyncIterator</i> interface.</td>
             </tr>
-            </tbody>
           </table>
         </emu-table>
       </emu-clause>
@@ -42952,7 +42844,6 @@ THH:mm:ss.sss
         <p>An object that implements the <i>AsyncIterator</i> interface must include the properties in <emu-xref href="#table-async-iterator-required"></emu-xref>. Such objects may also implement the properties in <emu-xref href="#table-async-iterator-optional"></emu-xref>.</p>
         <emu-table id="table-async-iterator-required" caption="<i>AsyncIterator</i> Interface Required Properties">
           <table>
-            <tbody>
             <tr>
               <th>Property</th>
               <th>Value</th>
@@ -42967,7 +42858,6 @@ THH:mm:ss.sss
                 <p>Additionally, the <i>IteratorResult</i> object that serves as a fulfillment value should have a *"value"* property whose value is not a promise (or "thenable"). However, this requirement is also not enforced.</p>
               </td>
             </tr>
-            </tbody>
           </table>
         </emu-table>
         <emu-note>
@@ -42975,7 +42865,6 @@ THH:mm:ss.sss
         </emu-note>
         <emu-table id="table-async-iterator-optional" caption="<i>AsyncIterator</i> Interface Optional Properties">
           <table>
-            <tbody>
             <tr>
               <th>Property</th>
               <th>Value</th>
@@ -42999,7 +42888,6 @@ THH:mm:ss.sss
                 <p>If the returned promise is fulfilled, the <i>IteratorResult</i> fulfillment value will typically have a *"done"* property whose value is *true*. Additionally, it should have a *"value"* property whose value is not a promise (or "thenable"), but this requirement is not enforced.</p>
               </td>
             </tr>
-            </tbody>
           </table>
         </emu-table>
         <emu-note>
@@ -43012,7 +42900,6 @@ THH:mm:ss.sss
         <p>The <i>IteratorResult</i> interface includes the properties listed in <emu-xref href="#table-iteratorresult-interface-properties"></emu-xref>:</p>
         <emu-table id="table-iteratorresult-interface-properties" caption="<i>IteratorResult</i> Interface Properties" oldids="table-55">
           <table>
-            <tbody>
             <tr>
               <th>
                 Property
@@ -43046,7 +42933,6 @@ THH:mm:ss.sss
                 If done is *false*, this is the current iteration element value. If done is *true*, this is the return value of the iterator, if it supplied one. If the iterator does not have a return value, *"value"* is *undefined*. In that case, the *"value"* property may be absent from the conforming object if it does not inherit an explicit *"value"* property.
               </td>
             </tr>
-            </tbody>
           </table>
         </emu-table>
       </emu-clause>
@@ -43204,16 +43090,15 @@ THH:mm:ss.sss
         <emu-table id="table-async-from-sync-iterator-internal-slots" caption="Internal Slots of Async-from-Sync Iterator Instances">
           <table>
             <thead>
-            <tr>
-              <th>
-                Internal Slot
-              </th>
-              <th>
-                Description
-              </th>
-            </tr>
+              <tr>
+                <th>
+                  Internal Slot
+                </th>
+                <th>
+                  Description
+                </th>
+              </tr>
             </thead>
-            <tbody>
             <tr>
               <td>
                 [[SyncIteratorRecord]]
@@ -43222,7 +43107,6 @@ THH:mm:ss.sss
                 A Record, of the type returned by GetIterator, representing the original synchronous iterator which is being adapted.
               </td>
             </tr>
-            </tbody>
           </table>
         </emu-table>
       </emu-clause>
@@ -43282,7 +43166,6 @@ THH:mm:ss.sss
         <p>PromiseCapability Records have the fields listed in <emu-xref href="#table-promisecapability-record-fields"></emu-xref>.</p>
         <emu-table id="table-promisecapability-record-fields" caption="PromiseCapability Record Fields" oldids="table-57">
           <table>
-            <tbody>
             <tr>
               <th>
                 Field Name
@@ -43327,7 +43210,6 @@ THH:mm:ss.sss
                 The function that is used to reject the given promise.
               </td>
             </tr>
-            </tbody>
           </table>
         </emu-table>
 
@@ -43353,7 +43235,6 @@ THH:mm:ss.sss
         <p>PromiseReaction records have the fields listed in <emu-xref href="#table-promisereaction-record-fields"></emu-xref>.</p>
         <emu-table id="table-promisereaction-record-fields" caption="PromiseReaction Record Fields" oldids="table-58">
           <table>
-            <tbody>
             <tr>
               <th>
                 Field Name
@@ -43398,7 +43279,6 @@ THH:mm:ss.sss
                 The function that should be applied to the incoming value, and whose return value will govern what happens to the derived promise. If [[Handler]] is ~empty~, a function that depends on the value of [[Type]] will be used instead.
               </td>
             </tr>
-            </tbody>
           </table>
         </emu-table>
       </emu-clause>
@@ -44301,7 +44181,6 @@ THH:mm:ss.sss
       <p>Promise instances are ordinary objects that inherit properties from the Promise prototype object (the intrinsic, %Promise.prototype%). Promise instances are initially created with the internal slots described in <emu-xref href="#table-internal-slots-of-promise-instances"></emu-xref>.</p>
       <emu-table id="table-internal-slots-of-promise-instances" caption="Internal Slots of Promise Instances" oldids="table-59">
         <table>
-          <tbody>
           <tr>
             <th>
               Internal Slot
@@ -44350,7 +44229,6 @@ THH:mm:ss.sss
               A boolean indicating whether the promise has ever had a fulfillment or rejection handler; used in unhandled rejection tracking.
             </td>
           </tr>
-          </tbody>
         </table>
       </emu-table>
     </emu-clause>
@@ -44633,7 +44511,6 @@ THH:mm:ss.sss
       <p>Generator instances are initially created with the internal slots described in <emu-xref href="#table-internal-slots-of-generator-instances"></emu-xref>.</p>
       <emu-table id="table-internal-slots-of-generator-instances" caption="Internal Slots of Generator Instances" oldids="table-56">
         <table>
-          <tbody>
           <tr>
             <th>
               Internal Slot
@@ -44666,7 +44543,6 @@ THH:mm:ss.sss
               A brand used to distinguish different kinds of generators. The [[GeneratorBrand]] of generators declared by ECMAScript source text is always ~empty~.
             </td>
           </tr>
-          </tbody>
         </table>
       </emu-table>
     </emu-clause>
@@ -44970,7 +44846,6 @@ THH:mm:ss.sss
       <p>AsyncGenerator instances are initially created with the internal slots described below:</p>
       <emu-table id="table-internal-slots-of-asyncgenerator-instances" caption="Internal Slots of AsyncGenerator Instances">
         <table>
-          <tbody>
           <tr>
             <th>Internal Slot</th>
             <th>Description</th>
@@ -44991,20 +44866,19 @@ THH:mm:ss.sss
             <td>[[GeneratorBrand]]</td>
             <td>A brand used to distinguish different kinds of async generators. The [[GeneratorBrand]] of async generators declared by ECMAScript source text is always ~empty~.</td>
           </tr>
-          </tbody>
         </table>
       </emu-table>
     </emu-clause>
 
     <emu-clause id="sec-asyncgenerator-abstract-operations">
       <h1>AsyncGenerator Abstract Operations</h1>
+
       <emu-clause id="sec-asyncgeneratorrequest-records">
         <h1>AsyncGeneratorRequest Records</h1>
         <p>An <dfn variants="AsyncGeneratorRequests">AsyncGeneratorRequest</dfn> is a Record value used to store information about how an async generator should be resumed and contains capabilities for fulfilling or rejecting the corresponding promise.</p>
         <p>They have the following fields:</p>
         <emu-table caption="AsyncGeneratorRequest Record Fields">
           <table>
-            <tbody>
             <tr>
               <th>Field Name</th>
               <th>Value</th>
@@ -45020,7 +44894,6 @@ THH:mm:ss.sss
               <td>A PromiseCapability Record</td>
               <td>The promise capabilities associated with this request.</td>
             </tr>
-            </tbody>
           </table>
         </emu-table>
       </emu-clause>
@@ -45380,6 +45253,7 @@ THH:mm:ss.sss
 
       <p>Every AsyncFunction instance is an ECMAScript function object and has the internal slots listed in <emu-xref href="#table-internal-slots-of-ecmascript-function-objects"></emu-xref>. The value of the [[IsClassConstructor]] internal slot for all such instances is *false*. AsyncFunction instances are not constructors and do not have a [[Construct]] internal method. AsyncFunction instances do not have a prototype property as they are not constructible.</p>
       <p>Each AsyncFunction instance has the following own properties:</p>
+
       <emu-clause id="sec-async-function-instances-length">
         <h1>length</h1>
         <p>The specification for the *"length"* property of Function instances given in <emu-xref href="#sec-function-instances-length"></emu-xref> also applies to AsyncFunction instances.</p>
@@ -45410,6 +45284,7 @@ THH:mm:ss.sss
           1. Perform ! AsyncBlockStart(_promiseCapability_, _asyncFunctionBody_, _asyncContext_).
         </emu-alg>
       </emu-clause>
+
       <emu-clause id="sec-asyncblockstart" type="abstract operation">
         <h1>
           AsyncBlockStart (
@@ -45693,7 +45568,6 @@ THH:mm:ss.sss
 
     <emu-table id="table-readsharedmemory-fields" caption="ReadSharedMemory Event Fields">
       <table>
-        <tbody>
         <tr>
           <th>Field Name</th>
           <th>Value</th>
@@ -45724,13 +45598,11 @@ THH:mm:ss.sss
           <td>A non-negative integer</td>
           <td>The size of the read.</td>
         </tr>
-        </tbody>
       </table>
     </emu-table>
 
     <emu-table id="table-writesharedmemory-fields" caption="WriteSharedMemory Event Fields">
       <table>
-        <tbody>
         <tr>
           <th>Field Name</th>
           <th>Value</th>
@@ -45766,13 +45638,11 @@ THH:mm:ss.sss
           <td>A List</td>
           <td>The List of byte values to be read by other events.</td>
         </tr>
-        </tbody>
       </table>
     </emu-table>
 
     <emu-table id="table-rmwsharedmemory-fields" caption="ReadModifyWriteSharedMemory Event Fields">
       <table>
-        <tbody>
         <tr>
           <th>Field Name</th>
           <th>Value</th>
@@ -45813,7 +45683,6 @@ THH:mm:ss.sss
           <td>A read-modify-write modification function</td>
           <td>An abstract closure that returns a modified List of byte values from a read List of byte values and [[Payload]].</td>
         </tr>
-        </tbody>
       </table>
     </emu-table>
 
@@ -45832,7 +45701,6 @@ THH:mm:ss.sss
     <p>An <dfn variants="Agent Events Records">Agent Events Record</dfn> is a Record with the following fields.</p>
     <emu-table id="table-agent-events-records" caption="Agent Events Record Fields">
       <table>
-        <tbody>
         <tr>
           <th>Field Name</th>
           <th>Value</th>
@@ -45853,7 +45721,6 @@ THH:mm:ss.sss
           <td>A List of pairs of Synchronize events</td>
           <td>Synchronize relationships introduced by the operational semantics.</td>
         </tr>
-        </tbody>
       </table>
     </emu-table>
   </emu-clause>
@@ -45863,7 +45730,6 @@ THH:mm:ss.sss
     <p>A <dfn variants="Chosen Value Records">Chosen Value Record</dfn> is a Record with the following fields.</p>
     <emu-table id="table-chosen-value-records" caption="Chosen Value Record Fields">
       <table>
-        <tbody>
         <tr>
           <th>Field Name</th>
           <th>Value</th>
@@ -45879,7 +45745,6 @@ THH:mm:ss.sss
           <td>A List of byte values</td>
           <td>The bytes that were nondeterministically chosen during evaluation.</td>
         </tr>
-        </tbody>
       </table>
     </emu-table>
   </emu-clause>
@@ -45889,7 +45754,6 @@ THH:mm:ss.sss
     <p>A <dfn variants="candidate executions">candidate execution</dfn> of the evaluation of an agent cluster is a Record with the following fields.</p>
     <emu-table id="table-candidate-execution-records" caption="Candidate Execution Record Fields">
       <table>
-        <tbody>
         <tr>
           <th>Field Name</th>
           <th>Value</th>
@@ -45935,7 +45799,6 @@ THH:mm:ss.sss
           <td>A happens-before Relation.</td>
           <td>Defined below.</td>
         </tr>
-        </tbody>
       </table>
     </emu-table>
 
@@ -45944,6 +45807,7 @@ THH:mm:ss.sss
 
   <emu-clause id="sec-abstract-operations-for-the-memory-model" oldids="sec-synchronizeeventset">
     <h1>Abstract Operations for the Memory Model</h1>
+
     <emu-clause id="sec-event-set" type="abstract operation">
       <h1>
         EventSet (
@@ -46047,6 +45911,7 @@ THH:mm:ss.sss
 
   <emu-clause id="sec-relations-of-candidate-executions">
     <h1>Relations of Candidate Executions</h1>
+
     <emu-clause id="sec-agent-order" aoid="agent-order">
       <h1>agent-order</h1>
       <p>For a candidate execution _execution_, _execution_.[[AgentOrder]] is a Relation on events that satisfies the following.</p>
@@ -46149,6 +46014,7 @@ THH:mm:ss.sss
 
   <emu-clause id="sec-properties-of-valid-executions">
     <h1>Properties of Valid Executions</h1>
+
     <emu-clause id="sec-valid-chosen-reads">
       <h1>Valid Chosen Reads</h1>
       <p>A candidate execution _execution_ has valid chosen reads if the following algorithm returns *true*.</p>
@@ -46462,11 +46328,11 @@ THH:mm:ss.sss
     <emu-prodref name="Identifier"></emu-prodref>
     <emu-prodref name="PrimaryExpression"></emu-prodref>
     <emu-prodref name="CoverParenthesizedExpressionAndArrowParameterList"></emu-prodref>
-    <p>When processing an instance of the production
-      <br>
-      <emu-prodref name="PrimaryExpression" a="parencover"></emu-prodref>
-      <br>
-      the interpretation of |CoverParenthesizedExpressionAndArrowParameterList| is refined using the following grammar:</p>
+    <p>
+      When processing an instance of the production<br>
+      <emu-prodref name="PrimaryExpression" a="parencover"></emu-prodref><br>
+      the interpretation of |CoverParenthesizedExpressionAndArrowParameterList| is refined using the following grammar:
+    </p>
     <emu-prodref name="ParenthesizedExpression"></emu-prodref>
     <p>&nbsp;</p>
     <emu-prodref name="Literal"></emu-prodref>
@@ -46493,11 +46359,11 @@ THH:mm:ss.sss
     <emu-prodref name="ImportMeta"></emu-prodref>
     <emu-prodref name="NewExpression"></emu-prodref>
     <emu-prodref name="CallExpression"></emu-prodref>
-    <p>When processing an instance of the production
-      <br>
-      <emu-prodref name="CallExpression" a="callcover"></emu-prodref>
-      <br>
-      the interpretation of |CoverCallExpressionAndAsyncArrowHead| is refined using the following grammar:</p>
+    <p>
+      When processing an instance of the production<br>
+      <emu-prodref name="CallExpression" a="callcover"></emu-prodref><br>
+      the interpretation of |CoverCallExpressionAndAsyncArrowHead| is refined using the following grammar:
+    </p>
     <emu-prodref name="CallMemberExpression"></emu-prodref>
     <p>&nbsp;</p>
     <emu-prodref name="SuperCall"></emu-prodref>
@@ -46527,11 +46393,11 @@ THH:mm:ss.sss
     <emu-prodref name="ConditionalExpression"></emu-prodref>
     <emu-prodref name="AssignmentExpression"></emu-prodref>
     <emu-prodref name="AssignmentOperator"></emu-prodref>
-    <p>In certain circumstances when processing an instance of the production
-      <br>
-      <emu-prodref name="AssignmentExpression" a="assignment"></emu-prodref>
-      <br>
-      the interpretation of |LeftHandSideExpression| is refined using the following grammar:</p>
+    <p>
+      In certain circumstances when processing an instance of the production<br>
+      <emu-prodref name="AssignmentExpression" a="assignment"></emu-prodref><br>
+      the interpretation of |LeftHandSideExpression| is refined using the following grammar:
+    </p>
     <emu-prodref name="AssignmentPattern"></emu-prodref>
     <emu-prodref name="ObjectAssignmentPattern"></emu-prodref>
     <emu-prodref name="ArrayAssignmentPattern"></emu-prodref>
@@ -46619,22 +46485,22 @@ THH:mm:ss.sss
     <emu-prodref name="ArrowParameters"></emu-prodref>
     <emu-prodref name="ConciseBody"></emu-prodref>
     <emu-prodref name="ExpressionBody"></emu-prodref>
-    <p>When processing an instance of the production
-      <br>
-      <emu-prodref name="ArrowParameters" a="parencover"></emu-prodref>
-      <br>
-      the interpretation of |CoverParenthesizedExpressionAndArrowParameterList| is refined using the following grammar:</p>
+    <p>
+      When processing an instance of the production<br>
+      <emu-prodref name="ArrowParameters" a="parencover"></emu-prodref><br>
+      the interpretation of |CoverParenthesizedExpressionAndArrowParameterList| is refined using the following grammar:
+    </p>
     <emu-prodref name="ArrowFormalParameters"></emu-prodref>
     <p>&nbsp;</p>
     <emu-prodref name="AsyncArrowFunction"></emu-prodref>
     <emu-prodref name="AsyncConciseBody"></emu-prodref>
     <emu-prodref name="AsyncArrowBindingIdentifier"></emu-prodref>
     <emu-prodref name="CoverCallExpressionAndAsyncArrowHead"></emu-prodref>
-    <p>When processing an instance of the production
-      <br>
-      <emu-prodref name="AsyncArrowFunction" a="callcover"></emu-prodref>
-      <br>
-      the interpretation of |CoverCallExpressionAndAsyncArrowHead| is refined using the following grammar:</p>
+    <p>
+      When processing an instance of the production<br>
+      <emu-prodref name="AsyncArrowFunction" a="callcover"></emu-prodref><br>
+      the interpretation of |CoverCallExpressionAndAsyncArrowHead| is refined using the following grammar:
+    </p>
     <emu-prodref name="AsyncArrowHead"></emu-prodref>
     <p>&nbsp;</p>
     <emu-prodref name="MethodDefinition"></emu-prodref>
@@ -47084,7 +46950,6 @@ THH:mm:ss.sss
       <p>The entries in <emu-xref href="#table-additional-well-known-intrinsic-objects"></emu-xref> are added to <emu-xref href="#table-well-known-intrinsic-objects"></emu-xref>.</p>
       <emu-table id="table-additional-well-known-intrinsic-objects" caption="Additional Well-known Intrinsic Objects" oldids="table-60">
         <table>
-          <tbody>
           <tr>
             <th>
               Intrinsic Name
@@ -47118,7 +46983,6 @@ THH:mm:ss.sss
               The `unescape` function (<emu-xref href="#sec-unescape-string"></emu-xref>)
             </td>
           </tr>
-          </tbody>
         </table>
       </emu-table>
 
@@ -47528,6 +47392,7 @@ THH:mm:ss.sss
       <p>The first use case is interoperable with the semantics of |Block| level function declarations provided by ECMAScript 2015. Any pre-existing ECMAScript code that employs that use case will operate using the Block level function declarations semantics defined by clauses <emu-xref href="#sec-ordinary-and-exotic-objects-behaviours"></emu-xref>, <emu-xref href="#sec-ecmascript-language-statements-and-declarations"></emu-xref>, and <emu-xref href="#sec-ecmascript-language-functions-and-classes"></emu-xref>.</p>
       <p>ECMAScript 2015 interoperability for the second and third use cases requires the following extensions to the clause <emu-xref href="#sec-ordinary-and-exotic-objects-behaviours"></emu-xref>, clause <emu-xref href="#sec-ecmascript-language-functions-and-classes"></emu-xref>, clause <emu-xref href="#sec-eval-x"></emu-xref> and clause <emu-xref href="#sec-globaldeclarationinstantiation"></emu-xref> semantics.</p>
       <p>If an ECMAScript implementation has a mechanism for reporting diagnostic warning messages, a warning should be produced when code contains a |FunctionDeclaration| for which these compatibility semantics are applied and introduce observable differences from non-compatibility semantics. For example, if a var binding is not introduced because its introduction would create an early error, a warning message should not be produced.</p>
+
       <emu-annex id="sec-web-compat-functiondeclarationinstantiation">
         <h1>Changes to FunctionDeclarationInstantiation</h1>
         <p>During FunctionDeclarationInstantiation the following steps are performed in place of step <emu-xref href="#step-functiondeclarationinstantiation-web-compat-insertion-point"></emu-xref>:</p>
@@ -47549,6 +47414,7 @@ THH:mm:ss.sss
                   1. Return NormalCompletion(~empty~).
         </emu-alg>
       </emu-annex>
+
       <emu-annex id="sec-web-compat-globaldeclarationinstantiation">
         <h1>Changes to GlobalDeclarationInstantiation</h1>
         <p>During GlobalDeclarationInstantiation the following steps are performed in place of step <emu-xref href="#step-globaldeclarationinstantiation-web-compat-insertion-point"></emu-xref>:</p>
@@ -47574,6 +47440,7 @@ THH:mm:ss.sss
                       1. Return NormalCompletion(~empty~).
         </emu-alg>
       </emu-annex>
+
       <emu-annex id="sec-web-compat-evaldeclarationinstantiation">
         <h1>Changes to EvalDeclarationInstantiation</h1>
         <p>During EvalDeclarationInstantiation the following steps are performed in place of step <emu-xref href="#step-evaldeclarationinstantiation-web-compat-insertion-point"></emu-xref>:</p>
@@ -47616,6 +47483,7 @@ THH:mm:ss.sss
                     1. Return NormalCompletion(~empty~).
         </emu-alg>
       </emu-annex>
+
       <emu-annex id="sec-block-duplicates-allowed-static-semantics">
         <h1>Changes to Block Static Semantics: Early Errors</h1>
         <p>The rules for the following production in <emu-xref href="#sec-block-static-semantics-early-errors"></emu-xref> are modified with the addition of the <ins>highlighted</ins> text:</p>
@@ -47629,6 +47497,7 @@ THH:mm:ss.sss
           </li>
         </ul>
       </emu-annex>
+
       <emu-annex id="sec-switch-duplicates-allowed-static-semantics">
         <h1>Changes to `switch` Statement Static Semantics: Early Errors</h1>
         <p>The rules for the following production in <emu-xref href="#sec-switch-statement-static-semantics-early-errors"></emu-xref> are modified with the addition of the <ins>highlighted</ins> text:</p>
@@ -47642,6 +47511,7 @@ THH:mm:ss.sss
           </li>
         </ul>
       </emu-annex>
+
       <emu-annex id="sec-web-compat-blockdeclarationinstantiation">
         <h1>Changes to BlockDeclarationInstantiation</h1>
         <p>During BlockDeclarationInstantiation the following steps are performed in place of step <emu-xref href="#step-blockdeclarationinstantiation-createmutablebinding"></emu-xref>:</p>
@@ -47798,7 +47668,6 @@ THH:mm:ss.sss
             Additional <emu-xref href="#sec-typeof-operator">`typeof`</emu-xref> Operator Results
           </emu-caption>
           <table>
-            <tbody>
             <tr>
               <th>
                 Type of _val_
@@ -47815,7 +47684,6 @@ THH:mm:ss.sss
                 *"undefined"*
               </td>
             </tr>
-            </tbody>
           </table>
         </emu-table>
       </emu-annex>
@@ -47884,6 +47752,7 @@ THH:mm:ss.sss
 <emu-annex id="sec-host-layering-points">
   <h1>Host Layering Points</h1>
   <p>See <emu-xref href="#sec-hosts-and-implementations"></emu-xref> for the definition of host.</p>
+
   <emu-annex id="sec-host-hooks-summary">
     <h1>Host Hooks</h1>
     <p><b>HostCallJobCallback(...)</b></p>
@@ -47899,6 +47768,7 @@ THH:mm:ss.sss
     <p><b>HostResolveImportedModule(...)</b></p>
     <p><b>InitializeHostDefinedRealm(...)</b></p>
   </emu-annex>
+
   <emu-annex id="sec-host-defined-fields-summary">
     <h1>Host-defined Fields</h1>
     <p>[[HostDefined]] on Realm Records: See <emu-xref href="#table-realm-record-fields"></emu-xref>.</p>
@@ -47908,18 +47778,22 @@ THH:mm:ss.sss
     <p>[[HostSynchronizesWith]] on Candidate Executions: See <emu-xref href="#table-candidate-execution-records"></emu-xref>.</p>
     <p>[[IsHTMLDDA]]: See <emu-xref href="#sec-IsHTMLDDA-internal-slot"></emu-xref>.</p>
   </emu-annex>
+
   <emu-annex id="sec-host-defined-objects-summary">
     <h1>Host-defined Objects</h1>
     <p>The global object: See clause <emu-xref href="#sec-global-object"></emu-xref>.</p>
   </emu-annex>
+
   <emu-annex id="sec-host-running-jobs">
     <h1>Running Jobs</h1>
     <p>Preparation steps before, and cleanup steps after, invocation of Job Abstract Closures. See <emu-xref href="#sec-jobs"></emu-xref>.</p>
   </emu-annex>
+
   <emu-annex id="sec-host-internal-methods-of-exotic-objects">
     <h1>Internal Methods of Exotic Objects</h1>
     <p>Any of the essential internal methods in <emu-xref href="#table-essential-internal-methods"></emu-xref> for any exotic object not specified within this specification.</p>
   </emu-annex>
+
   <emu-annex id="sec-host-built-in-objects-and-methods">
     <h1>Built-in Objects and Methods</h1>
     <p>Any built-in objects and methods not defined within this specification, except as restricted in <emu-xref href="#sec-forbidden-extensions"></emu-xref>.</p>
@@ -47985,11 +47859,13 @@ THH:mm:ss.sss
   <p><emu-xref href="#sec-atomics.notify"></emu-xref>: In ECMAScript 2019, `Atomics.wake` has been renamed to `Atomics.notify` to prevent confusion with `Atomics.wait`.</p>
   <p><emu-xref href="#sec-asyncfromsynciteratorcontinuation"></emu-xref>, <emu-xref href="#sec-asyncgeneratorresume"></emu-xref>: In ECMAScript 2019, the number of Jobs enqueued by `await` was reduced, which could create an observable difference in resolution order between a `then()` call and an `await` expression.</p>
 </emu-annex>
+
 <emu-annex id="sec-colophon">
   <h1>Colophon</h1>
   <p>This specification is authored on <a href="https://github.com/tc39/ecma262">GitHub</a> in a plaintext source format called <a href="https://github.com/bterlson/ecmarkup">Ecmarkup</a>. Ecmarkup is an HTML and Markdown dialect that provides a framework and toolset for authoring ECMAScript specifications in plaintext and processing the specification into a full-featured HTML rendering that follows the editorial conventions for this document. Ecmarkup builds on and integrates a number of other formats and technologies including <a href="https://github.com/rbuckton/grammarkdown">Grammarkdown</a> for defining syntax and <a href="https://github.com/domenic/ecmarkdown">Ecmarkdown</a> for authoring algorithm steps. PDF renderings of this specification are produced by printing the HTML rendering to a PDF.</p>
   <p>Prior editions of this specification were authored using Word&mdash;the Ecmarkup source text that formed the basis of this edition was produced by converting the ECMAScript 2015 Word document to Ecmarkup using an automated conversion tool.</p>
 </emu-annex>
+
 <emu-annex id="sec-bibliography">
   <h1>Bibliography</h1>
   <ol>
@@ -48046,5 +47922,3 @@ THH:mm:ss.sss
     </li>
   </ol>
 </emu-annex>
-</body>
-</html>


### PR DESCRIPTION
Automatic formatting of the markup using [a ~WIP~ ecmarkup formatter](https://github.com/tc39/ecmarkup/pull/367).

You can see that it mostly uses the same style we already do, i.e. does not change anything, with a few exceptions:
- useless `<tbody>` tags are dropped
- when referring to an optional nonterminal in prose, it's written `|Nonterminal?|` rather than `|Nonterminal_opt|`. We use both styles currently, but the `_opt` form more frequently; I decided to go with the less frequent style anyway because it matches how it's spelled in the grammar (which does not support the `_opt` suffix in source)
- when there's an `emu-grammar` which references the same LHS twice, those are collapsed into a single multiline production
- when there's an `emu-grammar` with some items expanded, all of the items are expanded

(The latter two have effects on the rendering. That's intentional.)

I recommend not manually reviewing the first commit; that just fiddles with the whitespace for a few tables so that the later commits are more readable.

~Marked as a draft until the formatter is ready and included in this PR, both as an npm script and enforced as a github action.~

Formatter is ready and included in this PR, both as an npm script and enforced as a github action.