### PR TITLE
Editorial: mostly stop using strings for special values

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -14941,7 +14941,7 @@
           1. Assert: _binding_ is a ResolvedBinding Record.
           1. Let _targetModule_ be _binding_.[[Module]].
           1. Assert: _targetModule_ is not *undefined*.
-          1. If _binding_.[[BindingName]] is *"\*namespace\*"*, then
+          1. If _binding_.[[BindingName]] is ~namespace~, then
             1. Return ? GetModuleNamespace(_targetModule_).
           1. Let _targetEnv_ be _targetModule_.[[Environment]].
           1. If _targetEnv_ is ~empty~, throw a *ReferenceError* exception.
@@ -26140,7 +26140,7 @@
                 ResolveExport(_exportName_ [, _resolveSet_])
               </td>
               <td>
-                <p>Return the binding of a name exported by this module. Bindings are represented by a <dfn id="resolvedbinding-record" variants="ResolvedBinding Records">ResolvedBinding Record</dfn>, of the form { [[Module]]: Module Record, [[BindingName]]: String }. If the export is a Module Namespace Object without a direct binding in any module, [[BindingName]] will be set to *"\*namespace\*"*. Return *null* if the name cannot be resolved, or *"ambiguous"* if multiple bindings were found.</p>
+                <p>Return the binding of a name exported by this module. Bindings are represented by a <dfn id="resolvedbinding-record" variants="ResolvedBinding Records">ResolvedBinding Record</dfn>, of the form { [[Module]]: Module Record, [[BindingName]]: String | ~namespace~ }. If the export is a Module Namespace Object without a direct binding in any module, [[BindingName]] will be set to ~namespace~. Return *null* if the name cannot be resolved, or *"ambiguous"* if multiple bindings were found.</p>
                 <p>Each time this operation is called with a specific _exportName_, _resolveSet_ pair as arguments it must return the same result if it completes normally.</p>
               </td>
             </tr>
@@ -27661,7 +27661,7 @@
             <dt>description</dt>
             <dd>
               <p>ResolveExport attempts to resolve an imported binding to the actual defining module and local binding name. The defining module may be the module represented by the Module Record this method was invoked on or some other module that is imported by that module. The parameter _resolveSet_ is used to detect unresolved circular import/export paths. If a pair consisting of specific Module Record and _exportName_ is reached that is already in _resolveSet_, an import circularity has been encountered. Before recursively calling ResolveExport, a pair consisting of _module_ and _exportName_ is added to _resolveSet_.</p>
-              <p>If a defining module is found, a ResolvedBinding Record { [[Module]], [[BindingName]] } is returned. This record identifies the resolved binding of the originally requested export, unless this is the export of a namespace with no local binding. In this case, [[BindingName]] will be set to *"\*namespace\*"*. If no definition was found or the request is found to be circular, *null* is returned. If the request is found to be ambiguous, the string *"ambiguous"* is returned.</p>
+              <p>If a defining module is found, a ResolvedBinding Record { [[Module]], [[BindingName]] } is returned. This record identifies the resolved binding of the originally requested export, unless this is the export of a namespace with no local binding. In this case, [[BindingName]] will be set to ~namespace~. If no definition was found or the request is found to be circular, *null* is returned. If the request is found to be ambiguous, the string *"ambiguous"* is returned.</p>
             </dd>
           </dl>
 
@@ -27681,7 +27681,7 @@
                 1. Let _importedModule_ be ? HostResolveImportedModule(_module_, _e_.[[ModuleRequest]]).
                 1. If _e_.[[ImportName]] is ~all~, then
                   1. Assert: _module_ does not provide the direct binding for this export.
-                  1. Return ResolvedBinding Record { [[Module]]: _importedModule_, [[BindingName]]: *"\*namespace\*"* }.
+                  1. Return ResolvedBinding Record { [[Module]]: _importedModule_, [[BindingName]]: ~namespace~ }.
                 1. Else,
                   1. Assert: _module_ imports a specific binding for this export.
                   1. Return _importedModule_.ResolveExport(_e_.[[ImportName]], _resolveSet_).
@@ -27699,7 +27699,9 @@
                 1. If _starResolution_ is *null*, set _starResolution_ to _resolution_.
                 1. Else,
                   1. Assert: There is more than one `*` import that includes the requested name.
-                  1. If _resolution_.[[Module]] and _starResolution_.[[Module]] are not the same Module Record or SameValue(_resolution_.[[BindingName]], _starResolution_.[[BindingName]]) is *false*, return *"ambiguous"*.
+                  1. If _resolution_.[[Module]] and _starResolution_.[[Module]] are not the same Module Record, return *"ambiguous"*.
+                  1. If _resolution_.[[BindingName]] is ~namespace~ and _starResolution_.[[BindingName]] is not ~namespace~, or if _resolution_.[[BindingName]] is not ~namespace~ and _starResolution_.[[BindingName]] is ~namespace~, return *"ambiguous"*.
+                  1. If _resolution_.[[BindingName]] is a String, _starResolution_.[[BindingName]] is a String, and SameValue(_resolution_.[[BindingName]], _starResolution_.[[BindingName]]) is *false*, return *"ambiguous"*.
             1. Return _starResolution_.
           </emu-alg>
         </emu-clause>
@@ -27731,7 +27733,7 @@
               1. Else,
                 1. Let _resolution_ be ? _importedModule_.ResolveExport(_in_.[[ImportName]]).
                 1. If _resolution_ is *null* or *"ambiguous"*, throw a *SyntaxError* exception.
-                1. If _resolution_.[[BindingName]] is *"\*namespace\*"*, then
+                1. If _resolution_.[[BindingName]] is ~namespace~, then
                   1. Let _namespace_ be ? GetModuleNamespace(_resolution_.[[Module]]).
                   1. Perform ! _env_.CreateImmutableBinding(_in_.[[LocalName]], *true*).
                   1. Call _env_.InitializeBinding(_in_.[[LocalName]], _namespace_).

--- a/spec.html
+++ b/spec.html
@@ -27345,10 +27345,10 @@
                 [[ImportName]]
               </td>
               <td>
-                String | null
+                String | null | ~all~ | ~all-but-default~
               </td>
               <td>
-                The name under which the desired binding is exported by the module identified by [[ModuleRequest]]. *null* if the |ExportDeclaration| does not have a |ModuleSpecifier|. *"\*"* indicates that the export request is for all exported bindings.
+                The name under which the desired binding is exported by the module identified by [[ModuleRequest]]. *null* if the |ExportDeclaration| does not have a |ModuleSpecifier|. ~all~ is used for `export * as ns from "mod"` declarations. ~all-but-default~ is used for `export * from "mod"` declarations.
               </td>
             </tr>
             <tr>
@@ -27534,7 +27534,7 @@
                   *"mod"*
                 </td>
                 <td>
-                  *"\*"*
+                  ~all-but-default~
                 </td>
                 <td>
                   *null*
@@ -27551,7 +27551,7 @@
                   *"mod"*
                 </td>
                 <td>
-                  *"\*"*
+                  ~all~
                 </td>
                 <td>
                   *null*
@@ -27597,7 +27597,8 @@
                   1. Else,
                     1. NOTE: This is a re-export of a single name.
                     1. Append the ExportEntry Record { [[ModuleRequest]]: _ie_.[[ModuleRequest]], [[ImportName]]: _ie_.[[ImportName]], [[LocalName]]: *null*, [[ExportName]]: _ee_.[[ExportName]] } to _indirectExportEntries_.
-              1. Else if _ee_.[[ImportName]] is *"\*"* and _ee_.[[ExportName]] is *null*, then
+              1. Else if _ee_.[[ImportName]] is ~all-but-default~, then
+                1. Assert: _ee_.[[ExportName]] is *null*.
                 1. Append _ee_ to _starExportEntries_.
               1. Else,
                 1. Append _ee_ to _indirectExportEntries_.
@@ -27678,7 +27679,7 @@
             1. For each ExportEntry Record _e_ of _module_.[[IndirectExportEntries]], do
               1. If SameValue(_exportName_, _e_.[[ExportName]]) is *true*, then
                 1. Let _importedModule_ be ? HostResolveImportedModule(_module_, _e_.[[ModuleRequest]]).
-                1. If _e_.[[ImportName]] is *"\*"*, then
+                1. If _e_.[[ImportName]] is ~all~, then
                   1. Assert: _module_ does not provide the direct binding for this export.
                   1. Return ResolvedBinding Record { [[Module]]: _importedModule_, [[BindingName]]: *"\*namespace\*"* }.
                 1. Else,
@@ -28401,13 +28402,13 @@
         </dl>
         <emu-grammar>ExportFromClause : `*`</emu-grammar>
         <emu-alg>
-          1. Let _entry_ be the ExportEntry Record { [[ModuleRequest]]: _module_, [[ImportName]]: *"\*"*, [[LocalName]]: *null*, [[ExportName]]: *null* }.
+          1. Let _entry_ be the ExportEntry Record { [[ModuleRequest]]: _module_, [[ImportName]]: ~all-but-default~, [[LocalName]]: *null*, [[ExportName]]: *null* }.
           1. Return a List whose sole element is _entry_.
         </emu-alg>
         <emu-grammar>ExportFromClause : `*` `as` IdentifierName</emu-grammar>
         <emu-alg>
           1. Let _exportName_ be the StringValue of |IdentifierName|.
-          1. Let _entry_ be the ExportEntry Record { [[ModuleRequest]]: _module_, [[ImportName]]: *"\*"*, [[LocalName]]: *null*, [[ExportName]]: _exportName_ }.
+          1. Let _entry_ be the ExportEntry Record { [[ModuleRequest]]: _module_, [[ImportName]]: ~all~, [[LocalName]]: *null*, [[ExportName]]: _exportName_ }.
           1. Return a List whose sole element is _entry_.
         </emu-alg>
         <emu-grammar>NamedExports : `{` `}`</emu-grammar>

--- a/spec.html
+++ b/spec.html
@@ -7215,8 +7215,8 @@
       <h1>Static Semantics: BoundNames</h1>
       <dl class="header">
       </dl>
-      <emu-note>
-        <p>*"\*default\*"* is used within this specification as a synthetic name for hoistable anonymous functions that are defined using export declarations.</p>
+      <emu-note id="note-star-default-star">
+        <p>*"\*default\*"* is used within this specification as a synthetic name for a module's default export when it does not have another name. An entry in the module's [[Environment]] is created with that name and holds the corresponding value, and resolving the export named *"default"* by calling <emu-xref href="#sec-resolveexport" title></emu-xref> for the module will return a ResolvedBinding Record whose [[BindingName]] is *"\*default\*"*, which will then resolve in the module's [[Environment]] to the above-mentioned value. This is done only for ease of specification, so that anonymous default exports can be resolved like any other export. The string *"\*default\*"* is never accessible to user code or to the module linking algorithm.</p>
       </emu-note>
       <emu-grammar>BindingIdentifier : Identifier</emu-grammar>
       <emu-alg>
@@ -28390,7 +28390,7 @@
           1. Return a List whose sole element is _entry_.
         </emu-alg>
         <emu-note>
-          <p>*"\*default\*"* is used within this specification as a synthetic name for anonymous default export values.</p>
+          <p>*"\*default\*"* is used within this specification as a synthetic name for anonymous default export values. See <emu-xref href="#note-star-default-star">this note</emu-xref> for more details.</p>
         </emu-note>
       </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -26140,7 +26140,7 @@
                 ResolveExport(_exportName_ [, _resolveSet_])
               </td>
               <td>
-                <p>Return the binding of a name exported by this module. Bindings are represented by a <dfn id="resolvedbinding-record" variants="ResolvedBinding Records">ResolvedBinding Record</dfn>, of the form { [[Module]]: Module Record, [[BindingName]]: String | ~namespace~ }. If the export is a Module Namespace Object without a direct binding in any module, [[BindingName]] will be set to ~namespace~. Return *null* if the name cannot be resolved, or *"ambiguous"* if multiple bindings were found.</p>
+                <p>Return the binding of a name exported by this module. Bindings are represented by a <dfn id="resolvedbinding-record" variants="ResolvedBinding Records">ResolvedBinding Record</dfn>, of the form { [[Module]]: Module Record, [[BindingName]]: String | ~namespace~ }. If the export is a Module Namespace Object without a direct binding in any module, [[BindingName]] will be set to ~namespace~. Return *null* if the name cannot be resolved, or ~ambiguous~ if multiple bindings were found.</p>
                 <p>Each time this operation is called with a specific _exportName_, _resolveSet_ pair as arguments it must return the same result if it completes normally.</p>
               </td>
             </tr>
@@ -27661,7 +27661,7 @@
             <dt>description</dt>
             <dd>
               <p>ResolveExport attempts to resolve an imported binding to the actual defining module and local binding name. The defining module may be the module represented by the Module Record this method was invoked on or some other module that is imported by that module. The parameter _resolveSet_ is used to detect unresolved circular import/export paths. If a pair consisting of specific Module Record and _exportName_ is reached that is already in _resolveSet_, an import circularity has been encountered. Before recursively calling ResolveExport, a pair consisting of _module_ and _exportName_ is added to _resolveSet_.</p>
-              <p>If a defining module is found, a ResolvedBinding Record { [[Module]], [[BindingName]] } is returned. This record identifies the resolved binding of the originally requested export, unless this is the export of a namespace with no local binding. In this case, [[BindingName]] will be set to ~namespace~. If no definition was found or the request is found to be circular, *null* is returned. If the request is found to be ambiguous, the string *"ambiguous"* is returned.</p>
+              <p>If a defining module is found, a ResolvedBinding Record { [[Module]], [[BindingName]] } is returned. This record identifies the resolved binding of the originally requested export, unless this is the export of a namespace with no local binding. In this case, [[BindingName]] will be set to ~namespace~. If no definition was found or the request is found to be circular, *null* is returned. If the request is found to be ambiguous, ~ambiguous~ is returned.</p>
             </dd>
           </dl>
 
@@ -27693,15 +27693,15 @@
             1. For each ExportEntry Record _e_ of _module_.[[StarExportEntries]], do
               1. Let _importedModule_ be ? HostResolveImportedModule(_module_, _e_.[[ModuleRequest]]).
               1. Let _resolution_ be ? _importedModule_.ResolveExport(_exportName_, _resolveSet_).
-              1. If _resolution_ is *"ambiguous"*, return *"ambiguous"*.
+              1. If _resolution_ is ~ambiguous~, return ~ambiguous~.
               1. If _resolution_ is not *null*, then
                 1. Assert: _resolution_ is a ResolvedBinding Record.
                 1. If _starResolution_ is *null*, set _starResolution_ to _resolution_.
                 1. Else,
                   1. Assert: There is more than one `*` import that includes the requested name.
-                  1. If _resolution_.[[Module]] and _starResolution_.[[Module]] are not the same Module Record, return *"ambiguous"*.
-                  1. If _resolution_.[[BindingName]] is ~namespace~ and _starResolution_.[[BindingName]] is not ~namespace~, or if _resolution_.[[BindingName]] is not ~namespace~ and _starResolution_.[[BindingName]] is ~namespace~, return *"ambiguous"*.
-                  1. If _resolution_.[[BindingName]] is a String, _starResolution_.[[BindingName]] is a String, and SameValue(_resolution_.[[BindingName]], _starResolution_.[[BindingName]]) is *false*, return *"ambiguous"*.
+                  1. If _resolution_.[[Module]] and _starResolution_.[[Module]] are not the same Module Record, return ~ambiguous~.
+                  1. If _resolution_.[[BindingName]] is ~namespace~ and _starResolution_.[[BindingName]] is not ~namespace~, or if _resolution_.[[BindingName]] is not ~namespace~ and _starResolution_.[[BindingName]] is ~namespace~, return ~ambiguous~.
+                  1. If _resolution_.[[BindingName]] is a String, _starResolution_.[[BindingName]] is a String, and SameValue(_resolution_.[[BindingName]], _starResolution_.[[BindingName]]) is *false*, return ~ambiguous~.
             1. Return _starResolution_.
           </emu-alg>
         </emu-clause>
@@ -27716,7 +27716,7 @@
           <emu-alg>
             1. For each ExportEntry Record _e_ of _module_.[[IndirectExportEntries]], do
               1. Let _resolution_ be ? _module_.ResolveExport(_e_.[[ExportName]]).
-              1. If _resolution_ is *null* or *"ambiguous"*, throw a *SyntaxError* exception.
+              1. If _resolution_ is *null* or ~ambiguous~, throw a *SyntaxError* exception.
               1. Assert: _resolution_ is a ResolvedBinding Record.
             1. Assert: All named exports from _module_ are resolvable.
             1. Let _realm_ be _module_.[[Realm]].
@@ -27732,7 +27732,7 @@
                 1. Call _env_.InitializeBinding(_in_.[[LocalName]], _namespace_).
               1. Else,
                 1. Let _resolution_ be ? _importedModule_.ResolveExport(_in_.[[ImportName]]).
-                1. If _resolution_ is *null* or *"ambiguous"*, throw a *SyntaxError* exception.
+                1. If _resolution_ is *null* or ~ambiguous~, throw a *SyntaxError* exception.
                 1. If _resolution_.[[BindingName]] is ~namespace~, then
                   1. Let _namespace_ be ? GetModuleNamespace(_resolution_.[[Module]]).
                   1. Perform ! _env_.CreateImmutableBinding(_in_.[[LocalName]], *true*).

--- a/spec.html
+++ b/spec.html
@@ -27196,10 +27196,10 @@
                 [[ImportName]]
               </td>
               <td>
-                String
+                String | ~namespace-object~
               </td>
               <td>
-                The name under which the desired binding is exported by the module identified by [[ModuleRequest]]. The value *"\*"* indicates that the import request is for the target module's namespace object.
+                The name under which the desired binding is exported by the module identified by [[ModuleRequest]]. The value ~namespace-object~ indicates that the import request is for the target module's namespace object.
               </td>
             </tr>
             <tr>
@@ -27257,7 +27257,7 @@
                   *"mod"*
                 </td>
                 <td>
-                  *"\*"*
+                  ~namespace-object~
                 </td>
                 <td>
                   *"ns"*
@@ -27591,7 +27591,7 @@
                   1. Append _ee_ to _localExportEntries_.
                 1. Else,
                   1. Let _ie_ be the element of _importEntries_ whose [[LocalName]] is the same as _ee_.[[LocalName]].
-                  1. If _ie_.[[ImportName]] is *"\*"*, then
+                  1. If _ie_.[[ImportName]] is ~namespace-object~, then
                     1. NOTE: This is a re-export of an imported module namespace object.
                     1. Append _ee_ to _localExportEntries_.
                   1. Else,
@@ -27724,7 +27724,7 @@
             1. For each ImportEntry Record _in_ of _module_.[[ImportEntries]], do
               1. Let _importedModule_ be ! HostResolveImportedModule(_module_, _in_.[[ModuleRequest]]).
               1. NOTE: The above call cannot fail because imported module requests are a subset of _module_.[[RequestedModules]], and these have been resolved earlier in this algorithm.
-              1. If _in_.[[ImportName]] is *"\*"*, then
+              1. If _in_.[[ImportName]] is ~namespace-object~, then
                 1. Let _namespace_ be ? GetModuleNamespace(_importedModule_).
                 1. Perform ! _env_.CreateImmutableBinding(_in_.[[LocalName]], *true*).
                 1. Call _env_.InitializeBinding(_in_.[[LocalName]], _namespace_).
@@ -28102,7 +28102,7 @@
         <emu-grammar>NameSpaceImport : `*` `as` ImportedBinding</emu-grammar>
         <emu-alg>
           1. Let _localName_ be the StringValue of |ImportedBinding|.
-          1. Let _entry_ be the ImportEntry Record { [[ModuleRequest]]: _module_, [[ImportName]]: *"\*"*, [[LocalName]]: _localName_ }.
+          1. Let _entry_ be the ImportEntry Record { [[ModuleRequest]]: _module_, [[ImportName]]: ~namespace-object~, [[LocalName]]: _localName_ }.
           1. Return a List whose sole element is _entry_.
         </emu-alg>
         <emu-grammar>NamedImports : `{` `}`</emu-grammar>


### PR DESCRIPTION
Replaces/ closes #2155.

There are four special strings used in the import/export machinery, one of which is used in three different ways:
- `"*"`, used in the [[ImportName]] field of an ExportEntry to mark an `export * from 'mod'`; this has been renamed to `~all-but-default~`
- `"*"`, used in the [[ImportName]] field of an ExportEntry to mark an `export * as foo from 'mod'` export; this has been renamed to `~all~`
- `"*"`, used in the [[ImportName]] field of an ImportEntry to mark an `import * as foo from 'mod'` import; this has been renamed to `~namespace-object~`
- `"*namespace*"`, used in the [[BindingName]] field of a ResolvedBinding to mark a `export * as foo from 'mod'`; this has been renamed to `~namespace~`
- `"ambiguous"`, used in the return value for `ResolveExport` when resolving a name exported by multiple `export * from 'mod'` exports; this has been renamed to `~ambiguous~`.
- `"*default*"`, used for default exports which do not have any other name; this has been left alone, and the note about it expanded.

The goal is to unblock https://github.com/tc39/ecma262/pull/2154 by ensuring that we never use a special string as a placeholder in a context where that PR would allow arbitrary well-formed strings to appear.

@michaelficarra and I spent a couple hours staring at all of this stuff, most of which was fixing our own confusion about how this worked, to wit:

We originally thought that `"*default*"` was such a string, but it turns out not to be - it is only used as a name strictly internal to a module, to provide the linkage between the `"default"` export and the local binding by using the same machinery as named exports.

And internally, for named exports, that linkage uses string names looked up in the actual scope object for the module. So the `"*default*"` string is used in a context which does actually require a string, and thus can't be trivially replaced by a spec enum. We considered modifying the machinery for default exports to work in a different way, but that seemed like it would be more complexity for little benefit, given that it does _not_ actually conflict with #2154, so we've left it along. I did expand the note about `"*default*"` to hopefully make this clearer to future readers.

On the other hand, `"*"` _was_ actually being used in a position which would conflict with #2154, as you can see from the [[ImportName]] column of the `import * as ns from "mod";` row in [this table](https://tc39.es/ecma262/#table-import-forms-mapping-to-importentry-records). So was `"*namespace*"`, as you can sort of see from step 9/10 of [this algorithm](https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-module-namespace-exotic-objects-get-p-receiver). (Edit: actually I guess `"*namespace*"` was ok, on thinking further - step 9 happens after the public -> local name translation has already occurred.)

So this PR does still block #2154, even though we didn't actually end up needing to deal with `"*default*"`.

---

Just to summarize the relevant machinery here, mostly for my own benefit:

An `import` creates an ImportEntry Record whose [[ImportName]] is the exported name and whose [[LocalName]] is strictly internal to the module. [[ImportName]] has/had a special case of `"*"` which indicated a request for the namespace object rather than any particular name.

An `export ... from 'foo'` creates an ExportEntry Record whose [[ExportName]] is the name visible to importers of this module and whose [[ImportName]] is the name exported by the upstream module ('foo'), and has/had the same special case for `"*"`.

An `export ...` without a `from` creates an ExportEntry Record whose [[ExportName]] is the name visible to importers of this module and whose [[LocalName]] is the name used within this module. [[LocalName]] has a special case of `"*default*"` for anonymous default exports, which is actually a name used on the module's Environment object alongside other top-level variables.

Resolution hooks up these entries to create a ResolvedBinding Record which holds the original module defining the export, and whose [[BindingName]] is the name within that module's environment. It has/had a special case of `"*namespace*"` which indicated a request for the namespace object rather than any particular name. The [[BindingName]] is derived from an ExportEntry's [[LocalName]], except when the request is for a namespace object. As such, it can be `"*default*"`, which will get looked up within the module's environment like any other name.

Also, if resolution is ambiguous, the string `"ambiguous"` is used instead of a ResolvedBinding. It's not used in a position where names occur at all.

So, the [[ImportName]] / [[ExportName]] fields hold the actual linker-exposed names, which are the things relaxed by #2154; the other names are strictly internal to a module. Of the special strings, only `"*"` was used in the linker-exposed position (in [[ImportName]]) and so only `"*"` actually needed to change. But we might as well get rid of the others while we're at it.