### PR TITLE
Editorial: Be consistent about the sense of "match" (and other phrasing)

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -47325,7 +47325,7 @@ THH:mm:ss.sss
       <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
       <ul>
         <li>
-          It is a Syntax Error if any <ins>strict mode</ins> source text is matched by this production.
+          It is a Syntax Error if any source text <ins>that is strict mode code</ins> is matched by this production.
         </li>
       </ul>
       <emu-note>

--- a/spec.html
+++ b/spec.html
@@ -18243,7 +18243,7 @@
         <emu-grammar>PropertyDefinition : CoverInitializedName</emu-grammar>
         <ul>
           <li>
-            Always throw a Syntax Error if source text is matched by this production.
+            It is a Syntax Error if any source text is matched by this production.
           </li>
         </ul>
         <emu-note>
@@ -22642,7 +22642,7 @@
       <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
       <ul>
         <li>
-          It is a Syntax Error if any source text is matched by this rule.
+          It is a Syntax Error if any source text is matched by this production.
         </li>
       </ul>
       <emu-note>
@@ -46797,7 +46797,7 @@ THH:mm:ss.sss
         <emu-grammar>ExtendedAtom :: InvalidBracedQuantifier</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if any source text is matched by this rule.
+            It is a Syntax Error if any source text is matched by this production.
           </li>
         </ul>
         <p>Additionally, the rules for the following productions are modified with the addition of the <ins>highlighted</ins> text:</p>
@@ -47325,7 +47325,7 @@ THH:mm:ss.sss
       <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
       <ul>
         <li>
-          It is a Syntax Error if any <ins>strict mode</ins> source text is matched by this rule.
+          It is a Syntax Error if any <ins>strict mode</ins> source text is matched by this production.
         </li>
       </ul>
       <emu-note>

--- a/spec.html
+++ b/spec.html
@@ -15768,7 +15768,7 @@
 </emu-clause>
 
 <emu-clause id="sec-ecmascript-language-source-code">
-  <h1>ECMAScript Language: Source Code</h1>
+  <h1>ECMAScript Language: Source Text</h1>
 
   <emu-clause id="sec-source-text">
     <h1>Source Text</h1>
@@ -16685,7 +16685,7 @@
           DecimalIntegerLiteral :: NonOctalDecimalIntegerLiteral
         </emu-grammar>
         <ul>
-          <li>It is a Syntax Error if the source code matched by this production is strict mode code.</li>
+          <li>It is a Syntax Error if the source text matched by this production is strict mode code.</li>
         </ul>
         <emu-note>In non-strict code, this syntax is Legacy.</emu-note>
       </emu-clause>
@@ -16952,7 +16952,7 @@
             NonOctalDecimalEscapeSequence
         </emu-grammar>
         <ul>
-          <li>It is a Syntax Error if the source code matched by this production is strict mode code.</li>
+          <li>It is a Syntax Error if the source text matched by this production is strict mode code.</li>
         </ul>
         <emu-note>In non-strict code, this syntax is Legacy.</emu-note>
         <emu-note>
@@ -19041,7 +19041,7 @@
               1. Let _argList_ be ? ArgumentListEvaluation of _arguments_.
               1. If _argList_ has no elements, return *undefined*.
               1. Let _evalArg_ be the first element of _argList_.
-              1. If the source code matched by this |CallExpression| is strict mode code, let _strictCaller_ be *true*. Otherwise let _strictCaller_ be *false*.
+              1. If the source text matched by this |CallExpression| is strict mode code, let _strictCaller_ be *true*. Otherwise let _strictCaller_ be *false*.
               1. Let _evalRealm_ be the current Realm Record.
               1. [id="step-callexpression-evaluation-direct-eval"] Return ? PerformEval(_evalArg_, _evalRealm_, _strictCaller_, *true*).
           1. Let _thisCall_ be this |CallExpression|.
@@ -23222,10 +23222,10 @@
       </emu-grammar>
       <ul>
         <li>
-          If the source code matched by |FormalParameters| is strict mode code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.
+          If the source text matched by |FormalParameters| is strict mode code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.
         </li>
         <li>
-          If |BindingIdentifier| is present and the source code matched by |BindingIdentifier| is strict mode code, it is a Syntax Error if the StringValue of |BindingIdentifier| is *"eval"* or *"arguments"*.
+          If |BindingIdentifier| is present and the source text matched by |BindingIdentifier| is strict mode code, it is a Syntax Error if the StringValue of |BindingIdentifier| is *"eval"* or *"arguments"*.
         </li>
         <li>
           It is a Syntax Error if FunctionBodyContainsUseStrict of |FunctionBody| is *true* and IsSimpleParameterList of |FormalParameters| is *false*.
@@ -23800,10 +23800,10 @@
       </emu-grammar>
       <ul>
         <li>
-          If the source code matched by |FormalParameters| is strict mode code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.
+          If the source text matched by |FormalParameters| is strict mode code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.
         </li>
         <li>
-          If |BindingIdentifier| is present and the source code matched by |BindingIdentifier| is strict mode code, it is a Syntax Error if the StringValue of |BindingIdentifier| is *"eval"* or *"arguments"*.
+          If |BindingIdentifier| is present and the source text matched by |BindingIdentifier| is strict mode code, it is a Syntax Error if the StringValue of |BindingIdentifier| is *"eval"* or *"arguments"*.
         </li>
         <li>
           It is a Syntax Error if FunctionBodyContainsUseStrict of |GeneratorBody| is *true* and IsSimpleParameterList of |FormalParameters| is *false*.
@@ -24039,8 +24039,8 @@
           `async` `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
       </emu-grammar>
       <ul>
-        <li>If the source code matched by |FormalParameters| is strict mode code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.</li>
-        <li>If |BindingIdentifier| is present and the source code matched by |BindingIdentifier| is strict mode code, it is a Syntax Error if the StringValue of |BindingIdentifier| is *"eval"* or *"arguments"*.</li>
+        <li>If the source text matched by |FormalParameters| is strict mode code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.</li>
+        <li>If |BindingIdentifier| is present and the source text matched by |BindingIdentifier| is strict mode code, it is a Syntax Error if the StringValue of |BindingIdentifier| is *"eval"* or *"arguments"*.</li>
         <li>It is a Syntax Error if FunctionBodyContainsUseStrict of |AsyncGeneratorBody| is *true* and IsSimpleParameterList of |FormalParameters| is *false*.</li>
         <li>It is a Syntax Error if any element of the BoundNames of |FormalParameters| also occurs in the LexicallyDeclaredNames of |AsyncGeneratorBody|.</li>
         <li>It is a Syntax Error if |FormalParameters| Contains |YieldExpression| is *true*.</li>
@@ -24985,8 +24985,8 @@
       <ul>
         <li>It is a Syntax Error if FunctionBodyContainsUseStrict of |AsyncFunctionBody| is *true* and IsSimpleParameterList of |FormalParameters| is *false*.</li>
         <li>It is a Syntax Error if |FormalParameters| Contains |AwaitExpression| is *true*.</li>
-        <li>If the source code matched by |FormalParameters| is strict mode code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.</li>
-        <li>If |BindingIdentifier| is present and the source code matched by |BindingIdentifier| is strict mode code, it is a Syntax Error if the StringValue of |BindingIdentifier| is *"eval"* or *"arguments"*.</li>
+        <li>If the source text matched by |FormalParameters| is strict mode code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.</li>
+        <li>If |BindingIdentifier| is present and the source text matched by |BindingIdentifier| is strict mode code, it is a Syntax Error if the StringValue of |BindingIdentifier| is *"eval"* or *"arguments"*.</li>
         <li>It is a Syntax Error if any element of the BoundNames of |FormalParameters| also occurs in the LexicallyDeclaredNames of |AsyncFunctionBody|.</li>
         <li>It is a Syntax Error if |FormalParameters| Contains |SuperProperty| is *true*.</li>
         <li>It is a Syntax Error if |AsyncFunctionBody| Contains |SuperProperty| is *true*.</li>
@@ -25259,7 +25259,7 @@
       <dl class="header">
       </dl>
       <emu-alg>
-        1. If the source code matched by _call_ is non-strict code, return *false*.
+        1. If the source text matched by _call_ is non-strict code, return *false*.
         1. If _call_ is not contained within a |FunctionBody|, |ConciseBody|, or |AsyncConciseBody|, return *false*.
         1. Let _body_ be the |FunctionBody|, |ConciseBody|, or |AsyncConciseBody| that most closely contains _call_.
         1. If _body_ is the |FunctionBody| of a |GeneratorBody|, return *false*.
@@ -25657,10 +25657,10 @@
       <emu-grammar>ScriptBody : StatementList</emu-grammar>
       <ul>
         <li>
-          It is a Syntax Error if |StatementList| Contains `super` unless the source code containing `super` is eval code that is being processed by a direct eval. Additional early error rules for `super` within direct eval are defined in <emu-xref href="#sec-performeval"></emu-xref>.
+          It is a Syntax Error if |StatementList| Contains `super` unless the source text containing `super` is eval code that is being processed by a direct eval. Additional early error rules for `super` within direct eval are defined in <emu-xref href="#sec-performeval"></emu-xref>.
         </li>
         <li>
-          It is a Syntax Error if |StatementList| Contains |NewTarget| unless the source code containing |NewTarget| is eval code that is being processed by a direct eval. Additional early error rules for |NewTarget| in direct eval are defined in <emu-xref href="#sec-performeval"></emu-xref>.
+          It is a Syntax Error if |StatementList| Contains |NewTarget| unless the source text containing |NewTarget| is eval code that is being processed by a direct eval. Additional early error rules for |NewTarget| in direct eval are defined in <emu-xref href="#sec-performeval"></emu-xref>.
         </li>
         <li>
           It is a Syntax Error if ContainsDuplicateLabels of |StatementList| with argument &laquo; &raquo; is *true*.
@@ -25672,7 +25672,7 @@
           It is a Syntax Error if ContainsUndefinedContinueTarget of |StatementList| with arguments &laquo; &raquo; and &laquo; &raquo; is *true*.
         </li>
         <li>
-          It is a Syntax Error if AllPrivateIdentifiersValid of |StatementList| with argument &laquo; &raquo; is *false* unless the source code containing |ScriptBody| is eval code that is being processed by a direct eval.
+          It is a Syntax Error if AllPrivateIdentifiersValid of |StatementList| with argument &laquo; &raquo; is *false* unless the source text containing |ScriptBody| is eval code that is being processed by a direct eval.
         </li>
       </ul>
     </emu-clause>
@@ -26209,7 +26209,7 @@
                 List of String
               </td>
               <td>
-                A List of all the |ModuleSpecifier| strings used by the module represented by this record to request the importation of a module. The List is source code occurrence ordered.
+                A List of all the |ModuleSpecifier| strings used by the module represented by this record to request the importation of a module. The List is source text occurrence ordered.
               </td>
             </tr>
             <tr>
@@ -35014,7 +35014,7 @@ THH:mm:ss.sss
       <h1>Pattern Semantics</h1>
       <p>A regular expression pattern is converted into an Abstract Closure using the process described below. An implementation is encouraged to use more efficient algorithms than the ones listed below, as long as the results are the same. The Abstract Closure is used as the value of a RegExp object's [[RegExpMatcher]] internal slot.</p>
       <p>A |Pattern| is either a BMP pattern or a Unicode pattern depending upon whether or not its associated flags contain a `u`. A BMP pattern matches against a String interpreted as consisting of a sequence of 16-bit values that are Unicode code points in the range of the Basic Multilingual Plane. A Unicode pattern matches against a String interpreted as consisting of Unicode code points encoded using UTF-16. In the context of describing the behaviour of a BMP pattern &ldquo;character&rdquo; means a single 16-bit Unicode BMP code point. In the context of describing the behaviour of a Unicode pattern &ldquo;character&rdquo; means a UTF-16 encoded code point (<emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>). In either context, &ldquo;character value&rdquo; means the numeric value of the corresponding non-encoded code point.</p>
-      <p>The syntax and semantics of |Pattern| is defined as if the source code for the |Pattern| was a List of |SourceCharacter| values where each |SourceCharacter| corresponds to a Unicode code point. If a BMP pattern contains a non-BMP |SourceCharacter| the entire pattern is encoded using UTF-16 and the individual code units of that encoding are used as the elements of the List.</p>
+      <p>The syntax and semantics of |Pattern| is defined as if the source text for the |Pattern| was a List of |SourceCharacter| values where each |SourceCharacter| corresponds to a Unicode code point. If a BMP pattern contains a non-BMP |SourceCharacter| the entire pattern is encoded using UTF-16 and the individual code units of that encoding are used as the elements of the List.</p>
       <emu-note>
         <p>For example, consider a pattern expressed in source text as the single non-BMP character U+1D11E (MUSICAL SYMBOL G CLEF). Interpreted as a Unicode pattern, it would be a single element (character) List consisting of the single code point 0x1D11E. However, interpreted as a BMP pattern, it is first UTF-16 encoded to produce a two element List consisting of the code units 0xD834 and 0xDD1E.</p>
         <p>Patterns are passed to the RegExp constructor as ECMAScript String values in which non-BMP characters are UTF-16 encoded. For example, the single character MUSICAL SYMBOL G CLEF pattern, expressed as a String value, is a String of length 2 whose elements were the code units 0xD834 and 0xDD1E. So no further translation of the string would be necessary to process it as a BMP pattern consisting of two pattern characters. However, to process it as a Unicode pattern UTF16SurrogatePairToCodePoint must be used in producing a List whose sole element is a single pattern character, the code point U+1D11E.</p>
@@ -46647,7 +46647,7 @@ THH:mm:ss.sss
 
     <emu-annex id="sec-html-like-comments">
       <h1>HTML-like Comments</h1>
-      <p>The syntax and semantics of <emu-xref href="#sec-comments"></emu-xref> is extended as follows except that this extension is not allowed when parsing source code using the goal symbol |Module|:</p>
+      <p>The syntax and semantics of <emu-xref href="#sec-comments"></emu-xref> is extended as follows except that this extension is not allowed when parsing source text using the goal symbol |Module|:</p>
       <h2>Syntax</h2>
       <emu-grammar type="definition">
         Comment ::
@@ -47325,7 +47325,7 @@ THH:mm:ss.sss
       <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
       <ul>
         <li>
-          It is a Syntax Error if any <ins>strict mode</ins> source code is matched by this rule.
+          It is a Syntax Error if any <ins>strict mode</ins> source text is matched by this rule.
         </li>
       </ul>
       <emu-note>
@@ -47490,7 +47490,7 @@ THH:mm:ss.sss
         <emu-grammar>Block : `{` StatementList `}`</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the LexicallyDeclaredNames of |StatementList| contains any duplicate entries<ins>, unless the source code matched by this production is not strict mode code and the duplicate entries are only bound by FunctionDeclarations</ins>.
+            It is a Syntax Error if the LexicallyDeclaredNames of |StatementList| contains any duplicate entries<ins>, unless the source text matched by this production is not strict mode code and the duplicate entries are only bound by FunctionDeclarations</ins>.
           </li>
           <li>
             It is a Syntax Error if any element of the LexicallyDeclaredNames of |StatementList| also occurs in the VarDeclaredNames of |StatementList|.
@@ -47504,7 +47504,7 @@ THH:mm:ss.sss
         <emu-grammar>SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the LexicallyDeclaredNames of |CaseBlock| contains any duplicate entries<ins>, unless the source code matched by this production is not strict mode code and the duplicate entries are only bound by FunctionDeclarations</ins>.
+            It is a Syntax Error if the LexicallyDeclaredNames of |CaseBlock| contains any duplicate entries<ins>, unless the source text matched by this production is not strict mode code and the duplicate entries are only bound by FunctionDeclarations</ins>.
           </li>
           <li>
             It is a Syntax Error if any element of the LexicallyDeclaredNames of |CaseBlock| also occurs in the VarDeclaredNames of |CaseBlock|.
@@ -47540,7 +47540,7 @@ THH:mm:ss.sss
           `if` `(` Expression[+In, ?Yield, ?Await] `)` FunctionDeclaration[?Yield, ?Await, ~Default] `else` FunctionDeclaration[?Yield, ?Await, ~Default]
           `if` `(` Expression[+In, ?Yield, ?Await] `)` FunctionDeclaration[?Yield, ?Await, ~Default] [lookahead != `else`]
       </emu-grammar>
-      <p>This production only applies when parsing non-strict code. Code matched by this production is processed as if each matching occurrence of |FunctionDeclaration[?Yield, ?Await, ~Default]| was the sole |StatementListItem| of a |BlockStatement| occupying that position in the source code. The semantics of such a synthetic |BlockStatement| includes the web legacy compatibility semantics specified in <emu-xref href="#sec-block-level-function-declarations-web-legacy-compatibility-semantics"></emu-xref>.</p>
+      <p>This production only applies when parsing non-strict code. Code matched by this production is processed as if each matching occurrence of |FunctionDeclaration[?Yield, ?Await, ~Default]| was the sole |StatementListItem| of a |BlockStatement| occupying that position in the source text. The semantics of such a synthetic |BlockStatement| includes the web legacy compatibility semantics specified in <emu-xref href="#sec-block-level-function-declarations-web-legacy-compatibility-semantics"></emu-xref>.</p>
     </emu-annex>
 
     <emu-annex id="sec-variablestatements-in-catch-blocks">

--- a/spec.html
+++ b/spec.html
@@ -11870,7 +11870,7 @@
         1. If _env_ is not present or if _env_ is *undefined*, then
           1. Set _env_ to the running execution context's LexicalEnvironment.
         1. Assert: _env_ is an Environment Record.
-        1. If the code matched by the syntactic production that is being evaluated is contained in strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
+        1. If the source text matched by the syntactic production that is being evaluated is contained in strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
         1. Return ? GetIdentifierReference(_env_, _name_, _strict_).
       </emu-alg>
       <emu-note>
@@ -17809,7 +17809,7 @@
       <emu-grammar>BindingIdentifier : Identifier</emu-grammar>
       <ul>
         <li>
-          It is a Syntax Error if the code matched by this production is contained in strict mode code and the StringValue of |Identifier| is *"arguments"* or *"eval"*.
+          It is a Syntax Error if the source text matched by this production is contained in strict mode code and the StringValue of |Identifier| is *"arguments"* or *"eval"*.
         </li>
       </ul>
       <emu-grammar>
@@ -17821,7 +17821,7 @@
       </emu-grammar>
       <ul>
         <li>
-          It is a Syntax Error if the code matched by this production is contained in strict mode code.
+          It is a Syntax Error if the source text matched by this production is contained in strict mode code.
         </li>
       </ul>
       <emu-grammar>
@@ -18243,7 +18243,7 @@
         <emu-grammar>PropertyDefinition : CoverInitializedName</emu-grammar>
         <ul>
           <li>
-            Always throw a Syntax Error if code is matched by this production.
+            Always throw a Syntax Error if source text is matched by this production.
           </li>
         </ul>
         <emu-note>
@@ -18846,7 +18846,7 @@
         </emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if any code is matched by this production.
+            It is a Syntax Error if any source text is matched by this production.
           </li>
         </ul>
         <emu-note>
@@ -18913,14 +18913,14 @@
         <emu-alg>
           1. Let _baseReference_ be the result of evaluating |MemberExpression|.
           1. Let _baseValue_ be ? GetValue(_baseReference_).
-          1. If the code matched by this |MemberExpression| is strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
+          1. If the source text matched by this |MemberExpression| is strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
           1. Return ? EvaluatePropertyAccessWithExpressionKey(_baseValue_, |Expression|, _strict_).
         </emu-alg>
         <emu-grammar>MemberExpression : MemberExpression `.` IdentifierName</emu-grammar>
         <emu-alg>
           1. Let _baseReference_ be the result of evaluating |MemberExpression|.
           1. Let _baseValue_ be ? GetValue(_baseReference_).
-          1. If the code matched by this |MemberExpression| is strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
+          1. If the source text matched by this |MemberExpression| is strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
           1. Return ! EvaluatePropertyAccessWithIdentifierKey(_baseValue_, |IdentifierName|, _strict_).
         </emu-alg>
         <emu-grammar>MemberExpression : MemberExpression `.` PrivateIdentifier</emu-grammar>
@@ -18934,14 +18934,14 @@
         <emu-alg>
           1. Let _baseReference_ be the result of evaluating |CallExpression|.
           1. Let _baseValue_ be ? GetValue(_baseReference_).
-          1. If the code matched by this |CallExpression| is strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
+          1. If the source text matched by this |CallExpression| is strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
           1. Return ? EvaluatePropertyAccessWithExpressionKey(_baseValue_, |Expression|, _strict_).
         </emu-alg>
         <emu-grammar>CallExpression : CallExpression `.` IdentifierName</emu-grammar>
         <emu-alg>
           1. Let _baseReference_ be the result of evaluating |CallExpression|.
           1. Let _baseValue_ be ? GetValue(_baseReference_).
-          1. If the code matched by this |CallExpression| is strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
+          1. If the source text matched by this |CallExpression| is strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
           1. Return ! EvaluatePropertyAccessWithIdentifierKey(_baseValue_, |IdentifierName|, _strict_).
         </emu-alg>
         <emu-grammar>CallExpression : CallExpression `.` PrivateIdentifier</emu-grammar>
@@ -19103,7 +19103,7 @@
           1. Let _propertyNameReference_ be the result of evaluating |Expression|.
           1. Let _propertyNameValue_ be ? GetValue(_propertyNameReference_).
           1. Let _propertyKey_ be ? ToPropertyKey(_propertyNameValue_).
-          1. If the code matched by this |SuperProperty| is strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
+          1. If the source text matched by this |SuperProperty| is strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
           1. Return ? MakeSuperPropertyReference(_actualThis_, _propertyKey_, _strict_).
         </emu-alg>
         <emu-grammar>SuperProperty : `super` `.` IdentifierName</emu-grammar>
@@ -19111,7 +19111,7 @@
           1. Let _env_ be GetThisEnvironment().
           1. Let _actualThis_ be ? _env_.GetThisBinding().
           1. Let _propertyKey_ be StringValue of |IdentifierName|.
-          1. If the code matched by this |SuperProperty| is strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
+          1. If the source text matched by this |SuperProperty| is strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
           1. Return ? MakeSuperPropertyReference(_actualThis_, _propertyKey_, _strict_).
         </emu-alg>
         <emu-grammar>SuperCall : `super` Arguments</emu-grammar>
@@ -19297,12 +19297,12 @@
         </emu-alg>
         <emu-grammar>OptionalChain : `?.` `[` Expression `]`</emu-grammar>
         <emu-alg>
-          1. If the code matched by this |OptionalChain| is strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
+          1. If the source text matched by this |OptionalChain| is strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
           1. Return ? EvaluatePropertyAccessWithExpressionKey(_baseValue_, |Expression|, _strict_).
         </emu-alg>
         <emu-grammar>OptionalChain : `?.` IdentifierName</emu-grammar>
         <emu-alg>
-          1. If the code matched by this |OptionalChain| is strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
+          1. If the source text matched by this |OptionalChain| is strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
           1. Return ! EvaluatePropertyAccessWithIdentifierKey(_baseValue_, |IdentifierName|, _strict_).
         </emu-alg>
         <emu-grammar>OptionalChain : `?.` PrivateIdentifier</emu-grammar>
@@ -19324,7 +19324,7 @@
           1. Let _optionalChain_ be |OptionalChain|.
           1. Let _newReference_ be ? ChainEvaluation of _optionalChain_ with arguments _baseValue_ and _baseReference_.
           1. Let _newValue_ be ? GetValue(_newReference_).
-          1. If the code matched by this |OptionalChain| is strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
+          1. If the source text matched by this |OptionalChain| is strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
           1. Return ? EvaluatePropertyAccessWithExpressionKey(_newValue_, |Expression|, _strict_).
         </emu-alg>
         <emu-grammar>OptionalChain : OptionalChain `.` IdentifierName</emu-grammar>
@@ -19332,7 +19332,7 @@
           1. Let _optionalChain_ be |OptionalChain|.
           1. Let _newReference_ be ? ChainEvaluation of _optionalChain_ with arguments _baseValue_ and _baseReference_.
           1. Let _newValue_ be ? GetValue(_newReference_).
-          1. If the code matched by this |OptionalChain| is strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
+          1. If the source text matched by this |OptionalChain| is strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
           1. Return ! EvaluatePropertyAccessWithIdentifierKey(_newValue_, |IdentifierName|, _strict_).
         </emu-alg>
         <emu-grammar>OptionalChain : OptionalChain `.` PrivateIdentifier</emu-grammar>
@@ -22432,7 +22432,7 @@
       <emu-grammar>WithStatement : `with` `(` Expression `)` Statement</emu-grammar>
       <ul>
         <li>
-          It is a Syntax Error if the code matched by this production is contained in strict mode code.
+          It is a Syntax Error if the source text matched by this production is contained in strict mode code.
         </li>
         <li>
           It is a Syntax Error if IsLabelledFunction(|Statement|) is *true*.
@@ -47540,7 +47540,7 @@ THH:mm:ss.sss
           `if` `(` Expression[+In, ?Yield, ?Await] `)` FunctionDeclaration[?Yield, ?Await, ~Default] `else` FunctionDeclaration[?Yield, ?Await, ~Default]
           `if` `(` Expression[+In, ?Yield, ?Await] `)` FunctionDeclaration[?Yield, ?Await, ~Default] [lookahead != `else`]
       </emu-grammar>
-      <p>This production only applies when parsing non-strict code. Code matched by this production is processed as if each matching occurrence of |FunctionDeclaration[?Yield, ?Await, ~Default]| was the sole |StatementListItem| of a |BlockStatement| occupying that position in the source text. The semantics of such a synthetic |BlockStatement| includes the web legacy compatibility semantics specified in <emu-xref href="#sec-block-level-function-declarations-web-legacy-compatibility-semantics"></emu-xref>.</p>
+      <p>This production only applies when parsing non-strict code. Source text matched by this production is processed as if each matching occurrence of |FunctionDeclaration[?Yield, ?Await, ~Default]| was the sole |StatementListItem| of a |BlockStatement| occupying that position in the source text. The semantics of such a synthetic |BlockStatement| includes the web legacy compatibility semantics specified in <emu-xref href="#sec-block-level-function-declarations-web-legacy-compatibility-semantics"></emu-xref>.</p>
     </emu-annex>
 
     <emu-annex id="sec-variablestatements-in-catch-blocks">

--- a/spec.html
+++ b/spec.html
@@ -11870,7 +11870,7 @@
         1. If _env_ is not present or if _env_ is *undefined*, then
           1. Set _env_ to the running execution context's LexicalEnvironment.
         1. Assert: _env_ is an Environment Record.
-        1. If the code matching the syntactic production that is being evaluated is contained in strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
+        1. If the code matched by the syntactic production that is being evaluated is contained in strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
         1. Return ? GetIdentifierReference(_env_, _name_, _strict_).
       </emu-alg>
       <emu-note>
@@ -16685,7 +16685,7 @@
           DecimalIntegerLiteral :: NonOctalDecimalIntegerLiteral
         </emu-grammar>
         <ul>
-          <li>It is a Syntax Error if the source code matching this production is strict mode code.</li>
+          <li>It is a Syntax Error if the source code matched by this production is strict mode code.</li>
         </ul>
         <emu-note>In non-strict code, this syntax is Legacy.</emu-note>
       </emu-clause>
@@ -16952,7 +16952,7 @@
             NonOctalDecimalEscapeSequence
         </emu-grammar>
         <ul>
-          <li>It is a Syntax Error if the source code matching this production is strict mode code.</li>
+          <li>It is a Syntax Error if the source code matched by this production is strict mode code.</li>
         </ul>
         <emu-note>In non-strict code, this syntax is Legacy.</emu-note>
         <emu-note>
@@ -18243,7 +18243,7 @@
         <emu-grammar>PropertyDefinition : CoverInitializedName</emu-grammar>
         <ul>
           <li>
-            Always throw a Syntax Error if code matches this production.
+            Always throw a Syntax Error if code is matched by this production.
           </li>
         </ul>
         <emu-note>
@@ -18846,7 +18846,7 @@
         </emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if any code matches this production.
+            It is a Syntax Error if any code is matched by this production.
           </li>
         </ul>
         <emu-note>
@@ -19041,7 +19041,7 @@
               1. Let _argList_ be ? ArgumentListEvaluation of _arguments_.
               1. If _argList_ has no elements, return *undefined*.
               1. Let _evalArg_ be the first element of _argList_.
-              1. If the source code matching this |CallExpression| is strict mode code, let _strictCaller_ be *true*. Otherwise let _strictCaller_ be *false*.
+              1. If the source code matched by this |CallExpression| is strict mode code, let _strictCaller_ be *true*. Otherwise let _strictCaller_ be *false*.
               1. Let _evalRealm_ be the current Realm Record.
               1. [id="step-callexpression-evaluation-direct-eval"] Return ? PerformEval(_evalArg_, _evalRealm_, _strictCaller_, *true*).
           1. Let _thisCall_ be this |CallExpression|.
@@ -22432,7 +22432,7 @@
       <emu-grammar>WithStatement : `with` `(` Expression `)` Statement</emu-grammar>
       <ul>
         <li>
-          It is a Syntax Error if the code that matches this production is contained in strict mode code.
+          It is a Syntax Error if the code matched by this production is contained in strict mode code.
         </li>
         <li>
           It is a Syntax Error if IsLabelledFunction(|Statement|) is *true*.
@@ -22642,7 +22642,7 @@
       <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
       <ul>
         <li>
-          It is a Syntax Error if any source text matches this rule.
+          It is a Syntax Error if any source text is matched by this rule.
         </li>
       </ul>
       <emu-note>
@@ -23222,10 +23222,10 @@
       </emu-grammar>
       <ul>
         <li>
-          If the source code matching |FormalParameters| is strict mode code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.
+          If the source code matched by |FormalParameters| is strict mode code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.
         </li>
         <li>
-          If |BindingIdentifier| is present and the source code matching |BindingIdentifier| is strict mode code, it is a Syntax Error if the StringValue of |BindingIdentifier| is *"eval"* or *"arguments"*.
+          If |BindingIdentifier| is present and the source code matched by |BindingIdentifier| is strict mode code, it is a Syntax Error if the StringValue of |BindingIdentifier| is *"eval"* or *"arguments"*.
         </li>
         <li>
           It is a Syntax Error if FunctionBodyContainsUseStrict of |FunctionBody| is *true* and IsSimpleParameterList of |FormalParameters| is *false*.
@@ -23800,10 +23800,10 @@
       </emu-grammar>
       <ul>
         <li>
-          If the source code matching |FormalParameters| is strict mode code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.
+          If the source code matched by |FormalParameters| is strict mode code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.
         </li>
         <li>
-          If |BindingIdentifier| is present and the source code matching |BindingIdentifier| is strict mode code, it is a Syntax Error if the StringValue of |BindingIdentifier| is *"eval"* or *"arguments"*.
+          If |BindingIdentifier| is present and the source code matched by |BindingIdentifier| is strict mode code, it is a Syntax Error if the StringValue of |BindingIdentifier| is *"eval"* or *"arguments"*.
         </li>
         <li>
           It is a Syntax Error if FunctionBodyContainsUseStrict of |GeneratorBody| is *true* and IsSimpleParameterList of |FormalParameters| is *false*.
@@ -24039,8 +24039,8 @@
           `async` `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
       </emu-grammar>
       <ul>
-        <li>If the source code matching |FormalParameters| is strict mode code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.</li>
-        <li>If |BindingIdentifier| is present and the source code matching |BindingIdentifier| is strict mode code, it is a Syntax Error if the StringValue of |BindingIdentifier| is *"eval"* or *"arguments"*.</li>
+        <li>If the source code matched by |FormalParameters| is strict mode code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.</li>
+        <li>If |BindingIdentifier| is present and the source code matched by |BindingIdentifier| is strict mode code, it is a Syntax Error if the StringValue of |BindingIdentifier| is *"eval"* or *"arguments"*.</li>
         <li>It is a Syntax Error if FunctionBodyContainsUseStrict of |AsyncGeneratorBody| is *true* and IsSimpleParameterList of |FormalParameters| is *false*.</li>
         <li>It is a Syntax Error if any element of the BoundNames of |FormalParameters| also occurs in the LexicallyDeclaredNames of |AsyncGeneratorBody|.</li>
         <li>It is a Syntax Error if |FormalParameters| Contains |YieldExpression| is *true*.</li>
@@ -24985,8 +24985,8 @@
       <ul>
         <li>It is a Syntax Error if FunctionBodyContainsUseStrict of |AsyncFunctionBody| is *true* and IsSimpleParameterList of |FormalParameters| is *false*.</li>
         <li>It is a Syntax Error if |FormalParameters| Contains |AwaitExpression| is *true*.</li>
-        <li>If the source code matching |FormalParameters| is strict mode code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.</li>
-        <li>If |BindingIdentifier| is present and the source code matching |BindingIdentifier| is strict mode code, it is a Syntax Error if the StringValue of |BindingIdentifier| is *"eval"* or *"arguments"*.</li>
+        <li>If the source code matched by |FormalParameters| is strict mode code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.</li>
+        <li>If |BindingIdentifier| is present and the source code matched by |BindingIdentifier| is strict mode code, it is a Syntax Error if the StringValue of |BindingIdentifier| is *"eval"* or *"arguments"*.</li>
         <li>It is a Syntax Error if any element of the BoundNames of |FormalParameters| also occurs in the LexicallyDeclaredNames of |AsyncFunctionBody|.</li>
         <li>It is a Syntax Error if |FormalParameters| Contains |SuperProperty| is *true*.</li>
         <li>It is a Syntax Error if |AsyncFunctionBody| Contains |SuperProperty| is *true*.</li>
@@ -25259,7 +25259,7 @@
       <dl class="header">
       </dl>
       <emu-alg>
-        1. If the source code matching _call_ is non-strict code, return *false*.
+        1. If the source code matched by _call_ is non-strict code, return *false*.
         1. If _call_ is not contained within a |FunctionBody|, |ConciseBody|, or |AsyncConciseBody|, return *false*.
         1. Let _body_ be the |FunctionBody|, |ConciseBody|, or |AsyncConciseBody| that most closely contains _call_.
         1. If _body_ is the |FunctionBody| of a |GeneratorBody|, return *false*.
@@ -28503,7 +28503,7 @@
         The RegExp pattern grammars in <emu-xref href="#sec-patterns"></emu-xref> and <emu-xref href="#sec-regular-expressions-patterns"></emu-xref> must not be extended to recognize any of the source characters A-Z or a-z as |IdentityEscape[+UnicodeMode]| when the <sub>[UnicodeMode]</sub> grammar parameter is present.
       </li>
       <li>
-        The Syntactic Grammar must not be extended in any manner that allows the token `:` to immediately follow source text that matches the |BindingIdentifier| nonterminal symbol.
+        The Syntactic Grammar must not be extended in any manner that allows the token `:` to immediately follow source text that is matched by the |BindingIdentifier| nonterminal symbol.
       </li>
       <li>
         When processing strict mode code, an implementation must not relax the early error rules of <emu-xref href="#sec-numeric-literals-early-errors"></emu-xref>.
@@ -29949,7 +29949,7 @@
             1. Let _body_ be ParseText(! StringToCodePoints(_bodyString_), _bodySym_).
             1. If _body_ is a List of errors, throw a *SyntaxError* exception.
             1. NOTE: The parameters and body are parsed separately to ensure that each is valid alone. For example, `new Function("/*", "*/ ) {")` is not legal.
-            1. NOTE: If this step is reached, _sourceText_ must match _exprSym_ (although the reverse implication does not hold). The purpose of the next two steps is to enforce any Early Error rules which apply to _exprSym_ directly.
+            1. NOTE: If this step is reached, _sourceText_ must have the syntax of _exprSym_ (although the reverse implication does not hold). The purpose of the next two steps is to enforce any Early Error rules which apply to _exprSym_ directly.
             1. Let _expr_ be ParseText(_sourceText_, _exprSym_).
             1. If _expr_ is a List of errors, throw a *SyntaxError* exception.
             1. Let _proto_ be ? GetPrototypeFromConstructor(_newTarget_, _fallbackProto_).
@@ -46797,7 +46797,7 @@ THH:mm:ss.sss
         <emu-grammar>ExtendedAtom :: InvalidBracedQuantifier</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if any source text matches this rule.
+            It is a Syntax Error if any source text is matched by this rule.
           </li>
         </ul>
         <p>Additionally, the rules for the following productions are modified with the addition of the <ins>highlighted</ins> text:</p>
@@ -47325,7 +47325,7 @@ THH:mm:ss.sss
       <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
       <ul>
         <li>
-          It is a Syntax Error if any <ins>strict mode</ins> source code matches this rule.
+          It is a Syntax Error if any <ins>strict mode</ins> source code is matched by this rule.
         </li>
       </ul>
       <emu-note>
@@ -47490,7 +47490,7 @@ THH:mm:ss.sss
         <emu-grammar>Block : `{` StatementList `}`</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the LexicallyDeclaredNames of |StatementList| contains any duplicate entries<ins>, unless the source code matching this production is not strict mode code and the duplicate entries are only bound by FunctionDeclarations</ins>.
+            It is a Syntax Error if the LexicallyDeclaredNames of |StatementList| contains any duplicate entries<ins>, unless the source code matched by this production is not strict mode code and the duplicate entries are only bound by FunctionDeclarations</ins>.
           </li>
           <li>
             It is a Syntax Error if any element of the LexicallyDeclaredNames of |StatementList| also occurs in the VarDeclaredNames of |StatementList|.
@@ -47504,7 +47504,7 @@ THH:mm:ss.sss
         <emu-grammar>SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the LexicallyDeclaredNames of |CaseBlock| contains any duplicate entries<ins>, unless the source code matching this production is not strict mode code and the duplicate entries are only bound by FunctionDeclarations</ins>.
+            It is a Syntax Error if the LexicallyDeclaredNames of |CaseBlock| contains any duplicate entries<ins>, unless the source code matched by this production is not strict mode code and the duplicate entries are only bound by FunctionDeclarations</ins>.
           </li>
           <li>
             It is a Syntax Error if any element of the LexicallyDeclaredNames of |CaseBlock| also occurs in the VarDeclaredNames of |CaseBlock|.
@@ -47540,7 +47540,7 @@ THH:mm:ss.sss
           `if` `(` Expression[+In, ?Yield, ?Await] `)` FunctionDeclaration[?Yield, ?Await, ~Default] `else` FunctionDeclaration[?Yield, ?Await, ~Default]
           `if` `(` Expression[+In, ?Yield, ?Await] `)` FunctionDeclaration[?Yield, ?Await, ~Default] [lookahead != `else`]
       </emu-grammar>
-      <p>This production only applies when parsing non-strict code. Code matching this production is processed as if each matching occurrence of |FunctionDeclaration[?Yield, ?Await, ~Default]| was the sole |StatementListItem| of a |BlockStatement| occupying that position in the source code. The semantics of such a synthetic |BlockStatement| includes the web legacy compatibility semantics specified in <emu-xref href="#sec-block-level-function-declarations-web-legacy-compatibility-semantics"></emu-xref>.</p>
+      <p>This production only applies when parsing non-strict code. Code matched by this production is processed as if each matching occurrence of |FunctionDeclaration[?Yield, ?Await, ~Default]| was the sole |StatementListItem| of a |BlockStatement| occupying that position in the source code. The semantics of such a synthetic |BlockStatement| includes the web legacy compatibility semantics specified in <emu-xref href="#sec-block-level-function-declarations-web-legacy-compatibility-semantics"></emu-xref>.</p>
     </emu-annex>
 
     <emu-annex id="sec-variablestatements-in-catch-blocks">


### PR DESCRIPTION
Say we parsed some source text according to a grammar, and we then want to use the verb "match". The question is, which 'way' does "match" go? The spec isn't consistent.

That is, given 'prod' (a nonterminal, production, or Parse Node) and 'text' (some source text, source code, or code points), the spec has both:
- A) prod matches text / text is matched by prod
and
- B) text matches prod / prod is matched by text

Almost always, the 'text' comes before the 'prod', so it's largely a choice between:
- A) text is matched by prod
and
- B) text matches prod

I looked through the spec and found about
- 65 occurrences of A
and
- 28 occurrences of B


Moreover, the only `<dfn>` we have involving "match" is "The <dfn>source text matched by</dfn> a grammar production", i.e. sense A.

So this PR changes occurrences of form B into form A.

(This PR was prompted by PR #2571 and agrees with it on the 2 lines that they both change.)