### PR TITLE
Editorial: Disambiguate "This property"

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -30167,7 +30167,6 @@
           1. Let _F_ be the *this* value.
           1. Return ? OrdinaryHasInstance(_F_, _V_).
         </emu-alg>
-        <p>The value of the *"name"* property of this function is *"[Symbol.hasInstance]"*.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
         <emu-note>
           <p>This is the default implementation of `@@hasInstance` that most functions inherit. `@@hasInstance` is called by the `instanceof` operator to determine whether a value is an instance of a specific constructor. An expression such as</p>
@@ -30181,6 +30180,7 @@
           <p>A constructor function can control which objects are recognized as its instances by `instanceof` by exposing a different `@@hasInstance` method on the function.</p>
         </emu-note>
         <p>This property is non-writable and non-configurable to prevent tampering that could be used to globally expose the target function of a bound function.</p>
+        <p>The value of the *"name"* property of this function is *"[Symbol.hasInstance]"*.</p>
       </emu-clause>
     </emu-clause>
 
@@ -30579,11 +30579,11 @@
         <emu-alg>
           1. Return ? thisSymbolValue(*this* value).
         </emu-alg>
-        <p>The value of the *"name"* property of this function is *"[Symbol.toPrimitive]"*.</p>
-        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
         <emu-note>
           <p>The argument is ignored.</p>
         </emu-note>
+        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+        <p>The value of the *"name"* property of this function is *"[Symbol.toPrimitive]"*.</p>
       </emu-clause>
 
       <emu-clause id="sec-symbol.prototype-@@tostringtag">
@@ -33389,8 +33389,8 @@ THH:mm:ss.sss
           1. Else, throw a *TypeError* exception.
           1. Return ? OrdinaryToPrimitive(_O_, _tryFirst_).
         </emu-alg>
-        <p>The value of the *"name"* property of this function is *"[Symbol.toPrimitive]"*.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+        <p>The value of the *"name"* property of this function is *"[Symbol.toPrimitive]"*.</p>
       </emu-clause>
     </emu-clause>
 


### PR DESCRIPTION
Each of these clauses:
- [Function.prototype[@@hasInstance]](https://tc39.es/ecma262/#sec-function.prototype-@@hasinstance)
- [Symbol.prototype[@@toPrimitive]](https://tc39.es/ecma262/#sec-symbol.prototype-@@toprimitive)
- [Date.prototype[@@toPrimitive]](https://tc39.es/ecma262/#sec-date.prototype-@@toprimitive)

has a pair of paragraphs of the form:
```
<p>The value of the *"name"* property of this function is *"[...]"*.</p>
<p>This property has the attributes { [[Writable]]: *false*, ...}.</p>
```
In the second para, "This property" appears to refer to the `name` property mentioned in the preceding para. But I'm pretty sure that it's supposed to refer to the `@@hasInstance` or `@@toPrimitive` property that is the subject of the whole section.

To avoid this ambiguity, this PR puts the `name` para *after* the "This property" para (and after any other such paras in the clause). (Note that [get %TypedArray%.prototype[@@toStringTag]](https://tc39.es/ecma262/#sec-get-%typedarray%.prototype-@@tostringtag) already has this arrangement.)

(This goes back to ES6.)