### PR TITLE
Editorial: Consistify prose for same-value properties

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -30994,12 +30994,12 @@
 
       <emu-clause id="sec-number.parsefloat">
         <h1>Number.parseFloat ( _string_ )</h1>
-        <p>The value of the `Number.parseFloat` data property is the same built-in function object that is the initial value of the *"parseFloat"* property of the global object defined in <emu-xref href="#sec-parsefloat-string"></emu-xref>.</p>
+        <p>The initial value of the *"parseFloat"* property is %parseFloat%.</p>
       </emu-clause>
 
       <emu-clause id="sec-number.parseint">
         <h1>Number.parseInt ( _string_, _radix_ )</h1>
-        <p>The value of the `Number.parseInt` data property is the same built-in function object that is the initial value of the *"parseInt"* property of the global object defined in <emu-xref href="#sec-parseint-string-radix"></emu-xref>.</p>
+        <p>The initial value of the *"parseInt"* property is %parseInt%.</p>
       </emu-clause>
 
       <emu-clause id="sec-number.positive_infinity">
@@ -37941,7 +37941,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-array.prototype-@@iterator">
         <h1>Array.prototype [ @@iterator ] ( )</h1>
-        <p>The initial value of the @@iterator property is the same function object as the initial value of the `Array.prototype.values` property.</p>
+        <p>The initial value of the @@iterator property is %Array.prototype.values%, defined in <emu-xref href="#sec-array.prototype.values"></emu-xref>.</p>
       </emu-clause>
 
       <emu-clause id="sec-array.prototype-@@unscopables">
@@ -39145,7 +39145,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-%typedarray%.prototype.tostring">
         <h1>%TypedArray%.prototype.toString ( )</h1>
-        <p>The initial value of the %TypedArray%`.prototype.toString` data property is the same built-in function object as the `Array.prototype.toString` method defined in <emu-xref href="#sec-array.prototype.tostring"></emu-xref>.</p>
+        <p>The initial value of the *"toString"* property is %Array.prototype.toString%, defined in <emu-xref href="#sec-array.prototype.tostring"></emu-xref>.</p>
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.values">
@@ -39160,7 +39160,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-%typedarray%.prototype-@@iterator">
         <h1>%TypedArray%.prototype [ @@iterator ] ( )</h1>
-        <p>The initial value of the @@iterator property is the same function object as the initial value of the %TypedArray%`.prototype.values` property.</p>
+        <p>The initial value of the @@iterator property is %TypedArray.prototype.values%, defined in <emu-xref href="#sec-%typedarray%.prototype.values"></emu-xref>.</p>
       </emu-clause>
 
       <emu-clause id="sec-get-%typedarray%.prototype-@@tostringtag">
@@ -39774,7 +39774,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-map.prototype-@@iterator">
         <h1>Map.prototype [ @@iterator ] ( )</h1>
-        <p>The initial value of the @@iterator property is the same function object as the initial value of the *"entries"* property.</p>
+        <p>The initial value of the @@iterator property is %Map.prototype.entries%, defined in <emu-xref href="#sec-map.prototype.entries"></emu-xref>.</p>
       </emu-clause>
 
       <emu-clause id="sec-map.prototype-@@tostringtag">
@@ -40032,7 +40032,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-set.prototype.keys">
         <h1>Set.prototype.keys ( )</h1>
-        <p>The initial value of the *"keys"* property is the same function object as the initial value of the *"values"* property.</p>
+        <p>The initial value of the *"keys"* property is %Set.prototype.values%, defined in <emu-xref href="#sec-set.prototype.values"></emu-xref>.</p>
         <emu-note>
           <p>For iteration purposes, a Set appears similar to a Map where each entry has the same value for its key and value.</p>
         </emu-note>
@@ -40063,7 +40063,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-set.prototype-@@iterator">
         <h1>Set.prototype [ @@iterator ] ( )</h1>
-        <p>The initial value of the @@iterator property is the same function object as the initial value of the *"values"* property.</p>
+        <p>The initial value of the @@iterator property is %Set.prototype.values%, defined in <emu-xref href="#sec-set.prototype.values"></emu-xref>.</p>
       </emu-clause>
 
       <emu-clause id="sec-set.prototype-@@tostringtag">
@@ -47231,7 +47231,7 @@ THH:mm:ss.sss
         <emu-note>
           <p>The property *"trimStart"* is preferred. The *"trimLeft"* property is provided principally for compatibility with old code. It is recommended that the *"trimStart"* property be used in new ECMAScript code.</p>
         </emu-note>
-        <p>The initial value of the *"trimLeft"* property is the same function object as the initial value of the `String.prototype.trimStart` property.</p>
+        <p>The initial value of the *"trimLeft"* property is %String.prototype.trimStart%, defined in <emu-xref href="#sec-string.prototype.trimstart"></emu-xref>.</p>
       </emu-annex>
 
       <emu-annex id="String.prototype.trimright">
@@ -47239,7 +47239,7 @@ THH:mm:ss.sss
         <emu-note>
           <p>The property *"trimEnd"* is preferred. The *"trimRight"* property is provided principally for compatibility with old code. It is recommended that the *"trimEnd"* property be used in new ECMAScript code.</p>
         </emu-note>
-        <p>The initial value of the *"trimRight"* property is the same function object as the initial value of the `String.prototype.trimEnd` property.</p>
+        <p>The initial value of the *"trimRight"* property is %String.prototype.trimEnd%, defined in <emu-xref href="#sec-string.prototype.trimend"></emu-xref>.</p>
       </emu-annex>
     </emu-annex>
 
@@ -47287,7 +47287,7 @@ THH:mm:ss.sss
         <emu-note>
           <p>The `toUTCString` method is preferred. The `toGMTString` method is provided principally for compatibility with old code.</p>
         </emu-note>
-        <p>The function object that is the initial value of `Date.prototype.toGMTString` is the same function object that is the initial value of `Date.prototype.toUTCString`.</p>
+        <p>The initial value of the *"toGMTString"* property is %Date.prototype.toUTCString%, defined in <emu-xref href="#sec-date.prototype.toutcstring"></emu-xref>.</p>
       </emu-annex>
     </emu-annex>
 


### PR DESCRIPTION
Use consistent prose when the initial values of two intrinsic-properties are the same object.
