### PR TITLE
Editorial: fix a couple typos

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -13663,7 +13663,7 @@
               1. Insert _d_ as the first element of _functionsToInitialize_.
         1. Let _argumentsObjectNeeded_ be *true*.
         1. If _func_.[[ThisMode]] is ~lexical~, then
-          1. NOTE: Arrow functions never have an arguments objects.
+          1. NOTE: Arrow functions never have an arguments object.
           1. Set _argumentsObjectNeeded_ to *false*.
         1. Else if *"arguments"* is an element of _parameterNames_, then
           1. Set _argumentsObjectNeeded_ to *false*.
@@ -27630,7 +27630,7 @@
             1. If SameValue(_exportName_, *"default"*) is *true*, then
               1. Assert: A `default` export was not explicitly defined by this module.
               1. Return *null*.
-              1. NOTE: A `default` export cannot be provided by an `export *` or `export * from "mod"` declaration.
+              1. NOTE: A `default` export cannot be provided by an `export * from "mod"` declaration.
             1. Let _starResolution_ be *null*.
             1. For each ExportEntry Record _e_ of _module_.[[StarExportEntries]], do
               1. Let _importedModule_ be ? HostResolveImportedModule(_module_, _e_.[[ModuleRequest]]).


### PR DESCRIPTION
- "an arguments objects" -> "an arguments object"
- remove reference to `export *;`, which is not a thing
