### PR TITLE
Editorial: Simplify runtime semantics for EvaluateBody

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -13314,33 +13314,33 @@
         </dl>
         <emu-grammar>FunctionBody : FunctionStatementList</emu-grammar>
         <emu-alg>
-          1. Return ? EvaluateFunctionBody of |FunctionBody| with arguments _functionObject_ and _argumentsList_.
+          1. Return EvaluateFunctionBody of |FunctionBody| with arguments _functionObject_ and _argumentsList_.
         </emu-alg>
         <emu-grammar>ConciseBody : ExpressionBody</emu-grammar>
         <emu-alg>
-          1. Return ? EvaluateConciseBody of |ConciseBody| with arguments _functionObject_ and _argumentsList_.
+          1. Return EvaluateConciseBody of |ConciseBody| with arguments _functionObject_ and _argumentsList_.
         </emu-alg>
         <emu-grammar>GeneratorBody : FunctionBody</emu-grammar>
         <emu-alg>
-          1. Return ? EvaluateGeneratorBody of |GeneratorBody| with arguments _functionObject_ and _argumentsList_.
+          1. Return EvaluateGeneratorBody of |GeneratorBody| with arguments _functionObject_ and _argumentsList_.
         </emu-alg>
         <emu-grammar>
           AsyncGeneratorBody : FunctionBody
         </emu-grammar>
         <emu-alg>
-          1. Return ? EvaluateAsyncGeneratorBody of |AsyncGeneratorBody| with arguments _functionObject_ and _argumentsList_.
+          1. Return EvaluateAsyncGeneratorBody of |AsyncGeneratorBody| with arguments _functionObject_ and _argumentsList_.
         </emu-alg>
         <emu-grammar>
           AsyncFunctionBody : FunctionBody
         </emu-grammar>
         <emu-alg>
-          1. Return ? EvaluateAsyncFunctionBody of |AsyncFunctionBody| with arguments _functionObject_ and _argumentsList_.
+          1. Return EvaluateAsyncFunctionBody of |AsyncFunctionBody| with arguments _functionObject_ and _argumentsList_.
         </emu-alg>
         <emu-grammar>
           AsyncConciseBody : ExpressionBody
         </emu-grammar>
         <emu-alg>
-          1. Return ? EvaluateAsyncConciseBody of |AsyncConciseBody| with arguments _functionObject_ and _argumentsList_.
+          1. Return EvaluateAsyncConciseBody of |AsyncConciseBody| with arguments _functionObject_ and _argumentsList_.
         </emu-alg>
         <emu-grammar>
           Initializer :


### PR DESCRIPTION
This editorial change simplifies potentially confusing runtime semantics for Evaluate Body, by removing the implicit ReturnIfAbrupt `?` shorthand.

# Motivation

Let us assume we have a completion record, `completionRecord` for the following algorithm:

```
1. Return ? Completion(completionRecord)
```

Consider the below rules:

- `?` is shorthand for `ReturnIfAbrupt`
- `ReturnIfAbrupt` is shorthand for the algorithm specified in `#sec-returnifabrupt`
- ECMAScript Language Values are implicitly converted into NormalCompletions as specified in `#sec-implicit-completion-values`

Expanding this algorithm, using the following rules we end up with the following:

```
1. If _completionRecord_ is an abrupt completion, return _completionRecord_
1. Else if _completionRecord_ is a Completion Record, set _completionRecord_ to _completionRecord_.[[Value]].
1. Return NormalCompletion(__completionRecord__)
```

Because we know `completionRecord` to be a completion record, we can deduce that the `?` operation is entirely pointless. Without it, the original algorithm becomes:

```
1. Return Completion(completionRecord)
```

The benefits of applying this transform are as follows:

- The new algorithm is succinct
- It less confusing, as using the `?` operator when a completion record is expected by the caller of this runtime semantic seems contradiction.

# Proving correctness of this PR

We know that:
- (1) when the specification states "the result of evaluating |Production|", that the result will be guaranteed to be a completion record, as all functions return completion records
- (2) the statement "Return Completion { ... }" will return a completion record

In this PR, we invoke 6 runtime semantics. We know that `?` will return an abrupt completion, so we only need to focus on the return statements of those six runtime semantics. The runtime semantics and their return statements are listed below:

- **Runtime Semantics: EvaluateFunctionBody**

  ```
  Return the result of evaluating |FunctionStatementList|.
  ```
  
- **Runtime Semantics: EvaluateConciseBody**

  ```
  Return the result of evaluating |ExpressionBody|.
  ```
  
- **Runtime Semantics: EvaluateGeneratorBody**

  ```
  Return Completion { [[Type]]: ~return~, [[Value]]: _G_, [[Target]]: ~empty~ }.
  ```
  
- **Runtime Semantics: EvaluateAsyncGeneratorBody**

  ```
  Return Completion { [[Type]]: ~return~, [[Value]]: _generator_, [[Target]]: ~empty~ }.
  ```
  
- **Runtime Semantics: EvaluateAsyncFunctionBody**

  ```
  Return Completion { [[Type]]: ~return~, [[Value]]: _promiseCapability_.[[Promise]], [[Target]]: ~empty~ }.
  ```
  
- **Runtime Semantics: EvaluateAsyncConciseBody**

  ```
  Return Completion { [[Type]]: ~return~, [[Value]]: _promiseCapability_.[[Promise]], [[Target]]: ~empty~ }.
  ```

All runtime semantics match rules (1) and (2) mentioned above. Thus, we know that invoking all these runtime semantics will return a completion record. Therefore, applying the transformation listed in the Motivation section is justified.
