### PR TITLE
Editorial: Use abstract closures in `Promise` static methods

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -43650,7 +43650,7 @@ THH:mm:ss.sss
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-performpromiseall" type="abstract operation">
+        <emu-clause id="sec-performpromiseall" oldids="sec-promise.all-resolve-element-functions" type="abstract operation">
           <h1>
             PerformPromiseAll (
               _iteratorRecord_: unknown,
@@ -43681,40 +43681,22 @@ THH:mm:ss.sss
               1. ReturnIfAbrupt(_nextValue_).
               1. Append *undefined* to _values_.
               1. Let _nextPromise_ be ? Call(_promiseResolve_, _constructor_, &laquo; _nextValue_ &raquo;).
-              1. Let _steps_ be the algorithm steps defined in <emu-xref href="#sec-promise.all-resolve-element-functions" title></emu-xref>.
-              1. Let _length_ be the number of non-optional parameters of the function definition in <emu-xref href="#sec-promise.all-resolve-element-functions" title></emu-xref>.
-              1. Let _onFulfilled_ be ! CreateBuiltinFunction(_steps_, _length_, *""*, &laquo; [[AlreadyCalled]], [[Index]], [[Values]], [[Capability]], [[RemainingElements]] &raquo;).
+              1. Let _fulfilledClosure_ be a new Abstract Closure with parameters (_value_) that captures _index_, _values_, _resultCapability_, and _remainingElementsCount_ and performs the following steps when called:
+                1. Let _F_ be the active function object.
+                1. If _F_.[[AlreadyCalled]] is *true*, return *undefined*.
+                1. Set _F_.[[AlreadyCalled]] to *true*.
+                1. Set _values_[_index_] to _value_.
+                1. Set _remainingElementsCount_.[[Value]] to _remainingElementsCount_.[[Value]] - 1.
+                1. If _remainingElementsCount_.[[Value]] is 0, then
+                  1. Let _valuesArray_ be ! CreateArrayFromList(_values_).
+                  1. Return ? Call(_resultCapability_.[[Resolve]], *undefined*, &laquo; _valuesArray_ &raquo;).
+                1. Return *undefined*.
+              1. Let _onFulfilled_ be ! CreateBuiltinFunction(_fulfilledClosure_, 1, *""*, &laquo; [[AlreadyCalled]] &raquo;).
               1. Set _onFulfilled_.[[AlreadyCalled]] to *false*.
-              1. Set _onFulfilled_.[[Index]] to _index_.
-              1. Set _onFulfilled_.[[Values]] to _values_.
-              1. Set _onFulfilled_.[[Capability]] to _resultCapability_.
-              1. Set _onFulfilled_.[[RemainingElements]] to _remainingElementsCount_.
               1. Set _remainingElementsCount_.[[Value]] to _remainingElementsCount_.[[Value]] + 1.
               1. Perform ? Invoke(_nextPromise_, *"then"*, &laquo; _onFulfilled_, _resultCapability_.[[Reject]] &raquo;).
               1. Set _index_ to _index_ + 1.
           </emu-alg>
-        </emu-clause>
-
-        <emu-clause id="sec-promise.all-resolve-element-functions">
-          <h1>`Promise.all` Resolve Element Functions</h1>
-          <p>A `Promise.all` resolve element function is an anonymous built-in function that is used to resolve a specific `Promise.all` element. Each `Promise.all` resolve element function has [[Index]], [[Values]], [[Capability]], [[RemainingElements]], and [[AlreadyCalled]] internal slots.</p>
-          <p>When a `Promise.all` resolve element function is called with argument _x_, the following steps are taken:</p>
-          <emu-alg>
-            1. Let _F_ be the active function object.
-            1. If _F_.[[AlreadyCalled]] is *true*, return *undefined*.
-            1. Set _F_.[[AlreadyCalled]] to *true*.
-            1. Let _index_ be _F_.[[Index]].
-            1. Let _values_ be _F_.[[Values]].
-            1. Let _promiseCapability_ be _F_.[[Capability]].
-            1. Let _remainingElementsCount_ be _F_.[[RemainingElements]].
-            1. Set _values_[_index_] to _x_.
-            1. Set _remainingElementsCount_.[[Value]] to _remainingElementsCount_.[[Value]] - 1.
-            1. If _remainingElementsCount_.[[Value]] is 0, then
-              1. Let _valuesArray_ be ! CreateArrayFromList(_values_).
-              1. Return ? Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _valuesArray_ &raquo;).
-            1. Return *undefined*.
-          </emu-alg>
-          <p>The *"length"* property of a `Promise.all` resolve element function is *1*<sub>𝔽</sub>.</p>
         </emu-clause>
       </emu-clause>
 
@@ -43738,7 +43720,7 @@ THH:mm:ss.sss
           <p>The `allSettled` function requires its *this* value to be a constructor function that supports the parameter conventions of the Promise constructor.</p>
         </emu-note>
 
-        <emu-clause id="sec-performpromiseallsettled" type="abstract operation">
+        <emu-clause id="sec-performpromiseallsettled" oldids="sec-promise.allsettled-resolve-element-functions,sec-promise.allsettled-reject-element-functions" type="abstract operation">
           <h1>
             PerformPromiseAllSettled (
               _iteratorRecord_: unknown,
@@ -43769,79 +43751,37 @@ THH:mm:ss.sss
               1. ReturnIfAbrupt(_nextValue_).
               1. Append *undefined* to _values_.
               1. Let _nextPromise_ be ? Call(_promiseResolve_, _constructor_, &laquo; _nextValue_ &raquo;).
-              1. Let _stepsFulfilled_ be the algorithm steps defined in <emu-xref href="#sec-promise.allsettled-resolve-element-functions" title></emu-xref>.
-              1. Let _lengthFulfilled_ be the number of non-optional parameters of the function definition in <emu-xref href="#sec-promise.allsettled-resolve-element-functions" title></emu-xref>.
-              1. Let _onFulfilled_ be ! CreateBuiltinFunction(_stepsFulfilled_, _lengthFulfilled_, *""*, &laquo; [[AlreadyCalled]], [[Index]], [[Values]], [[Capability]], [[RemainingElements]] &raquo;).
               1. Let _alreadyCalled_ be the Record { [[Value]]: *false* }.
-              1. Set _onFulfilled_.[[AlreadyCalled]] to _alreadyCalled_.
-              1. Set _onFulfilled_.[[Index]] to _index_.
-              1. Set _onFulfilled_.[[Values]] to _values_.
-              1. Set _onFulfilled_.[[Capability]] to _resultCapability_.
-              1. Set _onFulfilled_.[[RemainingElements]] to _remainingElementsCount_.
-              1. Let _stepsRejected_ be the algorithm steps defined in <emu-xref href="#sec-promise.allsettled-reject-element-functions" title></emu-xref>.
-              1. Let _lengthRejected_ be the number of non-optional parameters of the function definition in <emu-xref href="#sec-promise.allsettled-reject-element-functions" title></emu-xref>.
-              1. Let _onRejected_ be ! CreateBuiltinFunction(_stepsRejected_, _lengthRejected_, *""*, &laquo; [[AlreadyCalled]], [[Index]], [[Values]], [[Capability]], [[RemainingElements]] &raquo;).
-              1. Set _onRejected_.[[AlreadyCalled]] to _alreadyCalled_.
-              1. Set _onRejected_.[[Index]] to _index_.
-              1. Set _onRejected_.[[Values]] to _values_.
-              1. Set _onRejected_.[[Capability]] to _resultCapability_.
-              1. Set _onRejected_.[[RemainingElements]] to _remainingElementsCount_.
+              1. Let _fulfilledClosure_ be a new Abstract Closure with parameters (_value_) that captures _alreadyCalled_, _index_, _values_, _resultCapability_, and _remainingElementsCount_ and performs the following steps when called:
+                1. If _alreadyCalled_.[[Value]] is *true*, return *undefined*.
+                1. Set _alreadyCalled_.[[Value]] to *true*.
+                1. Let _obj_ be ! OrdinaryObjectCreate(%Object.prototype%).
+                1. Perform ! CreateDataPropertyOrThrow(_obj_, *"status"*, *"fulfilled"*).
+                1. Perform ! CreateDataPropertyOrThrow(_obj_, *"value"*, _value_).
+                1. Set _values_[_index_] to _obj_.
+                1. Set _remainingElementsCount_.[[Value]] to _remainingElementsCount_.[[Value]] - 1.
+                1. If _remainingElementsCount_.[[Value]] is 0, then
+                  1. Let _valuesArray_ be ! CreateArrayFromList(_values_).
+                  1. Return ? Call(_resultCapability_.[[Resolve]], *undefined*, &laquo; _valuesArray_ &raquo;).
+                1. Return *undefined*.
+              1. Let _onFulfilled_ be ! CreateBuiltinFunction(_fulfilledClosure_, 1, *""*, &laquo; &raquo;).
+              1. Let _rejectedClosure_ be a new Abstract Closure with parameters (_reason_) that captures _alreadyCalled_, _index_, _values_, _resultCapability_, and _remainingElementsCount_ and performs the following steps when called:
+                1. If _alreadyCalled_.[[Value]] is *true*, return *undefined*.
+                1. Set _alreadyCalled_.[[Value]] to *true*.
+                1. Let _obj_ be ! OrdinaryObjectCreate(%Object.prototype%).
+                1. Perform ! CreateDataPropertyOrThrow(_obj_, *"status"*, *"rejected"*).
+                1. Perform ! CreateDataPropertyOrThrow(_obj_, *"reason"*, _reason_).
+                1. Set _values_[_index_] to _obj_.
+                1. Set _remainingElementsCount_.[[Value]] to _remainingElementsCount_.[[Value]] - 1.
+                1. If _remainingElementsCount_.[[Value]] is 0, then
+                  1. Let _valuesArray_ be ! CreateArrayFromList(_values_).
+                  1. Return ? Call(_resultCapability_.[[Resolve]], *undefined*, &laquo; _valuesArray_ &raquo;).
+                1. Return *undefined*.
+              1. Let _onRejected_ be ! CreateBuiltinFunction(_rejectedClosure_, 1, *""*, &laquo; &raquo;).
               1. Set _remainingElementsCount_.[[Value]] to _remainingElementsCount_.[[Value]] + 1.
               1. Perform ? Invoke(_nextPromise_, *"then"*, &laquo; _onFulfilled_, _onRejected_ &raquo;).
               1. Set _index_ to _index_ + 1.
           </emu-alg>
-        </emu-clause>
-
-        <emu-clause id="sec-promise.allsettled-resolve-element-functions">
-          <h1>`Promise.allSettled` Resolve Element Functions</h1>
-          <p>A `Promise.allSettled` resolve element function is an anonymous built-in function that is used to resolve a specific `Promise.allSettled` element. Each `Promise.allSettled` resolve element function has [[Index]], [[Values]], [[Capability]], [[RemainingElements]], and [[AlreadyCalled]] internal slots.</p>
-          <p>When a `Promise.allSettled` resolve element function is called with argument _x_, the following steps are taken:</p>
-          <emu-alg>
-            1. Let _F_ be the active function object.
-            1. Let _alreadyCalled_ be _F_.[[AlreadyCalled]].
-            1. If _alreadyCalled_.[[Value]] is *true*, return *undefined*.
-            1. Set _alreadyCalled_.[[Value]] to *true*.
-            1. Let _index_ be _F_.[[Index]].
-            1. Let _values_ be _F_.[[Values]].
-            1. Let _promiseCapability_ be _F_.[[Capability]].
-            1. Let _remainingElementsCount_ be _F_.[[RemainingElements]].
-            1. Let _obj_ be ! OrdinaryObjectCreate(%Object.prototype%).
-            1. Perform ! CreateDataPropertyOrThrow(_obj_, *"status"*, *"fulfilled"*).
-            1. Perform ! CreateDataPropertyOrThrow(_obj_, *"value"*, _x_).
-            1. Set _values_[_index_] to _obj_.
-            1. Set _remainingElementsCount_.[[Value]] to _remainingElementsCount_.[[Value]] - 1.
-            1. If _remainingElementsCount_.[[Value]] is 0, then
-              1. Let _valuesArray_ be ! CreateArrayFromList(_values_).
-              1. Return ? Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _valuesArray_ &raquo;).
-            1. Return *undefined*.
-          </emu-alg>
-          <p>The *"length"* property of a `Promise.allSettled` resolve element function is *1*<sub>𝔽</sub>.</p>
-        </emu-clause>
-
-        <emu-clause id="sec-promise.allsettled-reject-element-functions">
-          <h1>`Promise.allSettled` Reject Element Functions</h1>
-          <p>A `Promise.allSettled` reject element function is an anonymous built-in function that is used to reject a specific `Promise.allSettled` element. Each `Promise.allSettled` reject element function has [[Index]], [[Values]], [[Capability]], [[RemainingElements]], and [[AlreadyCalled]] internal slots.</p>
-          <p>When a `Promise.allSettled` reject element function is called with argument _x_, the following steps are taken:</p>
-          <emu-alg>
-            1. Let _F_ be the active function object.
-            1. Let _alreadyCalled_ be _F_.[[AlreadyCalled]].
-            1. If _alreadyCalled_.[[Value]] is *true*, return *undefined*.
-            1. Set _alreadyCalled_.[[Value]] to *true*.
-            1. Let _index_ be _F_.[[Index]].
-            1. Let _values_ be _F_.[[Values]].
-            1. Let _promiseCapability_ be _F_.[[Capability]].
-            1. Let _remainingElementsCount_ be _F_.[[RemainingElements]].
-            1. Let _obj_ be ! OrdinaryObjectCreate(%Object.prototype%).
-            1. Perform ! CreateDataPropertyOrThrow(_obj_, *"status"*, *"rejected"*).
-            1. Perform ! CreateDataPropertyOrThrow(_obj_, *"reason"*, _x_).
-            1. Set _values_[_index_] to _obj_.
-            1. Set _remainingElementsCount_.[[Value]] to _remainingElementsCount_.[[Value]] - 1.
-            1. If _remainingElementsCount_.[[Value]] is 0, then
-              1. Let _valuesArray_ be ! CreateArrayFromList(_values_).
-              1. Return ? Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _valuesArray_ &raquo;).
-            1. Return *undefined*.
-          </emu-alg>
-          <p>The *"length"* property of a `Promise.allSettled` reject element function is *1*<sub>𝔽</sub>.</p>
         </emu-clause>
       </emu-clause>
 
@@ -43865,7 +43805,7 @@ THH:mm:ss.sss
           <p>The `any` function requires its *this* value to be a constructor function that supports the parameter conventions of the `Promise` constructor.</p>
         </emu-note>
 
-        <emu-clause id="sec-performpromiseany" type="abstract operation">
+        <emu-clause id="sec-performpromiseany" oldids="sec-promise.any-reject-element-functions" type="abstract operation">
           <h1>
             PerformPromiseAny (
               _iteratorRecord_: unknown,
@@ -43897,9 +43837,18 @@ THH:mm:ss.sss
               1. ReturnIfAbrupt(_nextValue_).
               1. Append *undefined* to _errors_.
               1. Let _nextPromise_ be ? Call(_promiseResolve_, _constructor_, &laquo; _nextValue_ &raquo;).
-              1. Let _stepsRejected_ be the algorithm steps defined in <emu-xref href="#sec-promise.any-reject-element-functions" title></emu-xref>.
-              1. Let _lengthRejected_ be the number of non-optional parameters of the function definition in <emu-xref href="#sec-promise.any-reject-element-functions" title></emu-xref>.
-              1. Let _onRejected_ be ! CreateBuiltinFunction(_stepsRejected_, _lengthRejected_, *""*, &laquo; [[AlreadyCalled]], [[Index]], [[Errors]], [[Capability]], [[RemainingElements]] &raquo;).
+              1. Let _rejectedClosure_ be a new Abstract Closure with parameters (_reason_) that captures _index_, _errors_, _resultCapability_, and _remainingElementsCount_ and performs the following steps when called:
+                1. Let _F_ be the active function object.
+                1. If _F_.[[AlreadyCalled]] is *true*, return *undefined*.
+                1. Set _F_.[[AlreadyCalled]] to *true*.
+                1. Set _errors_[_index_] to _reason_.
+                1. Set _remainingElementsCount_.[[Value]] to _remainingElementsCount_.[[Value]] - 1.
+                1. If _remainingElementsCount_.[[Value]] is 0, then
+                  1. Let _error_ be a newly created *AggregateError* object.
+                  1. Perform ! DefinePropertyOrThrow(_error_, *"errors"*, PropertyDescriptor { [[Configurable]]: *true*, [[Enumerable]]: *false*, [[Writable]]: *true*, [[Value]]: ! CreateArrayFromList(_errors_) }).
+                  1. Return ? Call(_resultCapability_.[[Reject]], *undefined*, &laquo; _error_ &raquo;).
+                1. Return *undefined*.
+              1. Let _onRejected_ be ! CreateBuiltinFunction(_rejectedClosure_, 1, *""*, &laquo; [[AlreadyCalled]] &raquo;).
               1. Set _onRejected_.[[AlreadyCalled]] to *false*.
               1. Set _onRejected_.[[Index]] to _index_.
               1. Set _onRejected_.[[Errors]] to _errors_.
@@ -43909,29 +43858,6 @@ THH:mm:ss.sss
               1. Perform ? Invoke(_nextPromise_, *"then"*, &laquo; _resultCapability_.[[Resolve]], _onRejected_ &raquo;).
               1. Set _index_ to _index_ + 1.
           </emu-alg>
-        </emu-clause>
-
-        <emu-clause id="sec-promise.any-reject-element-functions">
-          <h1>`Promise.any` Reject Element Functions</h1>
-          <p>A `Promise.any` reject element function is an anonymous built-in function that is used to reject a specific `Promise.any` element. Each `Promise.any` reject element function has [[Index]], [[Errors]], [[Capability]], [[RemainingElements]], and [[AlreadyCalled]] internal slots.</p>
-          <p>When a `Promise.any` reject element function is called with argument _x_, the following steps are taken:</p>
-          <emu-alg>
-            1. Let _F_ be the active function object.
-            1. If _F_.[[AlreadyCalled]] is *true*, return *undefined*.
-            1. Set _F_.[[AlreadyCalled]] to *true*.
-            1. Let _index_ be _F_.[[Index]].
-            1. Let _errors_ be _F_.[[Errors]].
-            1. Let _promiseCapability_ be _F_.[[Capability]].
-            1. Let _remainingElementsCount_ be _F_.[[RemainingElements]].
-            1. Set _errors_[_index_] to _x_.
-            1. Set _remainingElementsCount_.[[Value]] to _remainingElementsCount_.[[Value]] - 1.
-            1. If _remainingElementsCount_.[[Value]] is 0, then
-              1. Let _error_ be a newly created *AggregateError* object.
-              1. Perform ! DefinePropertyOrThrow(_error_, *"errors"*, PropertyDescriptor { [[Configurable]]: *true*, [[Enumerable]]: *false*, [[Writable]]: *true*, [[Value]]: ! CreateArrayFromList(_errors_) }).
-              1. Return ? Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _error_ &raquo;).
-            1. Return *undefined*.
-          </emu-alg>
-          <p>The *"length"* property of a `Promise.any` reject element function is *1*<sub>𝔽</sub>.</p>
         </emu-clause>
       </emu-clause>
 


### PR DESCRIPTION
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->

**Refs:** <https://github.com/tc39/ecma262/pull/2439>

---

I left <code>[CreateResolvingFunctions]</code> alone because the [Promise Resolve Functions] algorithm steps are rather long compared to `CreateResolvingFunctions` that has been converted to use Abstract Closures, and I didn’t want to only convert it halfway.

[CreateResolvingFunctions]: https://tc39.es/ecma262/#sec-createresolvingfunctions
[Promise Resolve Functions]: https://tc39.es/ecma262/#sec-promise-resolve-functions