### PR TITLE
Editorial: Complete structured headers in “Specification Types”

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -4088,7 +4088,7 @@
         <h1>
           UpdateEmpty (
             _completionRecord_: a Completion Record,
-            _value_: unknown,
+            _value_: an ECMAScript language value,
           ): a Completion Record
         </h1>
         <dl class="header">
@@ -4194,7 +4194,7 @@
       <emu-clause id="sec-getvalue" type="abstract operation">
         <h1>
           GetValue (
-            _V_: unknown,
+            _V_: a Completion Record, a Reference Record, or an ECMAScript language value,
           ): either a normal completion containing an ECMAScript language value or an abrupt completion
         </h1>
         <dl class="header">
@@ -4221,8 +4221,8 @@
       <emu-clause id="sec-putvalue" type="abstract operation">
         <h1>
           PutValue (
-            _V_: unknown,
-            _W_: unknown,
+            _V_: a Completion Record, a Reference Record, or an ECMAScript language value,
+            _W_: a Completion Record or an ECMAScript language value,
           ): either a normal completion containing ~unused~ or an abrupt completion
         </h1>
         <dl class="header">
@@ -4256,7 +4256,7 @@
       <emu-clause id="sec-getthisvalue" type="abstract operation">
         <h1>
           GetThisValue (
-            _V_: unknown,
+            _V_: a Reference Record,
           ): an ECMAScript language value
         </h1>
         <dl class="header">
@@ -4270,8 +4270,8 @@
       <emu-clause id="sec-initializereferencedbinding" type="abstract operation">
         <h1>
           InitializeReferencedBinding (
-            _V_: unknown,
-            _W_: unknown,
+            _V_: a Completion Record or a Reference Record,
+            _W_: a Completion Record or an ECMAScript language value,
           ): either a normal completion containing ~unused~ or an abrupt completion
         </h1>
         <dl class="header">
@@ -4390,7 +4390,7 @@
       <emu-clause id="sec-topropertydescriptor" type="abstract operation">
         <h1>
           ToPropertyDescriptor (
-            _Obj_: unknown,
+            _Obj_: an ECMAScript language value,
           ): either a normal completion containing a Property Descriptor or an abrupt completion
         </h1>
         <dl class="header">


### PR DESCRIPTION
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->

This fills in the remaining structured header type information in the “[ECMAScript Specification Types](https://tc39.es/ecma262/#sec-ecmascript-specification-types)” section.