### PR TITLE
Editorial: Add `Iterator Record` type

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -6909,12 +6909,66 @@
     <h1>Operations on Iterator Objects</h1>
     <p>See Common Iteration Interfaces (<emu-xref href="#sec-iteration"></emu-xref>).</p>
 
+    <emu-clause id="sec-iterator-records">
+      <h1>Iterator Records</h1>
+      <p>An <dfn variants="Iterator Records">Iterator Record</dfn> is a Record value used to encapsulate an Iterator or AsyncIterator along with the `next` method.</p>
+      <p>Iterator Records have the fields listed in <emu-xref href="#table-iterator-record-fields"></emu-xref>.</p>
+      <emu-table id="table-iterator-record-fields" caption="Iterator Record Fields">
+        <table>
+          <tr>
+            <th>
+              Field Name
+            </th>
+            <th>
+              Value
+            </th>
+            <th>
+              Meaning
+            </th>
+          </tr>
+          <tr>
+            <td>
+              [[Iterator]]
+            </td>
+            <td>
+              An object
+            </td>
+            <td>
+              An object that conforms to the <i>Iterator</i> or <i>AsyncIterator</i> interface.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[NextMethod]]
+            </td>
+            <td>
+              A function object
+            </td>
+            <td>
+              The `next` method of the [[Iterator]] object.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[Done]]
+            </td>
+            <td>
+              Boolean
+            </td>
+            <td>
+              Whether the iterator has been closed.
+            </td>
+          </tr>
+        </table>
+      </emu-table>
+    </emu-clause>
+
     <emu-clause id="sec-getiterator" type="abstract operation">
       <h1>
         GetIterator (
-          _obj_: unknown,
+          _obj_: an ECMAScript language value,
           optional _hint_: ~sync~ or ~async~,
-          optional _method_: unknown,
+          optional _method_: a function object,
         )
       </h1>
       <dl class="header">
@@ -6932,7 +6986,7 @@
         1. Let _iterator_ be ? Call(_method_, _obj_).
         1. If Type(_iterator_) is not Object, throw a *TypeError* exception.
         1. Let _nextMethod_ be ? GetV(_iterator_, *"next"*).
-        1. Let _iteratorRecord_ be the Record { [[Iterator]]: _iterator_, [[NextMethod]]: _nextMethod_, [[Done]]: *false* }.
+        1. Let _iteratorRecord_ be the Iterator Record { [[Iterator]]: _iterator_, [[NextMethod]]: _nextMethod_, [[Done]]: *false* }.
         1. Return _iteratorRecord_.
       </emu-alg>
     </emu-clause>
@@ -6940,8 +6994,8 @@
     <emu-clause id="sec-iteratornext" type="abstract operation">
       <h1>
         IteratorNext (
-          _iteratorRecord_: unknown,
-          optional _value_: unknown,
+          _iteratorRecord_: an Iterator Record,
+          optional _value_: an ECMAScript language value,
         )
       </h1>
       <dl class="header">
@@ -6985,7 +7039,7 @@
     <emu-clause id="sec-iteratorstep" type="abstract operation">
       <h1>
         IteratorStep (
-          _iteratorRecord_: unknown,
+          _iteratorRecord_: an Iterator Record,
         )
       </h1>
       <dl class="header">
@@ -7003,7 +7057,7 @@
     <emu-clause id="sec-iteratorclose" type="abstract operation">
       <h1>
         IteratorClose (
-          _iteratorRecord_: unknown,
+          _iteratorRecord_: an Iterator Record,
           _completion_: a Completion Record,
         )
       </h1>
@@ -7042,7 +7096,7 @@
     <emu-clause id="sec-asynciteratorclose" type="abstract operation">
       <h1>
         AsyncIteratorClose (
-          _iteratorRecord_: unknown,
+          _iteratorRecord_: an Iterator Record,
           _completion_: a Completion Record,
         )
       </h1>
@@ -7069,7 +7123,7 @@
     <emu-clause id="sec-createiterresultobject" type="abstract operation">
       <h1>
         CreateIterResultObject (
-          _value_: unknown,
+          _value_: an ECMAScript language value,
           _done_: a Boolean,
         )
       </h1>
@@ -7088,7 +7142,7 @@
     <emu-clause id="sec-createlistiteratorRecord" type="abstract operation" oldids="sec-createlistiterator,sec-listiteratornext-functions,sec-listiterator-next">
       <h1>
         CreateListIteratorRecord (
-          _list_: unknown,
+          _list_: a List,
         )
       </h1>
       <dl class="header">
@@ -7101,7 +7155,7 @@
             1. Perform ? GeneratorYield(! CreateIterResultObject(_E_, *false*)).
           1. Return *undefined*.
         1. Let _iterator_ be ! CreateIteratorFromClosure(_closure_, ~empty~, %IteratorPrototype%).
-        1. Return Record { [[Iterator]]: _iterator_, [[NextMethod]]: %GeneratorFunction.prototype.prototype.next%, [[Done]]: *false* }.
+        1. Return the Iterator Record { [[Iterator]]: _iterator_, [[NextMethod]]: %GeneratorFunction.prototype.prototype.next%, [[Done]]: *false* }.
       </emu-alg>
       <emu-note>
         <p>The list iterator object is never directly accessible to ECMAScript code.</p>
@@ -7111,8 +7165,8 @@
     <emu-clause id="sec-iterabletolist" type="abstract operation">
       <h1>
         IterableToList (
-          _items_: unknown,
-          optional _method_: unknown,
+          _items_: an ECMAScript language value,
+          optional _method_: a function object,
         )
       </h1>
       <dl class="header">
@@ -21958,7 +22012,7 @@
             1. Let _obj_ be ! ToObject(_exprValue_).
             1. Let _iterator_ be ? EnumerateObjectProperties(_obj_).
             1. Let _nextMethod_ be ! GetV(_iterator_, *"next"*).
-            1. Return the Record { [[Iterator]]: _iterator_, [[NextMethod]]: _nextMethod_, [[Done]]: *false* }.
+            1. Return the Iterator Record { [[Iterator]]: _iterator_, [[NextMethod]]: _nextMethod_, [[Done]]: *false* }.
           1. Else,
             1. Assert: _iterationKind_ is ~iterate~ or ~async-iterate~.
             1. If _iterationKind_ is ~async-iterate~, let _iteratorHint_ be ~async~.
@@ -42876,13 +42930,13 @@ THH:mm:ss.sss
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It is used to create an async iterator Record from a synchronous iterator Record.</dd>
+          <dd>It is used to create an async Iterator Record from a synchronous Iterator Record.</dd>
         </dl>
         <emu-alg>
           1. Let _asyncIterator_ be ! OrdinaryObjectCreate(%AsyncFromSyncIteratorPrototype%, &laquo; [[SyncIteratorRecord]] &raquo;).
           1. Set _asyncIterator_.[[SyncIteratorRecord]] to _syncIteratorRecord_.
           1. Let _nextMethod_ be ! Get(_asyncIterator_, *"next"*).
-          1. Let _iteratorRecord_ be the Record { [[Iterator]]: _asyncIterator_, [[NextMethod]]: _nextMethod_, [[Done]]: *false* }.
+          1. Let _iteratorRecord_ be the Iterator Record { [[Iterator]]: _asyncIterator_, [[NextMethod]]: _nextMethod_, [[Done]]: *false* }.
           1. Return _iteratorRecord_.
         </emu-alg>
       </emu-clause>
@@ -42986,7 +43040,7 @@ THH:mm:ss.sss
                 [[SyncIteratorRecord]]
               </td>
               <td>
-                A Record, of the type returned by GetIterator, representing the original synchronous iterator which is being adapted.
+                An Iterator Record representing the original synchronous iterator which is being adapted.
               </td>
             </tr>
           </table>


### PR DESCRIPTION
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->

This adds a `<dfn>` and `<emu‑table>` for “[Iterator Records](https://ci.tc39.es/preview/tc39/ecma262/pull/2591#sec-iterator-records)”.

---

Part of <https://github.com/tc39/ecma262/issues/2486>