### PR TITLE
Editorial: Consistify prose for intrinsic functions 

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -30130,7 +30130,7 @@
 
       <emu-clause id="sec-function.prototype-@@hasinstance">
         <h1>Function.prototype [ @@hasInstance ] ( _V_ )</h1>
-        <p>When the `@@hasInstance` method of an object _F_ is called with value _V_, the following steps are taken:</p>
+        <p>When the `@@hasInstance` method is called with value _V_, the following steps are taken:</p>
         <emu-alg>
           1. Let _F_ be the *this* value.
           1. Return ? OrdinaryHasInstance(_F_, _V_).
@@ -31059,7 +31059,7 @@
 
       <emu-clause id="sec-number.prototype.toexponential">
         <h1>Number.prototype.toExponential ( _fractionDigits_ )</h1>
-        <p>Return a String containing this Number value represented in decimal exponential notation with one digit before the significand's decimal point and _fractionDigits_ digits after the significand's decimal point. If _fractionDigits_ is *undefined*, include as many significand digits as necessary to uniquely specify the Number (just like in ToString except that in this case the Number is always output in exponential notation). Specifically, perform the following steps:</p>
+        <p>This method returns a String containing this Number value represented in decimal exponential notation with one digit before the significand's decimal point and _fractionDigits_ digits after the significand's decimal point. If _fractionDigits_ is *undefined*, it includes as many significand digits as necessary to uniquely specify the Number (just like in ToString except that in this case the Number is always output in exponential notation). Specifically, it performs the following steps:</p>
         <emu-alg>
           1. Let _x_ be ? thisNumberValue(*this* value).
           1. Let _f_ be ? ToIntegerOrInfinity(_fractionDigits_).
@@ -31157,7 +31157,7 @@
 
       <emu-clause id="sec-number.prototype.toprecision">
         <h1>Number.prototype.toPrecision ( _precision_ )</h1>
-        <p>Return a String containing this Number value represented either in decimal exponential notation with one digit before the significand's decimal point and <emu-eqn>_precision_ - 1</emu-eqn> digits after the significand's decimal point or in decimal fixed notation with _precision_ significant digits. If _precision_ is *undefined*, call ToString instead. Specifically, perform the following steps:</p>
+        <p>This method returns a String containing this Number value represented either in decimal exponential notation with one digit before the significand's decimal point and <emu-eqn>_precision_ - 1</emu-eqn> digits after the significand's decimal point or in decimal fixed notation with _precision_ significant digits. If _precision_ is *undefined*, it calls ToString instead. Specifically, it performs the following steps:</p>
         <emu-alg>
           1. Let _x_ be ? thisNumberValue(*this* value).
           1. If _precision_ is *undefined*, return ! ToString(_x_).
@@ -33659,7 +33659,7 @@ THH:mm:ss.sss
           1. Return *false*.
         </emu-alg>
         <emu-note>
-          <p>If _searchString_ appears as a <emu-not-ref>substring</emu-not-ref> of the result of converting this object to a String, at one or more indices that are greater than or equal to _position_, return *true*; otherwise, returns *false*. If _position_ is *undefined*, 0 is assumed, so as to search all of the String.</p>
+          <p>If _searchString_ appears as a <emu-not-ref>substring</emu-not-ref> of the result of converting this object to a String, at one or more indices that are greater than or equal to _position_, returns *true*; otherwise, returns *false*. If _position_ is *undefined*, 0 is assumed, so as to search all of the String.</p>
         </emu-note>
         <emu-note>
           <p>Throwing an exception if the first argument is a RegExp is specified in order to allow future editions to define extensions that allow such argument values.</p>
@@ -39232,9 +39232,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-%typedarray%.prototype.set" oldids="sec-%typedarray%.prototype.set-overloaded-offset">
         <h1>%TypedArray%.prototype.set ( _source_ [ , _offset_ ] )</h1>
-        <p>%TypedArray%`.prototype.set` is a function whose behaviour differs based upon the type of its first argument.</p>
-        <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
-        <p>Sets multiple values in this _TypedArray_, reading the values from _source_. The optional _offset_ value indicates the first element index in this _TypedArray_ where values are written. If omitted, it is assumed to be 0.</p>
+        <p>%TypedArray%`.prototype.set` sets multiple values in this _TypedArray_, reading the values from _source_. The details differ based upon the type of _source_. The optional _offset_ value indicates the first element index in this _TypedArray_ where values are written. If omitted, it is assumed to be 0.</p>
         <p>When the `set` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _target_ be the *this* value.
@@ -39248,6 +39246,7 @@ THH:mm:ss.sss
             1. Perform ? SetTypedArrayFromArrayLike(_target_, _targetOffset_, _source_).
           1. Return *undefined*.
         </emu-alg>
+        <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
 
         <emu-clause id="sec-settypedarrayfromtypedarray" type="abstract operation" oldids="sec-%typedarray%.prototype.set-typedarray-offset">
           <h1>
@@ -39338,7 +39337,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-%typedarray%.prototype.slice">
         <h1>%TypedArray%.prototype.slice ( _start_, _end_ )</h1>
-        <p>The interpretation and use of the arguments of %TypedArray%`.prototype.slice` are the same as for `Array.prototype.slice` as defined in <emu-xref href="#sec-array.prototype.slice"></emu-xref>. The following steps are taken:</p>
+        <p>The interpretation and use of the arguments of %TypedArray%`.prototype.slice` are the same as for `Array.prototype.slice` as defined in <emu-xref href="#sec-array.prototype.slice"></emu-xref>.</p>
         <p>When the `slice` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.

--- a/spec.html
+++ b/spec.html
@@ -13503,13 +13503,15 @@
 
       <emu-clause id="sec-%throwtypeerror%">
         <h1>%ThrowTypeError% ( )</h1>
-        <p>The <dfn>%ThrowTypeError%</dfn> intrinsic is an anonymous built-in function object that is defined once for each realm. When %ThrowTypeError% is called it performs the following steps:</p>
+        <p>This function is the <dfn>%ThrowTypeError%</dfn> intrinsic object.</p>
+        <p>It is an anonymous built-in function object that is defined once for each realm.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Throw a *TypeError* exception.
         </emu-alg>
-        <p>The value of the [[Extensible]] internal slot of a %ThrowTypeError% function is *false*.</p>
-        <p>The *"length"* property of a %ThrowTypeError% function has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
-        <p>The *"name"* property of a %ThrowTypeError% function has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
+        <p>The value of the [[Extensible]] internal slot of this function is *false*.</p>
+        <p>The *"length"* property of this function has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
+        <p>The *"name"* property of this function has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
     </emu-clause>
 
@@ -28616,7 +28618,8 @@
 
     <emu-clause id="sec-eval-x">
       <h1>eval ( _x_ )</h1>
-      <p>The `eval` function is the <dfn>%eval%</dfn> intrinsic object. When the `eval` function is called with one argument _x_, the following steps are taken:</p>
+      <p>This function is the <dfn>%eval%</dfn> intrinsic object.</p>
+      <p>It performs the following steps when called:</p>
       <emu-alg>
         1. Return ? PerformEval(_x_, *false*, *false*).
       </emu-alg>
@@ -28821,7 +28824,8 @@
 
     <emu-clause id="sec-isfinite-number">
       <h1>isFinite ( _number_ )</h1>
-      <p>The `isFinite` function is the <dfn>%isFinite%</dfn> intrinsic object. When the `isFinite` function is called with one argument _number_, the following steps are taken:</p>
+      <p>This function is the <dfn>%isFinite%</dfn> intrinsic object.</p>
+      <p>It performs the following steps when called:</p>
       <emu-alg>
         1. Let _num_ be ? ToNumber(_number_).
         1. If _num_ is *NaN*, *+&infin;*<sub>𝔽</sub>, or *-&infin;*<sub>𝔽</sub>, return *false*.
@@ -28831,7 +28835,8 @@
 
     <emu-clause id="sec-isnan-number">
       <h1>isNaN ( _number_ )</h1>
-      <p>The `isNaN` function is the <dfn>%isNaN%</dfn> intrinsic object. When the `isNaN` function is called with one argument _number_, the following steps are taken:</p>
+      <p>This function is the <dfn>%isNaN%</dfn> intrinsic object.</p>
+      <p>It performs the following steps when called:</p>
       <emu-alg>
         1. Let _num_ be ? ToNumber(_number_).
         1. If _num_ is *NaN*, return *true*.
@@ -28844,8 +28849,9 @@
 
     <emu-clause id="sec-parsefloat-string">
       <h1>parseFloat ( _string_ )</h1>
-      <p>The `parseFloat` function produces a Number value dictated by interpretation of the contents of the _string_ argument as a decimal literal.</p>
-      <p>The `parseFloat` function is the <dfn>%parseFloat%</dfn> intrinsic object. When the `parseFloat` function is called with one argument _string_, the following steps are taken:</p>
+      <p>This function produces a Number value dictated by interpretation of the contents of the _string_ argument as a decimal literal.</p>
+      <p>It is the <dfn>%parseFloat%</dfn> intrinsic object.</p>
+      <p>It performs the following steps when called:</p>
       <emu-alg>
         1. Let _inputString_ be ? ToString(_string_).
         1. Let _trimmedString_ be ! TrimString(_inputString_, ~start~).
@@ -28856,14 +28862,15 @@
         1. Return StringNumericValue of _parsedNumber_.
       </emu-alg>
       <emu-note>
-        <p>`parseFloat` may interpret only a leading portion of _string_ as a Number value; it ignores any code units that cannot be interpreted as part of the notation of a decimal literal, and no indication is given that any such code units were ignored.</p>
+        <p>This function may interpret only a leading portion of _string_ as a Number value; it ignores any code units that cannot be interpreted as part of the notation of a decimal literal, and no indication is given that any such code units were ignored.</p>
       </emu-note>
     </emu-clause>
 
     <emu-clause id="sec-parseint-string-radix">
       <h1>parseInt ( _string_, _radix_ )</h1>
-      <p>The `parseInt` function produces an integral Number dictated by interpretation of the contents of the _string_ argument according to the specified _radix_. Leading white space in _string_ is ignored. If _radix_ is *undefined* or 0, it is assumed to be 10 except when the number begins with the code unit pairs `0x` or `0X`, in which case a radix of 16 is assumed. If _radix_ is 16, the number may also optionally begin with the code unit pairs `0x` or `0X`.</p>
-      <p>The `parseInt` function is the <dfn>%parseInt%</dfn> intrinsic object. When the `parseInt` function is called, the following steps are taken:</p>
+      <p>This function produces an integral Number dictated by interpretation of the contents of the _string_ argument according to the specified _radix_. Leading white space in _string_ is ignored. If _radix_ is *undefined* or 0, it is assumed to be 10 except when the number begins with the code unit pairs `0x` or `0X`, in which case a radix of 16 is assumed. If _radix_ is 16, the number may also optionally begin with the code unit pairs `0x` or `0X`.</p>
+      <p>It is the <dfn>%parseInt%</dfn> intrinsic object.</p>
+      <p>It performs the following steps when called:</p>
       <emu-alg>
         1. Let _inputString_ be ? ToString(_string_).
         1. Let _S_ be ! TrimString(_inputString_, ~start~).
@@ -28891,7 +28898,7 @@
         1. Return 𝔽(_sign_ &times; _mathInt_).
       </emu-alg>
       <emu-note>
-        <p>`parseInt` may interpret only a leading portion of _string_ as an integer value; it ignores any code units that cannot be interpreted as part of the notation of an integer, and no indication is given that any such code units were ignored.</p>
+        <p>This function may interpret only a leading portion of _string_ as an integer value; it ignores any code units that cannot be interpreted as part of the notation of an integer, and no indication is given that any such code units were ignored.</p>
       </emu-note>
     </emu-clause>
 
@@ -29045,8 +29052,9 @@
 
       <emu-clause id="sec-decodeuri-encodeduri">
         <h1>decodeURI ( _encodedURI_ )</h1>
-        <p>The `decodeURI` function computes a new version of a URI in which each escape sequence and UTF-8 encoding of the sort that might be introduced by the `encodeURI` function is replaced with the UTF-16 encoding of the code points that it represents. Escape sequences that could not have been introduced by `encodeURI` are not replaced.</p>
-        <p>The `decodeURI` function is the <dfn>%decodeURI%</dfn> intrinsic object. When the `decodeURI` function is called with one argument _encodedURI_, the following steps are taken:</p>
+        <p>This function computes a new version of a URI in which each escape sequence and UTF-8 encoding of the sort that might be introduced by the `encodeURI` function is replaced with the UTF-16 encoding of the code points that it represents. Escape sequences that could not have been introduced by `encodeURI` are not replaced.</p>
+        <p>It is the <dfn>%decodeURI%</dfn> intrinsic object.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _uriString_ be ? ToString(_encodedURI_).
           1. Let _reservedURISet_ be a String containing one instance of each code unit valid in |uriReserved| plus *"#"*.
@@ -29059,8 +29067,9 @@
 
       <emu-clause id="sec-decodeuricomponent-encodeduricomponent">
         <h1>decodeURIComponent ( _encodedURIComponent_ )</h1>
-        <p>The `decodeURIComponent` function computes a new version of a URI in which each escape sequence and UTF-8 encoding of the sort that might be introduced by the `encodeURIComponent` function is replaced with the UTF-16 encoding of the code points that it represents.</p>
-        <p>The `decodeURIComponent` function is the <dfn>%decodeURIComponent%</dfn> intrinsic object. When the `decodeURIComponent` function is called with one argument _encodedURIComponent_, the following steps are taken:</p>
+        <p>This function computes a new version of a URI in which each escape sequence and UTF-8 encoding of the sort that might be introduced by the `encodeURIComponent` function is replaced with the UTF-16 encoding of the code points that it represents.</p>
+        <p>It is the <dfn>%decodeURIComponent%</dfn> intrinsic object.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _componentString_ be ? ToString(_encodedURIComponent_).
           1. Let _reservedURIComponentSet_ be the empty String.
@@ -29070,8 +29079,9 @@
 
       <emu-clause id="sec-encodeuri-uri">
         <h1>encodeURI ( _uri_ )</h1>
-        <p>The `encodeURI` function computes a new version of a UTF-16 encoded (<emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>) URI in which each instance of certain code points is replaced by one, two, three, or four escape sequences representing the UTF-8 encoding of the code points.</p>
-        <p>The `encodeURI` function is the <dfn>%encodeURI%</dfn> intrinsic object. When the `encodeURI` function is called with one argument _uri_, the following steps are taken:</p>
+        <p>This function computes a new version of a UTF-16 encoded (<emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>) URI in which each instance of certain code points is replaced by one, two, three, or four escape sequences representing the UTF-8 encoding of the code points.</p>
+        <p>It is the <dfn>%encodeURI%</dfn> intrinsic object.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _uriString_ be ? ToString(_uri_).
           1. Let _unescapedURISet_ be a String containing one instance of each code unit valid in |uriReserved| and |uriUnescaped| plus *"#"*.
@@ -29084,8 +29094,9 @@
 
       <emu-clause id="sec-encodeuricomponent-uricomponent">
         <h1>encodeURIComponent ( _uriComponent_ )</h1>
-        <p>The `encodeURIComponent` function computes a new version of a UTF-16 encoded (<emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>) URI in which each instance of certain code points is replaced by one, two, three, or four escape sequences representing the UTF-8 encoding of the code point.</p>
-        <p>The `encodeURIComponent` function is the <dfn>%encodeURIComponent%</dfn> intrinsic object. When the `encodeURIComponent` function is called with one argument _uriComponent_, the following steps are taken:</p>
+        <p>This function computes a new version of a UTF-16 encoded (<emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>) URI in which each instance of certain code points is replaced by one, two, three, or four escape sequences representing the UTF-8 encoding of the code point.</p>
+        <p>It is the <dfn>%encodeURIComponent%</dfn> intrinsic object.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _componentString_ be ? ToString(_uriComponent_).
           1. Let _unescapedURIComponentSet_ be a String containing one instance of each code unit valid in |uriUnescaped|.
@@ -29343,14 +29354,14 @@
 
       <emu-clause id="sec-object-value">
         <h1>Object ( [ _value_ ] )</h1>
-        <p>When the `Object` function is called with optional argument _value_, the following steps are taken:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. If NewTarget is neither *undefined* nor the active function, then
             1. Return ? OrdinaryCreateFromConstructor(NewTarget, *"%Object.prototype%"*).
           1. If _value_ is *undefined* or *null*, return OrdinaryObjectCreate(%Object.prototype%).
           1. Return ! ToObject(_value_).
         </emu-alg>
-        <p>The *"length"* property of the `Object` function is *1*<sub>𝔽</sub>.</p>
+        <p>The *"length"* property of this function is *1*<sub>𝔽</sub>.</p>
       </emu-clause>
     </emu-clause>
 
@@ -29365,7 +29376,8 @@
 
       <emu-clause id="sec-object.assign">
         <h1>Object.assign ( _target_, ..._sources_ )</h1>
-        <p>The `assign` function is used to copy the values of all of the enumerable own properties from one or more source objects to a _target_ object. When the `assign` function is called, the following steps are taken:</p>
+        <p>This function copies the values of all of the enumerable own properties from one or more source objects to a _target_ object.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _to_ be ? ToObject(_target_).
           1. If only one argument was passed, return _to_.
@@ -29380,12 +29392,13 @@
                   1. Perform ? Set(_to_, _nextKey_, _propValue_, *true*).
           1. Return _to_.
         </emu-alg>
-        <p>The *"length"* property of the `assign` function is *2*<sub>𝔽</sub>.</p>
+        <p>The *"length"* property of this function is *2*<sub>𝔽</sub>.</p>
       </emu-clause>
 
       <emu-clause id="sec-object.create">
         <h1>Object.create ( _O_, _Properties_ )</h1>
-        <p>The `create` function creates a new object with a specified prototype. When the `create` function is called, the following steps are taken:</p>
+        <p>This function creates a new object with a specified prototype.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. If Type(_O_) is neither Object nor Null, throw a *TypeError* exception.
           1. Let _obj_ be OrdinaryObjectCreate(_O_).
@@ -29397,7 +29410,8 @@
 
       <emu-clause id="sec-object.defineproperties">
         <h1>Object.defineProperties ( _O_, _Properties_ )</h1>
-        <p>The `defineProperties` function is used to add own properties and/or update the attributes of existing own properties of an object. When the `defineProperties` function is called, the following steps are taken:</p>
+        <p>This function adds own properties and/or updates the attributes of existing own properties of an object.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. If Type(_O_) is not Object, throw a *TypeError* exception.
           1. Return ? ObjectDefineProperties(_O_, _Properties_).
@@ -29433,7 +29447,8 @@
 
       <emu-clause id="sec-object.defineproperty">
         <h1>Object.defineProperty ( _O_, _P_, _Attributes_ )</h1>
-        <p>The `defineProperty` function is used to add an own property and/or update the attributes of an existing own property of an object. When the `defineProperty` function is called, the following steps are taken:</p>
+        <p>This function adds an own property and/or updates the attributes of an existing own property of an object.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. If Type(_O_) is not Object, throw a *TypeError* exception.
           1. Let _key_ be ? ToPropertyKey(_P_).
@@ -29445,7 +29460,7 @@
 
       <emu-clause id="sec-object.entries">
         <h1>Object.entries ( _O_ )</h1>
-        <p>When the `entries` function is called with argument _O_, the following steps are taken:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. Let _obj_ be ? ToObject(_O_).
           1. Let _nameList_ be ? EnumerableOwnPropertyNames(_obj_, ~key+value~).
@@ -29455,7 +29470,7 @@
 
       <emu-clause id="sec-object.freeze">
         <h1>Object.freeze ( _O_ )</h1>
-        <p>When the `freeze` function is called, the following steps are taken:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. If Type(_O_) is not Object, return _O_.
           1. Let _status_ be ? SetIntegrityLevel(_O_, ~frozen~).
@@ -29466,7 +29481,7 @@
 
       <emu-clause id="sec-object.fromentries" oldids="sec-create-data-property-on-object-functions">
         <h1>Object.fromEntries ( _iterable_ )</h1>
-        <p>When the `fromEntries` method is called with argument _iterable_, the following steps are taken:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. Perform ? RequireObjectCoercible(_iterable_).
           1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%).
@@ -29485,7 +29500,7 @@
 
       <emu-clause id="sec-object.getownpropertydescriptor">
         <h1>Object.getOwnPropertyDescriptor ( _O_, _P_ )</h1>
-        <p>When the `getOwnPropertyDescriptor` function is called, the following steps are taken:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. Let _obj_ be ? ToObject(_O_).
           1. Let _key_ be ? ToPropertyKey(_P_).
@@ -29496,7 +29511,7 @@
 
       <emu-clause id="sec-object.getownpropertydescriptors">
         <h1>Object.getOwnPropertyDescriptors ( _O_ )</h1>
-        <p>When the `getOwnPropertyDescriptors` function is called, the following steps are taken:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. Let _obj_ be ? ToObject(_O_).
           1. Let _ownKeys_ be ? <emu-meta effects="user-code">_obj_.[[OwnPropertyKeys]]()</emu-meta>.
@@ -29511,7 +29526,7 @@
 
       <emu-clause id="sec-object.getownpropertynames">
         <h1>Object.getOwnPropertyNames ( _O_ )</h1>
-        <p>When the `getOwnPropertyNames` function is called, the following steps are taken:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. Return CreateArrayFromList(? GetOwnPropertyKeys(_O_, ~string~)).
         </emu-alg>
@@ -29519,7 +29534,7 @@
 
       <emu-clause id="sec-object.getownpropertysymbols">
         <h1>Object.getOwnPropertySymbols ( _O_ )</h1>
-        <p>When the `getOwnPropertySymbols` function is called with argument _O_, the following steps are taken:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. Return CreateArrayFromList(? GetOwnPropertyKeys(_O_, ~symbol~)).
         </emu-alg>
@@ -29547,7 +29562,7 @@
 
       <emu-clause id="sec-object.getprototypeof">
         <h1>Object.getPrototypeOf ( _O_ )</h1>
-        <p>When the `getPrototypeOf` function is called with argument _O_, the following steps are taken:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. Let _obj_ be ? ToObject(_O_).
           1. Return ? <emu-meta effects="user-code">_obj_.[[GetPrototypeOf]]()</emu-meta>.
@@ -29556,7 +29571,7 @@
 
       <emu-clause id="sec-object.hasown">
         <h1>Object.hasOwn ( _O_, _P_ )</h1>
-        <p>When the `hasOwn` method is called, the following steps are taken:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. Let _obj_ be ? ToObject(_O_).
           1. Let _key_ be ? ToPropertyKey(_P_).
@@ -29566,7 +29581,7 @@
 
       <emu-clause id="sec-object.is">
         <h1>Object.is ( _value1_, _value2_ )</h1>
-        <p>When the `is` function is called with arguments _value1_ and _value2_, the following steps are taken:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. Return SameValue(_value1_, _value2_).
         </emu-alg>
@@ -29574,7 +29589,7 @@
 
       <emu-clause id="sec-object.isextensible">
         <h1>Object.isExtensible ( _O_ )</h1>
-        <p>When the `isExtensible` function is called with argument _O_, the following steps are taken:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. If Type(_O_) is not Object, return *false*.
           1. Return ? IsExtensible(_O_).
@@ -29583,7 +29598,7 @@
 
       <emu-clause id="sec-object.isfrozen">
         <h1>Object.isFrozen ( _O_ )</h1>
-        <p>When the `isFrozen` function is called with argument _O_, the following steps are taken:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. If Type(_O_) is not Object, return *true*.
           1. Return ? TestIntegrityLevel(_O_, ~frozen~).
@@ -29592,7 +29607,7 @@
 
       <emu-clause id="sec-object.issealed">
         <h1>Object.isSealed ( _O_ )</h1>
-        <p>When the `isSealed` function is called with argument _O_, the following steps are taken:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. If Type(_O_) is not Object, return *true*.
           1. Return ? TestIntegrityLevel(_O_, ~sealed~).
@@ -29601,7 +29616,7 @@
 
       <emu-clause id="sec-object.keys">
         <h1>Object.keys ( _O_ )</h1>
-        <p>When the `keys` function is called with argument _O_, the following steps are taken:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. Let _obj_ be ? ToObject(_O_).
           1. Let _nameList_ be ? EnumerableOwnPropertyNames(_obj_, ~key~).
@@ -29611,7 +29626,7 @@
 
       <emu-clause id="sec-object.preventextensions">
         <h1>Object.preventExtensions ( _O_ )</h1>
-        <p>When the `preventExtensions` function is called, the following steps are taken:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. If Type(_O_) is not Object, return _O_.
           1. Let _status_ be ? <emu-meta effects="user-code">_O_.[[PreventExtensions]]()</emu-meta>.
@@ -29628,7 +29643,7 @@
 
       <emu-clause id="sec-object.seal">
         <h1>Object.seal ( _O_ )</h1>
-        <p>When the `seal` function is called, the following steps are taken:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. If Type(_O_) is not Object, return _O_.
           1. Let _status_ be ? SetIntegrityLevel(_O_, ~sealed~).
@@ -29639,7 +29654,7 @@
 
       <emu-clause id="sec-object.setprototypeof">
         <h1>Object.setPrototypeOf ( _O_, _proto_ )</h1>
-        <p>When the `setPrototypeOf` function is called with arguments _O_ and _proto_, the following steps are taken:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. Set _O_ to ? RequireObjectCoercible(_O_).
           1. If Type(_proto_) is neither Object nor Null, throw a *TypeError* exception.
@@ -29652,7 +29667,7 @@
 
       <emu-clause id="sec-object.values">
         <h1>Object.values ( _O_ )</h1>
-        <p>When the `values` function is called with argument _O_, the following steps are taken:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. Let _obj_ be ? ToObject(_O_).
           1. Let _nameList_ be ? EnumerableOwnPropertyNames(_obj_, ~value~).
@@ -29678,7 +29693,7 @@
 
       <emu-clause id="sec-object.prototype.hasownproperty">
         <h1>Object.prototype.hasOwnProperty ( _V_ )</h1>
-        <p>When the `hasOwnProperty` method is called with argument _V_, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. [id="step-hasownproperty-topropertykey"] Let _P_ be ? ToPropertyKey(_V_).
           1. [id="step-hasownproperty-toobject"] Let _O_ be ? ToObject(*this* value).
@@ -29691,7 +29706,7 @@
 
       <emu-clause id="sec-object.prototype.isprototypeof">
         <h1>Object.prototype.isPrototypeOf ( _V_ )</h1>
-        <p>When the `isPrototypeOf` method is called with argument _V_, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. [id="step-isprototypeof-check-object"] If Type(_V_) is not Object, return *false*.
           1. [id="step-isprototypeof-toobject"] Let _O_ be ? ToObject(*this* value).
@@ -29707,7 +29722,7 @@
 
       <emu-clause id="sec-object.prototype.propertyisenumerable">
         <h1>Object.prototype.propertyIsEnumerable ( _V_ )</h1>
-        <p>When the `propertyIsEnumerable` method is called with argument _V_, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. [id="step-propertyisenumerable-topropertykey"] Let _P_ be ? ToPropertyKey(_V_).
           1. [id="step-propertyisenumerable-toobject"] Let _O_ be ? ToObject(*this* value).
@@ -29725,14 +29740,14 @@
 
       <emu-clause id="sec-object.prototype.tolocalestring">
         <h1>Object.prototype.toLocaleString ( [ _reserved1_ [ , _reserved2_ ] ] )</h1>
-        <p>When the `toLocaleString` method is called, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Return ? Invoke(_O_, *"toString"*).
         </emu-alg>
-        <p>The optional parameters to this function are not used but are intended to correspond to the parameter pattern used by ECMA-402 `toLocaleString` functions. Implementations that do not include ECMA-402 support must not use those parameter positions for other purposes.</p>
+        <p>The optional parameters to this method are not used but are intended to correspond to the parameter pattern used by ECMA-402 `toLocaleString` methods. Implementations that do not include ECMA-402 support must not use those parameter positions for other purposes.</p>
         <emu-note>
-          <p>This function provides a generic `toLocaleString` implementation for objects that have no locale-sensitive `toString` behaviour. `Array`, `Number`, `Date`, and %TypedArray% provide their own locale-sensitive `toLocaleString` methods.</p>
+          <p>This method provides a generic `toLocaleString` implementation for objects that have no locale-sensitive `toString` behaviour. `Array`, `Number`, `Date`, and %TypedArray% provide their own locale-sensitive `toLocaleString` methods.</p>
         </emu-note>
         <emu-note>
           <p>ECMA-402 intentionally does not provide an alternative to this default implementation.</p>
@@ -29741,7 +29756,7 @@
 
       <emu-clause id="sec-object.prototype.tostring">
         <h1>Object.prototype.toString ( )</h1>
-        <p>When the `toString` method is called, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. If the *this* value is *undefined*, return *"[object Undefined]"*.
           1. If the *this* value is *null*, return *"[object Null]"*.
@@ -29762,13 +29777,13 @@
           1. Return the string-concatenation of *"[object "*, _tag_, and *"]"*.
         </emu-alg>
         <emu-note>
-          <p>Historically, this function was occasionally used to access the String value of the [[Class]] internal slot that was used in previous editions of this specification as a nominal type tag for various built-in objects. The above definition of `toString` preserves compatibility for legacy code that uses `toString` as a test for those specific kinds of built-in objects. It does not provide a reliable type testing mechanism for other kinds of built-in or program defined objects. In addition, programs can use @@toStringTag in ways that will invalidate the reliability of such legacy type tests.</p>
+          <p>Historically, this method was occasionally used to access the String value of the [[Class]] internal slot that was used in previous editions of this specification as a nominal type tag for various built-in objects. The above definition of `toString` preserves compatibility for legacy code that uses `toString` as a test for those specific kinds of built-in objects. It does not provide a reliable type testing mechanism for other kinds of built-in or program defined objects. In addition, programs can use @@toStringTag in ways that will invalidate the reliability of such legacy type tests.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-object.prototype.valueof">
         <h1>Object.prototype.valueOf ( )</h1>
-        <p>When the `valueOf` method is called, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Return ? ToObject(*this* value).
         </emu-alg>
@@ -29806,7 +29821,7 @@
 
         <emu-clause id="sec-object.prototype.__defineGetter__">
           <h1>Object.prototype.__defineGetter__ ( _P_, _getter_ )</h1>
-          <p>When the `__defineGetter__` method is called with arguments _P_ and _getter_, the following steps are taken:</p>
+          <p>This method performs the following steps when called:</p>
           <emu-alg>
             1. Let _O_ be ? ToObject(*this* value).
             1. If IsCallable(_getter_) is *false*, throw a *TypeError* exception.
@@ -29819,7 +29834,7 @@
 
         <emu-clause id="sec-object.prototype.__defineSetter__">
           <h1>Object.prototype.__defineSetter__ ( _P_, _setter_ )</h1>
-          <p>When the `__defineSetter__` method is called with arguments _P_ and _setter_, the following steps are taken:</p>
+          <p>This method performs the following steps when called:</p>
           <emu-alg>
             1. Let _O_ be ? ToObject(*this* value).
             1. If IsCallable(_setter_) is *false*, throw a *TypeError* exception.
@@ -29832,7 +29847,7 @@
 
         <emu-clause id="sec-object.prototype.__lookupGetter__">
           <h1>Object.prototype.__lookupGetter__ ( _P_ )</h1>
-          <p>When the `__lookupGetter__` method is called with argument _P_, the following steps are taken:</p>
+          <p>This method performs the following steps when called:</p>
           <emu-alg>
             1. Let _O_ be ? ToObject(*this* value).
             1. Let _key_ be ? ToPropertyKey(_P_).
@@ -29848,7 +29863,7 @@
 
         <emu-clause id="sec-object.prototype.__lookupSetter__">
           <h1>Object.prototype.__lookupSetter__ ( _P_ )</h1>
-          <p>When the `__lookupSetter__` method is called with argument _P_, the following steps are taken:</p>
+          <p>This method performs the following steps when called:</p>
           <emu-alg>
             1. Let _O_ be ? ToObject(*this* value).
             1. Let _key_ be ? ToPropertyKey(_P_).
@@ -29885,8 +29900,8 @@
 
       <emu-clause id="sec-function-p1-p2-pn-body">
         <h1>Function ( _p1_, _p2_, &hellip; , _pn_, _body_ )</h1>
-        <p>The last argument specifies the body (executable code) of a function; any preceding arguments specify formal parameters.</p>
-        <p>When the `Function` function is called with some arguments _p1_, _p2_, &hellip; , _pn_, _body_ (where _n_ might be 0, that is, there are no &ldquo; _p_ &rdquo; arguments, and where _body_ might also not be provided), the following steps are taken:</p>
+        <p>The last argument (if any) specifies the body (executable code) of a function; any preceding arguments specify formal parameters.</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. Let _C_ be the active function object.
           1. Let _args_ be the _argumentsList_ that was passed to this function by [[Call]] or [[Construct]].
@@ -30032,7 +30047,7 @@
 
       <emu-clause id="sec-function.prototype.apply">
         <h1>Function.prototype.apply ( _thisArg_, _argArray_ )</h1>
-        <p>When the `apply` method is called with arguments _thisArg_ and _argArray_, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _func_ be the *this* value.
           1. If IsCallable(_func_) is *false*, throw a *TypeError* exception.
@@ -30053,7 +30068,7 @@
 
       <emu-clause id="sec-function.prototype.bind">
         <h1>Function.prototype.bind ( _thisArg_, ..._args_ )</h1>
-        <p>When the `bind` method is called with argument _thisArg_ and zero or more _args_, it performs the following steps:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _Target_ be the *this* value.
           1. If IsCallable(_Target_) is *false*, throw a *TypeError* exception.
@@ -30086,7 +30101,7 @@
 
       <emu-clause id="sec-function.prototype.call">
         <h1>Function.prototype.call ( _thisArg_, ..._args_ )</h1>
-        <p>When the `call` method is called with argument _thisArg_ and zero or more _args_, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _func_ be the *this* value.
           1. If IsCallable(_func_) is *false*, throw a *TypeError* exception.
@@ -30108,7 +30123,7 @@
 
       <emu-clause id="sec-function.prototype.tostring">
         <h1>Function.prototype.toString ( )</h1>
-        <p>When the `toString` method is called, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _func_ be the *this* value.
           1. If Type(_func_) is Object and _func_ has a [[SourceText]] internal slot and _func_.[[SourceText]] is a sequence of Unicode code points and HostHasSourceTextAvailable(_func_) is *true*, then
@@ -30130,7 +30145,7 @@
 
       <emu-clause id="sec-function.prototype-@@hasinstance">
         <h1>Function.prototype [ @@hasInstance ] ( _V_ )</h1>
-        <p>When the `@@hasInstance` method is called with value _V_, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _F_ be the *this* value.
           1. Return ? OrdinaryHasInstance(_F_, _V_).
@@ -30148,7 +30163,7 @@
           <p>A constructor function can control which objects are recognized as its instances by `instanceof` by exposing a different `@@hasInstance` method on the function.</p>
         </emu-note>
         <p>This property is non-writable and non-configurable to prevent tampering that could be used to globally expose the target function of a bound function.</p>
-        <p>The value of the *"name"* property of this function is *"[Symbol.hasInstance]"*.</p>
+        <p>The value of the *"name"* property of this method is *"[Symbol.hasInstance]"*.</p>
       </emu-clause>
     </emu-clause>
 
@@ -30212,7 +30227,7 @@
 
       <emu-clause id="sec-boolean-constructor-boolean-value">
         <h1>Boolean ( _value_ )</h1>
-        <p>When `Boolean` is called with argument _value_, the following steps are taken:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. Let _b_ be ToBoolean(_value_).
           1. If NewTarget is *undefined*, return _b_.
@@ -30264,7 +30279,7 @@
 
       <emu-clause id="sec-boolean.prototype.tostring">
         <h1>Boolean.prototype.toString ( )</h1>
-        <p>The following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _b_ be ? thisBooleanValue(*this* value).
           1. If _b_ is *true*, return *"true"*; else return *"false"*.
@@ -30273,7 +30288,7 @@
 
       <emu-clause id="sec-boolean.prototype.valueof">
         <h1>Boolean.prototype.valueOf ( )</h1>
-        <p>The following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Return ? thisBooleanValue(*this* value).
         </emu-alg>
@@ -30303,7 +30318,7 @@
 
       <emu-clause id="sec-symbol-description">
         <h1>Symbol ( [ _description_ ] )</h1>
-        <p>When `Symbol` is called with optional argument _description_, the following steps are taken:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. If NewTarget is not *undefined*, throw a *TypeError* exception.
           1. If _description_ is *undefined*, let _descString_ be *undefined*.
@@ -30329,7 +30344,7 @@
 
       <emu-clause id="sec-symbol.for">
         <h1>Symbol.for ( _key_ )</h1>
-        <p>When `Symbol.for` is called with argument _key_ it performs the following steps:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. Let _stringKey_ be ? ToString(_key_).
           1. For each element _e_ of the GlobalSymbolRegistry List, do
@@ -30399,7 +30414,7 @@
 
       <emu-clause id="sec-symbol.keyfor">
         <h1>Symbol.keyFor ( _sym_ )</h1>
-        <p>When `Symbol.keyFor` is called with argument _sym_ it performs the following steps:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. If Type(_sym_) is not Symbol, throw a *TypeError* exception.
           1. For each element _e_ of the GlobalSymbolRegistry List (see <emu-xref href="#sec-symbol.for"></emu-xref>), do
@@ -30496,7 +30511,7 @@
 
       <emu-clause id="sec-symbol.prototype.description">
         <h1>get Symbol.prototype.description</h1>
-        <p>`Symbol.prototype.description` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
+        <p>`Symbol.prototype.description` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _s_ be the *this* value.
           1. Let _sym_ be ? thisSymbolValue(_s_).
@@ -30506,7 +30521,7 @@
 
       <emu-clause id="sec-symbol.prototype.tostring">
         <h1>Symbol.prototype.toString ( )</h1>
-        <p>The following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _sym_ be ? thisSymbolValue(*this* value).
           1. Return SymbolDescriptiveString(_sym_).
@@ -30531,7 +30546,7 @@
 
       <emu-clause id="sec-symbol.prototype.valueof">
         <h1>Symbol.prototype.valueOf ( )</h1>
-        <p>The following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Return ? thisSymbolValue(*this* value).
         </emu-alg>
@@ -30539,8 +30554,8 @@
 
       <emu-clause id="sec-symbol.prototype-@@toprimitive">
         <h1>Symbol.prototype [ @@toPrimitive ] ( _hint_ )</h1>
-        <p>This function is called by ECMAScript language operators to convert a Symbol object to a primitive value.</p>
-        <p>When the `@@toPrimitive` method is called with argument _hint_, the following steps are taken:</p>
+        <p>This method is called by ECMAScript language operators to convert a Symbol object to a primitive value.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Return ? thisSymbolValue(*this* value).
         </emu-alg>
@@ -30548,7 +30563,7 @@
           <p>The argument is ignored.</p>
         </emu-note>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
-        <p>The value of the *"name"* property of this function is *"[Symbol.toPrimitive]"*.</p>
+        <p>The value of the *"name"* property of this method is *"[Symbol.toPrimitive]"*.</p>
       </emu-clause>
 
       <emu-clause id="sec-symbol.prototype-@@tostringtag">
@@ -30581,7 +30596,7 @@
 
       <emu-clause id="sec-error-message">
         <h1>Error ( _message_ [ , _options_ ] )</h1>
-        <p>When the `Error` function is called with argument _message_ and optional argument _options_, the following steps are taken:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. If NewTarget is *undefined*, let _newTarget_ be the active function object; else let _newTarget_ be NewTarget.
           1. Let _O_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%Error.prototype%"*, &laquo; [[ErrorData]] &raquo;).
@@ -30636,7 +30651,7 @@
 
       <emu-clause id="sec-error.prototype.tostring">
         <h1>Error.prototype.toString ( )</h1>
-        <p>The following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. If Type(_O_) is not Object, throw a *TypeError* exception.
@@ -30712,7 +30727,7 @@
 
         <emu-clause id="sec-nativeerror">
           <h1>_NativeError_ ( _message_ [ , _options_ ] )</h1>
-          <p>When a _NativeError_ function is called with argument _message_ and optional argument _options_, the following steps are taken:</p>
+          <p>Each _NativeError_ function performs the following steps when called:</p>
           <emu-alg>
             1. If NewTarget is *undefined*, let _newTarget_ be the active function object; else let _newTarget_ be NewTarget.
             1. [id="step-nativerror-ordinarycreatefromconstructor"] Let _O_ be ? OrdinaryCreateFromConstructor(_newTarget_, <code>"%<var>NativeError</var>.prototype%"</code>, &laquo; [[ErrorData]] &raquo;).
@@ -30788,7 +30803,7 @@
 
         <emu-clause id="sec-aggregate-error">
           <h1>AggregateError ( _errors_, _message_ [ , _options_ ] )</h1>
-          <p>When the *AggregateError* function is called with arguments _errors_ and _message_ and optional argument _options_, the following steps are taken:</p>
+          <p>This function performs the following steps when called:</p>
           <emu-alg>
             1. If NewTarget is *undefined*, let _newTarget_ be the active function object; else let _newTarget_ be NewTarget.
             1. Let _O_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%AggregateError.prototype%"*, &laquo; [[ErrorData]] &raquo;).
@@ -30894,7 +30909,7 @@
 
       <emu-clause id="sec-number-constructor-number-value">
         <h1>Number ( _value_ )</h1>
-        <p>When `Number` is called with argument _value_, the following steps are taken:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. If _value_ is present, then
             1. Let _prim_ be ? ToNumeric(_value_).
@@ -30926,7 +30941,7 @@
 
       <emu-clause id="sec-number.isfinite">
         <h1>Number.isFinite ( _number_ )</h1>
-        <p>When `Number.isFinite` is called with one argument _number_, the following steps are taken:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. If Type(_number_) is not Number, return *false*.
           1. If _number_ is *NaN*, *+&infin;*<sub>𝔽</sub>, or *-&infin;*<sub>𝔽</sub>, return *false*.
@@ -30936,7 +30951,7 @@
 
       <emu-clause id="sec-number.isinteger">
         <h1>Number.isInteger ( _number_ )</h1>
-        <p>When `Number.isInteger` is called with one argument _number_, the following steps are taken:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. Return IsIntegralNumber(_number_).
         </emu-alg>
@@ -30944,7 +30959,7 @@
 
       <emu-clause id="sec-number.isnan">
         <h1>Number.isNaN ( _number_ )</h1>
-        <p>When `Number.isNaN` is called with one argument _number_, the following steps are taken:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. If Type(_number_) is not Number, return *false*.
           1. If _number_ is *NaN*, return *true*.
@@ -30957,7 +30972,7 @@
 
       <emu-clause id="sec-number.issafeinteger">
         <h1>Number.isSafeInteger ( _number_ )</h1>
-        <p>When `Number.isSafeInteger` is called with one argument _number_, the following steps are taken:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. If IsIntegralNumber(_number_) is *true*, then
             1. If abs(ℝ(_number_)) &le; 2<sup>53</sup> - 1, return *true*.
@@ -31059,7 +31074,8 @@
 
       <emu-clause id="sec-number.prototype.toexponential">
         <h1>Number.prototype.toExponential ( _fractionDigits_ )</h1>
-        <p>This method returns a String containing this Number value represented in decimal exponential notation with one digit before the significand's decimal point and _fractionDigits_ digits after the significand's decimal point. If _fractionDigits_ is *undefined*, it includes as many significand digits as necessary to uniquely specify the Number (just like in ToString except that in this case the Number is always output in exponential notation). Specifically, it performs the following steps:</p>
+        <p>This method returns a String containing this Number value represented in decimal exponential notation with one digit before the significand's decimal point and _fractionDigits_ digits after the significand's decimal point. If _fractionDigits_ is *undefined*, it includes as many significand digits as necessary to uniquely specify the Number (just like in ToString except that in this case the Number is always output in exponential notation).</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _x_ be ? thisNumberValue(*this* value).
           1. Let _f_ be ? ToIntegerOrInfinity(_fractionDigits_).
@@ -31108,9 +31124,9 @@
       <emu-clause id="sec-number.prototype.tofixed">
         <h1>Number.prototype.toFixed ( _fractionDigits_ )</h1>
         <emu-note>
-          <p>`toFixed` returns a String containing this Number value represented in decimal fixed-point notation with _fractionDigits_ digits after the decimal point. If _fractionDigits_ is *undefined*, 0 is assumed.</p>
+          <p>This method returns a String containing this Number value represented in decimal fixed-point notation with _fractionDigits_ digits after the decimal point. If _fractionDigits_ is *undefined*, 0 is assumed.</p>
         </emu-note>
-        <p>The following steps are performed:</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _x_ be ? thisNumberValue(*this* value).
           1. Let _f_ be ? ToIntegerOrInfinity(_fractionDigits_).
@@ -31150,14 +31166,15 @@
 
       <emu-clause id="sec-number.prototype.tolocalestring">
         <h1>Number.prototype.toLocaleString ( [ _reserved1_ [ , _reserved2_ ] ] )</h1>
-        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the `Number.prototype.toLocaleString` method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of the `toLocaleString` method is used.</p>
-        <p>Produces a String value that represents this Number value formatted according to the conventions of the host environment's current locale. This function is implementation-defined, and it is permissible, but not encouraged, for it to return the same thing as `toString`.</p>
+        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used:</p>
+        <p>This method produces a String value that represents this Number value formatted according to the conventions of the host environment's current locale. This method is implementation-defined, and it is permissible, but not encouraged, for it to return the same thing as `toString`.</p>
         <p>The meanings of the optional parameters to this method are defined in the ECMA-402 specification; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
       </emu-clause>
 
       <emu-clause id="sec-number.prototype.toprecision">
         <h1>Number.prototype.toPrecision ( _precision_ )</h1>
-        <p>This method returns a String containing this Number value represented either in decimal exponential notation with one digit before the significand's decimal point and <emu-eqn>_precision_ - 1</emu-eqn> digits after the significand's decimal point or in decimal fixed notation with _precision_ significant digits. If _precision_ is *undefined*, it calls ToString instead. Specifically, it performs the following steps:</p>
+        <p>This method returns a String containing this Number value represented either in decimal exponential notation with one digit before the significand's decimal point and <emu-eqn>_precision_ - 1</emu-eqn> digits after the significand's decimal point or in decimal fixed notation with _precision_ significant digits. If _precision_ is *undefined*, it calls ToString instead.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _x_ be ? thisNumberValue(*this* value).
           1. If _precision_ is *undefined*, return ! ToString(_x_).
@@ -31203,7 +31220,7 @@
         <emu-note>
           <p>The optional _radix_ should be an integral Number value in the inclusive range *2*<sub>𝔽</sub> to *36*<sub>𝔽</sub>. If _radix_ is *undefined* then *10*<sub>𝔽</sub> is used as the value of _radix_.</p>
         </emu-note>
-        <p>The following steps are performed:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _x_ be ? thisNumberValue(*this* value).
           1. If _radix_ is *undefined*, let _radixMV_ be 10.
@@ -31212,8 +31229,8 @@
           1. If _radixMV_ = 10, return ! ToString(_x_).
           1. Return the String representation of this Number value using the radix specified by _radixMV_. Letters `a`-`z` are used for digits with values 10 through 35. The precise algorithm is implementation-defined, however the algorithm should be a generalization of that specified in <emu-xref href="#sec-numeric-types-number-tostring"></emu-xref>.
         </emu-alg>
-        <p>The `toString` function is not generic; it throws a *TypeError* exception if its *this* value is not a Number or a Number object. Therefore, it cannot be transferred to other kinds of objects for use as a method.</p>
-        <p>The *"length"* property of the `toString` method is *1*<sub>𝔽</sub>.</p>
+        <p>This method is not generic; it throws a *TypeError* exception if its *this* value is not a Number or a Number object. Therefore, it cannot be transferred to other kinds of objects for use as a method.</p>
+        <p>The *"length"* property of this method is *1*<sub>𝔽</sub>.</p>
       </emu-clause>
 
       <emu-clause id="sec-number.prototype.valueof">
@@ -31245,7 +31262,7 @@
 
       <emu-clause id="sec-bigint-constructor-number-value">
         <h1>BigInt ( _value_ )</h1>
-        <p>When `BigInt` is called with argument _value_, the following steps are taken:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. If NewTarget is not *undefined*, throw a *TypeError* exception.
           1. Let _prim_ be ? ToPrimitive(_value_, ~number~).
@@ -31279,7 +31296,7 @@
 
       <emu-clause id="sec-bigint.asintn">
         <h1>BigInt.asIntN ( _bits_, _bigint_ )</h1>
-        <p>When the `BigInt.asIntN` function is called with two arguments _bits_ and _bigint_, the following steps are taken:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. Set _bits_ to ? ToIndex(_bits_).
           1. Set _bigint_ to ? ToBigInt(_bigint_).
@@ -31290,7 +31307,7 @@
 
       <emu-clause id="sec-bigint.asuintn">
         <h1>BigInt.asUintN ( _bits_, _bigint_ )</h1>
-        <p>When the `BigInt.asUintN` function is called with two arguments _bits_ and _bigint_, the following steps are taken:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. Set _bits_ to ? ToIndex(_bits_).
           1. Set _bigint_ to ? ToBigInt(_bigint_).
@@ -31331,8 +31348,8 @@
 
       <emu-clause id="sec-bigint.prototype.tolocalestring">
         <h1>BigInt.prototype.toLocaleString ( [ _reserved1_ [ , _reserved2_ ] ] )</h1>
-        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the `BigInt.prototype.toLocaleString` method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of the `toLocaleString` method is used.</p>
-        <p>Produces a String value that represents this BigInt value formatted according to the conventions of the host environment's current locale. This function is implementation-defined, and it is permissible, but not encouraged, for it to return the same thing as `toString`.</p>
+        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used:</p>
+        <p>This method produces a String value that represents this BigInt value formatted according to the conventions of the host environment's current locale. This method is implementation-defined, and it is permissible, but not encouraged, for it to return the same thing as `toString`.</p>
         <p>The meanings of the optional parameters to this method are defined in the ECMA-402 specification; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
       </emu-clause>
 
@@ -31341,7 +31358,7 @@
         <emu-note>
           <p>The optional _radix_ should be an integral Number value in the inclusive range *2*<sub>𝔽</sub> to *36*<sub>𝔽</sub>. If _radix_ is *undefined* then *10*<sub>𝔽</sub> is used as the value of _radix_.</p>
         </emu-note>
-        <p>The following steps are performed:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _x_ be ? thisBigIntValue(*this* value).
           1. If _radix_ is *undefined*, let _radixMV_ be 10.
@@ -31350,7 +31367,7 @@
           1. If _radixMV_ = 10, return ! ToString(_x_).
           1. Return the String representation of this Number value using the radix specified by _radixMV_. Letters `a`-`z` are used for digits with values 10 through 35. The precise algorithm is implementation-defined, however the algorithm should be a generalization of that specified in <emu-xref href="#sec-numeric-types-bigint-tostring"></emu-xref>.
         </emu-alg>
-        <p>The `toString` function is not generic; it throws a *TypeError* exception if its *this* value is not a BigInt or a BigInt object. Therefore, it cannot be transferred to other kinds of objects for use as a method.</p>
+        <p>This method is not generic; it throws a *TypeError* exception if its *this* value is not a BigInt or a BigInt object. Therefore, it cannot be transferred to other kinds of objects for use as a method.</p>
       </emu-clause>
 
       <emu-clause id="sec-bigint.prototype.valueof">
@@ -31460,8 +31477,8 @@
 
       <emu-clause id="sec-math.abs">
         <h1>Math.abs ( _x_ )</h1>
-        <p>Returns the absolute value of _x_; the result has the same magnitude as _x_ but has positive sign.</p>
-        <p>When the `Math.abs` method is called with argument _x_, the following steps are taken:</p>
+        <p>This function returns the absolute value of _x_; the result has the same magnitude as _x_ but has positive sign.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
           1. If _n_ is *NaN*, return *NaN*.
@@ -31474,8 +31491,8 @@
 
       <emu-clause id="sec-math.acos">
         <h1>Math.acos ( _x_ )</h1>
-        <p>Returns the inverse cosine of _x_. The result is expressed in radians and ranges from *+0*<sub>𝔽</sub> to 𝔽(&pi;), inclusive.</p>
-        <p>When the `Math.acos` method is called with argument _x_, the following steps are taken:</p>
+        <p>This function returns the inverse cosine of _x_. The result is expressed in radians and ranges from *+0*<sub>𝔽</sub> to 𝔽(&pi;), inclusive.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
           1. If _n_ is *NaN*, _n_ &gt; *1*<sub>𝔽</sub>, or _n_ &lt; *-1*<sub>𝔽</sub>, return *NaN*.
@@ -31486,8 +31503,8 @@
 
       <emu-clause id="sec-math.acosh">
         <h1>Math.acosh ( _x_ )</h1>
-        <p>Returns the inverse hyperbolic cosine of _x_.</p>
-        <p>When the `Math.acosh` method is called with argument _x_, the following steps are taken:</p>
+        <p>This function returns the inverse hyperbolic cosine of _x_.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
           1. If _n_ is *NaN* or _n_ is *+&infin;*<sub>𝔽</sub>, return _n_.
@@ -31499,8 +31516,8 @@
 
       <emu-clause id="sec-math.asin">
         <h1>Math.asin ( _x_ )</h1>
-        <p>Returns the inverse sine of _x_. The result is expressed in radians and ranges from 𝔽(-&pi; / 2) to 𝔽(&pi; / 2), inclusive.</p>
-        <p>When the `Math.asin` method is called with argument _x_, the following steps are taken:</p>
+        <p>This function returns the inverse sine of _x_. The result is expressed in radians and ranges from 𝔽(-&pi; / 2) to 𝔽(&pi; / 2), inclusive.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
           1. If _n_ is *NaN*, _n_ is *+0*<sub>𝔽</sub>, or _n_ is *-0*<sub>𝔽</sub>, return _n_.
@@ -31511,8 +31528,8 @@
 
       <emu-clause id="sec-math.asinh">
         <h1>Math.asinh ( _x_ )</h1>
-        <p>Returns the inverse hyperbolic sine of _x_.</p>
-        <p>When the `Math.asinh` method is called with argument _x_, the following steps are taken:</p>
+        <p>This function returns the inverse hyperbolic sine of _x_.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
           1. If _n_ is *NaN*, _n_ is *+0*<sub>𝔽</sub>, _n_ is *-0*<sub>𝔽</sub>, _n_ is *+&infin;*<sub>𝔽</sub>, or _n_ is *-&infin;*<sub>𝔽</sub>, return _n_.
@@ -31522,8 +31539,8 @@
 
       <emu-clause id="sec-math.atan">
         <h1>Math.atan ( _x_ )</h1>
-        <p>Returns the inverse tangent of _x_. The result is expressed in radians and ranges from 𝔽(-&pi; / 2) to 𝔽(&pi; / 2), inclusive.</p>
-        <p>When the `Math.atan` method is called with argument _x_, the following steps are taken:</p>
+        <p>This function returns the inverse tangent of _x_. The result is expressed in radians and ranges from 𝔽(-&pi; / 2) to 𝔽(&pi; / 2), inclusive.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
           1. If _n_ is *NaN*, _n_ is *+0*<sub>𝔽</sub>, or _n_ is *-0*<sub>𝔽</sub>, return _n_.
@@ -31535,8 +31552,8 @@
 
       <emu-clause id="sec-math.atanh">
         <h1>Math.atanh ( _x_ )</h1>
-        <p>Returns the inverse hyperbolic tangent of _x_.</p>
-        <p>When the `Math.atanh` method is called with argument _x_, the following steps are taken:</p>
+        <p>This function returns the inverse hyperbolic tangent of _x_.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
           1. If _n_ is *NaN*, _n_ is *+0*<sub>𝔽</sub>, or _n_ is *-0*<sub>𝔽</sub>, return _n_.
@@ -31549,8 +31566,8 @@
 
       <emu-clause id="sec-math.atan2">
         <h1>Math.atan2 ( _y_, _x_ )</h1>
-        <p>Returns the inverse tangent of the quotient <emu-eqn>_y_ / _x_</emu-eqn> of the arguments _y_ and _x_, where the signs of _y_ and _x_ are used to determine the quadrant of the result. Note that it is intentional and traditional for the two-argument inverse tangent function that the argument named _y_ be first and the argument named _x_ be second. The result is expressed in radians and ranges from -&pi; to +&pi;, inclusive.</p>
-        <p>When the `Math.atan2` method is called with arguments _y_ and _x_, the following steps are taken:</p>
+        <p>This function returns the inverse tangent of the quotient <emu-eqn>_y_ / _x_</emu-eqn> of the arguments _y_ and _x_, where the signs of _y_ and _x_ are used to determine the quadrant of the result. Note that it is intentional and traditional for the two-argument inverse tangent function that the argument named _y_ be first and the argument named _x_ be second. The result is expressed in radians and ranges from -&pi; to +&pi;, inclusive.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _ny_ be ? ToNumber(_y_).
           1. Let _nx_ be ? ToNumber(_x_).
@@ -31585,8 +31602,8 @@
 
       <emu-clause id="sec-math.cbrt">
         <h1>Math.cbrt ( _x_ )</h1>
-        <p>Returns the cube root of _x_.</p>
-        <p>When the `Math.cbrt` method is called with argument _x_, the following steps are taken:</p>
+        <p>This function returns the cube root of _x_.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
           1. If _n_ is *NaN*, _n_ is *+0*<sub>𝔽</sub>, _n_ is *-0*<sub>𝔽</sub>, _n_ is *+&infin;*<sub>𝔽</sub>, or _n_ is *-&infin;*<sub>𝔽</sub>, return _n_.
@@ -31596,8 +31613,8 @@
 
       <emu-clause id="sec-math.ceil">
         <h1>Math.ceil ( _x_ )</h1>
-        <p>Returns the smallest (closest to -&infin;) integral Number value that is not less than _x_. If _x_ is already an integral Number, the result is _x_.</p>
-        <p>When the `Math.ceil` method is called with argument _x_, the following steps are taken:</p>
+        <p>This function returns the smallest (closest to -&infin;) integral Number value that is not less than _x_. If _x_ is already an integral Number, the result is _x_.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
           1. If _n_ is *NaN*, _n_ is *+0*<sub>𝔽</sub>, _n_ is *-0*<sub>𝔽</sub>, _n_ is *+&infin;*<sub>𝔽</sub>, or _n_ is *-&infin;*<sub>𝔽</sub>, return _n_.
@@ -31612,7 +31629,7 @@
 
       <emu-clause id="sec-math.clz32">
         <h1>Math.clz32 ( _x_ )</h1>
-        <p>When the `Math.clz32` method is called with argument _x_, the following steps are taken:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. Let _n_ be ? ToUint32(_x_).
           1. Let _p_ be the number of leading zero bits in the unsigned 32-bit binary representation of _n_.
@@ -31625,8 +31642,8 @@
 
       <emu-clause id="sec-math.cos">
         <h1>Math.cos ( _x_ )</h1>
-        <p>Returns the cosine of _x_. The argument is expressed in radians.</p>
-        <p>When the `Math.cos` method is called with argument _x_, the following steps are taken:</p>
+        <p>This function returns the cosine of _x_. The argument is expressed in radians.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
           1. If _n_ is *NaN*, _n_ is *+&infin;*<sub>𝔽</sub>, or _n_ is *-&infin;*<sub>𝔽</sub>, return *NaN*.
@@ -31637,8 +31654,8 @@
 
       <emu-clause id="sec-math.cosh">
         <h1>Math.cosh ( _x_ )</h1>
-        <p>Returns the hyperbolic cosine of _x_.</p>
-        <p>When the `Math.cosh` method is called with argument _x_, the following steps are taken:</p>
+        <p>This function returns the hyperbolic cosine of _x_.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
           1. If _n_ is *NaN*, return *NaN*.
@@ -31653,8 +31670,8 @@
 
       <emu-clause id="sec-math.exp">
         <h1>Math.exp ( _x_ )</h1>
-        <p>Returns the exponential function of _x_ (_e_ raised to the power of _x_, where _e_ is the base of the natural logarithms).</p>
-        <p>When the `Math.exp` method is called with argument _x_, the following steps are taken:</p>
+        <p>This function returns the exponential function of _x_ (_e_ raised to the power of _x_, where _e_ is the base of the natural logarithms).</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
           1. If _n_ is *NaN* or _n_ is *+&infin;*<sub>𝔽</sub>, return _n_.
@@ -31666,8 +31683,8 @@
 
       <emu-clause id="sec-math.expm1">
         <h1>Math.expm1 ( _x_ )</h1>
-        <p>Returns the result of subtracting 1 from the exponential function of _x_ (_e_ raised to the power of _x_, where _e_ is the base of the natural logarithms). The result is computed in a way that is accurate even when the value of _x_ is close to 0.</p>
-        <p>When the `Math.expm1` method is called with argument _x_, the following steps are taken:</p>
+        <p>This function returns the result of subtracting 1 from the exponential function of _x_ (_e_ raised to the power of _x_, where _e_ is the base of the natural logarithms). The result is computed in a way that is accurate even when the value of _x_ is close to 0.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
           1. If _n_ is *NaN*, _n_ is *+0*<sub>𝔽</sub>, _n_ is *-0*<sub>𝔽</sub>, or _n_ is *+&infin;*<sub>𝔽</sub>, return _n_.
@@ -31678,8 +31695,8 @@
 
       <emu-clause id="sec-math.floor">
         <h1>Math.floor ( _x_ )</h1>
-        <p>Returns the greatest (closest to +&infin;) integral Number value that is not greater than _x_. If _x_ is already an integral Number, the result is _x_.</p>
-        <p>When the `Math.floor` method is called with argument _x_, the following steps are taken:</p>
+        <p>This function returns the greatest (closest to +&infin;) integral Number value that is not greater than _x_. If _x_ is already an integral Number, the result is _x_.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
           1. If _n_ is *NaN*, _n_ is *+0*<sub>𝔽</sub>, _n_ is *-0*<sub>𝔽</sub>, _n_ is *+&infin;*<sub>𝔽</sub>, or _n_ is *-&infin;*<sub>𝔽</sub>, return _n_.
@@ -31694,7 +31711,7 @@
 
       <emu-clause id="sec-math.fround">
         <h1>Math.fround ( _x_ )</h1>
-        <p>When the `Math.fround` method is called with argument _x_, the following steps are taken:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
           1. If _n_ is *NaN*, return *NaN*.
@@ -31707,8 +31724,8 @@
 
       <emu-clause id="sec-math.hypot">
         <h1>Math.hypot ( ..._args_ )</h1>
-        <p>Returns the square root of the sum of squares of its arguments.</p>
-        <p>When the `Math.hypot` method is called with zero or more arguments which form the rest parameter ..._args_, the following steps are taken:</p>
+        <p>Given zero or more arguments, this function returns the square root of the sum of squares of its arguments.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _coerced_ be a new empty List.
           1. For each element _arg_ of _args_, do
@@ -31723,7 +31740,7 @@
           1. If _onlyZero_ is *true*, return *+0*<sub>𝔽</sub>.
           1. Return an implementation-approximated Number value representing the square root of the sum of squares of the mathematical values of the elements of _coerced_.
         </emu-alg>
-        <p>The *"length"* property of the `hypot` method is *2*<sub>𝔽</sub>.</p>
+        <p>The *"length"* property of this function is *2*<sub>𝔽</sub>.</p>
         <emu-note>
           <p>Implementations should take care to avoid the loss of precision from overflows and underflows that are prone to occur in naive implementations when this function is called with two or more arguments.</p>
         </emu-note>
@@ -31731,7 +31748,7 @@
 
       <emu-clause id="sec-math.imul">
         <h1>Math.imul ( _x_, _y_ )</h1>
-        <p>When `Math.imul` is called with arguments _x_ and _y_, the following steps are taken:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. Let _a_ be ℝ(? ToUint32(_x_)).
           1. Let _b_ be ℝ(? ToUint32(_y_)).
@@ -31742,8 +31759,8 @@
 
       <emu-clause id="sec-math.log">
         <h1>Math.log ( _x_ )</h1>
-        <p>Returns the natural logarithm of _x_.</p>
-        <p>When the `Math.log` method is called with argument _x_, the following steps are taken:</p>
+        <p>This function returns the natural logarithm of _x_.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
           1. If _n_ is *NaN* or _n_ is *+&infin;*<sub>𝔽</sub>, return _n_.
@@ -31756,8 +31773,8 @@
 
       <emu-clause id="sec-math.log1p">
         <h1>Math.log1p ( _x_ )</h1>
-        <p>Returns the natural logarithm of 1 + _x_. The result is computed in a way that is accurate even when the value of x is close to zero.</p>
-        <p>When the `Math.log1p` method is called with argument _x_, the following steps are taken:</p>
+        <p>This function returns the natural logarithm of 1 + _x_. The result is computed in a way that is accurate even when the value of x is close to zero.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
           1. If _n_ is *NaN*, _n_ is *+0*<sub>𝔽</sub>, _n_ is *-0*<sub>𝔽</sub>, or _n_ is *+&infin;*<sub>𝔽</sub>, return _n_.
@@ -31769,8 +31786,8 @@
 
       <emu-clause id="sec-math.log10">
         <h1>Math.log10 ( _x_ )</h1>
-        <p>Returns the base 10 logarithm of _x_.</p>
-        <p>When the `Math.log10` method is called with argument _x_, the following steps are taken:</p>
+        <p>This function returns the base 10 logarithm of _x_.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
           1. If _n_ is *NaN* or _n_ is *+&infin;*<sub>𝔽</sub>, return _n_.
@@ -31783,8 +31800,8 @@
 
       <emu-clause id="sec-math.log2">
         <h1>Math.log2 ( _x_ )</h1>
-        <p>Returns the base 2 logarithm of _x_.</p>
-        <p>When the `Math.log2` method is called with argument _x_, the following steps are taken:</p>
+        <p>This function returns the base 2 logarithm of _x_.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
           1. If _n_ is *NaN* or _n_ is *+&infin;*<sub>𝔽</sub>, return _n_.
@@ -31797,8 +31814,8 @@
 
       <emu-clause id="sec-math.max">
         <h1>Math.max ( ..._args_ )</h1>
-        <p>Given zero or more arguments, calls ToNumber on each of the arguments and returns the largest of the resulting values.</p>
-        <p>When the `Math.max` method is called with zero or more arguments which form the rest parameter ..._args_, the following steps are taken:</p>
+        <p>Given zero or more arguments, this function calls ToNumber on each of the arguments and returns the largest of the resulting values.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _coerced_ be a new empty List.
           1. For each element _arg_ of _args_, do
@@ -31814,13 +31831,13 @@
         <emu-note>
           <p>The comparison of values to determine the largest value is done using the IsLessThan algorithm except that *+0*<sub>𝔽</sub> is considered to be larger than *-0*<sub>𝔽</sub>.</p>
         </emu-note>
-        <p>The *"length"* property of the `max` method is *2*<sub>𝔽</sub>.</p>
+        <p>The *"length"* property of this function is *2*<sub>𝔽</sub>.</p>
       </emu-clause>
 
       <emu-clause id="sec-math.min">
         <h1>Math.min ( ..._args_ )</h1>
-        <p>Given zero or more arguments, calls ToNumber on each of the arguments and returns the smallest of the resulting values.</p>
-        <p>When the `Math.min` method is called with zero or more arguments which form the rest parameter ..._args_, the following steps are taken:</p>
+        <p>Given zero or more arguments, this function calls ToNumber on each of the arguments and returns the smallest of the resulting values.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _coerced_ be a new empty List.
           1. For each element _arg_ of _args_, do
@@ -31836,12 +31853,12 @@
         <emu-note>
           <p>The comparison of values to determine the largest value is done using the IsLessThan algorithm except that *+0*<sub>𝔽</sub> is considered to be larger than *-0*<sub>𝔽</sub>.</p>
         </emu-note>
-        <p>The *"length"* property of the `min` method is *2*<sub>𝔽</sub>.</p>
+        <p>The *"length"* property of this function is *2*<sub>𝔽</sub>.</p>
       </emu-clause>
 
       <emu-clause id="sec-math.pow">
         <h1>Math.pow ( _base_, _exponent_ )</h1>
-        <p>When the `Math.pow` method is called with arguments _base_ and _exponent_, the following steps are taken:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. Set _base_ to ? ToNumber(_base_).
           1. Set _exponent_ to ? ToNumber(_exponent_).
@@ -31851,14 +31868,14 @@
 
       <emu-clause id="sec-math.random">
         <h1>Math.random ( )</h1>
-        <p>Returns a Number value with positive sign, greater than or equal to *+0*<sub>𝔽</sub> but strictly less than *1*<sub>𝔽</sub>, chosen randomly or pseudo randomly with approximately uniform distribution over that range, using an implementation-defined algorithm or strategy. This function takes no arguments.</p>
+        <p>This function returns a Number value with positive sign, greater than or equal to *+0*<sub>𝔽</sub> but strictly less than *1*<sub>𝔽</sub>, chosen randomly or pseudo randomly with approximately uniform distribution over that range, using an implementation-defined algorithm or strategy.</p>
         <p>Each `Math.random` function created for distinct realms must produce a distinct sequence of values from successive calls.</p>
       </emu-clause>
 
       <emu-clause id="sec-math.round">
         <h1>Math.round ( _x_ )</h1>
-        <p>Returns the Number value that is closest to _x_ and is integral. If two integral Numbers are equally close to _x_, then the result is the Number value that is closer to +&infin;. If _x_ is already integral, the result is _x_.</p>
-        <p>When the `Math.round` method is called with argument _x_, the following steps are taken:</p>
+        <p>This function returns the Number value that is closest to _x_ and is integral. If two integral Numbers are equally close to _x_, then the result is the Number value that is closer to +&infin;. If _x_ is already integral, the result is _x_.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
           1. If _n_ is *NaN*, *+&infin;*<sub>𝔽</sub>, *-&infin;*<sub>𝔽</sub>, or an integral Number, return _n_.
@@ -31876,8 +31893,8 @@
 
       <emu-clause id="sec-math.sign">
         <h1>Math.sign ( _x_ )</h1>
-        <p>Returns the sign of _x_, indicating whether _x_ is positive, negative, or zero.</p>
-        <p>When the `Math.sign` method is called with argument _x_, the following steps are taken:</p>
+        <p>This function returns the sign of _x_, indicating whether _x_ is positive, negative, or zero.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
           1. If _n_ is *NaN*, _n_ is *+0*<sub>𝔽</sub>, or _n_ is *-0*<sub>𝔽</sub>, return _n_.
@@ -31888,8 +31905,8 @@
 
       <emu-clause id="sec-math.sin">
         <h1>Math.sin ( _x_ )</h1>
-        <p>Returns the sine of _x_. The argument is expressed in radians.</p>
-        <p>When the `Math.sin` method is called with argument _x_, the following steps are taken:</p>
+        <p>This function returns the sine of _x_. The argument is expressed in radians.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
           1. If _n_ is *NaN*, _n_ is *+0*<sub>𝔽</sub>, or _n_ is *-0*<sub>𝔽</sub>, return _n_.
@@ -31900,8 +31917,8 @@
 
       <emu-clause id="sec-math.sinh">
         <h1>Math.sinh ( _x_ )</h1>
-        <p>Returns the hyperbolic sine of _x_.</p>
-        <p>When the `Math.sinh` method is called with argument _x_, the following steps are taken:</p>
+        <p>This function returns the hyperbolic sine of _x_.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
           1. If _n_ is *NaN*, _n_ is *+0*<sub>𝔽</sub>, _n_ is *-0*<sub>𝔽</sub>, _n_ is *+&infin;*<sub>𝔽</sub>, or _n_ is *-&infin;*<sub>𝔽</sub>, return _n_.
@@ -31914,8 +31931,8 @@
 
       <emu-clause id="sec-math.sqrt">
         <h1>Math.sqrt ( _x_ )</h1>
-        <p>Returns the square root of _x_.</p>
-        <p>When the `Math.sqrt` method is called with argument _x_, the following steps are taken:</p>
+        <p>This function returns the square root of _x_.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
           1. If _n_ is *NaN*, _n_ is *+0*<sub>𝔽</sub>, _n_ is *-0*<sub>𝔽</sub>, or _n_ is *+&infin;*<sub>𝔽</sub>, return _n_.
@@ -31926,8 +31943,8 @@
 
       <emu-clause id="sec-math.tan">
         <h1>Math.tan ( _x_ )</h1>
-        <p>Returns the tangent of _x_. The argument is expressed in radians.</p>
-        <p>When the `Math.tan` method is called with argument _x_, the following steps are taken:</p>
+        <p>This function returns the tangent of _x_. The argument is expressed in radians.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
           1. If _n_ is *NaN*, _n_ is *+0*<sub>𝔽</sub>, or _n_ is *-0*<sub>𝔽</sub>, return _n_.
@@ -31938,8 +31955,8 @@
 
       <emu-clause id="sec-math.tanh">
         <h1>Math.tanh ( _x_ )</h1>
-        <p>Returns the hyperbolic tangent of _x_.</p>
-        <p>When the `Math.tanh` method is called with argument _x_, the following steps are taken:</p>
+        <p>This function returns the hyperbolic tangent of _x_.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
           1. If _n_ is *NaN*, _n_ is *+0*<sub>𝔽</sub>, or _n_ is *-0*<sub>𝔽</sub>, return _n_.
@@ -31954,8 +31971,8 @@
 
       <emu-clause id="sec-math.trunc">
         <h1>Math.trunc ( _x_ )</h1>
-        <p>Returns the integral part of the number _x_, removing any fractional digits. If _x_ is already integral, the result is _x_.</p>
-        <p>When the `Math.trunc` method is called with argument _x_, the following steps are taken:</p>
+        <p>This function returns the integral part of the number _x_, removing any fractional digits. If _x_ is already integral, the result is _x_.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
           1. If _n_ is *NaN*, _n_ is *+0*<sub>𝔽</sub>, _n_ is *-0*<sub>𝔽</sub>, _n_ is *+&infin;*<sub>𝔽</sub>, or _n_ is *-&infin;*<sub>𝔽</sub>, return _n_.
@@ -32413,7 +32430,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date" oldids="sec-date-constructor-date,sec-date-value,sec-date-year-month-date-hours-minutes-seconds-ms">
         <h1>Date ( ..._values_ )</h1>
-        <p>When the `Date` function is called, the following steps are taken:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. If NewTarget is *undefined*, then
             1. Let _now_ be the time value (UTC) identifying the current time.
@@ -32465,12 +32482,12 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.now">
         <h1>Date.now ( )</h1>
-        <p>The `now` function returns the time value designating the UTC date and time of the occurrence of the call to `now`.</p>
+        <p>This function returns the time value designating the UTC date and time of the occurrence of the call to it.</p>
       </emu-clause>
 
       <emu-clause id="sec-date.parse">
         <h1>Date.parse ( _string_ )</h1>
-        <p>The `parse` function applies the ToString operator to its argument. If ToString results in an abrupt completion the Completion Record is immediately returned. Otherwise, `parse` interprets the resulting String as a date and time; it returns a Number, the UTC time value corresponding to the date and time. The String may be interpreted as a local time, a UTC time, or a time in some other time zone, depending on the contents of the String. The function first attempts to parse the String according to the format described in Date Time String Format (<emu-xref href="#sec-date-time-string-format"></emu-xref>), including expanded years. If the String does not conform to that format the function may fall back to any implementation-specific heuristics or implementation-specific date formats. Strings that are unrecognizable or contain out-of-bounds format element values shall cause `Date.parse` to return *NaN*.</p>
+        <p>This function applies the ToString operator to its argument. If ToString results in an abrupt completion the Completion Record is immediately returned. Otherwise, this function interprets the resulting String as a date and time; it returns a Number, the UTC time value corresponding to the date and time. The String may be interpreted as a local time, a UTC time, or a time in some other time zone, depending on the contents of the String. The function first attempts to parse the String according to the format described in Date Time String Format (<emu-xref href="#sec-date-time-string-format"></emu-xref>), including expanded years. If the String does not conform to that format the function may fall back to any implementation-specific heuristics or implementation-specific date formats. Strings that are unrecognizable or contain out-of-bounds format element values shall cause this function to return *NaN*.</p>
         <p>If the String conforms to the <emu-xref href="#sec-date-time-string-format">Date Time String Format</emu-xref>, substitute values take the place of absent format elements. When the `MM` or `DD` elements are absent, *"01"* is used. When the `HH`, `mm`, or `ss` elements are absent, *"00"* is used. When the `sss` element is absent, *"000"* is used. When the UTC offset representation is absent, date-only forms are interpreted as a UTC time and date-time forms are interpreted as a local time.</p>
         <p>If `x` is any Date whose milliseconds amount is zero within a particular implementation of ECMAScript, then all of the following expressions should produce the same numeric value in that implementation, if all the properties referenced have their initial values:</p>
         <pre><code class="javascript">
@@ -32483,7 +32500,7 @@ THH:mm:ss.sss
         <pre><code class="javascript">
           Date.parse(x.toLocaleString())
         </code></pre>
-        <p>is not required to produce the same Number value as the preceding three expressions and, in general, the value produced by `Date.parse` is implementation-defined when given any String value that does not conform to the Date Time String Format (<emu-xref href="#sec-date-time-string-format"></emu-xref>) and that could not be produced in that implementation by the `toString` or `toUTCString` method.</p>
+        <p>is not required to produce the same Number value as the preceding three expressions and, in general, the value produced by this function is implementation-defined when given any String value that does not conform to the Date Time String Format (<emu-xref href="#sec-date-time-string-format"></emu-xref>) and that could not be produced in that implementation by the `toString` or `toUTCString` method.</p>
       </emu-clause>
 
       <emu-clause id="sec-date.prototype">
@@ -32494,7 +32511,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.utc">
         <h1>Date.UTC ( _year_ [ , _month_ [ , _date_ [ , _hours_ [ , _minutes_ [ , _seconds_ [ , _ms_ ] ] ] ] ] ] )</h1>
-        <p>When the `UTC` function is called, the following steps are taken:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. Let _y_ be ? ToNumber(_year_).
           1. If _month_ is present, let _m_ be ? ToNumber(_month_); else let _m_ be *+0*<sub>𝔽</sub>.
@@ -32509,9 +32526,9 @@ THH:mm:ss.sss
             1. If 0 &le; _yi_ &le; 99, let _yr_ be *1900*<sub>𝔽</sub> + 𝔽(_yi_); otherwise, let _yr_ be _y_.
           1. Return TimeClip(MakeDate(MakeDay(_yr_, _m_, _dt_), MakeTime(_h_, _min_, _s_, _milli_))).
         </emu-alg>
-        <p>The *"length"* property of the `UTC` function is *7*<sub>𝔽</sub>.</p>
+        <p>The *"length"* property of this function is *7*<sub>𝔽</sub>.</p>
         <emu-note>
-          <p>The `UTC` function differs from the Date constructor in two ways: it returns a time value as a Number, rather than creating a Date, and it interprets the arguments in UTC rather than as local time.</p>
+          <p>This function differs from the Date constructor in two ways: it returns a time value as a Number, rather than creating a Date, and it interprets the arguments in UTC rather than as local time.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -32541,7 +32558,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype.getdate">
         <h1>Date.prototype.getDate ( )</h1>
-        <p>The following steps are performed:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _t_ be ? thisTimeValue(*this* value).
           1. If _t_ is *NaN*, return *NaN*.
@@ -32551,7 +32568,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype.getday">
         <h1>Date.prototype.getDay ( )</h1>
-        <p>The following steps are performed:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _t_ be ? thisTimeValue(*this* value).
           1. If _t_ is *NaN*, return *NaN*.
@@ -32561,7 +32578,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype.getfullyear">
         <h1>Date.prototype.getFullYear ( )</h1>
-        <p>The following steps are performed:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _t_ be ? thisTimeValue(*this* value).
           1. If _t_ is *NaN*, return *NaN*.
@@ -32571,7 +32588,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype.gethours">
         <h1>Date.prototype.getHours ( )</h1>
-        <p>The following steps are performed:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _t_ be ? thisTimeValue(*this* value).
           1. If _t_ is *NaN*, return *NaN*.
@@ -32581,7 +32598,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype.getmilliseconds">
         <h1>Date.prototype.getMilliseconds ( )</h1>
-        <p>The following steps are performed:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _t_ be ? thisTimeValue(*this* value).
           1. If _t_ is *NaN*, return *NaN*.
@@ -32591,7 +32608,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype.getminutes">
         <h1>Date.prototype.getMinutes ( )</h1>
-        <p>The following steps are performed:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _t_ be ? thisTimeValue(*this* value).
           1. If _t_ is *NaN*, return *NaN*.
@@ -32601,7 +32618,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype.getmonth">
         <h1>Date.prototype.getMonth ( )</h1>
-        <p>The following steps are performed:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _t_ be ? thisTimeValue(*this* value).
           1. If _t_ is *NaN*, return *NaN*.
@@ -32611,7 +32628,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype.getseconds">
         <h1>Date.prototype.getSeconds ( )</h1>
-        <p>The following steps are performed:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _t_ be ? thisTimeValue(*this* value).
           1. If _t_ is *NaN*, return *NaN*.
@@ -32621,7 +32638,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype.gettime">
         <h1>Date.prototype.getTime ( )</h1>
-        <p>The following steps are performed:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Return ? thisTimeValue(*this* value).
         </emu-alg>
@@ -32629,7 +32646,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype.gettimezoneoffset">
         <h1>Date.prototype.getTimezoneOffset ( )</h1>
-        <p>The following steps are performed:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _t_ be ? thisTimeValue(*this* value).
           1. If _t_ is *NaN*, return *NaN*.
@@ -32639,7 +32656,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype.getutcdate">
         <h1>Date.prototype.getUTCDate ( )</h1>
-        <p>The following steps are performed:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _t_ be ? thisTimeValue(*this* value).
           1. If _t_ is *NaN*, return *NaN*.
@@ -32649,7 +32666,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype.getutcday">
         <h1>Date.prototype.getUTCDay ( )</h1>
-        <p>The following steps are performed:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _t_ be ? thisTimeValue(*this* value).
           1. If _t_ is *NaN*, return *NaN*.
@@ -32659,7 +32676,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype.getutcfullyear">
         <h1>Date.prototype.getUTCFullYear ( )</h1>
-        <p>The following steps are performed:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _t_ be ? thisTimeValue(*this* value).
           1. If _t_ is *NaN*, return *NaN*.
@@ -32669,7 +32686,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype.getutchours">
         <h1>Date.prototype.getUTCHours ( )</h1>
-        <p>The following steps are performed:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _t_ be ? thisTimeValue(*this* value).
           1. If _t_ is *NaN*, return *NaN*.
@@ -32679,7 +32696,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype.getutcmilliseconds">
         <h1>Date.prototype.getUTCMilliseconds ( )</h1>
-        <p>The following steps are performed:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _t_ be ? thisTimeValue(*this* value).
           1. If _t_ is *NaN*, return *NaN*.
@@ -32689,7 +32706,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype.getutcminutes">
         <h1>Date.prototype.getUTCMinutes ( )</h1>
-        <p>The following steps are performed:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _t_ be ? thisTimeValue(*this* value).
           1. If _t_ is *NaN*, return *NaN*.
@@ -32699,7 +32716,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype.getutcmonth">
         <h1>Date.prototype.getUTCMonth ( )</h1>
-        <p>The following steps are performed:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _t_ be ? thisTimeValue(*this* value).
           1. If _t_ is *NaN*, return *NaN*.
@@ -32709,7 +32726,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype.getutcseconds">
         <h1>Date.prototype.getUTCSeconds ( )</h1>
-        <p>The following steps are performed:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _t_ be ? thisTimeValue(*this* value).
           1. If _t_ is *NaN*, return *NaN*.
@@ -32719,7 +32736,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype.setdate">
         <h1>Date.prototype.setDate ( _date_ )</h1>
-        <p>The following steps are performed:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _t_ be ? thisTimeValue(*this* value).
           1. Let _dt_ be ? ToNumber(_date_).
@@ -32734,7 +32751,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype.setfullyear">
         <h1>Date.prototype.setFullYear ( _year_ [ , _month_ [ , _date_ ] ] )</h1>
-        <p>The following steps are performed:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _t_ be ? thisTimeValue(*this* value).
           1. Let _y_ be ? ToNumber(_year_).
@@ -32746,7 +32763,7 @@ THH:mm:ss.sss
           1. Set the [[DateValue]] internal slot of this Date object to _u_.
           1. Return _u_.
         </emu-alg>
-        <p>The *"length"* property of the `setFullYear` method is *3*<sub>𝔽</sub>.</p>
+        <p>The *"length"* property of this method is *3*<sub>𝔽</sub>.</p>
         <emu-note>
           <p>If _month_ is not present, this method behaves as if _month_ was present with the value `getMonth()`. If _date_ is not present, it behaves as if _date_ was present with the value `getDate()`.</p>
         </emu-note>
@@ -32754,7 +32771,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype.sethours">
         <h1>Date.prototype.setHours ( _hour_ [ , _min_ [ , _sec_ [ , _ms_ ] ] ] )</h1>
-        <p>The following steps are performed:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _t_ be ? thisTimeValue(*this* value).
           1. Let _h_ be ? ToNumber(_hour_).
@@ -32771,7 +32788,7 @@ THH:mm:ss.sss
           1. Set the [[DateValue]] internal slot of this Date object to _u_.
           1. Return _u_.
         </emu-alg>
-        <p>The *"length"* property of the `setHours` method is *4*<sub>𝔽</sub>.</p>
+        <p>The *"length"* property of this method is *4*<sub>𝔽</sub>.</p>
         <emu-note>
           <p>If _min_ is not present, this method behaves as if _min_ was present with the value `getMinutes()`. If _sec_ is not present, it behaves as if _sec_ was present with the value `getSeconds()`. If _ms_ is not present, it behaves as if _ms_ was present with the value `getMilliseconds()`.</p>
         </emu-note>
@@ -32779,7 +32796,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype.setmilliseconds">
         <h1>Date.prototype.setMilliseconds ( _ms_ )</h1>
-        <p>The following steps are performed:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _t_ be ? thisTimeValue(*this* value).
           1. Set _ms_ to ? ToNumber(_ms_).
@@ -32794,7 +32811,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype.setminutes">
         <h1>Date.prototype.setMinutes ( _min_ [ , _sec_ [ , _ms_ ] ] )</h1>
-        <p>The following steps are performed:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _t_ be ? thisTimeValue(*this* value).
           1. Let _m_ be ? ToNumber(_min_).
@@ -32809,7 +32826,7 @@ THH:mm:ss.sss
           1. Set the [[DateValue]] internal slot of this Date object to _u_.
           1. Return _u_.
         </emu-alg>
-        <p>The *"length"* property of the `setMinutes` method is *3*<sub>𝔽</sub>.</p>
+        <p>The *"length"* property of this method is *3*<sub>𝔽</sub>.</p>
         <emu-note>
           <p>If _sec_ is not present, this method behaves as if _sec_ was present with the value `getSeconds()`. If _ms_ is not present, this behaves as if _ms_ was present with the value `getMilliseconds()`.</p>
         </emu-note>
@@ -32817,7 +32834,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype.setmonth">
         <h1>Date.prototype.setMonth ( _month_ [ , _date_ ] )</h1>
-        <p>The following steps are performed:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _t_ be ? thisTimeValue(*this* value).
           1. Let _m_ be ? ToNumber(_month_).
@@ -32830,7 +32847,7 @@ THH:mm:ss.sss
           1. Set the [[DateValue]] internal slot of this Date object to _u_.
           1. Return _u_.
         </emu-alg>
-        <p>The *"length"* property of the `setMonth` method is *2*<sub>𝔽</sub>.</p>
+        <p>The *"length"* property of this method is *2*<sub>𝔽</sub>.</p>
         <emu-note>
           <p>If _date_ is not present, this method behaves as if _date_ was present with the value `getDate()`.</p>
         </emu-note>
@@ -32838,7 +32855,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype.setseconds">
         <h1>Date.prototype.setSeconds ( _sec_ [ , _ms_ ] )</h1>
-        <p>The following steps are performed:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _t_ be ? thisTimeValue(*this* value).
           1. Let _s_ be ? ToNumber(_sec_).
@@ -32851,7 +32868,7 @@ THH:mm:ss.sss
           1. Set the [[DateValue]] internal slot of this Date object to _u_.
           1. Return _u_.
         </emu-alg>
-        <p>The *"length"* property of the `setSeconds` method is *2*<sub>𝔽</sub>.</p>
+        <p>The *"length"* property of this method is *2*<sub>𝔽</sub>.</p>
         <emu-note>
           <p>If _ms_ is not present, this method behaves as if _ms_ was present with the value `getMilliseconds()`.</p>
         </emu-note>
@@ -32859,7 +32876,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype.settime">
         <h1>Date.prototype.setTime ( _time_ )</h1>
-        <p>The following steps are performed:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Perform ? thisTimeValue(*this* value).
           1. Let _t_ be ? ToNumber(_time_).
@@ -32871,7 +32888,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype.setutcdate">
         <h1>Date.prototype.setUTCDate ( _date_ )</h1>
-        <p>The following steps are performed:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _t_ be ? thisTimeValue(*this* value).
           1. Let _dt_ be ? ToNumber(_date_).
@@ -32885,7 +32902,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype.setutcfullyear">
         <h1>Date.prototype.setUTCFullYear ( _year_ [ , _month_ [ , _date_ ] ] )</h1>
-        <p>The following steps are performed:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _t_ be ? thisTimeValue(*this* value).
           1. If _t_ is *NaN*, set _t_ to *+0*<sub>𝔽</sub>.
@@ -32897,7 +32914,7 @@ THH:mm:ss.sss
           1. Set the [[DateValue]] internal slot of this Date object to _v_.
           1. Return _v_.
         </emu-alg>
-        <p>The *"length"* property of the `setUTCFullYear` method is *3*<sub>𝔽</sub>.</p>
+        <p>The *"length"* property of this method is *3*<sub>𝔽</sub>.</p>
         <emu-note>
           <p>If _month_ is not present, this method behaves as if _month_ was present with the value `getUTCMonth()`. If _date_ is not present, it behaves as if _date_ was present with the value `getUTCDate()`.</p>
         </emu-note>
@@ -32905,7 +32922,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype.setutchours">
         <h1>Date.prototype.setUTCHours ( _hour_ [ , _min_ [ , _sec_ [ , _ms_ ] ] ] )</h1>
-        <p>The following steps are performed:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _t_ be ? thisTimeValue(*this* value).
           1. Let _h_ be ? ToNumber(_hour_).
@@ -32921,7 +32938,7 @@ THH:mm:ss.sss
           1. Set the [[DateValue]] internal slot of this Date object to _v_.
           1. Return _v_.
         </emu-alg>
-        <p>The *"length"* property of the `setUTCHours` method is *4*<sub>𝔽</sub>.</p>
+        <p>The *"length"* property of this method is *4*<sub>𝔽</sub>.</p>
         <emu-note>
           <p>If _min_ is not present, this method behaves as if _min_ was present with the value `getUTCMinutes()`. If _sec_ is not present, it behaves as if _sec_ was present with the value `getUTCSeconds()`. If _ms_ is not present, it behaves as if _ms_ was present with the value `getUTCMilliseconds()`.</p>
         </emu-note>
@@ -32929,7 +32946,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype.setutcmilliseconds">
         <h1>Date.prototype.setUTCMilliseconds ( _ms_ )</h1>
-        <p>The following steps are performed:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _t_ be ? thisTimeValue(*this* value).
           1. Set _ms_ to ? ToNumber(_ms_).
@@ -32943,7 +32960,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype.setutcminutes">
         <h1>Date.prototype.setUTCMinutes ( _min_ [ , _sec_ [ , _ms_ ] ] )</h1>
-        <p>The following steps are performed:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _t_ be ? thisTimeValue(*this* value).
           1. Let _m_ be ? ToNumber(_min_).
@@ -32957,15 +32974,15 @@ THH:mm:ss.sss
           1. Set the [[DateValue]] internal slot of this Date object to _v_.
           1. Return _v_.
         </emu-alg>
-        <p>The *"length"* property of the `setUTCMinutes` method is *3*<sub>𝔽</sub>.</p>
+        <p>The *"length"* property of this method is *3*<sub>𝔽</sub>.</p>
         <emu-note>
-          <p>If _sec_ is not present, this method behaves as if _sec_ was present with the value `getUTCSeconds()`. If _ms_ is not present, it function behaves as if _ms_ was present with the value return by `getUTCMilliseconds()`.</p>
+          <p>If _sec_ is not present, this method behaves as if _sec_ was present with the value `getUTCSeconds()`. If _ms_ is not present, it behaves as if _ms_ was present with the value return by `getUTCMilliseconds()`.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-date.prototype.setutcmonth">
         <h1>Date.prototype.setUTCMonth ( _month_ [ , _date_ ] )</h1>
-        <p>The following steps are performed:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _t_ be ? thisTimeValue(*this* value).
           1. Let _m_ be ? ToNumber(_month_).
@@ -32977,7 +32994,7 @@ THH:mm:ss.sss
           1. Set the [[DateValue]] internal slot of this Date object to _v_.
           1. Return _v_.
         </emu-alg>
-        <p>The *"length"* property of the `setUTCMonth` method is *2*<sub>𝔽</sub>.</p>
+        <p>The *"length"* property of this method is *2*<sub>𝔽</sub>.</p>
         <emu-note>
           <p>If _date_ is not present, this method behaves as if _date_ was present with the value `getUTCDate()`.</p>
         </emu-note>
@@ -32985,7 +33002,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype.setutcseconds">
         <h1>Date.prototype.setUTCSeconds ( _sec_ [ , _ms_ ] )</h1>
-        <p>The following steps are performed:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _t_ be ? thisTimeValue(*this* value).
           1. Let _s_ be ? ToNumber(_sec_).
@@ -32997,7 +33014,7 @@ THH:mm:ss.sss
           1. Set the [[DateValue]] internal slot of this Date object to _v_.
           1. Return _v_.
         </emu-alg>
-        <p>The *"length"* property of the `setUTCSeconds` method is *2*<sub>𝔽</sub>.</p>
+        <p>The *"length"* property of this method is *2*<sub>𝔽</sub>.</p>
         <emu-note>
           <p>If _ms_ is not present, this method behaves as if _ms_ was present with the value `getUTCMilliseconds()`.</p>
         </emu-note>
@@ -33005,7 +33022,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype.todatestring">
         <h1>Date.prototype.toDateString ( )</h1>
-        <p>The following steps are performed:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be this Date object.
           1. Let _tv_ be ? thisTimeValue(_O_).
@@ -33017,13 +33034,13 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype.toisostring">
         <h1>Date.prototype.toISOString ( )</h1>
-        <p>If this time value is not a finite Number or if it corresponds with a year that cannot be represented in the <emu-xref href="#sec-date-time-string-format">Date Time String Format</emu-xref>, this function throws a *RangeError* exception. Otherwise, it returns a String representation of this time value in that format on the UTC time scale, including all format elements and the UTC offset representation *"Z"*.</p>
+        <p>If this time value is not a finite Number or if it corresponds with a year that cannot be represented in the <emu-xref href="#sec-date-time-string-format">Date Time String Format</emu-xref>, this method throws a *RangeError* exception. Otherwise, it returns a String representation of this time value in that format on the UTC time scale, including all format elements and the UTC offset representation *"Z"*.</p>
       </emu-clause>
 
       <emu-clause id="sec-date.prototype.tojson">
         <h1>Date.prototype.toJSON ( _key_ )</h1>
-        <p>This function provides a String representation of a Date for use by `JSON.stringify` (<emu-xref href="#sec-json.stringify"></emu-xref>).</p>
-        <p>When the `toJSON` method is called with argument _key_, the following steps are taken:</p>
+        <p>This method provides a String representation of a Date for use by `JSON.stringify` (<emu-xref href="#sec-json.stringify"></emu-xref>).</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _tv_ be ? ToPrimitive(_O_, ~number~).
@@ -33034,34 +33051,34 @@ THH:mm:ss.sss
           <p>The argument is ignored.</p>
         </emu-note>
         <emu-note>
-          <p>The `toJSON` function is intentionally generic; it does not require that its *this* value be a Date. Therefore, it can be transferred to other kinds of objects for use as a method. However, it does require that any such object have a `toISOString` method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be a Date. Therefore, it can be transferred to other kinds of objects for use as a method. However, it does require that any such object have a `toISOString` method.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-date.prototype.tolocaledatestring">
         <h1>Date.prototype.toLocaleDateString ( [ _reserved1_ [ , _reserved2_ ] ] )</h1>
-        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the `Date.prototype.toLocaleDateString` method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of the `toLocaleDateString` method is used.</p>
-        <p>This function returns a String value. The contents of the String are implementation-defined, but are intended to represent the &ldquo;date&rdquo; portion of the Date in the current time zone in a convenient, human-readable form that corresponds to the conventions of the host environment's current locale.</p>
+        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used:</p>
+        <p>This method returns a String value. The contents of the String are implementation-defined, but are intended to represent the &ldquo;date&rdquo; portion of the Date in the current time zone in a convenient, human-readable form that corresponds to the conventions of the host environment's current locale.</p>
         <p>The meaning of the optional parameters to this method are defined in the ECMA-402 specification; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
       </emu-clause>
 
       <emu-clause id="sec-date.prototype.tolocalestring">
         <h1>Date.prototype.toLocaleString ( [ _reserved1_ [ , _reserved2_ ] ] )</h1>
-        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the `Date.prototype.toLocaleString` method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of the `toLocaleString` method is used.</p>
-        <p>This function returns a String value. The contents of the String are implementation-defined, but are intended to represent the Date in the current time zone in a convenient, human-readable form that corresponds to the conventions of the host environment's current locale.</p>
+        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used:</p>
+        <p>This method returns a String value. The contents of the String are implementation-defined, but are intended to represent the Date in the current time zone in a convenient, human-readable form that corresponds to the conventions of the host environment's current locale.</p>
         <p>The meaning of the optional parameters to this method are defined in the ECMA-402 specification; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
       </emu-clause>
 
       <emu-clause id="sec-date.prototype.tolocaletimestring">
         <h1>Date.prototype.toLocaleTimeString ( [ _reserved1_ [ , _reserved2_ ] ] )</h1>
-        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the `Date.prototype.toLocaleTimeString` method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of the `toLocaleTimeString` method is used.</p>
-        <p>This function returns a String value. The contents of the String are implementation-defined, but are intended to represent the &ldquo;time&rdquo; portion of the Date in the current time zone in a convenient, human-readable form that corresponds to the conventions of the host environment's current locale.</p>
+        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used:</p>
+        <p>This method returns a String value. The contents of the String are implementation-defined, but are intended to represent the &ldquo;time&rdquo; portion of the Date in the current time zone in a convenient, human-readable form that corresponds to the conventions of the host environment's current locale.</p>
         <p>The meaning of the optional parameters to this method are defined in the ECMA-402 specification; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
       </emu-clause>
 
       <emu-clause id="sec-date.prototype.tostring">
         <h1>Date.prototype.toString ( )</h1>
-        <p>The following steps are performed:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _tv_ be ? thisTimeValue(*this* value).
           1. Return ToDateString(_tv_).
@@ -33070,7 +33087,7 @@ THH:mm:ss.sss
           <p>For any Date `d` such that `d.[[DateValue]]` is evenly divisible by 1000, the result of `Date.parse(d.toString())` = `d.valueOf()`. See <emu-xref href="#sec-date.parse"></emu-xref>.</p>
         </emu-note>
         <emu-note>
-          <p>The `toString` function is not generic; it throws a *TypeError* exception if its *this* value is not a Date. Therefore, it cannot be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is not generic; it throws a *TypeError* exception if its *this* value is not a Date. Therefore, it cannot be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
 
         <emu-clause id="sec-timestring" type="abstract operation">
@@ -33325,7 +33342,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype.totimestring">
         <h1>Date.prototype.toTimeString ( )</h1>
-        <p>The following steps are performed:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be this Date object.
           1. Let _tv_ be ? thisTimeValue(_O_).
@@ -33337,7 +33354,8 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype.toutcstring">
         <h1>Date.prototype.toUTCString ( )</h1>
-        <p>The `toUTCString` method returns a String value representing the instance in time corresponding to this time value. The format of the String is based upon "HTTP-date" from RFC 7231, generalized to support the full range of times supported by ECMAScript Dates. It performs the following steps when called:</p>
+        <p>This method returns a String value representing the instance in time corresponding to this time value. The format of the String is based upon "HTTP-date" from RFC 7231, generalized to support the full range of times supported by ECMAScript Dates.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be this Date object.
           1. Let _tv_ be ? thisTimeValue(_O_).
@@ -33354,7 +33372,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype.valueof">
         <h1>Date.prototype.valueOf ( )</h1>
-        <p>The following steps are performed:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Return ? thisTimeValue(*this* value).
         </emu-alg>
@@ -33362,8 +33380,8 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype-@@toprimitive">
         <h1>Date.prototype [ @@toPrimitive ] ( _hint_ )</h1>
-        <p>This function is called by ECMAScript language operators to convert a Date to a primitive value. The allowed values for _hint_ are *"default"*, *"number"*, and *"string"*. Dates are unique among built-in ECMAScript object in that they treat *"default"* as being equivalent to *"string"*, All other built-in ECMAScript objects treat *"default"* as being equivalent to *"number"*.</p>
-        <p>When the `@@toPrimitive` method is called with argument _hint_, the following steps are taken:</p>
+        <p>This method is called by ECMAScript language operators to convert a Date to a primitive value. The allowed values for _hint_ are *"default"*, *"number"*, and *"string"*. Dates are unique among built-in ECMAScript object in that they treat *"default"* as being equivalent to *"string"*, All other built-in ECMAScript objects treat *"default"* as being equivalent to *"number"*.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. If Type(_O_) is not Object, throw a *TypeError* exception.
@@ -33375,7 +33393,7 @@ THH:mm:ss.sss
           1. Return ? OrdinaryToPrimitive(_O_, _tryFirst_).
         </emu-alg>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
-        <p>The value of the *"name"* property of this function is *"[Symbol.toPrimitive]"*.</p>
+        <p>The value of the *"name"* property of this method is *"[Symbol.toPrimitive]"*.</p>
       </emu-clause>
     </emu-clause>
 
@@ -33405,7 +33423,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-string-constructor-string-value">
         <h1>String ( _value_ )</h1>
-        <p>When `String` is called with argument _value_, the following steps are taken:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. If _value_ is not present, let _s_ be the empty String.
           1. Else,
@@ -33427,7 +33445,8 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-string.fromcharcode">
         <h1>String.fromCharCode ( ..._codeUnits_ )</h1>
-        <p>The `String.fromCharCode` function may be called with any number of arguments which form the rest parameter _codeUnits_. The following steps are taken:</p>
+        <p>This function may be called with any number of arguments which form the rest parameter _codeUnits_.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _elements_ be a new empty List.
           1. For each element _next_ of _codeUnits_, do
@@ -33435,12 +33454,13 @@ THH:mm:ss.sss
             1. Append _nextCU_ to the end of _elements_.
           1. Return the String value whose code units are the elements in the List _elements_. If _codeUnits_ is empty, the empty String is returned.
         </emu-alg>
-        <p>The *"length"* property of the `fromCharCode` function is *1*<sub>𝔽</sub>.</p>
+        <p>The *"length"* property of this function is *1*<sub>𝔽</sub>.</p>
       </emu-clause>
 
       <emu-clause id="sec-string.fromcodepoint">
         <h1>String.fromCodePoint ( ..._codePoints_ )</h1>
-        <p>The `String.fromCodePoint` function may be called with any number of arguments which form the rest parameter _codePoints_. The following steps are taken:</p>
+        <p>This function may be called with any number of arguments which form the rest parameter _codePoints_.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _result_ be the empty String.
           1. For each element _next_ of _codePoints_, do
@@ -33451,7 +33471,7 @@ THH:mm:ss.sss
           1. Assert: If _codePoints_ is empty, then _result_ is the empty String.
           1. Return _result_.
         </emu-alg>
-        <p>The *"length"* property of the `fromCodePoint` function is *1*<sub>𝔽</sub>.</p>
+        <p>The *"length"* property of this function is *1*<sub>𝔽</sub>.</p>
       </emu-clause>
 
       <emu-clause id="sec-string.prototype">
@@ -33462,7 +33482,8 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-string.raw">
         <h1>String.raw ( _template_, ..._substitutions_ )</h1>
-        <p>The `String.raw` function may be called with a variable number of arguments. The first argument is _template_ and the remainder of the arguments form the List _substitutions_. The following steps are taken:</p>
+        <p>This function may be called with a variable number of arguments. The first argument is _template_ and the remainder of the arguments form the List _substitutions_.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _numberOfSubstitutions_ be the number of elements in _substitutions_.
           1. Let _cooked_ be ? ToObject(_template_).
@@ -33484,7 +33505,7 @@ THH:mm:ss.sss
             1. Set _nextIndex_ to _nextIndex_ + 1.
         </emu-alg>
         <emu-note>
-          <p>The `raw` function is intended for use as a tag function of a Tagged Template (<emu-xref href="#sec-tagged-templates"></emu-xref>). When called as such, the first argument will be a well formed template object and the rest parameter will contain the substitution values.</p>
+          <p>This function is intended for use as a tag function of a Tagged Template (<emu-xref href="#sec-tagged-templates"></emu-xref>). When called as such, the first argument will be a well formed template object and the rest parameter will contain the substitution values.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -33529,10 +33550,10 @@ THH:mm:ss.sss
       <emu-clause id="sec-string.prototype.charat">
         <h1>String.prototype.charAt ( _pos_ )</h1>
         <emu-note>
-          <p>Returns a single element String containing the code unit at index _pos_ within the String value resulting from converting this object to a String. If there is no element at that index, the result is the empty String. The result is a String value, not a String object.</p>
+          <p>This method returns a single element String containing the code unit at index _pos_ within the String value resulting from converting this object to a String. If there is no element at that index, the result is the empty String. The result is a String value, not a String object.</p>
           <p>If `pos` is an integral Number, then the result of `x.charAt(pos)` is equivalent to the result of `x.substring(pos, pos + 1)`.</p>
         </emu-note>
-        <p>When the `charAt` method is called with one argument _pos_, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
@@ -33542,16 +33563,16 @@ THH:mm:ss.sss
           1. Return the substring of _S_ from _position_ to _position_ + 1.
         </emu-alg>
         <emu-note>
-          <p>The `charAt` function is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-string.prototype.charcodeat">
         <h1>String.prototype.charCodeAt ( _pos_ )</h1>
         <emu-note>
-          <p>Returns a Number (a non-negative integral Number less than 2<sup>16</sup>) that is the numeric value of the code unit at index _pos_ within the String resulting from converting this object to a String. If there is no element at that index, the result is *NaN*.</p>
+          <p>This method returns a Number (a non-negative integral Number less than 2<sup>16</sup>) that is the numeric value of the code unit at index _pos_ within the String resulting from converting this object to a String. If there is no element at that index, the result is *NaN*.</p>
         </emu-note>
-        <p>When the `charCodeAt` method is called with one argument _pos_, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
@@ -33561,16 +33582,16 @@ THH:mm:ss.sss
           1. Return the Number value for the numeric value of the code unit at index _position_ within the String _S_.
         </emu-alg>
         <emu-note>
-          <p>The `charCodeAt` function is intentionally generic; it does not require that its *this* value be a String object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be a String object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-string.prototype.codepointat">
         <h1>String.prototype.codePointAt ( _pos_ )</h1>
         <emu-note>
-          <p>Returns a non-negative integral Number less than or equal to *0x10FFFF*<sub>𝔽</sub> that is the numeric value of the UTF-16 encoded code point (<emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>) starting at the string element at index _pos_ within the String resulting from converting this object to a String. If there is no element at that index, the result is *undefined*. If a valid UTF-16 <emu-xref href="#surrogate-pair"></emu-xref> does not begin at _pos_, the result is the code unit at _pos_.</p>
+          <p>This method returns a non-negative integral Number less than or equal to *0x10FFFF*<sub>𝔽</sub> that is the numeric value of the UTF-16 encoded code point (<emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>) starting at the string element at index _pos_ within the String resulting from converting this object to a String. If there is no element at that index, the result is *undefined*. If a valid UTF-16 <emu-xref href="#surrogate-pair"></emu-xref> does not begin at _pos_, the result is the code unit at _pos_.</p>
         </emu-note>
-        <p>When the `codePointAt` method is called with one argument _pos_, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
@@ -33581,16 +33602,16 @@ THH:mm:ss.sss
           1. Return 𝔽(_cp_.[[CodePoint]]).
         </emu-alg>
         <emu-note>
-          <p>The `codePointAt` function is intentionally generic; it does not require that its *this* value be a String object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be a String object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-string.prototype.concat">
         <h1>String.prototype.concat ( ..._args_ )</h1>
         <emu-note>
-          <p>When the `concat` method is called it returns the String value consisting of the code units of the *this* value (converted to a String) followed by the code units of each of the arguments converted to a String. The result is a String value, not a String object.</p>
+          <p>When this method is called it returns the String value consisting of the code units of the *this* value (converted to a String) followed by the code units of each of the arguments converted to a String. The result is a String value, not a String object.</p>
         </emu-note>
-        <p>When the `concat` method is called with zero or more arguments, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
@@ -33600,9 +33621,9 @@ THH:mm:ss.sss
             1. Set _R_ to the string-concatenation of _R_ and _nextString_.
           1. Return _R_.
         </emu-alg>
-        <p>The *"length"* property of the `concat` method is *1*<sub>𝔽</sub>.</p>
+        <p>The *"length"* property of this method is *1*<sub>𝔽</sub>.</p>
         <emu-note>
-          <p>The `concat` function is intentionally generic; it does not require that its *this* value be a String object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be a String object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
@@ -33613,7 +33634,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-string.prototype.endswith">
         <h1>String.prototype.endsWith ( _searchString_ [ , _endPosition_ ] )</h1>
-        <p>The following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
@@ -33631,19 +33652,19 @@ THH:mm:ss.sss
           1. Return SameValueNonNumeric(_substring_, _searchStr_).
         </emu-alg>
         <emu-note>
-          <p>Returns *true* if the sequence of code units of _searchString_ converted to a String is the same as the corresponding code units of this object (converted to a String) starting at _endPosition_ - length(this). Otherwise returns *false*.</p>
+          <p>This method returns *true* if the sequence of code units of _searchString_ converted to a String is the same as the corresponding code units of this object (converted to a String) starting at _endPosition_ - length(this). Otherwise it returns *false*.</p>
         </emu-note>
         <emu-note>
           <p>Throwing an exception if the first argument is a RegExp is specified in order to allow future editions to define extensions that allow such argument values.</p>
         </emu-note>
         <emu-note>
-          <p>The `endsWith` function is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-string.prototype.includes">
         <h1>String.prototype.includes ( _searchString_ [ , _position_ ] )</h1>
-        <p>The `includes` method takes two arguments, _searchString_ and _position_, and performs the following steps:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
@@ -33659,13 +33680,13 @@ THH:mm:ss.sss
           1. Return *false*.
         </emu-alg>
         <emu-note>
-          <p>If _searchString_ appears as a <emu-not-ref>substring</emu-not-ref> of the result of converting this object to a String, at one or more indices that are greater than or equal to _position_, returns *true*; otherwise, returns *false*. If _position_ is *undefined*, 0 is assumed, so as to search all of the String.</p>
+          <p>If _searchString_ appears as a <emu-not-ref>substring</emu-not-ref> of the result of converting this object to a String, at one or more indices that are greater than or equal to _position_, this function returns *true*; otherwise, it returns *false*. If _position_ is *undefined*, 0 is assumed, so as to search all of the String.</p>
         </emu-note>
         <emu-note>
           <p>Throwing an exception if the first argument is a RegExp is specified in order to allow future editions to define extensions that allow such argument values.</p>
         </emu-note>
         <emu-note>
-          <p>The `includes` function is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
@@ -33674,7 +33695,7 @@ THH:mm:ss.sss
         <emu-note>
           <p>If _searchString_ appears as a <emu-not-ref>substring</emu-not-ref> of the result of converting this object to a String, at one or more indices that are greater than or equal to _position_, then the smallest such index is returned; otherwise, *-1*<sub>𝔽</sub> is returned. If _position_ is *undefined*, *+0*<sub>𝔽</sub> is assumed, so as to search all of the String.</p>
         </emu-note>
-        <p>The `indexOf` method takes two arguments, _searchString_ and _position_, and performs the following steps:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
@@ -33686,7 +33707,7 @@ THH:mm:ss.sss
           1. Return 𝔽(StringIndexOf(_S_, _searchStr_, _start_)).
         </emu-alg>
         <emu-note>
-          <p>The `indexOf` function is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
@@ -33695,7 +33716,7 @@ THH:mm:ss.sss
         <emu-note>
           <p>If _searchString_ appears as a <emu-not-ref>substring</emu-not-ref> of the result of converting this object to a String at one or more indices that are smaller than or equal to _position_, then the greatest such index is returned; otherwise, *-1*<sub>𝔽</sub> is returned. If _position_ is *undefined*, the length of the String value is assumed, so as to search all of the String.</p>
         </emu-note>
-        <p>The `lastIndexOf` method takes two arguments, _searchString_ and _position_, and performs the following steps:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
@@ -33713,24 +33734,24 @@ THH:mm:ss.sss
           1. Return *-1*<sub>𝔽</sub>.
         </emu-alg>
         <emu-note>
-          <p>The `lastIndexOf` function is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-string.prototype.localecompare">
         <h1>String.prototype.localeCompare ( _that_ [ , _reserved1_ [ , _reserved2_ ] ] )</h1>
-        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the `localeCompare` method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of the `localeCompare` method is used.</p>
-        <p>When the `localeCompare` method is called with argument _that_, it returns a Number other than *NaN* representing the result of an implementation-defined locale-sensitive String comparison of the *this* value (converted to a String _S_) with _that_ (converted to a String _thatValue_). The result is intended to correspond with a sort order of String values according to conventions of the host environment's current locale, and will be negative when _S_ is ordered before _thatValue_, positive when _S_ is ordered after _thatValue_, and zero in all other cases (representing no relative ordering between _S_ and _thatValue_).</p>
-        <p>Before performing the comparisons, the following steps are performed to prepare the Strings:</p>
+        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used:</p>
+        <p>This method returns a Number other than *NaN* representing the result of an implementation-defined locale-sensitive String comparison of the *this* value (converted to a String _S_) with _that_ (converted to a String _thatValue_). The result is intended to correspond with a sort order of String values according to conventions of the host environment's current locale, and will be negative when _S_ is ordered before _thatValue_, positive when _S_ is ordered after _thatValue_, and zero in all other cases (representing no relative ordering between _S_ and _thatValue_).</p>
+        <p>Before performing the comparisons, this method performs the following steps to prepare the Strings:</p>
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
           1. Let _thatValue_ be ? ToString(_that_).
         </emu-alg>
         <p>The meaning of the optional second and third parameters to this method are defined in the ECMA-402 specification; implementations that do not include ECMA-402 support must not assign any other interpretation to those parameter positions.</p>
-        <p>The actual return values are implementation-defined to permit encoding additional information in them, but this method, when considered as a function of two arguments, is required to be a consistent comparator defining a total ordering on the set of all Strings. This method is also required to recognize and honour canonical equivalence according to the Unicode Standard, including returning *+0*<sub>𝔽</sub> when comparing distinguishable Strings that are canonically equivalent.</p>
+        <p>The actual return values are implementation-defined to permit encoding additional information in them, but this method, when considered as a method of two arguments, is required to be a consistent comparator defining a total ordering on the set of all Strings. This method is also required to recognize and honour canonical equivalence according to the Unicode Standard, including returning *+0*<sub>𝔽</sub> when comparing distinguishable Strings that are canonically equivalent.</p>
         <emu-note>
-          <p>The `localeCompare` method itself is not directly suitable as an argument to `Array.prototype.sort` because the latter requires a function of two arguments.</p>
+          <p>This method itself is not directly suitable as an argument to `Array.prototype.sort` because the latter requires a function of two arguments.</p>
         </emu-note>
         <emu-note>
           <p>This method may rely on whatever language- and/or locale-sensitive comparison functionality is available to the ECMAScript environment from the host environment, and is intended to compare according to the conventions of the host environment's current locale. However, regardless of comparison capabilities, this method must recognize and honour canonical equivalence according to the Unicode Standard&mdash;for example, the following comparisons must all return *+0*<sub>𝔽</sub>:</p>
@@ -33759,13 +33780,13 @@ THH:mm:ss.sss
           <p>It is recommended that this method should not honour Unicode compatibility equivalents or compatibility decompositions as defined in the Unicode Standard, chapter 3, section 3.7.</p>
         </emu-note>
         <emu-note>
-          <p>The `localeCompare` function is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-string.prototype.match">
         <h1>String.prototype.match ( _regexp_ )</h1>
-        <p>When the `match` method is called with argument _regexp_, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. If _regexp_ is neither *undefined* nor *null*, then
@@ -33777,14 +33798,14 @@ THH:mm:ss.sss
           1. Return ? Invoke(_rx_, @@match, &laquo; _S_ &raquo;).
         </emu-alg>
         <emu-note>
-          <p>The `match` function is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-string.prototype.matchall">
         <h1>String.prototype.matchAll ( _regexp_ )</h1>
-        <p>Performs a regular expression match of the String representing the *this* value against _regexp_ and returns an iterator. Each iteration result's value is an Array containing the results of the match, or *null* if the String did not match.</p>
-        <p>When the `matchAll` method is called, the following steps are taken:</p>
+        <p>This method performs a regular expression match of the String representing the *this* value against _regexp_ and returns an iterator. Each iteration result's value is an Array containing the results of the match, or *null* if the String did not match.</p>
+        <p>It performs the following steps when called:</p>
 
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
@@ -33801,13 +33822,13 @@ THH:mm:ss.sss
           1. Let _rx_ be ? RegExpCreate(_regexp_, *"g"*).
           1. Return ? Invoke(_rx_, @@matchAll, &laquo; _S_ &raquo;).
         </emu-alg>
-        <emu-note>The `matchAll` function is intentionally generic, it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</emu-note>
+        <emu-note>This method is intentionally generic, it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</emu-note>
         <emu-note>Similarly to `String.prototype.split`, `String.prototype.matchAll` is designed to typically act without mutating its inputs.</emu-note>
       </emu-clause>
 
       <emu-clause id="sec-string.prototype.normalize">
         <h1>String.prototype.normalize ( [ _form_ ] )</h1>
-        <p>When the `normalize` method is called with one argument _form_, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
@@ -33818,13 +33839,13 @@ THH:mm:ss.sss
           1. Return _ns_.
         </emu-alg>
         <emu-note>
-          <p>The `normalize` function is intentionally generic; it does not require that its *this* value be a String object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be a String object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-string.prototype.padend">
         <h1>String.prototype.padEnd ( _maxLength_ [ , _fillString_ ] )</h1>
-        <p>When the `padEnd` method is called, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Return ? StringPad(_O_, _maxLength_, _fillString_, ~end~).
@@ -33833,7 +33854,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-string.prototype.padstart">
         <h1>String.prototype.padStart ( _maxLength_ [ , _fillString_ ] )</h1>
-        <p>When the `padStart` method is called, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Return ? StringPad(_O_, _maxLength_, _fillString_, ~start~).
@@ -33889,7 +33910,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-string.prototype.repeat">
         <h1>String.prototype.repeat ( _count_ )</h1>
-        <p>The following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
@@ -33902,13 +33923,13 @@ THH:mm:ss.sss
           <p>This method creates the String value consisting of the code units of the *this* value (converted to String) repeated _count_ times.</p>
         </emu-note>
         <emu-note>
-          <p>The `repeat` function is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-string.prototype.replace">
         <h1>String.prototype.replace ( _searchValue_, _replaceValue_ )</h1>
-        <p>When the `replace` method is called with arguments _searchValue_ and _replaceValue_, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. If _searchValue_ is neither *undefined* nor *null*, then
@@ -33934,7 +33955,7 @@ THH:mm:ss.sss
           1. Return the string-concatenation of _preceding_, _replacement_, and _following_.
         </emu-alg>
         <emu-note>
-          <p>The `replace` function is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
 
         <emu-clause id="sec-getsubstitution" type="abstract operation" oldids="table-replacement-text-symbol-substitutions,table-45">
@@ -34016,7 +34037,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-string.prototype.replaceall">
         <h1>String.prototype.replaceAll ( _searchValue_, _replaceValue_ )</h1>
-        <p>When the `replaceAll` method is called with arguments _searchValue_ and _replaceValue_, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. If _searchValue_ is neither *undefined* nor *null*, then
@@ -34060,7 +34081,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-string.prototype.search">
         <h1>String.prototype.search ( _regexp_ )</h1>
-        <p>When the `search` method is called with argument _regexp_, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. If _regexp_ is neither *undefined* nor *null*, then
@@ -34072,13 +34093,14 @@ THH:mm:ss.sss
           1. Return ? Invoke(_rx_, @@search, &laquo; _string_ &raquo;).
         </emu-alg>
         <emu-note>
-          <p>The `search` function is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-string.prototype.slice">
         <h1>String.prototype.slice ( _start_, _end_ )</h1>
-        <p>The `slice` method takes two arguments, _start_ and _end_, and returns a <emu-not-ref>substring</emu-not-ref> of the result of converting this object to a String, starting from index _start_ and running to, but not including, index _end_ (or through the end of the String if _end_ is *undefined*). If _start_ is negative, it is treated as <emu-eqn>_sourceLength_ + _start_</emu-eqn> where _sourceLength_ is the length of the String. If _end_ is negative, it is treated as <emu-eqn>_sourceLength_ + _end_</emu-eqn> where _sourceLength_ is the length of the String. The result is a String value, not a String object. The following steps are taken:</p>
+        <p>This method returns a <emu-not-ref>substring</emu-not-ref> of the result of converting this object to a String, starting from index _start_ and running to, but not including, index _end_ (or through the end of the String if _end_ is *undefined*). If _start_ is negative, it is treated as <emu-eqn>_sourceLength_ + _start_</emu-eqn> where _sourceLength_ is the length of the String. If _end_ is negative, it is treated as <emu-eqn>_sourceLength_ + _end_</emu-eqn> where _sourceLength_ is the length of the String. The result is a String value, not a String object.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
@@ -34095,14 +34117,14 @@ THH:mm:ss.sss
           1. Return the substring of _S_ from _from_ to _to_.
         </emu-alg>
         <emu-note>
-          <p>The `slice` function is intentionally generic; it does not require that its *this* value be a String object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be a String object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-string.prototype.split">
         <h1>String.prototype.split ( _separator_, _limit_ )</h1>
-        <p>Returns an Array into which substrings of the result of converting this object to a String have been stored. The substrings are determined by searching from left to right for occurrences of _separator_; these occurrences are not part of any String in the returned array, but serve to divide up the String value. The value of _separator_ may be a String of any length or it may be an object, such as a RegExp, that has a @@split method.</p>
-        <p>When the `split` method is called, the following steps are taken:</p>
+        <p>This method returns an Array into which substrings of the result of converting this object to a String have been stored. The substrings are determined by searching from left to right for occurrences of _separator_; these occurrences are not part of any String in the returned array, but serve to divide up the String value. The value of _separator_ may be a String of any length or it may be an object, such as a RegExp, that has a @@split method.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. If _separator_ is neither *undefined* nor *null*, then
@@ -34141,13 +34163,13 @@ THH:mm:ss.sss
           <p>If _separator_ is *undefined*, then the result array contains just one String, which is the *this* value (converted to a String). If _limit_ is not *undefined*, then the output array is truncated so that it contains no more than _limit_ elements.</p>
         </emu-note>
         <emu-note>
-          <p>The `split` function is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-string.prototype.startswith">
         <h1>String.prototype.startsWith ( _searchString_ [ , _position_ ] )</h1>
-        <p>The following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
@@ -34165,22 +34187,22 @@ THH:mm:ss.sss
           1. Return SameValueNonNumeric(_substring_, _searchStr_).
         </emu-alg>
         <emu-note>
-          <p>This method returns *true* if the sequence of code units of _searchString_ converted to a String is the same as the corresponding code units of this object (converted to a String) starting at index _position_. Otherwise returns *false*.</p>
+          <p>This method returns *true* if the sequence of code units of _searchString_ converted to a String is the same as the corresponding code units of this object (converted to a String) starting at index _position_. Otherwise it returns *false*.</p>
         </emu-note>
         <emu-note>
           <p>Throwing an exception if the first argument is a RegExp is specified in order to allow future editions to define extensions that allow such argument values.</p>
         </emu-note>
         <emu-note>
-          <p>The `startsWith` function is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-string.prototype.substring">
         <h1>String.prototype.substring ( _start_, _end_ )</h1>
-        <p>The `substring` method takes two arguments, _start_ and _end_, and returns a <emu-not-ref>substring</emu-not-ref> of the result of converting this object to a String, starting from index _start_ and running to, but not including, index _end_ of the String (or through the end of the String if _end_ is *undefined*). The result is a String value, not a String object.</p>
+        <p>This method returns a <emu-not-ref>substring</emu-not-ref> of the result of converting this object to a String, starting from index _start_ and running to, but not including, index _end_ of the String (or through the end of the String if _end_ is *undefined*). The result is a String value, not a String object.</p>
         <p>If either argument is *NaN* or negative, it is replaced with zero; if either argument is larger than the length of the String, it is replaced with the length of the String.</p>
         <p>If _start_ is larger than _end_, they are swapped.</p>
-        <p>The following steps are taken:</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
@@ -34194,35 +34216,36 @@ THH:mm:ss.sss
           1. Return the substring of _S_ from _from_ to _to_.
         </emu-alg>
         <emu-note>
-          <p>The `substring` function is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-string.prototype.tolocalelowercase">
         <h1>String.prototype.toLocaleLowerCase ( [ _reserved1_ [ , _reserved2_ ] ] )</h1>
-        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the `toLocaleLowerCase` method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of the `toLocaleLowerCase` method is used.</p>
-        <p>This function interprets a String value as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>.</p>
-        <p>This function works exactly the same as `toLowerCase` except that it is intended to yield a locale-sensitive result corresponding with conventions of the host environment's current locale. There will only be a difference in the few cases (such as Turkish) where the rules for that language conflict with the regular Unicode case mappings.</p>
+        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used:</p>
+        <p>This method interprets a String value as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>.</p>
+        <p>It works exactly the same as `toLowerCase` except that it is intended to yield a locale-sensitive result corresponding with conventions of the host environment's current locale. There will only be a difference in the few cases (such as Turkish) where the rules for that language conflict with the regular Unicode case mappings.</p>
         <p>The meaning of the optional parameters to this method are defined in the ECMA-402 specification; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
         <emu-note>
-          <p>The `toLocaleLowerCase` function is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-string.prototype.tolocaleuppercase">
         <h1>String.prototype.toLocaleUpperCase ( [ _reserved1_ [ , _reserved2_ ] ] )</h1>
-        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the `toLocaleUpperCase` method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of the `toLocaleUpperCase` method is used.</p>
-        <p>This function interprets a String value as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>.</p>
-        <p>This function works exactly the same as `toUpperCase` except that it is intended to yield a locale-sensitive result corresponding with conventions of the host environment's current locale. There will only be a difference in the few cases (such as Turkish) where the rules for that language conflict with the regular Unicode case mappings.</p>
+        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used:</p>
+        <p>This method interprets a String value as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>.</p>
+        <p>It works exactly the same as `toUpperCase` except that it is intended to yield a locale-sensitive result corresponding with conventions of the host environment's current locale. There will only be a difference in the few cases (such as Turkish) where the rules for that language conflict with the regular Unicode case mappings.</p>
         <p>The meaning of the optional parameters to this method are defined in the ECMA-402 specification; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
         <emu-note>
-          <p>The `toLocaleUpperCase` function is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-string.prototype.tolowercase">
         <h1>String.prototype.toLowerCase ( )</h1>
-        <p>This function interprets a String value as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>. The following steps are taken:</p>
+        <p>This method interprets a String value as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
@@ -34233,43 +34256,43 @@ THH:mm:ss.sss
         </emu-alg>
         <p>The result must be derived according to the locale-insensitive case mappings in the Unicode Character Database (this explicitly includes not only the file <a href="https://unicode.org/Public/UCD/latest/ucd/UnicodeData.txt"><code>UnicodeData.txt</code></a>, but also all locale-insensitive mappings in the file <a href="https://unicode.org/Public/UCD/latest/ucd/SpecialCasing.txt"><code>SpecialCasing.txt</code></a> that accompanies it).</p>
         <emu-note>
-          <p>The case mapping of some code points may produce multiple code points. In this case the result String may not be the same length as the source String. Because both `toUpperCase` and `toLowerCase` have context-sensitive behaviour, the functions are not symmetrical. In other words, `s.toUpperCase().toLowerCase()` is not necessarily equal to `s.toLowerCase()`.</p>
+          <p>The case mapping of some code points may produce multiple code points. In this case the result String may not be the same length as the source String. Because both `toUpperCase` and `toLowerCase` have context-sensitive behaviour, the methods are not symmetrical. In other words, `s.toUpperCase().toLowerCase()` is not necessarily equal to `s.toLowerCase()`.</p>
         </emu-note>
         <emu-note>
-          <p>The `toLowerCase` function is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-string.prototype.tostring">
         <h1>String.prototype.toString ( )</h1>
-        <p>When the `toString` method is called, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Return ? thisStringValue(*this* value).
         </emu-alg>
         <emu-note>
-          <p>For a String object, the `toString` method happens to return the same thing as the `valueOf` method.</p>
+          <p>For a String object, this method happens to return the same thing as the `valueOf` method.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-string.prototype.touppercase">
         <h1>String.prototype.toUpperCase ( )</h1>
-        <p>This function interprets a String value as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>.</p>
-        <p>This function behaves in exactly the same way as `String.prototype.toLowerCase`, except that the String is mapped using the toUppercase algorithm of the Unicode Default Case Conversion.</p>
+        <p>This method interprets a String value as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>.</p>
+        <p>It behaves in exactly the same way as `String.prototype.toLowerCase`, except that the String is mapped using the toUppercase algorithm of the Unicode Default Case Conversion.</p>
         <emu-note>
-          <p>The `toUpperCase` function is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-string.prototype.trim">
         <h1>String.prototype.trim ( )</h1>
-        <p>This function interprets a String value as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>.</p>
-        <p>The following steps are taken:</p>
+        <p>This method interprets a String value as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
           1. Return ? TrimString(_S_, ~start+end~).
         </emu-alg>
         <emu-note>
-          <p>The `trim` function is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
 
         <emu-clause id="sec-trimstring" type="abstract operation">
@@ -34299,33 +34322,33 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-string.prototype.trimend">
         <h1>String.prototype.trimEnd ( )</h1>
-        <p>This function interprets a String value as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>.</p>
-        <p>The following steps are taken:</p>
+        <p>This method interprets a String value as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
           1. Return ? TrimString(_S_, ~end~).
         </emu-alg>
         <emu-note>
-          <p>The `trimEnd` function is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-string.prototype.trimstart">
         <h1>String.prototype.trimStart ( )</h1>
-        <p>This function interprets a String value as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>.</p>
-        <p>The following steps are taken:</p>
+        <p>This method interprets a String value as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
           1. Return ? TrimString(_S_, ~start~).
         </emu-alg>
         <emu-note>
-          <p>The `trimStart` function is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-string.prototype.valueof">
         <h1>String.prototype.valueOf ( )</h1>
-        <p>When the `valueOf` method is called, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Return ? thisStringValue(*this* value).
         </emu-alg>
@@ -34333,7 +34356,8 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-string.prototype-@@iterator" oldids="sec-createstringiterator,sec-properties-of-string-iterator-instances,table-46,table-internal-slots-of-string-iterator-instances">
         <h1>String.prototype [ @@iterator ] ( )</h1>
-        <p>When the `@@iterator` method is called it returns an Iterator object (<emu-xref href="#sec-iterator-interface"></emu-xref>) that iterates over the code points of a String value, returning each code point as a String value. The following steps are taken:</p>
+        <p>This method returns an Iterator object (<emu-xref href="#sec-iterator-interface"></emu-xref>) that iterates over the code points of a String value, returning each code point as a String value.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _s_ be ? ToString(_O_).
@@ -34349,7 +34373,7 @@ THH:mm:ss.sss
             1. Return *undefined*.
           1. Return CreateIteratorFromClosure(_closure_, *"%StringIteratorPrototype%"*, %StringIteratorPrototype%).
         </emu-alg>
-        <p>The value of the *"name"* property of this function is *"[Symbol.iterator]"*.</p>
+        <p>The value of the *"name"* property of this method is *"[Symbol.iterator]"*.</p>
       </emu-clause>
     </emu-clause>
 
@@ -36001,7 +36025,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-regexp-pattern-flags">
         <h1>RegExp ( _pattern_, _flags_ )</h1>
-        <p>The following steps are taken:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. Let _patternIsRegExp_ be ? IsRegExp(_pattern_).
           1. If NewTarget is *undefined*, then
@@ -36026,7 +36050,7 @@ THH:mm:ss.sss
           1. Return ? RegExpInitialize(_O_, _P_, _F_).
         </emu-alg>
         <emu-note>
-          <p>If pattern is supplied using a |StringLiteral|, the usual escape sequence substitutions are performed before the String is processed by RegExp. If pattern must contain an escape sequence to be recognized by RegExp, any U+005C (REVERSE SOLIDUS) code points must be escaped within the |StringLiteral| to prevent them being removed when the contents of the |StringLiteral| are formed.</p>
+          <p>If pattern is supplied using a |StringLiteral|, the usual escape sequence substitutions are performed before the String is processed by this function. If pattern must contain an escape sequence to be recognized by this function, any U+005C (REVERSE SOLIDUS) code points must be escaped within the |StringLiteral| to prevent them being removed when the contents of the |StringLiteral| are formed.</p>
         </emu-note>
       </emu-clause>
 
@@ -36174,7 +36198,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-get-regexp-@@species">
         <h1>get RegExp [ @@species ]</h1>
-        <p>`RegExp[@@species]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
+        <p>`RegExp[@@species]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Return the *this* value.
         </emu-alg>
@@ -36205,8 +36229,8 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-regexp.prototype.exec">
         <h1>RegExp.prototype.exec ( _string_ )</h1>
-        <p>Performs a regular expression match of _string_ against the regular expression and returns an Array containing the results of the match, or *null* if _string_ did not match.</p>
-        <p>The String ToString(_string_) is searched for an occurrence of the regular expression pattern as follows:</p>
+        <p>This method searches _string_ for an occurrence of the regular expression pattern and returns an Array containing the results of the match, or *null* if _string_ did not match.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _R_ be the *this* value.
           1. Perform ? RequireInternalSlot(_R_, [[RegExpMatcher]]).
@@ -36459,7 +36483,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-get-regexp.prototype.dotAll">
         <h1>get RegExp.prototype.dotAll</h1>
-        <p>`RegExp.prototype.dotAll` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
+        <p>`RegExp.prototype.dotAll` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _R_ be the *this* value.
           1. Let _cu_ be the code unit 0x0073 (LATIN SMALL LETTER S).
@@ -36489,7 +36513,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-get-regexp.prototype.flags">
         <h1>get RegExp.prototype.flags</h1>
-        <p>`RegExp.prototype.flags` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
+        <p>`RegExp.prototype.flags` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _R_ be the *this* value.
           1. If Type(_R_) is not Object, throw a *TypeError* exception.
@@ -36514,7 +36538,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-get-regexp.prototype.global">
         <h1>get RegExp.prototype.global</h1>
-        <p>`RegExp.prototype.global` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
+        <p>`RegExp.prototype.global` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _R_ be the *this* value.
           1. Let _cu_ be the code unit 0x0067 (LATIN SMALL LETTER G).
@@ -36524,7 +36548,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-get-regexp.prototype.hasIndices">
         <h1>get RegExp.prototype.hasIndices</h1>
-        <p>`RegExp.prototype.hasIndices` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
+        <p>`RegExp.prototype.hasIndices` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _R_ be the *this* value.
           1. Let _cu_ be the code unit 0x0064 (LATIN SMALL LETTER D).
@@ -36534,7 +36558,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-get-regexp.prototype.ignorecase">
         <h1>get RegExp.prototype.ignoreCase</h1>
-        <p>`RegExp.prototype.ignoreCase` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
+        <p>`RegExp.prototype.ignoreCase` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _R_ be the *this* value.
           1. Let _cu_ be the code unit 0x0069 (LATIN SMALL LETTER I).
@@ -36544,7 +36568,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-regexp.prototype-@@match">
         <h1>RegExp.prototype [ @@match ] ( _string_ )</h1>
-        <p>When the `@@match` method is called with argument _string_, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _rx_ be the *this* value.
           1. If Type(_rx_) is not Object, throw a *TypeError* exception.
@@ -36572,7 +36596,7 @@ THH:mm:ss.sss
                   1. Perform ? Set(_rx_, *"lastIndex"*, 𝔽(_nextIndex_), *true*).
                 1. Set _n_ to _n_ + 1.
         </emu-alg>
-        <p>The value of the *"name"* property of this function is *"[Symbol.match]"*.</p>
+        <p>The value of the *"name"* property of this method is *"[Symbol.match]"*.</p>
         <emu-note>
           <p>The @@match property is used by the IsRegExp abstract operation to identify objects that have the basic behaviour of regular expressions. The absence of a @@match property or the existence of such a property whose value does not Boolean coerce to *true* indicates that the object is not intended to be used as a regular expression object.</p>
         </emu-note>
@@ -36580,7 +36604,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-regexp-prototype-matchall">
         <h1>RegExp.prototype [ @@matchAll ] ( _string_ )</h1>
-        <p>When the `@@matchAll` method is called with argument _string_, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _R_ be the *this* value.
           1. If Type(_R_) is not Object, throw a *TypeError* exception.
@@ -36596,12 +36620,12 @@ THH:mm:ss.sss
           1. Else, let _fullUnicode_ be *false*.
           1. Return CreateRegExpStringIterator(_matcher_, _S_, _global_, _fullUnicode_).
         </emu-alg>
-        <p>The value of the *"name"* property of this function is *"[Symbol.matchAll]"*.</p>
+        <p>The value of the *"name"* property of this method is *"[Symbol.matchAll]"*.</p>
       </emu-clause>
 
       <emu-clause id="sec-get-regexp.prototype.multiline">
         <h1>get RegExp.prototype.multiline</h1>
-        <p>`RegExp.prototype.multiline` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
+        <p>`RegExp.prototype.multiline` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _R_ be the *this* value.
           1. Let _cu_ be the code unit 0x006D (LATIN SMALL LETTER M).
@@ -36611,7 +36635,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-regexp.prototype-@@replace">
         <h1>RegExp.prototype [ @@replace ] ( _string_, _replaceValue_ )</h1>
-        <p>When the `@@replace` method is called with arguments _string_ and _replaceValue_, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _rx_ be the *this* value.
           1. If Type(_rx_) is not Object, throw a *TypeError* exception.
@@ -36676,12 +36700,12 @@ THH:mm:ss.sss
           1. If _nextSourcePosition_ &ge; _lengthS_, return _accumulatedResult_.
           1. Return the string-concatenation of _accumulatedResult_ and the substring of _S_ from _nextSourcePosition_.
         </emu-alg>
-        <p>The value of the *"name"* property of this function is *"[Symbol.replace]"*.</p>
+        <p>The value of the *"name"* property of this method is *"[Symbol.replace]"*.</p>
       </emu-clause>
 
       <emu-clause id="sec-regexp.prototype-@@search">
         <h1>RegExp.prototype [ @@search ] ( _string_ )</h1>
-        <p>When the `@@search` method is called with argument _string_, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _rx_ be the *this* value.
           1. If Type(_rx_) is not Object, throw a *TypeError* exception.
@@ -36696,7 +36720,7 @@ THH:mm:ss.sss
           1. If _result_ is *null*, return *-1*<sub>𝔽</sub>.
           1. Return ? Get(_result_, *"index"*).
         </emu-alg>
-        <p>The value of the *"name"* property of this function is *"[Symbol.search]"*.</p>
+        <p>The value of the *"name"* property of this method is *"[Symbol.search]"*.</p>
         <emu-note>
           <p>The *"lastIndex"* and *"global"* properties of this RegExp object are ignored when performing the search. The *"lastIndex"* property is left unchanged.</p>
         </emu-note>
@@ -36704,7 +36728,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-get-regexp.prototype.source">
         <h1>get RegExp.prototype.source</h1>
-        <p>`RegExp.prototype.source` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
+        <p>`RegExp.prototype.source` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _R_ be the *this* value.
           1. If Type(_R_) is not Object, throw a *TypeError* exception.
@@ -36721,7 +36745,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-regexp.prototype-@@split">
         <h1>RegExp.prototype [ @@split ] ( _string_, _limit_ )</h1>
         <emu-note>
-          <p>Returns an Array into which substrings of the result of converting _string_ to a String have been stored. The substrings are determined by searching from left to right for matches of the *this* value regular expression; these occurrences are not part of any String in the returned array, but serve to divide up the String value.</p>
+          <p>This method returns an Array into which substrings of the result of converting _string_ to a String have been stored. The substrings are determined by searching from left to right for matches of the *this* value regular expression; these occurrences are not part of any String in the returned array, but serve to divide up the String value.</p>
           <p>The *this* value may be an empty regular expression or a regular expression that can match an empty String. In this case, the regular expression does not match the empty <emu-not-ref>substring</emu-not-ref> at the beginning or end of the input String, nor does it match the empty <emu-not-ref>substring</emu-not-ref> at the end of the previous separator match. (For example, if the regular expression matches the empty String, the String is split up into individual code unit elements; the length of the result array equals the length of the String, and each <emu-not-ref>substring</emu-not-ref> contains one code unit.) Only the first match at a given index of the String is considered, even if backtracking could yield a non-empty <emu-not-ref>substring</emu-not-ref> match at that index. (For example, `/a*?/[Symbol.split]("ab")` evaluates to the array `["a", "b"]`, while `/a*/[Symbol.split]("ab")` evaluates to the array `["","b"]`.)</p>
           <p>If _string_ is (or converts to) the empty String, the result depends on whether the regular expression can match the empty String. If it can, the result array contains no elements. Otherwise, the result array contains one element, which is the empty String.</p>
           <p>If the regular expression contains capturing parentheses, then each time _separator_ is matched the results (including any *undefined* results) of the capturing parentheses are spliced into the output array. For example,</p>
@@ -36730,7 +36754,7 @@ THH:mm:ss.sss
           <pre><code class="javascript">["A", undefined, "B", "bold", "/", "B", "and", undefined, "CODE", "coded", "/", "CODE", ""]</code></pre>
           <p>If _limit_ is not *undefined*, then the output array is truncated so that it contains no more than _limit_ elements.</p>
         </emu-note>
-        <p>When the `@@split` method is called, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _rx_ be the *this* value.
           1. If Type(_rx_) is not Object, throw a *TypeError* exception.
@@ -36782,15 +36806,15 @@ THH:mm:ss.sss
           1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_lengthA_)), _T_).
           1. Return _A_.
         </emu-alg>
-        <p>The value of the *"name"* property of this function is *"[Symbol.split]"*.</p>
+        <p>The value of the *"name"* property of this method is *"[Symbol.split]"*.</p>
         <emu-note>
-          <p>The `@@split` method ignores the value of the *"global"* and *"sticky"* properties of this RegExp object.</p>
+          <p>This method ignores the value of the *"global"* and *"sticky"* properties of this RegExp object.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-get-regexp.prototype.sticky">
         <h1>get RegExp.prototype.sticky</h1>
-        <p>`RegExp.prototype.sticky` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
+        <p>`RegExp.prototype.sticky` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _R_ be the *this* value.
           1. Let _cu_ be the code unit 0x0079 (LATIN SMALL LETTER Y).
@@ -36800,7 +36824,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-regexp.prototype.test">
         <h1>RegExp.prototype.test ( _S_ )</h1>
-        <p>The following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _R_ be the *this* value.
           1. If Type(_R_) is not Object, throw a *TypeError* exception.
@@ -36827,7 +36851,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-get-regexp.prototype.unicode">
         <h1>get RegExp.prototype.unicode</h1>
-        <p>`RegExp.prototype.unicode` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
+        <p>`RegExp.prototype.unicode` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _R_ be the *this* value.
           1. Let _cu_ be the code unit 0x0075 (LATIN SMALL LETTER U).
@@ -36932,7 +36956,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-array" oldids="sec-array-constructor-array,sec-array-len,sec-array-items">
         <h1>Array ( ..._values_ )</h1>
-        <p>When the `Array` function is called, the following steps are taken:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. If NewTarget is *undefined*, let _newTarget_ be the active function object; else let _newTarget_ be NewTarget.
           1. Let _proto_ be ? GetPrototypeFromConstructor(_newTarget_, *"%Array.prototype%"*).
@@ -36975,7 +36999,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-array.from">
         <h1>Array.from ( _items_ [ , _mapfn_ [ , _thisArg_ ] ] )</h1>
-        <p>When the `from` method is called, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _C_ be the *this* value.
           1. If _mapfn_ is *undefined*, let _mapping_ be *false*.
@@ -37027,13 +37051,13 @@ THH:mm:ss.sss
           1. Return _A_.
         </emu-alg>
         <emu-note>
-          <p>The `from` function is an intentionally generic factory method; it does not require that its *this* value be the Array constructor. Therefore it can be transferred to or inherited by any other constructors that may be called with a single numeric argument.</p>
+          <p>This method is an intentionally generic factory method; it does not require that its *this* value be the Array constructor. Therefore it can be transferred to or inherited by any other constructors that may be called with a single numeric argument.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-array.isarray">
         <h1>Array.isArray ( _arg_ )</h1>
-        <p>When the `isArray` method is called, the following steps are taken:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. Return ? IsArray(_arg_).
         </emu-alg>
@@ -37041,7 +37065,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-array.of">
         <h1>Array.of ( ..._items_ )</h1>
-        <p>When the `of` method is called, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _len_ be the number of elements in _items_.
           1. Let _lenNumber_ be 𝔽(_len_).
@@ -37060,7 +37084,7 @@ THH:mm:ss.sss
           1. Return _A_.
         </emu-alg>
         <emu-note>
-          <p>The `of` function is an intentionally generic factory method; it does not require that its *this* value be the Array constructor. Therefore it can be transferred to or inherited by other constructors that may be called with a single numeric argument.</p>
+          <p>This method is an intentionally generic factory method; it does not require that its *this* value be the Array constructor. Therefore it can be transferred to or inherited by other constructors that may be called with a single numeric argument.</p>
         </emu-note>
       </emu-clause>
 
@@ -37113,8 +37137,8 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-array.prototype.concat">
         <h1>Array.prototype.concat ( ..._items_ )</h1>
-        <p>Returns an array containing the array elements of the object followed by the array elements of each argument.</p>
-        <p>When the `concat` method is called, the following steps are taken:</p>
+        <p>This method returns an array containing the array elements of the object followed by the array elements of each argument.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _A_ be ? ArraySpeciesCreate(_O_, 0).
@@ -37142,12 +37166,12 @@ THH:mm:ss.sss
           1. [id="step-array-proto-concat-set-length"] Perform ? Set(_A_, *"length"*, 𝔽(_n_), *true*).
           1. Return _A_.
         </emu-alg>
-        <p>The *"length"* property of the `concat` method is *1*<sub>𝔽</sub>.</p>
+        <p>The *"length"* property of this method is *1*<sub>𝔽</sub>.</p>
         <emu-note>
           <p>The explicit setting of the *"length"* property in step <emu-xref href="#step-array-proto-concat-set-length"></emu-xref> is necessary to ensure that its value is correct in situations where the trailing elements of the result Array are not present.</p>
         </emu-note>
         <emu-note>
-          <p>The `concat` function is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
 
         <emu-clause id="sec-isconcatspreadable" type="abstract operation">
@@ -37180,7 +37204,7 @@ THH:mm:ss.sss
         <emu-note>
           <p>If _target_ is negative, it is treated as <emu-eqn>_length_ + _target_</emu-eqn> where _length_ is the length of the array. If _start_ is negative, it is treated as <emu-eqn>_length_ + _start_</emu-eqn>. If _end_ is negative, it is treated as <emu-eqn>_length_ + _end_</emu-eqn>.</p>
         </emu-note>
-        <p>When the `copyWithin` method is called, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
@@ -37219,13 +37243,13 @@ THH:mm:ss.sss
           1. Return _O_.
         </emu-alg>
         <emu-note>
-          <p>The `copyWithin` function is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-array.prototype.entries">
         <h1>Array.prototype.entries ( )</h1>
-        <p>When the `entries` method is called, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Return CreateArrayIterator(_O_, ~key+value~).
@@ -37241,7 +37265,7 @@ THH:mm:ss.sss
           <p>`every` does not directly mutate the object on which it is called but the object may be mutated by the calls to _callbackfn_.</p>
           <p>The range of elements processed by `every` is set before the first call to _callbackfn_. Elements which are appended to the array after the call to `every` begins will not be visited by _callbackfn_. If existing elements of the array are changed, their value as passed to _callbackfn_ will be the value at the time `every` visits them; elements that are deleted after the call to `every` begins and before being visited are not visited. `every` acts like the "for all" quantifier in mathematics. In particular, for an empty array, it returns *true*.</p>
         </emu-note>
-        <p>When the `every` method is called, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
@@ -37258,7 +37282,7 @@ THH:mm:ss.sss
           1. Return *true*.
         </emu-alg>
         <emu-note>
-          <p>The `every` function is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
@@ -37271,7 +37295,7 @@ THH:mm:ss.sss
         <emu-note>
           <p>If _start_ is negative, it is treated as <emu-eqn>_length_ + _start_</emu-eqn> where _length_ is the length of the array. If _end_ is negative, it is treated as <emu-eqn>_length_ + _end_</emu-eqn>.</p>
         </emu-note>
-        <p>When the `fill` method is called, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
@@ -37290,7 +37314,7 @@ THH:mm:ss.sss
           1. Return _O_.
         </emu-alg>
         <emu-note>
-          <p>The `fill` function is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
@@ -37303,7 +37327,7 @@ THH:mm:ss.sss
           <p>`filter` does not directly mutate the object on which it is called but the object may be mutated by the calls to _callbackfn_.</p>
           <p>The range of elements processed by `filter` is set before the first call to _callbackfn_. Elements which are appended to the array after the call to `filter` begins will not be visited by _callbackfn_. If existing elements of the array are changed their value as passed to _callbackfn_ will be the value at the time `filter` visits them; elements that are deleted after the call to `filter` begins and before being visited are not visited.</p>
         </emu-note>
-        <p>When the `filter` method is called, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
@@ -37324,7 +37348,7 @@ THH:mm:ss.sss
           1. Return _A_.
         </emu-alg>
         <emu-note>
-          <p>The `filter` function is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
@@ -37337,7 +37361,7 @@ THH:mm:ss.sss
           <p>`find` does not directly mutate the object on which it is called but the object may be mutated by the calls to _predicate_.</p>
           <p>The range of elements processed by `find` is set before the first call to _predicate_. Elements that are appended to the array after the call to `find` begins will not be visited by _predicate_. If existing elements of the array are changed, their value as passed to _predicate_ will be the value at the time that `find` visits them; elements that are deleted after the call to `find` begins and before being visited are still visited and are either looked up from the prototype or are *undefined*.</p>
         </emu-note>
-        <p>When the `find` method is called, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
@@ -37352,7 +37376,7 @@ THH:mm:ss.sss
           1. Return *undefined*.
         </emu-alg>
         <emu-note>
-          <p>The `find` function is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
@@ -37365,7 +37389,7 @@ THH:mm:ss.sss
           <p>`findIndex` does not directly mutate the object on which it is called but the object may be mutated by the calls to _predicate_.</p>
           <p>The range of elements processed by `findIndex` is set before the first call to _predicate_. Elements that are appended to the array after the call to `findIndex` begins will not be visited by _predicate_. If existing elements of the array are changed, their value as passed to _predicate_ will be the value at the time that `findIndex` visits them; elements that are deleted after the call to `findIndex` begins and before being visited are still visited and are either looked up from the prototype or are *undefined*.</p>
         </emu-note>
-        <p>When the `findIndex` method is called, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
@@ -37380,7 +37404,7 @@ THH:mm:ss.sss
           1. Return *-1*<sub>𝔽</sub>.
         </emu-alg>
         <emu-note>
-          <p>The `findIndex` function is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
@@ -37393,7 +37417,7 @@ THH:mm:ss.sss
           <p>`findLast` does not directly mutate the object on which it is called but the object may be mutated by the calls to _predicate_.</p>
           <p>The range of elements processed by `findLast` is set before the first call to _predicate_. Elements that are appended to the array after the call to `findLast` begins will not be visited by _predicate_. If existing elements of the array are changed, their value as passed to _predicate_ will be the value at the time that `findLast` visits them.</p>
         </emu-note>
-        <p>When the `findLast` method is called, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
@@ -37408,7 +37432,7 @@ THH:mm:ss.sss
           1. Return *undefined*.
         </emu-alg>
         <emu-note>
-          <p>The `findLast` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
@@ -37421,7 +37445,7 @@ THH:mm:ss.sss
           <p>`findLastIndex` does not directly mutate the object on which it is called but the object may be mutated by the calls to _predicate_.</p>
           <p>The range of elements processed by `findLastIndex` is set before the first call to _predicate_. Elements that are appended to the array after the call to `findLastIndex` begins will not be visited by _predicate_. If existing elements of the array are changed, their value as passed to _predicate_ will be the value at the time that `findLastIndex` visits them.</p>
         </emu-note>
-        <p>When the `findLastIndex` method is called, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
@@ -37436,13 +37460,13 @@ THH:mm:ss.sss
           1. Return *-1*<sub>𝔽</sub>.
         </emu-alg>
         <emu-note>
-          <p>The `findLastIndex` function is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-array.prototype.flat">
         <h1>Array.prototype.flat ( [ _depth_ ] )</h1>
-        <p>When the `flat` method is called, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _sourceLen_ be ? LengthOfArrayLike(_O_).
@@ -37500,7 +37524,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-array.prototype.flatmap">
         <h1>Array.prototype.flatMap ( _mapperFunction_ [ , _thisArg_ ] )</h1>
-        <p>When the `flatMap` method is called, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _sourceLen_ be ? LengthOfArrayLike(_O_).
@@ -37520,7 +37544,7 @@ THH:mm:ss.sss
           <p>`forEach` does not directly mutate the object on which it is called but the object may be mutated by the calls to _callbackfn_.</p>
           <p>The range of elements processed by `forEach` is set before the first call to _callbackfn_. Elements which are appended to the array after the call to `forEach` begins will not be visited by _callbackfn_. If existing elements of the array are changed, their value as passed to _callbackfn_ will be the value at the time `forEach` visits them; elements that are deleted after the call to `forEach` begins and before being visited are not visited.</p>
         </emu-note>
-        <p>When the `forEach` method is called, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
@@ -37536,17 +37560,17 @@ THH:mm:ss.sss
           1. Return *undefined*.
         </emu-alg>
         <emu-note>
-          <p>The `forEach` function is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-array.prototype.includes">
         <h1>Array.prototype.includes ( _searchElement_ [ , _fromIndex_ ] )</h1>
         <emu-note>
-          <p>`includes` compares _searchElement_ to the elements of the array, in ascending order, using the SameValueZero algorithm, and if found at any position, returns *true*; otherwise, *false* is returned.</p>
+          <p>This method compares _searchElement_ to the elements of the array, in ascending order, using the SameValueZero algorithm, and if found at any position, returns *true*; otherwise, it returns *false*.</p>
           <p>The optional second argument _fromIndex_ defaults to *+0*<sub>𝔽</sub> (i.e. the whole array is searched). If it is greater than or equal to the length of the array, *false* is returned, i.e. the array will not be searched. If it is less than *+0*<sub>𝔽</sub>, it is used as the offset from the end of the array to compute _fromIndex_. If the computed index is less than *+0*<sub>𝔽</sub>, the whole array will be searched.</p>
         </emu-note>
-        <p>When the `includes` method is called, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
@@ -37567,20 +37591,20 @@ THH:mm:ss.sss
           1. Return *false*.
         </emu-alg>
         <emu-note>
-          <p>The `includes` function is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
         <emu-note>
-          <p>The `includes` method intentionally differs from the similar `indexOf` method in two ways. First, it uses the SameValueZero algorithm, instead of IsStrictlyEqual, allowing it to detect *NaN* array elements. Second, it does not skip missing array elements, instead treating them as *undefined*.</p>
+          <p>This method intentionally differs from the similar `indexOf` method in two ways. First, it uses the SameValueZero algorithm, instead of IsStrictlyEqual, allowing it to detect *NaN* array elements. Second, it does not skip missing array elements, instead treating them as *undefined*.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-array.prototype.indexof">
         <h1>Array.prototype.indexOf ( _searchElement_ [ , _fromIndex_ ] )</h1>
-        <p>`indexOf` compares _searchElement_ to the elements of the array, in ascending order, using the IsStrictlyEqual algorithm, and if found at one or more indices, returns the smallest such index; otherwise, *-1*<sub>𝔽</sub> is returned.</p>
+        <p>This method compares _searchElement_ to the elements of the array, in ascending order, using the IsStrictlyEqual algorithm, and if found at one or more indices, returns the smallest such index; otherwise, it returns *-1*<sub>𝔽</sub>.</p>
         <emu-note>
           <p>The optional second argument _fromIndex_ defaults to *+0*<sub>𝔽</sub> (i.e. the whole array is searched). If it is greater than or equal to the length of the array, *-1*<sub>𝔽</sub> is returned, i.e. the array will not be searched. If it is less than *+0*<sub>𝔽</sub>, it is used as the offset from the end of the array to compute _fromIndex_. If the computed index is less than *+0*<sub>𝔽</sub>, the whole array will be searched.</p>
         </emu-note>
-        <p>When the `indexOf` method is called, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
@@ -37604,14 +37628,14 @@ THH:mm:ss.sss
           1. Return *-1*<sub>𝔽</sub>.
         </emu-alg>
         <emu-note>
-          <p>The `indexOf` function is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-array.prototype.join">
         <h1>Array.prototype.join ( _separator_ )</h1>
-        <p>The elements of the array are converted to Strings, and these Strings are then concatenated, separated by occurrences of the _separator_. If no separator is provided, a single comma is used as the separator.</p>
-        <p>When the `join` method is called, the following steps are taken:</p>
+        <p>This method converts the elements of the array to Strings, and then concatenates these Strings, separated by occurrences of the _separator_. If no separator is provided, a single comma is used as the separator.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
@@ -37628,13 +37652,13 @@ THH:mm:ss.sss
           1. Return _R_.
         </emu-alg>
         <emu-note>
-          <p>The `join` function is intentionally generic; it does not require that its *this* value be an Array. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be an Array. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-array.prototype.keys">
         <h1>Array.prototype.keys ( )</h1>
-        <p>When the `keys` method is called, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Return CreateArrayIterator(_O_, ~key~).
@@ -37644,10 +37668,10 @@ THH:mm:ss.sss
       <emu-clause id="sec-array.prototype.lastindexof">
         <h1>Array.prototype.lastIndexOf ( _searchElement_ [ , _fromIndex_ ] )</h1>
         <emu-note>
-          <p>`lastIndexOf` compares _searchElement_ to the elements of the array in descending order using the IsStrictlyEqual algorithm, and if found at one or more indices, returns the largest such index; otherwise, *-1*<sub>𝔽</sub> is returned.</p>
+          <p>This method compares _searchElement_ to the elements of the array in descending order using the IsStrictlyEqual algorithm, and if found at one or more indices, returns the largest such index; otherwise, it returns *-1*<sub>𝔽</sub>.</p>
           <p>The optional second argument _fromIndex_ defaults to the array's length minus one (i.e. the whole array is searched). If it is greater than or equal to the length of the array, the whole array will be searched. If it is less than *+0*<sub>𝔽</sub>, it is used as the offset from the end of the array to compute _fromIndex_. If the computed index is less than *+0*<sub>𝔽</sub>, *-1*<sub>𝔽</sub> is returned.</p>
         </emu-note>
-        <p>When the `lastIndexOf` method is called, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
@@ -37668,7 +37692,7 @@ THH:mm:ss.sss
           1. Return *-1*<sub>𝔽</sub>.
         </emu-alg>
         <emu-note>
-          <p>The `lastIndexOf` function is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
@@ -37681,7 +37705,7 @@ THH:mm:ss.sss
           <p>`map` does not directly mutate the object on which it is called but the object may be mutated by the calls to _callbackfn_.</p>
           <p>The range of elements processed by `map` is set before the first call to _callbackfn_. Elements which are appended to the array after the call to `map` begins will not be visited by _callbackfn_. If existing elements of the array are changed, their value as passed to _callbackfn_ will be the value at the time `map` visits them; elements that are deleted after the call to `map` begins and before being visited are not visited.</p>
         </emu-note>
-        <p>When the `map` method is called, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
@@ -37699,16 +37723,16 @@ THH:mm:ss.sss
           1. Return _A_.
         </emu-alg>
         <emu-note>
-          <p>The `map` function is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-array.prototype.pop">
         <h1>Array.prototype.pop ( )</h1>
         <emu-note>
-          <p>The last element of the array is removed from the array and returned.</p>
+          <p>This method removes the last element of the array and returns it.</p>
         </emu-note>
-        <p>When the `pop` method is called, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
@@ -37725,16 +37749,16 @@ THH:mm:ss.sss
             1. Return _element_.
         </emu-alg>
         <emu-note>
-          <p>The `pop` function is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-array.prototype.push">
         <h1>Array.prototype.push ( ..._items_ )</h1>
         <emu-note>
-          <p>The arguments are appended to the end of the array, in the order in which they appear. The new length of the array is returned as the result of the call.</p>
+          <p>This method appends the arguments to the end of the array, in the order in which they appear. It returns the new length of the array.</p>
         </emu-note>
-        <p>When the `push` method is called, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
@@ -37746,9 +37770,9 @@ THH:mm:ss.sss
           1. Perform ? Set(_O_, *"length"*, 𝔽(_len_), *true*).
           1. Return 𝔽(_len_).
         </emu-alg>
-        <p>The *"length"* property of the `push` method is *1*<sub>𝔽</sub>.</p>
+        <p>The *"length"* property of this method is *1*<sub>𝔽</sub>.</p>
         <emu-note>
-          <p>The `push` function is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
@@ -37760,7 +37784,7 @@ THH:mm:ss.sss
           <p>`reduce` does not directly mutate the object on which it is called but the object may be mutated by the calls to _callbackfn_.</p>
           <p>The range of elements processed by `reduce` is set before the first call to _callbackfn_. Elements that are appended to the array after the call to `reduce` begins will not be visited by _callbackfn_. If existing elements of the array are changed, their value as passed to _callbackfn_ will be the value at the time `reduce` visits them; elements that are deleted after the call to `reduce` begins and before being visited are not visited.</p>
         </emu-note>
-        <p>When the `reduce` method is called, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
@@ -37789,7 +37813,7 @@ THH:mm:ss.sss
           1. Return _accumulator_.
         </emu-alg>
         <emu-note>
-          <p>The `reduce` function is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
@@ -37801,7 +37825,7 @@ THH:mm:ss.sss
           <p>`reduceRight` does not directly mutate the object on which it is called but the object may be mutated by the calls to _callbackfn_.</p>
           <p>The range of elements processed by `reduceRight` is set before the first call to _callbackfn_. Elements that are appended to the array after the call to `reduceRight` begins will not be visited by _callbackfn_. If existing elements of the array are changed by _callbackfn_, their value as passed to _callbackfn_ will be the value at the time `reduceRight` visits them; elements that are deleted after the call to `reduceRight` begins and before being visited are not visited.</p>
         </emu-note>
-        <p>When the `reduceRight` method is called, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
@@ -37830,16 +37854,16 @@ THH:mm:ss.sss
           1. Return _accumulator_.
         </emu-alg>
         <emu-note>
-          <p>The `reduceRight` function is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-array.prototype.reverse">
         <h1>Array.prototype.reverse ( )</h1>
         <emu-note>
-          <p>The elements of the array are rearranged so as to reverse their order. The object is returned as the result of the call.</p>
+          <p>This method rearranges the elements of the array so as to reverse their order. It returns the object as the result of the call.</p>
         </emu-note>
-        <p>When the `reverse` method is called, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
@@ -37871,14 +37895,14 @@ THH:mm:ss.sss
           1. Return _O_.
         </emu-alg>
         <emu-note>
-          <p>The `reverse` function is intentionally generic; it does not require that its *this* value be an Array. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be an Array. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-array.prototype.shift">
         <h1>Array.prototype.shift ( )</h1>
-        <p>The first element of the array is removed from the array and returned.</p>
-        <p>When the `shift` method is called, the following steps are taken:</p>
+        <p>This method removes the first element of the array and returns it.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
@@ -37903,14 +37927,14 @@ THH:mm:ss.sss
           1. Return _first_.
         </emu-alg>
         <emu-note>
-          <p>The `shift` function is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-array.prototype.slice">
         <h1>Array.prototype.slice ( _start_, _end_ )</h1>
-        <p>The `slice` method returns an array containing the elements of the array from element _start_ up to, but not including, element _end_ (or through the end of the array if _end_ is *undefined*). If _start_ is negative, it is treated as <emu-eqn>_length_ + _start_</emu-eqn> where _length_ is the length of the array. If _end_ is negative, it is treated as <emu-eqn>_length_ + _end_</emu-eqn> where _length_ is the length of the array.</p>
-        <p>When the `slice` method is called, the following steps are taken:</p>
+        <p>This method returns an array containing the elements of the array from element _start_ up to, but not including, element _end_ (or through the end of the array if _end_ is *undefined*). If _start_ is negative, it is treated as <emu-eqn>_length_ + _start_</emu-eqn> where _length_ is the length of the array. If _end_ is negative, it is treated as <emu-eqn>_length_ + _end_</emu-eqn> where _length_ is the length of the array.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
@@ -37940,7 +37964,7 @@ THH:mm:ss.sss
           <p>The explicit setting of the *"length"* property of the result Array in step <emu-xref href="#step-array-proto-slice-set-length"></emu-xref> was necessary in previous editions of ECMAScript to ensure that its length was correct in situations where the trailing elements of the result Array were not present. Setting *"length"* became unnecessary starting in ES2015 when the result Array was initialized to its proper length rather than an empty Array but is carried forward to preserve backward compatibility.</p>
         </emu-note>
         <emu-note>
-          <p>The `slice` function is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
@@ -37953,7 +37977,7 @@ THH:mm:ss.sss
           <p>`some` does not directly mutate the object on which it is called but the object may be mutated by the calls to _callbackfn_.</p>
           <p>The range of elements processed by `some` is set before the first call to _callbackfn_. Elements that are appended to the array after the call to `some` begins will not be visited by _callbackfn_. If existing elements of the array are changed, their value as passed to _callbackfn_ will be the value at the time that `some` visits them; elements that are deleted after the call to `some` begins and before being visited are not visited. `some` acts like the "exists" quantifier in mathematics. In particular, for an empty array, it returns *false*.</p>
         </emu-note>
-        <p>When the `some` method is called, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
@@ -37970,14 +37994,14 @@ THH:mm:ss.sss
           1. Return *false*.
         </emu-alg>
         <emu-note>
-          <p>The `some` function is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-array.prototype.sort" oldids="sec-sortcompare">
         <h1>Array.prototype.sort ( _comparefn_ )</h1>
-        <p>The elements of this array are sorted. The sort must be stable (that is, elements that compare equal must remain in their original order). If _comparefn_ is not *undefined*, it should be a function that accepts two arguments _x_ and _y_ and returns a negative Number if _x_ &lt; _y_, a positive Number if _x_ &gt; _y_, or a zero otherwise.</p>
-        <p>When the `sort` method is called, the following steps are taken:</p>
+        <p>This method sorts the elements of this array. The sort must be stable (that is, elements that compare equal must remain in their original order). If _comparefn_ is not *undefined*, it should be a function that accepts two arguments _x_ and _y_ and returns a negative Number if _x_ &lt; _y_, a positive Number if _x_ &gt; _y_, or a zero otherwise.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. [id="step-array-sort-comparefn"] If _comparefn_ is not *undefined* and IsCallable(_comparefn_) is *false*, throw a *TypeError* exception.
           1. Let _obj_ be ? ToObject(*this* value).
@@ -38006,7 +38030,7 @@ THH:mm:ss.sss
           <p>Method calls performed by the ToString abstract operations in steps <emu-xref href="#step-sortcompare-tostring-x"></emu-xref> and <emu-xref href="#step-sortcompare-tostring-y"></emu-xref> have the potential to cause _SortCompare_ to not behave as a consistent comparator.</p>
         </emu-note>
         <emu-note>
-          <p>The `sort` function is intentionally generic; it does not require that its *this* value be an Array. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be an Array. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
 
         <emu-clause id="sec-sortindexedproperties" type="abstract operation">
@@ -38084,9 +38108,9 @@ THH:mm:ss.sss
       <emu-clause id="sec-array.prototype.splice">
         <h1>Array.prototype.splice ( _start_, _deleteCount_, ..._items_ )</h1>
         <emu-note>
-          <p>The _deleteCount_ elements of the array starting at integer index _start_ are replaced by the elements of _items_. An Array containing the deleted elements (if any) is returned.</p>
+          <p>This method deletes the _deleteCount_ elements of the array starting at integer index _start_ and replaces them with the elements of _items_. It returns an Array containing the deleted elements (if any).</p>
         </emu-note>
-        <p>When the `splice` method is called, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
@@ -38149,18 +38173,18 @@ THH:mm:ss.sss
           <p>The explicit setting of the *"length"* property of the result Array in step <emu-xref href="#step-array-proto-splice-set-length"></emu-xref> was necessary in previous editions of ECMAScript to ensure that its length was correct in situations where the trailing elements of the result Array were not present. Setting *"length"* became unnecessary starting in ES2015 when the result Array was initialized to its proper length rather than an empty Array but is carried forward to preserve backward compatibility.</p>
         </emu-note>
         <emu-note>
-          <p>The `splice` function is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-array.prototype.tolocalestring">
         <h1>Array.prototype.toLocaleString ( [ _reserved1_ [ , _reserved2_ ] ] )</h1>
-        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the `Array.prototype.toLocaleString` method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of the `toLocaleString` method is used.</p>
+        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used.</p>
         <emu-note>
-          <p>The first edition of ECMA-402 did not include a replacement specification for the `Array.prototype.toLocaleString` method.</p>
+          <p>The first edition of ECMA-402 did not include a replacement specification for this method.</p>
         </emu-note>
         <p>The meanings of the optional parameters to this method are defined in the ECMA-402 specification; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
-        <p>When the `toLocaleString` method is called, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _array_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_array_).
@@ -38178,16 +38202,16 @@ THH:mm:ss.sss
           1. Return _R_.
         </emu-alg>
         <emu-note>
-          <p>The elements of the array are converted to Strings using their `toLocaleString` methods, and these Strings are then concatenated, separated by occurrences of an implementation-defined locale-sensitive separator String. This function is analogous to `toString` except that it is intended to yield a locale-sensitive result corresponding with conventions of the host environment's current locale.</p>
+          <p>This method converts the elements of the array to Strings using their `toLocaleString` methods, and then concatenates these Strings, separated by occurrences of an implementation-defined locale-sensitive separator String. This method is analogous to `toString` except that it is intended to yield a locale-sensitive result corresponding with conventions of the host environment's current locale.</p>
         </emu-note>
         <emu-note>
-          <p>The `toLocaleString` function is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-array.prototype.tostring">
         <h1>Array.prototype.toString ( )</h1>
-        <p>When the `toString` method is called, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _array_ be ? ToObject(*this* value).
           1. Let _func_ be ? Get(_array_, *"join"*).
@@ -38195,14 +38219,14 @@ THH:mm:ss.sss
           1. Return ? Call(_func_, _array_).
         </emu-alg>
         <emu-note>
-          <p>The `toString` function is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-array.prototype.unshift">
         <h1>Array.prototype.unshift ( ..._items_ )</h1>
-        <p>The arguments are prepended to the start of the array, such that their order within the array is the same as the order in which they appear in the argument list.</p>
-        <p>When the `unshift` method is called, the following steps are taken:</p>
+        <p>This method prepends the arguments to the start of the array, such that their order within the array is the same as the order in which they appear in the argument list.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
@@ -38228,15 +38252,15 @@ THH:mm:ss.sss
           1. Perform ? Set(_O_, *"length"*, 𝔽(_len_ + _argCount_), *true*).
           1. Return 𝔽(_len_ + _argCount_).
         </emu-alg>
-        <p>The *"length"* property of the `unshift` method is *1*<sub>𝔽</sub>.</p>
+        <p>The *"length"* property of this method is *1*<sub>𝔽</sub>.</p>
         <emu-note>
-          <p>The `unshift` function is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-array.prototype.values">
         <h1>Array.prototype.values ( )</h1>
-        <p>When the `values` method is called, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Return CreateArrayIterator(_O_, ~value~).
@@ -38590,11 +38614,11 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-%typedarray%">
         <h1>%TypedArray% ( )</h1>
-        <p>The %TypedArray% constructor performs the following steps when called:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. Throw a *TypeError* exception.
         </emu-alg>
-        <p>The *"length"* property of the %TypedArray% constructor function is *+0*<sub>𝔽</sub>.</p>
+        <p>The *"length"* property of this function is *+0*<sub>𝔽</sub>.</p>
       </emu-clause>
     </emu-clause>
 
@@ -38609,7 +38633,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-%typedarray%.from">
         <h1>%TypedArray%.from ( _source_ [ , _mapfn_ [ , _thisArg_ ] ] )</h1>
-        <p>When the `from` method is called, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _C_ be the *this* value.
           1. If IsConstructor(_C_) is *false*, throw a *TypeError* exception.
@@ -38652,7 +38676,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-%typedarray%.of">
         <h1>%TypedArray%.of ( ..._items_ )</h1>
-        <p>When the `of` method is called, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _len_ be the number of elements in _items_.
           1. Let _C_ be the *this* value.
@@ -38760,8 +38784,8 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-%typedarray%.prototype.copywithin">
         <h1>%TypedArray%.prototype.copyWithin ( _target_, _start_ [ , _end_ ] )</h1>
-        <p>The interpretation and use of the arguments of %TypedArray%`.prototype.copyWithin` are the same as for `Array.prototype.copyWithin` as defined in <emu-xref href="#sec-array.prototype.copywithin"></emu-xref>.</p>
-        <p>When the `copyWithin` method is called, the following steps are taken:</p>
+        <p>The interpretation and use of the arguments of this method are the same as for `Array.prototype.copyWithin` as defined in <emu-xref href="#sec-array.prototype.copywithin"></emu-xref>.</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
@@ -38806,7 +38830,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-%typedarray%.prototype.entries">
         <h1>%TypedArray%.prototype.entries ( )</h1>
-        <p>When the `entries` method is called, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
@@ -38816,8 +38840,8 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-%typedarray%.prototype.every">
         <h1>%TypedArray%.prototype.every ( _callbackfn_ [ , _thisArg_ ] )</h1>
-        <p>The interpretation and use of the arguments of %TypedArray%`.prototype.every` are the same as for `Array.prototype.every` as defined in <emu-xref href="#sec-array.prototype.every"></emu-xref>.</p>
-        <p>When the `every` method is called, the following steps are taken:</p>
+        <p>The interpretation and use of the arguments of this method are the same as for `Array.prototype.every` as defined in <emu-xref href="#sec-array.prototype.every"></emu-xref>.</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
@@ -38832,13 +38856,13 @@ THH:mm:ss.sss
             1. Set _k_ to _k_ + 1.
           1. Return *true*.
         </emu-alg>
-        <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
+        <p>This method is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.fill">
         <h1>%TypedArray%.prototype.fill ( _value_ [ , _start_ [ , _end_ ] ] )</h1>
-        <p>The interpretation and use of the arguments of %TypedArray%`.prototype.fill` are the same as for `Array.prototype.fill` as defined in <emu-xref href="#sec-array.prototype.fill"></emu-xref>.</p>
-        <p>When the `fill` method is called, the following steps are taken:</p>
+        <p>The interpretation and use of the arguments of this method are the same as for `Array.prototype.fill` as defined in <emu-xref href="#sec-array.prototype.fill"></emu-xref>.</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
@@ -38864,8 +38888,8 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-%typedarray%.prototype.filter">
         <h1>%TypedArray%.prototype.filter ( _callbackfn_ [ , _thisArg_ ] )</h1>
-        <p>The interpretation and use of the arguments of %TypedArray%`.prototype.filter` are the same as for `Array.prototype.filter` as defined in <emu-xref href="#sec-array.prototype.filter"></emu-xref>.</p>
-        <p>When the `filter` method is called, the following steps are taken:</p>
+        <p>The interpretation and use of the arguments of this method are the same as for `Array.prototype.filter` as defined in <emu-xref href="#sec-array.prototype.filter"></emu-xref>.</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
@@ -38889,13 +38913,13 @@ THH:mm:ss.sss
             1. Set _n_ to _n_ + 1.
           1. Return _A_.
         </emu-alg>
-        <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
+        <p>This method is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.find">
         <h1>%TypedArray%.prototype.find ( _predicate_ [ , _thisArg_ ] )</h1>
-        <p>The interpretation and use of the arguments of %TypedArray%`.prototype.find` are the same as for `Array.prototype.find` as defined in <emu-xref href="#sec-array.prototype.find"></emu-xref>.</p>
-        <p>When the `find` method is called, the following steps are taken:</p>
+        <p>The interpretation and use of the arguments of this method are the same as for `Array.prototype.find` as defined in <emu-xref href="#sec-array.prototype.find"></emu-xref>.</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
@@ -38910,13 +38934,13 @@ THH:mm:ss.sss
             1. Set _k_ to _k_ + 1.
           1. Return *undefined*.
         </emu-alg>
-        <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
+        <p>This method is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.findindex">
         <h1>%TypedArray%.prototype.findIndex ( _predicate_ [ , _thisArg_ ] )</h1>
-        <p>The interpretation and use of the arguments of %TypedArray%`.prototype.findIndex` are the same as for `Array.prototype.findIndex` as defined in <emu-xref href="#sec-array.prototype.findindex"></emu-xref>.</p>
-        <p>When the `findIndex` method is called, the following steps are taken:</p>
+        <p>The interpretation and use of the arguments of this method are the same as for `Array.prototype.findIndex` as defined in <emu-xref href="#sec-array.prototype.findindex"></emu-xref>.</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
@@ -38931,13 +38955,13 @@ THH:mm:ss.sss
             1. Set _k_ to _k_ + 1.
           1. Return *-1*<sub>𝔽</sub>.
         </emu-alg>
-        <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
+        <p>This method is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.findlast">
         <h1>%TypedArray%.prototype.findLast ( _predicate_ [ , _thisArg_ ] )</h1>
-        <p>The interpretation and use of the arguments of %TypedArray%`.prototype.findLast` are the same as for `Array.prototype.findLast` as defined in <emu-xref href="#sec-array.prototype.findlast"></emu-xref>.</p>
-        <p>When the `findLast` method is called, the following steps are taken:</p>
+        <p>The interpretation and use of the arguments of this method are the same as for `Array.prototype.findLast` as defined in <emu-xref href="#sec-array.prototype.findlast"></emu-xref>.</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
@@ -38952,13 +38976,13 @@ THH:mm:ss.sss
             1. Set _k_ to _k_ - 1.
           1. Return *undefined*.
         </emu-alg>
-        <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
+        <p>This method is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.findlastindex">
         <h1>%TypedArray%.prototype.findLastIndex ( _predicate_ [ , _thisArg_ ] )</h1>
-        <p>The interpretation and use of the arguments of %TypedArray%`.prototype.findLastIndex` are the same as for `Array.prototype.findLastIndex` as defined in <emu-xref href="#sec-array.prototype.findlastindex"></emu-xref>.</p>
-        <p>When the `findLastIndex` method is called, the following steps are taken:</p>
+        <p>The interpretation and use of the arguments of this method are the same as for `Array.prototype.findLastIndex` as defined in <emu-xref href="#sec-array.prototype.findlastindex"></emu-xref>.</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
@@ -38973,13 +38997,13 @@ THH:mm:ss.sss
             1. Set _k_ to _k_ - 1.
           1. Return *-1*<sub>𝔽</sub>.
         </emu-alg>
-        <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
+        <p>This method is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.foreach">
         <h1>%TypedArray%.prototype.forEach ( _callbackfn_ [ , _thisArg_ ] )</h1>
-        <p>The interpretation and use of the arguments of %TypedArray%`.prototype.forEach` are the same as for `Array.prototype.forEach` as defined in <emu-xref href="#sec-array.prototype.foreach"></emu-xref>.</p>
-        <p>When the `forEach` method is called, the following steps are taken:</p>
+        <p>The interpretation and use of the arguments of this method are the same as for `Array.prototype.forEach` as defined in <emu-xref href="#sec-array.prototype.foreach"></emu-xref>.</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
@@ -38993,13 +39017,13 @@ THH:mm:ss.sss
             1. Set _k_ to _k_ + 1.
           1. Return *undefined*.
         </emu-alg>
-        <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
+        <p>This method is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.includes">
         <h1>%TypedArray%.prototype.includes ( _searchElement_ [ , _fromIndex_ ] )</h1>
-        <p>The interpretation and use of the arguments of %TypedArray%`.prototype.includes` are the same as for `Array.prototype.includes` as defined in <emu-xref href="#sec-array.prototype.includes"></emu-xref>.</p>
-        <p>When the `includes` method is called, the following steps are taken:</p>
+        <p>The interpretation and use of the arguments of this method are the same as for `Array.prototype.includes` as defined in <emu-xref href="#sec-array.prototype.includes"></emu-xref>.</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
@@ -39020,13 +39044,13 @@ THH:mm:ss.sss
             1. Set _k_ to _k_ + 1.
           1. Return *false*.
         </emu-alg>
-        <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
+        <p>This method is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.indexof">
         <h1>%TypedArray%.prototype.indexOf ( _searchElement_ [ , _fromIndex_ ] )</h1>
-        <p>The interpretation and use of the arguments of %TypedArray%`.prototype.indexOf` are the same as for `Array.prototype.indexOf` as defined in <emu-xref href="#sec-array.prototype.indexof"></emu-xref>.</p>
-        <p>When the `indexOf` method is called, the following steps are taken:</p>
+        <p>The interpretation and use of the arguments of this method are the same as for `Array.prototype.indexOf` as defined in <emu-xref href="#sec-array.prototype.indexof"></emu-xref>.</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
@@ -39050,13 +39074,13 @@ THH:mm:ss.sss
             1. Set _k_ to _k_ + 1.
           1. Return *-1*<sub>𝔽</sub>.
         </emu-alg>
-        <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
+        <p>This method is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.join">
         <h1>%TypedArray%.prototype.join ( _separator_ )</h1>
-        <p>The interpretation and use of the arguments of %TypedArray%`.prototype.join` are the same as for `Array.prototype.join` as defined in <emu-xref href="#sec-array.prototype.join"></emu-xref>.</p>
-        <p>When the `join` method is called, the following steps are taken:</p>
+        <p>The interpretation and use of the arguments of this method are the same as for `Array.prototype.join` as defined in <emu-xref href="#sec-array.prototype.join"></emu-xref>.</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
@@ -39073,12 +39097,12 @@ THH:mm:ss.sss
             1. Set _k_ to _k_ + 1.
           1. Return _R_.
         </emu-alg>
-        <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
+        <p>This method is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.keys">
         <h1>%TypedArray%.prototype.keys ( )</h1>
-        <p>When the `keys` method is called, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
@@ -39088,8 +39112,8 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-%typedarray%.prototype.lastindexof">
         <h1>%TypedArray%.prototype.lastIndexOf ( _searchElement_ [ , _fromIndex_ ] )</h1>
-        <p>The interpretation and use of the arguments of %TypedArray%`.prototype.lastIndexOf` are the same as for `Array.prototype.lastIndexOf` as defined in <emu-xref href="#sec-array.prototype.lastindexof"></emu-xref>.</p>
-        <p>When the `lastIndexOf` method is called, the following steps are taken:</p>
+        <p>The interpretation and use of the arguments of this method are the same as for `Array.prototype.lastIndexOf` as defined in <emu-xref href="#sec-array.prototype.lastindexof"></emu-xref>.</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
@@ -39110,7 +39134,7 @@ THH:mm:ss.sss
             1. Set _k_ to _k_ - 1.
           1. Return *-1*<sub>𝔽</sub>.
         </emu-alg>
-        <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
+        <p>This method is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
       </emu-clause>
 
       <emu-clause id="sec-get-%typedarray%.prototype.length">
@@ -39130,8 +39154,8 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-%typedarray%.prototype.map">
         <h1>%TypedArray%.prototype.map ( _callbackfn_ [ , _thisArg_ ] )</h1>
-        <p>The interpretation and use of the arguments of %TypedArray%`.prototype.map` are the same as for `Array.prototype.map` as defined in <emu-xref href="#sec-array.prototype.map"></emu-xref>.</p>
-        <p>When the `map` method is called, the following steps are taken:</p>
+        <p>The interpretation and use of the arguments of this method are the same as for `Array.prototype.map` as defined in <emu-xref href="#sec-array.prototype.map"></emu-xref>.</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
@@ -39147,13 +39171,13 @@ THH:mm:ss.sss
             1. Set _k_ to _k_ + 1.
           1. Return _A_.
         </emu-alg>
-        <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
+        <p>This method is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.reduce">
         <h1>%TypedArray%.prototype.reduce ( _callbackfn_ [ , _initialValue_ ] )</h1>
-        <p>The interpretation and use of the arguments of %TypedArray%`.prototype.reduce` are the same as for `Array.prototype.reduce` as defined in <emu-xref href="#sec-array.prototype.reduce"></emu-xref>.</p>
-        <p>When the `reduce` method is called, the following steps are taken:</p>
+        <p>The interpretation and use of the arguments of this method are the same as for `Array.prototype.reduce` as defined in <emu-xref href="#sec-array.prototype.reduce"></emu-xref>.</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
@@ -39175,13 +39199,13 @@ THH:mm:ss.sss
             1. Set _k_ to _k_ + 1.
           1. Return _accumulator_.
         </emu-alg>
-        <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
+        <p>This method is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.reduceright">
         <h1>%TypedArray%.prototype.reduceRight ( _callbackfn_ [ , _initialValue_ ] )</h1>
-        <p>The interpretation and use of the arguments of %TypedArray%`.prototype.reduceRight` are the same as for `Array.prototype.reduceRight` as defined in <emu-xref href="#sec-array.prototype.reduceright"></emu-xref>.</p>
-        <p>When the `reduceRight` method is called, the following steps are taken:</p>
+        <p>The interpretation and use of the arguments of this method are the same as for `Array.prototype.reduceRight` as defined in <emu-xref href="#sec-array.prototype.reduceright"></emu-xref>.</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
@@ -39203,13 +39227,13 @@ THH:mm:ss.sss
             1. Set _k_ to _k_ - 1.
           1. Return _accumulator_.
         </emu-alg>
-        <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
+        <p>This method is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.reverse">
         <h1>%TypedArray%.prototype.reverse ( )</h1>
-        <p>The interpretation and use of the arguments of %TypedArray%`.prototype.reverse` are the same as for `Array.prototype.reverse` as defined in <emu-xref href="#sec-array.prototype.reverse"></emu-xref>.</p>
-        <p>When the `reverse` method is called, the following steps are taken:</p>
+        <p>The interpretation and use of the arguments of this method are the same as for `Array.prototype.reverse` as defined in <emu-xref href="#sec-array.prototype.reverse"></emu-xref>.</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
@@ -39227,13 +39251,13 @@ THH:mm:ss.sss
             1. Set _lower_ to _lower_ + 1.
           1. Return _O_.
         </emu-alg>
-        <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
+        <p>This method is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.set" oldids="sec-%typedarray%.prototype.set-overloaded-offset">
         <h1>%TypedArray%.prototype.set ( _source_ [ , _offset_ ] )</h1>
-        <p>%TypedArray%`.prototype.set` sets multiple values in this _TypedArray_, reading the values from _source_. The details differ based upon the type of _source_. The optional _offset_ value indicates the first element index in this _TypedArray_ where values are written. If omitted, it is assumed to be 0.</p>
-        <p>When the `set` method is called, the following steps are taken:</p>
+        <p>This method sets multiple values in this _TypedArray_, reading the values from _source_. The details differ based upon the type of _source_. The optional _offset_ value indicates the first element index in this _TypedArray_ where values are written. If omitted, it is assumed to be 0.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _target_ be the *this* value.
           1. Perform ? RequireInternalSlot(_target_, [[TypedArrayName]]).
@@ -39246,7 +39270,7 @@ THH:mm:ss.sss
             1. Perform ? SetTypedArrayFromArrayLike(_target_, _targetOffset_, _source_).
           1. Return *undefined*.
         </emu-alg>
-        <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
+        <p>This method is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
 
         <emu-clause id="sec-settypedarrayfromtypedarray" type="abstract operation" oldids="sec-%typedarray%.prototype.set-typedarray-offset">
           <h1>
@@ -39337,8 +39361,8 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-%typedarray%.prototype.slice">
         <h1>%TypedArray%.prototype.slice ( _start_, _end_ )</h1>
-        <p>The interpretation and use of the arguments of %TypedArray%`.prototype.slice` are the same as for `Array.prototype.slice` as defined in <emu-xref href="#sec-array.prototype.slice"></emu-xref>.</p>
-        <p>When the `slice` method is called, the following steps are taken:</p>
+        <p>The interpretation and use of the arguments of this method are the same as for `Array.prototype.slice` as defined in <emu-xref href="#sec-array.prototype.slice"></emu-xref>.</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
@@ -39381,13 +39405,13 @@ THH:mm:ss.sss
                 1. Set _targetByteIndex_ to _targetByteIndex_ + 1.
           1. Return _A_.
         </emu-alg>
-        <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
+        <p>This method is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.some">
         <h1>%TypedArray%.prototype.some ( _callbackfn_ [ , _thisArg_ ] )</h1>
-        <p>The interpretation and use of the arguments of %TypedArray%`.prototype.some` are the same as for `Array.prototype.some` as defined in <emu-xref href="#sec-array.prototype.some"></emu-xref>.</p>
-        <p>When the `some` method is called, the following steps are taken:</p>
+        <p>The interpretation and use of the arguments of this method are the same as for `Array.prototype.some` as defined in <emu-xref href="#sec-array.prototype.some"></emu-xref>.</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
@@ -39402,14 +39426,14 @@ THH:mm:ss.sss
             1. Set _k_ to _k_ + 1.
           1. Return *false*.
         </emu-alg>
-        <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
+        <p>This method is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.sort" oldids="sec-typedarraysortcompare">
         <h1>%TypedArray%.prototype.sort ( _comparefn_ )</h1>
-        <p>%TypedArray%`.prototype.sort` is a distinct function that, except as described below, implements the same requirements as those of `Array.prototype.sort` as defined in <emu-xref href="#sec-array.prototype.sort"></emu-xref>. The implementation of the %TypedArray%`.prototype.sort` specification may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse.</p>
-        <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
-        <p>The following steps are performed:</p>
+        <p>This is a distinct method that, except as described below, implements the same requirements as those of `Array.prototype.sort` as defined in <emu-xref href="#sec-array.prototype.sort"></emu-xref>. The implementation of this method may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse.</p>
+        <p>This method is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. If _comparefn_ is not *undefined* and IsCallable(_comparefn_) is *false*, throw a *TypeError* exception.
           1. Let _obj_ be the *this* value.
@@ -39439,8 +39463,8 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-%typedarray%.prototype.subarray">
         <h1>%TypedArray%.prototype.subarray ( _begin_, _end_ )</h1>
-        <p>Returns a new _TypedArray_ whose element type is the same as this _TypedArray_ and whose ArrayBuffer is the same as the ArrayBuffer of this _TypedArray_, referencing the elements at _begin_, inclusive, up to _end_, exclusive. If either _begin_ or _end_ is negative, it refers to an index from the end of the array, as opposed to from the beginning.</p>
-        <p>When the `subarray` method is called, the following steps are taken:</p>
+        <p>This method returns a new _TypedArray_ whose element type is the same as this _TypedArray_ and whose ArrayBuffer is the same as the ArrayBuffer of this _TypedArray_, referencing the elements at _begin_, inclusive, up to _end_, exclusive. If either _begin_ or _end_ is negative, it refers to an index from the end of the array, as opposed to from the beginning.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? RequireInternalSlot(_O_, [[TypedArrayName]]).
@@ -39462,15 +39486,15 @@ THH:mm:ss.sss
           1. Let _argumentsList_ be &laquo; _buffer_, 𝔽(_beginByteOffset_), 𝔽(_newLength_) &raquo;.
           1. Return ? TypedArraySpeciesCreate(_O_, _argumentsList_).
         </emu-alg>
-        <p>This function is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
+        <p>This method is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.tolocalestring">
         <h1>%TypedArray%.prototype.toLocaleString ( [ _reserved1_ [ , _reserved2_ ] ] )</h1>
-        <p>%TypedArray%`.prototype.toLocaleString` is a distinct function that implements the same algorithm as `Array.prototype.toLocaleString` as defined in <emu-xref href="#sec-array.prototype.tolocalestring"></emu-xref> except that the *this* value's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of *"length"*. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
-        <p>This function is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
+        <p>This is a distinct method that implements the same algorithm as `Array.prototype.toLocaleString` as defined in <emu-xref href="#sec-array.prototype.tolocalestring"></emu-xref> except that the *this* value's [[ArrayLength]] internal slot is accessed in place of performing a [[Get]] of *"length"*. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
+        <p>This method is not generic. ValidateTypedArray is applied to the *this* value prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
         <emu-note>
-          <p>If the ECMAScript implementation includes the ECMA-402 Internationalization API this function is based upon the algorithm for `Array.prototype.toLocaleString` that is in the ECMA-402 specification.</p>
+          <p>If the ECMAScript implementation includes the ECMA-402 Internationalization API this method is based upon the algorithm for `Array.prototype.toLocaleString` that is in the ECMA-402 specification.</p>
         </emu-note>
       </emu-clause>
 
@@ -39481,7 +39505,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-%typedarray%.prototype.values">
         <h1>%TypedArray%.prototype.values ( )</h1>
-        <p>When the `values` method is called, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
@@ -39892,7 +39916,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-map-iterable">
         <h1>Map ( [ _iterable_ ] )</h1>
-        <p>When the `Map` function is called with optional argument _iterable_, the following steps are taken:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
           1. Let _map_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Map.prototype%"*, &laquo; [[MapData]] &raquo;).
@@ -39957,7 +39981,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-get-map-@@species">
         <h1>get Map [ @@species ]</h1>
-        <p>`Map[@@species]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
+        <p>`Map[@@species]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Return the *this* value.
         </emu-alg>
@@ -39980,7 +40004,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-map.prototype.clear">
         <h1>Map.prototype.clear ( )</h1>
-        <p>The following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _M_ be the *this* value.
           1. Perform ? RequireInternalSlot(_M_, [[MapData]]).
@@ -40002,7 +40026,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-map.prototype.delete">
         <h1>Map.prototype.delete ( _key_ )</h1>
-        <p>The following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _M_ be the *this* value.
           1. Perform ? RequireInternalSlot(_M_, [[MapData]]).
@@ -40021,7 +40045,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-map.prototype.entries">
         <h1>Map.prototype.entries ( )</h1>
-        <p>The following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _M_ be the *this* value.
           1. Return ? CreateMapIterator(_M_, ~key+value~).
@@ -40030,7 +40054,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-map.prototype.foreach">
         <h1>Map.prototype.forEach ( _callbackfn_ [ , _thisArg_ ] )</h1>
-        <p>When the `forEach` method is called with one or two arguments, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _M_ be the *this* value.
           1. Perform ? RequireInternalSlot(_M_, [[MapData]]).
@@ -40051,7 +40075,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-map.prototype.get">
         <h1>Map.prototype.get ( _key_ )</h1>
-        <p>The following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _M_ be the *this* value.
           1. Perform ? RequireInternalSlot(_M_, [[MapData]]).
@@ -40064,7 +40088,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-map.prototype.has">
         <h1>Map.prototype.has ( _key_ )</h1>
-        <p>The following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _M_ be the *this* value.
           1. Perform ? RequireInternalSlot(_M_, [[MapData]]).
@@ -40077,7 +40101,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-map.prototype.keys">
         <h1>Map.prototype.keys ( )</h1>
-        <p>The following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _M_ be the *this* value.
           1. Return ? CreateMapIterator(_M_, ~key~).
@@ -40086,7 +40110,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-map.prototype.set">
         <h1>Map.prototype.set ( _key_, _value_ )</h1>
-        <p>The following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _M_ be the *this* value.
           1. Perform ? RequireInternalSlot(_M_, [[MapData]]).
@@ -40104,7 +40128,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-get-map.prototype.size">
         <h1>get Map.prototype.size</h1>
-        <p>`Map.prototype.size` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
+        <p>`Map.prototype.size` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _M_ be the *this* value.
           1. Perform ? RequireInternalSlot(_M_, [[MapData]]).
@@ -40118,7 +40142,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-map.prototype.values">
         <h1>Map.prototype.values ( )</h1>
-        <p>The following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _M_ be the *this* value.
           1. Return ? CreateMapIterator(_M_, ~value~).
@@ -40224,7 +40248,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-set-iterable">
         <h1>Set ( [ _iterable_ ] )</h1>
-        <p>When the `Set` function is called with optional argument _iterable_, the following steps are taken:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
           1. Let _set_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Set.prototype%"*, &laquo; [[SetData]] &raquo;).
@@ -40259,7 +40283,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-get-set-@@species">
         <h1>get Set [ @@species ]</h1>
-        <p>`Set[@@species]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
+        <p>`Set[@@species]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Return the *this* value.
         </emu-alg>
@@ -40282,7 +40306,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-set.prototype.add">
         <h1>Set.prototype.add ( _value_ )</h1>
-        <p>The following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
           1. Perform ? RequireInternalSlot(_S_, [[SetData]]).
@@ -40298,7 +40322,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-set.prototype.clear">
         <h1>Set.prototype.clear ( )</h1>
-        <p>The following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
           1. Perform ? RequireInternalSlot(_S_, [[SetData]]).
@@ -40319,7 +40343,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-set.prototype.delete">
         <h1>Set.prototype.delete ( _value_ )</h1>
-        <p>The following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
           1. Perform ? RequireInternalSlot(_S_, [[SetData]]).
@@ -40337,7 +40361,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-set.prototype.entries">
         <h1>Set.prototype.entries ( )</h1>
-        <p>The following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
           1. Return ? CreateSetIterator(_S_, ~key+value~).
@@ -40349,7 +40373,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-set.prototype.foreach">
         <h1>Set.prototype.forEach ( _callbackfn_ [ , _thisArg_ ] )</h1>
-        <p>When the `forEach` method is called with one or two arguments, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
           1. Perform ? RequireInternalSlot(_S_, [[SetData]]).
@@ -40372,7 +40396,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-set.prototype.has">
         <h1>Set.prototype.has ( _value_ )</h1>
-        <p>The following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
           1. Perform ? RequireInternalSlot(_S_, [[SetData]]).
@@ -40393,7 +40417,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-get-set.prototype.size">
         <h1>get Set.prototype.size</h1>
-        <p>`Set.prototype.size` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
+        <p>`Set.prototype.size` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
           1. Perform ? RequireInternalSlot(_S_, [[SetData]]).
@@ -40407,7 +40431,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-set.prototype.values">
         <h1>Set.prototype.values ( )</h1>
-        <p>The following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
           1. Return ? CreateSetIterator(_S_, ~value~).
@@ -40519,7 +40543,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-weakmap-iterable">
         <h1>WeakMap ( [ _iterable_ ] )</h1>
-        <p>When the `WeakMap` function is called with optional argument _iterable_, the following steps are taken:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
           1. Let _map_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%WeakMap.prototype%"*, &laquo; [[WeakMapData]] &raquo;).
@@ -40566,7 +40590,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-weakmap.prototype.delete">
         <h1>WeakMap.prototype.delete ( _key_ )</h1>
-        <p>The following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _M_ be the *this* value.
           1. Perform ? RequireInternalSlot(_M_, [[WeakMapData]]).
@@ -40586,7 +40610,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-weakmap.prototype.get">
         <h1>WeakMap.prototype.get ( _key_ )</h1>
-        <p>The following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _M_ be the *this* value.
           1. Perform ? RequireInternalSlot(_M_, [[WeakMapData]]).
@@ -40600,7 +40624,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-weakmap.prototype.has">
         <h1>WeakMap.prototype.has ( _key_ )</h1>
-        <p>The following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _M_ be the *this* value.
           1. Perform ? RequireInternalSlot(_M_, [[WeakMapData]]).
@@ -40614,7 +40638,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-weakmap.prototype.set">
         <h1>WeakMap.prototype.set ( _key_, _value_ )</h1>
-        <p>The following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _M_ be the *this* value.
           1. Perform ? RequireInternalSlot(_M_, [[WeakMapData]]).
@@ -40665,7 +40689,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-weakset-iterable">
         <h1>WeakSet ( [ _iterable_ ] )</h1>
-        <p>When the `WeakSet` function is called with optional argument _iterable_, the following steps are taken:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
           1. Let _set_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%WeakSet.prototype%"*, &laquo; [[WeakSetData]] &raquo;).
@@ -40711,7 +40735,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-weakset.prototype.add">
         <h1>WeakSet.prototype.add ( _value_ )</h1>
-        <p>The following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
           1. Perform ? RequireInternalSlot(_S_, [[WeakSetData]]).
@@ -40732,7 +40756,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-weakset.prototype.delete">
         <h1>WeakSet.prototype.delete ( _value_ )</h1>
-        <p>The following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
           1. Perform ? RequireInternalSlot(_S_, [[WeakSetData]]).
@@ -40751,7 +40775,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-weakset.prototype.has">
         <h1>WeakSet.prototype.has ( _value_ )</h1>
-        <p>The following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
           1. Perform ? RequireInternalSlot(_S_, [[WeakSetData]]).
@@ -41119,7 +41143,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-arraybuffer-length">
         <h1>ArrayBuffer ( _length_ )</h1>
-        <p>When the `ArrayBuffer` function is called with argument _length_, the following steps are taken:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
           1. Let _byteLength_ be ? ToIndex(_length_).
@@ -41138,7 +41162,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-arraybuffer.isview">
         <h1>ArrayBuffer.isView ( _arg_ )</h1>
-        <p>The `isView` function takes one argument _arg_, and performs the following steps:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. If Type(_arg_) is not Object, return *false*.
           1. If _arg_ has a [[ViewedArrayBuffer]] internal slot, return *true*.
@@ -41154,7 +41178,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-get-arraybuffer-@@species">
         <h1>get ArrayBuffer [ @@species ]</h1>
-        <p>`ArrayBuffer[@@species]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
+        <p>`ArrayBuffer[@@species]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Return the *this* value.
         </emu-alg>
@@ -41177,7 +41201,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-get-arraybuffer.prototype.bytelength">
         <h1>get ArrayBuffer.prototype.byteLength</h1>
-        <p>`ArrayBuffer.prototype.byteLength` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
+        <p>`ArrayBuffer.prototype.byteLength` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? RequireInternalSlot(_O_, [[ArrayBufferData]]).
@@ -41195,7 +41219,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-arraybuffer.prototype.slice">
         <h1>ArrayBuffer.prototype.slice ( _start_, _end_ )</h1>
-        <p>The following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? RequireInternalSlot(_O_, [[ArrayBufferData]]).
@@ -41307,7 +41331,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-sharedarraybuffer-length">
         <h1>SharedArrayBuffer ( _length_ )</h1>
-        <p>When the `SharedArrayBuffer` function is called with argument _length_, the following steps are taken:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
           1. Let _byteLength_ be ? ToIndex(_length_).
@@ -41332,7 +41356,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-sharedarraybuffer-@@species">
         <h1>get SharedArrayBuffer [ @@species ]</h1>
-        <p>`SharedArrayBuffer[@@species]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
+        <p>`SharedArrayBuffer[@@species]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Return the *this* value.
         </emu-alg>
@@ -41352,7 +41376,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-get-sharedarraybuffer.prototype.bytelength">
         <h1>get SharedArrayBuffer.prototype.byteLength</h1>
-        <p>`SharedArrayBuffer.prototype.byteLength` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
+        <p>`SharedArrayBuffer.prototype.byteLength` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? RequireInternalSlot(_O_, [[ArrayBufferData]]).
@@ -41369,7 +41393,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-sharedarraybuffer.prototype.slice">
         <h1>SharedArrayBuffer.prototype.slice ( _start_, _end_ )</h1>
-        <p>The following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? RequireInternalSlot(_O_, [[ArrayBufferData]]).
@@ -41496,7 +41520,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-dataview-buffer-byteoffset-bytelength">
         <h1>DataView ( _buffer_ [ , _byteOffset_ [ , _byteLength_ ] ] )</h1>
-        <p>When the `DataView` function is called with at least one argument _buffer_, the following steps are taken:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
           1. Perform ? RequireInternalSlot(_buffer_, [[ArrayBufferData]]).
@@ -41546,7 +41570,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-get-dataview.prototype.buffer">
         <h1>get DataView.prototype.buffer</h1>
-        <p>`DataView.prototype.buffer` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
+        <p>`DataView.prototype.buffer` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? RequireInternalSlot(_O_, [[DataView]]).
@@ -41558,7 +41582,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-get-dataview.prototype.bytelength">
         <h1>get DataView.prototype.byteLength</h1>
-        <p>`DataView.prototype.byteLength` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
+        <p>`DataView.prototype.byteLength` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? RequireInternalSlot(_O_, [[DataView]]).
@@ -41572,7 +41596,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-get-dataview.prototype.byteoffset">
         <h1>get DataView.prototype.byteOffset</h1>
-        <p>`DataView.prototype.byteOffset` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
+        <p>`DataView.prototype.byteOffset` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? RequireInternalSlot(_O_, [[DataView]]).
@@ -41591,7 +41615,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-dataview.prototype.getbigint64">
         <h1>DataView.prototype.getBigInt64 ( _byteOffset_ [ , _littleEndian_ ] )</h1>
-        <p>When the `getBigInt64` method is called with argument _byteOffset_ and optional argument _littleEndian_, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _v_ be the *this* value.
           1. Return ? GetViewValue(_v_, _byteOffset_, _littleEndian_, ~BigInt64~).
@@ -41600,7 +41624,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-dataview.prototype.getbiguint64">
         <h1>DataView.prototype.getBigUint64 ( _byteOffset_ [ , _littleEndian_ ] )</h1>
-        <p>When the `getBigUint64` method is called with argument _byteOffset_ and optional argument _littleEndian_, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _v_ be the *this* value.
           1. Return ? GetViewValue(_v_, _byteOffset_, _littleEndian_, ~BigUint64~).
@@ -41609,7 +41633,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-dataview.prototype.getfloat32">
         <h1>DataView.prototype.getFloat32 ( _byteOffset_ [ , _littleEndian_ ] )</h1>
-        <p>When the `getFloat32` method is called with argument _byteOffset_ and optional argument _littleEndian_, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _v_ be the *this* value.
           1. If _littleEndian_ is not present, set _littleEndian_ to *false*.
@@ -41619,7 +41643,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-dataview.prototype.getfloat64">
         <h1>DataView.prototype.getFloat64 ( _byteOffset_ [ , _littleEndian_ ] )</h1>
-        <p>When the `getFloat64` method is called with argument _byteOffset_ and optional argument _littleEndian_, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _v_ be the *this* value.
           1. If _littleEndian_ is not present, set _littleEndian_ to *false*.
@@ -41629,7 +41653,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-dataview.prototype.getint8">
         <h1>DataView.prototype.getInt8 ( _byteOffset_ )</h1>
-        <p>When the `getInt8` method is called with argument _byteOffset_, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _v_ be the *this* value.
           1. Return ? GetViewValue(_v_, _byteOffset_, *true*, ~Int8~).
@@ -41638,7 +41662,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-dataview.prototype.getint16">
         <h1>DataView.prototype.getInt16 ( _byteOffset_ [ , _littleEndian_ ] )</h1>
-        <p>When the `getInt16` method is called with argument _byteOffset_ and optional argument _littleEndian_, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _v_ be the *this* value.
           1. If _littleEndian_ is not present, set _littleEndian_ to *false*.
@@ -41648,7 +41672,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-dataview.prototype.getint32">
         <h1>DataView.prototype.getInt32 ( _byteOffset_ [ , _littleEndian_ ] )</h1>
-        <p>When the `getInt32` method is called with argument _byteOffset_ and optional argument _littleEndian_, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _v_ be the *this* value.
           1. If _littleEndian_ is not present, set _littleEndian_ to *false*.
@@ -41658,7 +41682,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-dataview.prototype.getuint8">
         <h1>DataView.prototype.getUint8 ( _byteOffset_ )</h1>
-        <p>When the `getUint8` method is called with argument _byteOffset_, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _v_ be the *this* value.
           1. Return ? GetViewValue(_v_, _byteOffset_, *true*, ~Uint8~).
@@ -41667,7 +41691,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-dataview.prototype.getuint16">
         <h1>DataView.prototype.getUint16 ( _byteOffset_ [ , _littleEndian_ ] )</h1>
-        <p>When the `getUint16` method is called with argument _byteOffset_ and optional argument _littleEndian_, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _v_ be the *this* value.
           1. If _littleEndian_ is not present, set _littleEndian_ to *false*.
@@ -41677,7 +41701,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-dataview.prototype.getuint32">
         <h1>DataView.prototype.getUint32 ( _byteOffset_ [ , _littleEndian_ ] )</h1>
-        <p>When the `getUint32` method is called with argument _byteOffset_ and optional argument _littleEndian_, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _v_ be the *this* value.
           1. If _littleEndian_ is not present, set _littleEndian_ to *false*.
@@ -41687,7 +41711,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-dataview.prototype.setbigint64">
         <h1>DataView.prototype.setBigInt64 ( _byteOffset_, _value_ [ , _littleEndian_ ] )</h1>
-        <p>When the `setBigInt64` method is called with arguments _byteOffset_ and _value_ and optional argument _littleEndian_, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _v_ be the *this* value.
           1. Return ? SetViewValue(_v_, _byteOffset_, _littleEndian_, ~BigInt64~, _value_).
@@ -41696,7 +41720,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-dataview.prototype.setbiguint64">
         <h1>DataView.prototype.setBigUint64 ( _byteOffset_, _value_ [ , _littleEndian_ ] )</h1>
-        <p>When the `setBigUint64` method is called with arguments _byteOffset_ and _value_ and optional argument _littleEndian_, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _v_ be the *this* value.
           1. Return ? SetViewValue(_v_, _byteOffset_, _littleEndian_, ~BigUint64~, _value_).
@@ -41705,7 +41729,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-dataview.prototype.setfloat32">
         <h1>DataView.prototype.setFloat32 ( _byteOffset_, _value_ [ , _littleEndian_ ] )</h1>
-        <p>When the `setFloat32` method is called with arguments _byteOffset_ and _value_ and optional argument _littleEndian_, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _v_ be the *this* value.
           1. If _littleEndian_ is not present, set _littleEndian_ to *false*.
@@ -41715,7 +41739,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-dataview.prototype.setfloat64">
         <h1>DataView.prototype.setFloat64 ( _byteOffset_, _value_ [ , _littleEndian_ ] )</h1>
-        <p>When the `setFloat64` method is called with arguments _byteOffset_ and _value_ and optional argument _littleEndian_, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _v_ be the *this* value.
           1. If _littleEndian_ is not present, set _littleEndian_ to *false*.
@@ -41725,7 +41749,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-dataview.prototype.setint8">
         <h1>DataView.prototype.setInt8 ( _byteOffset_, _value_ )</h1>
-        <p>When the `setInt8` method is called with arguments _byteOffset_ and _value_, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _v_ be the *this* value.
           1. Return ? SetViewValue(_v_, _byteOffset_, *true*, ~Int8~, _value_).
@@ -41734,7 +41758,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-dataview.prototype.setint16">
         <h1>DataView.prototype.setInt16 ( _byteOffset_, _value_ [ , _littleEndian_ ] )</h1>
-        <p>When the `setInt16` method is called with arguments _byteOffset_ and _value_ and optional argument _littleEndian_, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _v_ be the *this* value.
           1. If _littleEndian_ is not present, set _littleEndian_ to *false*.
@@ -41744,7 +41768,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-dataview.prototype.setint32">
         <h1>DataView.prototype.setInt32 ( _byteOffset_, _value_ [ , _littleEndian_ ] )</h1>
-        <p>When the `setInt32` method is called with arguments _byteOffset_ and _value_ and optional argument _littleEndian_, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _v_ be the *this* value.
           1. If _littleEndian_ is not present, set _littleEndian_ to *false*.
@@ -41754,7 +41778,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-dataview.prototype.setuint8">
         <h1>DataView.prototype.setUint8 ( _byteOffset_, _value_ )</h1>
-        <p>When the `setUint8` method is called with arguments _byteOffset_ and _value_, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _v_ be the *this* value.
           1. Return ? SetViewValue(_v_, _byteOffset_, *true*, ~Uint8~, _value_).
@@ -41763,7 +41787,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-dataview.prototype.setuint16">
         <h1>DataView.prototype.setUint16 ( _byteOffset_, _value_ [ , _littleEndian_ ] )</h1>
-        <p>When the `setUint16` method is called with arguments _byteOffset_ and _value_ and optional argument _littleEndian_, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _v_ be the *this* value.
           1. If _littleEndian_ is not present, set _littleEndian_ to *false*.
@@ -41773,7 +41797,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-dataview.prototype.setuint32">
         <h1>DataView.prototype.setUint32 ( _byteOffset_, _value_ [ , _littleEndian_ ] )</h1>
-        <p>When the `setUint32` method is called with arguments _byteOffset_ and _value_ and optional argument _littleEndian_, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _v_ be the *this* value.
           1. If _littleEndian_ is not present, set _littleEndian_ to *false*.
@@ -42099,7 +42123,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-atomics.add">
       <h1>Atomics.add ( _typedArray_, _index_, _value_ )</h1>
-      <p>The following steps are taken:</p>
+      <p>This function performs the following steps when called:</p>
       <emu-alg>
         1. Let _type_ be TypedArrayElementType(_typedArray_).
         1. Let _isLittleEndian_ be the value of the [[LittleEndian]] field of the surrounding agent's Agent Record.
@@ -42120,7 +42144,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-atomics.and">
       <h1>Atomics.and ( _typedArray_, _index_, _value_ )</h1>
-      <p>The following steps are taken:</p>
+      <p>This function performs the following steps when called:</p>
       <emu-alg>
         1. Let _and_ be a new read-modify-write modification function with parameters (_xBytes_, _yBytes_) that captures nothing and performs the following steps atomically when called:
           1. Return ByteListBitwiseOp(`&amp;`, _xBytes_, _yBytes_).
@@ -42130,7 +42154,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-atomics.compareexchange">
       <h1>Atomics.compareExchange ( _typedArray_, _index_, _expectedValue_, _replacementValue_ )</h1>
-      <p>The following steps are taken:</p>
+      <p>This function performs the following steps when called:</p>
       <emu-alg>
         1. Let _buffer_ be ? ValidateIntegerTypedArray(_typedArray_).
         1. Let _block_ be _buffer_.[[ArrayBufferData]].
@@ -42172,7 +42196,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-atomics.exchange">
       <h1>Atomics.exchange ( _typedArray_, _index_, _value_ )</h1>
-      <p>The following steps are taken:</p>
+      <p>This function performs the following steps when called:</p>
       <emu-alg>
         1. Let _second_ be a new read-modify-write modification function with parameters (_oldBytes_, _newBytes_) that captures nothing and performs the following steps atomically when called:
           1. Return _newBytes_.
@@ -42182,7 +42206,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-atomics.islockfree">
       <h1>Atomics.isLockFree ( _size_ )</h1>
-      <p>The following steps are taken:</p>
+      <p>This function performs the following steps when called:</p>
       <emu-alg>
         1. Let _n_ be ? ToIntegerOrInfinity(_size_).
         1. Let _AR_ be the Agent Record of the surrounding agent.
@@ -42193,15 +42217,15 @@ THH:mm:ss.sss
         1. Return *false*.
       </emu-alg>
       <emu-note>
-        <p>`Atomics.isLockFree`() is an optimization primitive. The intuition is that if the atomic step of an atomic primitive (`compareExchange`, `load`, `store`, `add`, `sub`, `and`, `or`, `xor`, or `exchange`) on a datum of size _n_ bytes will be performed without the surrounding agent acquiring a lock outside the _n_ bytes comprising the datum, then `Atomics.isLockFree`(_n_) will return *true*. High-performance algorithms will use `Atomics.isLockFree` to determine whether to use locks or atomic operations in critical sections. If an atomic primitive is not lock-free then it is often more efficient for an algorithm to provide its own locking.</p>
+        <p>This function is an optimization primitive. The intuition is that if the atomic step of an atomic primitive (`compareExchange`, `load`, `store`, `add`, `sub`, `and`, `or`, `xor`, or `exchange`) on a datum of size _n_ bytes will be performed without the surrounding agent acquiring a lock outside the _n_ bytes comprising the datum, then `Atomics.isLockFree`(_n_) will return *true*. High-performance algorithms will use this function to determine whether to use locks or atomic operations in critical sections. If an atomic primitive is not lock-free then it is often more efficient for an algorithm to provide its own locking.</p>
         <p>`Atomics.isLockFree`(4) always returns *true* as that can be supported on all known relevant hardware. Being able to assume this will generally simplify programs.</p>
-        <p>Regardless of the value of `Atomics.isLockFree`, all atomic operations are guaranteed to be atomic. For example, they will never have a visible operation take place in the middle of the operation (e.g., "tearing").</p>
+        <p>Regardless of the value returned by this function, all atomic operations are guaranteed to be atomic. For example, they will never have a visible operation take place in the middle of the operation (e.g., "tearing").</p>
       </emu-note>
     </emu-clause>
 
     <emu-clause id="sec-atomics.load" oldids="sec-atomicload">
       <h1>Atomics.load ( _typedArray_, _index_ )</h1>
-      <p>The following steps are taken:</p>
+      <p>This function performs the following steps when called:</p>
       <emu-alg>
         1. Let _buffer_ be ? ValidateIntegerTypedArray(_typedArray_).
         1. Let _indexedPosition_ be ? ValidateAtomicAccess(_typedArray_, _index_).
@@ -42214,7 +42238,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-atomics.or">
       <h1>Atomics.or ( _typedArray_, _index_, _value_ )</h1>
-      <p>The following steps are taken:</p>
+      <p>This function performs the following steps when called:</p>
       <emu-alg>
         1. Let _or_ be a new read-modify-write modification function with parameters (_xBytes_, _yBytes_) that captures nothing and performs the following steps atomically when called:
           1. Return ByteListBitwiseOp(`|`, _xBytes_, _yBytes_).
@@ -42224,7 +42248,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-atomics.store">
       <h1>Atomics.store ( _typedArray_, _index_, _value_ )</h1>
-      <p>The following steps are taken:</p>
+      <p>This function performs the following steps when called:</p>
       <emu-alg>
         1. Let _buffer_ be ? ValidateIntegerTypedArray(_typedArray_).
         1. Let _indexedPosition_ be ? ValidateAtomicAccess(_typedArray_, _index_).
@@ -42240,7 +42264,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-atomics.sub">
       <h1>Atomics.sub ( _typedArray_, _index_, _value_ )</h1>
-      <p>The following steps are taken:</p>
+      <p>This function performs the following steps when called:</p>
       <emu-alg>
         1. Let _type_ be TypedArrayElementType(_typedArray_).
         1. Let _isLittleEndian_ be the value of the [[LittleEndian]] field of the surrounding agent's Agent Record.
@@ -42261,7 +42285,8 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-atomics.wait">
       <h1>Atomics.wait ( _typedArray_, _index_, _value_, _timeout_ )</h1>
-      <p>`Atomics.wait` puts the surrounding agent in a wait queue and puts it to sleep until it is notified or the sleep times out. The following steps are taken:</p>
+      <p>This function puts the surrounding agent in a wait queue and puts it to sleep until it is notified or the sleep times out.</p>
+      <p>It performs the following steps when called:</p>
       <emu-alg>
         1. Let _buffer_ be ? ValidateIntegerTypedArray(_typedArray_, *true*).
         1. If IsSharedArrayBuffer(_buffer_) is *false*, throw a *TypeError* exception.
@@ -42295,7 +42320,8 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-atomics.notify">
       <h1>Atomics.notify ( _typedArray_, _index_, _count_ )</h1>
-      <p>`Atomics.notify` notifies some agents that are sleeping in the wait queue. The following steps are taken:</p>
+      <p>This function notifies some agents that are sleeping in the wait queue.</p>
+      <p>It performs the following steps when called:</p>
       <emu-alg>
         1. Let _buffer_ be ? ValidateIntegerTypedArray(_typedArray_, *true*).
         1. Let _indexedPosition_ be ? ValidateAtomicAccess(_typedArray_, _index_).
@@ -42321,7 +42347,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-atomics.xor">
       <h1>Atomics.xor ( _typedArray_, _index_, _value_ )</h1>
-      <p>The following steps are taken:</p>
+      <p>This function performs the following steps when called:</p>
       <emu-alg>
         1. Let _xor_ be a new read-modify-write modification function with parameters (_xBytes_, _yBytes_) that captures nothing and performs the following steps atomically when called:
           1. Return ByteListBitwiseOp(`^`, _xBytes_, _yBytes_).
@@ -42352,7 +42378,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-json.parse">
       <h1>JSON.parse ( _text_ [ , _reviver_ ] )</h1>
-      <p>The `parse` function parses a JSON text (a JSON-formatted String) and produces an ECMAScript language value. The JSON format represents literals, arrays, and objects with a syntax similar to the syntax for ECMAScript literals, Array Initializers, and Object Initializers. After parsing, JSON objects are realized as ECMAScript objects. JSON arrays are realized as ECMAScript Array instances. JSON strings, numbers, booleans, and null are realized as ECMAScript Strings, Numbers, Booleans, and *null*.</p>
+      <p>This function parses a JSON text (a JSON-formatted String) and produces an ECMAScript language value. The JSON format represents literals, arrays, and objects with a syntax similar to the syntax for ECMAScript literals, Array Initializers, and Object Initializers. After parsing, JSON objects are realized as ECMAScript objects. JSON arrays are realized as ECMAScript Array instances. JSON strings, numbers, booleans, and null are realized as ECMAScript Strings, Numbers, Booleans, and *null*.</p>
       <p>The optional _reviver_ parameter is a function that takes two parameters, _key_ and _value_. It can filter and transform the results. It is called with each of the _key_/_value_ pairs produced by the parse, and its return value is used instead of the original value. If it returns what it received, the structure is not modified. If it returns *undefined* then the property is deleted from the result.</p>
       <emu-alg>
         1. Let _jsonString_ be ? ToString(_text_).
@@ -42373,7 +42399,7 @@ THH:mm:ss.sss
         1. Else,
           1. Return _unfiltered_.
       </emu-alg>
-      <p>The *"length"* property of the `parse` function is *2*<sub>𝔽</sub>.</p>
+      <p>The *"length"* property of this function is *2*<sub>𝔽</sub>.</p>
       <emu-note>
         <p>Valid JSON text is a subset of the ECMAScript |PrimaryExpression| syntax. Step <emu-xref href="#step-json-parse-validate"></emu-xref> verifies that _jsonString_ conforms to that subset, and step <emu-xref href="#step-json-parse-assert-type"></emu-xref> asserts that that parsing and evaluation returns a value of an appropriate type.</p>
         <p>However, because <emu-xref href="#sec-runtime-semantics-propertydefinitionevaluation"></emu-xref> behaves differently during `JSON.parse`, the same source text can produce different results when evaluated as a |PrimaryExpression| rather than as JSON. Furthermore, the Early Error for duplicate *"__proto__"* properties in object literals, which likewise does not apply during `JSON.parse`, means that not all texts accepted by `JSON.parse` are valid as a |PrimaryExpression|, despite matching the grammar.</p>
@@ -42427,8 +42453,8 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-json.stringify">
       <h1>JSON.stringify ( _value_ [ , _replacer_ [ , _space_ ] ] )</h1>
-      <p>The `stringify` function returns a String in UTF-16 encoded JSON format representing an ECMAScript language value, or *undefined*. It can take three parameters. The _value_ parameter is an ECMAScript language value, which is usually an object or array, although it can also be a String, Boolean, Number or *null*. The optional _replacer_ parameter is either a function that alters the way objects and arrays are stringified, or an array of Strings and Numbers that acts as an inclusion list for selecting the object properties that will be stringified. The optional _space_ parameter is a String or Number that allows the result to have white space injected into it to improve human readability.</p>
-      <p>These are the steps in stringifying an object:</p>
+      <p>This function returns a String in UTF-16 encoded JSON format representing an ECMAScript language value, or *undefined*. It can take three parameters. The _value_ parameter is an ECMAScript language value, which is usually an object or array, although it can also be a String, Boolean, Number or *null*. The optional _replacer_ parameter is either a function that alters the way objects and arrays are stringified, or an array of Strings and Numbers that acts as an inclusion list for selecting the object properties that will be stringified. The optional _space_ parameter is a String or Number that allows the result to have white space injected into it to improve human readability.</p>
+      <p>It performs the following steps when called:</p>
       <emu-alg>
         1. Let _stack_ be a new empty List.
         1. Let _indent_ be the empty String.
@@ -42471,9 +42497,9 @@ THH:mm:ss.sss
         1. Let _state_ be the JSON Serialization Record { [[ReplacerFunction]]: _ReplacerFunction_, [[Stack]]: _stack_, [[Indent]]: _indent_, [[Gap]]: _gap_, [[PropertyList]]: _PropertyList_ }.
         1. Return ? SerializeJSONProperty(_state_, the empty String, _wrapper_).
       </emu-alg>
-      <p>The *"length"* property of the `stringify` function is *3*<sub>𝔽</sub>.</p>
+      <p>The *"length"* property of this function is *3*<sub>𝔽</sub>.</p>
       <emu-note>
-        <p>JSON structures are allowed to be nested to any depth, but they must be acyclic. If _value_ is or contains a cyclic structure, then the stringify function must throw a *TypeError* exception. This is an example of a value that cannot be stringified:</p>
+        <p>JSON structures are allowed to be nested to any depth, but they must be acyclic. If _value_ is or contains a cyclic structure, then this function must throw a *TypeError* exception. This is an example of a value that cannot be stringified:</p>
         <pre><code class="javascript">
           a = [];
           a[0] = a;
@@ -42858,7 +42884,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-weak-ref-target">
         <h1>WeakRef ( _target_ )</h1>
-        <p>When the `WeakRef` function is called with argument _target_, the following steps are taken:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
           1. If Type(_target_) is not Object, throw a *TypeError* exception.
@@ -42909,7 +42935,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-weak-ref.prototype.deref">
         <h1>WeakRef.prototype.deref ( )</h1>
-        <p>The following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _weakRef_ be the *this* value.
           1. Perform ? RequireInternalSlot(_weakRef_, [[WeakRefTarget]]).
@@ -42996,7 +43022,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-finalization-registry-cleanup-callback">
         <h1>FinalizationRegistry ( _cleanupCallback_ )</h1>
-        <p>When the `FinalizationRegistry` function is called with argument _cleanupCallback_, the following steps are taken:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
           1. If IsCallable(_cleanupCallback_) is *false*, throw a *TypeError* exception.
@@ -43048,7 +43074,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-finalization-registry.prototype.register">
         <h1>FinalizationRegistry.prototype.register ( _target_, _heldValue_ [ , _unregisterToken_ ] )</h1>
-        <p>The following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _finalizationRegistry_ be the *this* value.
           1. Perform ? RequireInternalSlot(_finalizationRegistry_, [[Cells]]).
@@ -43069,7 +43095,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-finalization-registry.prototype.unregister">
         <h1>FinalizationRegistry.prototype.unregister ( _unregisterToken_ )</h1>
-        <p>The following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _finalizationRegistry_ be the *this* value.
           1. Perform ? RequireInternalSlot(_finalizationRegistry_, [[Cells]]).
@@ -43345,7 +43371,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-%iteratorprototype%-@@iterator">
         <h1>%IteratorPrototype% [ @@iterator ] ( )</h1>
-        <p>The following steps are taken:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. Return the *this* value.
         </emu-alg>
@@ -43366,7 +43392,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-asynciteratorprototype-asynciterator">
         <h1>%AsyncIteratorPrototype% [ @@asyncIterator ] ( )</h1>
-        <p>The following steps are taken:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. Return the *this* value.
         </emu-alg>
@@ -43987,7 +44013,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-promise-executor">
         <h1>Promise ( _executor_ )</h1>
-        <p>When the `Promise` function is called with argument _executor_, the following steps are taken:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
           1. If IsCallable(_executor_) is *false*, throw a *TypeError* exception.
@@ -44021,7 +44047,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-promise.all">
         <h1>Promise.all ( _iterable_ )</h1>
-        <p>The `all` function returns a new promise which is fulfilled with an array of fulfillment values for the passed promises, or rejects with the reason of the first passed promise that rejects. It resolves all elements of the passed iterable to promises as it runs this algorithm.</p>
+        <p>This function returns a new promise which is fulfilled with an array of fulfillment values for the passed promises, or rejects with the reason of the first passed promise that rejects. It resolves all elements of the passed iterable to promises as it runs this algorithm.</p>
         <emu-alg>
           1. Let _C_ be the *this* value.
           1. Let _promiseCapability_ be ? NewPromiseCapability(_C_).
@@ -44036,7 +44062,7 @@ THH:mm:ss.sss
           1. Return ? _result_.
         </emu-alg>
         <emu-note>
-          <p>The `all` function requires its *this* value to be a constructor function that supports the parameter conventions of the Promise constructor.</p>
+          <p>This function requires its *this* value to be a constructor function that supports the parameter conventions of the Promise constructor.</p>
         </emu-note>
 
         <emu-clause id="sec-getpromiseresolve" type="abstract operation">
@@ -44124,7 +44150,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-promise.allsettled">
         <h1>Promise.allSettled ( _iterable_ )</h1>
-        <p>The `allSettled` function returns a promise that is fulfilled with an array of promise state snapshots, but only after all the original promises have settled, i.e. become either fulfilled or rejected. It resolves all elements of the passed iterable to promises as it runs this algorithm.</p>
+        <p>This function returns a promise that is fulfilled with an array of promise state snapshots, but only after all the original promises have settled, i.e. become either fulfilled or rejected. It resolves all elements of the passed iterable to promises as it runs this algorithm.</p>
         <emu-alg>
           1. Let _C_ be the *this* value.
           1. Let _promiseCapability_ be ? NewPromiseCapability(_C_).
@@ -44139,7 +44165,7 @@ THH:mm:ss.sss
           1. Return ? _result_.
         </emu-alg>
         <emu-note>
-          <p>The `allSettled` function requires its *this* value to be a constructor function that supports the parameter conventions of the Promise constructor.</p>
+          <p>This function requires its *this* value to be a constructor function that supports the parameter conventions of the Promise constructor.</p>
         </emu-note>
 
         <emu-clause id="sec-performpromiseallsettled" type="abstract operation">
@@ -44251,7 +44277,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-promise.any">
         <h1>Promise.any ( _iterable_ )</h1>
-        <p>The `any` function returns a promise that is fulfilled by the first given promise to be fulfilled, or rejected with an `AggregateError` holding the rejection reasons if all of the given promises are rejected. It resolves all elements of the passed iterable to promises as it runs this algorithm.</p>
+        <p>This function returns a promise that is fulfilled by the first given promise to be fulfilled, or rejected with an `AggregateError` holding the rejection reasons if all of the given promises are rejected. It resolves all elements of the passed iterable to promises as it runs this algorithm.</p>
         <emu-alg>
           1. Let _C_ be the *this* value.
           1. Let _promiseCapability_ be ? NewPromiseCapability(_C_).
@@ -44266,7 +44292,7 @@ THH:mm:ss.sss
           1. Return ? _result_.
         </emu-alg>
         <emu-note>
-          <p>The `any` function requires its *this* value to be a constructor function that supports the parameter conventions of the `Promise` constructor.</p>
+          <p>This function requires its *this* value to be a constructor function that supports the parameter conventions of the `Promise` constructor.</p>
         </emu-note>
 
         <emu-clause id="sec-performpromiseany" type="abstract operation">
@@ -44347,7 +44373,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-promise.race">
         <h1>Promise.race ( _iterable_ )</h1>
-        <p>The `race` function returns a new promise which is settled in the same way as the first passed promise to settle. It resolves all elements of the passed _iterable_ to promises as it runs this algorithm.</p>
+        <p>This function returns a new promise which is settled in the same way as the first passed promise to settle. It resolves all elements of the passed _iterable_ to promises as it runs this algorithm.</p>
         <emu-alg>
           1. Let _C_ be the *this* value.
           1. Let _promiseCapability_ be ? NewPromiseCapability(_C_).
@@ -44365,7 +44391,7 @@ THH:mm:ss.sss
           <p>If the _iterable_ argument is empty or if none of the promises in _iterable_ ever settle then the pending promise returned by this method will never be settled.</p>
         </emu-note>
         <emu-note>
-          <p>The `race` function expects its *this* value to be a constructor function that supports the parameter conventions of the Promise constructor. It also expects that its *this* value provides a `resolve` method.</p>
+          <p>This function expects its *this* value to be a constructor function that supports the parameter conventions of the Promise constructor. It also expects that its *this* value provides a `resolve` method.</p>
         </emu-note>
 
         <emu-clause id="sec-performpromiserace" type="abstract operation">
@@ -44398,7 +44424,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-promise.reject">
         <h1>Promise.reject ( _r_ )</h1>
-        <p>The `reject` function returns a new promise rejected with the passed argument.</p>
+        <p>This function returns a new promise rejected with the passed argument.</p>
         <emu-alg>
           1. Let _C_ be the *this* value.
           1. Let _promiseCapability_ be ? NewPromiseCapability(_C_).
@@ -44406,20 +44432,20 @@ THH:mm:ss.sss
           1. Return _promiseCapability_.[[Promise]].
         </emu-alg>
         <emu-note>
-          <p>The `reject` function expects its *this* value to be a constructor function that supports the parameter conventions of the Promise constructor.</p>
+          <p>This function expects its *this* value to be a constructor function that supports the parameter conventions of the Promise constructor.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-promise.resolve">
         <h1>Promise.resolve ( _x_ )</h1>
-        <p>The `resolve` function returns either a new promise resolved with the passed argument, or the argument itself if the argument is a promise produced by this constructor.</p>
+        <p>This function returns either a new promise resolved with the passed argument, or the argument itself if the argument is a promise produced by this constructor.</p>
         <emu-alg>
           1. Let _C_ be the *this* value.
           1. If Type(_C_) is not Object, throw a *TypeError* exception.
           1. Return ? PromiseResolve(_C_, _x_).
         </emu-alg>
         <emu-note>
-          <p>The `resolve` function expects its *this* value to be a constructor function that supports the parameter conventions of the Promise constructor.</p>
+          <p>This function expects its *this* value to be a constructor function that supports the parameter conventions of the Promise constructor.</p>
         </emu-note>
 
         <emu-clause id="sec-promise-resolve" type="abstract operation">
@@ -44446,7 +44472,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-get-promise-@@species">
         <h1>get Promise [ @@species ]</h1>
-        <p>`Promise[@@species]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
+        <p>`Promise[@@species]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Return the *this* value.
         </emu-alg>
@@ -44469,7 +44495,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-promise.prototype.catch">
         <h1>Promise.prototype.catch ( _onRejected_ )</h1>
-        <p>When the `catch` method is called with argument _onRejected_, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _promise_ be the *this* value.
           1. Return ? Invoke(_promise_, *"then"*, &laquo; *undefined*, _onRejected_ &raquo;).
@@ -44483,7 +44509,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-promise.prototype.finally" oldids="sec-thenfinallyfunctions,sec-catchfinallyfunctions">
         <h1>Promise.prototype.finally ( _onFinally_ )</h1>
-        <p>When the `finally` method is called with argument _onFinally_, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _promise_ be the *this* value.
           1. If Type(_promise_) is not Object, throw a *TypeError* exception.
@@ -44515,7 +44541,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-promise.prototype.then">
         <h1>Promise.prototype.then ( _onFulfilled_, _onRejected_ )</h1>
-        <p>When the `then` method is called with arguments _onFulfilled_ and _onRejected_, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _promise_ be the *this* value.
           1. If IsPromise(_promise_) is *false*, throw a *TypeError* exception.
@@ -44675,8 +44701,8 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-generatorfunction">
         <h1>GeneratorFunction ( _p1_, _p2_, &hellip; , _pn_, _body_ )</h1>
-        <p>The last argument specifies the body (executable code) of a generator function; any preceding arguments specify formal parameters.</p>
-        <p>When the `GeneratorFunction` function is called with some arguments _p1_, _p2_, &hellip; , _pn_, _body_ (where _n_ might be 0, that is, there are no &ldquo;_p_&rdquo; arguments, and where _body_ might also not be provided), the following steps are taken:</p>
+        <p>The last argument (if any) specifies the body (executable code) of a generator function; any preceding arguments specify formal parameters.</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. Let _C_ be the active function object.
           1. Let _args_ be the _argumentsList_ that was passed to this function by [[Call]] or [[Construct]].
@@ -44781,8 +44807,8 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-asyncgeneratorfunction">
         <h1>AsyncGeneratorFunction ( _p1_, _p2_, &hellip; , _pn_, _body_ )</h1>
-        <p>The last argument specifies the body (executable code) of an async generator function; any preceding arguments specify formal parameters.</p>
-        <p>When the `AsyncGeneratorFunction` function is called with some arguments _p1_, _p2_, &hellip; , _pn_, _body_ (where _n_ might be 0, that is, there are no "_p_" arguments, and where _body_ might also not be provided), the following steps are taken:</p>
+        <p>The last argument (if any) specifies the body (executable code) of an async generator function; any preceding arguments specify formal parameters.</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. Let _C_ be the active function object.
           1. Let _args_ be the _argumentsList_ that was passed to this function by [[Call]] or [[Construct]].
@@ -44903,7 +44929,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-generator.prototype.return">
         <h1>Generator.prototype.return ( _value_ )</h1>
-        <p>The `return` method performs the following steps:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _g_ be the *this* value.
           1. Let _C_ be Completion Record { [[Type]]: ~return~, [[Value]]: _value_, [[Target]]: ~empty~ }.
@@ -44913,7 +44939,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-generator.prototype.throw">
         <h1>Generator.prototype.throw ( _exception_ )</h1>
-        <p>The `throw` method performs the following steps:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _g_ be the *this* value.
           1. Let _C_ be ThrowCompletion(_exception_).
@@ -45629,8 +45655,8 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-async-function-constructor-arguments">
         <h1>AsyncFunction ( _p1_, _p2_, &hellip; , _pn_, _body_ )</h1>
-        <p>The last argument specifies the body (executable code) of an async function. Any preceding arguments specify formal parameters.</p>
-        <p>When the `AsyncFunction` function is called with some arguments _p1_, _p2_, &hellip; , _pn_, _body_ (where _n_ might be 0, that is, there are no _p_ arguments, and where _body_ might also not be provided), the following steps are taken:</p>
+        <p>The last argument (if any) specifies the body (executable code) of an async function. Any preceding arguments specify formal parameters.</p>
+        <p>This function performs the following steps when called:</p>
 
         <emu-alg>
           1. Let _C_ be the active function object.
@@ -45785,7 +45811,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-reflect.apply">
       <h1>Reflect.apply ( _target_, _thisArgument_, _argumentsList_ )</h1>
-      <p>When the `apply` function is called with arguments _target_, _thisArgument_, and _argumentsList_, the following steps are taken:</p>
+      <p>This function performs the following steps when called:</p>
       <emu-alg>
         1. If IsCallable(_target_) is *false*, throw a *TypeError* exception.
         1. Let _args_ be ? CreateListFromArrayLike(_argumentsList_).
@@ -45796,7 +45822,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-reflect.construct">
       <h1>Reflect.construct ( _target_, _argumentsList_ [ , _newTarget_ ] )</h1>
-      <p>When the `construct` function is called with arguments _target_, _argumentsList_, and _newTarget_, the following steps are taken:</p>
+      <p>This function performs the following steps when called:</p>
       <emu-alg>
         1. If IsConstructor(_target_) is *false*, throw a *TypeError* exception.
         1. If _newTarget_ is not present, set _newTarget_ to _target_.
@@ -45808,7 +45834,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-reflect.defineproperty">
       <h1>Reflect.defineProperty ( _target_, _propertyKey_, _attributes_ )</h1>
-      <p>When the `defineProperty` function is called with arguments _target_, _propertyKey_, and _attributes_, the following steps are taken:</p>
+      <p>This function performs the following steps when called:</p>
       <emu-alg>
         1. If Type(_target_) is not Object, throw a *TypeError* exception.
         1. Let _key_ be ? ToPropertyKey(_propertyKey_).
@@ -45819,7 +45845,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-reflect.deleteproperty">
       <h1>Reflect.deleteProperty ( _target_, _propertyKey_ )</h1>
-      <p>When the `deleteProperty` function is called with arguments _target_ and _propertyKey_, the following steps are taken:</p>
+      <p>This function performs the following steps when called:</p>
       <emu-alg>
         1. If Type(_target_) is not Object, throw a *TypeError* exception.
         1. Let _key_ be ? ToPropertyKey(_propertyKey_).
@@ -45829,7 +45855,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-reflect.get">
       <h1>Reflect.get ( _target_, _propertyKey_ [ , _receiver_ ] )</h1>
-      <p>When the `get` function is called with arguments _target_, _propertyKey_, and _receiver_, the following steps are taken:</p>
+      <p>This function performs the following steps when called:</p>
       <emu-alg>
         1. If Type(_target_) is not Object, throw a *TypeError* exception.
         1. Let _key_ be ? ToPropertyKey(_propertyKey_).
@@ -45841,7 +45867,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-reflect.getownpropertydescriptor">
       <h1>Reflect.getOwnPropertyDescriptor ( _target_, _propertyKey_ )</h1>
-      <p>When the `getOwnPropertyDescriptor` function is called with arguments _target_ and _propertyKey_, the following steps are taken:</p>
+      <p>This function performs the following steps when called:</p>
       <emu-alg>
         1. If Type(_target_) is not Object, throw a *TypeError* exception.
         1. Let _key_ be ? ToPropertyKey(_propertyKey_).
@@ -45852,7 +45878,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-reflect.getprototypeof">
       <h1>Reflect.getPrototypeOf ( _target_ )</h1>
-      <p>When the `getPrototypeOf` function is called with argument _target_, the following steps are taken:</p>
+      <p>This function performs the following steps when called:</p>
       <emu-alg>
         1. If Type(_target_) is not Object, throw a *TypeError* exception.
         1. Return ? <emu-meta effects="user-code">_target_.[[GetPrototypeOf]]()</emu-meta>.
@@ -45861,7 +45887,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-reflect.has">
       <h1>Reflect.has ( _target_, _propertyKey_ )</h1>
-      <p>When the `has` function is called with arguments _target_ and _propertyKey_, the following steps are taken:</p>
+      <p>This function performs the following steps when called:</p>
       <emu-alg>
         1. If Type(_target_) is not Object, throw a *TypeError* exception.
         1. Let _key_ be ? ToPropertyKey(_propertyKey_).
@@ -45871,7 +45897,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-reflect.isextensible">
       <h1>Reflect.isExtensible ( _target_ )</h1>
-      <p>When the `isExtensible` function is called with argument _target_, the following steps are taken:</p>
+      <p>This function performs the following steps when called:</p>
       <emu-alg>
         1. If Type(_target_) is not Object, throw a *TypeError* exception.
         1. Return ? <emu-meta effects="user-code">_target_.[[IsExtensible]]()</emu-meta>.
@@ -45880,7 +45906,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-reflect.ownkeys">
       <h1>Reflect.ownKeys ( _target_ )</h1>
-      <p>When the `ownKeys` function is called with argument _target_, the following steps are taken:</p>
+      <p>This function performs the following steps when called:</p>
       <emu-alg>
         1. If Type(_target_) is not Object, throw a *TypeError* exception.
         1. Let _keys_ be ? <emu-meta effects="user-code">_target_.[[OwnPropertyKeys]]()</emu-meta>.
@@ -45890,7 +45916,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-reflect.preventextensions">
       <h1>Reflect.preventExtensions ( _target_ )</h1>
-      <p>When the `preventExtensions` function is called with argument _target_, the following steps are taken:</p>
+      <p>This function performs the following steps when called:</p>
       <emu-alg>
         1. If Type(_target_) is not Object, throw a *TypeError* exception.
         1. Return ? <emu-meta effects="user-code">_target_.[[PreventExtensions]]()</emu-meta>.
@@ -45899,7 +45925,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-reflect.set">
       <h1>Reflect.set ( _target_, _propertyKey_, _V_ [ , _receiver_ ] )</h1>
-      <p>When the `set` function is called with arguments _target_, _V_, _propertyKey_, and _receiver_, the following steps are taken:</p>
+      <p>This function performs the following steps when called:</p>
       <emu-alg>
         1. If Type(_target_) is not Object, throw a *TypeError* exception.
         1. Let _key_ be ? ToPropertyKey(_propertyKey_).
@@ -45911,7 +45937,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-reflect.setprototypeof">
       <h1>Reflect.setPrototypeOf ( _target_, _proto_ )</h1>
-      <p>When the `setPrototypeOf` function is called with arguments _target_ and _proto_, the following steps are taken:</p>
+      <p>This function performs the following steps when called:</p>
       <emu-alg>
         1. If Type(_target_) is not Object, throw a *TypeError* exception.
         1. If Type(_proto_) is not Object and _proto_ is not *null*, throw a *TypeError* exception.
@@ -45941,7 +45967,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-proxy-target-handler">
         <h1>Proxy ( _target_, _handler_ )</h1>
-        <p>When `Proxy` is called with arguments _target_ and _handler_, it performs the following steps:</p>
+        <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
           1. Return ? ProxyCreate(_target_, _handler_).
@@ -45960,7 +45986,8 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-proxy.revocable" oldids="sec-proxy-revocation-functions">
         <h1>Proxy.revocable ( _target_, _handler_ )</h1>
-        <p>The `Proxy.revocable` function is used to create a revocable Proxy object. When `Proxy.revocable` is called with arguments _target_ and _handler_, the following steps are taken:</p>
+        <p>This function creates a revocable Proxy object.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _p_ be ? ProxyCreate(_target_, _handler_).
           1. Let _revokerClosure_ be a new Abstract Closure with no parameters that captures nothing and performs the following steps when called:
@@ -47439,9 +47466,10 @@ THH:mm:ss.sss
 
       <emu-annex id="sec-escape-string">
         <h1>escape ( _string_ )</h1>
-        <p>The `escape` function is a property of the global object. It computes a new version of a String value in which certain code units have been replaced by a hexadecimal escape sequence.</p>
+        <p>This function is a property of the global object. It computes a new version of a String value in which certain code units have been replaced by a hexadecimal escape sequence.</p>
         <p>For those code units being replaced whose value is `0x00FF` or less, a two-digit escape sequence of the form <code>%<var>xx</var></code> is used. For those characters being replaced whose code unit value is greater than `0x00FF`, a four-digit escape sequence of the form <code>%u<var>xxxx</var></code> is used.</p>
-        <p>The `escape` function is the <dfn>%escape%</dfn> intrinsic object. When the `escape` function is called with one argument _string_, the following steps are taken:</p>
+        <p>It is the <dfn>%escape%</dfn> intrinsic object.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Set _string_ to ? ToString(_string_).
           1. Let _length_ be the length of _string_.
@@ -47473,8 +47501,9 @@ THH:mm:ss.sss
 
       <emu-annex id="sec-unescape-string">
         <h1>unescape ( _string_ )</h1>
-        <p>The `unescape` function is a property of the global object. It computes a new version of a String value in which each escape sequence of the sort that might be introduced by the `escape` function is replaced with the code unit that it represents.</p>
-        <p>The `unescape` function is the <dfn>%unescape%</dfn> intrinsic object. When the `unescape` function is called with one argument _string_, the following steps are taken:</p>
+        <p>This function is a property of the global object. It computes a new version of a String value in which each escape sequence of the sort that might be introduced by the `escape` function is replaced with the code unit that it represents.</p>
+        <p>It is the <dfn>%unescape%</dfn> intrinsic object.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Set _string_ to ? ToString(_string_).
           1. Let _length_ be the length of _string_.
@@ -47508,7 +47537,8 @@ THH:mm:ss.sss
 
       <emu-annex id="sec-string.prototype.substr">
         <h1>String.prototype.substr ( _start_, _length_ )</h1>
-        <p>The `substr` method takes two arguments, _start_ and _length_, and returns a <emu-not-ref>substring</emu-not-ref> of the result of converting the *this* value to a String, starting from index _start_ and running for _length_ code units (or through the end of the String if _length_ is *undefined*). If _start_ is negative, it is treated as <emu-eqn>_sourceLength_ + _start_</emu-eqn> where _sourceLength_ is the length of the String. The result is a String value, not a String object. The following steps are taken:</p>
+        <p>This method returns a <emu-not-ref>substring</emu-not-ref> of the result of converting the *this* value to a String, starting from index _start_ and running for _length_ code units (or through the end of the String if _length_ is *undefined*). If _start_ is negative, it is treated as <emu-eqn>_sourceLength_ + _start_</emu-eqn> where _sourceLength_ is the length of the String. The result is a String value, not a String object.</p>
+        <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
@@ -47523,13 +47553,13 @@ THH:mm:ss.sss
           1. Return the substring of _S_ from _intStart_ to _intEnd_.
         </emu-alg>
         <emu-note>
-          <p>The `substr` function is intentionally generic; it does not require that its *this* value be a String object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
+          <p>This method is intentionally generic; it does not require that its *this* value be a String object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
       </emu-annex>
 
       <emu-annex id="sec-string.prototype.anchor">
         <h1>String.prototype.anchor ( _name_ )</h1>
-        <p>When the `anchor` method is called with argument _name_, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
           1. Return ? CreateHTML(_S_, *"a"*, *"name"*, _name_).
@@ -47571,7 +47601,7 @@ THH:mm:ss.sss
 
       <emu-annex id="sec-string.prototype.big">
         <h1>String.prototype.big ( )</h1>
-        <p>When the `big` method is called with no arguments, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
           1. Return ? CreateHTML(_S_, *"big"*, *""*, *""*).
@@ -47580,7 +47610,7 @@ THH:mm:ss.sss
 
       <emu-annex id="sec-string.prototype.blink">
         <h1>String.prototype.blink ( )</h1>
-        <p>When the `blink` method is called with no arguments, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
           1. Return ? CreateHTML(_S_, *"blink"*, *""*, *""*).
@@ -47589,7 +47619,7 @@ THH:mm:ss.sss
 
       <emu-annex id="sec-string.prototype.bold">
         <h1>String.prototype.bold ( )</h1>
-        <p>When the `bold` method is called with no arguments, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
           1. Return ? CreateHTML(_S_, *"b"*, *""*, *""*).
@@ -47598,7 +47628,7 @@ THH:mm:ss.sss
 
       <emu-annex id="sec-string.prototype.fixed">
         <h1>String.prototype.fixed ( )</h1>
-        <p>When the `fixed` method is called with no arguments, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
           1. Return ? CreateHTML(_S_, *"tt"*, *""*, *""*).
@@ -47607,7 +47637,7 @@ THH:mm:ss.sss
 
       <emu-annex id="sec-string.prototype.fontcolor">
         <h1>String.prototype.fontcolor ( _color_ )</h1>
-        <p>When the `fontcolor` method is called with argument _color_, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
           1. Return ? CreateHTML(_S_, *"font"*, *"color"*, _color_).
@@ -47616,7 +47646,7 @@ THH:mm:ss.sss
 
       <emu-annex id="sec-string.prototype.fontsize">
         <h1>String.prototype.fontsize ( _size_ )</h1>
-        <p>When the `fontsize` method is called with argument _size_, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
           1. Return ? CreateHTML(_S_, *"font"*, *"size"*, _size_).
@@ -47625,7 +47655,7 @@ THH:mm:ss.sss
 
       <emu-annex id="sec-string.prototype.italics">
         <h1>String.prototype.italics ( )</h1>
-        <p>When the `italics` method is called with no arguments, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
           1. Return ? CreateHTML(_S_, *"i"*, *""*, *""*).
@@ -47634,7 +47664,7 @@ THH:mm:ss.sss
 
       <emu-annex id="sec-string.prototype.link">
         <h1>String.prototype.link ( _url_ )</h1>
-        <p>When the `link` method is called with argument _url_, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
           1. Return ? CreateHTML(_S_, *"a"*, *"href"*, _url_).
@@ -47643,7 +47673,7 @@ THH:mm:ss.sss
 
       <emu-annex id="sec-string.prototype.small">
         <h1>String.prototype.small ( )</h1>
-        <p>When the `small` method is called with no arguments, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
           1. Return ? CreateHTML(_S_, *"small"*, *""*, *""*).
@@ -47652,7 +47682,7 @@ THH:mm:ss.sss
 
       <emu-annex id="sec-string.prototype.strike">
         <h1>String.prototype.strike ( )</h1>
-        <p>When the `strike` method is called with no arguments, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
           1. Return ? CreateHTML(_S_, *"strike"*, *""*, *""*).
@@ -47661,7 +47691,7 @@ THH:mm:ss.sss
 
       <emu-annex id="sec-string.prototype.sub">
         <h1>String.prototype.sub ( )</h1>
-        <p>When the `sub` method is called with no arguments, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
           1. Return ? CreateHTML(_S_, *"sub"*, *""*, *""*).
@@ -47670,7 +47700,7 @@ THH:mm:ss.sss
 
       <emu-annex id="sec-string.prototype.sup">
         <h1>String.prototype.sup ( )</h1>
-        <p>When the `sup` method is called with no arguments, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
           1. Return ? CreateHTML(_S_, *"sup"*, *""*, *""*).
@@ -47702,7 +47732,7 @@ THH:mm:ss.sss
         <emu-note>
           <p>The `getFullYear` method is preferred for nearly all purposes, because it avoids the &ldquo;year 2000 problem.&rdquo;</p>
         </emu-note>
-        <p>When the `getYear` method is called with no arguments, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _t_ be ? thisTimeValue(*this* value).
           1. If _t_ is *NaN*, return *NaN*.
@@ -47715,7 +47745,7 @@ THH:mm:ss.sss
         <emu-note>
           <p>The `setFullYear` method is preferred for nearly all purposes, because it avoids the &ldquo;year 2000 problem.&rdquo;</p>
         </emu-note>
-        <p>When the `setYear` method is called with one argument _year_, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _t_ be ? thisTimeValue(*this* value).
           1. Let _y_ be ? ToNumber(_year_).
@@ -47736,7 +47766,7 @@ THH:mm:ss.sss
       <emu-annex id="sec-date.prototype.togmtstring">
         <h1>Date.prototype.toGMTString ( )</h1>
         <emu-note>
-          <p>The `toUTCString` method is preferred. The `toGMTString` method is provided principally for compatibility with old code.</p>
+          <p>The `toUTCString` method is preferred. This method is provided principally for compatibility with old code.</p>
         </emu-note>
         <p>The initial value of the *"toGMTString"* property is %Date.prototype.toUTCString%, defined in <emu-xref href="#sec-date.prototype.toutcstring"></emu-xref>.</p>
       </emu-annex>
@@ -47747,7 +47777,7 @@ THH:mm:ss.sss
 
       <emu-annex id="sec-regexp.prototype.compile">
         <h1>RegExp.prototype.compile ( _pattern_, _flags_ )</h1>
-        <p>When the `compile` method is called with arguments _pattern_ and _flags_, the following steps are taken:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Perform ? RequireInternalSlot(_O_, [[RegExpMatcher]]).
@@ -47761,7 +47791,7 @@ THH:mm:ss.sss
           1. Return ? RegExpInitialize(_O_, _P_, _F_).
         </emu-alg>
         <emu-note>
-          <p>The `compile` method completely reinitializes the *this* value RegExp with a new pattern and flags. An implementation may interpret use of this method as an assertion that the resulting RegExp object will be used multiple times and hence is a candidate for extra optimization.</p>
+          <p>This method completely reinitializes the *this* value RegExp with a new pattern and flags. An implementation may interpret use of this method as an assertion that the resulting RegExp object will be used multiple times and hence is a candidate for extra optimization.</p>
         </emu-note>
       </emu-annex>
     </emu-annex>


### PR DESCRIPTION
Issue #2576 didn't get very far, so I created this PR to spur discussion/decisions.

---

The first 4 commits perform small spot fixes.

The next 2 commits normalize the use of "method" vs "function". I started with the rule that a method is a function that is the value of a property of a prototype object, because it's easy for me to detect automatically, but then added special cases for [Typed]Array.{from,of}. I made each 'direction' (method-to-function vs function-to-method) a separate commit, because I think it's easier to review the changes that way, but they could probably be squashed later.

The remaining 12 commits perform various widespread normalizations on intrinsic function prose. I've left them as distinct commits in case you want me to back out particular changes. It might also help with review. Anyhow, they could probably be squashed too.

---

Resolves #2304 (at least to some extent: it depends on how broadly you interpret #2304)