### PR TITLE
Editorial: simplify Array.prototype.splice

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -37719,14 +37719,12 @@ THH:mm:ss.sss
           1. If _relativeStart_ is -&infin;, let _actualStart_ be 0.
           1. Else if _relativeStart_ &lt; 0, let _actualStart_ be max(_len_ + _relativeStart_, 0).
           1. Else, let _actualStart_ be min(_relativeStart_, _len_).
+          1. Let _insertCount_ be the number of elements in _items_.
           1. If _start_ is not present, then
-            1. Let _insertCount_ be 0.
             1. Let _actualDeleteCount_ be 0.
           1. Else if _deleteCount_ is not present, then
-            1. Let _insertCount_ be 0.
             1. Let _actualDeleteCount_ be _len_ - _actualStart_.
           1. Else,
-            1. Let _insertCount_ be the number of elements in _items_.
             1. Let _dc_ be ? ToIntegerOrInfinity(_deleteCount_).
             1. Let _actualDeleteCount_ be the result of clamping _dc_ between 0 and _len_ - _actualStart_.
           1. If _len_ + _insertCount_ - _actualDeleteCount_ &gt; 2<sup>53</sup> - 1, throw a *TypeError* exception.
@@ -37734,8 +37732,7 @@ THH:mm:ss.sss
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _actualDeleteCount_,
             1. Let _from_ be ! ToString(𝔽(_actualStart_ + _k_)).
-            1. Let _fromPresent_ be ? HasProperty(_O_, _from_).
-            1. If _fromPresent_ is *true*, then
+            1. If ? HasProperty(_O_, _from_) is *true*, then
               1. Let _fromValue_ be ? Get(_O_, _from_).
               1. Perform ? CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_k_)), _fromValue_).
             1. Set _k_ to _k_ + 1.
@@ -37746,12 +37743,10 @@ THH:mm:ss.sss
             1. Repeat, while _k_ &lt; (_len_ - _actualDeleteCount_),
               1. Let _from_ be ! ToString(𝔽(_k_ + _actualDeleteCount_)).
               1. Let _to_ be ! ToString(𝔽(_k_ + _itemCount_)).
-              1. Let _fromPresent_ be ? HasProperty(_O_, _from_).
-              1. If _fromPresent_ is *true*, then
+              1. If ? HasProperty(_O_, _from_) is *true*, then
                 1. Let _fromValue_ be ? Get(_O_, _from_).
                 1. Perform ? Set(_O_, _to_, _fromValue_, *true*).
               1. Else,
-                1. Assert: _fromPresent_ is *false*.
                 1. Perform ? DeletePropertyOrThrow(_O_, _to_).
               1. Set _k_ to _k_ + 1.
             1. Set _k_ to _len_.
@@ -37763,12 +37758,10 @@ THH:mm:ss.sss
             1. Repeat, while _k_ &gt; _actualStart_,
               1. Let _from_ be ! ToString(𝔽(_k_ + _actualDeleteCount_ - 1)).
               1. Let _to_ be ! ToString(𝔽(_k_ + _itemCount_ - 1)).
-              1. Let _fromPresent_ be ? HasProperty(_O_, _from_).
-              1. If _fromPresent_ is *true*, then
+              1. If ? HasProperty(_O_, _from_) is *true*, then
                 1. Let _fromValue_ be ? Get(_O_, _from_).
                 1. Perform ? Set(_O_, _to_, _fromValue_, *true*).
               1. Else,
-                1. Assert: _fromPresent_ is *false*.
                 1. Perform ? DeletePropertyOrThrow(_O_, _to_).
               1. Set _k_ to _k_ - 1.
           1. Set _k_ to _actualStart_.


### PR DESCRIPTION
I could also hoist up the `actualDeleteCount` logic, and get rid of the if/elseif/else chain entirely, but I'm not as convinced that one would be an improvement.

Noticed this while reviewing/implementing https://tc39.es/proposal-change-array-by-copy/#sec-array.prototype.toSpliced