### PR TITLE
Editorial: Use "SDO of |Foo|" form for all SDO invocations

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -9188,12 +9188,12 @@
       <emu-grammar>PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
       <emu-alg>
         1. Let _expr_ be the |ParenthesizedExpression| that is covered by |CoverParenthesizedExpressionAndArrowParameterList|.
-        1. Return the result of performing NamedEvaluation for _expr_ with argument _name_.
+        1. Return the result of performing NamedEvaluation of _expr_ with argument _name_.
       </emu-alg>
       <emu-grammar>ParenthesizedExpression : `(` Expression `)`</emu-grammar>
       <emu-alg>
         1. Assert: IsAnonymousFunctionDefinition(|Expression|) is *true*.
-        1. Return the result of performing NamedEvaluation for |Expression| with argument _name_.
+        1. Return the result of performing NamedEvaluation of |Expression| with argument _name_.
       </emu-alg>
       <emu-grammar>FunctionExpression : `function` `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
@@ -9299,7 +9299,7 @@
           1. If |ClassHeritage| is present, return *true*; otherwise return *false*.
         1. If |ClassHeritage| is present, then
           1. If |ClassHeritage| Contains _symbol_ is *true*, return *true*.
-        1. Return the result of ComputedPropertyContains for |ClassBody| with argument _symbol_.
+        1. Return the result of ComputedPropertyContains of |ClassBody| with argument _symbol_.
       </emu-alg>
       <emu-note>
         <p>Static semantic rules that depend upon substructure generally do not look into class bodies except for |PropertyName|s.</p>
@@ -9344,7 +9344,7 @@
       <emu-grammar>PropertyDefinition : MethodDefinition</emu-grammar>
       <emu-alg>
         1. If _symbol_ is |MethodDefinition|, return *true*.
-        1. Return the result of ComputedPropertyContains for |MethodDefinition| with argument _symbol_.
+        1. Return the result of ComputedPropertyContains of |MethodDefinition| with argument _symbol_.
       </emu-alg>
       <emu-grammar>LiteralPropertyName : IdentifierName</emu-grammar>
       <emu-alg>
@@ -9403,21 +9403,21 @@
           `set` ClassElementName `(` PropertySetParameterList `)` `{` FunctionBody `}`
       </emu-grammar>
       <emu-alg>
-        1. Return the result of ComputedPropertyContains for |ClassElementName| with argument _symbol_.
+        1. Return the result of ComputedPropertyContains of |ClassElementName| with argument _symbol_.
       </emu-alg>
       <emu-grammar>GeneratorMethod : `*` ClassElementName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
-        1. Return the result of ComputedPropertyContains for |ClassElementName| with argument _symbol_.
+        1. Return the result of ComputedPropertyContains of |ClassElementName| with argument _symbol_.
       </emu-alg>
       <emu-grammar>AsyncGeneratorMethod : `async` `*` ClassElementName `(` UniqueFormalParameters `)` `{` AsyncGeneratorBody `}`</emu-grammar>
       <emu-alg>
-        1. Return the result of ComputedPropertyContains for |ClassElementName| with argument _symbol_.
+        1. Return the result of ComputedPropertyContains of |ClassElementName| with argument _symbol_.
       </emu-alg>
       <emu-grammar>ClassElementList : ClassElementList ClassElement</emu-grammar>
       <emu-alg>
         1. Let _inList_ be ComputedPropertyContains of |ClassElementList| with argument _symbol_.
         1. If _inList_ is *true*, return *true*.
-        1. Return the result of ComputedPropertyContains for |ClassElement| with argument _symbol_.
+        1. Return the result of ComputedPropertyContains of |ClassElement| with argument _symbol_.
       </emu-alg>
       <emu-grammar>ClassElement : ClassStaticBlock</emu-grammar>
       <emu-alg>
@@ -9431,13 +9431,13 @@
         AsyncMethod : `async` ClassElementName `(` UniqueFormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
       <emu-alg>
-        1. Return the result of ComputedPropertyContains for |ClassElementName| with argument _symbol_.
+        1. Return the result of ComputedPropertyContains of |ClassElementName| with argument _symbol_.
       </emu-alg>
       <emu-grammar>
         FieldDefinition : ClassElementName Initializer?
       </emu-grammar>
       <emu-alg>
-        1. Return the result of ComputedPropertyContains for |ClassElementName| with argument _symbol_.
+        1. Return the result of ComputedPropertyContains of |ClassElementName| with argument _symbol_.
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -9517,7 +9517,7 @@
       <emu-grammar>BindingPattern : ObjectBindingPattern</emu-grammar>
       <emu-alg>
         1. Perform ? RequireObjectCoercible(_value_).
-        1. Return the result of performing BindingInitialization for |ObjectBindingPattern| using _value_ and _environment_ as arguments.
+        1. Return the result of performing BindingInitialization of |ObjectBindingPattern| using _value_ and _environment_ as arguments.
       </emu-alg>
       <emu-grammar>BindingPattern : ArrayBindingPattern</emu-grammar>
       <emu-alg>
@@ -9536,7 +9536,7 @@
           `{` BindingPropertyList `,` `}`
       </emu-grammar>
       <emu-alg>
-        1. Perform ? PropertyBindingInitialization for |BindingPropertyList| using _value_ and _environment_ as the arguments.
+        1. Perform ? PropertyBindingInitialization of |BindingPropertyList| using _value_ and _environment_ as the arguments.
         1. Return NormalCompletion(~empty~).
       </emu-alg>
       <emu-grammar>ObjectBindingPattern : `{` BindingRestProperty `}`</emu-grammar>
@@ -9595,24 +9595,24 @@
       <emu-alg>
         1. If |Elision| is present, then
           1. Perform ? IteratorDestructuringAssignmentEvaluation of |Elision| with _iteratorRecord_ as the argument.
-        1. Return the result of performing IteratorBindingInitialization for |BindingRestElement| with _iteratorRecord_ and _environment_ as arguments.
+        1. Return the result of performing IteratorBindingInitialization of |BindingRestElement| with _iteratorRecord_ and _environment_ as arguments.
       </emu-alg>
       <emu-grammar>ArrayBindingPattern : `[` BindingElementList `,` Elision `]`</emu-grammar>
       <emu-alg>
-        1. Perform ? IteratorBindingInitialization for |BindingElementList| with _iteratorRecord_ and _environment_ as arguments.
+        1. Perform ? IteratorBindingInitialization of |BindingElementList| with _iteratorRecord_ and _environment_ as arguments.
         1. Return the result of performing IteratorDestructuringAssignmentEvaluation of |Elision| with _iteratorRecord_ as the argument.
       </emu-alg>
       <emu-grammar>ArrayBindingPattern : `[` BindingElementList `,` Elision? BindingRestElement `]`</emu-grammar>
       <emu-alg>
-        1. Perform ? IteratorBindingInitialization for |BindingElementList| with _iteratorRecord_ and _environment_ as arguments.
+        1. Perform ? IteratorBindingInitialization of |BindingElementList| with _iteratorRecord_ and _environment_ as arguments.
         1. If |Elision| is present, then
           1. Perform ? IteratorDestructuringAssignmentEvaluation of |Elision| with _iteratorRecord_ as the argument.
-        1. Return the result of performing IteratorBindingInitialization for |BindingRestElement| with _iteratorRecord_ and _environment_ as arguments.
+        1. Return the result of performing IteratorBindingInitialization of |BindingRestElement| with _iteratorRecord_ and _environment_ as arguments.
       </emu-alg>
       <emu-grammar>BindingElementList : BindingElementList `,` BindingElisionElement</emu-grammar>
       <emu-alg>
-        1. Perform ? IteratorBindingInitialization for |BindingElementList| with _iteratorRecord_ and _environment_ as arguments.
-        1. Return the result of performing IteratorBindingInitialization for |BindingElisionElement| using _iteratorRecord_ and _environment_ as arguments.
+        1. Perform ? IteratorBindingInitialization of |BindingElementList| with _iteratorRecord_ and _environment_ as arguments.
+        1. Return the result of performing IteratorBindingInitialization of |BindingElisionElement| using _iteratorRecord_ and _environment_ as arguments.
       </emu-alg>
       <emu-grammar>BindingElisionElement : Elision BindingElement</emu-grammar>
       <emu-alg>
@@ -9635,7 +9635,7 @@
             1. ReturnIfAbrupt(_v_).
         1. If |Initializer| is present and _v_ is *undefined*, then
           1. If IsAnonymousFunctionDefinition(|Initializer|) is *true*, then
-            1. Set _v_ to the result of performing NamedEvaluation for |Initializer| with argument _bindingId_.
+            1. Set _v_ to the result of performing NamedEvaluation of |Initializer| with argument _bindingId_.
           1. Else,
             1. Let _defaultValue_ be the result of evaluating |Initializer|.
             1. Set _v_ to ? GetValue(_defaultValue_).
@@ -9703,13 +9703,13 @@
       </emu-alg>
       <emu-grammar>FormalParameters : FormalParameterList `,` FunctionRestParameter</emu-grammar>
       <emu-alg>
-        1. Perform ? IteratorBindingInitialization for |FormalParameterList| using _iteratorRecord_ and _environment_ as the arguments.
-        1. Return the result of performing IteratorBindingInitialization for |FunctionRestParameter| using _iteratorRecord_ and _environment_ as the arguments.
+        1. Perform ? IteratorBindingInitialization of |FormalParameterList| using _iteratorRecord_ and _environment_ as the arguments.
+        1. Return the result of performing IteratorBindingInitialization of |FunctionRestParameter| using _iteratorRecord_ and _environment_ as the arguments.
       </emu-alg>
       <emu-grammar>FormalParameterList : FormalParameterList `,` FormalParameter</emu-grammar>
       <emu-alg>
-        1. Perform ? IteratorBindingInitialization for |FormalParameterList| using _iteratorRecord_ and _environment_ as the arguments.
-        1. Return the result of performing IteratorBindingInitialization for |FormalParameter| using _iteratorRecord_ and _environment_ as the arguments.
+        1. Perform ? IteratorBindingInitialization of |FormalParameterList| using _iteratorRecord_ and _environment_ as the arguments.
+        1. Return the result of performing IteratorBindingInitialization of |FormalParameter| using _iteratorRecord_ and _environment_ as the arguments.
       </emu-alg>
       <emu-grammar>ArrowParameters : BindingIdentifier</emu-grammar>
       <emu-alg>
@@ -9723,7 +9723,7 @@
           1. Set _v_ to IteratorValue(_next_).
           1. If _v_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
           1. ReturnIfAbrupt(_v_).
-        1. Return the result of performing BindingInitialization for |BindingIdentifier| using _v_ and _environment_ as the arguments.
+        1. Return the result of performing BindingInitialization of |BindingIdentifier| using _v_ and _environment_ as the arguments.
       </emu-alg>
       <emu-grammar>ArrowParameters : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
       <emu-alg>
@@ -9744,7 +9744,7 @@
           1. Set _v_ to IteratorValue(_next_).
           1. If _v_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
           1. ReturnIfAbrupt(_v_).
-        1. Return the result of performing BindingInitialization for |BindingIdentifier| using _v_ and _environment_ as the arguments.
+        1. Return the result of performing BindingInitialization of |BindingIdentifier| using _v_ and _environment_ as the arguments.
       </emu-alg>
     </emu-clause>
 
@@ -13702,9 +13702,9 @@
           1. Let _parameterBindings_ be _parameterNames_.
         1. Let _iteratorRecord_ be CreateListIteratorRecord(_argumentsList_).
         1. If _hasDuplicates_ is *true*, then
-          1. Perform ? IteratorBindingInitialization for _formals_ with _iteratorRecord_ and *undefined* as arguments.
+          1. Perform ? IteratorBindingInitialization of _formals_ with _iteratorRecord_ and *undefined* as arguments.
         1. Else,
-          1. Perform ? IteratorBindingInitialization for _formals_ with _iteratorRecord_ and _env_ as arguments.
+          1. Perform ? IteratorBindingInitialization of _formals_ with _iteratorRecord_ and _env_ as arguments.
         1. If _hasParameterExpressions_ is *false*, then
           1. NOTE: Only a single Environment Record is needed for the parameters and top-level vars.
           1. Let _instantiatedVarNames_ be a copy of the List _parameterBindings_.
@@ -18093,12 +18093,12 @@
         </emu-alg>
         <emu-grammar>Elision : Elision `,`</emu-grammar>
         <emu-alg>
-          1. Return the result of performing ArrayAccumulation for |Elision| with arguments _array_ and _nextIndex_ + 1.
+          1. Return the result of performing ArrayAccumulation of |Elision| with arguments _array_ and _nextIndex_ + 1.
         </emu-alg>
         <emu-grammar>ElementList : Elision? AssignmentExpression</emu-grammar>
         <emu-alg>
           1. If |Elision| is present, then
-            1. Set _nextIndex_ to the result of performing ArrayAccumulation for |Elision| with arguments _array_ and _nextIndex_.
+            1. Set _nextIndex_ to the result of performing ArrayAccumulation of |Elision| with arguments _array_ and _nextIndex_.
             1. ReturnIfAbrupt(_nextIndex_).
           1. Let _initResult_ be the result of evaluating |AssignmentExpression|.
           1. Let _initValue_ be ? GetValue(_initResult_).
@@ -18108,16 +18108,16 @@
         <emu-grammar>ElementList : Elision? SpreadElement</emu-grammar>
         <emu-alg>
           1. If |Elision| is present, then
-            1. Set _nextIndex_ to the result of performing ArrayAccumulation for |Elision| with arguments _array_ and _nextIndex_.
+            1. Set _nextIndex_ to the result of performing ArrayAccumulation of |Elision| with arguments _array_ and _nextIndex_.
             1. ReturnIfAbrupt(_nextIndex_).
-          1. Return the result of performing ArrayAccumulation for |SpreadElement| with arguments _array_ and _nextIndex_.
+          1. Return the result of performing ArrayAccumulation of |SpreadElement| with arguments _array_ and _nextIndex_.
         </emu-alg>
         <emu-grammar>ElementList : ElementList `,` Elision? AssignmentExpression</emu-grammar>
         <emu-alg>
-          1. Set _nextIndex_ to the result of performing ArrayAccumulation for |ElementList| with arguments _array_ and _nextIndex_.
+          1. Set _nextIndex_ to the result of performing ArrayAccumulation of |ElementList| with arguments _array_ and _nextIndex_.
           1. ReturnIfAbrupt(_nextIndex_).
           1. If |Elision| is present, then
-            1. Set _nextIndex_ to the result of performing ArrayAccumulation for |Elision| with arguments _array_ and _nextIndex_.
+            1. Set _nextIndex_ to the result of performing ArrayAccumulation of |Elision| with arguments _array_ and _nextIndex_.
             1. ReturnIfAbrupt(_nextIndex_).
           1. Let _initResult_ be the result of evaluating |AssignmentExpression|.
           1. Let _initValue_ be ? GetValue(_initResult_).
@@ -18126,12 +18126,12 @@
         </emu-alg>
         <emu-grammar>ElementList : ElementList `,` Elision? SpreadElement</emu-grammar>
         <emu-alg>
-          1. Set _nextIndex_ to the result of performing ArrayAccumulation for |ElementList| with arguments _array_ and _nextIndex_.
+          1. Set _nextIndex_ to the result of performing ArrayAccumulation of |ElementList| with arguments _array_ and _nextIndex_.
           1. ReturnIfAbrupt(_nextIndex_).
           1. If |Elision| is present, then
-            1. Set _nextIndex_ to the result of performing ArrayAccumulation for |Elision| with arguments _array_ and _nextIndex_.
+            1. Set _nextIndex_ to the result of performing ArrayAccumulation of |Elision| with arguments _array_ and _nextIndex_.
             1. ReturnIfAbrupt(_nextIndex_).
-          1. Return the result of performing ArrayAccumulation for |SpreadElement| with arguments _array_ and _nextIndex_.
+          1. Return the result of performing ArrayAccumulation of |SpreadElement| with arguments _array_ and _nextIndex_.
         </emu-alg>
         <emu-grammar>SpreadElement : `...` AssignmentExpression</emu-grammar>
         <emu-alg>
@@ -18156,24 +18156,24 @@
         <emu-alg>
           1. Let _array_ be ! ArrayCreate(0).
           1. If |Elision| is present, then
-            1. Let _len_ be the result of performing ArrayAccumulation for |Elision| with arguments _array_ and 0.
+            1. Let _len_ be the result of performing ArrayAccumulation of |Elision| with arguments _array_ and 0.
             1. ReturnIfAbrupt(_len_).
           1. Return _array_.
         </emu-alg>
         <emu-grammar>ArrayLiteral : `[` ElementList `]`</emu-grammar>
         <emu-alg>
           1. Let _array_ be ! ArrayCreate(0).
-          1. Let _len_ be the result of performing ArrayAccumulation for |ElementList| with arguments _array_ and 0.
+          1. Let _len_ be the result of performing ArrayAccumulation of |ElementList| with arguments _array_ and 0.
           1. ReturnIfAbrupt(_len_).
           1. Return _array_.
         </emu-alg>
         <emu-grammar>ArrayLiteral : `[` ElementList `,` Elision? `]`</emu-grammar>
         <emu-alg>
           1. Let _array_ be ! ArrayCreate(0).
-          1. Let _nextIndex_ be the result of performing ArrayAccumulation for |ElementList| with arguments _array_ and 0.
+          1. Let _nextIndex_ be the result of performing ArrayAccumulation of |ElementList| with arguments _array_ and 0.
           1. ReturnIfAbrupt(_nextIndex_).
           1. If |Elision| is present, then
-            1. Let _len_ be the result of performing ArrayAccumulation for |Elision| with arguments _array_ and _nextIndex_.
+            1. Let _len_ be the result of performing ArrayAccumulation of |Elision| with arguments _array_ and _nextIndex_.
             1. ReturnIfAbrupt(_len_).
           1. Return _array_.
         </emu-alg>
@@ -20661,7 +20661,7 @@
         </emu-grammar>
         <emu-alg>
           1. Perform ? RequireObjectCoercible(_value_).
-          1. Perform ? PropertyDestructuringAssignmentEvaluation for |AssignmentPropertyList| using _value_ as the argument.
+          1. Perform ? PropertyDestructuringAssignmentEvaluation of |AssignmentPropertyList| using _value_ as the argument.
           1. Return NormalCompletion(~empty~).
         </emu-alg>
         <emu-grammar>ArrayAssignmentPattern : `[` `]`</emu-grammar>
@@ -20751,7 +20751,7 @@
           1. Let _v_ be ? GetV(_value_, _P_).
           1. If |Initializer?| is present and _v_ is *undefined*, then
             1. If IsAnonymousFunctionDefinition(|Initializer|) is *true*, then
-              1. Set _v_ to the result of performing NamedEvaluation for |Initializer| with argument _P_.
+              1. Set _v_ to the result of performing NamedEvaluation of |Initializer| with argument _P_.
             1. Else,
               1. Let _defaultValue_ be the result of evaluating |Initializer|.
               1. Set _v_ to ? GetValue(_defaultValue_).
@@ -21199,7 +21199,7 @@
           1. Let _rhs_ be the result of evaluating |Initializer|.
           1. Let _value_ be ? GetValue(_rhs_).
           1. Let _env_ be the running execution context's LexicalEnvironment.
-          1. Return the result of performing BindingInitialization for |BindingPattern| using _value_ and _env_ as the arguments.
+          1. Return the result of performing BindingInitialization of |BindingPattern| using _value_ and _env_ as the arguments.
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -21259,7 +21259,7 @@
         <emu-alg>
           1. Let _rhs_ be the result of evaluating |Initializer|.
           1. Let _rval_ be ? GetValue(_rhs_).
-          1. Return the result of performing BindingInitialization for |BindingPattern| passing _rval_ and *undefined* as arguments.
+          1. Return the result of performing BindingInitialization of |BindingPattern| passing _rval_ and *undefined* as arguments.
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -21334,7 +21334,7 @@
         <emu-grammar>BindingProperty : SingleNameBinding</emu-grammar>
         <emu-alg>
           1. Let _name_ be the string that is the only element of BoundNames of |SingleNameBinding|.
-          1. Perform ? KeyedBindingInitialization for |SingleNameBinding| using _value_, _environment_, and _name_ as the arguments.
+          1. Perform ? KeyedBindingInitialization of |SingleNameBinding| using _value_, _environment_, and _name_ as the arguments.
           1. Return a List whose sole element is _name_.
         </emu-alg>
 
@@ -21386,7 +21386,7 @@
           1. If |Initializer| is present and _v_ is *undefined*, then
             1. Let _defaultValue_ be the result of evaluating |Initializer|.
             1. Set _v_ to ? GetValue(_defaultValue_).
-          1. Return the result of performing BindingInitialization for |BindingPattern| passing _v_ and _environment_ as arguments.
+          1. Return the result of performing BindingInitialization of |BindingPattern| passing _v_ and _environment_ as arguments.
         </emu-alg>
         <emu-grammar>SingleNameBinding : BindingIdentifier Initializer?</emu-grammar>
         <emu-alg>
@@ -21395,7 +21395,7 @@
           1. Let _v_ be ? GetV(_value_, _propertyName_).
           1. If |Initializer| is present and _v_ is *undefined*, then
             1. If IsAnonymousFunctionDefinition(|Initializer|) is *true*, then
-              1. Set _v_ to the result of performing NamedEvaluation for |Initializer| with argument _bindingId_.
+              1. Set _v_ to the result of performing NamedEvaluation of |Initializer| with argument _bindingId_.
             1. Else,
               1. Let _defaultValue_ be the result of evaluating |Initializer|.
               1. Set _v_ to ? GetValue(_defaultValue_).
@@ -21929,7 +21929,7 @@
         </emu-note>
         <emu-grammar>ForDeclaration : LetOrConst ForBinding</emu-grammar>
         <emu-alg>
-          1. Return the result of performing BindingInitialization for |ForBinding| passing _value_ and _environment_ as the arguments.
+          1. Return the result of performing BindingInitialization of |ForBinding| passing _value_ and _environment_ as the arguments.
         </emu-alg>
       </emu-clause>
 
@@ -22088,7 +22088,7 @@
               1. Assert: _lhsKind_ is ~lexicalBinding~.
               1. Assert: _lhs_ is a |ForDeclaration|.
               1. Let _iterationEnv_ be NewDeclarativeEnvironment(_oldEnv_).
-              1. Perform ForDeclarationBindingInstantiation for _lhs_ passing _iterationEnv_ as the argument.
+              1. Perform ForDeclarationBindingInstantiation of _lhs_ passing _iterationEnv_ as the argument.
               1. Set the running execution context's LexicalEnvironment to _iterationEnv_.
               1. If _destructuring_ is *false*, then
                 1. Assert: _lhs_ binds a single name.


### PR DESCRIPTION
This makes the invocation form consistent for the user-code effect propagation in #2548.