### PR TITLE
Editorial: Reword field 'types'

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -3987,7 +3987,7 @@
               [[Type]]
             </td>
             <td>
-              One of ~normal~, ~break~, ~continue~, ~return~, or ~throw~
+              ~normal~, ~break~, ~continue~, ~return~, or ~throw~
             </td>
             <td>
               The type of completion that occurred.
@@ -3998,7 +3998,7 @@
               [[Value]]
             </td>
             <td>
-              any ECMAScript language value or ~empty~
+              an ECMAScript language value or ~empty~
             </td>
             <td>
               The value that was produced.
@@ -4009,7 +4009,7 @@
               [[Target]]
             </td>
             <td>
-              any ECMAScript string or ~empty~
+              a String or ~empty~
             </td>
             <td>
               The target label for directed control transfers.
@@ -4141,35 +4141,22 @@
           </tr>
           <tr>
             <td oldids="sec-getbase,ao-getbase">[[Base]]</td>
-            <td>
-              One of:
-              <ul>
-                <li>
-                  any ECMAScript language value,
-                </li>
-                <li>
-                  an Environment Record, or
-                </li>
-                <li>
-                  ~unresolvable~.
-                </li>
-              </ul>
-            </td>
+            <td>an ECMAScript language value, an Environment Record, or ~unresolvable~</td>
             <td>The value or Environment Record which holds the binding. A [[Base]] of ~unresolvable~ indicates that the binding could not be resolved.</td>
           </tr>
           <tr>
             <td oldids="sec-getreferencedname,ao-getreferencedname">[[ReferencedName]]</td>
-            <td>String, Symbol, or Private Name</td>
+            <td>a String, a Symbol, or a Private Name</td>
             <td>The name of the binding. Always a String if [[Base]] value is an Environment Record.</td>
           </tr>
           <tr>
             <td oldids="sec-isstrictreference,ao-isstrictreference">[[Strict]]</td>
-            <td>Boolean</td>
+            <td>a Boolean</td>
             <td>*true* if the Reference Record originated in strict mode code, *false* otherwise.</td>
           </tr>
           <tr>
             <td>[[ThisValue]]</td>
-            <td>any ECMAScript language value or ~empty~</td>
+            <td>an ECMAScript language value or ~empty~</td>
             <td>If not ~empty~, the Reference Record represents a property binding that was expressed using the `super` keyword; it is called a <dfn id="super-reference-record" oldids="super-reference" variants="Super Reference Records">Super Reference Record</dfn> and its [[Base]] value will never be an Environment Record. In that case, the [[ThisValue]] field holds the *this* value at the time the Reference Record was created.</td>
           </tr>
         </table>
@@ -4649,7 +4636,7 @@
               ~field~ and ~method~
             </td>
             <td>
-              any ECMAScript language value
+              an ECMAScript language value
             </td>
             <td>
               The value of the field.
@@ -4663,7 +4650,7 @@
               ~accessor~
             </td>
             <td>
-              Function or Undefined
+              a function object or *undefined*
             </td>
             <td>
               The getter for a private accessor.
@@ -4677,7 +4664,7 @@
               ~accessor~
             </td>
             <td>
-              Function or Undefined
+              a function object or *undefined*
             </td>
             <td>
               The setter for a private accessor.
@@ -4709,7 +4696,7 @@
               [[Name]]
             </td>
             <td>
-              a Private Name, a String value, or a Symbol value.
+              a Private Name, a String, or a Symbol
             </td>
             <td>
               The name of the field.
@@ -4720,7 +4707,7 @@
               [[Initializer]]
             </td>
             <td>
-              an ECMAScript function object, or ~empty~
+              a function object or ~empty~
             </td>
             <td>
               The initializer of the field, if any.
@@ -4757,7 +4744,7 @@
               [[BodyFunction]]
             </td>
             <td>
-              An function object.
+              a function object
             </td>
             <td>
               The function object to be called during static initialization of a class.
@@ -10345,7 +10332,7 @@
                 [[BindingObject]]
               </td>
               <td>
-                Object
+                an Object
               </td>
               <td>
                 The binding object of this Environment Record.
@@ -10356,7 +10343,7 @@
                 [[IsWithEnvironment]]
               </td>
               <td>
-                Boolean
+                a Boolean
               </td>
               <td>
                 Indicates whether this Environment Record is created for a `with` statement.
@@ -10570,7 +10557,7 @@
                 [[ThisValue]]
               </td>
               <td>
-                Any
+                an ECMAScript language value
               </td>
               <td>
                 This is the *this* value used for this invocation of the function.
@@ -10581,7 +10568,7 @@
                 [[ThisBindingStatus]]
               </td>
               <td>
-                ~lexical~ | ~initialized~ | ~uninitialized~
+                ~lexical~, ~initialized~, or ~uninitialized~
               </td>
               <td>
                 If the value is ~lexical~, this is an |ArrowFunction| and does not have a local *this* value.
@@ -10592,7 +10579,7 @@
                 [[FunctionObject]]
               </td>
               <td>
-                Object
+                an Object
               </td>
               <td>
                 The function object whose invocation caused this Environment Record to be created.
@@ -10603,7 +10590,7 @@
                 [[NewTarget]]
               </td>
               <td>
-                Object | *undefined*
+                an Object or *undefined*
               </td>
               <td>
                 If this Environment Record was created by the [[Construct]] internal method, [[NewTarget]] is the value of the [[Construct]] _newTarget_ parameter. Otherwise, its value is *undefined*.
@@ -10744,7 +10731,7 @@
                 [[ObjectRecord]]
               </td>
               <td>
-                Object Environment Record
+                an object Environment Record
               </td>
               <td>
                 Binding object is the global object. It contains global built-in bindings as well as |FunctionDeclaration|, |GeneratorDeclaration|, |AsyncFunctionDeclaration|, |AsyncGeneratorDeclaration|, and |VariableDeclaration| bindings in global code for the associated realm.
@@ -10755,7 +10742,7 @@
                 [[GlobalThisValue]]
               </td>
               <td>
-                Object
+                an Object
               </td>
               <td>
                 The value returned by `this` in global scope. Hosts may provide any ECMAScript Object value.
@@ -10766,7 +10753,7 @@
                 [[DeclarativeRecord]]
               </td>
               <td>
-                Declarative Environment Record
+                a declarative Environment Record
               </td>
               <td>
                 <emu-not-ref>Contains</emu-not-ref> bindings for all declarations in global code for the associated realm code except for |FunctionDeclaration|, |GeneratorDeclaration|, |AsyncFunctionDeclaration|, |AsyncGeneratorDeclaration|, and |VariableDeclaration| bindings.
@@ -10777,7 +10764,7 @@
                 [[VarNames]]
               </td>
               <td>
-                List of String
+                a List of Strings
               </td>
               <td>
                 The string names bound by |FunctionDeclaration|, |GeneratorDeclaration|, |AsyncFunctionDeclaration|, |AsyncGeneratorDeclaration|, and |VariableDeclaration| declarations in global code for the associated realm.
@@ -11518,7 +11505,7 @@
             [[OuterPrivateEnvironment]]
           </td>
           <td>
-            PrivateEnvironment Record | *null*
+            a PrivateEnvironment Record or *null*
           </td>
           <td>
             The PrivateEnvironment Record of the nearest containing class. *null* if the class with which this PrivateEnvironment Record is associated is not contained in any other class.
@@ -11529,7 +11516,7 @@
             [[Names]]
           </td>
           <td>
-            List of Private Names.
+            a List of Private Names
           </td>
           <td>
             The Private Names declared by this class.
@@ -11601,7 +11588,7 @@
             [[Intrinsics]]
           </td>
           <td>
-            Record whose field names are intrinsic keys and whose values are objects
+            a Record whose field names are intrinsic keys and whose values are objects
           </td>
           <td>
             The intrinsic values used by code associated with this realm
@@ -11612,7 +11599,7 @@
             [[GlobalObject]]
           </td>
           <td>
-            Object
+            an Object
           </td>
           <td>
             The global object for this realm
@@ -11623,7 +11610,7 @@
             [[GlobalEnv]]
           </td>
           <td>
-            global Environment Record
+            a global Environment Record
           </td>
           <td>
             The global environment for this realm
@@ -11634,7 +11621,7 @@
             [[TemplateMap]]
           </td>
           <td>
-            A List of Record { [[Site]]: Parse Node, [[Array]]: Object }.
+            a List of Record { [[Site]]: Parse Node, [[Array]]: Object }
           </td>
           <td>
             <p>Template objects are canonicalized separately for each realm using its Realm Record's [[TemplateMap]]. Each [[Site]] value is a Parse Node that is a |TemplateLiteral|. The associated [[Array]] value is the corresponding template object that is passed to a tag function.</p>
@@ -11646,7 +11633,7 @@
             [[HostDefined]]
           </td>
           <td>
-            Any, default value is *undefined*.
+            anything (default value is *undefined*)
           </td>
           <td>
             Field reserved for use by hosts that need to associate additional information with a Realm Record.
@@ -12002,7 +11989,7 @@
               [[Callback]]
             </td>
             <td>
-              A function object
+              a function object
             </td>
             <td>
               The function to invoke when the Job is invoked.
@@ -12013,7 +12000,7 @@
               [[HostDefined]]
             </td>
             <td>
-              Any, default value is ~empty~.
+              anything (default value is ~empty~)
             </td>
             <td>
               Field reserved for use by hosts.
@@ -12134,42 +12121,42 @@
         </tr>
         <tr>
           <td>[[LittleEndian]]</td>
-          <td>Boolean</td>
+          <td>a Boolean</td>
           <td>The default value computed for the <em>isLittleEndian</em> parameter when it is needed by the algorithms GetValueFromBuffer and SetValueInBuffer. The choice is implementation-defined and should be the alternative that is most efficient for the implementation. Once the value has been observed it cannot change.</td>
         </tr>
         <tr>
           <td>[[CanBlock]]</td>
-          <td>Boolean</td>
+          <td>a Boolean</td>
           <td>Determines whether the agent can block or not.</td>
         </tr>
         <tr>
           <td>[[Signifier]]</td>
-          <td>Any globally-unique value</td>
+          <td>a globally-unique value</td>
           <td>Uniquely identifies the agent within its agent cluster.</td>
         </tr>
         <tr>
           <td>[[IsLockFree1]]</td>
-          <td>Boolean</td>
+          <td>a Boolean</td>
           <td>*true* if atomic operations on one-<emu-not-ref>byte values</emu-not-ref> are lock-free, *false* otherwise.</td>
         </tr>
         <tr>
           <td>[[IsLockFree2]]</td>
-          <td>Boolean</td>
+          <td>a Boolean</td>
           <td>*true* if atomic operations on two-<emu-not-ref>byte values</emu-not-ref> are lock-free, *false* otherwise.</td>
         </tr>
         <tr>
           <td>[[IsLockFree8]]</td>
-          <td>Boolean</td>
+          <td>a Boolean</td>
           <td>*true* if atomic operations on eight-<emu-not-ref>byte values</emu-not-ref> are lock-free, *false* otherwise.</td>
         </tr>
         <tr>
           <td>[[CandidateExecution]]</td>
-          <td>A candidate execution Record</td>
+          <td>a candidate execution Record</td>
           <td>See the memory model.</td>
         </tr>
         <tr>
           <td>[[KeptAlive]]</td>
-          <td>List of objects</td>
+          <td>a List of Objects</td>
           <td>Initially a new empty List, representing the list of objects to be kept alive until the end of the current Job</td>
         </tr>
       </table>
@@ -25720,7 +25707,7 @@
               [[Realm]]
             </td>
             <td>
-              Realm Record | *undefined*
+              a Realm Record or *undefined*
             </td>
             <td>
               The realm within which this script was created. *undefined* if not yet assigned.
@@ -25742,7 +25729,7 @@
               [[HostDefined]]
             </td>
             <td>
-              Any, default value is ~empty~.
+              anything (default value is ~empty~)
             </td>
             <td>
               Field reserved for use by host environments that need to associate additional information with a script.
@@ -26051,7 +26038,7 @@
                 [[Realm]]
               </td>
               <td>
-                Realm Record
+                a Realm Record
               </td>
               <td>
                 The Realm within which this module was created.
@@ -26062,7 +26049,7 @@
                 [[Environment]]
               </td>
               <td>
-                module Environment Record | ~empty~
+                a module Environment Record or ~empty~
               </td>
               <td>
                 The Environment Record containing the top level bindings for this module. This field is set when the module is linked.
@@ -26073,7 +26060,7 @@
                 [[Namespace]]
               </td>
               <td>
-                Object | ~empty~
+                an Object or ~empty~
               </td>
               <td>
                 The Module Namespace Object (<emu-xref href="#sec-module-namespace-objects"></emu-xref>) if one has been created for this module.
@@ -26084,7 +26071,7 @@
                 [[HostDefined]]
               </td>
               <td>
-                Any, default value is *undefined*.
+                anything (default value is *undefined*)
               </td>
               <td>
                 Field reserved for use by host environments that need to associate additional information with a module.
@@ -26162,7 +26149,7 @@
                 [[Status]]
               </td>
               <td>
-                ~unlinked~ | ~linking~ | ~linked~ | ~evaluating~ | ~evaluating-async~ | ~evaluated~
+                ~unlinked~, ~linking~, ~linked~, ~evaluating~, ~evaluating-async~, or ~evaluated~
               </td>
               <td>
                 Initially ~unlinked~. Transitions to ~linking~, ~linked~, ~evaluating~, possibly ~evaluating-async~, ~evaluated~ (in that order) as the module progresses throughout its lifecycle. ~evaluating-async~ indicates this module is queued to execute on completion of its asynchronous dependencies or it is a module whose [[HasTLA]] field is *true* that has been executed and is pending top-level completion.
@@ -26173,7 +26160,7 @@
                 [[EvaluationError]]
               </td>
               <td>
-                An abrupt completion | ~empty~
+                an abrupt completion or ~empty~
               </td>
               <td>
                 A completion of type ~throw~ representing the exception that occurred during evaluation. *undefined* if no exception occurred or if [[Status]] is not ~evaluated~.
@@ -26184,7 +26171,7 @@
                 [[DFSIndex]]
               </td>
               <td>
-                Integer | ~empty~
+                an integer or ~empty~
               </td>
               <td>
                 Auxiliary field used during Link and Evaluate only. If [[Status]] is ~linking~ or ~evaluating~, this non-negative number records the point at which the module was first visited during the depth-first traversal of the dependency graph.
@@ -26195,7 +26182,7 @@
                 [[DFSAncestorIndex]]
               </td>
               <td>
-                Integer | ~empty~
+                an integer or ~empty~
               </td>
               <td>
                 Auxiliary field used during Link and Evaluate only. If [[Status]] is ~linking~ or ~evaluating~, this is either the module's own [[DFSIndex]] or that of an "earlier" module in the same strongly connected component.
@@ -26206,7 +26193,7 @@
                 [[RequestedModules]]
               </td>
               <td>
-                List of String
+                a List of Strings
               </td>
               <td>
                 A List of all the |ModuleSpecifier| strings used by the module represented by this record to request the importation of a module. The List is source text occurrence ordered.
@@ -26217,7 +26204,7 @@
                 [[CycleRoot]]
               </td>
               <td>
-                Cyclic Module Record | ~empty~
+                a Cyclic Module Record or ~empty~
               </td>
               <td>
                 The first visited module of the cycle, the root DFS ancestor of the strongly connected component. For a module not in a cycle this would be the module itself. Once Evaluate has completed, a module's [[DFSAncestorIndex]] is equal to the [[DFSIndex]] of its [[CycleRoot]].
@@ -26228,7 +26215,7 @@
                 [[HasTLA]]
               </td>
               <td>
-                Boolean
+                a Boolean
               </td>
               <td>
                 Whether this module is individually asynchronous (for example, if it's a Source Text Module Record containing a top-level await). Having an asynchronous dependency does not mean this field is *true*. This field must not change after the module is parsed.
@@ -26239,7 +26226,7 @@
                 [[AsyncEvaluation]]
               </td>
               <td>
-                Boolean
+                a Boolean
               </td>
               <td>
                 Whether this module is either itself asynchronous or has an asynchronous dependency. Note: The order in which this field is set is used to order queued executions, see <emu-xref href="#sec-async-module-execution-fulfilled"></emu-xref>.
@@ -26250,7 +26237,7 @@
                 [[TopLevelCapability]]
               </td>
               <td>
-                PromiseCapability Record | ~empty~
+                a PromiseCapability Record or ~empty~
               </td>
               <td>
                 If this module is the [[CycleRoot]] of some cycle, and Evaluate() was called on some module in that cycle, this field contains the PromiseCapability Record for that entire evaluation. It is used to settle the Promise object that is returned from the Evaluate() abstract method. This field will be ~empty~ for any dependencies of that module, unless a top-level Evaluate() has been initiated for some of those dependencies.
@@ -26261,7 +26248,7 @@
                 [[AsyncParentModules]]
               </td>
               <td>
-                List of Cyclic Module Records
+                a List of Cyclic Module Records
               </td>
               <td>
                 If this module or a dependency has [[HasTLA]] *true*, and execution is in progress, this tracks the parent importers of this module for the top-level execution job. These parent modules will not start executing before this module has successfully completed execution.
@@ -26272,7 +26259,7 @@
                 [[PendingAsyncDependencies]]
               </td>
               <td>
-                Integer | ~empty~
+                an integer or ~empty~
               </td>
               <td>
                 If this module has any asynchronous dependencies, this tracks the number of asynchronous dependency modules remaining to execute for this module. A module with asynchronous dependencies will be executed when this field reaches 0 and there are no execution errors.
@@ -27052,7 +27039,7 @@
                 [[Context]]
               </td>
               <td>
-                An ECMAScript execution context.
+                an ECMAScript execution context
               </td>
               <td>
                 The execution context associated with this module.
@@ -27063,7 +27050,7 @@
                 [[ImportMeta]]
               </td>
               <td>
-                Object
+                an Object
               </td>
               <td>
                 An object exposed through the `import.meta` meta property. It is ~empty~ until it is accessed by ECMAScript code.
@@ -27074,7 +27061,7 @@
                 [[ImportEntries]]
               </td>
               <td>
-                List of ImportEntry Records
+                a List of ImportEntry Records
               </td>
               <td>
                 A List of ImportEntry records derived from the code of this module.
@@ -27085,7 +27072,7 @@
                 [[LocalExportEntries]]
               </td>
               <td>
-                List of ExportEntry Records
+                a List of ExportEntry Records
               </td>
               <td>
                 A List of ExportEntry records derived from the code of this module that correspond to declarations that occur within the module.
@@ -27096,7 +27083,7 @@
                 [[IndirectExportEntries]]
               </td>
               <td>
-                List of ExportEntry Records
+                a List of ExportEntry Records
               </td>
               <td>
                 A List of ExportEntry records derived from the code of this module that correspond to reexported imports that occur within the module or exports from `export * as namespace` declarations.
@@ -27107,7 +27094,7 @@
                 [[StarExportEntries]]
               </td>
               <td>
-                List of ExportEntry Records
+                a List of ExportEntry Records
               </td>
               <td>
                 A List of ExportEntry records derived from the code of this module that correspond to `export *` declarations that occur within the module, not including `export * as namespace` declarations.
@@ -27134,7 +27121,7 @@
                 [[ModuleRequest]]
               </td>
               <td>
-                String
+                a String
               </td>
               <td>
                 String value of the |ModuleSpecifier| of the |ImportDeclaration|.
@@ -27145,7 +27132,7 @@
                 [[ImportName]]
               </td>
               <td>
-                String | ~namespace-object~
+                a String or ~namespace-object~
               </td>
               <td>
                 The name under which the desired binding is exported by the module identified by [[ModuleRequest]]. The value ~namespace-object~ indicates that the import request is for the target module's namespace object.
@@ -27156,7 +27143,7 @@
                 [[LocalName]]
               </td>
               <td>
-                String
+                a String
               </td>
               <td>
                 The name that is used to locally access the imported value from within the importing module.
@@ -27268,7 +27255,7 @@
                 [[ExportName]]
               </td>
               <td>
-                String | null
+                a String or *null*
               </td>
               <td>
                 The name used to export this binding by this module.
@@ -27279,7 +27266,7 @@
                 [[ModuleRequest]]
               </td>
               <td>
-                String | null
+                a String or *null*
               </td>
               <td>
                 The String value of the |ModuleSpecifier| of the |ExportDeclaration|. *null* if the |ExportDeclaration| does not have a |ModuleSpecifier|.
@@ -27290,7 +27277,7 @@
                 [[ImportName]]
               </td>
               <td>
-                String | null | ~all~ | ~all-but-default~
+                a String, *null*, ~all~, or ~all-but-default~
               </td>
               <td>
                 The name under which the desired binding is exported by the module identified by [[ModuleRequest]]. *null* if the |ExportDeclaration| does not have a |ModuleSpecifier|. ~all~ is used for `export * as ns from "mod"` declarations. ~all-but-default~ is used for `export * from "mod"` declarations.
@@ -27301,7 +27288,7 @@
                 [[LocalName]]
               </td>
               <td>
-                String | null
+                a String or *null*
               </td>
               <td>
                 The name that is used to locally access the exported value from within the importing module. *null* if the exported value is not locally accessible from within the module.
@@ -30342,7 +30329,7 @@
                 [[Key]]
               </td>
               <td>
-                A String
+                a String
               </td>
               <td>
                 A string key used to globally identify a Symbol.
@@ -30353,7 +30340,7 @@
                 [[Symbol]]
               </td>
               <td>
-                A Symbol
+                a Symbol
               </td>
               <td>
                 A symbol that can be retrieved from any realm.
@@ -43129,7 +43116,7 @@ THH:mm:ss.sss
                 [[Promise]]
               </td>
               <td>
-                An object
+                an Object
               </td>
               <td>
                 An object that is usable as a promise.
@@ -43140,7 +43127,7 @@ THH:mm:ss.sss
                 [[Resolve]]
               </td>
               <td>
-                A function object
+                a function object
               </td>
               <td>
                 The function that is used to resolve the given promise.
@@ -43151,7 +43138,7 @@ THH:mm:ss.sss
                 [[Reject]]
               </td>
               <td>
-                A function object
+                a function object
               </td>
               <td>
                 The function that is used to reject the given promise.
@@ -43198,7 +43185,7 @@ THH:mm:ss.sss
                 [[Capability]]
               </td>
               <td>
-                A PromiseCapability Record, or *undefined*
+                a PromiseCapability Record or *undefined*
               </td>
               <td>
                 The capabilities of the promise for which this record provides a reaction handler.
@@ -43209,7 +43196,7 @@ THH:mm:ss.sss
                 [[Type]]
               </td>
               <td>
-                ~Fulfill~ | ~Reject~
+                ~Fulfill~ or ~Reject~
               </td>
               <td>
                 The [[Type]] is used when [[Handler]] is ~empty~ to allow for behaviour specific to the settlement type.
@@ -43220,7 +43207,7 @@ THH:mm:ss.sss
                 [[Handler]]
               </td>
               <td>
-                A JobCallback Record | ~empty~.
+                a JobCallback Record or ~empty~
               </td>
               <td>
                 The function that should be applied to the incoming value, and whose return value will govern what happens to the derived promise. If [[Handler]] is ~empty~, a function that depends on the value of [[Type]] will be used instead.
@@ -44833,12 +44820,12 @@ THH:mm:ss.sss
             </tr>
             <tr>
               <td>[[Completion]]</td>
-              <td>A Completion record</td>
+              <td>a Completion Record</td>
               <td>The completion which should be used to resume the async generator.</td>
             </tr>
             <tr>
               <td>[[Capability]]</td>
-              <td>A PromiseCapability Record</td>
+              <td>a PromiseCapability Record</td>
               <td>The promise capabilities associated with this request.</td>
             </tr>
           </table>
@@ -45522,27 +45509,27 @@ THH:mm:ss.sss
         </tr>
         <tr>
           <td>[[Order]]</td>
-          <td>~SeqCst~ | ~Unordered~</td>
+          <td>~SeqCst~ or ~Unordered~</td>
           <td>The weakest ordering guaranteed by the memory model for the event.</td>
         </tr>
         <tr>
           <td>[[NoTear]]</td>
-          <td>A Boolean</td>
+          <td>a Boolean</td>
           <td>Whether this event is allowed to read from multiple write events on equal range as this event.</td>
         </tr>
         <tr>
           <td>[[Block]]</td>
-          <td>A Shared Data Block</td>
+          <td>a Shared Data Block</td>
           <td>The block the event operates on.</td>
         </tr>
         <tr>
           <td>[[ByteIndex]]</td>
-          <td>A non-negative integer</td>
+          <td>a non-negative integer</td>
           <td>The byte address of the read in [[Block]].</td>
         </tr>
         <tr>
           <td>[[ElementSize]]</td>
-          <td>A non-negative integer</td>
+          <td>a non-negative integer</td>
           <td>The size of the read.</td>
         </tr>
       </table>
@@ -45557,32 +45544,32 @@ THH:mm:ss.sss
         </tr>
         <tr>
           <td>[[Order]]</td>
-          <td>~SeqCst~ | ~Unordered~ | ~Init~</td>
+          <td>~SeqCst~, ~Unordered~, or ~Init~</td>
           <td>The weakest ordering guaranteed by the memory model for the event.</td>
         </tr>
         <tr>
           <td>[[NoTear]]</td>
-          <td>A Boolean</td>
+          <td>a Boolean</td>
           <td>Whether this event is allowed to be read from multiple read events with equal range as this event.</td>
         </tr>
         <tr>
           <td>[[Block]]</td>
-          <td>A Shared Data Block</td>
+          <td>a Shared Data Block</td>
           <td>The block the event operates on.</td>
         </tr>
         <tr>
           <td>[[ByteIndex]]</td>
-          <td>A non-negative integer</td>
+          <td>a non-negative integer</td>
           <td>The byte address of the write in [[Block]].</td>
         </tr>
         <tr>
           <td>[[ElementSize]]</td>
-          <td>A non-negative integer</td>
+          <td>a non-negative integer</td>
           <td>The size of the write.</td>
         </tr>
         <tr>
           <td>[[Payload]]</td>
-          <td>A List</td>
+          <td>a List</td>
           <td>The List of byte values to be read by other events.</td>
         </tr>
       </table>
@@ -45607,27 +45594,27 @@ THH:mm:ss.sss
         </tr>
         <tr>
           <td>[[Block]]</td>
-          <td>A Shared Data Block</td>
+          <td>a Shared Data Block</td>
           <td>The block the event operates on.</td>
         </tr>
         <tr>
           <td>[[ByteIndex]]</td>
-          <td>A non-negative integer</td>
+          <td>a non-negative integer</td>
           <td>The byte address of the read-modify-write in [[Block]].</td>
         </tr>
         <tr>
           <td>[[ElementSize]]</td>
-          <td>A non-negative integer</td>
+          <td>a non-negative integer</td>
           <td>The size of the read-modify-write.</td>
         </tr>
         <tr>
           <td>[[Payload]]</td>
-          <td>A List</td>
+          <td>a List</td>
           <td>The List of byte values to be passed to [[ModifyOp]].</td>
         </tr>
         <tr>
           <td>[[ModifyOp]]</td>
-          <td>A read-modify-write modification function</td>
+          <td>a read-modify-write modification function</td>
           <td>An abstract closure that returns a modified List of byte values from a read List of byte values and [[Payload]].</td>
         </tr>
       </table>
@@ -45655,17 +45642,17 @@ THH:mm:ss.sss
         </tr>
         <tr>
           <td>[[AgentSignifier]]</td>
-          <td>A value that admits equality testing</td>
+          <td>a value that admits equality testing</td>
           <td>The agent whose evaluation resulted in this ordering.</td>
         </tr>
         <tr>
           <td>[[EventList]]</td>
-          <td>A List of events</td>
+          <td>a List of events</td>
           <td>Events are appended to the list during evaluation.</td>
         </tr>
         <tr>
           <td>[[AgentSynchronizesWith]]</td>
-          <td>A List of pairs of Synchronize events</td>
+          <td>a List of pairs of Synchronize events</td>
           <td>Synchronize relationships introduced by the operational semantics.</td>
         </tr>
       </table>
@@ -45684,12 +45671,12 @@ THH:mm:ss.sss
         </tr>
         <tr>
           <td>[[Event]]</td>
-          <td>A Shared Data Block event</td>
+          <td>a Shared Data Block event</td>
           <td>The ReadSharedMemory or ReadModifyWriteSharedMemory event that was introduced for this chosen value.</td>
         </tr>
         <tr>
           <td>[[ChosenValue]]</td>
-          <td>A List of byte values</td>
+          <td>a List of byte values</td>
           <td>The bytes that were nondeterministically chosen during evaluation.</td>
         </tr>
       </table>
@@ -45708,42 +45695,42 @@ THH:mm:ss.sss
         </tr>
         <tr>
           <td>[[EventsRecords]]</td>
-          <td>A List of Agent Events Records.</td>
+          <td>a List of Agent Events Records</td>
           <td>Maps an agent to Lists of events appended during the evaluation.</td>
         </tr>
         <tr>
           <td>[[ChosenValues]]</td>
-          <td>A List of Chosen Value Records.</td>
+          <td>a List of Chosen Value Records</td>
           <td>Maps ReadSharedMemory or ReadModifyWriteSharedMemory events to the List of byte values chosen during the evaluation.</td>
         </tr>
         <tr>
           <td>[[AgentOrder]]</td>
-          <td>An agent-order Relation.</td>
+          <td>an agent-order Relation</td>
           <td>Defined below.</td>
         </tr>
         <tr>
           <td>[[ReadsBytesFrom]]</td>
-          <td>A reads-bytes-from mathematical function.</td>
+          <td>a reads-bytes-from mathematical function</td>
           <td>Defined below.</td>
         </tr>
         <tr>
           <td>[[ReadsFrom]]</td>
-          <td>A reads-from Relation.</td>
+          <td>a reads-from Relation</td>
           <td>Defined below.</td>
         </tr>
         <tr>
           <td>[[HostSynchronizesWith]]</td>
-          <td>A host-synchronizes-with Relation.</td>
+          <td>a host-synchronizes-with Relation</td>
           <td>Defined below.</td>
         </tr>
         <tr>
           <td>[[SynchronizesWith]]</td>
-          <td>A synchronizes-with Relation.</td>
+          <td>a synchronizes-with Relation</td>
           <td>Defined below.</td>
         </tr>
         <tr>
           <td>[[HappensBefore]]</td>
-          <td>A happens-before Relation.</td>
+          <td>a happens-before Relation</td>
           <td>Defined below.</td>
         </tr>
       </table>


### PR DESCRIPTION
In tables that 'declare' the fields of a Record schema, reword the 'types' (in the `Value` or `Value Type` column) to use the same (or similar) style as the parameters of abstract operations.

(Currently, they're in a variety of styles.)