### PR TITLE
Editorial: Note how edge case in GetSubstitution can arise

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -33809,6 +33809,7 @@ THH:mm:ss.sss
                 1. Let _matchLength_ be the number of code units in _matched_.
                 1. Let _tailPos_ be _position_ + _matchLength_.
                 1. Let _refReplacement_ be the substring of _str_ from min(_tailPos_, _stringLength_).
+                1. NOTE: _tailPos_ can exceed _stringLength_ only if this abstract operation was invoked by a call to the intrinsic @@replace method of %RegExp.prototype% on an object whose *"exec"* property is not the intrinsic %RegExp.prototype.exec%.
               1. Else if _templateRemainder_ starts with *"$"* followed by 1 or more decimal digits, then
                 1. Let _found_ be *false*.
                 1. For each integer _d_ of &laquo; 2, 1 &raquo;, do


### PR DESCRIPTION
This adds the note I suggested [here](https://github.com/tc39/ecma262/pull/2484#discussion_r684597033).

It's a bit wordy because the edge case can only happen in very specific circumstances. I'm very open to suggestions for improved wording here.