### PR TITLE
Editorial: Introduce the term "must cover" (replaces "is [not] covering")

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -553,6 +553,11 @@
       <p>Productions of the syntactic grammar are distinguished by having just one colon &ldquo;<b>:</b>&rdquo; as punctuation.</p>
       <p>The syntactic grammar as presented in clauses <emu-xref href="#sec-ecmascript-language-expressions"></emu-xref> through <emu-xref href="#sec-ecmascript-language-scripts-and-modules"></emu-xref> is not a complete account of which token sequences are accepted as a correct ECMAScript |Script| or |Module|. Certain additional token sequences are also accepted, namely, those that would be described by the grammar if only semicolons were added to the sequence in certain places (such as before line terminator characters). Furthermore, certain token sequences that are described by the grammar are not considered acceptable if a line terminator character appears in certain &ldquo;awkward&rdquo; places.</p>
       <p>In certain cases, in order to avoid ambiguities, the syntactic grammar uses generalized productions that permit token sequences that do not form a valid ECMAScript |Script| or |Module|. For example, this technique is used for object literals and object destructuring patterns. In such cases a more restrictive <em>supplemental grammar</em> is provided that further restricts the acceptable token sequences. Typically, an early error rule will then define an error condition if "_P_ is not <dfn>covering</dfn> an _N_", where _P_ is a Parse Node (an instance of the generalized production) and _N_ is a nonterminal from the supplemental grammar. Here, the sequence of tokens originally matched by _P_ is parsed again using _N_ as the goal symbol. (If _N_ takes grammatical parameters, then they are set to the same values used when _P_ was originally parsed.) An error occurs if the sequence of tokens cannot be parsed as a single instance of _N_, with no tokens left over. Subsequently, algorithms access the result of the parse using a phrase of the form "the _N_ that is <dfn>covered</dfn> by _P_". This will always be a Parse Node (an instance of _N_, unique for a given _P_), since any parsing failure would have been detected by an early error rule.</p>
+      <p>An early error rule of the form: "_P_ <dfn id="must-cover">must cover</dfn> an _N_" is a shorthand for:</p>
+      <ul>
+        <li>It is a Syntax Error if _P_ is not covering an _N_.</li>
+        <li>All Early Error rules for _N_ and its derived productions also apply to the _N_ that is covered by _P_.</li>
+      </ul>
     </emu-clause>
 
     <emu-clause id="sec-grammar-notation" namespace="grammar-notation">
@@ -18632,10 +18637,7 @@
         <emu-grammar>PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if |CoverParenthesizedExpressionAndArrowParameterList| is not covering a |ParenthesizedExpression|.
-          </li>
-          <li>
-            All Early Error rules for |ParenthesizedExpression| and its derived productions also apply to the |ParenthesizedExpression| that is covered by |CoverParenthesizedExpressionAndArrowParameterList|.
+            |CoverParenthesizedExpressionAndArrowParameterList| must cover a |ParenthesizedExpression|.
           </li>
         </ul>
       </emu-clause>
@@ -20266,10 +20268,7 @@
       <p>If |LeftHandSideExpression| is an |ObjectLiteral| or an |ArrayLiteral|, the following Early Error rules are applied:</p>
       <ul>
         <li>
-          It is a Syntax Error if |LeftHandSideExpression| is not covering an |AssignmentPattern|.
-        </li>
-        <li>
-          All Early Error rules for |AssignmentPattern| and its derived productions also apply to the |AssignmentPattern| that is covered by |LeftHandSideExpression|.
+          |LeftHandSideExpression| must cover an |AssignmentPattern|.
         </li>
       </ul>
       <p>If |LeftHandSideExpression| is neither an |ObjectLiteral| nor an |ArrayLiteral|, the following Early Error rule is applied:</p>
@@ -20543,10 +20542,7 @@
         <p>If |LeftHandSideExpression| is an |ObjectLiteral| or an |ArrayLiteral|, the following Early Error rules are applied:</p>
         <ul>
           <li>
-            It is a Syntax Error if |LeftHandSideExpression| is not covering an |AssignmentPattern|.
-          </li>
-          <li>
-            All Early Error rules for |AssignmentPattern| and its derived productions also apply to the |AssignmentPattern| that is covered by |LeftHandSideExpression|.
+            |LeftHandSideExpression| must cover an |AssignmentPattern|.
           </li>
         </ul>
         <p>If |LeftHandSideExpression| is neither an |ObjectLiteral| nor an |ArrayLiteral|, the following Early Error rule is applied:</p>
@@ -21754,10 +21750,7 @@
         <p>If |LeftHandSideExpression| is either an |ObjectLiteral| or an |ArrayLiteral|, the following Early Error rules are applied:</p>
         <ul>
           <li>
-            It is a Syntax Error if |LeftHandSideExpression| is not covering an |AssignmentPattern|.
-          </li>
-          <li>
-            All Early Error rules for |AssignmentPattern| and its derived productions also apply to the |AssignmentPattern| that is covered by |LeftHandSideExpression|.
+            |LeftHandSideExpression| must cover an |AssignmentPattern|.
           </li>
         </ul>
         <p>If |LeftHandSideExpression| is neither an |ObjectLiteral| nor an |ArrayLiteral|, the following Early Error rule is applied:</p>
@@ -23359,10 +23352,7 @@
       <emu-grammar>ArrowParameters : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
       <ul>
         <li>
-          It is a Syntax Error if |CoverParenthesizedExpressionAndArrowParameterList| is not covering an |ArrowFormalParameters|.
-        </li>
-        <li>
-          All early error rules for |ArrowFormalParameters| and its derived productions also apply to the |ArrowFormalParameters| that is covered by |CoverParenthesizedExpressionAndArrowParameterList|.
+          |CoverParenthesizedExpressionAndArrowParameterList| must cover an |ArrowFormalParameters|.
         </li>
       </ul>
     </emu-clause>
@@ -25067,12 +25057,11 @@
         AsyncArrowFunction : CoverCallExpressionAndAsyncArrowHead `=>` AsyncConciseBody
       </emu-grammar>
       <ul>
+        <li>|CoverCallExpressionAndAsyncArrowHead| must cover an |AsyncArrowHead|.</li>
         <li>It is a Syntax Error if |CoverCallExpressionAndAsyncArrowHead| Contains |YieldExpression| is *true*.</li>
         <li>It is a Syntax Error if |CoverCallExpressionAndAsyncArrowHead| Contains |AwaitExpression| is *true*.</li>
-        <li>It is a Syntax Error if |CoverCallExpressionAndAsyncArrowHead| is not covering an |AsyncArrowHead|.</li>
         <li>It is a Syntax Error if any element of the BoundNames of |CoverCallExpressionAndAsyncArrowHead| also occurs in the LexicallyDeclaredNames of |AsyncConciseBody|.</li>
         <li>It is a Syntax Error if AsyncConciseBodyContainsUseStrict of |AsyncConciseBody| is *true* and IsSimpleParameterList of |CoverCallExpressionAndAsyncArrowHead| is *false*.</li>
-        <li>All Early Error rules for |AsyncArrowHead| and its derived productions apply to the |AsyncArrowHead| that is covered by |CoverCallExpressionAndAsyncArrowHead|.</li>
       </ul>
     </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -552,12 +552,17 @@
       <emu-note>Parse Nodes are specification artefacts, and implementations are not required to use an analogous data structure.</emu-note>
       <p>Productions of the syntactic grammar are distinguished by having just one colon &ldquo;<b>:</b>&rdquo; as punctuation.</p>
       <p>The syntactic grammar as presented in clauses <emu-xref href="#sec-ecmascript-language-expressions"></emu-xref> through <emu-xref href="#sec-ecmascript-language-scripts-and-modules"></emu-xref> is not a complete account of which token sequences are accepted as a correct ECMAScript |Script| or |Module|. Certain additional token sequences are also accepted, namely, those that would be described by the grammar if only semicolons were added to the sequence in certain places (such as before line terminator characters). Furthermore, certain token sequences that are described by the grammar are not considered acceptable if a line terminator character appears in certain &ldquo;awkward&rdquo; places.</p>
-      <p>In certain cases, in order to avoid ambiguities, the syntactic grammar uses generalized productions that permit token sequences that do not form a valid ECMAScript |Script| or |Module|. For example, this technique is used for object literals and object destructuring patterns. In such cases a more restrictive <em>supplemental grammar</em> is provided that further restricts the acceptable token sequences. Typically, an early error rule will then define an error condition if "_P_ is not <dfn>covering</dfn> an _N_", where _P_ is a Parse Node (an instance of the generalized production) and _N_ is a nonterminal from the supplemental grammar. Here, the sequence of tokens originally matched by _P_ is parsed again using _N_ as the goal symbol. (If _N_ takes grammatical parameters, then they are set to the same values used when _P_ was originally parsed.) An error occurs if the sequence of tokens cannot be parsed as a single instance of _N_, with no tokens left over. Subsequently, algorithms access the result of the parse using a phrase of the form "the _N_ that is <dfn>covered</dfn> by _P_". This will always be a Parse Node (an instance of _N_, unique for a given _P_), since any parsing failure would have been detected by an early error rule.</p>
-      <p>An early error rule of the form: "_P_ <dfn id="must-cover">must cover</dfn> an _N_" is a shorthand for:</p>
-      <ul>
-        <li>It is a Syntax Error if _P_ is not covering an _N_.</li>
-        <li>All Early Error rules for _N_ and its derived productions also apply to the _N_ that is covered by _P_.</li>
-      </ul>
+      <p>In certain cases, in order to avoid ambiguities, the syntactic grammar uses generalized productions that permit token sequences that do not form a valid ECMAScript |Script| or |Module|. For example, this technique is used for object literals and object destructuring patterns. In such cases a more restrictive <em>supplemental grammar</em> is provided that further restricts the acceptable token sequences. Typically, an early error rule will then state that, in certain contexts, "_P_ <dfn id="must-cover">must cover</dfn> an _N_", where _P_ is a Parse Node (an instance of the generalized production) and _N_ is a nonterminal from the supplemental grammar. This means:</p>
+      <ol>
+        <li>The sequence of tokens originally matched by _P_ is parsed again using _N_ as the goal symbol. If _N_ takes grammatical parameters, then they are set to the same values used when _P_ was originally parsed.</li>
+        <li>If the sequence of tokens can be parsed as a single instance of _N_, with no tokens left over, then:
+          <ol>
+            <li>We refer to that instance of _N_ (a Parse Node, unique for a given _P_) as "the _N_ that is <dfn>covered</dfn> by _P_".</li>
+            <li>All Early Error rules for _N_ and its derived productions also apply to the _N_ that is covered by _P_.</li>
+          </ol>
+        </li>
+        <li>Otherwise (if the parse fails), it is an early Syntax Error.</li>
+      </ol>
     </emu-clause>
 
     <emu-clause id="sec-grammar-notation" namespace="grammar-notation">


### PR DESCRIPTION
The early error rules:
- It is a Syntax Error if _P_ is not covering an _N_.
- All Early Error rules for _N_ and its derived productions also apply to the _N_ that is covered by _P_.

always occur together, so replace them with the single rule:
- _P_ must cover an _N_.