### PR TITLE
Editorial: Eliminate "the code point value of X"

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -16972,7 +16972,7 @@
             The SV of <emu-grammar>SingleStringCharacters :: SingleStringCharacter SingleStringCharacters</emu-grammar> is the string-concatenation of the SV of |SingleStringCharacter| and the SV of |SingleStringCharacters|.
           </li>
           <li>
-            The SV of <emu-grammar>DoubleStringCharacter :: SourceCharacter but not one of `"` or `\` or LineTerminator</emu-grammar> is the result of performing UTF16EncodeCodePoint on the code point value of |SourceCharacter|.
+            The SV of <emu-grammar>DoubleStringCharacter :: SourceCharacter but not one of `"` or `\` or LineTerminator</emu-grammar> is the result of performing UTF16EncodeCodePoint on the code point matched by |SourceCharacter|.
           </li>
           <li>
             The SV of <emu-grammar>DoubleStringCharacter :: &lt;LS&gt;</emu-grammar> is the String value consisting of the code unit 0x2028 (LINE SEPARATOR).
@@ -16984,7 +16984,7 @@
             The SV of <emu-grammar>DoubleStringCharacter :: LineContinuation</emu-grammar> is the empty String.
           </li>
           <li>
-            The SV of <emu-grammar>SingleStringCharacter :: SourceCharacter but not one of `'` or `\` or LineTerminator</emu-grammar> is the result of performing UTF16EncodeCodePoint on the code point value of |SourceCharacter|.
+            The SV of <emu-grammar>SingleStringCharacter :: SourceCharacter but not one of `'` or `\` or LineTerminator</emu-grammar> is the result of performing UTF16EncodeCodePoint on the code point matched by |SourceCharacter|.
           </li>
           <li>
             The SV of <emu-grammar>SingleStringCharacter :: &lt;LS&gt;</emu-grammar> is the String value consisting of the code unit 0x2028 (LINE SEPARATOR).
@@ -17148,7 +17148,7 @@
         </emu-table>
         <ul>
           <li>
-            The SV of <emu-grammar>NonEscapeCharacter :: SourceCharacter but not one of EscapeCharacter or LineTerminator</emu-grammar> is the result of performing UTF16EncodeCodePoint on the code point value of |SourceCharacter|.
+            The SV of <emu-grammar>NonEscapeCharacter :: SourceCharacter but not one of EscapeCharacter or LineTerminator</emu-grammar> is the result of performing UTF16EncodeCodePoint on the code point matched by |SourceCharacter|.
           </li>
           <li>
             The SV of <emu-grammar>EscapeSequence :: LegacyOctalEscapeSequence</emu-grammar> is the String value consisting of the code unit whose value is the MV of |LegacyOctalEscapeSequence|.
@@ -17382,7 +17382,7 @@
             The TV of <emu-grammar>TemplateCharacters :: TemplateCharacter TemplateCharacters</emu-grammar> is *undefined* if either the TV of |TemplateCharacter| is *undefined* or the TV of |TemplateCharacters| is *undefined*. Otherwise, it is the string-concatenation of the TV of |TemplateCharacter| and the TV of |TemplateCharacters|.
           </li>
           <li>
-            The TV of <emu-grammar>TemplateCharacter :: SourceCharacter but not one of ``` or `\` or `$` or LineTerminator</emu-grammar> is the result of performing UTF16EncodeCodePoint on the code point value of |SourceCharacter|.
+            The TV of <emu-grammar>TemplateCharacter :: SourceCharacter but not one of ``` or `\` or `$` or LineTerminator</emu-grammar> is the result of performing UTF16EncodeCodePoint on the code point matched by |SourceCharacter|.
           </li>
           <li>
             The TV of <emu-grammar>TemplateCharacter :: `$`</emu-grammar> is the String value consisting of the code unit 0x0024 (DOLLAR SIGN).
@@ -17425,7 +17425,7 @@
             The TRV of <emu-grammar>TemplateCharacters :: TemplateCharacter TemplateCharacters</emu-grammar> is the string-concatenation of the TRV of |TemplateCharacter| and the TRV of |TemplateCharacters|.
           </li>
           <li>
-            The TRV of <emu-grammar>TemplateCharacter :: SourceCharacter but not one of ``` or `\` or `$` or LineTerminator</emu-grammar> is the result of performing UTF16EncodeCodePoint on the code point value of |SourceCharacter|.
+            The TRV of <emu-grammar>TemplateCharacter :: SourceCharacter but not one of ``` or `\` or `$` or LineTerminator</emu-grammar> is the result of performing UTF16EncodeCodePoint on the code point matched by |SourceCharacter|.
           </li>
           <li>
             The TRV of <emu-grammar>TemplateCharacter :: `$`</emu-grammar> is the String value consisting of the code unit 0x0024 (DOLLAR SIGN).
@@ -33518,7 +33518,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-string.prototype.codepointat">
         <h1>String.prototype.codePointAt ( _pos_ )</h1>
         <emu-note>
-          <p>Returns a non-negative integral Number less than or equal to *0x10FFFF*<sub>𝔽</sub> that is the code point value of the UTF-16 encoded code point (<emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>) starting at the string element at index _pos_ within the String resulting from converting this object to a String. If there is no element at that index, the result is *undefined*. If a valid UTF-16 <emu-xref href="#surrogate-pair"></emu-xref> does not begin at _pos_, the result is the code unit at _pos_.</p>
+          <p>Returns a non-negative integral Number less than or equal to *0x10FFFF*<sub>𝔽</sub> that is the numeric value of the UTF-16 encoded code point (<emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>) starting at the string element at index _pos_ within the String resulting from converting this object to a String. If there is no element at that index, the result is *undefined*. If a valid UTF-16 <emu-xref href="#surrogate-pair"></emu-xref> does not begin at _pos_, the result is the code unit at _pos_.</p>
         </emu-note>
         <p>When the `codePointAt` method is called with one argument _pos_, the following steps are taken:</p>
         <emu-alg>
@@ -34578,7 +34578,7 @@ THH:mm:ss.sss
         <emu-grammar>RegExpIdentifierStart :: `\` RegExpUnicodeEscapeSequence</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the CharacterValue of |RegExpUnicodeEscapeSequence| is not the code point value of some code point matched by the |IdentifierStartChar| lexical grammar production.
+            It is a Syntax Error if the CharacterValue of |RegExpUnicodeEscapeSequence| is not the numeric value of some code point matched by the |IdentifierStartChar| lexical grammar production.
           </li>
         </ul>
         <emu-grammar>RegExpIdentifierStart :: UnicodeLeadSurrogate UnicodeTrailSurrogate</emu-grammar>
@@ -34590,7 +34590,7 @@ THH:mm:ss.sss
         <emu-grammar>RegExpIdentifierPart :: `\` RegExpUnicodeEscapeSequence</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the CharacterValue of |RegExpUnicodeEscapeSequence| is not the code point value of some code point matched by the |IdentifierPartChar| lexical grammar production.
+            It is a Syntax Error if the CharacterValue of |RegExpUnicodeEscapeSequence| is not the numeric value of some code point matched by the |IdentifierPartChar| lexical grammar production.
           </li>
         </ul>
         <emu-grammar>RegExpIdentifierPart :: UnicodeLeadSurrogate UnicodeTrailSurrogate</emu-grammar>
@@ -34674,30 +34674,30 @@ THH:mm:ss.sss
           ClassAtom :: `-`
         </emu-grammar>
         <emu-alg>
-          1. Return the code point value of U+002D (HYPHEN-MINUS).
+          1. Return the numeric value of U+002D (HYPHEN-MINUS).
         </emu-alg>
         <emu-grammar>
           ClassAtomNoDash :: SourceCharacter but not one of `\` or `]` or `-`
         </emu-grammar>
         <emu-alg>
           1. Let _ch_ be the code point matched by |SourceCharacter|.
-          1. Return the code point value of _ch_.
+          1. Return the numeric value of _ch_.
         </emu-alg>
         <emu-grammar>
           ClassEscape :: `b`
         </emu-grammar>
         <emu-alg>
-          1. Return the code point value of U+0008 (BACKSPACE).
+          1. Return the numeric value of U+0008 (BACKSPACE).
         </emu-alg>
         <emu-grammar>
           ClassEscape :: `-`
         </emu-grammar>
         <emu-alg>
-          1. Return the code point value of U+002D (HYPHEN-MINUS).
+          1. Return the numeric value of U+002D (HYPHEN-MINUS).
         </emu-alg>
         <emu-grammar>CharacterEscape :: ControlEscape</emu-grammar>
         <emu-alg>
-          1. Return the code point value according to <emu-xref href="#table-controlescape-code-point-values"></emu-xref>.
+          1. Return the numeric value according to <emu-xref href="#table-controlescape-code-point-values"></emu-xref>.
         </emu-alg>
         <emu-table id="table-controlescape-code-point-values" caption="ControlEscape Code Point Values" oldids="table-47">
           <table>
@@ -34706,7 +34706,7 @@ THH:mm:ss.sss
                 ControlEscape
               </th>
               <th>
-                Code Point Value
+                Numeric Value
               </th>
               <th>
                 Code Point
@@ -34808,12 +34808,12 @@ THH:mm:ss.sss
         <emu-grammar>CharacterEscape :: `c` ControlLetter</emu-grammar>
         <emu-alg>
           1. Let _ch_ be the code point matched by |ControlLetter|.
-          1. Let _i_ be _ch_'s code point value.
+          1. Let _i_ be the numeric value of _ch_.
           1. Return the remainder of dividing _i_ by 32.
         </emu-alg>
         <emu-grammar>CharacterEscape :: `0` [lookahead &notin; DecimalDigit]</emu-grammar>
         <emu-alg>
-          1. Return the code point value of U+0000 (NULL).
+          1. Return the numeric value of U+0000 (NULL).
         </emu-alg>
         <emu-note>
           <p>`\\0` represents the &lt;NUL&gt; character and cannot be followed by a decimal digit.</p>
@@ -34827,7 +34827,7 @@ THH:mm:ss.sss
           1. Let _lead_ be the CharacterValue of |HexLeadSurrogate|.
           1. Let _trail_ be the CharacterValue of |HexTrailSurrogate|.
           1. Let _cp_ be UTF16SurrogatePairToCodePoint(_lead_, _trail_).
-          1. Return the code point value of _cp_.
+          1. Return the numeric value of _cp_.
         </emu-alg>
         <emu-grammar>RegExpUnicodeEscapeSequence :: `u` Hex4Digits</emu-grammar>
         <emu-alg>
@@ -34850,7 +34850,7 @@ THH:mm:ss.sss
         <emu-grammar>CharacterEscape :: IdentityEscape</emu-grammar>
         <emu-alg>
           1. Let _ch_ be the code point matched by |IdentityEscape|.
-          1. Return the code point value of _ch_.
+          1. Return the numeric value of _ch_.
         </emu-alg>
       </emu-clause>
 
@@ -46773,12 +46773,12 @@ THH:mm:ss.sss
           ClassAtomNoDash :: `\` [lookahead == `c`]
         </emu-grammar>
         <emu-alg>
-          1. Return the code point value of U+005C (REVERSE SOLIDUS).
+          1. Return the numeric value of U+005C (REVERSE SOLIDUS).
         </emu-alg>
         <emu-grammar>ClassEscape :: `c` ClassControlLetter</emu-grammar>
         <emu-alg>
           1. Let _ch_ be the code point matched by |ClassControlLetter|.
-          1. Let _i_ be _ch_'s code point value.
+          1. Let _i_ be the numeric value of _ch_.
           1. Return the remainder of dividing _i_ by 32.
         </emu-alg>
         <emu-grammar>CharacterEscape :: LegacyOctalEscapeSequence</emu-grammar>


### PR DESCRIPTION
In a phrase such as "the String value of a string literal", we understand that the string literal is not a String value, but we do something to it to get a String value, the value denoted by the phrase.

By analogy, we would expect that in "the code point value of X", X is not a code point, but we do something to it to get a code point value, which is the value denoted by the phrase.  However, that's not the case: the intent is that X *is* a code point, and the phrase denotes its underlying integer value.

(Exception: The phrase "the code point value of |SourceCharacter|" *does* appear to denote a code point, namely the one matched by |SourceCharacter|.)

I think this phrasing (which goes back to ES3) is confusing, so this PR eliminates it.

Notes:
- The phrase "code point value" is okay if it's basically just a synonym for "code point", so a few such occurrences remain.
- Commit bfecd4f in PR #971 did something similar for code *units*, eliminating the phrase "code unit value". That commit plus this PR are steps toward resolving Issue #2181.)
- I've presented this as multiple commits, but I think it would be okay to squash them before merging.