### PR TITLE
Editorial: GlobalDeclarationInstantiation takes a Script

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -25847,13 +25847,13 @@
     <emu-clause id="sec-globaldeclarationinstantiation" type="abstract operation">
       <h1>
         GlobalDeclarationInstantiation (
-          _script_: a |ScriptBody| Parse Node,
+          _script_: a |Script| Parse Node,
           _env_: a global Environment Record,
         ): either a normal completion containing ~unused~ or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>_script_ is the |ScriptBody| for which the execution context is being established. _env_ is the global environment in which bindings are to be created.</dd>
+        <dd>_script_ is the |Script| for which the execution context is being established. _env_ is the global environment in which bindings are to be created.</dd>
       </dl>
       <emu-note>
         <p>When an execution context is established for evaluating scripts, declarations are instantiated in the current global environment. Each global binding declared in the code is instantiated.</p>


### PR DESCRIPTION
GlobalDeclarationInstantiation's `_script_` parameter is a *Script* Parse Node, not a *ScriptBody* Parse Node.

(I thought I had fixed this already, but I was remembering Issue #2354, which identified the problem in passing.)