### PR TITLE
Editorial: Remove ! from IsCallable invocation, be consistent with others.

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -37074,7 +37074,7 @@ THH:mm:ss.sss
           <dl class="header">
           </dl>
           <emu-alg>
-            1. Assert: If _mapperFunction_ is present, then ! IsCallable(_mapperFunction_) is *true*, _thisArg_ is present, and _depth_ is 1.
+            1. Assert: If _mapperFunction_ is present, then IsCallable(_mapperFunction_) is *true*, _thisArg_ is present, and _depth_ is 1.
             1. Let _targetIndex_ be _start_.
             1. Let _sourceIndex_ be *+0*<sub>𝔽</sub>.
             1. Repeat, while ℝ(_sourceIndex_) &lt; _sourceLen_,

--- a/spec.html
+++ b/spec.html
@@ -37108,7 +37108,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _sourceLen_ be ? LengthOfArrayLike(_O_).
-          1. If ! IsCallable(_mapperFunction_) is *false*, throw a *TypeError* exception.
+          1. If IsCallable(_mapperFunction_) is *false*, throw a *TypeError* exception.
           1. Let _A_ be ? ArraySpeciesCreate(_O_, 0).
           1. Perform ? FlattenIntoArray(_A_, _O_, _sourceLen_, 0, 1, _mapperFunction_, _thisArg_).
           1. Return _A_.


### PR DESCRIPTION
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->

NOW, I'm just wondering why other methods(forEach/map...) don't have this.
Should it be consistent ?
THANKS...