### PR TITLE
Editorial: Fix sign of zero in Number::remainder

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1897,6 +1897,7 @@
             1. If _n_ is *+0*<sub>𝔽</sub> or _n_ is *-0*<sub>𝔽</sub>, return _n_.
             1. Assert: _n_ and _d_ are finite and non-zero.
             1. Let _r_ be ℝ(_n_) - (ℝ(_d_) &times; _q_) where _q_ is an integer that is negative if and only if _n_ and _d_ have opposite sign, and whose magnitude is as large as possible without exceeding the magnitude of ℝ(_n_) / ℝ(_d_).
+            1. If _r_ is 0 and _n_ &lt; *+0*<sub>𝔽</sub>, return *-0*<sub>𝔽</sub>.
             1. Return 𝔽(_r_).
           </emu-alg>
           <emu-note>


### PR DESCRIPTION
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
Fixes #2611.

Added the line suggested by @michaelficarra. I changed the phrase “is negative” to “&lt; +0<sub>𝔽</sub>” for the consistency with other part of the spec.