### PR TITLE
Markup: add `sdo` types to `emu-clause` in missing parts

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -17862,7 +17862,7 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-identifiers-runtime-semantics-evaluation">
+    <emu-clause id="sec-identifiers-runtime-semantics-evaluation" type="sdo">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>IdentifierReference : Identifier</emu-grammar>
       <emu-alg>
@@ -17927,7 +17927,7 @@
     <emu-clause id="sec-this-keyword">
       <h1>The `this` Keyword</h1>
 
-      <emu-clause id="sec-this-keyword-runtime-semantics-evaluation">
+      <emu-clause id="sec-this-keyword-runtime-semantics-evaluation" type="sdo">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>PrimaryExpression : `this`</emu-grammar>
         <emu-alg>
@@ -17952,7 +17952,7 @@
           StringLiteral
       </emu-grammar>
 
-      <emu-clause id="sec-literals-runtime-semantics-evaluation">
+      <emu-clause id="sec-literals-runtime-semantics-evaluation" type="sdo">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>Literal : NullLiteral</emu-grammar>
         <emu-alg>
@@ -18076,7 +18076,7 @@
         </emu-note>
       </emu-clause>
 
-      <emu-clause id="sec-array-initializer-runtime-semantics-evaluation">
+      <emu-clause id="sec-array-initializer-runtime-semantics-evaluation" type="sdo">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>ArrayLiteral : `[` Elision? `]`</emu-grammar>
         <emu-alg>
@@ -18223,7 +18223,7 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-object-initializer-runtime-semantics-evaluation">
+      <emu-clause id="sec-object-initializer-runtime-semantics-evaluation" type="sdo">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>ObjectLiteral : `{` `}`</emu-grammar>
         <emu-alg>
@@ -18363,7 +18363,7 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-regular-expression-literals-runtime-semantics-evaluation">
+      <emu-clause id="sec-regular-expression-literals-runtime-semantics-evaluation" type="sdo">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>PrimaryExpression : RegularExpressionLiteral</emu-grammar>
         <emu-alg>
@@ -18577,7 +18577,7 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-template-literals-runtime-semantics-evaluation">
+      <emu-clause id="sec-template-literals-runtime-semantics-evaluation" type="sdo">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>TemplateLiteral : NoSubstitutionTemplate</emu-grammar>
         <emu-alg>
@@ -18647,7 +18647,7 @@
         </ul>
       </emu-clause>
 
-      <emu-clause id="sec-grouping-operator-runtime-semantics-evaluation">
+      <emu-clause id="sec-grouping-operator-runtime-semantics-evaluation" type="sdo">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
         <emu-alg>
@@ -18830,7 +18830,7 @@
         <p>where &lt;<i>identifier-name-string</i>&gt; is the result of evaluating StringValue of |IdentifierName|.</p>
       </emu-note>
 
-      <emu-clause id="sec-property-accessors-runtime-semantics-evaluation">
+      <emu-clause id="sec-property-accessors-runtime-semantics-evaluation" type="sdo">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>MemberExpression : MemberExpression `[` Expression `]`</emu-grammar>
         <emu-alg>
@@ -18914,7 +18914,7 @@
     <emu-clause id="sec-new-operator">
       <h1>The `new` Operator</h1>
 
-      <emu-clause id="sec-new-operator-runtime-semantics-evaluation">
+      <emu-clause id="sec-new-operator-runtime-semantics-evaluation" type="sdo">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>NewExpression : `new` NewExpression</emu-grammar>
         <emu-alg>
@@ -18950,7 +18950,7 @@
     <emu-clause id="sec-function-calls">
       <h1>Function Calls</h1>
 
-      <emu-clause id="sec-function-calls-runtime-semantics-evaluation">
+      <emu-clause id="sec-function-calls-runtime-semantics-evaluation" type="sdo">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>CallExpression : CoverCallExpressionAndAsyncArrowHead</emu-grammar>
         <emu-alg>
@@ -19017,7 +19017,7 @@
     <emu-clause id="sec-super-keyword">
       <h1>The `super` Keyword</h1>
 
-      <emu-clause id="sec-super-keyword-runtime-semantics-evaluation">
+      <emu-clause id="sec-super-keyword-runtime-semantics-evaluation" type="sdo">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>SuperProperty : `super` `[` Expression `]`</emu-grammar>
         <emu-alg>
@@ -19166,7 +19166,7 @@
       <h1>Optional Chains</h1>
       <emu-note>An optional chain is a chain of one or more property accesses and function calls, the first of which begins with the token `?.`.</emu-note>
 
-      <emu-clause id="sec-optional-chaining-evaluation">
+      <emu-clause id="sec-optional-chaining-evaluation" type="sdo">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>
           OptionalExpression :
@@ -19272,7 +19272,7 @@
     <emu-clause id="sec-import-calls">
       <h1>Import Calls</h1>
 
-      <emu-clause id="sec-import-call-runtime-semantics-evaluation">
+      <emu-clause id="sec-import-call-runtime-semantics-evaluation" type="sdo">
         <h1>Runtime Semantics: Evaluation</h1>
 
         <emu-grammar>ImportCall : `import` `(` AssignmentExpression `)`</emu-grammar>
@@ -19295,7 +19295,7 @@
         <p>A tagged template is a function call where the arguments of the call are derived from a |TemplateLiteral| (<emu-xref href="#sec-template-literals"></emu-xref>). The actual arguments include a template object (<emu-xref href="#sec-gettemplateobject"></emu-xref>) and the values produced by evaluating the expressions embedded within the |TemplateLiteral|.</p>
       </emu-note>
 
-      <emu-clause id="sec-tagged-templates-runtime-semantics-evaluation">
+      <emu-clause id="sec-tagged-templates-runtime-semantics-evaluation" type="sdo">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>MemberExpression : MemberExpression TemplateLiteral</emu-grammar>
         <emu-alg>
@@ -19319,7 +19319,7 @@
     <emu-clause id="sec-meta-properties">
       <h1>Meta Properties</h1>
 
-      <emu-clause id="sec-meta-properties-runtime-semantics-evaluation">
+      <emu-clause id="sec-meta-properties-runtime-semantics-evaluation" type="sdo">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>NewTarget : `new` `.` `target`</emu-grammar>
         <emu-alg>
@@ -19430,7 +19430,7 @@
     <emu-clause id="sec-postfix-increment-operator">
       <h1>Postfix Increment Operator</h1>
 
-      <emu-clause id="sec-postfix-increment-operator-runtime-semantics-evaluation">
+      <emu-clause id="sec-postfix-increment-operator-runtime-semantics-evaluation" type="sdo">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>UpdateExpression : LeftHandSideExpression `++`</emu-grammar>
         <emu-alg>
@@ -19450,7 +19450,7 @@
     <emu-clause id="sec-postfix-decrement-operator">
       <h1>Postfix Decrement Operator</h1>
 
-      <emu-clause id="sec-postfix-decrement-operator-runtime-semantics-evaluation">
+      <emu-clause id="sec-postfix-decrement-operator-runtime-semantics-evaluation" type="sdo">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>UpdateExpression : LeftHandSideExpression `--`</emu-grammar>
         <emu-alg>
@@ -19470,7 +19470,7 @@
     <emu-clause id="sec-prefix-increment-operator">
       <h1>Prefix Increment Operator</h1>
 
-      <emu-clause id="sec-prefix-increment-operator-runtime-semantics-evaluation">
+      <emu-clause id="sec-prefix-increment-operator-runtime-semantics-evaluation" type="sdo">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>UpdateExpression : `++` UnaryExpression</emu-grammar>
         <emu-alg>
@@ -19490,7 +19490,7 @@
     <emu-clause id="sec-prefix-decrement-operator">
       <h1>Prefix Decrement Operator</h1>
 
-      <emu-clause id="sec-prefix-decrement-operator-runtime-semantics-evaluation">
+      <emu-clause id="sec-prefix-decrement-operator-runtime-semantics-evaluation" type="sdo">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>UpdateExpression : `--` UnaryExpression</emu-grammar>
         <emu-alg>
@@ -19547,7 +19547,7 @@
         </emu-note>
       </emu-clause>
 
-      <emu-clause id="sec-delete-operator-runtime-semantics-evaluation">
+      <emu-clause id="sec-delete-operator-runtime-semantics-evaluation" type="sdo">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>UnaryExpression : `delete` UnaryExpression</emu-grammar>
         <emu-alg>
@@ -19581,7 +19581,7 @@
     <emu-clause id="sec-void-operator">
       <h1>The `void` Operator</h1>
 
-      <emu-clause id="sec-void-operator-runtime-semantics-evaluation">
+      <emu-clause id="sec-void-operator-runtime-semantics-evaluation" type="sdo">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>UnaryExpression : `void` UnaryExpression</emu-grammar>
         <emu-alg>
@@ -19598,7 +19598,7 @@
     <emu-clause id="sec-typeof-operator">
       <h1>The `typeof` Operator</h1>
 
-      <emu-clause id="sec-typeof-operator-runtime-semantics-evaluation">
+      <emu-clause id="sec-typeof-operator-runtime-semantics-evaluation" type="sdo">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>UnaryExpression : `typeof` UnaryExpression</emu-grammar>
         <emu-alg>
@@ -19704,7 +19704,7 @@
         <p>The unary + operator converts its operand to Number type.</p>
       </emu-note>
 
-      <emu-clause id="sec-unary-plus-operator-runtime-semantics-evaluation">
+      <emu-clause id="sec-unary-plus-operator-runtime-semantics-evaluation" type="sdo">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>UnaryExpression : `+` UnaryExpression</emu-grammar>
         <emu-alg>
@@ -19720,7 +19720,7 @@
         <p>The unary `-` operator converts its operand to Number type and then negates it. Negating *+0*<sub>𝔽</sub> produces *-0*<sub>𝔽</sub>, and negating *-0*<sub>𝔽</sub> produces *+0*<sub>𝔽</sub>.</p>
       </emu-note>
 
-      <emu-clause id="sec-unary-minus-operator-runtime-semantics-evaluation">
+      <emu-clause id="sec-unary-minus-operator-runtime-semantics-evaluation" type="sdo">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>UnaryExpression : `-` UnaryExpression</emu-grammar>
         <emu-alg>
@@ -19739,7 +19739,7 @@
     <emu-clause id="sec-bitwise-not-operator">
       <h1>Bitwise NOT Operator ( `~` )</h1>
 
-      <emu-clause id="sec-bitwise-not-operator-runtime-semantics-evaluation">
+      <emu-clause id="sec-bitwise-not-operator-runtime-semantics-evaluation" type="sdo">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>UnaryExpression : `~` UnaryExpression</emu-grammar>
         <emu-alg>
@@ -19758,7 +19758,7 @@
     <emu-clause id="sec-logical-not-operator">
       <h1>Logical NOT Operator ( `!` )</h1>
 
-      <emu-clause id="sec-logical-not-operator-runtime-semantics-evaluation">
+      <emu-clause id="sec-logical-not-operator-runtime-semantics-evaluation" type="sdo">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>UnaryExpression : `!` UnaryExpression</emu-grammar>
         <emu-alg>
@@ -19781,7 +19781,7 @@
         UpdateExpression[?Yield, ?Await] `**` ExponentiationExpression[?Yield, ?Await]
     </emu-grammar>
 
-    <emu-clause id="sec-exp-operator-runtime-semantics-evaluation">
+    <emu-clause id="sec-exp-operator-runtime-semantics-evaluation" type="sdo">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>
         ExponentiationExpression : UpdateExpression `**` ExponentiationExpression
@@ -19811,7 +19811,7 @@
       </ul>
     </emu-note>
 
-    <emu-clause id="sec-multiplicative-operators-runtime-semantics-evaluation">
+    <emu-clause id="sec-multiplicative-operators-runtime-semantics-evaluation" type="sdo">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>MultiplicativeExpression : MultiplicativeExpression MultiplicativeOperator ExponentiationExpression</emu-grammar>
       <emu-alg>
@@ -19837,7 +19837,7 @@
         <p>The addition operator either performs string concatenation or numeric addition.</p>
       </emu-note>
 
-      <emu-clause id="sec-addition-operator-plus-runtime-semantics-evaluation">
+      <emu-clause id="sec-addition-operator-plus-runtime-semantics-evaluation" type="sdo">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>AdditiveExpression : AdditiveExpression `+` MultiplicativeExpression</emu-grammar>
         <emu-alg>
@@ -19852,7 +19852,7 @@
         <p>The `-` operator performs subtraction, producing the difference of its operands.</p>
       </emu-note>
 
-      <emu-clause id="sec-subtraction-operator-minus-runtime-semantics-evaluation">
+      <emu-clause id="sec-subtraction-operator-minus-runtime-semantics-evaluation" type="sdo">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>AdditiveExpression : AdditiveExpression `-` MultiplicativeExpression</emu-grammar>
         <emu-alg>
@@ -19879,7 +19879,7 @@
         <p>Performs a bitwise left shift operation on the left operand by the amount specified by the right operand.</p>
       </emu-note>
 
-      <emu-clause id="sec-left-shift-operator-runtime-semantics-evaluation">
+      <emu-clause id="sec-left-shift-operator-runtime-semantics-evaluation" type="sdo">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>ShiftExpression : ShiftExpression `&lt;&lt;` AdditiveExpression</emu-grammar>
         <emu-alg>
@@ -19894,7 +19894,7 @@
         <p>Performs a sign-filling bitwise right shift operation on the left operand by the amount specified by the right operand.</p>
       </emu-note>
 
-      <emu-clause id="sec-signed-right-shift-operator-runtime-semantics-evaluation">
+      <emu-clause id="sec-signed-right-shift-operator-runtime-semantics-evaluation" type="sdo">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>ShiftExpression : ShiftExpression `&gt;&gt;` AdditiveExpression</emu-grammar>
         <emu-alg>
@@ -19909,7 +19909,7 @@
         <p>Performs a zero-filling bitwise right shift operation on the left operand by the amount specified by the right operand.</p>
       </emu-note>
 
-      <emu-clause id="sec-unsigned-right-shift-operator-runtime-semantics-evaluation">
+      <emu-clause id="sec-unsigned-right-shift-operator-runtime-semantics-evaluation" type="sdo">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>ShiftExpression : ShiftExpression `&gt;&gt;&gt;` AdditiveExpression</emu-grammar>
         <emu-alg>
@@ -19940,7 +19940,7 @@
       <p>The <sub>[In]</sub> grammar parameter is needed to avoid confusing the `in` operator in a relational expression with the `in` operator in a `for` statement.</p>
     </emu-note>
 
-    <emu-clause id="sec-relational-operators-runtime-semantics-evaluation">
+    <emu-clause id="sec-relational-operators-runtime-semantics-evaluation" type="sdo">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>RelationalExpression : RelationalExpression `&lt;` ShiftExpression</emu-grammar>
       <emu-alg>
@@ -20048,7 +20048,7 @@
         EqualityExpression[?In, ?Yield, ?Await] `!==` RelationalExpression[?In, ?Yield, ?Await]
     </emu-grammar>
 
-    <emu-clause id="sec-equality-operators-runtime-semantics-evaluation">
+    <emu-clause id="sec-equality-operators-runtime-semantics-evaluation" type="sdo">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>EqualityExpression : EqualityExpression `==` RelationalExpression</emu-grammar>
       <emu-alg>
@@ -20143,7 +20143,7 @@
         BitwiseORExpression[?In, ?Yield, ?Await] `|` BitwiseXORExpression[?In, ?Yield, ?Await]
     </emu-grammar>
 
-    <emu-clause id="sec-binary-bitwise-operators-runtime-semantics-evaluation">
+    <emu-clause id="sec-binary-bitwise-operators-runtime-semantics-evaluation" type="sdo">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>BitwiseANDExpression : BitwiseANDExpression `&amp;` EqualityExpression</emu-grammar>
       <emu-alg>
@@ -20187,7 +20187,7 @@
       <p>The value produced by a `&amp;&amp;` or `||` operator is not necessarily of type Boolean. The value produced will always be the value of one of the two operand expressions.</p>
     </emu-note>
 
-    <emu-clause id="sec-binary-logical-operators-runtime-semantics-evaluation">
+    <emu-clause id="sec-binary-logical-operators-runtime-semantics-evaluation" type="sdo">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>LogicalANDExpression : LogicalANDExpression `&amp;&amp;` BitwiseORExpression</emu-grammar>
       <emu-alg>
@@ -20231,7 +20231,7 @@
       <p>The grammar for a |ConditionalExpression| in ECMAScript is slightly different from that in C and Java, which each allow the second subexpression to be an |Expression| but restrict the third expression to be a |ConditionalExpression|. The motivation for this difference in ECMAScript is to allow an assignment expression to be governed by either arm of a conditional and to eliminate the confusing and fairly useless case of a comma expression as the centre expression.</p>
     </emu-note>
 
-    <emu-clause id="sec-conditional-operator-runtime-semantics-evaluation">
+    <emu-clause id="sec-conditional-operator-runtime-semantics-evaluation" type="sdo">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>ConditionalExpression : ShortCircuitExpression `?` AssignmentExpression `:` AssignmentExpression</emu-grammar>
       <emu-alg>
@@ -20296,7 +20296,7 @@
       </ul>
     </emu-clause>
 
-    <emu-clause id="sec-assignment-operators-runtime-semantics-evaluation">
+    <emu-clause id="sec-assignment-operators-runtime-semantics-evaluation" type="sdo">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>AssignmentExpression : LeftHandSideExpression `=` AssignmentExpression</emu-grammar>
       <emu-alg>
@@ -20844,7 +20844,7 @@
         Expression[?In, ?Yield, ?Await] `,` AssignmentExpression[?In, ?Yield, ?Await]
     </emu-grammar>
 
-    <emu-clause id="sec-comma-operator-runtime-semantics-evaluation">
+    <emu-clause id="sec-comma-operator-runtime-semantics-evaluation" type="sdo">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>Expression : Expression `,` AssignmentExpression</emu-grammar>
       <emu-alg>
@@ -20899,7 +20899,7 @@
   <emu-clause id="sec-statement-semantics">
     <h1>Statement Semantics</h1>
 
-    <emu-clause id="sec-statement-semantics-runtime-semantics-evaluation">
+    <emu-clause id="sec-statement-semantics-runtime-semantics-evaluation" type="sdo">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>
         HoistableDeclaration :
@@ -20960,7 +20960,7 @@
       </ul>
     </emu-clause>
 
-    <emu-clause id="sec-block-runtime-semantics-evaluation">
+    <emu-clause id="sec-block-runtime-semantics-evaluation" type="sdo">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>Block : `{` `}`</emu-grammar>
       <emu-alg>
@@ -21078,7 +21078,7 @@
         </ul>
       </emu-clause>
 
-      <emu-clause id="sec-let-and-const-declarations-runtime-semantics-evaluation">
+      <emu-clause id="sec-let-and-const-declarations-runtime-semantics-evaluation" type="sdo">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>LexicalDeclaration : LetOrConst BindingList `;`</emu-grammar>
         <emu-alg>
@@ -21140,7 +21140,7 @@
           BindingPattern[?Yield, ?Await] Initializer[?In, ?Yield, ?Await]
       </emu-grammar>
 
-      <emu-clause id="sec-variable-statement-runtime-semantics-evaluation">
+      <emu-clause id="sec-variable-statement-runtime-semantics-evaluation" type="sdo">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>VariableStatement : `var` VariableDeclarationList `;`</emu-grammar>
         <emu-alg>
@@ -21331,7 +21331,7 @@
         `;`
     </emu-grammar>
 
-    <emu-clause id="sec-empty-statement-runtime-semantics-evaluation">
+    <emu-clause id="sec-empty-statement-runtime-semantics-evaluation" type="sdo">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>EmptyStatement : `;`</emu-grammar>
       <emu-alg>
@@ -21351,7 +21351,7 @@
       <p>An |ExpressionStatement| cannot start with a U+007B (LEFT CURLY BRACKET) because that might make it ambiguous with a |Block|. An |ExpressionStatement| cannot start with the `function` or `class` keywords because that would make it ambiguous with a |FunctionDeclaration|, a |GeneratorDeclaration|, or a |ClassDeclaration|. An |ExpressionStatement| cannot start with `async function` because that would make it ambiguous with an |AsyncFunctionDeclaration| or a |AsyncGeneratorDeclaration|. An |ExpressionStatement| cannot start with the two token sequence `let [` because that would make it ambiguous with a `let` |LexicalDeclaration| whose first |LexicalBinding| was an |ArrayBindingPattern|.</p>
     </emu-note>
 
-    <emu-clause id="sec-expression-statement-runtime-semantics-evaluation">
+    <emu-clause id="sec-expression-statement-runtime-semantics-evaluation" type="sdo">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>ExpressionStatement : Expression `;`</emu-grammar>
       <emu-alg>
@@ -21393,7 +21393,7 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-if-statement-runtime-semantics-evaluation">
+    <emu-clause id="sec-if-statement-runtime-semantics-evaluation" type="sdo">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
       <emu-alg>
@@ -22047,7 +22047,7 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-for-in-and-for-of-statements-runtime-semantics-evaluation">
+      <emu-clause id="sec-for-in-and-for-of-statements-runtime-semantics-evaluation" type="sdo">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>
           BindingIdentifier :
@@ -22251,7 +22251,7 @@
       </ul>
     </emu-clause>
 
-    <emu-clause id="sec-continue-statement-runtime-semantics-evaluation">
+    <emu-clause id="sec-continue-statement-runtime-semantics-evaluation" type="sdo">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>ContinueStatement : `continue` `;`</emu-grammar>
       <emu-alg>
@@ -22284,7 +22284,7 @@
       </ul>
     </emu-clause>
 
-    <emu-clause id="sec-break-statement-runtime-semantics-evaluation">
+    <emu-clause id="sec-break-statement-runtime-semantics-evaluation" type="sdo">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>BreakStatement : `break` `;`</emu-grammar>
       <emu-alg>
@@ -22310,7 +22310,7 @@
       <p>A `return` statement causes a function to cease execution and, in most cases, returns a value to the caller. If |Expression| is omitted, the return value is *undefined*. Otherwise, the return value is the value of |Expression|. A `return` statement may not actually return a value to the caller depending on surrounding context. For example, in a `try` block, a `return` statement's completion record may be replaced with another completion record during evaluation of the `finally` block.</p>
     </emu-note>
 
-    <emu-clause id="sec-return-statement-runtime-semantics-evaluation">
+    <emu-clause id="sec-return-statement-runtime-semantics-evaluation" type="sdo">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>ReturnStatement : `return` `;`</emu-grammar>
       <emu-alg>
@@ -22357,7 +22357,7 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-with-statement-runtime-semantics-evaluation">
+    <emu-clause id="sec-with-statement-runtime-semantics-evaluation" type="sdo">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>WithStatement : `with` `(` Expression `)` Statement</emu-grammar>
       <emu-alg>
@@ -22500,7 +22500,7 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-switch-statement-runtime-semantics-evaluation">
+    <emu-clause id="sec-switch-statement-runtime-semantics-evaluation" type="sdo">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
       <emu-alg>
@@ -22581,7 +22581,7 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-labelled-statements-runtime-semantics-evaluation">
+    <emu-clause id="sec-labelled-statements-runtime-semantics-evaluation" type="sdo">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
       <emu-alg>
@@ -22664,7 +22664,7 @@
         `throw` [no LineTerminator here] Expression[+In, ?Yield, ?Await] `;`
     </emu-grammar>
 
-    <emu-clause id="sec-throw-statement-runtime-semantics-evaluation">
+    <emu-clause id="sec-throw-statement-runtime-semantics-evaluation" type="sdo">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>ThrowStatement : `throw` Expression `;`</emu-grammar>
       <emu-alg>
@@ -22750,7 +22750,7 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-try-statement-runtime-semantics-evaluation">
+    <emu-clause id="sec-try-statement-runtime-semantics-evaluation" type="sdo">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>TryStatement : `try` Block Catch</emu-grammar>
       <emu-alg>
@@ -22786,7 +22786,7 @@
         `debugger` `;`
     </emu-grammar>
 
-    <emu-clause id="sec-debugger-statement-runtime-semantics-evaluation">
+    <emu-clause id="sec-debugger-statement-runtime-semantics-evaluation" type="sdo">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-note>
         <p>Evaluating a |DebuggerStatement| may allow an implementation to cause a breakpoint when run under a debugger. If a debugger is not present or active this statement has no observable effect.</p>
@@ -23279,7 +23279,7 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-function-definitions-runtime-semantics-evaluation">
+    <emu-clause id="sec-function-definitions-runtime-semantics-evaluation" type="sdo">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>FunctionDeclaration : `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
@@ -23415,7 +23415,7 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-arrow-function-definitions-runtime-semantics-evaluation">
+    <emu-clause id="sec-arrow-function-definitions-runtime-semantics-evaluation" type="sdo">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>ArrowFunction : ArrowParameters `=>` ConciseBody</emu-grammar>
       <emu-alg>
@@ -23833,7 +23833,7 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-generator-function-definitions-runtime-semantics-evaluation">
+    <emu-clause id="sec-generator-function-definitions-runtime-semantics-evaluation" type="sdo">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>
         GeneratorExpression : `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` GeneratorBody `}`
@@ -24066,7 +24066,7 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-asyncgenerator-definitions-evaluation">
+    <emu-clause id="sec-asyncgenerator-definitions-evaluation" type="sdo">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>
         AsyncGeneratorExpression : `async` `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
@@ -24796,7 +24796,7 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-class-definitions-runtime-semantics-evaluation">
+    <emu-clause id="sec-class-definitions-runtime-semantics-evaluation" type="sdo">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>ClassDeclaration : `class` BindingIdentifier ClassTail</emu-grammar>
       <emu-alg>
@@ -25000,7 +25000,7 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-async-function-definitions-runtime-semantics-evaluation">
+    <emu-clause id="sec-async-function-definitions-runtime-semantics-evaluation" type="sdo">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>
         AsyncFunctionExpression :
@@ -25144,7 +25144,7 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-async-arrow-function-definitions-runtime-semantics-evaluation">
+    <emu-clause id="sec-async-arrow-function-definitions-runtime-semantics-evaluation" type="sdo">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>
         AsyncArrowFunction :
@@ -25597,7 +25597,7 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-script-semantics-runtime-semantics-evaluation">
+    <emu-clause id="sec-script-semantics-runtime-semantics-evaluation" type="sdo">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>Script : [empty]</emu-grammar>
       <emu-alg>
@@ -27810,7 +27810,7 @@
         </emu-note>
       </emu-clause>
 
-      <emu-clause id="sec-module-semantics-runtime-semantics-evaluation">
+      <emu-clause id="sec-module-semantics-runtime-semantics-evaluation" type="sdo">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>Module : [empty]</emu-grammar>
         <emu-alg>
@@ -28331,7 +28331,7 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-exports-runtime-semantics-evaluation">
+      <emu-clause id="sec-exports-runtime-semantics-evaluation" type="sdo">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>
           ExportDeclaration :


### PR DESCRIPTION
I believe that all syntax-directed operations (SDOs) should have `type` attribute with `"sdo"` in their `emu-clause` HTML elements. So, I searched all the missing parts and added `type` attributes with `"sdo"` to them.