### PR TITLE
Editorial: Use consistent phrasing for parameters that are Number or BigInt

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -40845,7 +40845,7 @@ THH:mm:ss.sss
         <h1>
           NumericToRawBytes (
             _type_: a TypedArray element type,
-            _value_: a BigInt or a Number,
+            _value_: a Number or a BigInt,
             _isLittleEndian_: a Boolean,
           ): a List of byte values
         </h1>


### PR DESCRIPTION
Before this change, NumericToRawBytes is the odd one out (it uses "a BigInt or a Number" while SameValueNonNumeric and SetValueInBuffer and GetModifySetValueInBuffer all use "a Number or a BigInt").