### PR TITLE
Editorial: Eliminate "present" and "absent" fields

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -4290,8 +4290,9 @@
         </dl>
         <emu-alg>
           1. If _Desc_ is *undefined*, return *false*.
-          1. If _Desc_ does not have a [[Get]] field and _Desc_ does not have a [[Set]] field, return *false*.
-          1. Return *true*.
+          1. If _Desc_ has a [[Get]] field, return *true*.
+          1. If _Desc_ has a [[Set]] field, return *true*.
+          1. Return *false*.
         </emu-alg>
       </emu-clause>
 
@@ -4305,8 +4306,9 @@
         </dl>
         <emu-alg>
           1. If _Desc_ is *undefined*, return *false*.
-          1. If _Desc_ does not have a [[Value]] field and _Desc_ does not have a [[Writable]] field, return *false*.
-          1. Return *true*.
+          1. If _Desc_ has a [[Value]] field, return *true*.
+          1. If _Desc_ has a [[Writable]] field, return *true*.
+          1. Return *false*.
         </emu-alg>
       </emu-clause>
 
@@ -4320,8 +4322,9 @@
         </dl>
         <emu-alg>
           1. If _Desc_ is *undefined*, return *false*.
-          1. If IsAccessorDescriptor(_Desc_) and IsDataDescriptor(_Desc_) are both *false*, return *true*.
-          1. Return *false*.
+          1. If IsAccessorDescriptor(_Desc_) is *true*, return *false*.
+          1. If IsDataDescriptor(_Desc_) is *true*, return *false*.
+          1. Return *true*.
         </emu-alg>
       </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -12675,9 +12675,9 @@
             1. If _extensible_ is *false*, return *false*.
             1. If _O_ is *undefined*, return *true*.
             1. If ! IsAccessorDescriptor(_Desc_) is *true*, then
-              1. Create an own accessor property named _P_ of object _O_ whose [[Get]], [[Set]], [[Enumerable]], and [[Configurable]] attribute values are described by _Desc_. If the value of an attribute field of _Desc_ is absent, the attribute of the newly created property is set to its <emu-xref href="#table-object-property-attributes">default value</emu-xref>.
+              1. Create an own accessor property named _P_ of object _O_ whose [[Get]], [[Set]], [[Enumerable]], and [[Configurable]] attributes are set to the value of the corresponding field in _Desc_ if _Desc_ has that field, or to the attribute's <emu-xref href="#table-object-property-attributes">default value</emu-xref> otherwise.
             1. Else,
-              1. Create an own data property named _P_ of object _O_ whose [[Value]], [[Writable]], [[Enumerable]], and [[Configurable]] attribute values are described by _Desc_. If the value of an attribute field of _Desc_ is absent, the attribute of the newly created property is set to its <emu-xref href="#table-object-property-attributes">default value</emu-xref>.
+              1. Create an own data property named _P_ of object _O_ whose [[Value]], [[Writable]], [[Enumerable]], and [[Configurable]] attributes are set to the value of the corresponding field in _Desc_ if _Desc_ has that field, or to the attribute's <emu-xref href="#table-object-property-attributes">default value</emu-xref> otherwise.
             1. Return *true*.
           1. Assert: _current_ is a fully populated Property Descriptor.
           1. If every field in _Desc_ is absent, return *true*.
@@ -12695,11 +12695,11 @@
             1. If ! IsDataDescriptor(_current_) is *true* and ! IsAccessorDescriptor(_Desc_) is *true*, then
               1. If _Desc_ has a [[Configurable]] field, let _configurable_ be _Desc_.[[Configurable]]; else let _configurable_ be _current_.[[Configurable]].
               1. If _Desc_ has a [[Enumerable]] field, let _enumerable_ be _Desc_.[[Enumerable]]; else let _enumerable_ be _current_.[[Enumerable]].
-              1. Replace the property named _P_ of object _O_ with an accessor property having [[Configurable]] and [[Enumerable]] attributes set to _configurable_ and _enumerable_, respectively, and each other attribute set to its corresponding value in _Desc_ if present, otherwise to its <emu-xref href="#table-object-property-attributes">default value</emu-xref>.
+              1. Replace the property named _P_ of object _O_ with an accessor property whose [[Configurable]] and [[Enumerable]] attributes are set to _configurable_ and _enumerable_, respectively, and whose [[Get]] and [[Set]] attributes are set to the value of the corresponding field in _Desc_ if _Desc_ has that field, or to the attribute's <emu-xref href="#table-object-property-attributes">default value</emu-xref> otherwise.
             1. Else if ! IsAccessorDescriptor(_current_) is *true* and ! IsDataDescriptor(_Desc_) is *true*, then
               1. If _Desc_ has a [[Configurable]] field, let _configurable_ be _Desc_.[[Configurable]]; else let _configurable_ be _current_.[[Configurable]].
               1. If _Desc_ has a [[Enumerable]] field, let _enumerable_ be _Desc_.[[Enumerable]]; else let _enumerable_ be _current_.[[Enumerable]].
-              1. Replace the property named _P_ of object _O_ with a data property having [[Configurable]] and [[Enumerable]] attributes set to _configurable_ and _enumerable_, respectively, and each other attribute set to its corresponding value in _Desc_ if present, otherwise to its <emu-xref href="#table-object-property-attributes">default value</emu-xref>.
+              1. Replace the property named _P_ of object _O_ with a data property whose [[Configurable]] and [[Enumerable]] attributes are set to _configurable_ and _enumerable_, respectively, and whose [[Value]] and [[Writable]] attributes are set to the value of the corresponding field in _Desc_ if _Desc_ has that field, or to the attribute's <emu-xref href="#table-object-property-attributes">default value</emu-xref> otherwise.
             1. Else,
               1. For each field of _Desc_ that is present, set the corresponding attribute of the property named _P_ of object _O_ to the value of the field.
           1. Return *true*.

--- a/spec.html
+++ b/spec.html
@@ -4276,7 +4276,7 @@
 
     <emu-clause id="sec-property-descriptor-specification-type">
       <h1>The Property Descriptor Specification Type</h1>
-      <p>The <dfn variants="Property Descriptors">Property Descriptor</dfn> type is used to explain the manipulation and reification of Object property attributes. Values of the Property Descriptor type are Records. Each field's name is an attribute name and its value is a corresponding attribute value as specified in <emu-xref href="#sec-property-attributes"></emu-xref>. In addition, any field may be present or absent. The schema name used within this specification to tag literal descriptions of Property Descriptor records is &ldquo;PropertyDescriptor&rdquo;.</p>
+      <p>The <dfn variants="Property Descriptors">Property Descriptor</dfn> type is used to explain the manipulation and reification of Object property attributes. A Property Descriptor is a Record with zero or more fields, where each field's name is an attribute name and its value is a corresponding attribute value as specified in <emu-xref href="#sec-property-attributes"></emu-xref>. The schema name used within this specification to tag literal descriptions of Property Descriptor records is &ldquo;PropertyDescriptor&rdquo;.</p>
       <p>Property Descriptor values may be further classified as data Property Descriptors and accessor Property Descriptors based upon the existence or use of certain fields. A data Property Descriptor is one that includes any fields named either [[Value]] or [[Writable]]. An accessor Property Descriptor is one that includes any fields named either [[Get]] or [[Set]]. Any Property Descriptor may have fields named [[Enumerable]] and [[Configurable]]. A Property Descriptor value may not be both a data Property Descriptor and an accessor Property Descriptor; however, it may be neither (in which case it is a generic Property Descriptor). A <dfn>fully populated Property Descriptor</dfn> is one that is either an accessor Property Descriptor or a data Property Descriptor and that has all of the corresponding fields defined in <emu-xref href="#table-object-property-attributes"></emu-xref>.</p>
       <p>The following abstract operations are used in this specification to operate upon Property Descriptor values:</p>
 
@@ -12680,7 +12680,7 @@
               1. Create an own data property named _P_ of object _O_ whose [[Value]], [[Writable]], [[Enumerable]], and [[Configurable]] attributes are set to the value of the corresponding field in _Desc_ if _Desc_ has that field, or to the attribute's <emu-xref href="#table-object-property-attributes">default value</emu-xref> otherwise.
             1. Return *true*.
           1. Assert: _current_ is a fully populated Property Descriptor.
-          1. If every field in _Desc_ is absent, return *true*.
+          1. If _Desc_ does not have any fields, return *true*.
           1. If _current_.[[Configurable]] is *false*, then
             1. If _Desc_ has a [[Configurable]] field and _Desc_.[[Configurable]] is *true*, return *false*.
             1. If _Desc_ has an [[Enumerable]] field and ! SameValue(_Desc_.[[Enumerable]], _current_.[[Enumerable]]) is *false*, return *false*.
@@ -12701,7 +12701,7 @@
               1. If _Desc_ has a [[Enumerable]] field, let _enumerable_ be _Desc_.[[Enumerable]]; else let _enumerable_ be _current_.[[Enumerable]].
               1. Replace the property named _P_ of object _O_ with a data property whose [[Configurable]] and [[Enumerable]] attributes are set to _configurable_ and _enumerable_, respectively, and whose [[Value]] and [[Writable]] attributes are set to the value of the corresponding field in _Desc_ if _Desc_ has that field, or to the attribute's <emu-xref href="#table-object-property-attributes">default value</emu-xref> otherwise.
             1. Else,
-              1. For each field of _Desc_ that is present, set the corresponding attribute of the property named _P_ of object _O_ to the value of the field.
+              1. For each field of _Desc_, set the corresponding attribute of the property named _P_ of object _O_ to the value of the field.
           1. Return *true*.
         </emu-alg>
       </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -4290,7 +4290,7 @@
         </dl>
         <emu-alg>
           1. If _Desc_ is *undefined*, return *false*.
-          1. If both _Desc_.[[Get]] and _Desc_.[[Set]] are absent, return *false*.
+          1. If _Desc_ does not have a [[Get]] field and _Desc_ does not have a [[Set]] field, return *false*.
           1. Return *true*.
         </emu-alg>
       </emu-clause>
@@ -4305,7 +4305,7 @@
         </dl>
         <emu-alg>
           1. If _Desc_ is *undefined*, return *false*.
-          1. If both _Desc_.[[Value]] and _Desc_.[[Writable]] are absent, return *false*.
+          1. If _Desc_ does not have a [[Value]] field and _Desc_ does not have a [[Writable]] field, return *false*.
           1. Return *true*.
         </emu-alg>
       </emu-clause>
@@ -14067,7 +14067,7 @@
         <dl class="header">
         </dl>
         <emu-alg>
-          1. If _Desc_.[[Value]] is absent, then
+          1. If _Desc_ does not have a [[Value]] field, then
             1. Return OrdinaryDefineOwnProperty(_A_, *"length"*, _Desc_).
           1. Let _newLenDesc_ be a copy of _Desc_.
           1. [id="step-arraysetlength-newlen"] Let _newLen_ be ? ToUint32(_Desc_.[[Value]]).
@@ -14081,7 +14081,7 @@
           1. If _newLen_ &ge; _oldLen_, then
             1. Return OrdinaryDefineOwnProperty(_A_, *"length"*, _newLenDesc_).
           1. If _oldLenDesc_.[[Writable]] is *false*, return *false*.
-          1. If _newLenDesc_.[[Writable]] is absent or is *true*, let _newWritable_ be *true*.
+          1. If _newLenDesc_ does not have a [[Writable]] field or _newLenDesc_.[[Writable]] is *true*, let _newWritable_ be *true*.
           1. Else,
             1. NOTE: Setting the [[Writable]] attribute to *false* is deferred in case any elements cannot be deleted.
             1. Let _newWritable_ be *false*.


### PR DESCRIPTION
When processing the merge of PR #2620, I noticed that although it had taken care of `_rec_.[[Field]] is present`, there were also cases of `_rec_.[[Field]] is absent` that should probably be handled similarly. And then I noticed that that still left some references to "present" and "absent" fields. So this PR is to clean all that up. And the last commit is a bonus.

There's actually one place left that uses "present" when talking about a field, and that's in [Table 9: PrivateElement Fields](https://tc39.es/ecma262/#table-privateelement-fields), where one of the column-headers is "Values of the [[Kind]] field for which it is present" (where "it" is the field that a given row is declaring). I couldn't think of a good way to change that to the "record has a field" wording.
