### PR TITLE
Markup: add missing `example` attributes to example algorithms

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -848,7 +848,7 @@
       <p>but the Evaluation operation does not associate an algorithm with that production. In that case, the Evaluation operation implicitly includes an association of the form:</p>
       <p><b>Runtime Semantics: Evaluation</b></p>
       <emu-grammar example>Block : `{` StatementList `}`</emu-grammar>
-      <emu-alg>
+      <emu-alg example>
         1. Return the result of evaluating |StatementList|.
       </emu-alg>
     </emu-clause>
@@ -4430,7 +4430,7 @@
       <p>In algorithm steps that create an Abstract Closure, values are captured with the verb "capture" followed by a list of aliases. When an Abstract Closure is created, it captures the value that is associated with each alias at that time. In steps that specify the algorithm to be performed when an Abstract Closure is called, each captured value is referred to by the alias that was used to capture the value.</p>
       <p>If an Abstract Closure returns a Completion Record, that Completion Record's [[Type]] must be either ~normal~ or ~throw~.</p>
       <p>Abstract Closures are created inline as part of other algorithms, shown in the following example.</p>
-      <emu-alg>
+      <emu-alg example>
         1. Let _addend_ be 41.
         1. Let _closure_ be a new Abstract Closure with parameters (_x_) that captures _addend_ and performs the following steps when called:
           1. Return _x_ + _addend_.


### PR DESCRIPTION
I added missing `example` attributes to algorithms that are clearly used for example.