### PR TITLE
Editorial: Factor out BuiltinCallOrConstruct

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -13744,22 +13744,8 @@
         <dd>a built-in function object _F_</dd>
       </dl>
       <emu-alg>
-        1. Let _callerContext_ be the running execution context.
-        1. If _callerContext_ is not already suspended, suspend _callerContext_.
-        1. Let _calleeContext_ be a new execution context.
-        1. Set the Function of _calleeContext_ to _F_.
-        1. Let _calleeRealm_ be _F_.[[Realm]].
-        1. Set the Realm of _calleeContext_ to _calleeRealm_.
-        1. Set the ScriptOrModule of _calleeContext_ to *null*.
-        1. Perform any necessary implementation-defined initialization of _calleeContext_.
-        1. Push _calleeContext_ onto the execution context stack; _calleeContext_ is now the running execution context.
-        1. [id="step-call-builtin-function-result"] Let _result_ be the Completion Record that is <emu-meta effects="user-code">the result of evaluating</emu-meta> _F_ in a manner that conforms to the specification of _F_. _thisArgument_ is the *this* value, _argumentsList_ provides the named parameters, and the NewTarget value is *undefined*.
-        1. Remove _calleeContext_ from the execution context stack and restore _callerContext_ as the running execution context.
-        1. Return ? _result_.
+        1. Return ? BuiltinCallOrConstruct(_F_, _thisArgument_, _argumentsList_, *undefined*).
       </emu-alg>
-      <emu-note>
-        <p>When _calleeContext_ is removed from the execution context stack it must not be destroyed if it has been suspended and retained by an accessible Generator for later resumption.</p>
-      </emu-note>
     </emu-clause>
 
     <emu-clause id="sec-built-in-function-objects-construct-argumentslist-newtarget" type="internal method">
@@ -13772,13 +13758,40 @@
       <dl class="header">
         <dt>for</dt>
         <dd>a built-in function object _F_ (when the method is present)</dd>
-
-        <dt>description</dt>
-        <dd>The steps performed are the same as [[Call]] (see <emu-xref href="#sec-built-in-function-objects-call-thisargument-argumentslist"></emu-xref>) except that step <emu-xref href="#step-call-builtin-function-result"></emu-xref> is replaced by:</dd>
       </dl>
-      <emu-alg replaces-step="step-call-builtin-function-result">
-        1. Let _result_ be the Completion Record that is <emu-meta effects="user-code">the result of evaluating</emu-meta> _F_ in a manner that conforms to the specification of _F_. The *this* value is uninitialized, _argumentsList_ provides the named parameters, and _newTarget_ provides the NewTarget value.
+      <emu-alg>
+        1. Return ? BuiltinCallOrConstruct(_F_, ~uninitialized~, _argumentsList_, _newTarget_).
       </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-builtincallorconstruct" type="abstract operation">
+      <h1>
+        BuiltinCallOrConstruct (
+          _F_: a built-in function object,
+          _thisArgument_: an ECMAScript language value or ~uninitialized~,
+          _argumentsList_: a List of ECMAScript language values,
+          _newTarget_: a constructor or *undefined*,
+        ): either a normal completion containing an ECMAScript language value or a throw completion
+      </h1>
+      <dl class="header">
+      </dl>
+      <emu-alg>
+        1. Let _callerContext_ be the running execution context.
+        1. If _callerContext_ is not already suspended, suspend _callerContext_.
+        1. Let _calleeContext_ be a new execution context.
+        1. Set the Function of _calleeContext_ to _F_.
+        1. Let _calleeRealm_ be _F_.[[Realm]].
+        1. Set the Realm of _calleeContext_ to _calleeRealm_.
+        1. Set the ScriptOrModule of _calleeContext_ to *null*.
+        1. Perform any necessary implementation-defined initialization of _calleeContext_.
+        1. Push _calleeContext_ onto the execution context stack; _calleeContext_ is now the running execution context.
+        1. [id="step-call-builtin-function-result"] Let _result_ be the Completion Record that is <emu-meta effects="user-code">the result of evaluating</emu-meta> _F_ in a manner that conforms to the specification of _F_. If _thisArgument_ is ~uninitialized~, the *this* value is uninitialized; otherwise, _thisArgument_ provides the *this* value. _argumentsList_ provides the named parameters. _newTarget_ provides the NewTarget value.
+        1. Remove _calleeContext_ from the execution context stack and restore _callerContext_ as the running execution context.
+        1. Return ? _result_.
+      </emu-alg>
+      <emu-note>
+        <p>When _calleeContext_ is removed from the execution context stack it must not be destroyed if it has been suspended and retained by an accessible Generator for later resumption.</p>
+      </emu-note>
     </emu-clause>
 
     <emu-clause id="sec-createbuiltinfunction" type="abstract operation">


### PR DESCRIPTION
... so that the [[Construct]] for ~exotic~ built-ins can be defined properly, instead of "the same as [[Call]] except that step 10 is different".

<strike>The second commit is a bonus, changing "a built-in function" to "an exotic built-in function" where appropriate. This is mostly of benefit in 10.3 Built-in Function Objects, where (in the status quo) the reader could be misled into thinking that these internal methods are for *all* built-in functions.</strike>