### PR TITLE
Normative: Use IntegerIndexedElementSet in %TypedArray%.prototype.set

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -39118,25 +39118,17 @@ THH:mm:ss.sss
             1. Let _targetBuffer_ be _target_.[[ViewedArrayBuffer]].
             1. If IsDetachedBuffer(_targetBuffer_) is *true*, throw a *TypeError* exception.
             1. Let _targetLength_ be _target_.[[ArrayLength]].
-            1. Let _targetElementSize_ be TypedArrayElementSize(_target_).
-            1. Let _targetType_ be TypedArrayElementType(_target_).
-            1. Let _targetByteOffset_ be _target_.[[ByteOffset]].
             1. Let _src_ be ? ToObject(_source_).
             1. Let _srcLength_ be ? LengthOfArrayLike(_src_).
             1. If _targetOffset_ is +&infin;, throw a *RangeError* exception.
             1. If _srcLength_ + _targetOffset_ &gt; _targetLength_, throw a *RangeError* exception.
-            1. Let _targetByteIndex_ be _targetOffset_ &times; _targetElementSize_ + _targetByteOffset_.
             1. Let _k_ be 0.
-            1. Let _limit_ be _targetByteIndex_ + _targetElementSize_ &times; _srcLength_.
-            1. Repeat, while _targetByteIndex_ &lt; _limit_,
+            1. Repeat, while _k_ &lt; _srcLength_,
               1. Let _Pk_ be ! ToString(𝔽(_k_)).
               1. Let _value_ be ? Get(_src_, _Pk_).
-              1. If _target_.[[ContentType]] is ~BigInt~, set _value_ to ? ToBigInt(_value_).
-              1. Otherwise, set _value_ to ? ToNumber(_value_).
-              1. If IsDetachedBuffer(_targetBuffer_) is *true*, throw a *TypeError* exception.
-              1. Perform SetValueInBuffer(_targetBuffer_, _targetByteIndex_, _targetType_, _value_, *true*, ~Unordered~).
+              1. Let _targetIndex_ be 𝔽(_targetOffset_ + _k_).
+              1. Perform ? IntegerIndexedElementSet(_target_, _targetIndex_, _value_).
               1. Set _k_ to _k_ + 1.
-              1. Set _targetByteIndex_ to _targetByteIndex_ + _targetElementSize_.
             1. Return ~unused~.
           </emu-alg>
         </emu-clause>


### PR DESCRIPTION
As part of #2208 and other good stuff from @rkirsling, we changed it so that TypedArray accesses on TAs with detached buffer don't throw.

In implementing resizable buffers, @marjakh noticed in https://github.com/tc39/proposal-resizablearraybuffer/issues/86 that [`TypedArray.prototype.set`](https://tc39.es/ecma262/#sec-%typedarray%.prototype.set) would need a per-loop iteration detached / "did the buffer resize" check in [SetTypedArrayFromArrayLike](https://tc39.es/ecma262/#sec-settypedarrayfromarraylike). In investigating this, my conclusion is that the array-like case of `TypedArray.prototype.set`, to be maximally consistent with the direction we went, is to use Set and *not* throw on detached or "did the buffer resize".

My best guess as to why SetTypedArrayFromArrayLike partially inlines the logic of IntegerIndexedElementSet today is that it was copied from the SetTypedArrayFromTypedArray AO, and since it partially inlined the logic, when we updated IntegerIndexedElementSet we missed this one.

At the same time, most engines *do* agree on throwing on detach, so it can also be argued we should retain this throw check.

```javascript
function detach(ab) {                                                                                                                                                                                                                                                       
  if (ArrayBuffer.transfer) {                                                                                                                                                                                                                                               
    ArrayBuffer.transfer(ab);                                                                                                                                                                                                                                               
  } else if (ArrayBuffer.detach) {                                                                                                                                                                                                                                          
    ArrayBuffer.detach(ab);                                                                                                                                                                                                                                                 
  } else if (typeof detachArrayBuffer === "function") {                                                                                                                                                                                                                     
    detachArrayBuffer(ab);                                                                                                                                                                                                                                                  
  } else if (typeof transferArrayBuffer === "function") {                                                                                                                                                                                                                   
    transferArrayBuffer(ab)                                                                                                                                                                                                                                                 
  } else if (typeof Worker === "function") {                                                                                                                                                                                                                                
    try { eval("%ArrayBufferDetach(ab)") } catch (e) {                                                                                                                                                                                                                      
      var w = new Worker("", {type: "string"});                                                                                                                                                                                                                             
      w.postMessage(ab, [ab]);                                                                                                                                                                                                                                              
      w.terminate();                                                                                                                                                                                                                                                        
    }                                                                                                                                                                                                                                                                       
  } else {                                                                                                                                                                                                                                                                  
    throw new TypeError("cannot detach array buffer");                                                                                                                                                                                                                      
  }                                                                                                                                                                                                                                                                         
}                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                            
let ta = new Uint32Array(4);                                                                                                                                                                                                                                                
let array_like = { get 0() { detach(ta.buffer); return 42; },                                                                                                                                                                                                                
                   length: 1 };                                                                                                                                                                                                                                             
ta.set(array_like);
```

```
$ eshost ./test-ta-p-set-detach.js 
#### ch


#### jsc

TypeError: Underlying ArrayBuffer has been detached from the view

#### sm

TypeError: attempting to access detached ArrayBuffer

#### v8

TypeError: Cannot perform set on a detached ArrayBuffer

#### xs

TypeError: cannot detach array buffer
```