### PR TITLE
Editorial: NormalCompletion/ThrowCompletion create a Completion Record

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -4037,7 +4037,7 @@
         <dl class="header">
         </dl>
         <emu-alg>
-          1. Return Completion { [[Type]]: ~normal~, [[Value]]: _value_, [[Target]]: ~empty~ }.
+          1. Return Completion Record { [[Type]]: ~normal~, [[Value]]: _value_, [[Target]]: ~empty~ }.
         </emu-alg>
       </emu-clause>
 
@@ -4050,7 +4050,7 @@
         <dl class="header">
         </dl>
         <emu-alg>
-          1. Return Completion { [[Type]]: ~throw~, [[Value]]: _value_, [[Target]]: ~empty~ }.
+          1. Return Completion Record { [[Type]]: ~throw~, [[Value]]: _value_, [[Target]]: ~empty~ }.
         </emu-alg>
       </emu-clause>
 
@@ -4066,7 +4066,7 @@
         <emu-alg>
           1. Assert: If _completionRecord_.[[Type]] is either ~return~ or ~throw~, then _completionRecord_.[[Value]] is not ~empty~.
           1. If _completionRecord_.[[Value]] is not ~empty~, return Completion(_completionRecord_).
-          1. Return Completion { [[Type]]: _completionRecord_.[[Type]], [[Value]]: _value_, [[Target]]: _completionRecord_.[[Target]] }.
+          1. Return Completion Record { [[Type]]: _completionRecord_.[[Type]], [[Value]]: _value_, [[Target]]: _completionRecord_.[[Target]] }.
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -13280,7 +13280,7 @@
           1. Else,
             1. Let _rhs_ be the result of evaluating |AssignmentExpression|.
             1. Let _value_ be ? GetValue(_rhs_).
-          1. Return Completion { [[Type]]: ~return~, [[Value]]: _value_, [[Target]]: ~empty~ }.
+          1. Return Completion Record { [[Type]]: ~return~, [[Value]]: _value_, [[Target]]: ~empty~ }.
         </emu-alg>
         <emu-note>
           <p>Even though field initializers constitute a function boundary, calling FunctionDeclarationInstantiation does not have any observable effect and so is omitted.</p>
@@ -21954,7 +21954,7 @@
           1. Let _exprValue_ be ? GetValue(_exprRef_).
           1. If _iterationKind_ is ~enumerate~, then
             1. If _exprValue_ is *undefined* or *null*, then
-              1. Return Completion { [[Type]]: ~break~, [[Value]]: ~empty~, [[Target]]: ~empty~ }.
+              1. Return Completion Record { [[Type]]: ~break~, [[Value]]: ~empty~, [[Target]]: ~empty~ }.
             1. Let _obj_ be ! ToObject(_exprValue_).
             1. Let _iterator_ be ? EnumerateObjectProperties(_obj_).
             1. Let _nextMethod_ be ! GetV(_iterator_, *"next"*).
@@ -22256,12 +22256,12 @@
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>ContinueStatement : `continue` `;`</emu-grammar>
       <emu-alg>
-        1. Return Completion { [[Type]]: ~continue~, [[Value]]: ~empty~, [[Target]]: ~empty~ }.
+        1. Return Completion Record { [[Type]]: ~continue~, [[Value]]: ~empty~, [[Target]]: ~empty~ }.
       </emu-alg>
       <emu-grammar>ContinueStatement : `continue` LabelIdentifier `;`</emu-grammar>
       <emu-alg>
         1. Let _label_ be the StringValue of |LabelIdentifier|.
-        1. Return Completion { [[Type]]: ~continue~, [[Value]]: ~empty~, [[Target]]: _label_ }.
+        1. Return Completion Record { [[Type]]: ~continue~, [[Value]]: ~empty~, [[Target]]: _label_ }.
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -22289,12 +22289,12 @@
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>BreakStatement : `break` `;`</emu-grammar>
       <emu-alg>
-        1. Return Completion { [[Type]]: ~break~, [[Value]]: ~empty~, [[Target]]: ~empty~ }.
+        1. Return Completion Record { [[Type]]: ~break~, [[Value]]: ~empty~, [[Target]]: ~empty~ }.
       </emu-alg>
       <emu-grammar>BreakStatement : `break` LabelIdentifier `;`</emu-grammar>
       <emu-alg>
         1. Let _label_ be the StringValue of |LabelIdentifier|.
-        1. Return Completion { [[Type]]: ~break~, [[Value]]: ~empty~, [[Target]]: _label_ }.
+        1. Return Completion Record { [[Type]]: ~break~, [[Value]]: ~empty~, [[Target]]: _label_ }.
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -22315,14 +22315,14 @@
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>ReturnStatement : `return` `;`</emu-grammar>
       <emu-alg>
-        1. Return Completion { [[Type]]: ~return~, [[Value]]: *undefined*, [[Target]]: ~empty~ }.
+        1. Return Completion Record { [[Type]]: ~return~, [[Value]]: *undefined*, [[Target]]: ~empty~ }.
       </emu-alg>
       <emu-grammar>ReturnStatement : `return` Expression `;`</emu-grammar>
       <emu-alg>
         1. Let _exprRef_ be the result of evaluating |Expression|.
         1. Let _exprValue_ be ? GetValue(_exprRef_).
         1. If ! GetGeneratorKind() is ~async~, set _exprValue_ to ? Await(_exprValue_).
-        1. Return Completion { [[Type]]: ~return~, [[Value]]: _exprValue_, [[Target]]: ~empty~ }.
+        1. Return Completion Record { [[Type]]: ~return~, [[Value]]: _exprValue_, [[Target]]: ~empty~ }.
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -23426,7 +23426,7 @@
       <emu-alg>
         1. Let _exprRef_ be the result of evaluating |AssignmentExpression|.
         1. Let _exprValue_ be ? GetValue(_exprRef_).
-        1. Return Completion { [[Type]]: ~return~, [[Value]]: _exprValue_, [[Target]]: ~empty~ }.
+        1. Return Completion Record { [[Type]]: ~return~, [[Value]]: _exprValue_, [[Target]]: ~empty~ }.
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -23756,7 +23756,7 @@
         1. Let _G_ be ? OrdinaryCreateFromConstructor(_functionObject_, *"%GeneratorFunction.prototype.prototype%"*, &laquo; [[GeneratorState]], [[GeneratorContext]], [[GeneratorBrand]] &raquo;).
         1. Set _G_.[[GeneratorBrand]] to ~empty~.
         1. Perform GeneratorStart(_G_, |FunctionBody|).
-        1. Return Completion { [[Type]]: ~return~, [[Value]]: _G_, [[Target]]: ~empty~ }.
+        1. Return Completion Record { [[Type]]: ~return~, [[Value]]: _G_, [[Target]]: ~empty~ }.
       </emu-alg>
     </emu-clause>
 
@@ -23884,7 +23884,7 @@
               1. Else, set _received_ to GeneratorYield(_innerResult_).
             1. Else,
               1. NOTE: If _iterator_ does not have a `throw` method, this throw is going to terminate the `yield*` loop. But first we need to give _iterator_ a chance to clean up.
-              1. Let _closeCompletion_ be Completion { [[Type]]: ~normal~, [[Value]]: ~empty~, [[Target]]: ~empty~ }.
+              1. Let _closeCompletion_ be Completion Record { [[Type]]: ~normal~, [[Value]]: ~empty~, [[Target]]: ~empty~ }.
               1. If _generatorKind_ is ~async~, perform ? AsyncIteratorClose(_iteratorRecord_, _closeCompletion_).
               1. Else, perform ? IteratorClose(_iteratorRecord_, _closeCompletion_).
               1. NOTE: The next step throws a *TypeError* to indicate that there was a `yield*` protocol violation: _iterator_ does not have a `throw` method.
@@ -23901,7 +23901,7 @@
             1. Let _done_ be ? IteratorComplete(_innerReturnResult_).
             1. If _done_ is *true*, then
               1. Let _value_ be ? IteratorValue(_innerReturnResult_).
-              1. Return Completion { [[Type]]: ~return~, [[Value]]: _value_, [[Target]]: ~empty~ }.
+              1. Return Completion Record { [[Type]]: ~return~, [[Value]]: _value_, [[Target]]: ~empty~ }.
             1. If _generatorKind_ is ~async~, set _received_ to AsyncGeneratorYield(? IteratorValue(_innerReturnResult_)).
             1. Else, set _received_ to GeneratorYield(_innerReturnResult_).
       </emu-alg>
@@ -23981,7 +23981,7 @@
         1. Let _generator_ be ? OrdinaryCreateFromConstructor(_functionObject_, *"%AsyncGeneratorFunction.prototype.prototype%"*, &laquo; [[AsyncGeneratorState]], [[AsyncGeneratorContext]], [[AsyncGeneratorQueue]], [[GeneratorBrand]] &raquo;).
         1. Set _generator_.[[GeneratorBrand]] to ~empty~.
         1. Perform ! AsyncGeneratorStart(_generator_, |FunctionBody|).
-        1. Return Completion { [[Type]]: ~return~, [[Value]]: _generator_, [[Target]]: ~empty~ }.
+        1. Return Completion Record { [[Type]]: ~return~, [[Value]]: _generator_, [[Target]]: ~empty~ }.
       </emu-alg>
     </emu-clause>
 
@@ -24997,7 +24997,7 @@
           1. Perform ! AsyncFunctionStart(_promiseCapability_, |FunctionBody|).
         1. Else,
           1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _declResult_.[[Value]] &raquo;).
-        1. Return Completion { [[Type]]: ~return~, [[Value]]: _promiseCapability_.[[Promise]], [[Target]]: ~empty~ }.
+        1. Return Completion Record { [[Type]]: ~return~, [[Value]]: _promiseCapability_.[[Promise]], [[Target]]: ~empty~ }.
       </emu-alg>
     </emu-clause>
 
@@ -25104,7 +25104,7 @@
           1. Perform ! AsyncFunctionStart(_promiseCapability_, |ExpressionBody|).
         1. Else,
           1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _declResult_.[[Value]] &raquo;).
-        1. Return Completion { [[Type]]: ~return~, [[Value]]: _promiseCapability_.[[Promise]], [[Target]]: ~empty~ }.
+        1. Return Completion Record { [[Type]]: ~return~, [[Value]]: _promiseCapability_.[[Promise]], [[Target]]: ~empty~ }.
       </emu-alg>
     </emu-clause>
 
@@ -44342,7 +44342,7 @@ THH:mm:ss.sss
         <p>The `return` method performs the following steps:</p>
         <emu-alg>
           1. Let _g_ be the *this* value.
-          1. Let _C_ be Completion { [[Type]]: ~return~, [[Value]]: _value_, [[Target]]: ~empty~ }.
+          1. Let _C_ be Completion Record { [[Type]]: ~return~, [[Value]]: _value_, [[Target]]: ~empty~ }.
           1. Return ? GeneratorResumeAbrupt(_g_, _C_, ~empty~).
         </emu-alg>
       </emu-clause>
@@ -44654,7 +44654,7 @@ THH:mm:ss.sss
           1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
           1. Let _result_ be AsyncGeneratorValidate(_generator_, ~empty~).
           1. IfAbruptRejectPromise(_result_, _promiseCapability_).
-          1. Let _completion_ be Completion { [[Type]]: ~return~, [[Value]]: _value_, [[Target]]: ~empty~ }.
+          1. Let _completion_ be Completion Record { [[Type]]: ~return~, [[Value]]: _value_, [[Target]]: ~empty~ }.
           1. Perform ! AsyncGeneratorEnqueue(_generator_, _completion_, _promiseCapability_).
           1. Let _state_ be _generator_.[[AsyncGeneratorState]].
           1. If _state_ is either ~suspendedStart~ or ~completed~, then
@@ -44891,7 +44891,7 @@ THH:mm:ss.sss
           1. Let _awaited_ be Await(_resumptionValue_.[[Value]]).
           1. If _awaited_.[[Type]] is ~throw~, return Completion(_awaited_).
           1. Assert: _awaited_.[[Type]] is ~normal~.
-          1. Return Completion { [[Type]]: ~return~, [[Value]]: _awaited_.[[Value]], [[Target]]: ~empty~ }.
+          1. Return Completion Record { [[Type]]: ~return~, [[Value]]: _awaited_.[[Value]], [[Target]]: ~empty~ }.
         </emu-alg>
       </emu-clause>
 


### PR DESCRIPTION
Currently, "return Completion" links to the Completion() AO, which isn't what's happening here.