### PR TITLE
Editorial: Factor out AO RunSuspendedContext()

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -12009,6 +12009,27 @@
         1. Return _currentRealm_.[[GlobalObject]].
       </emu-alg>
     </emu-clause>
+
+    <emu-clause id="sec-runsuspendedcontext" type="abstract operation">
+      <h1>
+        RunSuspendedContext (
+          _context_: an execution context,
+          _completionRecord_: a Completion Record,
+        ): either a normal completion containing either an ECMAScript language value or ~unused~, or an abrupt completion
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It resumes _context_ (sending it _completionRecord_ as the resumption value), and waits for the result.</dd>
+      </dl>
+      <emu-alg>
+        1. Let _callerContext_ be the running execution context.
+        1. Suspend _callerContext_.
+        1. Push _context_ onto the execution context stack; _context_ is now the running execution context.
+        1. <emu-meta effects="user-code">Resume the suspended evaluation of _context_</emu-meta> using _completionRecord_ as the result of the operation that suspended it. Let _result_ be the Completion Record returned by the resumed computation.
+        1. Assert: When we reach this step, _context_ has already been removed from the execution context stack and _callerContext_ is the running execution context again.
+        1. Return Completion(_result_).
+      </emu-alg>
+    </emu-clause>
   </emu-clause>
 
   <emu-clause id="sec-jobs" oldids="sec-jobs-and-job-queues,sec-enqueuejob,sec-runjobs,job-queue">
@@ -28680,9 +28701,9 @@
             <emu-alg>
               1. Assert: _module_ has been linked and declarations in its module environment have been instantiated.
               1. Let _moduleContext_ be _module_.[[Context]].
-              1. Suspend the running execution context.
               1. If _module_.[[HasTLA]] is *false*, then
                 1. Assert: _capability_ is not present.
+                1. Suspend the running execution context.
                 1. Push _moduleContext_ onto the execution context stack; _moduleContext_ is now the running execution context.
                 1. Let _result_ be Completion(Evaluation of _module_.[[ECMAScriptCode]]).
                 1. Suspend _moduleContext_ and remove it from the execution context stack.
@@ -50638,13 +50659,8 @@ THH:mm:ss.sss
           1. If _state_ is ~completed~, return CreateIteratorResultObject(*undefined*, *true*).
           1. Assert: _state_ is either ~suspended-start~ or ~suspended-yield~.
           1. Let _genContext_ be _generator_.[[GeneratorContext]].
-          1. Let _methodContext_ be the running execution context.
-          1. Suspend _methodContext_.
           1. Set _generator_.[[GeneratorState]] to ~executing~.
-          1. Push _genContext_ onto the execution context stack; _genContext_ is now the running execution context.
-          1. <emu-meta effects="user-code">Resume the suspended evaluation of _genContext_</emu-meta> using NormalCompletion(_value_) as the result of the operation that suspended it. Let _result_ be the value returned by the resumed computation.
-          1. Assert: When we return here, _genContext_ has already been removed from the execution context stack and _methodContext_ is the currently running execution context.
-          1. Return ? _result_.
+          1. Return ? RunSuspendedContext(_genContext_, NormalCompletion(_value_)).
         </emu-alg>
       </emu-clause>
 
@@ -50670,13 +50686,8 @@ THH:mm:ss.sss
             1. Return ? _abruptCompletion_.
           1. Assert: _state_ is ~suspended-yield~.
           1. Let _genContext_ be _generator_.[[GeneratorContext]].
-          1. Let _methodContext_ be the running execution context.
-          1. Suspend _methodContext_.
           1. Set _generator_.[[GeneratorState]] to ~executing~.
-          1. Push _genContext_ onto the execution context stack; _genContext_ is now the running execution context.
-          1. <emu-meta effects="user-code">Resume the suspended evaluation of _genContext_</emu-meta> using _abruptCompletion_ as the result of the operation that suspended it. Let _result_ be the Completion Record returned by the resumed computation.
-          1. Assert: When we return here, _genContext_ has already been removed from the execution context stack and _methodContext_ is the currently running execution context.
-          1. Return ? _result_.
+          1. Return ? RunSuspendedContext(_genContext_, _abruptCompletion_).
         </emu-alg>
       </emu-clause>
 
@@ -51044,13 +51055,8 @@ THH:mm:ss.sss
         <emu-alg>
           1. Assert: _generator_.[[AsyncGeneratorState]] is either ~suspended-start~ or ~suspended-yield~.
           1. Let _genContext_ be _generator_.[[AsyncGeneratorContext]].
-          1. Let _callerContext_ be the running execution context.
-          1. Suspend _callerContext_.
           1. Set _generator_.[[AsyncGeneratorState]] to ~executing~.
-          1. Push _genContext_ onto the execution context stack; _genContext_ is now the running execution context.
-          1. <emu-meta effects="user-code">Resume the suspended evaluation of _genContext_</emu-meta> using _completion_ as the result of the operation that suspended it. Let _result_ be the Completion Record returned by the resumed computation.
-          1. Assert: _result_ is never an abrupt completion.
-          1. Assert: When we return here, _genContext_ has already been removed from the execution context stack and _callerContext_ is the currently running execution context.
+          1. Perform ! RunSuspendedContext(_genContext_, _completion_).
           1. Return ~unused~.
         </emu-alg>
       </emu-clause>
@@ -51301,7 +51307,6 @@ THH:mm:ss.sss
         <dl class="header">
         </dl>
         <emu-alg>
-          1. Let _runningContext_ be the running execution context.
           1. Let _closure_ be a new Abstract Closure with no parameters that captures _promiseCapability_ and _asyncBody_ and performs the following steps when called:
             1. Let _acAsyncContext_ be the running execution context.
             1. If _asyncBody_ is a Parse Node, then
@@ -51320,10 +51325,9 @@ THH:mm:ss.sss
               1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, « _result_.[[Value]] »).
             1. [id="step-asyncblockstart-return-undefined"] Return NormalCompletion(~unused~).
           1. Set the code evaluation state of _asyncContext_ such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
-          1. Push _asyncContext_ onto the execution context stack; _asyncContext_ is now the running execution context.
-          1. <emu-meta effects="user-code">Resume the suspended evaluation of _asyncContext_</emu-meta>. Let _result_ be the value returned by the resumed computation.
-          1. Assert: When we return here, _asyncContext_ has already been removed from the execution context stack and _runningContext_ is the currently running execution context.
-          1. Assert: _result_ is a normal completion with a value of ~unused~. The possible sources of this value are Await or, if the async function doesn't await anything, step <emu-xref href="#step-asyncblockstart-return-undefined"></emu-xref> above.
+          1. Let _result_ be ! RunSuspendedContext(_asyncContext_, NormalCompletion(~empty~)).
+          1. Assert: _result_ is ~unused~.
+          1. NOTE: The possible sources of _result_ values are Await or, if the async function doesn't await anything, step <emu-xref href="#step-asyncblockstart-return-undefined"></emu-xref> above.
           1. Return ~unused~.
         </emu-alg>
       </emu-clause>
@@ -51340,19 +51344,13 @@ THH:mm:ss.sss
           1. Let _asyncContext_ be the running execution context.
           1. Let _promise_ be ? PromiseResolve(%Promise%, _value_).
           1. Let _fulfilledClosure_ be a new Abstract Closure with parameters (_v_) that captures _asyncContext_ and performs the following steps when called:
-            1. Let _prevContext_ be the running execution context.
-            1. Suspend _prevContext_.
-            1. Push _asyncContext_ onto the execution context stack; _asyncContext_ is now the running execution context.
-            1. <emu-meta effects="user-code">Resume the suspended evaluation of _asyncContext_</emu-meta> using NormalCompletion(_v_) as the result of the operation that suspended it.
-            1. Assert: When we reach this step, _asyncContext_ has already been removed from the execution context stack and _prevContext_ is the currently running execution context.
+            1. Perform Completion(RunSuspendedContext(_asyncContext_, NormalCompletion(_v_))).
+            1. NOTE: The Completion Record returned by RunSuspendedContext is intentionally ignored.
             1. Return NormalCompletion(*undefined*).
           1. Let _onFulfilled_ be CreateBuiltinFunction(_fulfilledClosure_, 1, *""*, « »).
           1. Let _rejectedClosure_ be a new Abstract Closure with parameters (_reason_) that captures _asyncContext_ and performs the following steps when called:
-            1. Let _prevContext_ be the running execution context.
-            1. Suspend _prevContext_.
-            1. Push _asyncContext_ onto the execution context stack; _asyncContext_ is now the running execution context.
-            1. <emu-meta effects="user-code">Resume the suspended evaluation of _asyncContext_</emu-meta> using ThrowCompletion(_reason_) as the result of the operation that suspended it.
-            1. Assert: When we reach this step, _asyncContext_ has already been removed from the execution context stack and _prevContext_ is the currently running execution context.
+            1. Perform Completion(RunSuspendedContext(_asyncContext_, ThrowCompletion(_reason_))).
+            1. NOTE: The Completion Record returned by RunSuspendedContext is intentionally ignored.
             1. Return NormalCompletion(*undefined*).
           1. Let _onRejected_ be CreateBuiltinFunction(_rejectedClosure_, 1, *""*, « »).
           1. Perform PerformPromiseThen(_promise_, _onFulfilled_, _onRejected_).


### PR DESCRIPTION
This doesn't address the semantics of Suspend/Resume, just factors out a common chunk of code.

This PR is split into 6 commits where it's easier to confirm the correctness. They're probably fine to be squashed before landing.