### PR TITLE
Editorial: Eliminate weird `Return` notes

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -4090,9 +4090,10 @@
           1. Let _onRejected_ be CreateBuiltinFunction(_rejectedClosure_, 1, *""*, « »).
           1. Perform PerformPromiseThen(_promise_, _onFulfilled_, _onRejected_).
           1. Remove _asyncContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
-          1. Set the code evaluation state of _asyncContext_ such that when evaluation is resumed with a Completion Record _completion_, the following steps of the algorithm that invoked Await will be performed, with _completion_ available.
-          1. Return NormalCompletion(~unused~).
-          1. NOTE: This returns to the evaluation of the operation that had most previously resumed evaluation of _asyncContext_.
+          1. Let _callerContext_ be the running execution context.
+          1. Resume _callerContext_ passing ~empty~. If _asyncContext_ is ever resumed again, let _completion_ be the Completion Record with which it is resumed.
+          1. Assert: If control reaches here, then _asyncContext_ is the running execution context again.
+          1. NOTE: The following steps of the algorithm that invoked Await will be performed, with _completion_ available.
         </emu-alg>
 
         <p>where all aliases in the above steps, with the exception of _completion_, are ephemeral and visible only in the steps pertaining to Await.</p>
@@ -45169,11 +45170,10 @@ THH:mm:ss.sss
           1. Assert: GetGeneratorKind() is ~sync~.
           1. Set _generator_.[[GeneratorState]] to ~suspendedYield~.
           1. Remove _genContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
-          1. [declared="resumptionValue"] Set the code evaluation state of _genContext_ such that when evaluation is resumed with a Completion Record _resumptionValue_ the following steps will be performed:
-            1. Return _resumptionValue_.
-            1. NOTE: This returns to the evaluation of the |YieldExpression| that originally called this abstract operation.
-          1. Return _iterNextObj_.
-          1. NOTE: This returns to the evaluation of the operation that had most previously resumed evaluation of _genContext_.
+          1. Let _callerContext_ be the running execution context.
+          1. Resume _callerContext_ passing NormalCompletion(_iterNextObj_). If _genContext_ is ever resumed again, let _resumptionValue_ be the Completion Record with which it is resumed.
+          1. Assert: If control reaches here, then _genContext_ is the running execution context again.
+          1. Return _resumptionValue_.
         </emu-alg>
       </emu-clause>
 
@@ -45553,11 +45553,10 @@ THH:mm:ss.sss
           1. Else,
             1. Set _generator_.[[AsyncGeneratorState]] to ~suspendedYield~.
             1. Remove _genContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
-            1. Set the code evaluation state of _genContext_ such that when evaluation is resumed with a Completion Record _resumptionValue_ the following steps will be performed:
-              1. Return ? AsyncGeneratorUnwrapYieldResumption(_resumptionValue_).
-              1. NOTE: When the above step returns, it returns to the evaluation of the |YieldExpression| production that originally called this abstract operation.
-            1. Return *undefined*.
-            1. NOTE: This returns to the evaluation of the operation that had most previously resumed evaluation of _genContext_.
+            1. Let _callerContext_ be the running execution context.
+            1. Resume _callerContext_ passing *undefined*. If _genContext_ is ever resumed again, let _resumptionValue_ be the Completion Record with which it is resumed.
+            1. Assert: If control reaches here, then _genContext_ is the running execution context again.
+            1. Return ? AsyncGeneratorUnwrapYieldResumption(_resumptionValue_).
         </emu-alg>
       </emu-clause>
 


### PR DESCRIPTION
That is, eliminate NOTE-steps that tell you where a Return-step returns to.

Resolves #2400 by performing the transformation outlined in https://github.com/tc39/ecma262/issues/2400#issuecomment-832335872

This PR goes in roughly the same direction as #2429, but not as far, so maybe it has a better chance of being approved.