### PR TITLE
Editorial: `Object.getOwnProperty{Names,Symbols}`: refactor where the List is converted

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -29461,7 +29461,7 @@
         <h1>Object.getOwnPropertyNames ( _O_ )</h1>
         <p>When the `getOwnPropertyNames` function is called, the following steps are taken:</p>
         <emu-alg>
-          1. Return ? GetOwnPropertyKeys(_O_, ~string~).
+          1. Return ! CreateArrayFromList(? GetOwnPropertyKeys(_O_, ~string~)).
         </emu-alg>
       </emu-clause>
 
@@ -29469,7 +29469,7 @@
         <h1>Object.getOwnPropertySymbols ( _O_ )</h1>
         <p>When the `getOwnPropertySymbols` function is called with argument _O_, the following steps are taken:</p>
         <emu-alg>
-          1. Return ? GetOwnPropertyKeys(_O_, ~symbol~).
+          1. Return ! CreateArrayFromList(? GetOwnPropertyKeys(_O_, ~symbol~)).
         </emu-alg>
 
         <emu-clause id="sec-getownpropertykeys" type="abstract operation">
@@ -29488,7 +29488,7 @@
             1. For each element _nextKey_ of _keys_, do
               1. If Type(_nextKey_) is Symbol and _type_ is ~symbol~ or Type(_nextKey_) is String and _type_ is ~string~, then
                 1. Append _nextKey_ as the last element of _nameList_.
-            1. Return CreateArrayFromList(_nameList_).
+            1. Return _nameList_.
           </emu-alg>
         </emu-clause>
       </emu-clause>


### PR DESCRIPTION
Extracted this from #2547.