### PR TITLE
Meta: publish biblio to npm

### DIFF
--- a/.github/workflows/publish-biblio.yml
+++ b/.github/workflows/publish-biblio.yml
@@ -1,0 +1,27 @@
+name: 'ecma-262-biblio'
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    name: 'publish ecma262-biblio'
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'tc39/ecma262' }}
+
+    steps:
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 'lts/*'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Publish biblio
+        run: scripts/publish-biblio.sh
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_FOR_TC39_USER }}

--- a/biblio/README.md
+++ b/biblio/README.md
@@ -1,0 +1,9 @@
+# ECMA-262 Bibliography
+
+This package, available on npm as `@tc39/ecma262-biblio`, contains a machine-readable representation of the terms, clauses, grammar, and abstract operations defined in ECMA-262. This will primarily be of use to people working with the specification itself.
+
+If added as a dependency to a project using ecmarkup, you can load it by passing `--load-biblio @tc39/ecma262-biblio`.
+
+It is automatically updated whenever ECMA-262 is. It is inherently unstable: editorial changes to the specification may add, remove, or modify the biblio, which may break your build (for example, if using ecmarkup with `--lint-spec --strict`). As such, **the usual semver guarantees do not hold**. You should pin a precise version of this package.
+
+Major version bumps may be used for breaking changes to the format of the biblio itself. Minor version bumps may be used for non-breaking additions to the biblio format.

--- a/biblio/package.json
+++ b/biblio/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@tc39/ecma262-biblio",
+  "version": "VERSIONED-DURING-PUBLISH",
+  "description": "Machine-readable representation of the internals of the ecma-262 spec",
+  "keywords": [
+    "ecmascript"
+  ],
+  "author": "TC39",
+  "main": "biblio.json",
+  "exports": {
+    ".": "./biblio.json",
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "biblio.json"
+  ],
+  "license": "SEE LICENSE IN LICENSE.md"
+}

--- a/scripts/publish-biblio.sh
+++ b/scripts/publish-biblio.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+
+$(npm bin)/ecmarkup --verbose spec.html --write-biblio biblio/biblio.json /dev/null
+
+cp LICENSE.md biblio/
+
+cd biblio
+
+COMMIT_COUNT=$(git rev-list --count HEAD)
+npm version --no-git-tag-version "1.0.${COMMIT_COUNT}"
+
+SHORT_COMMIT=$(git rev-parse --short HEAD)
+LONG_COMMIT=$(git rev-parse --verify HEAD)
+echo "
+This version was built from commit [${SHORT_COMMIT}](https://github.com/tc39/ecma262/tree/${LONG_COMMIT})." >> README.md
+
+npm publish --access public


### PR DESCRIPTION
Fixes https://github.com/tc39/ecmarkup/issues/251. Fixes https://github.com/tc39/ecma262/issues/2321.

I haven't tested this, but it will probably work.

~Also, we need to pick a name for it. `ecma262-biblio` seems like an obvious choice. We could choose to scope it under the `@tc39` namespace, but to my understanding we can have it be controlled by that organization even if we place it at the top-level scope.~ Edit: went with `@tc39/ecma262-biblio`.

As for version numbers, ~right now I'm just using the number of seconds since 1970 as the patch version~ edit: went with number of commits on the branch, with an explicit callout in the readme that the package does not follow semver (since the biblio can change at any time, which can break your build if you depend on it for ecmarkup and build using `--strict`).