### PR TITLE
Editorial: Change many "abrupt completion" to "throw completion"

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1366,7 +1366,7 @@
               BigInt::exponentiate
             </td>
             <td>
-              either a normal completion containing a BigInt or an abrupt completion
+              either a normal completion containing a BigInt or a throw completion
             </td>
           </tr>
 
@@ -1412,7 +1412,7 @@
               BigInt::divide
             </td>
             <td>
-              either a normal completion containing a BigInt or an abrupt completion
+              either a normal completion containing a BigInt or a throw completion
             </td>
           </tr>
 
@@ -1435,7 +1435,7 @@
               BigInt::remainder
             </td>
             <td>
-              either a normal completion containing a BigInt or an abrupt completion
+              either a normal completion containing a BigInt or a throw completion
             </td>
           </tr>
 
@@ -2290,7 +2290,7 @@
             BigInt::exponentiate (
               _base_: a BigInt,
               _exponent_: a BigInt,
-            ): either a normal completion containing a BigInt or an abrupt completion
+            ): either a normal completion containing a BigInt or a throw completion
           </h1>
           <dl class="header">
           </dl>
@@ -2321,7 +2321,7 @@
             BigInt::divide (
               _x_: a BigInt,
               _y_: a BigInt,
-            ): either a normal completion containing a BigInt or an abrupt completion
+            ): either a normal completion containing a BigInt or a throw completion
           </h1>
           <dl class="header">
           </dl>
@@ -2337,7 +2337,7 @@
             BigInt::remainder (
               _n_: a BigInt,
               _d_: a BigInt,
-            ): either a normal completion containing a BigInt or an abrupt completion
+            ): either a normal completion containing a BigInt or a throw completion
           </h1>
           <dl class="header">
           </dl>
@@ -4399,7 +4399,7 @@
         <h1>
           ToPropertyDescriptor (
             _Obj_: unknown,
-          ): either a normal completion containing a Property Descriptor or an abrupt completion
+          ): either a normal completion containing a Property Descriptor or a throw completion
         </h1>
         <dl class="header">
         </dl>
@@ -4494,7 +4494,7 @@
         <h1>
           CreateByteDataBlock (
             _size_: a non-negative integer,
-          ): either a normal completion containing a Data Block or an abrupt completion
+          ): either a normal completion containing a Data Block or a throw completion
         </h1>
         <dl class="header">
         </dl>
@@ -4509,7 +4509,7 @@
         <h1>
           CreateSharedByteDataBlock (
             _size_: a non-negative integer,
-          ): either a normal completion containing a Shared Data Block or an abrupt completion
+          ): either a normal completion containing a Shared Data Block or a throw completion
         </h1>
         <dl class="header">
         </dl>
@@ -4756,7 +4756,7 @@
         ToPrimitive (
           _input_: an ECMAScript language value,
           optional _preferredType_: ~string~ or ~number~,
-        ): either a normal completion containing an ECMAScript language value or an abrupt completion
+        ): either a normal completion containing an ECMAScript language value or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -4787,7 +4787,7 @@
           OrdinaryToPrimitive (
             _O_: an Object,
             _hint_: ~string~ or ~number~,
-          ): either a normal completion containing an ECMAScript language value or an abrupt completion
+          ): either a normal completion containing an ECMAScript language value or a throw completion
         </h1>
         <dl class="header">
         </dl>
@@ -4901,7 +4901,7 @@
       <h1>
         ToNumeric (
           _value_: unknown,
-        ): either a normal completion containing either a Number or a BigInt, or an abrupt completion
+        ): either a normal completion containing either a Number or a BigInt, or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -4918,7 +4918,7 @@
       <h1>
         ToNumber (
           _argument_: unknown,
-        ): either a normal completion containing a Number or an abrupt completion
+        ): either a normal completion containing a Number or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -5161,7 +5161,7 @@
       <h1>
         ToIntegerOrInfinity (
           _argument_: an ECMAScript language value,
-        ): either a normal completion containing either an integer, +&infin;, or -&infin;, or an abrupt completion
+        ): either a normal completion containing either an integer, +&infin;, or -&infin;, or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -5182,7 +5182,7 @@
       <h1>
         ToInt32 (
           _argument_: unknown,
-        ): either a normal completion containing an integral Number or an abrupt completion
+        ): either a normal completion containing an integral Number or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -5215,7 +5215,7 @@
       <h1>
         ToUint32 (
           _argument_: unknown,
-        ): either a normal completion containing an integral Number or an abrupt completion
+        ): either a normal completion containing an integral Number or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -5251,7 +5251,7 @@
       <h1>
         ToInt16 (
           _argument_: unknown,
-        ): either a normal completion containing an integral Number or an abrupt completion
+        ): either a normal completion containing an integral Number or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -5270,7 +5270,7 @@
       <h1>
         ToUint16 (
           _argument_: unknown,
-        ): either a normal completion containing an integral Number or an abrupt completion
+        ): either a normal completion containing an integral Number or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -5300,7 +5300,7 @@
       <h1>
         ToInt8 (
           _argument_: unknown,
-        ): either a normal completion containing an integral Number or an abrupt completion
+        ): either a normal completion containing an integral Number or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -5319,7 +5319,7 @@
       <h1>
         ToUint8 (
           _argument_: unknown,
-        ): either a normal completion containing an integral Number or an abrupt completion
+        ): either a normal completion containing an integral Number or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -5338,7 +5338,7 @@
       <h1>
         ToUint8Clamp (
           _argument_: unknown,
-        ): either a normal completion containing an integral Number or an abrupt completion
+        ): either a normal completion containing an integral Number or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -5364,7 +5364,7 @@
       <h1>
         ToBigInt (
           _argument_: unknown,
-        ): either a normal completion containing a BigInt or an abrupt completion
+        ): either a normal completion containing a BigInt or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -5497,7 +5497,7 @@
       <h1>
         ToBigInt64 (
           _argument_: unknown,
-        ): either a normal completion containing a BigInt or an abrupt completion
+        ): either a normal completion containing a BigInt or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -5514,7 +5514,7 @@
       <h1>
         ToBigUint64 (
           _argument_: unknown,
-        ): either a normal completion containing a BigInt or an abrupt completion
+        ): either a normal completion containing a BigInt or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -5531,7 +5531,7 @@
       <h1>
         ToString (
           _argument_: unknown,
-        ): either a normal completion containing a String or an abrupt completion
+        ): either a normal completion containing a String or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -5624,7 +5624,7 @@
       <h1>
         ToObject (
           _argument_: unknown,
-        ): either a normal completion containing an Object or an abrupt completion
+        ): either a normal completion containing an Object or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -5712,7 +5712,7 @@
       <h1>
         ToPropertyKey (
           _argument_: unknown,
-        ): either a normal completion containing a property key or an abrupt completion
+        ): either a normal completion containing a property key or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -5730,7 +5730,7 @@
       <h1>
         ToLength (
           _argument_: an ECMAScript language value,
-        ): either a normal completion containing an integral Number or an abrupt completion
+        ): either a normal completion containing an integral Number or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -5766,7 +5766,7 @@
       <h1>
         ToIndex (
           _value_: an ECMAScript language value,
-        ): either a normal completion containing a non-negative integer or an abrupt completion
+        ): either a normal completion containing a non-negative integer or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -5792,7 +5792,7 @@
       <h1>
         RequireObjectCoercible (
           _argument_: unknown,
-        ): either a normal completion containing an ECMAScript language value or an abrupt completion
+        ): either a normal completion containing an ECMAScript language value or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -5880,7 +5880,7 @@
       <h1>
         IsArray (
           _argument_: unknown,
-        ): either a normal completion containing a Boolean or an abrupt completion
+        ): either a normal completion containing a Boolean or a throw completion
       </h1>
       <dl class="header">
       </dl>
@@ -5933,7 +5933,7 @@
       <h1>
         IsExtensible (
           _O_: an Object,
-        ): either a normal completion containing a Boolean or an abrupt completion
+        ): either a normal completion containing a Boolean or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -5983,7 +5983,7 @@
       <h1>
         IsRegExp (
           _argument_: unknown,
-        ): either a normal completion containing a Boolean or an abrupt completion
+        ): either a normal completion containing a Boolean or a throw completion
       </h1>
       <dl class="header">
       </dl>
@@ -6114,7 +6114,7 @@
           _x_: an ECMAScript language value,
           _y_: an ECMAScript language value,
           _LeftFirst_: a Boolean,
-        ): either a normal completion containing either a Boolean or *undefined*, or an abrupt completion
+        ): either a normal completion containing either a Boolean or *undefined*, or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -6172,7 +6172,7 @@
         IsLooselyEqual (
           _x_: an ECMAScript language value,
           _y_: an ECMAScript language value,
-        ): either a normal completion containing a Boolean or an abrupt completion
+        ): either a normal completion containing a Boolean or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -6260,7 +6260,7 @@
         Get (
           _O_: an Object,
           _P_: a property key,
-        ): either a normal completion containing an ECMAScript language value or an abrupt completion
+        ): either a normal completion containing an ECMAScript language value or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -6276,7 +6276,7 @@
         GetV (
           _V_: an ECMAScript language value,
           _P_: a property key,
-        ): either a normal completion containing an ECMAScript language value or an abrupt completion
+        ): either a normal completion containing an ECMAScript language value or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -6295,7 +6295,7 @@
           _P_: a property key,
           _V_: an ECMAScript language value,
           _Throw_: a Boolean,
-        ): either a normal completion containing ~unused~ or an abrupt completion
+        ): either a normal completion containing ~unused~ or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -6314,7 +6314,7 @@
           _O_: an Object,
           _P_: a property key,
           _V_: an ECMAScript language value,
-        ): either a normal completion containing a Boolean or an abrupt completion
+        ): either a normal completion containing a Boolean or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -6358,7 +6358,7 @@
           _O_: an Object,
           _P_: a property key,
           _V_: an ECMAScript language value,
-        ): either a normal completion containing a Boolean or an abrupt completion
+        ): either a normal completion containing a Boolean or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -6403,7 +6403,7 @@
           _O_: an Object,
           _P_: a property key,
           _desc_: a Property Descriptor,
-        ): either a normal completion containing ~unused~ or an abrupt completion
+        ): either a normal completion containing ~unused~ or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -6421,7 +6421,7 @@
         DeletePropertyOrThrow (
           _O_: an Object,
           _P_: a property key,
-        ): either a normal completion containing ~unused~ or an abrupt completion
+        ): either a normal completion containing ~unused~ or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -6439,7 +6439,7 @@
         GetMethod (
           _V_: an ECMAScript language value,
           _P_: a property key,
-        ): either a normal completion containing either a function object or *undefined*, or an abrupt completion
+        ): either a normal completion containing either a function object or *undefined*, or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -6458,7 +6458,7 @@
         HasProperty (
           _O_: an Object,
           _P_: a property key,
-        ): either a normal completion containing a Boolean or an abrupt completion
+        ): either a normal completion containing a Boolean or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -6474,7 +6474,7 @@
         HasOwnProperty (
           _O_: an Object,
           _P_: a property key,
-        ): either a normal completion containing a Boolean or an abrupt completion
+        ): either a normal completion containing a Boolean or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -6493,7 +6493,7 @@
           _F_: an ECMAScript language value,
           _V_: an ECMAScript language value,
           optional _argumentsList_: a List of ECMAScript language values,
-        ): either a normal completion containing an ECMAScript language value or an abrupt completion
+        ): either a normal completion containing an ECMAScript language value or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -6512,7 +6512,7 @@
           _F_: a constructor,
           optional _argumentsList_: unknown,
           optional _newTarget_: a constructor,
-        ): either a normal completion containing an Object or an abrupt completion
+        ): either a normal completion containing an Object or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -6533,7 +6533,7 @@
         SetIntegrityLevel (
           _O_: an Object,
           _level_: ~sealed~ or ~frozen~,
-        ): either a normal completion containing a Boolean or an abrupt completion
+        ): either a normal completion containing a Boolean or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -6565,7 +6565,7 @@
         TestIntegrityLevel (
           _O_: an Object,
           _level_: ~sealed~ or ~frozen~,
-        ): either a normal completion containing a Boolean or an abrupt completion
+        ): either a normal completion containing a Boolean or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -6610,7 +6610,7 @@
       <h1>
         LengthOfArrayLike (
           _obj_: an Object,
-        ): either a normal completion containing a non-negative integer or an abrupt completion
+        ): either a normal completion containing a non-negative integer or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -6633,7 +6633,7 @@
         CreateListFromArrayLike (
           _obj_: unknown,
           optional _elementTypes_: a List of names of ECMAScript Language Types,
-        ): either a normal completion containing a List or an abrupt completion
+        ): either a normal completion containing a List or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -6661,7 +6661,7 @@
           _V_: an ECMAScript language value,
           _P_: a property key,
           optional _argumentsList_: a List of ECMAScript language values,
-        ): either a normal completion containing an ECMAScript language value or an abrupt completion
+        ): either a normal completion containing an ECMAScript language value or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -6680,7 +6680,7 @@
         OrdinaryHasInstance (
           _C_: an ECMAScript language value,
           _O_: unknown,
-        ): either a normal completion containing a Boolean or an abrupt completion
+        ): either a normal completion containing a Boolean or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -6706,7 +6706,7 @@
         SpeciesConstructor (
           _O_: an Object,
           _defaultConstructor_: a constructor,
-        ): either a normal completion containing a constructor or an abrupt completion
+        ): either a normal completion containing a constructor or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -6728,7 +6728,7 @@
         EnumerableOwnPropertyNames (
           _O_: an Object,
           _kind_: ~key~, ~value~, or ~key+value~,
-        ): either a normal completion containing a List or an abrupt completion
+        ): either a normal completion containing a List or a throw completion
       </h1>
       <dl class="header">
       </dl>
@@ -6755,7 +6755,7 @@
       <h1>
         GetFunctionRealm (
           _obj_: a function object,
-        ): either a normal completion containing a Realm Record or an abrupt completion
+        ): either a normal completion containing a Realm Record or a throw completion
       </h1>
       <dl class="header">
       </dl>
@@ -6782,7 +6782,7 @@
           _target_: an Object,
           _source_: an ECMAScript language value,
           _excludedItems_: a List of property keys,
-        ): either a normal completion containing ~unused~ or an abrupt completion
+        ): either a normal completion containing ~unused~ or a throw completion
       </h1>
       <dl class="header">
       </dl>
@@ -6830,7 +6830,7 @@
           _O_: an Object,
           _P_: a Private Name,
           _value_: an ECMAScript language value,
-        ): either a normal completion containing ~unused~ or an abrupt completion
+        ): either a normal completion containing ~unused~ or a throw completion
       </h1>
       <dl class="header">
       </dl>
@@ -6847,7 +6847,7 @@
         PrivateMethodOrAccessorAdd (
           _O_: an Object,
           _method_: a PrivateElement,
-        ): either a normal completion containing ~unused~ or an abrupt completion
+        ): either a normal completion containing ~unused~ or a throw completion
       </h1>
       <dl class="header">
       </dl>
@@ -6868,7 +6868,7 @@
         PrivateGet (
           _O_: an Object,
           _P_: a Private Name,
-        ): either a normal completion containing an ECMAScript language value or an abrupt completion
+        ): either a normal completion containing an ECMAScript language value or a throw completion
       </h1>
       <dl class="header">
       </dl>
@@ -6890,7 +6890,7 @@
           _O_: an Object,
           _P_: a Private Name,
           _value_: an ECMAScript language value,
-        ): either a normal completion containing ~unused~ or an abrupt completion
+        ): either a normal completion containing ~unused~ or a throw completion
       </h1>
       <dl class="header">
       </dl>
@@ -6915,7 +6915,7 @@
         DefineField (
           _receiver_: an Object,
           _fieldRecord_: a ClassFieldDefinition Record,
-        ): either a normal completion containing ~unused~ or an abrupt completion
+        ): either a normal completion containing ~unused~ or a throw completion
       </h1>
       <dl class="header">
       </dl>
@@ -6939,7 +6939,7 @@
         InitializeInstanceElements (
           _O_: an Object,
           _constructor_: an ECMAScript function object,
-        ): either a normal completion containing ~unused~ or an abrupt completion
+        ): either a normal completion containing ~unused~ or a throw completion
       </h1>
       <dl class="header">
       </dl>
@@ -7019,7 +7019,7 @@
           _obj_: an ECMAScript language value,
           optional _hint_: ~sync~ or ~async~,
           optional _method_: a function object,
-        ): either a normal completion containing an Iterator Record or an abrupt completion
+        ): either a normal completion containing an Iterator Record or a throw completion
       </h1>
       <dl class="header">
       </dl>
@@ -7046,7 +7046,7 @@
         IteratorNext (
           _iteratorRecord_: an Iterator Record,
           optional _value_: an ECMAScript language value,
-        ): either a normal completion containing an Object or an abrupt completion
+        ): either a normal completion containing an Object or a throw completion
       </h1>
       <dl class="header">
       </dl>
@@ -7064,7 +7064,7 @@
       <h1>
         IteratorComplete (
           _iterResult_: an Object,
-        ): either a normal completion containing a Boolean or an abrupt completion
+        ): either a normal completion containing a Boolean or a throw completion
       </h1>
       <dl class="header">
       </dl>
@@ -7077,7 +7077,7 @@
       <h1>
         IteratorValue (
           _iterResult_: an Object,
-        ): either a normal completion containing an ECMAScript language value or an abrupt completion
+        ): either a normal completion containing an ECMAScript language value or a throw completion
       </h1>
       <dl class="header">
       </dl>
@@ -7090,7 +7090,7 @@
       <h1>
         IteratorStep (
           _iteratorRecord_: an Iterator Record,
-        ): either a normal completion containing either an Object or *false*, or an abrupt completion
+        ): either a normal completion containing either an Object or *false*, or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -7217,7 +7217,7 @@
         IterableToList (
           _items_: an ECMAScript language value,
           optional _method_: a function object,
-        ): either a normal completion containing a List or an abrupt completion
+        ): either a normal completion containing a List or a throw completion
       </h1>
       <dl class="header">
       </dl>
@@ -10245,7 +10245,7 @@
               _N_: a String,
               _V_: an ECMAScript language value,
               _S_: a Boolean,
-            ): either a normal completion containing ~unused~ or an abrupt completion
+            ): either a normal completion containing ~unused~ or a throw completion
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -10279,7 +10279,7 @@
             GetBindingValue (
               _N_: a String,
               _S_: a Boolean,
-            ): either a normal completion containing an ECMAScript language value or an abrupt completion
+            ): either a normal completion containing an ECMAScript language value or a throw completion
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -10404,7 +10404,7 @@
           <h1>
             HasBinding (
               _N_: a String,
-            ): either a normal completion containing a Boolean or an abrupt completion
+            ): either a normal completion containing a Boolean or a throw completion
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -10431,7 +10431,7 @@
             CreateMutableBinding (
               _N_: a String,
               _D_: a Boolean,
-            ): either a normal completion containing ~unused~ or an abrupt completion
+            ): either a normal completion containing ~unused~ or a throw completion
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -10460,7 +10460,7 @@
             InitializeBinding (
               _N_: a String,
               _V_: an ECMAScript language value,
-            ): either a normal completion containing ~unused~ or an abrupt completion
+            ): either a normal completion containing ~unused~ or a throw completion
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -10484,7 +10484,7 @@
               _N_: a String,
               _V_: an ECMAScript language value,
               _S_: a Boolean,
-            ): either a normal completion containing ~unused~ or an abrupt completion
+            ): either a normal completion containing ~unused~ or a throw completion
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -10507,7 +10507,7 @@
             GetBindingValue (
               _N_: a String,
               _S_: a Boolean,
-            ): either a normal completion containing an ECMAScript language value or an abrupt completion
+            ): either a normal completion containing an ECMAScript language value or a throw completion
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -10529,7 +10529,7 @@
           <h1>
             DeleteBinding (
               _N_: a String,
-            ): either a normal completion containing a Boolean or an abrupt completion
+            ): either a normal completion containing a Boolean or a throw completion
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -10691,7 +10691,7 @@
           <h1>
             BindThisValue (
               _V_: an ECMAScript language value,
-            ): either a normal completion containing an ECMAScript language value or an abrupt completion
+            ): either a normal completion containing an ECMAScript language value or a throw completion
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -10730,7 +10730,7 @@
         </emu-clause>
 
         <emu-clause id="sec-function-environment-records-getthisbinding" type="concrete method">
-          <h1>GetThisBinding ( ): either a normal completion containing an ECMAScript language value or an abrupt completion</h1>
+          <h1>GetThisBinding ( ): either a normal completion containing an ECMAScript language value or a throw completion</h1>
           <dl class="header">
             <dt>for</dt>
             <dd>a function Environment Record _envRec_</dd>
@@ -10743,7 +10743,7 @@
         </emu-clause>
 
         <emu-clause id="sec-getsuperbase" type="concrete method">
-          <h1>GetSuperBase ( ): either a normal completion containing either an Object, *null*, or *undefined*, or an abrupt completion</h1>
+          <h1>GetSuperBase ( ): either a normal completion containing either an Object, *null*, or *undefined*, or a throw completion</h1>
           <dl class="header">
             <dt>for</dt>
             <dd>a function Environment Record _envRec_</dd>
@@ -10904,7 +10904,7 @@
           <h1>
             HasBinding (
               _N_: a String,
-            ): either a normal completion containing a Boolean or an abrupt completion
+            ): either a normal completion containing a Boolean or a throw completion
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -10926,7 +10926,7 @@
             CreateMutableBinding (
               _N_: a String,
               _D_: a Boolean,
-            ): either a normal completion containing ~unused~ or an abrupt completion
+            ): either a normal completion containing ~unused~ or a throw completion
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -10947,7 +10947,7 @@
             CreateImmutableBinding (
               _N_: a String,
               _S_: a Boolean,
-            ): either a normal completion containing ~unused~ or an abrupt completion
+            ): either a normal completion containing ~unused~ or a throw completion
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -10968,7 +10968,7 @@
             InitializeBinding (
               _N_: a String,
               _V_: an ECMAScript language value,
-            ): either a normal completion containing ~unused~ or an abrupt completion
+            ): either a normal completion containing ~unused~ or a throw completion
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -10993,7 +10993,7 @@
               _N_: a String,
               _V_: an ECMAScript language value,
               _S_: a Boolean,
-            ): either a normal completion containing ~unused~ or an abrupt completion
+            ): either a normal completion containing ~unused~ or a throw completion
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -11016,7 +11016,7 @@
             GetBindingValue (
               _N_: a String,
               _S_: a Boolean,
-            ): either a normal completion containing an ECMAScript language value or an abrupt completion
+            ): either a normal completion containing an ECMAScript language value or a throw completion
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -11038,7 +11038,7 @@
           <h1>
             DeleteBinding (
               _N_: a String,
-            ): either a normal completion containing a Boolean or an abrupt completion
+            ): either a normal completion containing a Boolean or a throw completion
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -11157,7 +11157,7 @@
           <h1>
             HasRestrictedGlobalProperty (
               _N_: a String,
-            ): either a normal completion containing a Boolean or an abrupt completion
+            ): either a normal completion containing a Boolean or a throw completion
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -11183,7 +11183,7 @@
           <h1>
             CanDeclareGlobalVar (
               _N_: a String,
-            ): either a normal completion containing a Boolean or an abrupt completion
+            ): either a normal completion containing a Boolean or a throw completion
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -11205,7 +11205,7 @@
           <h1>
             CanDeclareGlobalFunction (
               _N_: a String,
-            ): either a normal completion containing a Boolean or an abrupt completion
+            ): either a normal completion containing a Boolean or a throw completion
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -11230,7 +11230,7 @@
             CreateGlobalVarBinding (
               _N_: a String,
               _D_: a Boolean,
-            ): either a normal completion containing ~unused~ or an abrupt completion
+            ): either a normal completion containing ~unused~ or a throw completion
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -11260,7 +11260,7 @@
               _N_: a String,
               _V_: an ECMAScript language value,
               _D_: a Boolean,
-            ): either a normal completion containing ~unused~ or an abrupt completion
+            ): either a normal completion containing ~unused~ or a throw completion
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -11329,7 +11329,7 @@
             GetBindingValue (
               _N_: a String,
               _S_: a Boolean,
-            ): either a normal completion containing an ECMAScript language value or an abrupt completion
+            ): either a normal completion containing an ECMAScript language value or a throw completion
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -11422,7 +11422,7 @@
             _env_: an Environment Record or *null*,
             _name_: a String,
             _strict_: a Boolean,
-          ): either a normal completion containing a Reference Record or an abrupt completion
+          ): either a normal completion containing a Reference Record or a throw completion
         </h1>
         <dl class="header">
         </dl>
@@ -11749,7 +11749,7 @@
       <h1>
         SetDefaultGlobalBindings (
           _realmRec_: unknown,
-        ): either a normal completion containing an Object or an abrupt completion
+        ): either a normal completion containing an Object or a throw completion
       </h1>
       <dl class="header">
       </dl>
@@ -11896,7 +11896,7 @@
         ResolveBinding (
           _name_: a String,
           optional _env_: an Environment Record or *undefined*,
-        ): either a normal completion containing a Reference Record or an abrupt completion
+        ): either a normal completion containing a Reference Record or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -11935,7 +11935,7 @@
     </emu-clause>
 
     <emu-clause id="sec-resolvethisbinding" type="abstract operation">
-      <h1>ResolveThisBinding ( ): either a normal completion containing an ECMAScript language value or an abrupt completion</h1>
+      <h1>ResolveThisBinding ( ): either a normal completion containing an ECMAScript language value or a throw completion</h1>
       <dl class="header">
         <dt>description</dt>
         <dd>It determines the binding of the keyword `this` using the LexicalEnvironment of the running execution context.</dd>
@@ -12087,7 +12087,7 @@
           _jobCallback_: a JobCallback Record,
           _V_: an ECMAScript language value,
           _argumentsList_: a List of ECMAScript language values,
-        ): either a normal completion containing an ECMAScript language value or an abrupt completion
+        ): either a normal completion containing an ECMAScript language value or a throw completion
       </h1>
       <dl class="header">
       </dl>
@@ -12132,7 +12132,7 @@
   </emu-clause>
 
   <emu-clause id="sec-initializehostdefinedrealm" type="abstract operation">
-    <h1>InitializeHostDefinedRealm ( ): either a normal completion containing ~unused~ or an abrupt completion</h1>
+    <h1>InitializeHostDefinedRealm ( ): either a normal completion containing ~unused~ or a throw completion</h1>
     <dl class="header">
     </dl>
 
@@ -12477,7 +12477,7 @@
     <h1>
       CleanupFinalizationRegistry (
         _finalizationRegistry_: a FinalizationRegistry,
-      ): either a normal completion containing ~unused~ or an abrupt completion
+      ): either a normal completion containing ~unused~ or a throw completion
     </h1>
     <dl class="header">
     </dl>
@@ -12667,7 +12667,7 @@
         [[DefineOwnProperty]] (
           _P_: a property key,
           _Desc_: a Property Descriptor,
-        ): either a normal completion containing a Boolean or an abrupt completion
+        ): either a normal completion containing a Boolean or a throw completion
       </h1>
       <dl class="header">
         <dt>for</dt>
@@ -12683,7 +12683,7 @@
             _O_: an Object,
             _P_: a property key,
             _Desc_: a Property Descriptor,
-          ): either a normal completion containing a Boolean or an abrupt completion
+          ): either a normal completion containing a Boolean or a throw completion
         </h1>
         <dl class="header">
         </dl>
@@ -12765,7 +12765,7 @@
       <h1>
         [[HasProperty]] (
           _P_: a property key,
-        ): either a normal completion containing a Boolean or an abrupt completion
+        ): either a normal completion containing a Boolean or a throw completion
       </h1>
       <dl class="header">
         <dt>for</dt>
@@ -12780,7 +12780,7 @@
           OrdinaryHasProperty (
             _O_: an Object,
             _P_: a property key,
-          ): either a normal completion containing a Boolean or an abrupt completion
+          ): either a normal completion containing a Boolean or a throw completion
         </h1>
         <dl class="header">
         </dl>
@@ -12800,7 +12800,7 @@
         [[Get]] (
           _P_: a property key,
           _Receiver_: an ECMAScript language value,
-        ): either a normal completion containing an ECMAScript language value or an abrupt completion
+        ): either a normal completion containing an ECMAScript language value or a throw completion
       </h1>
       <dl class="header">
         <dt>for</dt>
@@ -12817,7 +12817,7 @@
             _O_: an Object,
             _P_: a property key,
             _Receiver_: an ECMAScript language value,
-          ): either a normal completion containing an ECMAScript language value or an abrupt completion
+          ): either a normal completion containing an ECMAScript language value or a throw completion
         </h1>
         <dl class="header">
         </dl>
@@ -12843,7 +12843,7 @@
           _P_: a property key,
           _V_: an ECMAScript language value,
           _Receiver_: an ECMAScript language value,
-        ): either a normal completion containing a Boolean or an abrupt completion
+        ): either a normal completion containing a Boolean or a throw completion
       </h1>
       <dl class="header">
         <dt>for</dt>
@@ -12860,7 +12860,7 @@
             _P_: a property key,
             _V_: an ECMAScript language value,
             _Receiver_: an ECMAScript language value,
-          ): either a normal completion containing a Boolean or an abrupt completion
+          ): either a normal completion containing a Boolean or a throw completion
         </h1>
         <dl class="header">
         </dl>
@@ -12879,7 +12879,7 @@
             _V_: an ECMAScript language value,
             _Receiver_: an ECMAScript language value,
             _ownDesc_: a Property Descriptor or *undefined*,
-          ): either a normal completion containing a Boolean or an abrupt completion
+          ): either a normal completion containing a Boolean or a throw completion
         </h1>
         <dl class="header">
         </dl>
@@ -12916,7 +12916,7 @@
       <h1>
         [[Delete]] (
           _P_: a property key,
-        ): either a normal completion containing a Boolean or an abrupt completion
+        ): either a normal completion containing a Boolean or a throw completion
       </h1>
       <dl class="header">
         <dt>for</dt>
@@ -12931,7 +12931,7 @@
           OrdinaryDelete (
             _O_: an Object,
             _P_: a property key,
-          ): either a normal completion containing a Boolean or an abrupt completion
+          ): either a normal completion containing a Boolean or a throw completion
         </h1>
         <dl class="header">
         </dl>
@@ -13008,7 +13008,7 @@
           _constructor_: unknown,
           _intrinsicDefaultProto_: a String,
           optional _internalSlotsList_: a List of names of internal slots,
-        ): either a normal completion containing an Object or an abrupt completion
+        ): either a normal completion containing an Object or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -13026,7 +13026,7 @@
         GetPrototypeFromConstructor (
           _constructor_: a function object,
           _intrinsicDefaultProto_: a String,
-        ): either a normal completion containing an Object or an abrupt completion
+        ): either a normal completion containing an Object or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -13050,7 +13050,7 @@
         RequireInternalSlot (
           _O_: unknown,
           _internalSlot_: unknown,
-        ): either a normal completion containing ~unused~ or an abrupt completion
+        ): either a normal completion containing ~unused~ or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -13255,7 +13255,7 @@
         [[Call]] (
           _thisArgument_: an ECMAScript language value,
           _argumentsList_: a List of ECMAScript language values,
-        ): either a normal completion containing an ECMAScript language value or an abrupt completion
+        ): either a normal completion containing an ECMAScript language value or a throw completion
       </h1>
       <dl class="header">
         <dt>for</dt>
@@ -13424,7 +13424,7 @@
         [[Construct]] (
           _argumentsList_: a List of ECMAScript language values,
           _newTarget_: a constructor,
-        ): either a normal completion containing an Object or an abrupt completion
+        ): either a normal completion containing an Object or a throw completion
       </h1>
       <dl class="header">
         <dt>for</dt>
@@ -13814,7 +13814,7 @@
         [[Call]] (
           _thisArgument_: an ECMAScript language value,
           _argumentsList_: a List of ECMAScript language values,
-        ): either a normal completion containing an ECMAScript language value or an abrupt completion
+        ): either a normal completion containing an ECMAScript language value or a throw completion
       </h1>
       <dl class="header">
         <dt>for</dt>
@@ -13844,7 +13844,7 @@
         [[Construct]] (
           _argumentsList_: a List of ECMAScript language values,
           _newTarget_: a constructor,
-        ): either a normal completion containing an Object or an abrupt completion
+        ): either a normal completion containing an Object or a throw completion
       </h1>
       <dl class="header">
         <dt>for</dt>
@@ -13960,7 +13960,7 @@
           [[Call]] (
             _thisArgument_: an ECMAScript language value,
             _argumentsList_: a List of ECMAScript language values,
-          ): either a normal completion containing an ECMAScript language value or an abrupt completion
+          ): either a normal completion containing an ECMAScript language value or a throw completion
         </h1>
         <dl class="header">
           <dt>for</dt>
@@ -13980,7 +13980,7 @@
           [[Construct]] (
             _argumentsList_: a List of ECMAScript language values,
             _newTarget_: a constructor,
-          ): either a normal completion containing an Object or an abrupt completion
+          ): either a normal completion containing an Object or a throw completion
         </h1>
         <dl class="header">
           <dt>for</dt>
@@ -14002,7 +14002,7 @@
             _targetFunction_: a function object,
             _boundThis_: an ECMAScript language value,
             _boundArgs_: a List of ECMAScript language values,
-          ): either a normal completion containing a function object or an abrupt completion
+          ): either a normal completion containing a function object or a throw completion
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -14038,7 +14038,7 @@
           [[DefineOwnProperty]] (
             _P_: a property key,
             _Desc_: a Property Descriptor,
-          ): either a normal completion containing a Boolean or an abrupt completion
+          ): either a normal completion containing a Boolean or a throw completion
         </h1>
         <dl class="header">
           <dt>for</dt>
@@ -14071,7 +14071,7 @@
           ArrayCreate (
             _length_: a non-negative integer,
             optional _proto_: unknown,
-          ): either a normal completion containing an Array exotic object or an abrupt completion
+          ): either a normal completion containing an Array exotic object or a throw completion
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -14093,7 +14093,7 @@
           ArraySpeciesCreate (
             _originalArray_: unknown,
             _length_: a non-negative integer,
-          ): either a normal completion containing an Object or an abrupt completion
+          ): either a normal completion containing an Object or a throw completion
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -14125,7 +14125,7 @@
           ArraySetLength (
             _A_: an Array,
             _Desc_: a Property Descriptor,
-          ): either a normal completion containing a Boolean or an abrupt completion
+          ): either a normal completion containing a Boolean or a throw completion
         </h1>
         <dl class="header">
         </dl>
@@ -14372,7 +14372,7 @@
           [[Get]] (
             _P_: a property key,
             _Receiver_: an ECMAScript language value,
-          ): either a normal completion containing an ECMAScript language value or an abrupt completion
+          ): either a normal completion containing an ECMAScript language value or a throw completion
         </h1>
         <dl class="header">
           <dt>for</dt>
@@ -14395,7 +14395,7 @@
             _P_: a property key,
             _V_: an ECMAScript language value,
             _Receiver_: an ECMAScript language value,
-          ): either a normal completion containing a Boolean or an abrupt completion
+          ): either a normal completion containing a Boolean or a throw completion
         </h1>
         <dl class="header">
           <dt>for</dt>
@@ -14418,7 +14418,7 @@
         <h1>
           [[Delete]] (
             _P_: a property key,
-          ): either a normal completion containing a Boolean or an abrupt completion
+          ): either a normal completion containing a Boolean or a throw completion
         </h1>
         <dl class="header">
           <dt>for</dt>
@@ -14578,7 +14578,7 @@
         <h1>
           [[HasProperty]] (
             _P_: a property key,
-          ): either a normal completion containing a Boolean or an abrupt completion
+          ): either a normal completion containing a Boolean or a throw completion
         </h1>
         <dl class="header">
           <dt>for</dt>
@@ -14597,7 +14597,7 @@
           [[DefineOwnProperty]] (
             _P_: a property key,
             _Desc_: a Property Descriptor,
-          ): either a normal completion containing a Boolean or an abrupt completion
+          ): either a normal completion containing a Boolean or a throw completion
         </h1>
         <dl class="header">
           <dt>for</dt>
@@ -14623,7 +14623,7 @@
           [[Get]] (
             _P_: a property key,
             _Receiver_: an ECMAScript language value,
-          ): either a normal completion containing an ECMAScript language value or an abrupt completion
+          ): either a normal completion containing an ECMAScript language value or a throw completion
         </h1>
         <dl class="header">
           <dt>for</dt>
@@ -14644,7 +14644,7 @@
             _P_: a property key,
             _V_: an ECMAScript language value,
             _Receiver_: an ECMAScript language value,
-          ): either a normal completion containing a Boolean or an abrupt completion
+          ): either a normal completion containing a Boolean or a throw completion
         </h1>
         <dl class="header">
           <dt>for</dt>
@@ -14766,7 +14766,7 @@
             _O_: an Integer-Indexed exotic object,
             _index_: a Number,
             _value_: an ECMAScript language value,
-          ): either a normal completion containing ~unused~ or an abrupt completion
+          ): either a normal completion containing ~unused~ or a throw completion
         </h1>
         <dl class="header">
         </dl>
@@ -14882,7 +14882,7 @@
         <h1>
           [[GetOwnProperty]] (
             _P_: a property key,
-          ): either a normal completion containing either a Property Descriptor or *undefined*, or an abrupt completion
+          ): either a normal completion containing either a Property Descriptor or *undefined*, or a throw completion
         </h1>
         <dl class="header">
           <dt>for</dt>
@@ -14902,7 +14902,7 @@
           [[DefineOwnProperty]] (
             _P_: a property key,
             _Desc_: a Property Descriptor,
-          ): either a normal completion containing a Boolean or an abrupt completion
+          ): either a normal completion containing a Boolean or a throw completion
         </h1>
         <dl class="header">
           <dt>for</dt>
@@ -14944,7 +14944,7 @@
           [[Get]] (
             _P_: a property key,
             _Receiver_: an ECMAScript language value,
-          ): either a normal completion containing an ECMAScript language value or an abrupt completion
+          ): either a normal completion containing an ECMAScript language value or a throw completion
         </h1>
         <dl class="header">
           <dt>for</dt>
@@ -15060,7 +15060,7 @@
         <h1>
           [[SetPrototypeOf]] (
             _V_: an Object or *null*,
-          ): either a normal completion containing a Boolean or an abrupt completion
+          ): either a normal completion containing a Boolean or a throw completion
         </h1>
         <dl class="header">
           <dt>for</dt>
@@ -15076,7 +15076,7 @@
           SetImmutablePrototype (
             _O_: unknown,
             _V_: an Object or *null*,
-          ): either a normal completion containing a Boolean or an abrupt completion
+          ): either a normal completion containing a Boolean or a throw completion
         </h1>
         <dl class="header">
         </dl>
@@ -15217,7 +15217,7 @@
     <p>In the following algorithm descriptions, assume _O_ is an ECMAScript Proxy object, _P_ is a property key value, _V_ is any ECMAScript language value and _Desc_ is a Property Descriptor record.</p>
 
     <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-getprototypeof" type="internal method">
-      <h1>[[GetPrototypeOf]] ( ): either a normal completion containing either an Object or *null*, or an abrupt completion</h1>
+      <h1>[[GetPrototypeOf]] ( ): either a normal completion containing either an Object or *null*, or a throw completion</h1>
       <dl class="header">
         <dt>for</dt>
         <dd>a Proxy exotic object _O_</dd>
@@ -15255,7 +15255,7 @@
       <h1>
         [[SetPrototypeOf]] (
           _V_: an Object or *null*,
-        ): either a normal completion containing a Boolean or an abrupt completion
+        ): either a normal completion containing a Boolean or a throw completion
       </h1>
       <dl class="header">
         <dt>for</dt>
@@ -15291,7 +15291,7 @@
     </emu-clause>
 
     <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-isextensible" type="internal method">
-      <h1>[[IsExtensible]] ( ): either a normal completion containing a Boolean or an abrupt completion</h1>
+      <h1>[[IsExtensible]] ( ): either a normal completion containing a Boolean or a throw completion</h1>
       <dl class="header">
         <dt>for</dt>
         <dd>a Proxy exotic object _O_</dd>
@@ -15323,7 +15323,7 @@
     </emu-clause>
 
     <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-preventextensions" type="internal method">
-      <h1>[[PreventExtensions]] ( ): either a normal completion containing a Boolean or an abrupt completion</h1>
+      <h1>[[PreventExtensions]] ( ): either a normal completion containing a Boolean or a throw completion</h1>
       <dl class="header">
         <dt>for</dt>
         <dd>a Proxy exotic object _O_</dd>
@@ -15359,7 +15359,7 @@
       <h1>
         [[GetOwnProperty]] (
           _P_: a property key,
-        ): either a normal completion containing either a Property Descriptor or *undefined*, or an abrupt completion
+        ): either a normal completion containing either a Property Descriptor or *undefined*, or a throw completion
       </h1>
       <dl class="header">
         <dt>for</dt>
@@ -15425,7 +15425,7 @@
         [[DefineOwnProperty]] (
           _P_: a property key,
           _Desc_: a Property Descriptor,
-        ): either a normal completion containing a Boolean or an abrupt completion
+        ): either a normal completion containing a Boolean or a throw completion
       </h1>
       <dl class="header">
         <dt>for</dt>
@@ -15483,7 +15483,7 @@
       <h1>
         [[HasProperty]] (
           _P_: a property key,
-        ): either a normal completion containing a Boolean or an abrupt completion
+        ): either a normal completion containing a Boolean or a throw completion
       </h1>
       <dl class="header">
         <dt>for</dt>
@@ -15527,7 +15527,7 @@
         [[Get]] (
           _P_: a property key,
           _Receiver_: an ECMAScript language value,
-        ): either a normal completion containing an ECMAScript language value or an abrupt completion
+        ): either a normal completion containing an ECMAScript language value or a throw completion
       </h1>
       <dl class="header">
         <dt>for</dt>
@@ -15569,7 +15569,7 @@
           _P_: a property key,
           _V_: an ECMAScript language value,
           _Receiver_: an ECMAScript language value,
-        ): either a normal completion containing a Boolean or an abrupt completion
+        ): either a normal completion containing a Boolean or a throw completion
       </h1>
       <dl class="header">
         <dt>for</dt>
@@ -15613,7 +15613,7 @@
       <h1>
         [[Delete]] (
           _P_: a property key,
-        ): either a normal completion containing a Boolean or an abrupt completion
+        ): either a normal completion containing a Boolean or a throw completion
       </h1>
       <dl class="header">
         <dt>for</dt>
@@ -15653,7 +15653,7 @@
     </emu-clause>
 
     <emu-clause id="sec-proxy-object-internal-methods-and-internal-slots-ownpropertykeys" type="internal method">
-      <h1>[[OwnPropertyKeys]] ( ): either a normal completion containing a List of property keys or an abrupt completion</h1>
+      <h1>[[OwnPropertyKeys]] ( ): either a normal completion containing a List of property keys or a throw completion</h1>
       <dl class="header">
         <dt>for</dt>
         <dd>a Proxy exotic object _O_</dd>
@@ -15721,7 +15721,7 @@
         [[Call]] (
           _thisArgument_: an ECMAScript language value,
           _argumentsList_: a List of ECMAScript language values,
-        ): either a normal completion containing an ECMAScript language value or an abrupt completion
+        ): either a normal completion containing an ECMAScript language value or a throw completion
       </h1>
       <dl class="header">
         <dt>for</dt>
@@ -15748,7 +15748,7 @@
         [[Construct]] (
           _argumentsList_: a List of ECMAScript language values,
           _newTarget_: a constructor,
-        ): either a normal completion containing an Object or an abrupt completion
+        ): either a normal completion containing an Object or a throw completion
       </h1>
       <dl class="header">
         <dt>for</dt>
@@ -15786,7 +15786,7 @@
         ProxyCreate (
           _target_: unknown,
           _handler_: unknown,
-        ): either a normal completion containing a Proxy exotic object or an abrupt completion
+        ): either a normal completion containing a Proxy exotic object or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -19183,7 +19183,7 @@
             _actualThis_: unknown,
             _propertyKey_: unknown,
             _strict_: unknown,
-          ): either a normal completion containing a Super Reference Record or an abrupt completion
+          ): either a normal completion containing a Super Reference Record or a throw completion
         </h1>
         <dl class="header">
         </dl>
@@ -20122,7 +20122,7 @@
         InstanceofOperator (
           _V_: an ECMAScript language value,
           _target_: an ECMAScript language value,
-        ): either a normal completion containing a Boolean or an abrupt completion
+        ): either a normal completion containing a Boolean or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -20507,7 +20507,7 @@
           _lval_: an ECMAScript language value,
           _opText_: `**`, `*`, `/`, `%`, `+`, `-`, `&lt;&lt;`, `&gt;&gt;`, `&gt;&gt;&gt;`, `&amp;`, `^`, or `|`,
           _rval_: an ECMAScript language value,
-        ): either a normal completion containing either a String, a BigInt, or a Number, or an abrupt completion
+        ): either a normal completion containing either a String, a BigInt, or a Number, or a throw completion
       </h1>
       <dl class="header">
       </dl>
@@ -21790,7 +21790,7 @@
         <h1>
           CreatePerIterationEnvironment (
             _perIterationBindings_: unknown,
-          ): either a normal completion containing ~unused~ or an abrupt completion
+          ): either a normal completion containing ~unused~ or a throw completion
         </h1>
         <dl class="header">
         </dl>
@@ -25850,7 +25850,7 @@
         GlobalDeclarationInstantiation (
           _script_: a |ScriptBody| Parse Node,
           _env_: a global Environment Record,
-        ): either a normal completion containing ~unused~ or an abrupt completion
+        ): either a normal completion containing ~unused~ or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -26210,7 +26210,7 @@
                 [[EvaluationError]]
               </td>
               <td>
-                an abrupt completion or ~empty~
+                a throw completion or ~empty~
               </td>
               <td>
                 A throw completion representing the exception that occurred during evaluation. *undefined* if no exception occurred or if [[Status]] is not ~evaluated~.
@@ -26348,7 +26348,7 @@
         </emu-table>
 
         <emu-clause id="sec-moduledeclarationlinking" type="concrete method" oldids="sec-moduledeclarationinstantiation">
-          <h1>Link ( ): either a normal completion containing ~unused~ or an abrupt completion</h1>
+          <h1>Link ( ): either a normal completion containing ~unused~ or a throw completion</h1>
           <dl class="header">
             <dt>for</dt>
             <dd>a Cyclic Module Record _module_</dd>
@@ -26378,7 +26378,7 @@
                 _module_: a Module Record,
                 _stack_: unknown,
                 _index_: a non-negative integer,
-              ): either a normal completion containing a non-negative integer or an abrupt completion
+              ): either a normal completion containing a non-negative integer or a throw completion
             </h1>
             <dl class="header">
               <dt>description</dt>
@@ -26465,7 +26465,7 @@
                 _module_: a Module Record,
                 _stack_: unknown,
                 _index_: a non-negative integer,
-              ): either a normal completion containing a non-negative integer or an abrupt completion
+              ): either a normal completion containing a non-negative integer or a throw completion
             </h1>
             <dl class="header">
               <dt>description</dt>
@@ -27597,7 +27597,7 @@
           <h1>
             GetExportedNames (
               optional _exportStarSet_: a List of Source Text Module Records,
-            ): either a normal completion containing a List of either Strings or *null*, or an abrupt completion
+            ): either a normal completion containing a List of either Strings or *null*, or a throw completion
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -27635,7 +27635,7 @@
             ResolveExport (
               _exportName_: a String,
               optional _resolveSet_: a List of Records that have [[Module]] and [[ExportName]] fields,
-            ): either a normal completion containing either a ResolvedBinding Record, *null*, or ~ambiguous~, or an abrupt completion
+            ): either a normal completion containing either a ResolvedBinding Record, *null*, or ~ambiguous~, or a throw completion
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -27690,7 +27690,7 @@
         </emu-clause>
 
         <emu-clause id="sec-source-text-module-record-initialize-environment" type="concrete method">
-          <h1>InitializeEnvironment ( ): either a normal completion containing ~unused~ or an abrupt completion</h1>
+          <h1>InitializeEnvironment ( ): either a normal completion containing ~unused~ or a throw completion</h1>
           <dl class="header">
             <dt>for</dt>
             <dd>a Source Text Module Record _module_</dd>
@@ -27761,7 +27761,7 @@
           <h1>
             ExecuteModule (
               optional _capability_: unknown,
-            ): either a normal completion containing ~unused~ or an abrupt completion
+            ): either a normal completion containing ~unused~ or a throw completion
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -27798,7 +27798,7 @@
           HostResolveImportedModule (
             _referencingScriptOrModule_: a Script Record, a Module Record, or *null*,
             _specifier_: a |ModuleSpecifier| String,
-          ): either a normal completion containing a Module Record or an abrupt completion
+          ): either a normal completion containing a Module Record or a throw completion
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -27917,7 +27917,7 @@
         <h1>
           GetModuleNamespace (
             _module_: an instance of a concrete subclass of Module Record,
-          ): either a normal completion containing either a Module Namespace Object or ~empty~, or an abrupt completion
+          ): either a normal completion containing either a Module Namespace Object or ~empty~, or a throw completion
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -28648,7 +28648,7 @@
             _callerRealm_: unknown,
             _strictCaller_: unknown,
             _direct_: unknown,
-          ): either a normal completion containing an ECMAScript language value or an abrupt completion
+          ): either a normal completion containing an ECMAScript language value or a throw completion
         </h1>
         <dl class="header">
         </dl>
@@ -28720,7 +28720,7 @@
           HostEnsureCanCompileStrings (
             _callerRealm_: a Realm Record,
             _calleeRealm_: a Realm Record,
-          ): either a normal completion containing ~unused~ or an abrupt completion
+          ): either a normal completion containing ~unused~ or a throw completion
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -28741,7 +28741,7 @@
             _lexEnv_: unknown,
             _privateEnv_: unknown,
             _strict_: unknown,
-          ): either a normal completion containing ~unused~ or an abrupt completion
+          ): either a normal completion containing ~unused~ or a throw completion
         </h1>
         <dl class="header">
         </dl>
@@ -28975,7 +28975,7 @@
             Encode (
               _string_: a String,
               _unescapedSet_: a String,
-            ): either a normal completion containing a String or an abrupt completion
+            ): either a normal completion containing a String or a throw completion
           </h1>
           <dl class="header">
             <dt>description</dt>
@@ -29009,7 +29009,7 @@
             Decode (
               _string_: a String,
               _reservedSet_: a String,
-            ): either a normal completion containing a String or an abrupt completion
+            ): either a normal completion containing a String or a throw completion
           </h1>
           <dl class="header">
             <dt>description</dt>
@@ -29429,7 +29429,7 @@
             ObjectDefineProperties (
               _O_: an Object,
               _Properties_: unknown,
-            ): either a normal completion containing an Object or an abrupt completion
+            ): either a normal completion containing an Object or a throw completion
           </h1>
           <dl class="header">
           </dl>
@@ -29550,7 +29550,7 @@
             GetOwnPropertyKeys (
               _O_: unknown,
               _type_: ~string~ or ~symbol~,
-            ): either a normal completion containing a List of property keys or an abrupt completion
+            ): either a normal completion containing a List of property keys or a throw completion
           </h1>
           <dl class="header">
           </dl>
@@ -29929,7 +29929,7 @@
               _newTarget_: a constructor,
               _kind_: ~normal~, ~generator~, ~async~, or ~asyncGenerator~,
               _args_: a List of ECMAScript language values,
-            ): either a normal completion containing a function object or an abrupt completion
+            ): either a normal completion containing a function object or a throw completion
           </h1>
           <dl class="header">
             <dt>description</dt>
@@ -30882,7 +30882,7 @@
           InstallErrorCause (
             _O_: an Object,
             _options_: an ECMAScript language value,
-          ): either a normal completion containing ~unused~ or an abrupt completion
+          ): either a normal completion containing ~unused~ or a throw completion
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -31281,7 +31281,7 @@
           <h1>
             NumberToBigInt (
               _number_: a Number,
-            ): either a normal completion containing a BigInt or an abrupt completion
+            ): either a normal completion containing a BigInt or a throw completion
           </h1>
           <dl class="header">
           </dl>
@@ -33870,7 +33870,7 @@ THH:mm:ss.sss
               _maxLength_: an ECMAScript language value,
               _fillString_: an ECMAScript language value,
               _placement_: ~start~ or ~end~,
-            ): either a normal completion containing a String or an abrupt completion
+            ): either a normal completion containing a String or a throw completion
           </h1>
           <dl class="header">
           </dl>
@@ -33970,7 +33970,7 @@ THH:mm:ss.sss
               _captures_: a possibly empty List, each of whose elements is a String or *undefined*,
               _namedCaptures_: an Object or *undefined*,
               _replacementTemplate_: a String,
-            ): either a normal completion containing a String or an abrupt completion
+            ): either a normal completion containing a String or a throw completion
           </h1>
           <dl class="header">
             <dt>description</dt>
@@ -34305,7 +34305,7 @@ THH:mm:ss.sss
             TrimString (
               _string_: an ECMAScript language value,
               _where_: ~start~, ~end~, or ~start+end~,
-            ): either a normal completion containing a String or an abrupt completion
+            ): either a normal completion containing a String or a throw completion
           </h1>
           <dl class="header">
             <dt>description</dt>
@@ -36000,7 +36000,7 @@ THH:mm:ss.sss
           <h1>
             RegExpAlloc (
               _newTarget_: unknown,
-            ): either a normal completion containing an Object or an abrupt completion
+            ): either a normal completion containing an Object or a throw completion
           </h1>
           <dl class="header">
           </dl>
@@ -36017,7 +36017,7 @@ THH:mm:ss.sss
               _obj_: an Object,
               _pattern_: an ECMAScript language value,
               _flags_: an ECMAScript language value,
-            ): either a normal completion containing an Object or an abrupt completion
+            ): either a normal completion containing an Object or a throw completion
           </h1>
           <dl class="header">
           </dl>
@@ -36069,7 +36069,7 @@ THH:mm:ss.sss
             RegExpCreate (
               _P_: unknown,
               _F_: unknown,
-            ): either a normal completion containing an Object or an abrupt completion
+            ): either a normal completion containing an Object or a throw completion
           </h1>
           <dl class="header">
           </dl>
@@ -36158,7 +36158,7 @@ THH:mm:ss.sss
             RegExpExec (
               _R_: an Object,
               _S_: a String,
-            ): either a normal completion containing either an Object or *null*, or an abrupt completion
+            ): either a normal completion containing either an Object or *null*, or a throw completion
           </h1>
           <dl class="header">
           </dl>
@@ -36181,7 +36181,7 @@ THH:mm:ss.sss
             RegExpBuiltinExec (
               _R_: an initialized RegExp instance,
               _S_: a String,
-            ): either a normal completion containing either an Array exotic object or *null*, or an abrupt completion
+            ): either a normal completion containing either an Array exotic object or *null*, or a throw completion
           </h1>
           <dl class="header">
           </dl>
@@ -36409,7 +36409,7 @@ THH:mm:ss.sss
             RegExpHasFlag (
               _R_: an ECMAScript language value,
               _codeUnit_: a code unit,
-            ): either a normal completion containing either a Boolean or *undefined*, or an abrupt completion
+            ): either a normal completion containing either a Boolean or *undefined*, or a throw completion
           </h1>
           <dl class="header">
           </dl>
@@ -37092,7 +37092,7 @@ THH:mm:ss.sss
           <h1>
             IsConcatSpreadable (
               _O_: unknown,
-            ): either a normal completion containing a Boolean or an abrupt completion
+            ): either a normal completion containing a Boolean or a throw completion
           </h1>
           <dl class="header">
           </dl>
@@ -37347,7 +37347,7 @@ THH:mm:ss.sss
               _depth_: a non-negative integer or +&infin;,
               optional _mapperFunction_: unknown,
               optional _thisArg_: unknown,
-            ): either a normal completion containing a non-negative integer or an abrupt completion
+            ): either a normal completion containing a non-negative integer or a throw completion
           </h1>
           <dl class="header">
           </dl>
@@ -39093,7 +39093,7 @@ THH:mm:ss.sss
               _target_: a TypedArray,
               _targetOffset_: a non-negative integer or +&infin;,
               _source_: a TypedArray,
-            ): either a normal completion containing ~unused~ or an abrupt completion
+            ): either a normal completion containing ~unused~ or a throw completion
           </h1>
           <dl class="header">
             <dt>description</dt>
@@ -39148,7 +39148,7 @@ THH:mm:ss.sss
               _target_: a TypedArray,
               _targetOffset_: a non-negative integer or +&infin;,
               _source_: an ECMAScript language value, but not a TypedArray,
-            ): either a normal completion containing ~unused~ or an abrupt completion
+            ): either a normal completion containing ~unused~ or a throw completion
           </h1>
           <dl class="header">
             <dt>description</dt>
@@ -39358,7 +39358,7 @@ THH:mm:ss.sss
           TypedArraySpeciesCreate (
             _exemplar_: a TypedArray,
             _argumentList_: unknown,
-          ): either a normal completion containing a TypedArray or an abrupt completion
+          ): either a normal completion containing a TypedArray or a throw completion
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -39379,7 +39379,7 @@ THH:mm:ss.sss
           TypedArrayCreate (
             _constructor_: unknown,
             _argumentList_: unknown,
-          ): either a normal completion containing a TypedArray or an abrupt completion
+          ): either a normal completion containing a TypedArray or a throw completion
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -39398,7 +39398,7 @@ THH:mm:ss.sss
         <h1>
           ValidateTypedArray (
             _O_: unknown,
-          ): either a normal completion containing ~unused~ or an abrupt completion
+          ): either a normal completion containing ~unused~ or a throw completion
         </h1>
         <dl class="header">
         </dl>
@@ -39492,7 +39492,7 @@ THH:mm:ss.sss
               _newTarget_: unknown,
               _defaultProto_: unknown,
               optional _length_: a non-negative integer,
-            ): either a normal completion containing a TypedArray or an abrupt completion
+            ): either a normal completion containing a TypedArray or a throw completion
           </h1>
           <dl class="header">
             <dt>description</dt>
@@ -39520,7 +39520,7 @@ THH:mm:ss.sss
             InitializeTypedArrayFromTypedArray (
               _O_: a TypedArray,
               _srcArray_: a TypedArray,
-            ): either a normal completion containing ~unused~ or an abrupt completion
+            ): either a normal completion containing ~unused~ or a throw completion
           </h1>
           <dl class="header">
           </dl>
@@ -39563,7 +39563,7 @@ THH:mm:ss.sss
               _buffer_: an ArrayBuffer or a SharedArrayBuffer,
               _byteOffset_: an ECMAScript language value,
               _length_: an ECMAScript language value,
-            ): either a normal completion containing ~unused~ or an abrupt completion
+            ): either a normal completion containing ~unused~ or a throw completion
           </h1>
           <dl class="header">
           </dl>
@@ -39595,7 +39595,7 @@ THH:mm:ss.sss
             InitializeTypedArrayFromList (
               _O_: a TypedArray,
               _values_: a List of ECMAScript language values,
-            ): either a normal completion containing ~unused~ or an abrupt completion
+            ): either a normal completion containing ~unused~ or a throw completion
           </h1>
           <dl class="header">
           </dl>
@@ -39618,7 +39618,7 @@ THH:mm:ss.sss
             InitializeTypedArrayFromArrayLike (
               _O_: a TypedArray,
               _arrayLike_: an Object, but not a TypedArray or an ArrayBuffer,
-            ): either a normal completion containing ~unused~ or an abrupt completion
+            ): either a normal completion containing ~unused~ or a throw completion
           </h1>
           <dl class="header">
           </dl>
@@ -39640,7 +39640,7 @@ THH:mm:ss.sss
             AllocateTypedArrayBuffer (
               _O_: a TypedArray,
               _length_: a non-negative integer,
-            ): either a normal completion containing ~unused~ or an abrupt completion
+            ): either a normal completion containing ~unused~ or a throw completion
           </h1>
           <dl class="header">
             <dt>description</dt>
@@ -39752,7 +39752,7 @@ THH:mm:ss.sss
             _target_: unknown,
             _iterable_: an ECMAScript language value, but not *undefined* or *null*,
             _adder_: a function object,
-          ): either a normal completion containing an ECMAScript language value or an abrupt completion
+          ): either a normal completion containing an ECMAScript language value or a throw completion
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -39991,7 +39991,7 @@ THH:mm:ss.sss
           CreateMapIterator (
             _map_: an ECMAScript language value,
             _kind_: ~key+value~, ~key~, or ~value~,
-          ): either a normal completion containing a Generator or an abrupt completion
+          ): either a normal completion containing a Generator or a throw completion
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -40280,7 +40280,7 @@ THH:mm:ss.sss
           CreateSetIterator (
             _set_: an ECMAScript language value,
             _kind_: ~key+value~ or ~value~,
-          ): either a normal completion containing a Generator or an abrupt completion
+          ): either a normal completion containing a Generator or a throw completion
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -40648,7 +40648,7 @@ THH:mm:ss.sss
           AllocateArrayBuffer (
             _constructor_: unknown,
             _byteLength_: a non-negative integer,
-          ): either a normal completion containing an ArrayBuffer or an abrupt completion
+          ): either a normal completion containing an ArrayBuffer or a throw completion
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -40682,7 +40682,7 @@ THH:mm:ss.sss
           DetachArrayBuffer (
             _arrayBuffer_: an ArrayBuffer,
             optional _key_: unknown,
-          ): either a normal completion containing ~unused~ or an abrupt completion
+          ): either a normal completion containing ~unused~ or a throw completion
         </h1>
         <dl class="header">
         </dl>
@@ -40705,7 +40705,7 @@ THH:mm:ss.sss
             _srcBuffer_: an ArrayBuffer or a SharedArrayBuffer,
             _srcByteOffset_: a non-negative integer,
             _srcLength_: a non-negative integer,
-          ): either a normal completion containing an ArrayBuffer or an abrupt completion
+          ): either a normal completion containing an ArrayBuffer or a throw completion
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -41093,7 +41093,7 @@ THH:mm:ss.sss
           AllocateSharedArrayBuffer (
             _constructor_: unknown,
             _byteLength_: a non-negative integer,
-          ): either a normal completion containing a SharedArrayBuffer or an abrupt completion
+          ): either a normal completion containing a SharedArrayBuffer or a throw completion
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -41267,7 +41267,7 @@ THH:mm:ss.sss
             _requestIndex_: unknown,
             _isLittleEndian_: unknown,
             _type_: unknown,
-          ): either a normal completion containing either a Number or a BigInt, or an abrupt completion
+          ): either a normal completion containing either a Number or a BigInt, or a throw completion
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -41297,7 +41297,7 @@ THH:mm:ss.sss
             _isLittleEndian_: unknown,
             _type_: unknown,
             _value_: unknown,
-          ): either a normal completion containing *undefined* or an abrupt completion
+          ): either a normal completion containing *undefined* or a throw completion
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -41669,7 +41669,7 @@ THH:mm:ss.sss
           ValidateIntegerTypedArray (
             _typedArray_: unknown,
             optional _waitable_: a Boolean,
-          ): either a normal completion containing either an ArrayBuffer or a SharedArrayBuffer, or an abrupt completion
+          ): either a normal completion containing either an ArrayBuffer or a SharedArrayBuffer, or a throw completion
         </h1>
         <dl class="header">
         </dl>
@@ -41691,7 +41691,7 @@ THH:mm:ss.sss
           ValidateAtomicAccess (
             _typedArray_: a TypedArray,
             _requestIndex_: unknown,
-          ): either a normal completion containing an integer or an abrupt completion
+          ): either a normal completion containing an integer or a throw completion
         </h1>
         <dl class="header">
         </dl>
@@ -41871,7 +41871,7 @@ THH:mm:ss.sss
             _index_: unknown,
             _value_: unknown,
             _op_: a read-modify-write modification function,
-          ): either a normal completion containing either a Number or a BigInt, or an abrupt completion
+          ): either a normal completion containing either a Number or a BigInt, or a throw completion
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -42225,7 +42225,7 @@ THH:mm:ss.sss
             _holder_: an Object,
             _name_: a String,
             _reviver_: a function object,
-          ): either a normal completion containing an ECMAScript language value or an abrupt completion
+          ): either a normal completion containing an ECMAScript language value or a throw completion
         </h1>
         <dl class="header">
         </dl>
@@ -42356,7 +42356,7 @@ THH:mm:ss.sss
             _state_: unknown,
             _key_: unknown,
             _holder_: unknown,
-          ): either a normal completion containing either *undefined* or a String, or an abrupt completion
+          ): either a normal completion containing either *undefined* or a String, or a throw completion
         </h1>
         <dl class="header">
         </dl>
@@ -42535,7 +42535,7 @@ THH:mm:ss.sss
           SerializeJSONObject (
             _state_: unknown,
             _value_: an Object,
-          ): either a normal completion containing a String or an abrupt completion
+          ): either a normal completion containing a String or a throw completion
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -42581,7 +42581,7 @@ THH:mm:ss.sss
           SerializeJSONArray (
             _state_: unknown,
             _value_: an ECMAScript language value,
-          ): either a normal completion containing a String or an abrupt completion
+          ): either a normal completion containing a String or a throw completion
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -43582,7 +43582,7 @@ THH:mm:ss.sss
         <h1>
           NewPromiseCapability (
             _C_: unknown,
-          ): either a normal completion containing a PromiseCapability Record or an abrupt completion
+          ): either a normal completion containing a PromiseCapability Record or a throw completion
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -43843,7 +43843,7 @@ THH:mm:ss.sss
           <h1>
             GetPromiseResolve (
               _promiseConstructor_: a constructor,
-            ): either a normal completion containing a function object or an abrupt completion
+            ): either a normal completion containing a function object or a throw completion
           </h1>
           <dl class="header">
           </dl>
@@ -43861,7 +43861,7 @@ THH:mm:ss.sss
               _constructor_: a constructor,
               _resultCapability_: a PromiseCapability Record,
               _promiseResolve_: a function object,
-            ): either a normal completion containing an ECMAScript language value or an abrupt completion
+            ): either a normal completion containing an ECMAScript language value or a throw completion
           </h1>
           <dl class="header">
           </dl>
@@ -43949,7 +43949,7 @@ THH:mm:ss.sss
               _constructor_: a constructor,
               _resultCapability_: a PromiseCapability Record,
               _promiseResolve_: a function object,
-            ): either a normal completion containing an ECMAScript language value or an abrupt completion
+            ): either a normal completion containing an ECMAScript language value or a throw completion
           </h1>
           <dl class="header">
           </dl>
@@ -44076,7 +44076,7 @@ THH:mm:ss.sss
               _constructor_: a constructor,
               _resultCapability_: a PromiseCapability Record,
               _promiseResolve_: a function object,
-            ): either a normal completion containing an ECMAScript language value or an abrupt completion
+            ): either a normal completion containing an ECMAScript language value or a throw completion
           </h1>
           <dl class="header">
           </dl>
@@ -44175,7 +44175,7 @@ THH:mm:ss.sss
               _constructor_: a constructor,
               _resultCapability_: a PromiseCapability Record,
               _promiseResolve_: a function object,
-            ): either a normal completion containing an ECMAScript language value or an abrupt completion
+            ): either a normal completion containing an ECMAScript language value or a throw completion
           </h1>
           <dl class="header">
           </dl>
@@ -44227,7 +44227,7 @@ THH:mm:ss.sss
             PromiseResolve (
               _C_: a constructor,
               _x_: an ECMAScript language value,
-            ): either a normal completion containing an ECMAScript language value or an abrupt completion
+            ): either a normal completion containing an ECMAScript language value or a throw completion
           </h1>
           <dl class="header">
             <dt>description</dt>
@@ -44824,7 +44824,7 @@ THH:mm:ss.sss
           GeneratorValidate (
             _generator_: unknown,
             _generatorBrand_: unknown,
-          ): either a normal completion containing either ~suspendedStart~, ~suspendedYield~, or ~completed~, or an abrupt completion
+          ): either a normal completion containing either ~suspendedStart~, ~suspendedYield~, or ~completed~, or a throw completion
         </h1>
         <dl class="header">
         </dl>
@@ -44845,7 +44845,7 @@ THH:mm:ss.sss
             _generator_: unknown,
             _value_: unknown,
             _generatorBrand_: unknown,
-          ): either a normal completion containing an ECMAScript language value or an abrupt completion
+          ): either a normal completion containing an ECMAScript language value or a throw completion
         </h1>
         <dl class="header">
         </dl>
@@ -44870,7 +44870,7 @@ THH:mm:ss.sss
             _generator_: unknown,
             _abruptCompletion_: a return completion or a throw completion,
             _generatorBrand_: unknown,
-          ): either a normal completion containing an ECMAScript language value or an abrupt completion
+          ): either a normal completion containing an ECMAScript language value or a throw completion
         </h1>
         <dl class="header">
         </dl>
@@ -45176,7 +45176,7 @@ THH:mm:ss.sss
           AsyncGeneratorValidate (
             _generator_: unknown,
             _generatorBrand_: unknown,
-          ): either a normal completion containing ~unused~ or an abrupt completion
+          ): either a normal completion containing ~unused~ or a throw completion
         </h1>
         <dl class="header">
         </dl>
@@ -45320,7 +45320,7 @@ THH:mm:ss.sss
         <h1>
           AsyncGeneratorAwaitReturn (
             _generator_: an AsyncGenerator,
-          ): either a normal completion containing ~unused~ or an abrupt completion
+          ): either a normal completion containing ~unused~ or a throw completion
         </h1>
         <dl class="header">
         </dl>
@@ -47341,7 +47341,7 @@ THH:mm:ss.sss
               _tag_: a String,
               _attribute_: a String,
               _value_: unknown,
-            ): either a normal completion containing a String or an abrupt completion
+            ): either a normal completion containing a String or a throw completion
           </h1>
           <dl class="header">
           </dl>


### PR DESCRIPTION
This is a follow-up to PR #2547, which tagged many operations as returning a normal completion or an abrupt completion. But in most cases, the only abrupt completion possible is a throw completion. So this PR changes lots of "abrupt completion" to the more precise "throw completion".

The first two commits deal with internal methods and host hooks, which the spec explicitly constrains to return normal+throw completions. The third commit deals with ~200 other operations, which I found via static analysis.

Of the ~50 remaining operations that still say "abrupt completion", I think quite a few should likewise change to "throw completion", but it would take more sophisticated analysis to be sure.