### PR TITLE
Editorial: Move class and method related abstract operations to more relevant section

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -13518,89 +13518,6 @@
       </emu-clause>
     </emu-clause>
 
-    <emu-clause id="sec-makeconstructor" type="abstract operation">
-      <h1>
-        MakeConstructor (
-          _F_: an ECMAScript function object or a built-in function object,
-          optional _writablePrototype_: a Boolean,
-          optional _prototype_: an Object,
-        ): ~unused~
-      </h1>
-      <dl class="header">
-        <dt>description</dt>
-        <dd>It converts _F_ into a constructor.</dd>
-      </dl>
-      <emu-alg>
-        1. If _F_ is an ECMAScript function object, then
-          1. Assert: IsConstructor(_F_) is *false*.
-          1. Assert: _F_ is an extensible object that does not have a *"prototype"* own property.
-          1. Set _F_.[[Construct]] to the definition specified in <emu-xref href="#sec-ecmascript-function-objects-construct-argumentslist-newtarget"></emu-xref>.
-        1. Else,
-          1. Set _F_.[[Construct]] to the definition specified in <emu-xref href="#sec-built-in-function-objects-construct-argumentslist-newtarget"></emu-xref>.
-        1. Set _F_.[[ConstructorKind]] to ~base~.
-        1. If _writablePrototype_ is not present, set _writablePrototype_ to *true*.
-        1. If _prototype_ is not present, then
-          1. Set _prototype_ to OrdinaryObjectCreate(%Object.prototype%).
-          1. Perform ! DefinePropertyOrThrow(_prototype_, *"constructor"*, PropertyDescriptor { [[Value]]: _F_, [[Writable]]: _writablePrototype_, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
-        1. Perform ! DefinePropertyOrThrow(_F_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: _writablePrototype_, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
-        1. Return ~unused~.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-makeclassconstructor" type="abstract operation">
-      <h1>
-        MakeClassConstructor (
-          _F_: an ECMAScript function object,
-        ): ~unused~
-      </h1>
-      <dl class="header">
-      </dl>
-      <emu-alg>
-        1. Assert: _F_.[[IsClassConstructor]] is *false*.
-        1. Set _F_.[[IsClassConstructor]] to *true*.
-        1. Return ~unused~.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-makemethod" type="abstract operation">
-      <h1>
-        MakeMethod (
-          _F_: an ECMAScript function object,
-          _homeObject_: an Object,
-        ): ~unused~
-      </h1>
-      <dl class="header">
-        <dt>description</dt>
-        <dd>It configures _F_ as a method.</dd>
-      </dl>
-      <emu-alg>
-        1. Set _F_.[[HomeObject]] to _homeObject_.
-        1. Return ~unused~.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-definemethodproperty" type="abstract operation">
-      <h1>
-        DefineMethodProperty (
-          _homeObject_: an Object,
-          _key_: a property key or Private Name,
-          _closure_: a function object,
-          _enumerable_: a Boolean,
-        ): a PrivateElement or ~unused~
-      </h1>
-      <dl class="header">
-      </dl>
-      <emu-alg>
-        1. Assert: _homeObject_ is an ordinary, extensible object with no non-configurable properties.
-        1. If _key_ is a Private Name, then
-          1. Return PrivateElement { [[Key]]: _key_, [[Kind]]: ~method~, [[Value]]: _closure_ }.
-        1. Else,
-          1. Let _desc_ be the PropertyDescriptor { [[Value]]: _closure_, [[Writable]]: *true*, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
-          1. Perform ! DefinePropertyOrThrow(_homeObject_, _key_, _desc_).
-          1. Return ~unused~.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-setfunctionname" type="abstract operation">
       <h1>
         SetFunctionName (
@@ -23285,6 +23202,35 @@
       </ul>
     </emu-clause>
 
+    <emu-clause id="sec-makeconstructor" type="abstract operation">
+      <h1>
+        MakeConstructor (
+          _F_: an ECMAScript function object or a built-in function object,
+          optional _writablePrototype_: a Boolean,
+          optional _prototype_: an Object,
+        ): ~unused~
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It converts _F_ into a constructor.</dd>
+      </dl>
+      <emu-alg>
+        1. If _F_ is an ECMAScript function object, then
+          1. Assert: IsConstructor(_F_) is *false*.
+          1. Assert: _F_ is an extensible object that does not have a *"prototype"* own property.
+          1. Set _F_.[[Construct]] to the definition specified in <emu-xref href="#sec-ecmascript-function-objects-construct-argumentslist-newtarget"></emu-xref>.
+        1. Else,
+          1. Set _F_.[[Construct]] to the definition specified in <emu-xref href="#sec-built-in-function-objects-construct-argumentslist-newtarget"></emu-xref>.
+        1. Set _F_.[[ConstructorKind]] to ~base~.
+        1. If _writablePrototype_ is not present, set _writablePrototype_ to *true*.
+        1. If _prototype_ is not present, then
+          1. Set _prototype_ to OrdinaryObjectCreate(%Object.prototype%).
+          1. Perform ! DefinePropertyOrThrow(_prototype_, *"constructor"*, PropertyDescriptor { [[Value]]: _F_, [[Writable]]: _writablePrototype_, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
+        1. Perform ! DefinePropertyOrThrow(_F_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: _writablePrototype_, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
+        1. Return ~unused~.
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-static-semantics-functionbodycontainsusestrict" oldids="sec-function-definitions-static-semantics-containsusestrict" type="sdo">
       <h1>Static Semantics: FunctionBodyContainsUseStrict ( ): a Boolean</h1>
       <dl class="header">
@@ -23607,6 +23553,45 @@
       <emu-alg>
         1. If |UniqueFormalParameters| Contains |SuperCall| is *true*, return *true*.
         1. Return |AsyncFunctionBody| Contains |SuperCall|.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-makemethod" type="abstract operation">
+      <h1>
+        MakeMethod (
+          _F_: an ECMAScript function object,
+          _homeObject_: an Object,
+        ): ~unused~
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It configures _F_ as a method.</dd>
+      </dl>
+      <emu-alg>
+        1. Set _F_.[[HomeObject]] to _homeObject_.
+        1. Return ~unused~.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-definemethodproperty" type="abstract operation">
+      <h1>
+        DefineMethodProperty (
+          _homeObject_: an Object,
+          _key_: a property key or Private Name,
+          _closure_: a function object,
+          _enumerable_: a Boolean,
+        ): a PrivateElement or ~unused~
+      </h1>
+      <dl class="header">
+      </dl>
+      <emu-alg>
+        1. Assert: _homeObject_ is an ordinary, extensible object with no non-configurable properties.
+        1. If _key_ is a Private Name, then
+          1. Return PrivateElement { [[Key]]: _key_, [[Kind]]: ~method~, [[Value]]: _closure_ }.
+        1. Else,
+          1. Let _desc_ be the PropertyDescriptor { [[Value]]: _closure_, [[Writable]]: *true*, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
+          1. Perform ! DefinePropertyOrThrow(_homeObject_, _key_, _desc_).
+          1. Return ~unused~.
       </emu-alg>
     </emu-clause>
 
@@ -24633,6 +24618,21 @@
       </emu-grammar>
       <emu-alg>
         1. Return ContainsArguments of |ClassElementName|.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-makeclassconstructor" type="abstract operation">
+      <h1>
+        MakeClassConstructor (
+          _F_: an ECMAScript function object,
+        ): ~unused~
+      </h1>
+      <dl class="header">
+      </dl>
+      <emu-alg>
+        1. Assert: _F_.[[IsClassConstructor]] is *false*.
+        1. Set _F_.[[IsClassConstructor]] to *true*.
+        1. Return ~unused~.
       </emu-alg>
     </emu-clause>
 


### PR DESCRIPTION
Moves the following abstract operations to a more relevant section:

- MakeConstructor
- MakeClassConstructor
- MakeMethod
- DefineMethodProperty

These abstract operations are used primarily in the *ECMAScript
Language: Functions and Classes* section, despite being defined in
*10.2 ECMAScript Function Objects*. I found myself jumping back and
forth frequently while working on the Decorators branch, and it seemed
like it would make more sense for them to be located near to where they
are used.
