### PR TITLE
Editorial: Use Abstract Closure to set the code eval state

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -45228,7 +45228,9 @@ THH:mm:ss.sss
           1. Assert: The value of _generator_.[[GeneratorState]] is *undefined*.
           1. Let _genContext_ be the running execution context.
           1. Set the Generator component of _genContext_ to _generator_.
-          1. [fence-effects="user-code"] Set the code evaluation state of _genContext_ such that when evaluation is resumed for that execution context the following steps will be performed:
+          1. Let _closure_ be a new Abstract Closure with no parameters that captures _generatorBody_ and performs the following steps when called:
+            1. Let _genContext_ be the running execution context.
+            1. Let _generator_ be the Generator component of _genContext_.
             1. If _generatorBody_ is a Parse Node, then
               1. Let _result_ be Completion(Evaluation of _generatorBody_).
             1. Else,
@@ -45244,6 +45246,7 @@ THH:mm:ss.sss
               1. Assert: _result_.[[Type]] is ~throw~.
               1. Return ? _result_.
             1. Return CreateIterResultObject(_resultValue_, *true*).
+          1. Set the code evaluation state of _genContext_ such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
           1. Set _generator_.[[GeneratorContext]] to _genContext_.
           1. Set _generator_.[[GeneratorState]] to ~suspendedStart~.
           1. Return ~unused~.
@@ -45580,7 +45583,9 @@ THH:mm:ss.sss
           1. Assert: _generator_.[[AsyncGeneratorState]] is *undefined*.
           1. Let _genContext_ be the running execution context.
           1. Set the Generator component of _genContext_ to _generator_.
-          1. [fence-effects="user-code"] Set the code evaluation state of _genContext_ such that when evaluation is resumed for that execution context the following steps will be performed:
+          1. Let _closure_ be a new Abstract Closure with no parameters that captures _generatorBody_ and performs the following steps when called:
+            1. Let _genContext_ be the running execution context.
+            1. Let _generator_ be the Generator component of _genContext_.
             1. If _generatorBody_ is a Parse Node, then
               1. Let _result_ be Completion(Evaluation of _generatorBody_).
             1. Else,
@@ -45594,6 +45599,7 @@ THH:mm:ss.sss
             1. Perform AsyncGeneratorCompleteStep(_generator_, _result_, *true*).
             1. Perform AsyncGeneratorDrainQueue(_generator_).
             1. Return *undefined*.
+          1. Set the code evaluation state of _genContext_ such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
           1. Set _generator_.[[AsyncGeneratorContext]] to _genContext_.
           1. Set _generator_.[[AsyncGeneratorState]] to ~suspendedStart~.
           1. Set _generator_.[[AsyncGeneratorQueue]] to a new empty List.
@@ -45972,7 +45978,8 @@ THH:mm:ss.sss
         <emu-alg>
           1. Assert: _promiseCapability_ is a PromiseCapability Record.
           1. Let _runningContext_ be the running execution context.
-          1. [fence-effects="user-code"] Set the code evaluation state of _asyncContext_ such that when evaluation is resumed for that execution context the following steps will be performed:
+          1. Let _closure_ be a new Abstract Closure with no parameters that captures _promiseCapability_ and _asyncBody_ and performs the following steps when called:
+            1. Let _asyncContext_ be the running execution context.
             1. Let _result_ be Completion(Evaluation of _asyncBody_).
             1. Assert: If we return here, the async function either threw an exception or performed an implicit or explicit return; all awaiting is done.
             1. Remove _asyncContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
@@ -45984,6 +45991,7 @@ THH:mm:ss.sss
               1. Assert: _result_.[[Type]] is ~throw~.
               1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, « _result_.[[Value]] »).
             1. [id="step-asyncblockstart-return-undefined"] Return ~unused~.
+          1. Set the code evaluation state of _asyncContext_ such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
           1. Push _asyncContext_ onto the execution context stack; _asyncContext_ is now the running execution context.
           1. <emu-meta effects="user-code">Resume the suspended evaluation of _asyncContext_</emu-meta>. Let _result_ be the value returned by the resumed computation.
           1. Assert: When we return here, _asyncContext_ has already been removed from the execution context stack and _runningContext_ is the currently running execution context.


### PR DESCRIPTION
In GeneratorStart, AsyncGeneratorStart, and AsyncBlockStart, there is the following construct:
```
1. Set the code evaluation state of _context_ such that when evaluation
   is resumed for that execution context the following steps will be performed:
   1. <inner-steps>
```
This is a fairly novel construct, but we can reduce the novelty. Specifically, consider the `<inner-steps>`: they are to be performed later, but can refer to aliases defined in the outer algorithm. These are things that we see in Abstract Closures, so we can pull out those aspects of the construct:
```
1. Let _closure_ be a new Abstract Closure with no parameters
   that captures <aliases> and performs the following steps when called:
   1. <inner steps>
1. Set the code evaluation state of _context_ such that when evaluation
   is resumed for that execution context, _closure_ will be invoked.
```
(This has the side benefit of making the captures explicit.)

In this PR, the first commit makes the above change, and the second commit reduces the number of captured aliases by 'reconstructing' some of them within the closure.

---

I wasn't sure what to do about the `[fence-effects="user-code"]` annotation, but I'm guessing that ecmarkup's handling of Abstract Closures takes care of it. (Another side benefit.)

---

(There are also "Set the code eval state" steps in Await, GeneratorYield, and AsyncGeneratorYield, but I'm assuming that #2429 or #2665 will eliminate them.)