### PR TITLE
Normative: handle broken promises in AsyncGenerator.prototype.return

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -48562,7 +48562,14 @@ THH:mm:ss.sss
           1. Let _next_ be the first element of _queue_.
           1. Let _completion_ be Completion(_next_.[[Completion]]).
           1. Assert: _completion_ is a return completion.
-          1. Let _promise_ be ? PromiseResolve(%Promise%, _completion_.[[Value]]).
+          1. Let _promiseCompletion_ be Completion(PromiseResolve(%Promise%, _completion_.[[Value]])).
+          1. If _promiseCompletion_ is an abrupt completion, then
+            1. Set _generator_.[[AsyncGeneratorState]] to ~completed~.
+            1. Perform AsyncGeneratorCompleteStep(_generator_, _promiseCompletion_, *true*).
+            1. Perform AsyncGeneratorDrainQueue(_generator_).
+            1. Return ~unused~.
+          1. Assert: _promiseCompletion_ is a normal completion.
+          1. Let _promise_ be _promiseCompletion_.[[Value]].
           1. Let _fulfilledClosure_ be a new Abstract Closure with parameters (_value_) that captures _generator_ and performs the following steps when called:
             1. Set _generator_.[[AsyncGeneratorState]] to ~completed~.
             1. Let _result_ be NormalCompletion(_value_).

--- a/spec.html
+++ b/spec.html
@@ -48263,7 +48263,7 @@ THH:mm:ss.sss
           1. Let _state_ be _generator_.[[AsyncGeneratorState]].
           1. If _state_ is either ~suspended-start~ or ~completed~, then
             1. Set _generator_.[[AsyncGeneratorState]] to ~awaiting-return~.
-            1. Perform ! AsyncGeneratorAwaitReturn(_generator_).
+            1. Perform AsyncGeneratorAwaitReturn(_generator_).
           1. Else if _state_ is ~suspended-yield~, then
             1. Perform AsyncGeneratorResume(_generator_, _completion_).
           1. Else,
@@ -48552,7 +48552,7 @@ THH:mm:ss.sss
         <h1>
           AsyncGeneratorAwaitReturn (
             _generator_: an AsyncGenerator,
-          ): either a normal completion containing ~unused~ or a throw completion
+          ): ~unused~
         </h1>
         <dl class="header">
         </dl>
@@ -48609,7 +48609,7 @@ THH:mm:ss.sss
             1. Let _completion_ be Completion(_next_.[[Completion]]).
             1. If _completion_ is a return completion, then
               1. Set _generator_.[[AsyncGeneratorState]] to ~awaiting-return~.
-              1. Perform ! AsyncGeneratorAwaitReturn(_generator_).
+              1. Perform AsyncGeneratorAwaitReturn(_generator_).
               1. Set _done_ to *true*.
             1. Else,
               1. If _completion_ is a normal completion, then


### PR DESCRIPTION
Fixes https://github.com/tc39/ecma262/issues/2412 by trapping the exception and using it to reject the promise returned by the call to `AsyncGenerator.prototype.return`.


## Background 1: broken promises

You can make a promise which throws when you try to `await` or `Promise.resolve` it:

```js
let brokenPromise = Promise.resolve(42);
Object.defineProperty(brokenPromise, 'constructor', {
  get: function () {
    throw new Error('broken promise');
  }
});
```
(see [PromiseResolve](https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise-resolve) step 1.a.)

If you `await` such a value, or pass it to `Promise.resolve`, it will synchronously throw an exception.


## Background 2: `AsyncGenerator.prototype.return`

Generators have a `.next()` method which asks for the next value. Async generators have the same thing, except it returns a promise. Because the generator might be blocked on an `await` when you call `.next()`, they have an internal queue of requests to service once they're unblocked.

Generators also have a `.return(x)` method, used for cleanup, which injects a return completion at the current `yield` and resumes execution of the generator. If called before the generator has started, or after it's finished, the call to `.return` returns `{ done: true, value: [the value passed to .return] }`.

Async generators also have a `.return`, with some differences:
- It returns a promise
- As with `.next`, it's queued (in fact it shares the queue with `.next`)
- Once a call gets to the head of the queue, if the generator has completed, it will `await` the passed value before returning it in the result object (matching what happens if you do a normal `return x;` from an async generator).


## The problem

Right now the spec doesn't account for the possibility of a broken promise passed to `.return`. It has an assertion that this doesn't happen, and that assertion can be violated:

```js
let brokenPromise = Promise.resolve(42);
Object.defineProperty(brokenPromise, 'constructor', {
  get: function () {
    throw new Error('broken promise');
  }
});

{
  let gen = (async function* () { })();
  gen.return(brokenPromise);
}

// or
{
  let unblock;
  let blocking = new Promise(res => { unblock = res; });

  let gen = (async function* (){ await blocking; })();
  gen.next();

  // generator is now blocked on the blocking promise
  // further calls to `.next` or `.return` will be queued until it settles

  gen.return(brokenPromise);

  unblock();
}
```

Both of these calls violate an assertion in the spec: the first in [`AsyncGenerator.prototype.return`](https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-asyncgenerator-prototype-return) step 8.a, the second in [AsyncGeneratorDrainQueue](https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-asyncgeneratordrainqueue) step 5.c.ii.

## Current behavior

XS never triggers the broken promise, and ChakraCore doesn't implement async generators.

For the first example, calling `.return` with a broken promise while the generator is not blocked: In SpiderMonkey, V8, and GraalJS, it synchronously throws. In JavaScriptCore, it returns a promise which never settles, and the exception disappears into the void.

For the second example, calling `.return` with a broken promise while the generator is blocked: all engines return a promise which never settles. In V8 and JavaScriptCore, the exception disappears into the void. In SpiderMonkey and GraalJS, the exception is thrown outside of any handlers (in SpiderMonkey this is observable in the console or with `onerror`).


## Proposed behavior

The behavior this PR implements is to catch the exception and use it to reject the promise returned by `AsyncGenerator.prototype.return`. This doesn't match any implementation but seems like the only reasonable behavior, holding everything else constant.
