### PR TITLE
Editorial: tweak DestructuringAssignmentEvaluation

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -20678,6 +20678,18 @@
           1. Perform ? PropertyDestructuringAssignmentEvaluation of |AssignmentPropertyList| with argument _value_.
           1. Return ~unused~.
         </emu-alg>
+        <emu-grammar>ObjectAssignmentPattern : `{` AssignmentRestProperty `}`</emu-grammar>
+        <emu-alg>
+          1. Perform ? RequireObjectCoercible(_value_).
+          1. Let _excludedNames_ be a new empty List.
+          1. Return ? RestDestructuringAssignmentEvaluation of |AssignmentRestProperty| with arguments _value_ and _excludedNames_.
+        </emu-alg>
+        <emu-grammar>ObjectAssignmentPattern : `{` AssignmentPropertyList `,` AssignmentRestProperty `}`</emu-grammar>
+        <emu-alg>
+          1. Perform ? RequireObjectCoercible(_value_).
+          1. Let _excludedNames_ be ? PropertyDestructuringAssignmentEvaluation of |AssignmentPropertyList| with argument _value_.
+          1. Return ? RestDestructuringAssignmentEvaluation of |AssignmentRestProperty| with arguments _value_ and _excludedNames_.
+        </emu-alg>
         <emu-grammar>ArrayAssignmentPattern : `[` `]`</emu-grammar>
         <emu-alg>
           1. Let _iteratorRecord_ be ? GetIterator(_value_).
@@ -20725,19 +20737,6 @@
             1. Set _status_ to Completion(IteratorDestructuringAssignmentEvaluation of |AssignmentRestElement| with argument _iteratorRecord_).
           1. If _iteratorRecord_.[[Done]] is *false*, return ? IteratorClose(_iteratorRecord_, _status_).
           1. Return ? _status_.
-        </emu-alg>
-        <emu-grammar>ObjectAssignmentPattern : `{` AssignmentRestProperty `}`</emu-grammar>
-        <emu-alg>
-          1. Perform ? RequireObjectCoercible(_value_).
-          1. Let _excludedNames_ be a new empty List.
-          1. Return ? RestDestructuringAssignmentEvaluation of |AssignmentRestProperty| with arguments _value_ and _excludedNames_.
-        </emu-alg>
-
-        <emu-grammar>ObjectAssignmentPattern : `{` AssignmentPropertyList `,` AssignmentRestProperty `}`</emu-grammar>
-        <emu-alg>
-          1. Perform ? RequireObjectCoercible(_value_).
-          1. Let _excludedNames_ be ? PropertyDestructuringAssignmentEvaluation of |AssignmentPropertyList| with argument _value_.
-          1. Return ? RestDestructuringAssignmentEvaluation of |AssignmentRestProperty| with arguments _value_ and _excludedNames_.
         </emu-alg>
       </emu-clause>
 


### PR DESCRIPTION
The [DestructuringAssignmentEvaluation](https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-runtime-semantics-destructuringassignmentevaluation) SDO is defined over the the various Object and Array assignment patterns. Some of the Object cases were before the Array cases and some of them were after, presumably reflecting the fact that [Object rest was added later](https://github.com/tc39/proposal-object-rest-spread). This PR makes all the Object cases be consecutive.