### PR TITLE
Editorial: work around ecmarkup limititation with replacement step numbering

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -47541,25 +47541,26 @@ THH:mm:ss.sss
         <h1>Changes to GlobalDeclarationInstantiation</h1>
         <p>During GlobalDeclarationInstantiation the following steps are performed in place of step <emu-xref href="#step-globaldeclarationinstantiation-web-compat-insertion-point"></emu-xref>:</p>
         <emu-alg replaces-step="step-globaldeclarationinstantiation-web-compat-insertion-point">
-          1. Let _strict_ be IsStrict of _script_.
-          1. If _strict_ is *false*, then
-            1. Let _declaredFunctionOrVarNames_ be the list-concatenation of _declaredFunctionNames_ and _declaredVarNames_.
-            1. For each |FunctionDeclaration| _f_ that is directly contained in the |StatementList| of a |Block|, |CaseClause|, or |DefaultClause| Contained within _script_, do
-              1. Let _F_ be StringValue of the |BindingIdentifier| of _f_.
-              1. If replacing the |FunctionDeclaration| _f_ with a |VariableStatement| that has _F_ as a |BindingIdentifier| would not produce any Early Errors for _script_, then
-                1. If _env_.HasLexicalDeclaration(_F_) is *false*, then
-                  1. Let _fnDefinable_ be ? _env_.CanDeclareGlobalVar(_F_).
-                  1. If _fnDefinable_ is *true*, then
-                    1. NOTE: A var binding for _F_ is only instantiated here if it is neither a VarDeclaredName nor the name of another |FunctionDeclaration|.
-                    1. If _declaredFunctionOrVarNames_ does not contain _F_, then
-                      1. Perform ? _env_.CreateGlobalVarBinding(_F_, *false*).
-                      1. Append _F_ to _declaredFunctionOrVarNames_.
-                    1. When the |FunctionDeclaration| _f_ is evaluated, perform the following steps in place of the |FunctionDeclaration| Evaluation algorithm provided in <emu-xref href="#sec-function-definitions-runtime-semantics-evaluation"></emu-xref>:
-                      1. Let _genv_ be the running execution context's VariableEnvironment.
-                      1. Let _benv_ be the running execution context's LexicalEnvironment.
-                      1. Let _fobj_ be ! _benv_.GetBindingValue(_F_, *false*).
-                      1. Perform ? <emu-meta effects="user-code">_genv_.SetMutableBinding</emu-meta>(_F_, _fobj_, *false*).
-                      1. Return ~unused~.
+          1. Perform the following steps:
+            1. Let _strict_ be IsStrict of _script_.
+            1. If _strict_ is *false*, then
+              1. Let _declaredFunctionOrVarNames_ be the list-concatenation of _declaredFunctionNames_ and _declaredVarNames_.
+              1. For each |FunctionDeclaration| _f_ that is directly contained in the |StatementList| of a |Block|, |CaseClause|, or |DefaultClause| Contained within _script_, do
+                1. Let _F_ be StringValue of the |BindingIdentifier| of _f_.
+                1. If replacing the |FunctionDeclaration| _f_ with a |VariableStatement| that has _F_ as a |BindingIdentifier| would not produce any Early Errors for _script_, then
+                  1. If _env_.HasLexicalDeclaration(_F_) is *false*, then
+                    1. Let _fnDefinable_ be ? _env_.CanDeclareGlobalVar(_F_).
+                    1. If _fnDefinable_ is *true*, then
+                      1. NOTE: A var binding for _F_ is only instantiated here if it is neither a VarDeclaredName nor the name of another |FunctionDeclaration|.
+                      1. If _declaredFunctionOrVarNames_ does not contain _F_, then
+                        1. Perform ? _env_.CreateGlobalVarBinding(_F_, *false*).
+                        1. Append _F_ to _declaredFunctionOrVarNames_.
+                      1. When the |FunctionDeclaration| _f_ is evaluated, perform the following steps in place of the |FunctionDeclaration| Evaluation algorithm provided in <emu-xref href="#sec-function-definitions-runtime-semantics-evaluation"></emu-xref>:
+                        1. Let _genv_ be the running execution context's VariableEnvironment.
+                        1. Let _benv_ be the running execution context's LexicalEnvironment.
+                        1. Let _fobj_ be ! _benv_.GetBindingValue(_F_, *false*).
+                        1. Perform ? <emu-meta effects="user-code">_genv_.SetMutableBinding</emu-meta>(_F_, _fobj_, *false*).
+                        1. Return ~unused~.
         </emu-alg>
       </emu-annex>
 
@@ -47643,11 +47644,12 @@ THH:mm:ss.sss
         </emu-alg>
         <p>During BlockDeclarationInstantiation the following steps are performed in place of step <emu-xref href="#step-blockdeclarationinstantiation-initializebinding"></emu-xref>:</p>
         <emu-alg replaces-step="step-blockdeclarationinstantiation-initializebinding">
-          1. If the binding for _fn_ in _env_ is an uninitialized binding, then
-            1. Perform ! _env_.InitializeBinding(_fn_, _fo_).
-          1. Else,
-            1. Assert: _d_ is a |FunctionDeclaration|.
-            1. Perform ! _env_.SetMutableBinding(_fn_, _fo_, *false*).
+          1. Perform the following steps:
+            1. If the binding for _fn_ in _env_ is an uninitialized binding, then
+              1. Perform ! _env_.InitializeBinding(_fn_, _fo_).
+            1. Else,
+              1. Assert: _d_ is a |FunctionDeclaration|.
+              1. Perform ! _env_.SetMutableBinding(_fn_, _fo_, *false*).
         </emu-alg>
       </emu-annex>
     </emu-annex>
@@ -47775,10 +47777,11 @@ THH:mm:ss.sss
 
       <emu-annex id="sec-IsHTMLDDA-internal-slot-aec">
         <h1>Changes to IsLooselyEqual</h1>
-        <p>The following steps replace step <emu-xref href="#step-abstract-equality-comparison-web-compat-insertion-point"></emu-xref> of the IsLooselyEqual algorithm:</p>
-        <emu-alg>
-          1. If Type(_x_) is Object and _x_ has an [[IsHTMLDDA]] internal slot and _y_ is either *null* or *undefined*, return *true*.
-          1. If _x_ is either *null* or *undefined* and Type(_y_) is Object and _y_ has an [[IsHTMLDDA]] internal slot, return *true*.
+        <p>During IsLooselyEqual the following steps are performed in place of step <emu-xref href="#step-abstract-equality-comparison-web-compat-insertion-point"></emu-xref>:</p>
+        <emu-alg replaces-step="step-abstract-equality-comparison-web-compat-insertion-point">
+          1. Perform the following steps:
+            1. If Type(_x_) is Object and _x_ has an [[IsHTMLDDA]] internal slot and _y_ is either *null* or *undefined*, return *true*.
+            1. If _x_ is either *null* or *undefined* and Type(_y_) is Object and _y_ has an [[IsHTMLDDA]] internal slot, return *true*.
         </emu-alg>
       </emu-annex>
 


### PR DESCRIPTION
Ecmarkup currently doesn't number steps nicely when replacing one step with multiple. See https://github.com/tc39/ecmarkup/issues/418. This uses the workaround described in that issue. Additionally, I changed the phrasing in [B.3.6.2](https://tc39.es/ecma262/#sec-IsHTMLDDA-internal-slot-aec) to match the phrasing used to replace steps elsewhere in Annex B.