### PR TITLE
Meta: biblio: add `commit` field to package.json every publish

### DIFF
--- a/biblio/package.json
+++ b/biblio/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@tc39/ecma262-biblio",
   "version": "VERSIONED-DURING-PUBLISH",
+  "commit": "POPULATED-DURING-PUBLISH",
   "description": "Machine-readable representation of the internals of the ecma-262 spec",
   "keywords": [
     "ecmascript"

--- a/scripts/publish-biblio.sh
+++ b/scripts/publish-biblio.sh
@@ -17,4 +17,6 @@ LONG_COMMIT=$(git rev-parse --verify HEAD)
 echo "
 This version was built from commit [${SHORT_COMMIT}](https://github.com/tc39/ecma262/tree/${LONG_COMMIT})." >> README.md
 
+npm pkg set commit="${LONG_COMMIT}"
+
 npm publish --access public


### PR DESCRIPTION
This will allow `npm show @tc39/ecma262-biblio@X specSHA` to print out the sha it's built from, for any version X after this is merged.