### PR TITLE
Editorial: Expand the use of 'type' syntax

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -42844,7 +42844,7 @@ THH:mm:ss.sss
                 `@@iterator`
               </td>
               <td>
-                A function that returns an <i>Iterator</i> object.
+                a function that returns an <i>Iterator</i> object
               </td>
               <td>
                 The returned object must conform to the <i>Iterator</i> interface.
@@ -42875,7 +42875,7 @@ THH:mm:ss.sss
                 *"next"*
               </td>
               <td>
-                A function that returns an <i>IteratorResult</i> object.
+                a function that returns an <i>IteratorResult</i> object
               </td>
               <td>
                 The returned object must conform to the <i>IteratorResult</i> interface. If a previous call to the `next` method of an <i>Iterator</i> has returned an <i>IteratorResult</i> object whose *"done"* property is *true*, then all subsequent calls to the `next` method of that object should also return an <i>IteratorResult</i> object whose *"done"* property is *true*. However, this requirement is not enforced.
@@ -42904,7 +42904,7 @@ THH:mm:ss.sss
                 *"return"*
               </td>
               <td>
-                A function that returns an <i>IteratorResult</i> object.
+                a function that returns an <i>IteratorResult</i> object
               </td>
               <td>
                 The returned object must conform to the <i>IteratorResult</i> interface. Invoking this method notifies the <i>Iterator</i> object that the caller does not intend to make any more `next` method calls to the <i>Iterator</i>. The returned <i>IteratorResult</i> object will typically have a *"done"* property whose value is *true*, and a *"value"* property with the value passed as the argument of the `return` method. However, this requirement is not enforced.
@@ -42915,7 +42915,7 @@ THH:mm:ss.sss
                 *"throw"*
               </td>
               <td>
-                A function that returns an <i>IteratorResult</i> object.
+                a function that returns an <i>IteratorResult</i> object
               </td>
               <td>
                 The returned object must conform to the <i>IteratorResult</i> interface. Invoking this method notifies the <i>Iterator</i> object that the caller has detected an error condition. The argument may be used to identify the error condition and typically will be an exception object. A typical response is to `throw` the value passed as the argument. If the method does not `throw`, the returned <i>IteratorResult</i> object will typically have a *"done"* property whose value is *true*.
@@ -42940,7 +42940,7 @@ THH:mm:ss.sss
             </tr>
             <tr>
               <td>`@@asyncIterator`</td>
-              <td>A function that returns an <i>AsyncIterator</i> object.</td>
+              <td>a function that returns an <i>AsyncIterator</i> object</td>
               <td>The returned object must conform to the <i>AsyncIterator</i> interface.</td>
             </tr>
           </table>
@@ -42959,7 +42959,7 @@ THH:mm:ss.sss
             </tr>
             <tr>
               <td>*"next"*</td>
-              <td>A function that returns a promise for an <i>IteratorResult</i> object.</td>
+              <td>a function that returns a promise for an <i>IteratorResult</i> object</td>
               <td>
                 <p>The returned promise, when fulfilled, must fulfill with an object that conforms to the <i>IteratorResult</i> interface. If a previous call to the `next` method of an <i>AsyncIterator</i> has returned a promise for an <i>IteratorResult</i> object whose *"done"* property is *true*, then all subsequent calls to the `next` method of that object should also return a promise for an <i>IteratorResult</i> object whose *"done"* property is *true*. However, this requirement is not enforced.</p>
 
@@ -42980,7 +42980,7 @@ THH:mm:ss.sss
             </tr>
             <tr>
               <td>*"return"*</td>
-              <td>A function that returns a promise for an <i>IteratorResult</i> object.</td>
+              <td>a function that returns a promise for an <i>IteratorResult</i> object</td>
               <td>
                 <p>The returned promise, when fulfilled, must fulfill with an object that conforms to the <i>IteratorResult</i> interface. Invoking this method notifies the <i>AsyncIterator</i> object that the caller does not intend to make any more `next` method calls to the <i>AsyncIterator</i>. The returned promise will fulfill with an <i>IteratorResult</i> object which will typically have a *"done"* property whose value is *true*, and a *"value"* property with the value passed as the argument of the `return` method. However, this requirement is not enforced.</p>
 
@@ -42989,7 +42989,7 @@ THH:mm:ss.sss
             </tr>
             <tr>
               <td>*"throw"*</td>
-              <td>A function that returns a promise for an <i>IteratorResult</i> object.</td>
+              <td>a function that returns a promise for an <i>IteratorResult</i> object</td>
               <td>
                 <p>The returned promise, when fulfilled, must fulfill with an object that conforms to the <i>IteratorResult</i> interface. Invoking this method notifies the <i>AsyncIterator</i> object that the caller has detected an error condition. The argument may be used to identify the error condition and typically will be an exception object. A typical response is to return a rejected promise which rejects with the value passed as the argument.</p>
 
@@ -43024,7 +43024,7 @@ THH:mm:ss.sss
                 *"done"*
               </td>
               <td>
-                Either *true* or *false*.
+                either *true* or *false*
               </td>
               <td>
                 This is the result status of an <em>iterator</em> `next` method call. If the end of the iterator was reached *"done"* is *true*. If the end was not reached *"done"* is *false* and a value is available. If a *"done"* property (either own or inherited) does not exist, it is considered to have the value *false*.
@@ -43035,7 +43035,7 @@ THH:mm:ss.sss
                 *"value"*
               </td>
               <td>
-                Any ECMAScript language value.
+                an ECMAScript language value
               </td>
               <td>
                 If done is *false*, this is the current iteration element value. If done is *true*, this is the return value of the iterator, if it supplied one. If the iterator does not have a return value, *"value"* is *undefined*. In that case, the *"value"* property may be absent from the conforming object if it does not inherit an explicit *"value"* property.

--- a/spec.html
+++ b/spec.html
@@ -13075,7 +13075,7 @@
             [[Environment]]
           </td>
           <td>
-            Environment Record
+            an Environment Record
           </td>
           <td>
             The Environment Record that the function was closed over. Used as the outer environment when evaluating the code of the function.
@@ -13086,7 +13086,7 @@
             [[PrivateEnvironment]]
           </td>
           <td>
-            PrivateEnvironment Record | *null*
+            a PrivateEnvironment Record or *null*
           </td>
           <td>
             The PrivateEnvironment Record for Private Names that the function was closed over. *null* if this function is not syntactically contained within a class. Used as the outer PrivateEnvironment for inner classes when evaluating the code of the function.
@@ -13097,7 +13097,7 @@
             [[FormalParameters]]
           </td>
           <td>
-            Parse Node
+            a Parse Node
           </td>
           <td>
             The root parse node of the source text that defines the function's formal parameter list.
@@ -13108,7 +13108,7 @@
             [[ECMAScriptCode]]
           </td>
           <td>
-            Parse Node
+            a Parse Node
           </td>
           <td>
             The root parse node of the source text that defines the function's body.
@@ -13119,7 +13119,7 @@
             [[ConstructorKind]]
           </td>
           <td>
-            ~base~ | ~derived~
+            ~base~ or ~derived~
           </td>
           <td>
             Whether or not the function is a derived class constructor.
@@ -13130,7 +13130,7 @@
             [[Realm]]
           </td>
           <td>
-            Realm Record
+            a Realm Record
           </td>
           <td>
             The realm in which the function was created and which provides any intrinsic objects that are accessed when evaluating the function.
@@ -13141,7 +13141,7 @@
             [[ScriptOrModule]]
           </td>
           <td>
-            Script Record or Module Record
+            a Script Record or a Module Record
           </td>
           <td>
             The script or module in which the function was created.
@@ -13152,7 +13152,7 @@
             [[ThisMode]]
           </td>
           <td>
-            ~lexical~ | ~strict~ | ~global~
+            ~lexical~, ~strict~, or ~global~
           </td>
           <td>
             Defines how `this` references are interpreted within the formal parameters and code body of the function. ~lexical~ means that `this` refers to the *this* value of a lexically enclosing function. ~strict~ means that the *this* value is used exactly as provided by an invocation of the function. ~global~ means that a *this* value of *undefined* or *null* is interpreted as a reference to the global object, and any other *this* value is first passed to ToObject.
@@ -13163,7 +13163,7 @@
             [[Strict]]
           </td>
           <td>
-            Boolean
+            a Boolean
           </td>
           <td>
             *true* if this is a strict function, *false* if this is a non-strict function.
@@ -13174,7 +13174,7 @@
             [[HomeObject]]
           </td>
           <td>
-            Object
+            an Object
           </td>
           <td>
             If the function uses `super`, this is the object whose [[GetPrototypeOf]] provides the object where `super` property lookups begin.
@@ -13185,7 +13185,7 @@
             [[SourceText]]
           </td>
           <td>
-            sequence of Unicode code points
+            a sequence of Unicode code points
           </td>
           <td>
             The <emu-xref href="#sec-source-text">source text</emu-xref> that defines the function.
@@ -13196,7 +13196,7 @@
             [[Fields]]
           </td>
           <td>
-            List of ClassFieldDefinition Records
+            a List of ClassFieldDefinition Records
           </td>
           <td>
             If the function is a class, this is a list of Records representing the non-static fields and corresponding initializers of the class.
@@ -13207,7 +13207,7 @@
             [[PrivateMethods]]
           </td>
           <td>
-            List of PrivateElements
+            a List of PrivateElements
           </td>
           <td>
             If the function is a class, this is a list representing the non-static private methods and accessors of the class.
@@ -13218,7 +13218,7 @@
             [[ClassFieldInitializerName]]
           </td>
           <td>
-            String | Symbol | Private Name | ~empty~
+            a String, a Symbol, a Private Name, or ~empty~
           </td>
           <td>
             If the function is created as the initializer of a class field, the name to use for NamedEvaluation of the field; ~empty~ otherwise.
@@ -13229,7 +13229,7 @@
             [[IsClassConstructor]]
           </td>
           <td>
-            Boolean
+            a Boolean
           </td>
           <td>
             Indicates whether the function is a class constructor. (If *true*, invoking the function's [[Call]] will immediately throw a *TypeError* exception.)
@@ -13912,7 +13912,7 @@
               [[BoundTargetFunction]]
             </td>
             <td>
-              Callable Object
+              a callable Object
             </td>
             <td>
               The wrapped function object.
@@ -13923,7 +13923,7 @@
               [[BoundThis]]
             </td>
             <td>
-              Any
+              an ECMAScript language value
             </td>
             <td>
               The value that is always passed as the *this* value when calling the wrapped function.
@@ -13934,7 +13934,7 @@
               [[BoundArguments]]
             </td>
             <td>
-              List of Any
+              a List of ECMAScript language values
             </td>
             <td>
               A list of values whose elements are used as the first arguments to any call to the wrapped function.
@@ -14798,7 +14798,7 @@
               [[Module]]
             </td>
             <td>
-              Module Record
+              a Module Record
             </td>
             <td>
               The Module Record whose exports this namespace exposes.
@@ -14809,7 +14809,7 @@
               [[Exports]]
             </td>
             <td>
-              List of String
+              a List of Strings
             </td>
             <td>
               A List whose elements are the String values of the exported names exposed as own properties of this object. The list is ordered as if an Array of those String values had been sorted using %Array.prototype.sort% using *undefined* as _comparefn_.

--- a/spec.html
+++ b/spec.html
@@ -6970,7 +6970,7 @@
               [[Iterator]]
             </td>
             <td>
-              An object
+              an Object
             </td>
             <td>
               An object that conforms to the <i>Iterator</i> or <i>AsyncIterator</i> interface.
@@ -6981,7 +6981,7 @@
               [[NextMethod]]
             </td>
             <td>
-              A function object
+              a function object
             </td>
             <td>
               The `next` method of the [[Iterator]] object.
@@ -6992,7 +6992,7 @@
               [[Done]]
             </td>
             <td>
-              Boolean
+              a Boolean
             </td>
             <td>
               Whether the iterator has been closed.

--- a/spec.html
+++ b/spec.html
@@ -22287,12 +22287,18 @@
                   Internal Slot
                 </th>
                 <th>
+                  Type
+                </th>
+                <th>
                   Description
                 </th>
               </tr>
               <tr>
                 <td>
                   [[Object]]
+                </td>
+                <td>
+                  an Object
                 </td>
                 <td>
                   The Object value whose properties are being iterated.
@@ -22303,6 +22309,9 @@
                   [[ObjectWasVisited]]
                 </td>
                 <td>
+                  a Boolean
+                </td>
+                <td>
                   *true* if the iterator has invoked [[OwnPropertyKeys]] on [[Object]], *false* otherwise.
                 </td>
               </tr>
@@ -22311,7 +22320,10 @@
                   [[VisitedKeys]]
                 </td>
                 <td>
-                  A list of String values which have been emitted by this iterator thus far.
+                  a List of Strings
+                </td>
+                <td>
+                  The values that have been emitted by this iterator thus far.
                 </td>
               </tr>
               <tr>
@@ -22319,7 +22331,10 @@
                   [[RemainingKeys]]
                 </td>
                 <td>
-                  A list of String values remaining to be emitted for the current object, before iterating the properties of its prototype (if its prototype is not *null*).
+                  a List of Strings
+                </td>
+                <td>
+                  The values remaining to be emitted for the current object, before iterating the properties of its prototype (if its prototype is not *null*).
                 </td>
               </tr>
             </table>
@@ -43024,7 +43039,7 @@ THH:mm:ss.sss
                 *"done"*
               </td>
               <td>
-                either *true* or *false*
+                a Boolean
               </td>
               <td>
                 This is the result status of an <em>iterator</em> `next` method call. If the end of the iterator was reached *"done"* is *true*. If the end was not reached *"done"* is *false* and a value is available. If a *"done"* property (either own or inherited) does not exist, it is considered to have the value *false*.
@@ -43203,6 +43218,9 @@ THH:mm:ss.sss
                   Internal Slot
                 </th>
                 <th>
+                  Type
+                </th>
+                <th>
                   Description
                 </th>
               </tr>
@@ -43212,7 +43230,10 @@ THH:mm:ss.sss
                 [[SyncIteratorRecord]]
               </td>
               <td>
-                An Iterator Record representing the original synchronous iterator which is being adapted.
+                an Iterator Record
+              </td>
+              <td>
+                Represents the original synchronous iterator which is being adapted.
               </td>
             </tr>
           </table>
@@ -44300,6 +44321,9 @@ THH:mm:ss.sss
               Internal Slot
             </th>
             <th>
+              Type
+            </th>
+            <th>
               Description
             </th>
           </tr>
@@ -44308,12 +44332,18 @@ THH:mm:ss.sss
               [[PromiseState]]
             </td>
             <td>
-              One of ~pending~, ~fulfilled~, or ~rejected~. Governs how a promise will react to incoming calls to its `then` method.
+              ~pending~, ~fulfilled~, or ~rejected~
+            </td>
+            <td>
+              Governs how a promise will react to incoming calls to its `then` method.
             </td>
           </tr>
           <tr>
             <td>
               [[PromiseResult]]
+            </td>
+            <td>
+              an ECMAScript language value
             </td>
             <td>
               The value with which the promise has been fulfilled or rejected, if any. Only meaningful if [[PromiseState]] is not ~pending~.
@@ -44324,7 +44354,10 @@ THH:mm:ss.sss
               [[PromiseFulfillReactions]]
             </td>
             <td>
-              A List of PromiseReaction records to be processed when/if the promise transitions from the ~pending~ state to the ~fulfilled~ state.
+              a List of PromiseReaction Records
+            </td>
+            <td>
+              Records to be processed when/if the promise transitions from the ~pending~ state to the ~fulfilled~ state.
             </td>
           </tr>
           <tr>
@@ -44332,7 +44365,10 @@ THH:mm:ss.sss
               [[PromiseRejectReactions]]
             </td>
             <td>
-              A List of PromiseReaction records to be processed when/if the promise transitions from the ~pending~ state to the ~rejected~ state.
+              a List of PromiseReaction Records
+            </td>
+            <td>
+              Records to be processed when/if the promise transitions from the ~pending~ state to the ~rejected~ state.
             </td>
           </tr>
           <tr>
@@ -44340,7 +44376,10 @@ THH:mm:ss.sss
               [[PromiseIsHandled]]
             </td>
             <td>
-              A boolean indicating whether the promise has ever had a fulfillment or rejection handler; used in unhandled rejection tracking.
+              a Boolean
+            </td>
+            <td>
+              Indicates whether the promise has ever had a fulfillment or rejection handler; used in unhandled rejection tracking.
             </td>
           </tr>
         </table>
@@ -44630,6 +44669,9 @@ THH:mm:ss.sss
               Internal Slot
             </th>
             <th>
+              Type
+            </th>
+            <th>
               Description
             </th>
           </tr>
@@ -44638,12 +44680,18 @@ THH:mm:ss.sss
               [[GeneratorState]]
             </td>
             <td>
-              The current execution state of the generator. The possible values are: *undefined*, ~suspendedStart~, ~suspendedYield~, ~executing~, and ~completed~.
+              *undefined*, ~suspendedStart~, ~suspendedYield~, ~executing~, or ~completed~
+            </td>
+            <td>
+              The current execution state of the generator.
             </td>
           </tr>
           <tr>
             <td>
               [[GeneratorContext]]
+            </td>
+            <td>
+              an execution context
             </td>
             <td>
               The execution context that is used when executing the code of this generator.
@@ -44652,6 +44700,9 @@ THH:mm:ss.sss
           <tr>
             <td>
               [[GeneratorBrand]]
+            </td>
+            <td>
+              a String or ~empty~
             </td>
             <td>
               A brand used to distinguish different kinds of generators. The [[GeneratorBrand]] of generators declared by ECMAScript source text is always ~empty~.
@@ -44962,22 +45013,27 @@ THH:mm:ss.sss
         <table>
           <tr>
             <th>Internal Slot</th>
+            <th>Type</th>
             <th>Description</th>
           </tr>
           <tr>
             <td>[[AsyncGeneratorState]]</td>
-            <td>The current execution state of the async generator. The possible values are: *undefined*, ~suspendedStart~, ~suspendedYield~, ~executing~, ~awaiting-return~, and ~completed~.</td>
+            <td>*undefined*, ~suspendedStart~, ~suspendedYield~, ~executing~, ~awaiting-return~, or ~completed~</td>
+            <td>The current execution state of the async generator.</td>
           </tr>
           <tr>
             <td>[[AsyncGeneratorContext]]</td>
+            <td>an execution context</td>
             <td>The execution context that is used when executing the code of this async generator.</td>
           </tr>
           <tr>
             <td>[[AsyncGeneratorQueue]]</td>
-            <td>A List of AsyncGeneratorRequest records which represent requests to resume the async generator. Except during state transitions, it is nonempty if and only if [[AsyncGeneratorState]] is either ~executing~ or ~awaiting-return~.</td>
+            <td>a List of AsyncGeneratorRequest Records</td>
+            <td>Records which represent requests to resume the async generator. Except during state transitions, it is nonempty if and only if [[AsyncGeneratorState]] is either ~executing~ or ~awaiting-return~.</td>
           </tr>
           <tr>
             <td>[[GeneratorBrand]]</td>
+            <td>a String or ~empty~</td>
             <td>A brand used to distinguish different kinds of async generators. The [[GeneratorBrand]] of async generators declared by ECMAScript source text is always ~empty~.</td>
           </tr>
         </table>


### PR DESCRIPTION
Similar to PR #2602, which used 'type' syntax when declaring record fields, this PR uses it when declaring:
- the require/optional properties of interfaces, and
- the internal slots of objects.

Also, there's a bonus commit that fixes up the field types of a recently added record.