### PR TITLE
Normative: Allow toString of a built-in function to output a computed property name

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -30115,24 +30115,49 @@
           1. Assert: Type(_func_) is Object.
           1. If _func_ has a [[SourceText]] internal slot and _func_.[[SourceText]] is a sequence of Unicode code points and HostHasSourceTextAvailable(_func_) is *true*, then
             1. Return CodePointsToString(_func_.[[SourceText]]).
-          1. Let _sourceText_ be an implementation-defined sequence of Unicode code points that represents _func_ using the syntax of |NativeFunction|. If _func_ is a <emu-xref href="#sec-built-in-function-objects">built-in function object</emu-xref>, the portion of _sourceText_ corresponding to |NativeFunctionName| must be StringToCodePoints(_func_.[[InitialName]]).
+          1. Let _sourceText_ be an implementation-defined sequence of Unicode code points that represents _func_ using the syntax of |NativeFunction|. If _func_ is a <emu-xref href="#sec-built-in-function-objects">built-in function object</emu-xref>, NativeFunctionName of ParseText(_sourceText_, |NativeFunction|) must be _func_.[[InitialName]].
           1. Return CodePointsToString(_sourceText_).
         </emu-alg>
         <emu-note>
           <p>Every <emu-xref href="#sec-built-in-function-objects">built-in function object</emu-xref> has an [[InitialName]] internal slot with String value equal to the initial value of its *"name"* property, which for some functions is explicitly specified with contents that match the syntax of |ComputedPropertyName| rather than |LiteralPropertyName|. See <emu-xref href="#sec-ecmascript-standard-built-in-objects"></emu-xref>.</p>
         </emu-note>
+
         <emu-grammar type="definition">
           NativeFunction :
             `function` NativeFunctionName `(` FormalParameters[~Yield, ~Await] `)` `{` `[` `native` `code` `]` `}`
 
           NativeFunctionName :
             [empty]
-            NativeFunctionAccessor? PropertyName[~Yield, ~Await]
+            NativeFunctionAccessor? NativeFunctionBaseName
+            `[` StringLiteral `]`
 
           NativeFunctionAccessor :
             `get`
             `set`
+
+          NativeFunctionBaseName :
+            PropertyName[~Yield, ~Await] but not `[` StringLiteral `]`
         </emu-grammar>
+
+        <emu-clause id="sec-nativefunctionname" type="sdo">
+          <h1>Runtime Semantics: NativeFunctionName ( ): a String</h1>
+          <dl class="header">
+            <dt>description</dt>
+            <dd>It returns the name of a function object represented by synthetic source text.</dd>
+          </dl>
+          <emu-grammar>NativeFunction : `function` NativeFunctionName `(` FormalParameters[~Yield, ~Await] `)` `{` `[` `native` `code` `]` `}`</emu-grammar>
+          <emu-alg>
+            1. If |NativeFunctionName| is <emu-grammar>NativeFunctionName : [empty]</emu-grammar> , then
+              1. Return *""*.
+            1. If |NativeFunctionName| is <emu-grammar>NativeFunctionName : NativeFunctionAccessor? NativeFunctionBaseName</emu-grammar> , then
+              1. Let _sourceText_ be the source text matched by |NativeFunctionName|.
+              1. Return CodePointsToString(_sourceText_).
+            1. Assert: |NativeFunctionName| is <emu-grammar>NativeFunctionName : `[` StringLiteral `]`</emu-grammar> .
+            1. Let _nameNode_ be the |StringLiteral| of |NativeFunctionName|.
+            1. Let _name_ be the result of evaluating _nameNode_.
+            1. Return _name_.
+          </emu-alg>
+        </emu-clause>
       </emu-clause>
 
       <emu-clause id="sec-function.prototype-@@hasinstance">

--- a/spec.html
+++ b/spec.html
@@ -30111,18 +30111,16 @@
         <p>When the `toString` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _func_ be the *this* value.
-          1. If Type(_func_) is Object and _func_ has a [[SourceText]] internal slot and _func_.[[SourceText]] is a sequence of Unicode code points and HostHasSourceTextAvailable(_func_) is *true*, then
-            1. Let _sourceText_ be _func_.[[SourceText]].
-          1. Else if _func_ is a <emu-xref href="#sec-built-in-function-objects">built-in function object</emu-xref>, then
-            1. NOTE: Every <emu-xref href="#sec-built-in-function-objects">built-in function object</emu-xref> has an [[InitialName]] internal slot with String value matching the initial value of its *"name"* property, which might be explicitly specified with contents that match the syntax of |ComputedPropertyName| rather than |LiteralPropertyName|. See <emu-xref href="#sec-ecmascript-standard-built-in-objects"></emu-xref>.
-            1. Let _sourceText_ be an implementation-defined sequence of Unicode code points that represents _func_ using the syntax of |NativeFunction| in which the portion of the sequence matched by |NativeFunctionName| is StringToCodePoints(_func_.[[InitialName]]).
-          1. Else if Type(_func_) is Object and IsCallable(_func_) is *true*, then
-            1. Let _sourceText_ be an implementation-defined sequence of Unicode code points that represents _func_ using the syntax of |NativeFunction|.
-          1. Else,
-            1. Throw a *TypeError* exception.
+          1. If IsCallable(_func_) is *false*, throw a *TypeError* exception.
+          1. Assert: Type(_func_) is Object.
+          1. If _func_ has a [[SourceText]] internal slot and _func_.[[SourceText]] is a sequence of Unicode code points and HostHasSourceTextAvailable(_func_) is *true*, then
+            1. Return CodePointsToString(_func_.[[SourceText]]).
+          1. Let _sourceText_ be an implementation-defined sequence of Unicode code points that represents _func_ using the syntax of |NativeFunction|. If _func_ is a <emu-xref href="#sec-built-in-function-objects">built-in function object</emu-xref>, the portion of _sourceText_ corresponding to |NativeFunctionName| must be StringToCodePoints(_func_.[[InitialName]]).
           1. Return CodePointsToString(_sourceText_).
         </emu-alg>
-
+        <emu-note>
+          <p>Every <emu-xref href="#sec-built-in-function-objects">built-in function object</emu-xref> has an [[InitialName]] internal slot with String value equal to the initial value of its *"name"* property, which for some functions is explicitly specified with contents that match the syntax of |ComputedPropertyName| rather than |LiteralPropertyName|. See <emu-xref href="#sec-ecmascript-standard-built-in-objects"></emu-xref>.</p>
+        </emu-note>
         <emu-grammar type="definition">
           NativeFunction :
             `function` NativeFunctionName `(` FormalParameters[~Yield, ~Await] `)` `{` `[` `native` `code` `]` `}`

--- a/spec.html
+++ b/spec.html
@@ -30112,15 +30112,24 @@
         <emu-alg>
           1. Let _func_ be the *this* value.
           1. If Type(_func_) is Object and _func_ has a [[SourceText]] internal slot and _func_.[[SourceText]] is a sequence of Unicode code points and HostHasSourceTextAvailable(_func_) is *true*, then
-            1. Return CodePointsToString(_func_.[[SourceText]]).
-          1. If _func_ is a <emu-xref href="#sec-built-in-function-objects">built-in function object</emu-xref>, return an implementation-defined String source code representation of _func_. The representation must have the syntax of a |NativeFunction|. Additionally, if _func_ has an [[InitialName]] internal slot and _func_.[[InitialName]] is a String, the portion of the returned String that would be matched by |NativeFunctionAccessor?| |PropertyName| must be the value of _func_.[[InitialName]].
-          1. If Type(_func_) is Object and IsCallable(_func_) is *true*, return an implementation-defined String source code representation of _func_. The representation must have the syntax of a |NativeFunction|.
-          1. Throw a *TypeError* exception.
+            1. Let _sourceText_ be _func_.[[SourceText]].
+          1. Else if _func_ is a <emu-xref href="#sec-built-in-function-objects">built-in function object</emu-xref>, then
+            1. NOTE: Every <emu-xref href="#sec-built-in-function-objects">built-in function object</emu-xref> has an [[InitialName]] internal slot with String value matching the initial value of its *"name"* property, which might be explicitly specified with contents that match the syntax of |ComputedPropertyName| rather than |LiteralPropertyName|. See <emu-xref href="#sec-ecmascript-standard-built-in-objects"></emu-xref>.
+            1. Let _sourceText_ be an implementation-defined sequence of Unicode code points that represents _func_ using the syntax of |NativeFunction| in which the portion of the sequence matched by |NativeFunctionName| is StringToCodePoints(_func_.[[InitialName]]).
+          1. Else if Type(_func_) is Object and IsCallable(_func_) is *true*, then
+            1. Let _sourceText_ be an implementation-defined sequence of Unicode code points that represents _func_ using the syntax of |NativeFunction|.
+          1. Else,
+            1. Throw a *TypeError* exception.
+          1. Return CodePointsToString(_sourceText_).
         </emu-alg>
 
         <emu-grammar type="definition">
           NativeFunction :
-            `function` NativeFunctionAccessor? PropertyName[~Yield, ~Await]? `(` FormalParameters[~Yield, ~Await] `)` `{` `[` `native` `code` `]` `}`
+            `function` NativeFunctionName `(` FormalParameters[~Yield, ~Await] `)` `{` `[` `native` `code` `]` `}`
+
+          NativeFunctionName :
+            [empty]
+            NativeFunctionAccessor? PropertyName[~Yield, ~Await]
 
           NativeFunctionAccessor :
             `get`


### PR DESCRIPTION
e.g., as output by XS:
```sh
$ eshost -se 'Proxy.revocable({}, {}).revoke.toString()'
#### ChakraCore, SpiderMonkey
function() {
    [native code]
}

#### engine262, GraalJS, Hermes, V8
function () { [native code] }

#### JavaScriptCore
function () {
    [native code]
}

#### Moddable XS
function [""] (){[native code]}
```