### PR TITLE
Editorial: `StringPad`: refactor to be completionless

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -33101,7 +33101,7 @@ THH:mm:ss.sss
             1. Let _yv_ be YearFromTime(_tv_).
             1. If _yv_ &ge; *+0*<sub>𝔽</sub>, let _yearSign_ be the empty String; otherwise, let _yearSign_ be *"-"*.
             1. Let _year_ be the String representation of abs(ℝ(_yv_)), formatted as a decimal number.
-            1. Let _paddedYear_ be ! StringPad(_year_, *4*<sub>𝔽</sub>, *"0"*, ~start~).
+            1. Let _paddedYear_ be StringPad(_year_, 4, *"0"*, ~start~).
             1. Return the string-concatenation of _weekday_, the code unit 0x0020 (SPACE), _month_, the code unit 0x0020 (SPACE), _day_, the code unit 0x0020 (SPACE), _yearSign_, and _paddedYear_.
           </emu-alg>
           <emu-table id="sec-todatestring-day-names" caption="Names of days of the week">
@@ -33346,7 +33346,7 @@ THH:mm:ss.sss
           1. Let _yv_ be YearFromTime(_tv_).
           1. If _yv_ &ge; *+0*<sub>𝔽</sub>, let _yearSign_ be the empty String; otherwise, let _yearSign_ be *"-"*.
           1. Let _year_ be the String representation of abs(ℝ(_yv_)), formatted as a decimal number.
-          1. Let _paddedYear_ be ! StringPad(_year_, *4*<sub>𝔽</sub>, *"0"*, ~start~).
+          1. Let _paddedYear_ be StringPad(_year_, 4, *"0"*, ~start~).
           1. Return the string-concatenation of _weekday_, *","*, the code unit 0x0020 (SPACE), _day_, the code unit 0x0020 (SPACE), _month_, the code unit 0x0020 (SPACE), _yearSign_, _paddedYear_, the code unit 0x0020 (SPACE), and TimeString(_tv_).
         </emu-alg>
       </emu-clause>
@@ -33805,7 +33805,11 @@ THH:mm:ss.sss
         <p>When the `padEnd` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
-          1. Return ? StringPad(_O_, _maxLength_, _fillString_, ~end~).
+          1. Let _S_ be ? ToString(_O_).
+          1. Let _maxLen_ be ℝ(? ToLength(_maxLength_)).
+          1. If _fillString_ is *undefined*, let _filler_ be the String value consisting solely of the code unit 0x0020 (SPACE).
+          1. Else, let _filler_ be ? ToString(_fillString_).
+          1. Return StringPad(_S_, _maxLen_, _filler_, ~end~).
         </emu-alg>
       </emu-clause>
 
@@ -33814,29 +33818,29 @@ THH:mm:ss.sss
         <p>When the `padStart` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
-          1. Return ? StringPad(_O_, _maxLength_, _fillString_, ~start~).
+          1. Let _S_ be ? ToString(_O_).
+          1. Let _maxLen_ be ℝ(? ToLength(_maxLength_)).
+          1. If _fillString_ is *undefined*, let _filler_ be the String value consisting solely of the code unit 0x0020 (SPACE).
+          1. Else, let _filler_ be ? ToString(_fillString_).
+          1. Return StringPad(_S_, _maxLen_, _filler_, ~end~).
         </emu-alg>
 
         <emu-clause id="sec-stringpad" type="abstract operation">
           <h1>
             StringPad (
-              _O_: an ECMAScript language value,
-              _maxLength_: an ECMAScript language value,
-              _fillString_: an ECMAScript language value,
+              _S_: a String,
+              _maxLength_: a non-negative integer that is less than 2<sup>53</sup>,
+              _filler_: a String,
               _placement_: ~start~ or ~end~,
-            ): either a normal completion containing a String or an abrupt completion
+            ): a String
           </h1>
           <dl class="header">
           </dl>
           <emu-alg>
-            1. Let _S_ be ? ToString(_O_).
-            1. Let _intMaxLength_ be ℝ(? ToLength(_maxLength_)).
             1. Let _stringLength_ be the length of _S_.
-            1. If _intMaxLength_ &le; _stringLength_, return _S_.
-            1. If _fillString_ is *undefined*, let _filler_ be the String value consisting solely of the code unit 0x0020 (SPACE).
-            1. Else, let _filler_ be ? ToString(_fillString_).
+            1. If _maxLength_ &le; _stringLength_, return _S_.
             1. If _filler_ is the empty String, return _S_.
-            1. Let _fillLen_ be _intMaxLength_ - _stringLength_.
+            1. Let _fillLen_ be _maxLength_ - _stringLength_.
             1. Let _truncatedStringFiller_ be the String value consisting of repeated concatenations of _filler_ truncated to length _fillLen_.
             1. If _placement_ is ~start~, return the string-concatenation of _truncatedStringFiller_ and _S_.
             1. Else, return the string-concatenation of _S_ and _truncatedStringFiller_.


### PR DESCRIPTION
The observable order of exceptions should be maintained, and now StringPad doesn't need to return a completion record.

Whichever lands first, this or #2693 (probably that one), I'll be happy to update the other.