### PR TITLE
Editorial: Fix the return-type of CompilePattern

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -35082,7 +35082,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-compilepattern" type="sdo" oldids="sec-pattern">
-        <h1>Runtime Semantics: CompilePattern ( ): an Abstract Closure that takes a String and a non-negative integer and returns a MatchResult</h1>
+        <h1>Runtime Semantics: CompilePattern ( ): an Abstract Closure that takes a List of characters and a non-negative integer and returns a MatchResult</h1>
         <dl class="header">
         </dl>
         <emu-grammar>Pattern :: Disjunction</emu-grammar>


### PR DESCRIPTION
PR #1713 changed the signature of the Abstract Closure created+returned by CompilePattern, but didn't make the corresponding change to the return-type in the section heading.

(No uses in downstream specs.)