### PR TITLE
Editorial: Handled -0 case in 'Number::multiply'

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1867,6 +1867,12 @@
               1. If _x_ is *+0*<sub>𝔽</sub> or _x_ is *-0*<sub>𝔽</sub>, return *NaN*.
               1. If _x_ &gt; *+0*<sub>𝔽</sub>, return _y_.
               1. Return -_y_.
+            1. If _x_ is *-0*<sub>𝔽</sub>, then
+              1. If _y_ is *-0*<sub>𝔽</sub> or _y_ &lt; *-0*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
+              1. Else, return *-0*<sub>𝔽</sub>.
+            1. If _y_ is *-0*<sub>𝔽</sub>, then
+              1. If _x_ &lt; *-0*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
+              1. Else, return *-0*<sub>𝔽</sub>.
             1. Return 𝔽(ℝ(_x_) &times; ℝ(_y_)).
           </emu-alg>
           <emu-note>


### PR DESCRIPTION
In [Number::multiply](https://tc39.es/ecma262/#sec-numeric-types-number-multiply), it seems that it evaluates `(-0) * (+0)` to `+0` which is different to [previous specification](http://262.ecma-international.org/11.0/#sec-numeric-types-number-multiply). Currently, it fails following test262 tests according to our implementation [ESMeta](https://github.com/es-meta/esmeta):
- test/language/expressions/multiplication/S11.5.1_A4_T2.js