### PR TITLE
Editorial: removes redundant step from Array.prototype.splice

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -37887,8 +37887,7 @@ THH:mm:ss.sss
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
           1. Let _relativeStart_ be ? ToIntegerOrInfinity(_start_).
-          1. If _relativeStart_ is -&infin;, let _actualStart_ be 0.
-          1. Else if _relativeStart_ &lt; 0, let _actualStart_ be max(_len_ + _relativeStart_, 0).
+          1. If _relativeStart_ &lt; 0, let _actualStart_ be max(_len_ + _relativeStart_, 0).
           1. Else, let _actualStart_ be min(_relativeStart_, _len_).
           1. Let _insertCount_ be the number of elements in _items_.
           1. If _start_ is not present, then


### PR DESCRIPTION
Closes: #2701

@syg pointed out that this step is not necessary when it was copied for https://tc39.es/proposal-change-array-by-copy/#sec-array.prototype.toSpliced
