### PR TITLE
Editorial: Fix CreateUnmappedArgumentsObject's return-type

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -14434,7 +14434,7 @@
         <h1>
           CreateUnmappedArgumentsObject (
             _argumentsList_: unknown,
-          ): an arguments exotic object
+          ): an ordinary object
         </h1>
         <dl class="header">
         </dl>


### PR DESCRIPTION
CreateUnmappedArgumentsObject creates an ordinary object, not an arguments exotic object.
(See [10.4.4 Arguments Exotic Objects](https://tc39.es/ecma262/#sec-arguments-exotic-objects) Note 1).