### PR TITLE
Editorial: Align the algorithm steps and description of CanonicalNumericIndexString

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -2635,7 +2635,7 @@
         </li>
       </ul>
       <p>Properties are identified using key values. A <dfn variants="property keys">property key</dfn> value is either an ECMAScript String value or a Symbol value. All String and Symbol values, including the empty String, are valid as property keys. A <dfn id="property-name">property name</dfn> is a property key that is a String value.</p>
-      <p>An <dfn id="integer-index" variants="integer indices">integer index</dfn> is a String-valued property key that is a canonical numeric String (see <emu-xref href="#sec-canonicalnumericindexstring"></emu-xref>) and whose numeric value is either *+0*<sub>𝔽</sub> or a positive integral Number &le; 𝔽(2<sup>53</sup> - 1). An <dfn id="array-index" variants="array indices">array index</dfn> is an integer index whose numeric value _i_ is in the range <emu-eqn>*+0*<sub>𝔽</sub> &le; _i_ &lt; 𝔽(2<sup>32</sup> - 1)</emu-eqn>.</p>
+      <p>An <dfn id="integer-index" variants="integer indices">integer index</dfn> is a String-valued property key that is a canonical numeric string and whose numeric value is either *+0*<sub>𝔽</sub> or a positive integral Number &le; 𝔽(2<sup>53</sup> - 1). An <dfn id="array-index" variants="array indices">array index</dfn> is an integer index whose numeric value _i_ is in the range <emu-eqn>*+0*<sub>𝔽</sub> &le; _i_ &lt; 𝔽(2<sup>32</sup> - 1)</emu-eqn>.</p>
       <p>Property keys are used to access properties and their values. There are two kinds of access for properties: <em>get</em> and <em>set</em>, corresponding to value retrieval and assignment, respectively. The properties accessible via get and set access includes both <em>own properties</em> that are a direct part of an object and <em>inherited properties</em> which are provided by another associated object via a property inheritance relationship. Inherited properties may be either own or inherited properties of the associated object. Each own property of an object must each have a key value that is distinct from the key values of the other own properties of that object.</p>
       <p>All objects are logically collections of properties, but there are multiple forms of objects that differ in their semantics for accessing and manipulating their properties. Please see <emu-xref href="#sec-object-internal-methods-and-internal-slots"></emu-xref> for definitions of the multiple forms of objects.</p>
 
@@ -5756,7 +5756,7 @@
         1. If SameValue(! ToString(_n_), _argument_) is *false*, return *undefined*.
         1. Return _n_.
       </emu-alg>
-      <p>A <em>canonical numeric string</em> is any String value for which the CanonicalNumericIndexString abstract operation does not return *undefined*.</p>
+      <p>A <dfn variants="canonical numeric strings">canonical numeric string</dfn> is any String value for which the CanonicalNumericIndexString abstract operation does not return *undefined*.</p>
     </emu-clause>
 
     <emu-clause id="sec-toindex" type="abstract operation">

--- a/spec.html
+++ b/spec.html
@@ -5753,8 +5753,8 @@
       <emu-alg>
         1. If _argument_ is *"-0"*, return *-0*<sub>𝔽</sub>.
         1. Let _n_ be ! ToNumber(_argument_).
-        1. If SameValue(! ToString(_n_), _argument_) is *false*, return *undefined*.
-        1. Return _n_.
+        1. If SameValue(! ToString(_n_), _argument_) is *true*, return _n_.
+        1. Return *undefined*.
       </emu-alg>
       <p>A <dfn variants="canonical numeric strings">canonical numeric string</dfn> is any String value for which the CanonicalNumericIndexString abstract operation does not return *undefined*.</p>
     </emu-clause>


### PR DESCRIPTION
* Use a "return number [if canonical], otherwise return `undefined`" step sequence in correspondence with the description.
* Make "canonical numeric string" a linkable \<dfn> term.