### PR TITLE
Editorial: MakeMatchIndicesIndexPairArray: avoid creating a property on undefined

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -36322,6 +36322,7 @@ THH:mm:ss.sss
                 1. Let _matchIndexPair_ be *undefined*.
               1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_i_)), _matchIndexPair_).
               1. If _i_ &gt; 0 and _groupNames_[_i_ - 1] is not *undefined*, then
+                1. Assert: _groups_ is not *undefined*.
                 1. Perform ! CreateDataPropertyOrThrow(_groups_, _groupNames_[_i_ - 1], _matchIndexPair_).
             1. Return _A_.
           </emu-alg>


### PR DESCRIPTION
This is currently a _potential_ spec bug, not an actual one. This AO is not called such that this would be an error, but there are no assertions to prevent it from being one.