### PR TITLE
Editorial: `ToZeroPaddedDecimalString`: this AO is nonsensical on a negative integer

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -33871,7 +33871,7 @@ THH:mm:ss.sss
         <emu-clause id="sec-tozeropaddeddecimalstring" type="abstract operation">
           <h1>
             ToZeroPaddedDecimalString (
-              _n_: an integer,
+              _n_: a non-negative integer,
               _minLength_: a non-negative integer,
             ): a String
           </h1>


### PR DESCRIPTION
`ToZeroPaddedDecimalString(-1, 3)` would produce `0-1`, for example, prior to this change.