### PR TITLE
Meta: bump ecmarkup to 12.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://tc39.es/ecma262/#sec-copyright-and-software-license",
       "dependencies": {
-        "ecmarkup": "^11.0.1"
+        "ecmarkup": "^12.0.1"
       },
       "devDependencies": {
         "glob": "^7.1.6",
@@ -720,9 +720,9 @@
       }
     },
     "node_modules/ecmarkup": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-11.0.1.tgz",
-      "integrity": "sha512-1cuSL0T0jTnW9FJetThqeuqzCCQ9ExKmy2vFhFbh22xJbuKADLL3+EUmFxtI25JTwnzqdY4MMUDriO3e13DEjg==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-12.0.1.tgz",
+      "integrity": "sha512-ER84eweK0LSlHpvtONUrQki0Wswq9OaXeTkv5HmfxmEueGRXhzCjUggkuWN93I0qFk8pqSNPN5R3GHczh1Ckmw==",
       "dependencies": {
         "chalk": "^4.1.2",
         "command-line-args": "^5.2.0",
@@ -2935,9 +2935,9 @@
       }
     },
     "ecmarkup": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-11.0.1.tgz",
-      "integrity": "sha512-1cuSL0T0jTnW9FJetThqeuqzCCQ9ExKmy2vFhFbh22xJbuKADLL3+EUmFxtI25JTwnzqdY4MMUDriO3e13DEjg==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-12.0.1.tgz",
+      "integrity": "sha512-ER84eweK0LSlHpvtONUrQki0Wswq9OaXeTkv5HmfxmEueGRXhzCjUggkuWN93I0qFk8pqSNPN5R3GHczh1Ckmw==",
       "requires": {
         "chalk": "^4.1.2",
         "command-line-args": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "license": "SEE LICENSE IN https://tc39.es/ecma262/#sec-copyright-and-software-license",
   "homepage": "https://tc39.es/ecma262/",
   "dependencies": {
-    "ecmarkup": "^11.0.1"
+    "ecmarkup": "^12.0.1"
   },
   "devDependencies": {
     "glob": "^7.1.6",

--- a/scripts/publish-biblio.sh
+++ b/scripts/publish-biblio.sh
@@ -10,7 +10,7 @@ cp LICENSE.md biblio/
 cd biblio
 
 COMMIT_COUNT=$(git rev-list --count HEAD)
-npm version --no-git-tag-version "1.0.${COMMIT_COUNT}"
+npm version --no-git-tag-version "2.0.${COMMIT_COUNT}"
 
 SHORT_COMMIT=$(git rev-parse --short HEAD)
 LONG_COMMIT=$(git rev-parse --verify HEAD)

--- a/spec.html
+++ b/spec.html
@@ -56,6 +56,7 @@
   shortname: ECMA-262
   status: draft
   location: https://tc39.es/ecma262/
+  markEffects: true
 </pre>
 <p><img src="img/ecma-logo.svg" id="ecma-logo"></p>
 <div id="metadata-block">


### PR DESCRIPTION
This includes [a breaking change to the biblio format](https://github.com/tc39/ecmarkup/pull/425), so it also bumps the version number of the published biblio file.

Also, effects are now put into the biblio. Since the rendering of effects in proposals would be wrong unless they do extra work to manually mark any effects, they are not rendered by default, and `markEffects: true` must be added to enable them here.

~Edit: ugh, this has a bug apparently, don't land until it's bumped.~ Fixed in 12.0.1.