### PR TITLE
Normative: remove Symbol.species from InitializeTypedArrayFromTypedArray

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -39079,8 +39079,7 @@ THH:mm:ss.sss
             1. Else, let _same_ be SameValue(_srcBuffer_, _targetBuffer_).
             1. If _same_ is *true*, then
               1. Let _srcByteLength_ be _source_.[[ByteLength]].
-              1. Set _srcBuffer_ to ? <emu-meta suppress-effects="user-code">CloneArrayBuffer(_srcBuffer_, _srcByteOffset_, _srcByteLength_, %ArrayBuffer%)</emu-meta>.
-              1. NOTE: %ArrayBuffer% is used to clone _srcBuffer_ because is it known to not have any observable side-effects.
+              1. Set _srcBuffer_ to ? CloneArrayBuffer(_srcBuffer_, _srcByteOffset_, _srcByteLength_).
               1. Let _srcByteIndex_ be 0.
             1. Else, let _srcByteIndex_ be _srcByteOffset_.
             1. Let _targetByteIndex_ be _targetOffset_ &times; _targetElementSize_ + _targetByteOffset_.
@@ -39494,15 +39493,10 @@ THH:mm:ss.sss
             1. Let _srcByteOffset_ be _srcArray_.[[ByteOffset]].
             1. Let _elementLength_ be _srcArray_.[[ArrayLength]].
             1. Let _byteLength_ be _elementSize_ &times; _elementLength_.
-            1. If IsSharedArrayBuffer(_srcData_) is *false*, then
-              1. Let _bufferConstructor_ be ? SpeciesConstructor(_srcData_, %ArrayBuffer%).
-            1. Else,
-              1. Let _bufferConstructor_ be %ArrayBuffer%.
             1. If _elementType_ is the same as _srcType_, then
-              1. Let _data_ be ? CloneArrayBuffer(_srcData_, _srcByteOffset_, _byteLength_, _bufferConstructor_).
+              1. Let _data_ be ? CloneArrayBuffer(_srcData_, _srcByteOffset_, _byteLength_).
             1. Else,
-              1. Let _data_ be ? AllocateArrayBuffer(_bufferConstructor_, _byteLength_).
-              1. If IsDetachedBuffer(_srcData_) is *true*, throw a *TypeError* exception.
+              1. Let _data_ be ? <emu-meta suppress-effects="user-code">AllocateArrayBuffer(%ArrayBuffer%, _byteLength_)</emu-meta>.
               1. If _srcArray_.[[ContentType]] &ne; _O_.[[ContentType]], throw a *TypeError* exception.
               1. Let _srcByteIndex_ be _srcByteOffset_.
               1. Let _targetByteIndex_ be 0.
@@ -40670,7 +40664,6 @@ THH:mm:ss.sss
             _srcBuffer_: an ArrayBuffer or a SharedArrayBuffer,
             _srcByteOffset_: a non-negative integer,
             _srcLength_: a non-negative integer,
-            _cloneConstructor_: a constructor,
           ): either a normal completion containing an ArrayBuffer or an abrupt completion
         </h1>
         <dl class="header">
@@ -40678,8 +40671,8 @@ THH:mm:ss.sss
           <dd>It creates a new ArrayBuffer whose data is a copy of _srcBuffer_'s data over the range starting at _srcByteOffset_ and continuing for _srcLength_ bytes.</dd>
         </dl>
         <emu-alg>
-          1. Let _targetBuffer_ be ? AllocateArrayBuffer(_cloneConstructor_, _srcLength_).
-          1. If IsDetachedBuffer(_srcBuffer_) is *true*, throw a *TypeError* exception.
+          1. Assert: IsDetachedBuffer(_srcBuffer_) is *false*.
+          1. Let _targetBuffer_ be ? <emu-meta suppress-effects="user-code">AllocateArrayBuffer(%ArrayBuffer%, _srcLength_)</emu-meta>.
           1. Let _srcBlock_ be _srcBuffer_.[[ArrayBufferData]].
           1. Let _targetBlock_ be _targetBuffer_.[[ArrayBufferData]].
           1. Perform CopyDataBlockBytes(_targetBlock_, 0, _srcBlock_, _srcByteOffset_, _srcLength_).


### PR DESCRIPTION
Closes #2677
