### PR TITLE
Normative: allow duplicate named capture groups

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -35986,7 +35986,7 @@ THH:mm:ss.sss
             It is a Syntax Error if CountLeftCapturingParensWithin(|Pattern|) ≥ 2<sup>32</sup> - 1.
           </li>
           <li>
-            It is a Syntax Error if |Pattern| contains two or more |GroupSpecifier|s for which the CapturingGroupName of |GroupSpecifier| is the same.
+            It is a Syntax Error if |Pattern| contains two distinct |GroupSpecifier|s _x_ and _y_ such that the CapturingGroupName of _x_ is the CapturingGroupName of _y_ and such that MightBothParticipate(_x_, _y_) is *true*.
           </li>
         </ul>
         <emu-grammar>QuantifierPrefix :: `{` DecimalDigits `,` DecimalDigits `}`</emu-grammar>
@@ -36129,6 +36129,22 @@ THH:mm:ss.sss
           1. Assert: _node_ is an instance of a production in <emu-xref href="#sec-patterns">the RegExp Pattern grammar</emu-xref>.
           1. Let _pattern_ be the |Pattern| containing _node_.
           1. Return the number of <emu-grammar>Atom :: `(` GroupSpecifier? Disjunction `)`</emu-grammar> Parse Nodes contained within _pattern_ that either occur before _node_ or contain _node_.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-mightbothparticipate" type="abstract operation">
+        <h1>
+          Static Semantics: MightBothParticipate (
+            _x_: a Parse Node,
+            _y_: a Parse Node,
+          ): a Boolean
+        </h1>
+        <dl class="header">
+        </dl>
+        <emu-alg>
+          1. Assert: _x_ and _y_ have the same enclosing |Pattern|.
+          1. If the enclosing |Pattern| contains a <emu-grammar>Disjunction :: Alternative `|` Disjunction</emu-grammar> Parse Node such that either _x_ is contained within the |Alternative| and _y_ is contained within the derived |Disjunction|, or _x_ is contained within the derived |Disjunction| and _y_ is contained within the |Alternative|, return *false*.
+          1. Return *true*.
         </emu-alg>
       </emu-clause>
 
@@ -37189,7 +37205,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _n_ be the CapturingGroupNumber of |DecimalEscape|.
           1. Assert: _n_ ≤ _rer_.[[CapturingGroupsCount]].
-          1. Return BackreferenceMatcher(_rer_, _n_, _direction_).
+          1. Return BackreferenceMatcher(_rer_, « _n_ », _direction_).
         </emu-alg>
         <emu-note>
           <p>An escape sequence of the form `\\` followed by a non-zero decimal number _n_ matches the result of the _n_<sup>th</sup> set of capturing parentheses (<emu-xref href="#sec-pattern-notation"></emu-xref>). It is an error if the regular expression has fewer than _n_ capturing parentheses. If the regular expression has _n_ or more capturing parentheses but the _n_<sup>th</sup> one is *undefined* because it has not captured anything, then the backreference always succeeds.</p>
@@ -37225,10 +37241,11 @@ THH:mm:ss.sss
         <emu-grammar>AtomEscape :: `k` GroupName</emu-grammar>
         <emu-alg>
           1. Let _matchingGroupSpecifiers_ be GroupSpecifiersThatMatch(|GroupName|).
-          1. Assert: _matchingGroupSpecifiers_ contains a single |GroupSpecifier|.
-          1. Let _groupSpecifier_ be the sole element of _matchingGroupSpecifiers_.
-          1. Let _parenIndex_ be CountLeftCapturingParensBefore(_groupSpecifier_).
-          1. Return BackreferenceMatcher(_rer_, _parenIndex_, _direction_).
+          1. Let _parenIndices_ be a new empty List.
+          1. For each |GroupSpecifier| _groupSpecifier_ of _matchingGroupSpecifiers_, do
+            1. Let _parenIndex_ be CountLeftCapturingParensBefore(_groupSpecifier_).
+            1. Append _parenIndex_ to _parenIndices_.
+          1. Return BackreferenceMatcher(_rer_, _parenIndices_, _direction_).
         </emu-alg>
 
         <emu-clause id="sec-runtime-semantics-charactersetmatcher-abstract-operation" type="abstract operation">
@@ -37271,20 +37288,23 @@ THH:mm:ss.sss
           <h1>
             BackreferenceMatcher (
               _rer_: a RegExp Record,
-              _n_: a positive integer,
+              _ns_: a List of positive integers,
               _direction_: ~forward~ or ~backward~,
             ): a Matcher
           </h1>
           <dl class="header">
           </dl>
           <emu-alg>
-            1. Assert: _n_ ≥ 1.
-            1. Return a new Matcher with parameters (_x_, _c_) that captures _rer_, _n_, and _direction_ and performs the following steps when called:
+            1. Return a new Matcher with parameters (_x_, _c_) that captures _rer_, _ns_, and _direction_ and performs the following steps when called:
               1. Assert: _x_ is a MatchState.
               1. Assert: _c_ is a MatcherContinuation.
               1. Let _Input_ be _x_.[[Input]].
               1. Let _cap_ be _x_.[[Captures]].
-              1. Let _r_ be _cap_[_n_].
+              1. Let _r_ be *undefined*.
+              1. For each integer _n_ of _ns_, do
+                1. If _cap_[_n_] is not *undefined*, then
+                  1. Assert: _r_ is *undefined*.
+                  1. Set _r_ to _cap_[_n_].
               1. If _r_ is *undefined*, return _c_(_x_).
               1. Let _e_ be _x_.[[EndIndex]].
               1. Let _rs_ be _r_.[[StartIndex]].
@@ -38523,6 +38543,7 @@ THH:mm:ss.sss
             1. Let _groups_ be *undefined*.
             1. Let _hasGroups_ be *false*.
           1. Perform ! CreateDataPropertyOrThrow(_A_, *"groups"*, _groups_).
+          1. Let _matchedGroupNames_ be a new empty List.
           1. For each integer _i_ such that 1 ≤ _i_ ≤ _n_, in ascending order, do
             1. Let _captureI_ be _i_<sup>th</sup> element of _r_.[[Captures]].
             1. If _captureI_ is *undefined*, then
@@ -38540,8 +38561,14 @@ THH:mm:ss.sss
             1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_i_)), _capturedValue_).
             1. If the _i_<sup>th</sup> capture of _R_ was defined with a |GroupName|, then
               1. Let _s_ be the CapturingGroupName of that |GroupName|.
-              1. Perform ! CreateDataPropertyOrThrow(_groups_, _s_, _capturedValue_).
-              1. Append _s_ to _groupNames_.
+              1. If _matchedGroupNames_ contains _s_, then
+                1. Assert: _capturedValue_ is *undefined*.
+                1. Append *undefined* to _groupNames_.
+              1. Else,
+                1. If _capturedValue_ is not *undefined*, append _s_ to _matchedGroupNames_.
+                1. NOTE: If there are multiple groups named _s_, _groups_ may already have an _s_ property at this point. However, because _groups_ is an ordinary object whose properties are all writable data properties, the call to CreateDataPropertyOrThrow is nevertheless guaranteed to succeed.
+                1. Perform ! CreateDataPropertyOrThrow(_groups_, _s_, _capturedValue_).
+                1. Append _s_ to _groupNames_.
             1. Else,
               1. Append *undefined* to _groupNames_.
           1. If _hasIndices_ is *true*, then
@@ -38684,7 +38711,9 @@ THH:mm:ss.sss
             1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_i_)), _matchIndexPair_).
             1. If _i_ > 0 and _groupNames_[_i_ - 1] is not *undefined*, then
               1. Assert: _groups_ is not *undefined*.
-              1. Perform ! CreateDataPropertyOrThrow(_groups_, _groupNames_[_i_ - 1], _matchIndexPair_).
+              1. Let _s_ be _groupNames_[_i_ - 1].
+              1. NOTE: If there are multiple groups named _s_, _groups_ may already have an _s_ property at this point. However, because _groups_ is an ordinary object whose properties are all writable data properties, the call to CreateDataPropertyOrThrow is nevertheless guaranteed to succeed.
+              1. Perform ! CreateDataPropertyOrThrow(_groups_, _s_, _matchIndexPair_).
           1. Return _A_.
         </emu-alg>
       </emu-clause>


### PR DESCRIPTION
This allows you to have a regex like

```js
/(?<year>[0-9]{4})-[0-9]{2}|[0-9]{2}-(?<year>[0-9]{4})/
```
where a capturing group name is re-used across alternatives. It continues to be illegal to re-use a name within the same alternative.

~~As currently specified, it also enforces that named backreferences correspond to capturing groups in the same alternative, which would make the following (currently legal) program illegal:~~

```js
/(?<a>x)|\k<a>/
```

~~There is no reason to write this because the `\k` can never refer to anything, meaning it will always match the empty string. For this reason I think it should have been illegal in the first place. But if we want to preserve that behavior, it's easy enough to specify.~~

EDIT: updated so that the above remains legal, per plenary.

(I have a [proposal repo](https://github.com/bakkot/proposal-duplicate-named-capturing-groups) for this, but figured it might as well be a PR.)
