### PR TITLE
Editorial: Fix wording bug by tweaking CapturingGroupName

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -34652,7 +34652,7 @@ THH:mm:ss.sss
         <emu-grammar>AtomEscape :: `k` GroupName</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the enclosing |Pattern| does not contain a |GroupSpecifier| with an enclosed |GroupName| whose CapturingGroupName equals the CapturingGroupName of this production's |GroupName|.
+            It is a Syntax Error if GroupSpecifiersThatMatch(|GroupName|) is empty.
           </li>
         </ul>
         <emu-grammar>AtomEscape :: DecimalEscape</emu-grammar>
@@ -35008,6 +35008,25 @@ THH:mm:ss.sss
         </emu-grammar>
         <emu-alg>
           1. Return the List, in source text order, of Unicode code points in the source text matched by this production.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-groupspecifiersthatmatch" type="abstract operation">
+        <h1>
+          Static Semantics: GroupSpecifiersThatMatch (
+            _thisGroupName_: a |GroupName| Parse Node,
+          ): a List of |GroupSpecifier| Parse Nodes
+        </h1>
+        <dl class="header">
+        </dl>
+        <emu-alg>
+          1. Let _name_ be the CapturingGroupName of _thisGroupName_.
+          1. Let _pattern_ be the |Pattern| containing _thisGroupName_.
+          1. Let _result_ be a new empty List.
+          1. For each |GroupSpecifier| _gs_ that _pattern_ contains, do
+            1. If _gs_ is an instance of the production <emu-grammar>GroupSpecifier :: `?` GroupName</emu-grammar> and the CapturingGroupName of that |GroupName| is the same value as _name_, then
+              1. Append _gs_ to _result_.
+          1. Return _result_.
         </emu-alg>
       </emu-clause>
 
@@ -35599,9 +35618,10 @@ THH:mm:ss.sss
         </emu-alg>
         <emu-grammar>AtomEscape :: `k` GroupName</emu-grammar>
         <emu-alg>
-          1. Search the enclosing |Pattern| for an instance of a |GroupSpecifier| containing a |GroupName| which has a CapturingGroupName equal to the CapturingGroupName of |GroupName|.
-          1. Assert: A unique such |GroupSpecifier| is found.
-          1. Let _parenIndex_ be CountLeftCapturingParensBefore(the located |GroupSpecifier|).
+          1. Let _matchingGroupSpecifiers_ be GroupSpecifiersThatMatch(|GroupName|).
+          1. Assert: _matchingGroupSpecifiers_ contains a single |GroupSpecifier|.
+          1. Let _groupSpecifier_ be the sole element of _matchingGroupSpecifiers_.
+          1. Let _parenIndex_ be CountLeftCapturingParensBefore(_groupSpecifier_).
           1. Return BackreferenceMatcher(_parenIndex_, _direction_).
         </emu-alg>
 

--- a/spec.html
+++ b/spec.html
@@ -34470,7 +34470,7 @@ THH:mm:ss.sss
           `.`
           `\` AtomEscape[?UnicodeMode, ?N]
           CharacterClass[?UnicodeMode]
-          `(` GroupSpecifier[?UnicodeMode] Disjunction[?UnicodeMode, ?N] `)`
+          `(` GroupSpecifier[?UnicodeMode]? Disjunction[?UnicodeMode, ?N] `)`
           `(` `?` `:` Disjunction[?UnicodeMode, ?N] `)`
 
         SyntaxCharacter :: one of
@@ -34502,7 +34502,6 @@ THH:mm:ss.sss
           `A` `B` `C` `D` `E` `F` `G` `H` `I` `J` `K` `L` `M` `N` `O` `P` `Q` `R` `S` `T` `U` `V` `W` `X` `Y` `Z`
 
         GroupSpecifier[UnicodeMode] ::
-          [empty]
           `?` GroupName[?UnicodeMode]
 
         GroupName[UnicodeMode] ::
@@ -34640,7 +34639,7 @@ THH:mm:ss.sss
             It is a Syntax Error if CountLeftCapturingParensWithin(|Pattern|) &ge; 2<sup>32</sup> - 1.
           </li>
           <li>
-            It is a Syntax Error if |Pattern| contains multiple |GroupSpecifier|s whose |GroupName|s have the same CapturingGroupName.
+            It is a Syntax Error if |Pattern| contains two or more |GroupSpecifier|s for which CapturingGroupName of |GroupSpecifier| is the same.
           </li>
         </ul>
         <emu-grammar>QuantifierPrefix :: `{` DecimalDigits `,` DecimalDigits `}`</emu-grammar>
@@ -34728,14 +34727,14 @@ THH:mm:ss.sss
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It returns the number of left-capturing parentheses in _node_. A <dfn variants="left-capturing parentheses">left-capturing parenthesis</dfn> is any `(` pattern character that is matched by the `(` terminal of the <emu-grammar>Atom :: `(` GroupSpecifier Disjunction `)`</emu-grammar> production.</dd>
+          <dd>It returns the number of left-capturing parentheses in _node_. A <dfn variants="left-capturing parentheses">left-capturing parenthesis</dfn> is any `(` pattern character that is matched by the `(` terminal of the <emu-grammar>Atom :: `(` GroupSpecifier? Disjunction `)`</emu-grammar> production.</dd>
         </dl>
         <emu-note>
           <p>This section is amended in <emu-xref href="#sec-countleftcapturingparens-annexb"></emu-xref>.</p>
         </emu-note>
         <emu-alg>
           1. Assert: _node_ is an instance of a production in <emu-xref href="#sec-patterns">the RegExp Pattern grammar</emu-xref>.
-          1. Return the number of <emu-grammar>Atom :: `(` GroupSpecifier Disjunction `)`</emu-grammar> Parse Nodes contained within _node_.
+          1. Return the number of <emu-grammar>Atom :: `(` GroupSpecifier? Disjunction `)`</emu-grammar> Parse Nodes contained within _node_.
         </emu-alg>
       </emu-clause>
 
@@ -34755,7 +34754,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Assert: _node_ is an instance of a production in <emu-xref href="#sec-patterns">the RegExp Pattern grammar</emu-xref>.
           1. Let _pattern_ be the |Pattern| containing _node_.
-          1. Return the number of <emu-grammar>Atom :: `(` GroupSpecifier Disjunction `)`</emu-grammar> Parse Nodes contained within _pattern_ that either occur before _node_ or contain _node_.
+          1. Return the number of <emu-grammar>Atom :: `(` GroupSpecifier? Disjunction `)`</emu-grammar> Parse Nodes contained within _pattern_ that either occur before _node_ or contain _node_.
         </emu-alg>
       </emu-clause>
 
@@ -35024,7 +35023,7 @@ THH:mm:ss.sss
           1. Let _pattern_ be the |Pattern| containing _thisGroupName_.
           1. Let _result_ be a new empty List.
           1. For each |GroupSpecifier| _gs_ that _pattern_ contains, do
-            1. If _gs_ is an instance of the production <emu-grammar>GroupSpecifier :: `?` GroupName</emu-grammar> and the CapturingGroupName of that |GroupName| is the same value as _name_, then
+            1. If the CapturingGroupName of _gs_ is the same value as _name_, then
               1. Append _gs_ to _result_.
           1. Return _result_.
         </emu-alg>
@@ -35565,7 +35564,7 @@ THH:mm:ss.sss
           1. Let _cc_ be CompileCharacterClass of |CharacterClass|.
           1. Return CharacterSetMatcher(_cc_.[[CharSet]], _cc_.[[Invert]], _direction_).
         </emu-alg>
-        <emu-grammar>Atom :: `(` GroupSpecifier Disjunction `)`</emu-grammar>
+        <emu-grammar>Atom :: `(` GroupSpecifier? Disjunction `)`</emu-grammar>
         <emu-alg>
           1. Let _m_ be CompileSubpattern of |Disjunction| with argument _direction_.
           1. Let _parenIndex_ be CountLeftCapturingParensBefore(|Atom|).
@@ -46989,7 +46988,7 @@ THH:mm:ss.sss
           `\` AtomEscape[~UnicodeMode, ?N]
           `\` [lookahead == `c`]
           CharacterClass[~UnicodeMode]
-          `(` GroupSpecifier[~UnicodeMode] Disjunction[~UnicodeMode, ?N] `)`
+          `(` GroupSpecifier[~UnicodeMode]? Disjunction[~UnicodeMode, ?N] `)`
           `(` `?` `:` Disjunction[~UnicodeMode, ?N] `)`
           InvalidBracedQuantifier
           ExtendedPatternCharacter
@@ -47079,7 +47078,7 @@ THH:mm:ss.sss
 
       <emu-annex id="sec-countleftcapturingparens-annexb">
         <h1>Static Semantics: CountLeftCapturingParensWithin and CountLeftCapturingParensBefore</h1>
-        <p>In the definitions of CountLeftCapturingParensWithin and CountLeftCapturingParensBefore, references to &ldquo;<emu-grammar>Atom :: `(` GroupSpecifier Disjunction `)`</emu-grammar> &rdquo; are to be interpreted as meaning &ldquo;<emu-grammar>Atom :: `(` GroupSpecifier Disjunction `)`</emu-grammar> &rdquo; or &ldquo;<emu-grammar>ExtendedAtom :: `(` GroupSpecifier Disjunction `)`</emu-grammar> &rdquo;.</p>
+        <p>In the definitions of CountLeftCapturingParensWithin and CountLeftCapturingParensBefore, references to &ldquo;<emu-grammar>Atom :: `(` GroupSpecifier? Disjunction `)`</emu-grammar> &rdquo; are to be interpreted as meaning &ldquo;<emu-grammar>Atom :: `(` GroupSpecifier? Disjunction `)`</emu-grammar> &rdquo; or &ldquo;<emu-grammar>ExtendedAtom :: `(` GroupSpecifier? Disjunction `)`</emu-grammar> &rdquo;.</p>
       </emu-annex>
 
       <emu-annex id="sec-patterns-static-semantics-is-character-class-annexb">

--- a/spec.html
+++ b/spec.html
@@ -34640,7 +34640,7 @@ THH:mm:ss.sss
             It is a Syntax Error if CountLeftCapturingParensWithin(|Pattern|) &ge; 2<sup>32</sup> - 1.
           </li>
           <li>
-            It is a Syntax Error if |Pattern| contains multiple |GroupSpecifier|s whose enclosed |RegExpIdentifierName|s have the same CapturingGroupName.
+            It is a Syntax Error if |Pattern| contains multiple |GroupSpecifier|s whose |GroupName|s have the same CapturingGroupName.
           </li>
         </ul>
         <emu-grammar>QuantifierPrefix :: `{` DecimalDigits `,` DecimalDigits `}`</emu-grammar>
@@ -34652,7 +34652,7 @@ THH:mm:ss.sss
         <emu-grammar>AtomEscape :: `k` GroupName</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the enclosing |Pattern| does not contain a |GroupSpecifier| with an enclosed |RegExpIdentifierName| whose CapturingGroupName equals the CapturingGroupName of the |RegExpIdentifierName| of this production's |GroupName|.
+            It is a Syntax Error if the enclosing |Pattern| does not contain a |GroupSpecifier| with an enclosed |GroupName| whose CapturingGroupName equals the CapturingGroupName of this production's |GroupName|.
           </li>
         </ul>
         <emu-grammar>AtomEscape :: DecimalEscape</emu-grammar>
@@ -35016,9 +35016,7 @@ THH:mm:ss.sss
         <dl class="header">
         </dl>
         <emu-grammar>
-          RegExpIdentifierName ::
-            RegExpIdentifierStart
-            RegExpIdentifierName RegExpIdentifierPart
+          GroupName :: `&lt;` RegExpIdentifierName `&gt;`
         </emu-grammar>
         <emu-alg>
           1. Let _idTextUnescaped_ be RegExpIdentifierCodePoints of |RegExpIdentifierName|.
@@ -35601,7 +35599,7 @@ THH:mm:ss.sss
         </emu-alg>
         <emu-grammar>AtomEscape :: `k` GroupName</emu-grammar>
         <emu-alg>
-          1. Search the enclosing |Pattern| for an instance of a |GroupSpecifier| containing a |RegExpIdentifierName| which has a CapturingGroupName equal to the CapturingGroupName of the |RegExpIdentifierName| contained in |GroupName|.
+          1. Search the enclosing |Pattern| for an instance of a |GroupSpecifier| containing a |GroupName| which has a CapturingGroupName equal to the CapturingGroupName of |GroupName|.
           1. Assert: A unique such |GroupSpecifier| is found.
           1. Let _parenIndex_ be CountLeftCapturingParensBefore(the located |GroupSpecifier|).
           1. Return BackreferenceMatcher(_parenIndex_, _direction_).
@@ -36244,7 +36242,7 @@ THH:mm:ss.sss
                 1. Append _capture_ to _indices_.
               1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_i_)), _capturedValue_).
               1. If the _i_<sup>th</sup> capture of _R_ was defined with a |GroupName|, then
-                1. Let _s_ be the CapturingGroupName of the corresponding |RegExpIdentifierName|.
+                1. Let _s_ be the CapturingGroupName of that |GroupName|.
                 1. Perform ! CreateDataPropertyOrThrow(_groups_, _s_, _capturedValue_).
                 1. Append _s_ to _groupNames_.
               1. Else,


### PR DESCRIPTION
While reviewing #2721, I noticed a wording bug in the current spec:

Because the nonterminal _RegExpIdentifierName_ is defined recursively, a _GroupSpecifier_ usually contains/encloses **multiple** _RegExpIdentifierNames_.

So in a phrasing such as:
`a |GroupSpecifier| containing a |RegExpIdentifierName| which has ...`
the spec only intends the 'topmost' _RegExpIdentifierName_, but any of the 'deeper' _RegExpIdentifierNames_ could satisfy the phrase.

E.g., consider `/(?<NotTheOne>foo)\k<TheOne>/`. This *should* be a syntax error, because the _AtomEscape_ `\k<TheOne>` doesn't have a matching _GroupSpecifier_. But the _GroupSpecifier_ `?<NotTheOne>` *does* contain/enclose a _RegExpIdentifierName_ `TheOne` that matches the _GroupName_ of the _AtomEscape_, and so there isn't a syntax error.

There are 3 spots in the spec that are subject to this bug. This PR fixes them.

---

It's possible to select the 'topmost' _RegExpIdentifierName_ just by tweaking the wording at the problem spots. However, this would lengthen some already-lengthy sentences (because you have to involve the _GroupName_ parent of the _RegExpIdentifierName_).

But I noticed that the only reason we're accessing the _RegExpIdentifierName_ is to invoke `CapturingGroupName` on it. So if we change `CapturingGroupName` to instead operate on the _GroupName_, then accessing its _RegExpIdentifierName_ child (and not any deeper _RegExpIdentifierName_) becomes the easiest thing to do, and everything (including the definition of `CapturingGroupName` itself) gets slightly simpler.

That's the first commit.

(There are no references to `CapturingGroupName` in downstream specs.)

---

The second commit is a bonus. It factors out the idea of finding the _GroupSpecifier_(s) that match a given _GroupName_, and presents it as the abstract operation `GroupSpecifiersThatMatch`. (This should make the changes of #2721 a bit easier too.)
