### PR TITLE
Normative: Remove detach check in TypedArray.prototype.sort comparator

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -39228,7 +39228,6 @@ THH:mm:ss.sss
             1. Assert: Both Type(_x_) and Type(_y_) are Number or both are BigInt.
             1. If _comparefn_ is not *undefined*, then
               1. Let _v_ be ? ToNumber(? Call(_comparefn_, *undefined*, &laquo; _x_, _y_ &raquo;)).
-              1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
               1. If _v_ is *NaN*, return *+0*<sub>𝔽</sub>.
               1. Return _v_.
             1. If _x_ and _y_ are both *NaN*, return *+0*<sub>𝔽</sub>.


### PR DESCRIPTION
Consensus for this was gotten as part of #2646.