### PR TITLE
Editoral: Simplify Proxy.revocable revoke function

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -45737,16 +45737,14 @@ THH:mm:ss.sss
         <p>The `Proxy.revocable` function is used to create a revocable Proxy object. When `Proxy.revocable` is called with arguments _target_ and _handler_, the following steps are taken:</p>
         <emu-alg>
           1. Let _p_ be ? ProxyCreate(_target_, _handler_).
-          1. Let _revokerClosure_ be a new Abstract Closure with no parameters that captures nothing and performs the following steps when called:
-            1. Let _F_ be the active function object.
-            1. Let _p_ be _F_.[[RevocableProxy]].
+          1. Let _revokerClosure_ be a new Abstract Closure with no parameters that captures _p_ and performs the following steps when called:
             1. If _p_ is *null*, return *undefined*.
-            1. Set _F_.[[RevocableProxy]] to *null*.
             1. Assert: _p_ is a Proxy object.
             1. Set _p_.[[ProxyTarget]] to *null*.
             1. Set _p_.[[ProxyHandler]] to *null*.
+            1. Let _p_ be *null.
             1. Return *undefined*.
-          1. Let _revoker_ be CreateBuiltinFunction(_revokerClosure_, 0, *""*, &laquo; [[RevocableProxy]] &raquo;).
+          1. Let _revoker_ be CreateBuiltinFunction(_revokerClosure_, 0, *""*).
           1. Set _revoker_.[[RevocableProxy]] to _p_.
           1. Let _result_ be OrdinaryObjectCreate(%Object.prototype%).
           1. Perform ! CreateDataPropertyOrThrow(_result_, *"proxy"*, _p_).


### PR DESCRIPTION
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->

Removes `[[RevocableProxy]]` internal slot, use Abstract Operation captures the proxy needed.
