### PR TITLE
Editorial: Note that StringNumericLiteral cannot contain NumericLiteralSeparator

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -5058,6 +5058,9 @@
             <li>
               A |StringNumericLiteral| cannot include a |BigIntLiteralSuffix|.
             </li>
+            <li>
+              A |StringNumericLiteral| cannot include a |NumericLiteralSeparator|.
+            </li>
           </ul>
         </emu-note>
 


### PR DESCRIPTION
See: https://github.com/tc39/proposal-numeric-separator/issues/32