### PR TITLE
Editorial: Fix "classFieldIntializerName" spelling error in PerformEval

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -28664,8 +28664,8 @@
               1. Set _inFunction_ to *true*.
               1. Set _inMethod_ to _thisEnvRec_.HasSuperBinding().
               1. If _F_.[[ConstructorKind]] is ~derived~, set _inDerivedConstructor_ to *true*.
-              1. Let _classFieldIntializerName_ be _F_.[[ClassFieldInitializerName]].
-              1. If _classFieldIntializerName_ is not ~empty~, set _inClassFieldInitializer_ to *true*.
+              1. Let _classFieldInitializerName_ be _F_.[[ClassFieldInitializerName]].
+              1. If _classFieldInitializerName_ is not ~empty~, set _inClassFieldInitializer_ to *true*.
           1. Perform the following substeps in an implementation-defined order, possibly interleaving parsing and error detection:
             1. Let _script_ be ParseText(StringToCodePoints(_x_), |Script|).
             1. If _script_ is a List of errors, throw a *SyntaxError* exception.


### PR DESCRIPTION
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
