### PR TITLE
Normative: allow named capture groups in Annex B non-u regex grammar

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -46979,7 +46979,7 @@ THH:mm:ss.sss
           `\` AtomEscape[~UnicodeMode, ?N]
           `\` [lookahead == `c`]
           CharacterClass[~UnicodeMode]
-          `(` Disjunction[~UnicodeMode, ?N] `)`
+          `(` GroupSpecifier[~UnicodeMode] Disjunction[~UnicodeMode, ?N] `)`
           `(` `?` `:` Disjunction[~UnicodeMode, ?N] `)`
           InvalidBracedQuantifier
           ExtendedPatternCharacter
@@ -47069,7 +47069,7 @@ THH:mm:ss.sss
 
       <emu-annex id="sec-countleftcapturingparens-annexb">
         <h1>Static Semantics: CountLeftCapturingParensWithin and CountLeftCapturingParensBefore</h1>
-        <p>In the definitions of CountLeftCapturingParensWithin and CountLeftCapturingParensBefore, references to &ldquo;<emu-grammar>Atom :: `(` GroupSpecifier Disjunction `)`</emu-grammar> &rdquo; are to be interpreted as meaning &ldquo;<emu-grammar>Atom :: `(` GroupSpecifier Disjunction `)`</emu-grammar> &rdquo; or &ldquo;<emu-grammar>ExtendedAtom :: `(` Disjunction `)`</emu-grammar> &rdquo;.</p>
+        <p>In the definitions of CountLeftCapturingParensWithin and CountLeftCapturingParensBefore, references to &ldquo;<emu-grammar>Atom :: `(` GroupSpecifier Disjunction `)`</emu-grammar> &rdquo; are to be interpreted as meaning &ldquo;<emu-grammar>Atom :: `(` GroupSpecifier Disjunction `)`</emu-grammar> &rdquo; or &ldquo;<emu-grammar>ExtendedAtom :: `(` GroupSpecifier Disjunction `)`</emu-grammar> &rdquo;.</p>
       </emu-annex>
 
       <emu-annex id="sec-patterns-static-semantics-is-character-class-annexb">


### PR DESCRIPTION
Fixes https://github.com/tc39/ecma262/issues/1673.

Capturing group names were introduced in https://github.com/tc39/ecma262/issues/1673, in both `u` and non-`u` regexes, but the alternate grammar for regexes in Annex B (i.e., the actual grammar for regexes) replaces in non-`u` regexes the nonterminal (`Atom`) which derives `GroupSpecifier`, and that PR neglected to update the new nonterminal (`ExtendedAtom`). This PR corrects that oversight.

I've marked this as a normative change rather than editorial because the current spec is, technically, coherent. However, the current spec does not match committee intent or web reality, so in my view we can land this without asking for consensus.