### PR TITLE
Editorial: Improve consistency of mathematical conventions

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1010,7 +1010,7 @@
       </ul>
 
       <p>In the language of this specification, numerical values are distinguished among different numeric kinds using subscript suffixes. The subscript <sub>𝔽</sub> refers to Numbers, and the subscript <sub>ℤ</sub> refers to BigInts. Numeric values without a subscript suffix refer to mathematical values.</p>
-      <p>Numeric operators such as +, &times;, =, and &ge; refer to those operations as determined by the type of the operands. When applied to mathematical values, the operators refer to the usual mathematical operations. When applied to extended mathematical values, the operators refer to the usual mathematical operations over the extended real numbers; indeterminate forms are not defined and their use in this specification should be considered an editorial error. When applied to Numbers, the operators refer to the relevant operations within IEEE 754-2019. When applied to BigInts, the operators refer to the usual mathematical operations applied to the mathematical value of the BigInt.</p>
+      <p>Numeric operators such as +, -, &times;, =, and &ge; refer to those operations as determined by the type of the operands. When applied to mathematical values, the operators refer to the usual mathematical operations. When applied to extended mathematical values, the operators refer to the usual mathematical operations over the extended real numbers; indeterminate forms are not defined and their use in this specification should be considered an editorial error. When applied to Numbers, the operators refer to the relevant operations within IEEE 754-2019. When applied to BigInts, the operators refer to the usual mathematical operations applied to the mathematical value of the BigInt.</p>
       <p>In general, when this specification refers to a numerical value, such as in the phrase, "the length of _y_" or "the integer represented by the four hexadecimal digits ...", without explicitly specifying a numeric kind, the phrase refers to a mathematical value. Phrases which refer to a Number or a BigInt value are explicitly annotated as such; for example, "the Number value for the number of code points in &hellip;" or "the BigInt value for &hellip;".</p>
       <p>Numeric operators applied to mixed-type operands (such as a Number and a mathematical value) are not defined and should be considered an editorial error in this specification.</p>
       <p>This specification denotes most numeric values in base 10; it also uses numeric values of the form 0x followed by digits 0-9 or A-F as base-16 values.</p>
@@ -17401,7 +17401,7 @@
           `u` `{` CodePoint [lookahead &notin; HexDigit] [lookahead != `}`]
 
         NotCodePoint ::
-          HexDigits[~Sep] [> but only if MV of |HexDigits| > 0x10FFFF]
+          HexDigits[~Sep] [> but only if MV of |HexDigits| &gt; 0x10FFFF]
 
         CodePoint ::
           HexDigits[~Sep] [> but only if MV of |HexDigits| &le; 0x10FFFF]

--- a/spec.html
+++ b/spec.html
@@ -17401,7 +17401,7 @@
           `u` `{` CodePoint [lookahead &notin; HexDigit] [lookahead != `}`]
 
         NotCodePoint ::
-          HexDigits[~Sep] [> but only if MV of |HexDigits| &gt; 0x10FFFF]
+          HexDigits[~Sep] [> but only if MV of |HexDigits| > 0x10FFFF]
 
         CodePoint ::
           HexDigits[~Sep] [> but only if MV of |HexDigits| &le; 0x10FFFF]


### PR DESCRIPTION
* ~~Escape `>` as `&gt;`.~~
* Make clear that the symbol used for mathematical subtraction is `-` (U+002D HYPHEN-MINUS) rather than e.g. `–` (U+2013 EN DASH) or `−` (U+2212 MINUS SIGN).

Ref https://github.com/tc39/ecma402/pull/672