### PR TITLE
Refactor the "enforce format" job to output literal backticks rather than command output

### DIFF
--- a/.github/workflows/enforce-format.yml
+++ b/.github/workflows/enforce-format.yml
@@ -14,4 +14,4 @@ jobs:
         with:
           node-version: lts/*
           use-npm-ci: true
-      - run: 'if ! $(npm bin)/emu-format --check spec.html; then echo "You need to run `npm run format`"; exit 1; fi'
+      - run: 'if ! $(npm bin)/emu-format --check spec.html; then echo "You need to run \`npm run format\`"; exit 1; fi'


### PR DESCRIPTION
cf. https://github.com/tc39/ecma262/runs/5979841913?check_suite_focus=true
```
Run if ! $(npm bin)/emu-format --check spec.html; then echo "You need to run `npm run format`"; exit 1; fi
Need formatting:
spec.html
You need to run 
> ecma262@1.0.0 format
> emu-format --write spec.html
```