### PR TITLE
Editorial: Use "surrounding agent" in favor of "calling agent"

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -41689,7 +41689,7 @@ THH:mm:ss.sss
         <dl class="header">
         </dl>
         <emu-alg>
-          1. Assert: The calling agent is not in the critical section for any WaiterList.
+          1. Assert: The surrounding agent is not in the critical section for any WaiterList.
           1. Wait until no agent is in the critical section for _WL_, then enter the critical section for _WL_ (without allowing any other agent to enter).
           1. If _WL_ has a Synchronize event, then
             1. NOTE: A _WL_ whose critical section has been entered at least once has a Synchronize event set by LeaveCriticalSection.
@@ -41714,8 +41714,8 @@ THH:mm:ss.sss
         <dl class="header">
         </dl>
         <emu-alg>
-          1. Assert: The calling agent is in the critical section for _WL_.
-          1. Let _execution_ be the [[CandidateExecution]] field of the calling surrounding's Agent Record.
+          1. Assert: The surrounding agent is in the critical section for _WL_.
+          1. Let _execution_ be the [[CandidateExecution]] field of the surrounding agent's Agent Record.
           1. Let _eventsRecord_ be the Agent Events Record in _execution_.[[EventsRecords]] whose [[AgentSignifier]] is AgentSignifier().
           1. Let _leaverEventList_ be _eventsRecord_.[[EventList]].
           1. Let _leaveEvent_ be a new Synchronize event.
@@ -41736,7 +41736,7 @@ THH:mm:ss.sss
         <dl class="header">
         </dl>
         <emu-alg>
-          1. Assert: The calling agent is in the critical section for _WL_.
+          1. Assert: The surrounding agent is in the critical section for _WL_.
           1. Assert: _W_ is not on the list of waiters in any WaiterList.
           1. Add _W_ to the end of the list of waiters in _WL_.
           1. Return ~unused~.
@@ -41753,7 +41753,7 @@ THH:mm:ss.sss
         <dl class="header">
         </dl>
         <emu-alg>
-          1. Assert: The calling agent is in the critical section for _WL_.
+          1. Assert: The surrounding agent is in the critical section for _WL_.
           1. Assert: _W_ is on the list of waiters in _WL_.
           1. Remove _W_ from the list of waiters in _WL_.
           1. Return ~unused~.
@@ -41770,7 +41770,7 @@ THH:mm:ss.sss
         <dl class="header">
         </dl>
         <emu-alg>
-          1. Assert: The calling agent is in the critical section for _WL_.
+          1. Assert: The surrounding agent is in the critical section for _WL_.
           1. Let _L_ be a new empty List.
           1. Let _S_ be a reference to the list of waiters in _WL_.
           1. Repeat, while _c_ &gt; 0 and _S_ is not an empty List,
@@ -41793,7 +41793,7 @@ THH:mm:ss.sss
         <dl class="header">
         </dl>
         <emu-alg>
-          1. Assert: The calling agent is in the critical section for _WL_.
+          1. Assert: The surrounding agent is in the critical section for _WL_.
           1. Assert: _W_ is equivalent to AgentSignifier().
           1. Assert: _W_ is on the list of waiters in _WL_.
           1. Assert: AgentCanSuspend() is *true*.
@@ -41814,7 +41814,7 @@ THH:mm:ss.sss
         <dl class="header">
         </dl>
         <emu-alg>
-          1. Assert: The calling agent is in the critical section for _WL_.
+          1. Assert: The surrounding agent is in the critical section for _WL_.
           1. Notify the agent _W_.
           1. Return ~unused~.
         </emu-alg>
@@ -41992,7 +41992,7 @@ THH:mm:ss.sss
         1. Return *false*.
       </emu-alg>
       <emu-note>
-        <p>`Atomics.isLockFree`() is an optimization primitive. The intuition is that if the atomic step of an atomic primitive (`compareExchange`, `load`, `store`, `add`, `sub`, `and`, `or`, `xor`, or `exchange`) on a datum of size _n_ bytes will be performed without the calling agent acquiring a lock outside the _n_ bytes comprising the datum, then `Atomics.isLockFree`(_n_) will return *true*. High-performance algorithms will use `Atomics.isLockFree` to determine whether to use locks or atomic operations in critical sections. If an atomic primitive is not lock-free then it is often more efficient for an algorithm to provide its own locking.</p>
+        <p>`Atomics.isLockFree`() is an optimization primitive. The intuition is that if the atomic step of an atomic primitive (`compareExchange`, `load`, `store`, `add`, `sub`, `and`, `or`, `xor`, or `exchange`) on a datum of size _n_ bytes will be performed without the surrounding agent acquiring a lock outside the _n_ bytes comprising the datum, then `Atomics.isLockFree`(_n_) will return *true*. High-performance algorithms will use `Atomics.isLockFree` to determine whether to use locks or atomic operations in critical sections. If an atomic primitive is not lock-free then it is often more efficient for an algorithm to provide its own locking.</p>
         <p>`Atomics.isLockFree`(4) always returns *true* as that can be supported on all known relevant hardware. Being able to assume this will generally simplify programs.</p>
         <p>Regardless of the value of `Atomics.isLockFree`, all atomic operations are guaranteed to be atomic. For example, they will never have a visible operation take place in the middle of the operation (e.g., "tearing").</p>
       </emu-note>
@@ -42060,7 +42060,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-atomics.wait">
       <h1>Atomics.wait ( _typedArray_, _index_, _value_, _timeout_ )</h1>
-      <p>`Atomics.wait` puts the calling agent in a wait queue and puts it to sleep until it is notified or the sleep times out. The following steps are taken:</p>
+      <p>`Atomics.wait` puts the surrounding agent in a wait queue and puts it to sleep until it is notified or the sleep times out. The following steps are taken:</p>
       <emu-alg>
         1. Let _buffer_ be ? ValidateIntegerTypedArray(_typedArray_, *true*).
         1. If IsSharedArrayBuffer(_buffer_) is *false*, throw a *TypeError* exception.


### PR DESCRIPTION
Closes #1721

In parts having to do with Atomics, we use the phrase "surrounding
agent" interchangeably with "calling agent". This PR makes the phrasing
uniform.

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
