### PR TITLE
Editorial: Make the steps of IsLessThan for String values more explicit

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -6129,12 +6129,14 @@
           1. Let _py_ be ? ToPrimitive(_y_, ~number~).
           1. Let _px_ be ? ToPrimitive(_x_, ~number~).
         1. [id="step-arc-string-check"] If Type(_px_) is String and Type(_py_) is String, then
-          1. If IsStringPrefix(_py_, _px_) is *true*, return *false*.
-          1. If IsStringPrefix(_px_, _py_) is *true*, return *true*.
-          1. Let _k_ be the smallest non-negative integer such that the code unit at index _k_ within _px_ is different from the code unit at index _k_ within _py_. (There must be such a _k_, for neither String is a prefix of the other.)
-          1. Let _m_ be the integer that is the numeric value of the code unit at index _k_ within _px_.
-          1. Let _n_ be the integer that is the numeric value of the code unit at index _k_ within _py_.
-          1. If _m_ &lt; _n_, return *true*. Otherwise, return *false*.
+          1. Let _lx_ be the length of _px_.
+          1. Let _ly_ be the length of _py_.
+          1. For each integer _i_ starting with 0 such that _i_ &lt; min(_lx_, _ly_), in ascending order, do
+            1. Let _cx_ be the integer that is the numeric value of the code unit at index _i_ within _px_.
+            1. Let _cy_ be the integer that is the numeric value of the code unit at index _i_ within _py_.
+            1. If _cx_ &lt; _cy_, return *true*.
+            1. If _cx_ &gt; _cy_, return *false*.
+          1. If _lx_ &lt; _ly_, return *true*. Otherwise, return *false*.
         1. Else,
           1. If Type(_px_) is BigInt and Type(_py_) is String, then
             1. Let _ny_ be StringToBigInt(_py_).
@@ -6163,7 +6165,7 @@
         <p>Step <emu-xref href="#step-arc-string-check"></emu-xref> differs from step <emu-xref href="#step-binary-op-string-check"></emu-xref> in the algorithm that handles the addition operator `+` (<emu-xref href="#sec-applystringornumericbinaryoperator"></emu-xref>) by using the logical-and operation instead of the logical-or operation.</p>
       </emu-note>
       <emu-note>
-        <p>The comparison of Strings uses a simple lexicographic ordering on sequences of code unit values. There is no attempt to use the more complex, semantically oriented definitions of character or string equality and collating order defined in the Unicode specification. Therefore String values that are canonically equal according to the Unicode Standard could test as unequal. In effect this algorithm assumes that both Strings are already in normalized form. Also, note that for strings containing supplementary characters, lexicographic ordering on sequences of UTF-16 code unit values differs from that on sequences of code point values.</p>
+        <p>The comparison of Strings uses a simple lexicographic ordering on sequences of UTF-16 code unit values. There is no attempt to use the more complex, semantically oriented definitions of character or string equality and collating order defined in the Unicode specification. Therefore String values that are canonically equal according to the Unicode Standard but not in the same normalization form could test as unequal. Also note that lexicographic ordering by <em>code unit</em> differs from ordering by <em>code point</em> for Strings containing surrogate pairs.</p>
       </emu-note>
     </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -5996,26 +5996,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-isstringprefix" type="abstract operation">
-      <h1>
-        IsStringPrefix (
-          _p_: a String,
-          _q_: a String,
-        ): a Boolean
-      </h1>
-      <dl class="header">
-        <dt>description</dt>
-        <dd>It determines if _p_ is a prefix of _q_.</dd>
-      </dl>
-      <emu-alg>
-        1. If StringIndexOf(_q_, _p_, 0) is 0, return *true*.
-        1. Else, return *false*.
-      </emu-alg>
-      <emu-note>
-        <p>Any String is a prefix of itself.</p>
-      </emu-note>
-    </emu-clause>
-
     <emu-clause id="sec-isstringwellformedunicode" type="abstract operation">
       <h1>
         Static Semantics: IsStringWellFormedUnicode (


### PR DESCRIPTION
This should simplify reading and also help with KAIST-like efforts.