### PR TITLE
Editorial: Simplify GetSubstitution

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -33991,24 +33991,20 @@ THH:mm:ss.sss
                 1. Let _refReplacement_ be the substring of _str_ from min(_tailPos_, _stringLength_).
                 1. NOTE: _tailPos_ can exceed _stringLength_ only if this abstract operation was invoked by a call to the intrinsic @@replace method of %RegExp.prototype% on an object whose *"exec"* property is not the intrinsic %RegExp.prototype.exec%.
               1. Else if _templateRemainder_ starts with *"$"* followed by 1 or more decimal digits, then
-                1. Let _found_ be *false*.
-                1. For each integer _d_ of &laquo; 2, 1 &raquo;, do
-                  1. If _found_ is *false* and _templateRemainder_ starts with *"$"* followed by _d_ or more decimal digits, then
-                    1. Set _found_ to *true*.
-                    1. Let _ref_ be the substring of _templateRemainder_ from 0 to 1 + _d_.
-                    1. Let _digits_ be the substring of _templateRemainder_ from 1 to 1 + _d_.
-                    1. Let _index_ be ℝ(StringToNumber(_digits_)).
-                    1. Assert: 0 &le; _index_ &le; 99.
-                    1. If _index_ = 0, then
-                      1. Let _refReplacement_ be _ref_.
-                    1. Else if _index_ &le; the number of elements in _captures_, then
-                      1. Let _capture_ be _captures_[_index_ - 1].
-                      1. If _capture_ is *undefined*, then
-                        1. Let _refReplacement_ be the empty String.
-                      1. Else,
-                        1. Let _refReplacement_ be _capture_.
-                    1. Else,
-                      1. Let _refReplacement_ be _ref_.
+                1. If _templateRemainder_ starts with *"$"* followed by 2 or more decimal digits, let _digitCount_ be 2. Otherwise, let _digitCount_ be 1.
+                1. Let _ref_ be the substring of _templateRemainder_ from 0 to 1 + _digitCount_.
+                1. Let _digits_ be the substring of _templateRemainder_ from 1 to 1 + _digitCount_.
+                1. Let _index_ be ℝ(StringToNumber(_digits_)).
+                1. Assert: 0 &le; _index_ &le; 99.
+                1. Let _captureLen_ be the number of elements in _captures_.
+                1. If 1 &le; _index_ &le; _captureLen_, then
+                  1. Let _capture_ be _captures_[_index_ - 1].
+                  1. If _capture_ is *undefined*, then
+                    1. Let _refReplacement_ be the empty String.
+                  1. Else,
+                    1. Let _refReplacement_ be _capture_.
+                1. Else,
+                  1. Let _refReplacement_ be _ref_.
               1. Else if _templateRemainder_ starts with *"$&lt;"*, then
                 1. Let _gtPos_ be StringIndexOf(_templateRemainder_, *"&gt;"*, 0).
                 1. If _gtPos_ = -1 or _namedCaptures_ is *undefined*, then


### PR DESCRIPTION
* Remove an unnecessary "for each" step
* Combine out-of-bounds index branches
* Make aliases more clear
* Replace "number of code units in [string]" with "length of"