### PR TITLE
Editorial: Declare "JSON Serialization Record"

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -42317,7 +42317,7 @@ THH:mm:ss.sss
           1. Let _gap_ be the empty String.
         1. Let _wrapper_ be OrdinaryObjectCreate(%Object.prototype%).
         1. Perform ! CreateDataPropertyOrThrow(_wrapper_, the empty String, _value_).
-        1. Let _state_ be the Record { [[ReplacerFunction]]: _ReplacerFunction_, [[Stack]]: _stack_, [[Indent]]: _indent_, [[Gap]]: _gap_, [[PropertyList]]: _PropertyList_ }.
+        1. Let _state_ be the JSON Serialization Record { [[ReplacerFunction]]: _ReplacerFunction_, [[Stack]]: _stack_, [[Indent]]: _indent_, [[Gap]]: _gap_, [[PropertyList]]: _PropertyList_ }.
         1. Return ? SerializeJSONProperty(_state_, the empty String, _wrapper_).
       </emu-alg>
       <p>The *"length"* property of the `stringify` function is *3*<sub>𝔽</sub>.</p>
@@ -42359,10 +42359,50 @@ THH:mm:ss.sss
         <p>An object is rendered as U+007B (LEFT CURLY BRACKET) followed by zero or more properties, separated with a U+002C (COMMA), closed with a U+007D (RIGHT CURLY BRACKET). A property is a quoted String representing the key or property name, a U+003A (COLON), and then the stringified property value. An array is rendered as an opening U+005B (LEFT SQUARE BRACKET followed by zero or more values, separated with a U+002C (COMMA), closed with a U+005D (RIGHT SQUARE BRACKET).</p>
       </emu-note>
 
+      <emu-clause id="sec-json-serialization-record">
+        <h1>JSON Serialization Record</h1>
+        <p>A <dfn variants="JSON Serialization Records">JSON Serialization Record</dfn> is a Record value used to enable serialization to the JSON format.</p>
+        <p>JSON Serialization Records have the fields listed in <emu-xref href="#table-json-serialization-record"></emu-xref>.</p>
+        <emu-table id="table-json-serialization-record" caption="JSON Serialization Record Fields">
+          <table>
+            <tr>
+              <th>Field Name</th>
+              <th>Value</th>
+              <th>Meaning</th>
+            </tr>
+            <tr>
+              <td>[[ReplacerFunction]]</td>
+              <td>a function object or *undefined*</td>
+              <td>A function that can supply replacement values for object properties (from JSON.stringify's _replacer_ parameter).</td>
+            </tr>
+            <tr>
+              <td>[[PropertyList]]</td>
+              <td>either a List of Strings or *undefined*</td>
+              <td>The names of properties to include when serializing a non-array object (from JSON.stringify's _replacer_ parameter).</td>
+            </tr>
+            <tr>
+              <td>[[Gap]]</td>
+              <td>a String</td>
+              <td>The unit of indentation (from JSON.stringify's _space_ parameter).</td>
+            </tr>
+            <tr>
+              <td>[[Stack]]</td>
+              <td>a List of Objects</td>
+              <td>The set of nested objects that are in the process of being serialized. Used to detect cyclic structures.</td>
+            </tr>
+            <tr>
+              <td>[[Indent]]</td>
+              <td>a String</td>
+              <td>The current indentation.</td>
+            </tr>
+          </table>
+        </emu-table>
+      </emu-clause>
+
       <emu-clause id="sec-serializejsonproperty" type="abstract operation">
         <h1>
           SerializeJSONProperty (
-            _state_: unknown,
+            _state_: a JSON Serialization Record,
             _key_: unknown,
             _holder_: unknown,
           ): either a normal completion containing either *undefined* or a String, or a throw completion
@@ -42542,7 +42582,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-serializejsonobject" type="abstract operation">
         <h1>
           SerializeJSONObject (
-            _state_: unknown,
+            _state_: a JSON Serialization Record,
             _value_: an Object,
           ): either a normal completion containing a String or a throw completion
         </h1>
@@ -42588,7 +42628,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-serializejsonarray" type="abstract operation">
         <h1>
           SerializeJSONArray (
-            _state_: unknown,
+            _state_: a JSON Serialization Record,
             _value_: an ECMAScript language value,
           ): either a normal completion containing a String or a throw completion
         </h1>


### PR DESCRIPTION
Currently, `JSON.stringify` creates a Record without a named schema, and that gets passed to the `_state_` parameter (of type 'unknown') of the various `SerializeJSONFoo` operations. Instead, declare the `JSON Serialization Record` schema for this purpose.