### PR TITLE
Editorial: Make `Evaluation` more like regular SDOs

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -842,7 +842,7 @@
         1. [id="step-sdo-invocation-example-2"] Perform SyntaxDirectedOperation of _someParseNode_.
         1. [id="step-sdo-invocation-example-3"] Perform SyntaxDirectedOperation of _someParseNode_ with argument *"value"*.
       </emu-alg>
-      <p>Unless explicitly specified otherwise, all chain productions have an implicit definition for every operation that might be applied to that production's left-hand side nonterminal. The implicit definition simply reapplies the same operation with the same parameters, if any, to the chain production's sole right-hand side nonterminal and then returns the result. For example, assume that some algorithm has a step of the form: &ldquo;Return the result of evaluating |Block|&rdquo; and that there is a production:</p>
+      <p>Unless explicitly specified otherwise, all chain productions have an implicit definition for every operation that might be applied to that production's left-hand side nonterminal. The implicit definition simply reapplies the same operation with the same parameters, if any, to the chain production's sole right-hand side nonterminal and then returns the result. For example, assume that some algorithm has a step of the form: &ldquo;Return Evaluation of |Block|&rdquo; and that there is a production:</p>
       <emu-grammar example>
         Block :
           `{` StatementList `}`
@@ -851,7 +851,7 @@
       <p><b>Runtime Semantics: Evaluation</b></p>
       <emu-grammar example>Block : `{` StatementList `}`</emu-grammar>
       <emu-alg example>
-        1. Return the result of evaluating |StatementList|.
+        1. Return Evaluation of |StatementList|.
       </emu-alg>
     </emu-clause>
 
@@ -961,7 +961,7 @@
         <ul>
           <li>when the result of applying Completion, NormalCompletion, or ThrowCompletion is directly returned</li>
           <li>when the result of constructing a Completion Record is directly returned</li>
-          <li>when directly returning with the phrase "the result of evaluating"</li>
+          <li>when directly returning with the phrase "Evaluation of"</li>
         </ul>
         <p>It is an editorial error if a Completion Record is returned from such an abstract operation through any other means. For example, within these abstract operations,</p>
         <emu-alg example>
@@ -9662,7 +9662,7 @@
           1. If IsAnonymousFunctionDefinition(|Initializer|) is *true*, then
             1. Set _v_ to ? NamedEvaluation of |Initializer| with argument _bindingId_.
           1. Else,
-            1. Let _defaultValue_ be the result of evaluating |Initializer|.
+            1. Let _defaultValue_ be Evaluation of |Initializer|.
             1. Set _v_ to ? GetValue(_defaultValue_).
         1. If _environment_ is *undefined*, return ? PutValue(_lhs_, _v_).
         1. Return ? InitializeReferencedBinding(_lhs_, _v_).
@@ -9680,7 +9680,7 @@
             1. If _v_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
             1. ReturnIfAbrupt(_v_).
         1. If |Initializer| is present and _v_ is *undefined*, then
-          1. Let _defaultValue_ be the result of evaluating |Initializer|.
+          1. Let _defaultValue_ be Evaluation of |Initializer|.
           1. Set _v_ to ? GetValue(_defaultValue_).
         1. Return ? BindingInitialization of |BindingPattern| with arguments _v_ and _environment_.
       </emu-alg>
@@ -13381,7 +13381,7 @@
           1. If IsAnonymousFunctionDefinition(|AssignmentExpression|) is *true*, then
             1. Let _value_ be ? NamedEvaluation of |Initializer| with argument _functionObject_.[[ClassFieldInitializerName]].
           1. Else,
-            1. Let _rhs_ be the result of evaluating |AssignmentExpression|.
+            1. Let _rhs_ be Evaluation of |AssignmentExpression|.
             1. Let _value_ be ? GetValue(_rhs_).
           1. Return Completion Record { [[Type]]: ~return~, [[Value]]: _value_, [[Target]]: ~empty~ }.
         </emu-alg>
@@ -18136,7 +18136,7 @@
         <emu-alg>
           1. If |Elision| is present, then
             1. Set _nextIndex_ to ? ArrayAccumulation of |Elision| with arguments _array_ and _nextIndex_.
-          1. Let _initResult_ be the result of evaluating |AssignmentExpression|.
+          1. Let _initResult_ be Evaluation of |AssignmentExpression|.
           1. Let _initValue_ be ? GetValue(_initResult_).
           1. Let _created_ be ! CreateDataPropertyOrThrow(_array_, ! ToString(𝔽(_nextIndex_)), _initValue_).
           1. Return _nextIndex_ + 1.
@@ -18152,7 +18152,7 @@
           1. Set _nextIndex_ to ? ArrayAccumulation of |ElementList| with arguments _array_ and _nextIndex_.
           1. If |Elision| is present, then
             1. Set _nextIndex_ to ? ArrayAccumulation of |Elision| with arguments _array_ and _nextIndex_.
-          1. Let _initResult_ be the result of evaluating |AssignmentExpression|.
+          1. Let _initResult_ be Evaluation of |AssignmentExpression|.
           1. Let _initValue_ be ? GetValue(_initResult_).
           1. Let _created_ be ! CreateDataPropertyOrThrow(_array_, ! ToString(𝔽(_nextIndex_)), _initValue_).
           1. Return _nextIndex_ + 1.
@@ -18166,7 +18166,7 @@
         </emu-alg>
         <emu-grammar>SpreadElement : `...` AssignmentExpression</emu-grammar>
         <emu-alg>
-          1. Let _spreadRef_ be the result of evaluating |AssignmentExpression|.
+          1. Let _spreadRef_ be Evaluation of |AssignmentExpression|.
           1. Let _spreadObj_ be ? GetValue(_spreadRef_).
           1. Let _iteratorRecord_ be ? GetIterator(_spreadObj_).
           1. Repeat,
@@ -18355,7 +18355,7 @@
         </emu-alg>
         <emu-grammar>ComputedPropertyName : `[` AssignmentExpression `]`</emu-grammar>
         <emu-alg>
-          1. Let _exprValue_ be the result of evaluating |AssignmentExpression|.
+          1. Let _exprValue_ be Evaluation of |AssignmentExpression|.
           1. Let _propName_ be ? GetValue(_exprValue_).
           1. Return ? ToPropertyKey(_propName_).
         </emu-alg>
@@ -18377,7 +18377,7 @@
         </emu-alg>
         <emu-grammar>PropertyDefinition : `...` AssignmentExpression</emu-grammar>
         <emu-alg>
-          1. Let _exprValue_ be the result of evaluating |AssignmentExpression|.
+          1. Let _exprValue_ be Evaluation of |AssignmentExpression|.
           1. Let _fromValue_ be ? GetValue(_exprValue_).
           1. Let _excludedNames_ be a new empty List.
           1. Perform ? CopyDataProperties(_object_, _fromValue_, _excludedNames_).
@@ -18386,7 +18386,7 @@
         <emu-grammar>PropertyDefinition : IdentifierReference</emu-grammar>
         <emu-alg>
           1. Let _propName_ be StringValue of |IdentifierReference|.
-          1. Let _exprValue_ be the result of evaluating |IdentifierReference|.
+          1. Let _exprValue_ be Evaluation of |IdentifierReference|.
           1. Let _propValue_ be ? GetValue(_exprValue_).
           1. Assert: _object_ is an ordinary, extensible object with no non-configurable properties.
           1. Perform ! CreateDataPropertyOrThrow(_object_, _propName_, _propValue_).
@@ -18394,7 +18394,7 @@
         </emu-alg>
         <emu-grammar>PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar>
         <emu-alg>
-          1. Let _propKey_ be the result of evaluating |PropertyName|.
+          1. Let _propKey_ be Evaluation of |PropertyName|.
           1. ReturnIfAbrupt(_propKey_).
           1. If this |PropertyDefinition| is contained within a |Script| that is being evaluated for JSON.parse (see step <emu-xref href="#step-json-parse-eval"></emu-xref> of <emu-xref href="#sec-json.parse">JSON.parse</emu-xref>), then
             1. Let _isProtoSetter_ be *false*.
@@ -18405,7 +18405,7 @@
           1. If IsAnonymousFunctionDefinition(|AssignmentExpression|) is *true* and _isProtoSetter_ is *false*, then
             1. Let _propValue_ be ? NamedEvaluation of |AssignmentExpression| with argument _propKey_.
           1. Else,
-            1. Let _exprValueRef_ be the result of evaluating |AssignmentExpression|.
+            1. Let _exprValueRef_ be Evaluation of |AssignmentExpression|.
             1. Let _propValue_ be ? GetValue(_exprValueRef_).
           1. If _isProtoSetter_ is *true*, then
             1. If Type(_propValue_) is either Object or Null, then
@@ -18670,14 +18670,14 @@
         </emu-alg>
         <emu-grammar>TemplateMiddleList : TemplateMiddle Expression</emu-grammar>
         <emu-alg>
-          1. Let _subRef_ be the result of evaluating |Expression|.
+          1. Let _subRef_ be Evaluation of |Expression|.
           1. Let _sub_ be ? GetValue(_subRef_).
           1. Return &laquo; _sub_ &raquo;.
         </emu-alg>
         <emu-grammar>TemplateMiddleList : TemplateMiddleList TemplateMiddle Expression</emu-grammar>
         <emu-alg>
           1. Let _preceding_ be ? SubstitutionEvaluation of |TemplateMiddleList|.
-          1. Let _nextRef_ be the result of evaluating |Expression|.
+          1. Let _nextRef_ be Evaluation of |Expression|.
           1. Let _next_ be ? GetValue(_nextRef_).
           1. Return the list-concatenation of _preceding_ and &laquo; _next_ &raquo;.
         </emu-alg>
@@ -18692,10 +18692,10 @@
         <emu-grammar>SubstitutionTemplate : TemplateHead Expression TemplateSpans</emu-grammar>
         <emu-alg>
           1. Let _head_ be the TV of |TemplateHead| as defined in <emu-xref href="#sec-template-literal-lexical-components"></emu-xref>.
-          1. Let _subRef_ be the result of evaluating |Expression|.
+          1. Let _subRef_ be Evaluation of |Expression|.
           1. Let _sub_ be ? GetValue(_subRef_).
           1. Let _middle_ be ? ToString(_sub_).
-          1. Let _tail_ be the result of evaluating |TemplateSpans|.
+          1. Let _tail_ be Evaluation of |TemplateSpans|.
           1. ReturnIfAbrupt(_tail_).
           1. Return the string-concatenation of _head_, _middle_, and _tail_.
         </emu-alg>
@@ -18708,7 +18708,7 @@
         </emu-alg>
         <emu-grammar>TemplateSpans : TemplateMiddleList TemplateTail</emu-grammar>
         <emu-alg>
-          1. Let _head_ be the result of evaluating |TemplateMiddleList|.
+          1. Let _head_ be Evaluation of |TemplateMiddleList|.
           1. ReturnIfAbrupt(_head_).
           1. Let _tail_ be the TV of |TemplateTail| as defined in <emu-xref href="#sec-template-literal-lexical-components"></emu-xref>.
           1. Return the string-concatenation of _head_ and _tail_.
@@ -18716,7 +18716,7 @@
         <emu-grammar>TemplateMiddleList : TemplateMiddle Expression</emu-grammar>
         <emu-alg>
           1. Let _head_ be the TV of |TemplateMiddle| as defined in <emu-xref href="#sec-template-literal-lexical-components"></emu-xref>.
-          1. Let _subRef_ be the result of evaluating |Expression|.
+          1. Let _subRef_ be Evaluation of |Expression|.
           1. Let _sub_ be ? GetValue(_subRef_).
           1. Let _middle_ be ? ToString(_sub_).
           1. Return the string-concatenation of _head_ and _middle_.
@@ -18726,10 +18726,10 @@
         </emu-note>
         <emu-grammar>TemplateMiddleList : TemplateMiddleList TemplateMiddle Expression</emu-grammar>
         <emu-alg>
-          1. Let _rest_ be the result of evaluating |TemplateMiddleList|.
+          1. Let _rest_ be Evaluation of |TemplateMiddleList|.
           1. ReturnIfAbrupt(_rest_).
           1. Let _middle_ be the TV of |TemplateMiddle| as defined in <emu-xref href="#sec-template-literal-lexical-components"></emu-xref>.
-          1. Let _subRef_ be the result of evaluating |Expression|.
+          1. Let _subRef_ be Evaluation of |Expression|.
           1. Let _sub_ be ? GetValue(_subRef_).
           1. Let _last_ be ? ToString(_sub_).
           1. Return the string-concatenation of _rest_, _middle_, and _last_.
@@ -18758,14 +18758,14 @@
         <emu-grammar>PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
         <emu-alg>
           1. Let _expr_ be the |ParenthesizedExpression| that is covered by |CoverParenthesizedExpressionAndArrowParameterList|.
-          1. Return the result of evaluating _expr_.
+          1. Return Evaluation of _expr_.
         </emu-alg>
         <emu-grammar>ParenthesizedExpression : `(` Expression `)`</emu-grammar>
         <emu-alg>
-          1. Return the result of evaluating |Expression|. This may be of type Reference.
+          1. Return Evaluation of |Expression|. This may be of type Reference.
         </emu-alg>
         <emu-note>
-          <p>This algorithm does not apply GetValue to the result of evaluating |Expression|. The principal motivation for this is so that operators such as `delete` and `typeof` may be applied to parenthesized expressions.</p>
+          <p>This algorithm does not apply GetValue to Evaluation of |Expression|. The principal motivation for this is so that operators such as `delete` and `typeof` may be applied to parenthesized expressions.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -18940,42 +18940,42 @@
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>MemberExpression : MemberExpression `[` Expression `]`</emu-grammar>
         <emu-alg>
-          1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+          1. Let _baseReference_ be Evaluation of |MemberExpression|.
           1. Let _baseValue_ be ? GetValue(_baseReference_).
           1. If the source text matched by this |MemberExpression| is strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
           1. Return ? EvaluatePropertyAccessWithExpressionKey(_baseValue_, |Expression|, _strict_).
         </emu-alg>
         <emu-grammar>MemberExpression : MemberExpression `.` IdentifierName</emu-grammar>
         <emu-alg>
-          1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+          1. Let _baseReference_ be Evaluation of |MemberExpression|.
           1. Let _baseValue_ be ? GetValue(_baseReference_).
           1. If the source text matched by this |MemberExpression| is strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
           1. Return EvaluatePropertyAccessWithIdentifierKey(_baseValue_, |IdentifierName|, _strict_).
         </emu-alg>
         <emu-grammar>MemberExpression : MemberExpression `.` PrivateIdentifier</emu-grammar>
         <emu-alg>
-          1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+          1. Let _baseReference_ be Evaluation of |MemberExpression|.
           1. Let _baseValue_ be ? GetValue(_baseReference_).
           1. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
           1. Return MakePrivateReference(_baseValue_, _fieldNameString_).
         </emu-alg>
         <emu-grammar>CallExpression : CallExpression `[` Expression `]`</emu-grammar>
         <emu-alg>
-          1. Let _baseReference_ be the result of evaluating |CallExpression|.
+          1. Let _baseReference_ be Evaluation of |CallExpression|.
           1. Let _baseValue_ be ? GetValue(_baseReference_).
           1. If the source text matched by this |CallExpression| is strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
           1. Return ? EvaluatePropertyAccessWithExpressionKey(_baseValue_, |Expression|, _strict_).
         </emu-alg>
         <emu-grammar>CallExpression : CallExpression `.` IdentifierName</emu-grammar>
         <emu-alg>
-          1. Let _baseReference_ be the result of evaluating |CallExpression|.
+          1. Let _baseReference_ be Evaluation of |CallExpression|.
           1. Let _baseValue_ be ? GetValue(_baseReference_).
           1. If the source text matched by this |CallExpression| is strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
           1. Return EvaluatePropertyAccessWithIdentifierKey(_baseValue_, |IdentifierName|, _strict_).
         </emu-alg>
         <emu-grammar>CallExpression : CallExpression `.` PrivateIdentifier</emu-grammar>
         <emu-alg>
-          1. Let _baseReference_ be the result of evaluating |CallExpression|.
+          1. Let _baseReference_ be Evaluation of |CallExpression|.
           1. Let _baseValue_ be ? GetValue(_baseReference_).
           1. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
           1. Return MakePrivateReference(_baseValue_, _fieldNameString_).
@@ -18994,7 +18994,7 @@
       <dl class="header">
       </dl>
       <emu-alg>
-        1. Let _propertyNameReference_ be the result of evaluating _expression_.
+        1. Let _propertyNameReference_ be Evaluation of _expression_.
         1. Let _propertyNameValue_ be ? GetValue(_propertyNameReference_).
         1. Let _propertyKey_ be ? ToPropertyKey(_propertyNameValue_).
         1. Return the Reference Record { [[Base]]: _baseValue_, [[ReferencedName]]: _propertyKey_, [[Strict]]: _strict_, [[ThisValue]]: ~empty~ }.
@@ -19041,7 +19041,7 @@
           <dl class="header">
           </dl>
           <emu-alg>
-            1. Let _ref_ be the result of evaluating _constructExpr_.
+            1. Let _ref_ be Evaluation of _constructExpr_.
             1. Let _constructor_ be ? GetValue(_ref_).
             1. If _arguments_ is ~empty~, let _argList_ be a new empty List.
             1. Else,
@@ -19063,7 +19063,7 @@
           1. Let _expr_ be the |CallMemberExpression| that is covered by |CoverCallExpressionAndAsyncArrowHead|.
           1. Let _memberExpr_ be the |MemberExpression| of _expr_.
           1. Let _arguments_ be the |Arguments| of _expr_.
-          1. Let _ref_ be the result of evaluating _memberExpr_.
+          1. Let _ref_ be Evaluation of _memberExpr_.
           1. Let _func_ be ? GetValue(_ref_).
           1. If _ref_ is a Reference Record, IsPropertyReference(_ref_) is *false*, and _ref_.[[ReferencedName]] is *"eval"*, then
             1. If SameValue(_func_, %eval%) is *true*, then
@@ -19079,7 +19079,7 @@
         <p>A |CallExpression| evaluation that executes step <emu-xref href="#step-callexpression-evaluation-direct-eval"></emu-xref> is a <dfn variants="direct evals">direct eval</dfn>.</p>
         <emu-grammar>CallExpression : CallExpression Arguments</emu-grammar>
         <emu-alg>
-          1. Let _ref_ be the result of evaluating |CallExpression|.
+          1. Let _ref_ be Evaluation of |CallExpression|.
           1. Let _func_ be ? GetValue(_ref_).
           1. Let _thisCall_ be this |CallExpression|.
           1. Let _tailCall_ be IsInTailPosition(_thisCall_).
@@ -19126,7 +19126,7 @@
         <emu-alg>
           1. Let _env_ be GetThisEnvironment().
           1. Let _actualThis_ be ? _env_.GetThisBinding().
-          1. Let _propertyNameReference_ be the result of evaluating |Expression|.
+          1. Let _propertyNameReference_ be Evaluation of |Expression|.
           1. Let _propertyNameValue_ be ? GetValue(_propertyNameReference_).
           1. Let _propertyKey_ be ? ToPropertyKey(_propertyNameValue_).
           1. If the source text matched by this |SuperProperty| is strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
@@ -19206,14 +19206,14 @@
         </emu-alg>
         <emu-grammar>ArgumentList : AssignmentExpression</emu-grammar>
         <emu-alg>
-          1. Let _ref_ be the result of evaluating |AssignmentExpression|.
+          1. Let _ref_ be Evaluation of |AssignmentExpression|.
           1. Let _arg_ be ? GetValue(_ref_).
           1. Return &laquo; _arg_ &raquo;.
         </emu-alg>
         <emu-grammar>ArgumentList : `...` AssignmentExpression</emu-grammar>
         <emu-alg>
           1. Let _list_ be a new empty List.
-          1. Let _spreadRef_ be the result of evaluating |AssignmentExpression|.
+          1. Let _spreadRef_ be Evaluation of |AssignmentExpression|.
           1. Let _spreadObj_ be ? GetValue(_spreadRef_).
           1. Let _iteratorRecord_ be ? GetIterator(_spreadObj_).
           1. Repeat,
@@ -19225,14 +19225,14 @@
         <emu-grammar>ArgumentList : ArgumentList `,` AssignmentExpression</emu-grammar>
         <emu-alg>
           1. Let _precedingArgs_ be ? ArgumentListEvaluation of |ArgumentList|.
-          1. Let _ref_ be the result of evaluating |AssignmentExpression|.
+          1. Let _ref_ be Evaluation of |AssignmentExpression|.
           1. Let _arg_ be ? GetValue(_ref_).
           1. Return the list-concatenation of _precedingArgs_ and &laquo; _arg_ &raquo;.
         </emu-alg>
         <emu-grammar>ArgumentList : ArgumentList `,` `...` AssignmentExpression</emu-grammar>
         <emu-alg>
           1. Let _precedingArgs_ be ? ArgumentListEvaluation of |ArgumentList|.
-          1. Let _spreadRef_ be the result of evaluating |AssignmentExpression|.
+          1. Let _spreadRef_ be Evaluation of |AssignmentExpression|.
           1. Let _iteratorRecord_ be ? GetIterator(? GetValue(_spreadRef_)).
           1. Repeat,
             1. Let _next_ be ? IteratorStep(_iteratorRecord_).
@@ -19255,7 +19255,7 @@
         </emu-alg>
         <emu-grammar>SubstitutionTemplate : TemplateHead Expression TemplateSpans</emu-grammar>
         <emu-alg>
-          1. Let _firstSubRef_ be the result of evaluating |Expression|.
+          1. Let _firstSubRef_ be Evaluation of |Expression|.
           1. Let _firstSub_ be ? GetValue(_firstSubRef_).
           1. Let _restSub_ be ? SubstitutionEvaluation of |TemplateSpans|.
           1. Assert: _restSub_ is a possibly empty List.
@@ -19275,7 +19275,7 @@
             MemberExpression OptionalChain
         </emu-grammar>
         <emu-alg>
-          1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+          1. Let _baseReference_ be Evaluation of |MemberExpression|.
           1. Let _baseValue_ be ? GetValue(_baseReference_).
           1. If _baseValue_ is *undefined* or *null*, then
             1. Return *undefined*.
@@ -19286,7 +19286,7 @@
             CallExpression OptionalChain
         </emu-grammar>
         <emu-alg>
-          1. Let _baseReference_ be the result of evaluating |CallExpression|.
+          1. Let _baseReference_ be Evaluation of |CallExpression|.
           1. Let _baseValue_ be ? GetValue(_baseReference_).
           1. If _baseValue_ is *undefined* or *null*, then
             1. Return *undefined*.
@@ -19297,7 +19297,7 @@
             OptionalExpression OptionalChain
         </emu-grammar>
         <emu-alg>
-          1. Let _baseReference_ be the result of evaluating |OptionalExpression|.
+          1. Let _baseReference_ be Evaluation of |OptionalExpression|.
           1. Let _baseValue_ be ? GetValue(_baseReference_).
           1. If _baseValue_ is *undefined* or *null*, then
             1. Return *undefined*.
@@ -19380,7 +19380,7 @@
         <emu-grammar>ImportCall : `import` `(` AssignmentExpression `)`</emu-grammar>
         <emu-alg>
           1. Let _referencingScriptOrModule_ be GetActiveScriptOrModule().
-          1. Let _argRef_ be the result of evaluating |AssignmentExpression|.
+          1. Let _argRef_ be Evaluation of |AssignmentExpression|.
           1. Let _specifier_ be ? GetValue(_argRef_).
           1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
           1. Let _specifierString_ be Completion(ToString(_specifier_)).
@@ -19401,7 +19401,7 @@
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>MemberExpression : MemberExpression TemplateLiteral</emu-grammar>
         <emu-alg>
-          1. Let _tagRef_ be the result of evaluating |MemberExpression|.
+          1. Let _tagRef_ be Evaluation of |MemberExpression|.
           1. Let _tagFunc_ be ? GetValue(_tagRef_).
           1. Let _thisCall_ be this |MemberExpression|.
           1. Let _tailCall_ be IsInTailPosition(_thisCall_).
@@ -19409,7 +19409,7 @@
         </emu-alg>
         <emu-grammar>CallExpression : CallExpression TemplateLiteral</emu-grammar>
         <emu-alg>
-          1. Let _tagRef_ be the result of evaluating |CallExpression|.
+          1. Let _tagRef_ be Evaluation of |CallExpression|.
           1. Let _tagFunc_ be ? GetValue(_tagRef_).
           1. Let _thisCall_ be this |CallExpression|.
           1. Let _tailCall_ be IsInTailPosition(_thisCall_).
@@ -19536,7 +19536,7 @@
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>UpdateExpression : LeftHandSideExpression `++`</emu-grammar>
         <emu-alg>
-          1. Let _lhs_ be the result of evaluating |LeftHandSideExpression|.
+          1. Let _lhs_ be Evaluation of |LeftHandSideExpression|.
           1. Let _oldValue_ be ? ToNumeric(? GetValue(_lhs_)).
           1. If Type(_oldValue_) is Number, then
             1. Let _newValue_ be Number::add(_oldValue_, *1*<sub>𝔽</sub>).
@@ -19556,7 +19556,7 @@
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>UpdateExpression : LeftHandSideExpression `--`</emu-grammar>
         <emu-alg>
-          1. Let _lhs_ be the result of evaluating |LeftHandSideExpression|.
+          1. Let _lhs_ be Evaluation of |LeftHandSideExpression|.
           1. Let _oldValue_ be ? ToNumeric(? GetValue(_lhs_)).
           1. If Type(_oldValue_) is Number, then
             1. Let _newValue_ be Number::subtract(_oldValue_, *1*<sub>𝔽</sub>).
@@ -19576,7 +19576,7 @@
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>UpdateExpression : `++` UnaryExpression</emu-grammar>
         <emu-alg>
-          1. Let _expr_ be the result of evaluating |UnaryExpression|.
+          1. Let _expr_ be Evaluation of |UnaryExpression|.
           1. Let _oldValue_ be ? ToNumeric(? GetValue(_expr_)).
           1. If Type(_oldValue_) is Number, then
             1. Let _newValue_ be Number::add(_oldValue_, *1*<sub>𝔽</sub>).
@@ -19596,7 +19596,7 @@
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>UpdateExpression : `--` UnaryExpression</emu-grammar>
         <emu-alg>
-          1. Let _expr_ be the result of evaluating |UnaryExpression|.
+          1. Let _expr_ be Evaluation of |UnaryExpression|.
           1. Let _oldValue_ be ? ToNumeric(? GetValue(_expr_)).
           1. If Type(_oldValue_) is Number, then
             1. Let _newValue_ be Number::subtract(_oldValue_, *1*<sub>𝔽</sub>).
@@ -19653,7 +19653,7 @@
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>UnaryExpression : `delete` UnaryExpression</emu-grammar>
         <emu-alg>
-          1. Let _ref_ be the result of evaluating |UnaryExpression|.
+          1. Let _ref_ be Evaluation of |UnaryExpression|.
           1. ReturnIfAbrupt(_ref_).
           1. If _ref_ is not a Reference Record, return *true*.
           1. If IsUnresolvableReference(_ref_) is *true*, then
@@ -19687,7 +19687,7 @@
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>UnaryExpression : `void` UnaryExpression</emu-grammar>
         <emu-alg>
-          1. Let _expr_ be the result of evaluating |UnaryExpression|.
+          1. Let _expr_ be Evaluation of |UnaryExpression|.
           1. Perform ? GetValue(_expr_).
           1. Return *undefined*.
         </emu-alg>
@@ -19704,7 +19704,7 @@
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>UnaryExpression : `typeof` UnaryExpression</emu-grammar>
         <emu-alg>
-          1. Let _val_ be the result of evaluating |UnaryExpression|.
+          1. Let _val_ be Evaluation of |UnaryExpression|.
           1. If _val_ is a Reference Record, then
             1. If IsUnresolvableReference(_val_) is *true*, return *"undefined"*.
           1. Set _val_ to ? GetValue(_val_).
@@ -19811,7 +19811,7 @@
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>UnaryExpression : `+` UnaryExpression</emu-grammar>
         <emu-alg>
-          1. Let _expr_ be the result of evaluating |UnaryExpression|.
+          1. Let _expr_ be Evaluation of |UnaryExpression|.
           1. Return ? ToNumber(? GetValue(_expr_)).
         </emu-alg>
       </emu-clause>
@@ -19827,7 +19827,7 @@
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>UnaryExpression : `-` UnaryExpression</emu-grammar>
         <emu-alg>
-          1. Let _expr_ be the result of evaluating |UnaryExpression|.
+          1. Let _expr_ be Evaluation of |UnaryExpression|.
           1. Let _oldValue_ be ? ToNumeric(? GetValue(_expr_)).
           1. Let _T_ be Type(_oldValue_).
           1. If Type(_oldValue_) is Number, then
@@ -19846,7 +19846,7 @@
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>UnaryExpression : `~` UnaryExpression</emu-grammar>
         <emu-alg>
-          1. Let _expr_ be the result of evaluating |UnaryExpression|.
+          1. Let _expr_ be Evaluation of |UnaryExpression|.
           1. Let _oldValue_ be ? ToNumeric(? GetValue(_expr_)).
           1. Let _T_ be Type(_oldValue_).
           1. If Type(_oldValue_) is Number, then
@@ -19865,7 +19865,7 @@
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>UnaryExpression : `!` UnaryExpression</emu-grammar>
         <emu-alg>
-          1. Let _expr_ be the result of evaluating |UnaryExpression|.
+          1. Let _expr_ be Evaluation of |UnaryExpression|.
           1. Let _oldValue_ be ToBoolean(? GetValue(_expr_)).
           1. If _oldValue_ is *true*, return *false*.
           1. Return *true*.
@@ -20047,53 +20047,53 @@
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>RelationalExpression : RelationalExpression `&lt;` ShiftExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be the result of evaluating |RelationalExpression|.
+        1. Let _lref_ be Evaluation of |RelationalExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
-        1. Let _rref_ be the result of evaluating |ShiftExpression|.
+        1. Let _rref_ be Evaluation of |ShiftExpression|.
         1. Let _rval_ be ? GetValue(_rref_).
         1. Let _r_ be ? IsLessThan(_lval_, _rval_, *true*).
         1. If _r_ is *undefined*, return *false*. Otherwise, return _r_.
       </emu-alg>
       <emu-grammar>RelationalExpression : RelationalExpression `&gt;` ShiftExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be the result of evaluating |RelationalExpression|.
+        1. Let _lref_ be Evaluation of |RelationalExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
-        1. Let _rref_ be the result of evaluating |ShiftExpression|.
+        1. Let _rref_ be Evaluation of |ShiftExpression|.
         1. Let _rval_ be ? GetValue(_rref_).
         1. Let _r_ be ? IsLessThan(_rval_, _lval_, *false*).
         1. If _r_ is *undefined*, return *false*. Otherwise, return _r_.
       </emu-alg>
       <emu-grammar>RelationalExpression : RelationalExpression `&lt;=` ShiftExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be the result of evaluating |RelationalExpression|.
+        1. Let _lref_ be Evaluation of |RelationalExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
-        1. Let _rref_ be the result of evaluating |ShiftExpression|.
+        1. Let _rref_ be Evaluation of |ShiftExpression|.
         1. Let _rval_ be ? GetValue(_rref_).
         1. Let _r_ be ? IsLessThan(_rval_, _lval_, *false*).
         1. If _r_ is *true* or *undefined*, return *false*. Otherwise, return *true*.
       </emu-alg>
       <emu-grammar>RelationalExpression : RelationalExpression `&gt;=` ShiftExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be the result of evaluating |RelationalExpression|.
+        1. Let _lref_ be Evaluation of |RelationalExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
-        1. Let _rref_ be the result of evaluating |ShiftExpression|.
+        1. Let _rref_ be Evaluation of |ShiftExpression|.
         1. Let _rval_ be ? GetValue(_rref_).
         1. Let _r_ be ? IsLessThan(_lval_, _rval_, *true*).
         1. If _r_ is *true* or *undefined*, return *false*. Otherwise, return *true*.
       </emu-alg>
       <emu-grammar>RelationalExpression : RelationalExpression `instanceof` ShiftExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be the result of evaluating |RelationalExpression|.
+        1. Let _lref_ be Evaluation of |RelationalExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
-        1. Let _rref_ be the result of evaluating |ShiftExpression|.
+        1. Let _rref_ be Evaluation of |ShiftExpression|.
         1. Let _rval_ be ? GetValue(_rref_).
         1. Return ? InstanceofOperator(_lval_, _rval_).
       </emu-alg>
       <emu-grammar>RelationalExpression : RelationalExpression `in` ShiftExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be the result of evaluating |RelationalExpression|.
+        1. Let _lref_ be Evaluation of |RelationalExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
-        1. Let _rref_ be the result of evaluating |ShiftExpression|.
+        1. Let _rref_ be Evaluation of |ShiftExpression|.
         1. Let _rval_ be ? GetValue(_rref_).
         1. If Type(_rval_) is not Object, throw a *TypeError* exception.
         1. Return ? HasProperty(_rval_, ? ToPropertyKey(_lval_)).
@@ -20101,7 +20101,7 @@
       <emu-grammar>RelationalExpression : PrivateIdentifier `in` ShiftExpression</emu-grammar>
       <emu-alg>
         1. Let _privateIdentifier_ be the StringValue of |PrivateIdentifier|.
-        1. Let _rref_ be the result of evaluating |ShiftExpression|.
+        1. Let _rref_ be Evaluation of |ShiftExpression|.
         1. Let _rval_ be ? GetValue(_rref_).
         1. If Type(_rval_) is not Object, throw a *TypeError* exception.
         1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
@@ -20155,34 +20155,34 @@
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>EqualityExpression : EqualityExpression `==` RelationalExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be the result of evaluating |EqualityExpression|.
+        1. Let _lref_ be Evaluation of |EqualityExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
-        1. Let _rref_ be the result of evaluating |RelationalExpression|.
+        1. Let _rref_ be Evaluation of |RelationalExpression|.
         1. Let _rval_ be ? GetValue(_rref_).
         1. Return ? IsLooselyEqual(_rval_, _lval_).
       </emu-alg>
       <emu-grammar>EqualityExpression : EqualityExpression `!=` RelationalExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be the result of evaluating |EqualityExpression|.
+        1. Let _lref_ be Evaluation of |EqualityExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
-        1. Let _rref_ be the result of evaluating |RelationalExpression|.
+        1. Let _rref_ be Evaluation of |RelationalExpression|.
         1. Let _rval_ be ? GetValue(_rref_).
         1. Let _r_ be ? IsLooselyEqual(_rval_, _lval_).
         1. If _r_ is *true*, return *false*. Otherwise, return *true*.
       </emu-alg>
       <emu-grammar>EqualityExpression : EqualityExpression `===` RelationalExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be the result of evaluating |EqualityExpression|.
+        1. Let _lref_ be Evaluation of |EqualityExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
-        1. Let _rref_ be the result of evaluating |RelationalExpression|.
+        1. Let _rref_ be Evaluation of |RelationalExpression|.
         1. Let _rval_ be ? GetValue(_rref_).
         1. Return IsStrictlyEqual(_rval_, _lval_).
       </emu-alg>
       <emu-grammar>EqualityExpression : EqualityExpression `!==` RelationalExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be the result of evaluating |EqualityExpression|.
+        1. Let _lref_ be Evaluation of |EqualityExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
-        1. Let _rref_ be the result of evaluating |RelationalExpression|.
+        1. Let _rref_ be Evaluation of |RelationalExpression|.
         1. Let _rval_ be ? GetValue(_rref_).
         1. Let _r_ be IsStrictlyEqual(_rval_, _lval_).
         1. If _r_ is *true*, return *false*. Otherwise, return *true*.
@@ -20294,28 +20294,28 @@
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>LogicalANDExpression : LogicalANDExpression `&amp;&amp;` BitwiseORExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be the result of evaluating |LogicalANDExpression|.
+        1. Let _lref_ be Evaluation of |LogicalANDExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
         1. Let _lbool_ be ToBoolean(_lval_).
         1. If _lbool_ is *false*, return _lval_.
-        1. Let _rref_ be the result of evaluating |BitwiseORExpression|.
+        1. Let _rref_ be Evaluation of |BitwiseORExpression|.
         1. Return ? GetValue(_rref_).
       </emu-alg>
       <emu-grammar>LogicalORExpression : LogicalORExpression `||` LogicalANDExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be the result of evaluating |LogicalORExpression|.
+        1. Let _lref_ be Evaluation of |LogicalORExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
         1. Let _lbool_ be ToBoolean(_lval_).
         1. If _lbool_ is *true*, return _lval_.
-        1. Let _rref_ be the result of evaluating |LogicalANDExpression|.
+        1. Let _rref_ be Evaluation of |LogicalANDExpression|.
         1. Return ? GetValue(_rref_).
       </emu-alg>
       <emu-grammar>CoalesceExpression : CoalesceExpressionHead `??` BitwiseORExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be the result of evaluating |CoalesceExpressionHead|.
+        1. Let _lref_ be Evaluation of |CoalesceExpressionHead|.
         1. Let _lval_ be ? GetValue(_lref_).
         1. If _lval_ is *undefined* or *null*, then
-          1. Let _rref_ be the result of evaluating |BitwiseORExpression|.
+          1. Let _rref_ be Evaluation of |BitwiseORExpression|.
           1. Return ? GetValue(_rref_).
         1. Otherwise, return _lval_.
       </emu-alg>
@@ -20338,13 +20338,13 @@
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>ConditionalExpression : ShortCircuitExpression `?` AssignmentExpression `:` AssignmentExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be the result of evaluating |ShortCircuitExpression|.
+        1. Let _lref_ be Evaluation of |ShortCircuitExpression|.
         1. Let _lval_ be ToBoolean(? GetValue(_lref_)).
         1. If _lval_ is *true*, then
-          1. Let _trueRef_ be the result of evaluating the first |AssignmentExpression|.
+          1. Let _trueRef_ be Evaluation of the first |AssignmentExpression|.
           1. Return ? GetValue(_trueRef_).
         1. Else,
-          1. Let _falseRef_ be the result of evaluating the second |AssignmentExpression|.
+          1. Let _falseRef_ be Evaluation of the second |AssignmentExpression|.
           1. Return ? GetValue(_falseRef_).
       </emu-alg>
     </emu-clause>
@@ -20404,26 +20404,26 @@
       <emu-grammar>AssignmentExpression : LeftHandSideExpression `=` AssignmentExpression</emu-grammar>
       <emu-alg>
         1. If |LeftHandSideExpression| is neither an |ObjectLiteral| nor an |ArrayLiteral|, then
-          1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+          1. Let _lref_ be Evaluation of |LeftHandSideExpression|.
           1. ReturnIfAbrupt(_lref_).
           1. If IsAnonymousFunctionDefinition(|AssignmentExpression|) and IsIdentifierRef of |LeftHandSideExpression| are both *true*, then
             1. Let _rval_ be ? NamedEvaluation of |AssignmentExpression| with argument _lref_.[[ReferencedName]].
           1. Else,
-            1. Let _rref_ be the result of evaluating |AssignmentExpression|.
+            1. Let _rref_ be Evaluation of |AssignmentExpression|.
             1. Let _rval_ be ? GetValue(_rref_).
           1. [id="step-assignmentexpression-evaluation-simple-putvalue"] Perform ? PutValue(_lref_, _rval_).
           1. Return _rval_.
         1. Let _assignmentPattern_ be the |AssignmentPattern| that is covered by |LeftHandSideExpression|.
-        1. Let _rref_ be the result of evaluating |AssignmentExpression|.
+        1. Let _rref_ be Evaluation of |AssignmentExpression|.
         1. Let _rval_ be ? GetValue(_rref_).
         1. Perform ? DestructuringAssignmentEvaluation of _assignmentPattern_ with argument _rval_.
         1. Return _rval_.
       </emu-alg>
       <emu-grammar>AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+        1. Let _lref_ be Evaluation of |LeftHandSideExpression|.
         1. [id="step-assignmentexpression-evaluation-compound-getvalue"] Let _lval_ be ? GetValue(_lref_).
-        1. Let _rref_ be the result of evaluating |AssignmentExpression|.
+        1. Let _rref_ be Evaluation of |AssignmentExpression|.
         1. Let _rval_ be ? GetValue(_rref_).
         1. Let _assignmentOpText_ be the source text matched by |AssignmentOperator|.
         1. Let _opText_ be the sequence of Unicode code points associated with _assignmentOpText_ in the following table:
@@ -20451,41 +20451,41 @@
       </emu-alg>
       <emu-grammar>AssignmentExpression : LeftHandSideExpression `&amp;&amp;=` AssignmentExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+        1. Let _lref_ be Evaluation of |LeftHandSideExpression|.
         1. [id="step-assignmentexpression-evaluation-lgcl-and-getvalue"] Let _lval_ be ? GetValue(_lref_).
         1. Let _lbool_ be ToBoolean(_lval_).
         1. If _lbool_ is *false*, return _lval_.
         1. If IsAnonymousFunctionDefinition(|AssignmentExpression|) is *true* and IsIdentifierRef of |LeftHandSideExpression| is *true*, then
           1. Let _rval_ be ? NamedEvaluation of |AssignmentExpression| with argument _lref_.[[ReferencedName]].
         1. Else,
-          1. Let _rref_ be the result of evaluating |AssignmentExpression|.
+          1. Let _rref_ be Evaluation of |AssignmentExpression|.
           1. Let _rval_ be ? GetValue(_rref_).
         1. [id="step-assignmentexpression-evaluation-lgcl-and-putvalue"] Perform ? PutValue(_lref_, _rval_).
         1. Return _rval_.
       </emu-alg>
       <emu-grammar>AssignmentExpression : LeftHandSideExpression `||=` AssignmentExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+        1. Let _lref_ be Evaluation of |LeftHandSideExpression|.
         1. [id="step-assignmentexpression-evaluation-lgcl-or-getvalue"] Let _lval_ be ? GetValue(_lref_).
         1. Let _lbool_ be ToBoolean(_lval_).
         1. If _lbool_ is *true*, return _lval_.
         1. If IsAnonymousFunctionDefinition(|AssignmentExpression|) is *true* and IsIdentifierRef of |LeftHandSideExpression| is *true*, then
           1. Let _rval_ be ? NamedEvaluation of |AssignmentExpression| with argument _lref_.[[ReferencedName]].
         1. Else,
-          1. Let _rref_ be the result of evaluating |AssignmentExpression|.
+          1. Let _rref_ be Evaluation of |AssignmentExpression|.
           1. Let _rval_ be ? GetValue(_rref_).
         1. [id="step-assignmentexpression-evaluation-lgcl-or-putvalue"] Perform ? PutValue(_lref_, _rval_).
         1. Return _rval_.
       </emu-alg>
       <emu-grammar>AssignmentExpression : LeftHandSideExpression `??=` AssignmentExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+        1. Let _lref_ be Evaluation of |LeftHandSideExpression|.
         1. [id="step-assignmentexpression-evaluation-lgcl-nullish-getvalue"] Let _lval_ be ? GetValue(_lref_).
         1. If _lval_ is neither *undefined* nor *null*, return _lval_.
         1. If IsAnonymousFunctionDefinition(|AssignmentExpression|) is *true* and IsIdentifierRef of |LeftHandSideExpression| is *true*, then
           1. Let _rval_ be ? NamedEvaluation of |AssignmentExpression| with argument _lref_.[[ReferencedName]].
         1. Else,
-          1. Let _rref_ be the result of evaluating |AssignmentExpression|.
+          1. Let _rref_ be Evaluation of |AssignmentExpression|.
           1. Let _rval_ be ? GetValue(_rref_).
         1. [id="step-assignmentexpression-evaluation-lgcl-nullish-putvalue"] Perform ? PutValue(_lref_, _rval_).
         1. Return _rval_.
@@ -20572,9 +20572,9 @@
       <dl class="header">
       </dl>
       <emu-alg>
-        1. Let _lref_ be the result of evaluating _leftOperand_.
+        1. Let _lref_ be Evaluation of _leftOperand_.
         1. Let _lval_ be ? GetValue(_lref_).
-        1. Let _rref_ be the result of evaluating _rightOperand_.
+        1. Let _rref_ be Evaluation of _rightOperand_.
         1. Let _rval_ be ? GetValue(_rref_).
         1. Return ? ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
       </emu-alg>
@@ -20772,7 +20772,7 @@
             1. If IsAnonymousFunctionDefinition(|Initializer|) is *true*, then
               1. Set _v_ to ? NamedEvaluation of |Initializer| with argument _P_.
             1. Else,
-              1. Let _defaultValue_ be the result of evaluating |Initializer|.
+              1. Let _defaultValue_ be Evaluation of |Initializer|.
               1. Set _v_ to ? GetValue(_defaultValue_).
           1. Perform ? PutValue(_lref_, _v_).
           1. Return &laquo; _P_ &raquo;.
@@ -20780,7 +20780,7 @@
 
         <emu-grammar>AssignmentProperty : PropertyName `:` AssignmentElement</emu-grammar>
         <emu-alg>
-          1. Let _name_ be the result of evaluating |PropertyName|.
+          1. Let _name_ be Evaluation of |PropertyName|.
           1. ReturnIfAbrupt(_name_).
           1. Perform ? KeyedDestructuringAssignmentEvaluation of |AssignmentElement| with arguments _value_ and _name_.
           1. Return &laquo; _name_ &raquo;.
@@ -20798,7 +20798,7 @@
         </dl>
         <emu-grammar>AssignmentRestProperty : `...` DestructuringAssignmentTarget</emu-grammar>
         <emu-alg>
-          1. Let _lref_ be the result of evaluating |DestructuringAssignmentTarget|.
+          1. Let _lref_ be Evaluation of |DestructuringAssignmentTarget|.
           1. ReturnIfAbrupt(_lref_).
           1. Let _restObj_ be OrdinaryObjectCreate(%Object.prototype%).
           1. Perform ? CopyDataProperties(_restObj_, _value_, _excludedNames_).
@@ -20854,7 +20854,7 @@
         <emu-grammar>AssignmentElement : DestructuringAssignmentTarget Initializer?</emu-grammar>
         <emu-alg>
           1. If |DestructuringAssignmentTarget| is neither an |ObjectLiteral| nor an |ArrayLiteral|, then
-            1. Let _lref_ be the result of evaluating |DestructuringAssignmentTarget|.
+            1. Let _lref_ be Evaluation of |DestructuringAssignmentTarget|.
             1. ReturnIfAbrupt(_lref_).
           1. If _iteratorRecord_.[[Done]] is *false*, then
             1. Let _next_ be Completion(IteratorStep(_iteratorRecord_)).
@@ -20870,7 +20870,7 @@
             1. If IsAnonymousFunctionDefinition(|Initializer|) is *true* and IsIdentifierRef of |DestructuringAssignmentTarget| is *true*, then
               1. Let _v_ be ? NamedEvaluation of |Initializer| with argument _lref_.[[ReferencedName]].
             1. Else,
-              1. Let _defaultValue_ be the result of evaluating |Initializer|.
+              1. Let _defaultValue_ be Evaluation of |Initializer|.
               1. Let _v_ be ? GetValue(_defaultValue_).
           1. Else, let _v_ be _value_.
           1. If |DestructuringAssignmentTarget| is an |ObjectLiteral| or an |ArrayLiteral|, then
@@ -20884,7 +20884,7 @@
         <emu-grammar>AssignmentRestElement : `...` DestructuringAssignmentTarget</emu-grammar>
         <emu-alg>
           1. If |DestructuringAssignmentTarget| is neither an |ObjectLiteral| nor an |ArrayLiteral|, then
-            1. Let _lref_ be the result of evaluating |DestructuringAssignmentTarget|.
+            1. Let _lref_ be Evaluation of |DestructuringAssignmentTarget|.
             1. ReturnIfAbrupt(_lref_).
           1. Let _A_ be ! ArrayCreate(0).
           1. Let _n_ be 0.
@@ -20918,14 +20918,14 @@
         <emu-grammar>AssignmentElement : DestructuringAssignmentTarget Initializer?</emu-grammar>
         <emu-alg>
           1. If |DestructuringAssignmentTarget| is neither an |ObjectLiteral| nor an |ArrayLiteral|, then
-            1. Let _lref_ be the result of evaluating |DestructuringAssignmentTarget|.
+            1. Let _lref_ be Evaluation of |DestructuringAssignmentTarget|.
             1. ReturnIfAbrupt(_lref_).
           1. Let _v_ be ? GetV(_value_, _propertyName_).
           1. If |Initializer| is present and _v_ is *undefined*, then
             1. If IsAnonymousFunctionDefinition(|Initializer|) and IsIdentifierRef of |DestructuringAssignmentTarget| are both *true*, then
               1. Let _rhsValue_ be ? NamedEvaluation of |Initializer| with argument _lref_.[[ReferencedName]].
             1. Else,
-              1. Let _defaultValue_ be the result of evaluating |Initializer|.
+              1. Let _defaultValue_ be Evaluation of |Initializer|.
               1. Let _rhsValue_ be ? GetValue(_defaultValue_).
           1. Else, let _rhsValue_ be _v_.
           1. If |DestructuringAssignmentTarget| is an |ObjectLiteral| or an |ArrayLiteral|, then
@@ -20950,9 +20950,9 @@
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>Expression : Expression `,` AssignmentExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be the result of evaluating |Expression|.
+        1. Let _lref_ be Evaluation of |Expression|.
         1. Perform ? GetValue(_lref_).
-        1. Let _rref_ be the result of evaluating |AssignmentExpression|.
+        1. Let _rref_ be Evaluation of |AssignmentExpression|.
         1. Return ? GetValue(_rref_).
       </emu-alg>
       <emu-note>
@@ -21016,7 +21016,7 @@
         HoistableDeclaration : FunctionDeclaration
       </emu-grammar>
       <emu-alg>
-        1. Return the result of evaluating |FunctionDeclaration|.
+        1. Return Evaluation of |FunctionDeclaration|.
       </emu-alg>
       <emu-grammar>
         BreakableStatement :
@@ -21074,7 +21074,7 @@
         1. Let _blockEnv_ be NewDeclarativeEnvironment(_oldEnv_).
         1. Perform BlockDeclarationInstantiation(|StatementList|, _blockEnv_).
         1. Set the running execution context's LexicalEnvironment to _blockEnv_.
-        1. Let _blockValue_ be the result of evaluating |StatementList|.
+        1. Let _blockValue_ be Evaluation of |StatementList|.
         1. Set the running execution context's LexicalEnvironment to _oldEnv_.
         1. Return _blockValue_.
       </emu-alg>
@@ -21083,9 +21083,9 @@
       </emu-note>
       <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
       <emu-alg>
-        1. Let _sl_ be the result of evaluating |StatementList|.
+        1. Let _sl_ be Evaluation of |StatementList|.
         1. ReturnIfAbrupt(_sl_).
-        1. Let _s_ be the result of evaluating |StatementListItem|.
+        1. Let _s_ be Evaluation of |StatementListItem|.
         1. Return ? UpdateEmpty(_s_, _sl_).
       </emu-alg>
       <emu-note>
@@ -21185,15 +21185,15 @@
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>LexicalDeclaration : LetOrConst BindingList `;`</emu-grammar>
         <emu-alg>
-          1. Let _next_ be the result of evaluating |BindingList|.
+          1. Let _next_ be Evaluation of |BindingList|.
           1. ReturnIfAbrupt(_next_).
           1. Return ~empty~.
         </emu-alg>
         <emu-grammar>BindingList : BindingList `,` LexicalBinding</emu-grammar>
         <emu-alg>
-          1. Let _next_ be the result of evaluating |BindingList|.
+          1. Let _next_ be Evaluation of |BindingList|.
           1. ReturnIfAbrupt(_next_).
-          1. Return the result of evaluating |LexicalBinding|.
+          1. Return Evaluation of |LexicalBinding|.
         </emu-alg>
         <emu-grammar>LexicalBinding : BindingIdentifier</emu-grammar>
         <emu-alg>
@@ -21211,14 +21211,14 @@
           1. If IsAnonymousFunctionDefinition(|Initializer|) is *true*, then
             1. Let _value_ be ? NamedEvaluation of |Initializer| with argument _bindingId_.
           1. Else,
-            1. Let _rhs_ be the result of evaluating |Initializer|.
+            1. Let _rhs_ be Evaluation of |Initializer|.
             1. Let _value_ be ? GetValue(_rhs_).
           1. Perform ? InitializeReferencedBinding(_lhs_, _value_).
           1. Return ~empty~.
         </emu-alg>
         <emu-grammar>LexicalBinding : BindingPattern Initializer</emu-grammar>
         <emu-alg>
-          1. Let _rhs_ be the result of evaluating |Initializer|.
+          1. Let _rhs_ be Evaluation of |Initializer|.
           1. Let _value_ be ? GetValue(_rhs_).
           1. Let _env_ be the running execution context's LexicalEnvironment.
           1. Return ? BindingInitialization of |BindingPattern| with arguments _value_ and _env_.
@@ -21249,15 +21249,15 @@
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>VariableStatement : `var` VariableDeclarationList `;`</emu-grammar>
         <emu-alg>
-          1. Let _next_ be the result of evaluating |VariableDeclarationList|.
+          1. Let _next_ be Evaluation of |VariableDeclarationList|.
           1. ReturnIfAbrupt(_next_).
           1. Return ~empty~.
         </emu-alg>
         <emu-grammar>VariableDeclarationList : VariableDeclarationList `,` VariableDeclaration</emu-grammar>
         <emu-alg>
-          1. Let _next_ be the result of evaluating |VariableDeclarationList|.
+          1. Let _next_ be Evaluation of |VariableDeclarationList|.
           1. ReturnIfAbrupt(_next_).
-          1. Return the result of evaluating |VariableDeclaration|.
+          1. Return Evaluation of |VariableDeclaration|.
         </emu-alg>
         <emu-grammar>VariableDeclaration : BindingIdentifier</emu-grammar>
         <emu-alg>
@@ -21270,7 +21270,7 @@
           1. If IsAnonymousFunctionDefinition(|Initializer|) is *true*, then
             1. Let _value_ be ? NamedEvaluation of |Initializer| with argument _bindingId_.
           1. Else,
-            1. Let _rhs_ be the result of evaluating |Initializer|.
+            1. Let _rhs_ be Evaluation of |Initializer|.
             1. Let _value_ be ? GetValue(_rhs_).
           1. [id="step-vardecllist-evaluation-putvalue"] Perform ? PutValue(_lhs_, _value_).
           1. Return ~empty~.
@@ -21280,7 +21280,7 @@
         </emu-note>
         <emu-grammar>VariableDeclaration : BindingPattern Initializer</emu-grammar>
         <emu-alg>
-          1. Let _rhs_ be the result of evaluating |Initializer|.
+          1. Let _rhs_ be Evaluation of |Initializer|.
           1. Let _rval_ be ? GetValue(_rhs_).
           1. Return ? BindingInitialization of |BindingPattern| with arguments _rval_ and *undefined*.
         </emu-alg>
@@ -21363,7 +21363,7 @@
 
         <emu-grammar>BindingProperty : PropertyName `:` BindingElement</emu-grammar>
         <emu-alg>
-          1. Let _P_ be the result of evaluating |PropertyName|.
+          1. Let _P_ be Evaluation of |PropertyName|.
           1. ReturnIfAbrupt(_P_).
           1. Perform ? KeyedBindingInitialization of |BindingElement| with arguments _value_, _environment_, and _P_.
           1. Return &laquo; _P_ &raquo;.
@@ -21407,7 +21407,7 @@
         <emu-alg>
           1. Let _v_ be ? GetV(_value_, _propertyName_).
           1. If |Initializer| is present and _v_ is *undefined*, then
-            1. Let _defaultValue_ be the result of evaluating |Initializer|.
+            1. Let _defaultValue_ be Evaluation of |Initializer|.
             1. Set _v_ to ? GetValue(_defaultValue_).
           1. Return ? BindingInitialization of |BindingPattern| with arguments _v_ and _environment_.
         </emu-alg>
@@ -21420,7 +21420,7 @@
             1. If IsAnonymousFunctionDefinition(|Initializer|) is *true*, then
               1. Set _v_ to ? NamedEvaluation of |Initializer| with argument _bindingId_.
             1. Else,
-              1. Let _defaultValue_ be the result of evaluating |Initializer|.
+              1. Let _defaultValue_ be Evaluation of |Initializer|.
               1. Set _v_ to ? GetValue(_defaultValue_).
           1. If _environment_ is *undefined*, return ? PutValue(_lhs_, _v_).
           1. Return ? InitializeReferencedBinding(_lhs_, _v_).
@@ -21461,7 +21461,7 @@
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>ExpressionStatement : Expression `;`</emu-grammar>
       <emu-alg>
-        1. Let _exprRef_ be the result of evaluating |Expression|.
+        1. Let _exprRef_ be Evaluation of |Expression|.
         1. Return ? GetValue(_exprRef_).
       </emu-alg>
     </emu-clause>
@@ -21503,22 +21503,22 @@
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
       <emu-alg>
-        1. Let _exprRef_ be the result of evaluating |Expression|.
+        1. Let _exprRef_ be Evaluation of |Expression|.
         1. Let _exprValue_ be ToBoolean(? GetValue(_exprRef_)).
         1. If _exprValue_ is *true*, then
-          1. Let _stmtCompletion_ be the result of evaluating the first |Statement|.
+          1. Let _stmtCompletion_ be Evaluation of the first |Statement|.
         1. Else,
-          1. Let _stmtCompletion_ be the result of evaluating the second |Statement|.
+          1. Let _stmtCompletion_ be Evaluation of the second |Statement|.
         1. Return ? UpdateEmpty(_stmtCompletion_, *undefined*).
       </emu-alg>
       <emu-grammar>IfStatement : `if` `(` Expression `)` Statement</emu-grammar>
       <emu-alg>
-        1. Let _exprRef_ be the result of evaluating |Expression|.
+        1. Let _exprRef_ be Evaluation of |Expression|.
         1. Let _exprValue_ be ToBoolean(? GetValue(_exprRef_)).
         1. If _exprValue_ is *false*, then
           1. Return *undefined*.
         1. Else,
-          1. Let _stmtCompletion_ be the result of evaluating |Statement|.
+          1. Let _stmtCompletion_ be Evaluation of |Statement|.
           1. Return ? UpdateEmpty(_stmtCompletion_, *undefined*).
       </emu-alg>
     </emu-clause>
@@ -21619,10 +21619,10 @@
         <emu-alg>
           1. Let _V_ be *undefined*.
           1. Repeat,
-            1. Let _stmtResult_ be the result of evaluating |Statement|.
+            1. Let _stmtResult_ be Evaluation of |Statement|.
             1. If LoopContinues(_stmtResult_, _labelSet_) is *false*, return ? UpdateEmpty(_stmtResult_, _V_).
             1. If _stmtResult_.[[Value]] is not ~empty~, set _V_ to _stmtResult_.[[Value]].
-            1. Let _exprRef_ be the result of evaluating |Expression|.
+            1. Let _exprRef_ be Evaluation of |Expression|.
             1. Let _exprValue_ be ? GetValue(_exprRef_).
             1. If ToBoolean(_exprValue_) is *false*, return _V_.
         </emu-alg>
@@ -21662,10 +21662,10 @@
         <emu-alg>
           1. Let _V_ be *undefined*.
           1. Repeat,
-            1. Let _exprRef_ be the result of evaluating |Expression|.
+            1. Let _exprRef_ be Evaluation of |Expression|.
             1. Let _exprValue_ be ? GetValue(_exprRef_).
             1. If ToBoolean(_exprValue_) is *false*, return _V_.
-            1. Let _stmtResult_ be the result of evaluating |Statement|.
+            1. Let _stmtResult_ be Evaluation of |Statement|.
             1. If LoopContinues(_stmtResult_, _labelSet_) is *false*, return ? UpdateEmpty(_stmtResult_, _V_).
             1. If _stmtResult_.[[Value]] is not ~empty~, set _V_ to _stmtResult_.[[Value]].
         </emu-alg>
@@ -21717,13 +21717,13 @@
         <emu-grammar>ForStatement : `for` `(` Expression? `;` Expression? `;` Expression? `)` Statement</emu-grammar>
         <emu-alg>
           1. If the first |Expression| is present, then
-            1. Let _exprRef_ be the result of evaluating the first |Expression|.
+            1. Let _exprRef_ be Evaluation of the first |Expression|.
             1. Perform ? GetValue(_exprRef_).
           1. Return ? ForBodyEvaluation(the second |Expression|, the third |Expression|, |Statement|, &laquo; &raquo;, _labelSet_).
         </emu-alg>
         <emu-grammar>ForStatement : `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement</emu-grammar>
         <emu-alg>
-          1. Let _varDcl_ be the result of evaluating |VariableDeclarationList|.
+          1. Let _varDcl_ be Evaluation of |VariableDeclarationList|.
           1. ReturnIfAbrupt(_varDcl_).
           1. Return ? ForBodyEvaluation(the first |Expression|, the second |Expression|, |Statement|, &laquo; &raquo;, _labelSet_).
         </emu-alg>
@@ -21739,7 +21739,7 @@
             1. Else,
               1. Perform ! _loopEnv_.CreateMutableBinding(_dn_, *false*).
           1. Set the running execution context's LexicalEnvironment to _loopEnv_.
-          1. Let _forDcl_ be the result of evaluating |LexicalDeclaration|.
+          1. Let _forDcl_ be Evaluation of |LexicalDeclaration|.
           1. If _forDcl_ is an abrupt completion, then
             1. Set the running execution context's LexicalEnvironment to _oldEnv_.
             1. Return ? _forDcl_.
@@ -21767,15 +21767,15 @@
           1. Perform ? CreatePerIterationEnvironment(_perIterationBindings_).
           1. Repeat,
             1. If _test_ is not ~[empty]~, then
-              1. Let _testRef_ be the result of evaluating _test_.
+              1. Let _testRef_ be Evaluation of _test_.
               1. Let _testValue_ be ? GetValue(_testRef_).
               1. If ToBoolean(_testValue_) is *false*, return _V_.
-            1. Let _result_ be the result of evaluating _stmt_.
+            1. Let _result_ be Evaluation of _stmt_.
             1. If LoopContinues(_result_, _labelSet_) is *false*, return ? UpdateEmpty(_result_, _V_).
             1. If _result_.[[Value]] is not ~empty~, set _V_ to _result_.[[Value]].
             1. Perform ? CreatePerIterationEnvironment(_perIterationBindings_).
             1. If _increment_ is not ~[empty]~, then
-              1. Let _incRef_ be the result of evaluating _increment_.
+              1. Let _incRef_ be Evaluation of _increment_.
               1. Perform ? GetValue(_incRef_).
         </emu-alg>
       </emu-clause>
@@ -22055,7 +22055,7 @@
             1. For each String _name_ of _uninitializedBoundNames_, do
               1. Perform ! _newEnv_.CreateMutableBinding(_name_, *false*).
             1. Set the running execution context's LexicalEnvironment to _newEnv_.
-          1. Let _exprRef_ be the result of evaluating _expr_.
+          1. Let _exprRef_ be Evaluation of _expr_.
           1. Set the running execution context's LexicalEnvironment to _oldEnv_.
           1. Let _exprValue_ be ? GetValue(_exprRef_).
           1. If _iterationKind_ is ~enumerate~, then
@@ -22104,7 +22104,7 @@
             1. Let _nextValue_ be ? IteratorValue(_nextResult_).
             1. If _lhsKind_ is either ~assignment~ or ~varBinding~, then
               1. If _destructuring_ is *false*, then
-                1. Let _lhsRef_ be the result of evaluating _lhs_. (It may be evaluated repeatedly.)
+                1. Let _lhsRef_ be Evaluation of _lhs_. (It may be evaluated repeatedly.)
             1. Else,
               1. Assert: _lhsKind_ is ~lexicalBinding~.
               1. Assert: _lhs_ is a |ForDeclaration|.
@@ -22140,7 +22140,7 @@
               1. Else,
                 1. Assert: _iterationKind_ is ~iterate~.
                 1. Return ? IteratorClose(_iteratorRecord_, _status_).
-            1. Let _result_ be the result of evaluating _stmt_.
+            1. Let _result_ be Evaluation of _stmt_.
             1. Set the running execution context's LexicalEnvironment to _oldEnv_.
             1. If LoopContinues(_result_, _labelSet_) is *false*, then
               1. If _iterationKind_ is ~enumerate~, then
@@ -22440,7 +22440,7 @@
       </emu-alg>
       <emu-grammar>ReturnStatement : `return` Expression `;`</emu-grammar>
       <emu-alg>
-        1. Let _exprRef_ be the result of evaluating |Expression|.
+        1. Let _exprRef_ be Evaluation of |Expression|.
         1. Let _exprValue_ be ? GetValue(_exprRef_).
         1. If GetGeneratorKind() is ~async~, set _exprValue_ to ? Await(_exprValue_).
         1. Return Completion Record { [[Type]]: ~return~, [[Value]]: _exprValue_, [[Target]]: ~empty~ }.
@@ -22483,12 +22483,12 @@
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>WithStatement : `with` `(` Expression `)` Statement</emu-grammar>
       <emu-alg>
-        1. Let _val_ be the result of evaluating |Expression|.
+        1. Let _val_ be Evaluation of |Expression|.
         1. Let _obj_ be ? ToObject(? GetValue(_val_)).
         1. Let _oldEnv_ be the running execution context's LexicalEnvironment.
         1. Let _newEnv_ be NewObjectEnvironment(_obj_, *true*, _oldEnv_).
         1. Set the running execution context's LexicalEnvironment to _newEnv_.
-        1. Let _C_ be the result of evaluating |Statement|.
+        1. Let _C_ be Evaluation of |Statement|.
         1. Set the running execution context's LexicalEnvironment to _oldEnv_.
         1. Return ? UpdateEmpty(_C_, *undefined*).
       </emu-alg>
@@ -22554,7 +22554,7 @@
           1. If _found_ is *false*, then
             1. Set _found_ to ? CaseClauseIsSelected(_C_, _input_).
           1. If _found_ is *true*, then
-            1. Let _R_ be the result of evaluating _C_.
+            1. Let _R_ be Evaluation of _C_.
             1. If _R_.[[Value]] is not ~empty~, set _V_ to _R_.[[Value]].
             1. If _R_ is an abrupt completion, return ? UpdateEmpty(_R_, _V_).
         1. Return _V_.
@@ -22571,7 +22571,7 @@
           1. If _found_ is *false*, then
             1. Set _found_ to ? CaseClauseIsSelected(_C_, _input_).
           1. If _found_ is *true*, then
-            1. Let _R_ be the result of evaluating _C_.
+            1. Let _R_ be Evaluation of _C_.
             1. If _R_.[[Value]] is not ~empty~, set _V_ to _R_.[[Value]].
             1. If _R_ is an abrupt completion, return ? UpdateEmpty(_R_, _V_).
         1. Let _foundInB_ be *false*.
@@ -22584,16 +22584,16 @@
             1. If _foundInB_ is *false*, then
               1. Set _foundInB_ to ? CaseClauseIsSelected(_C_, _input_).
             1. If _foundInB_ is *true*, then
-              1. Let _R_ be the result of evaluating |CaseClause| _C_.
+              1. Let _R_ be Evaluation of |CaseClause| _C_.
               1. If _R_.[[Value]] is not ~empty~, set _V_ to _R_.[[Value]].
               1. If _R_ is an abrupt completion, return ? UpdateEmpty(_R_, _V_).
         1. If _foundInB_ is *true*, return _V_.
-        1. Let _R_ be the result of evaluating |DefaultClause|.
+        1. Let _R_ be Evaluation of |DefaultClause|.
         1. If _R_.[[Value]] is not ~empty~, set _V_ to _R_.[[Value]].
         1. If _R_ is an abrupt completion, return ? UpdateEmpty(_R_, _V_).
         1. NOTE: The following is another complete iteration of the second |CaseClauses|.
         1. For each |CaseClause| _C_ of _B_, do
-          1. Let _R_ be the result of evaluating |CaseClause| _C_.
+          1. Let _R_ be Evaluation of |CaseClause| _C_.
           1. If _R_.[[Value]] is not ~empty~, set _V_ to _R_.[[Value]].
           1. If _R_ is an abrupt completion, return ? UpdateEmpty(_R_, _V_).
         1. Return _V_.
@@ -22613,7 +22613,7 @@
       </dl>
       <emu-alg>
         1. Assert: _C_ is an instance of the production <emu-grammar>CaseClause : `case` Expression `:` StatementList?</emu-grammar>.
-        1. Let _exprRef_ be the result of evaluating the |Expression| of _C_.
+        1. Let _exprRef_ be Evaluation of the |Expression| of _C_.
         1. Let _clauseSelector_ be ? GetValue(_exprRef_).
         1. Return IsStrictlyEqual(_input_, _clauseSelector_).
       </emu-alg>
@@ -22626,7 +22626,7 @@
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
       <emu-alg>
-        1. Let _exprRef_ be the result of evaluating |Expression|.
+        1. Let _exprRef_ be Evaluation of |Expression|.
         1. Let _switchValue_ be ? GetValue(_exprRef_).
         1. Let _oldEnv_ be the running execution context's LexicalEnvironment.
         1. Let _blockEnv_ be NewDeclarativeEnvironment(_oldEnv_).
@@ -22645,7 +22645,7 @@
       </emu-alg>
       <emu-grammar>CaseClause : `case` Expression `:` StatementList</emu-grammar>
       <emu-alg>
-        1. Return the result of evaluating |StatementList|.
+        1. Return Evaluation of |StatementList|.
       </emu-alg>
       <emu-grammar>DefaultClause : `default` `:`</emu-grammar>
       <emu-alg>
@@ -22653,7 +22653,7 @@
       </emu-alg>
       <emu-grammar>DefaultClause : `default` `:` StatementList</emu-grammar>
       <emu-alg>
-        1. Return the result of evaluating |StatementList|.
+        1. Return Evaluation of |StatementList|.
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -22730,7 +22730,7 @@
       </emu-alg>
       <emu-grammar>BreakableStatement : SwitchStatement</emu-grammar>
       <emu-alg>
-        1. Let _stmtResult_ be the result of evaluating |SwitchStatement|.
+        1. Let _stmtResult_ be Evaluation of |SwitchStatement|.
         1. If _stmtResult_.[[Type]] is ~break~, then
           1. If _stmtResult_.[[Target]] is ~empty~, then
             1. If _stmtResult_.[[Value]] is ~empty~, set _stmtResult_ to NormalCompletion(*undefined*).
@@ -22751,7 +22751,7 @@
       </emu-alg>
       <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
       <emu-alg>
-        1. Return the result of evaluating |FunctionDeclaration|.
+        1. Return Evaluation of |FunctionDeclaration|.
       </emu-alg>
       <emu-grammar>
         Statement :
@@ -22769,7 +22769,7 @@
           DebuggerStatement
       </emu-grammar>
       <emu-alg>
-        1. Return the result of evaluating |Statement|.
+        1. Return Evaluation of |Statement|.
       </emu-alg>
       <emu-note>
         <p>The only two productions of |Statement| which have special semantics for LabelledEvaluation are |BreakableStatement| and |LabelledStatement|.</p>
@@ -22789,7 +22789,7 @@
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>ThrowStatement : `throw` Expression `;`</emu-grammar>
       <emu-alg>
-        1. Let _exprRef_ be the result of evaluating |Expression|.
+        1. Let _exprRef_ be Evaluation of |Expression|.
         1. Let _exprValue_ be ? GetValue(_exprRef_).
         1. Return ThrowCompletion(_exprValue_).
       </emu-alg>
@@ -22858,13 +22858,13 @@
         1. If _status_ is an abrupt completion, then
           1. Set the running execution context's LexicalEnvironment to _oldEnv_.
           1. Return ? _status_.
-        1. Let _B_ be the result of evaluating |Block|.
+        1. Let _B_ be Evaluation of |Block|.
         1. Set the running execution context's LexicalEnvironment to _oldEnv_.
         1. Return ? _B_.
       </emu-alg>
       <emu-grammar>Catch : `catch` Block</emu-grammar>
       <emu-alg>
-        1. Return the result of evaluating |Block|.
+        1. Return Evaluation of |Block|.
       </emu-alg>
       <emu-note>
         <p>No matter how control leaves the |Block| the LexicalEnvironment is always restored to its former state.</p>
@@ -22875,24 +22875,24 @@
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>TryStatement : `try` Block Catch</emu-grammar>
       <emu-alg>
-        1. Let _B_ be the result of evaluating |Block|.
+        1. Let _B_ be Evaluation of |Block|.
         1. If _B_.[[Type]] is ~throw~, let _C_ be Completion(CatchClauseEvaluation of |Catch| with argument _B_.[[Value]]).
         1. Else, let _C_ be _B_.
         1. Return ? UpdateEmpty(_C_, *undefined*).
       </emu-alg>
       <emu-grammar>TryStatement : `try` Block Finally</emu-grammar>
       <emu-alg>
-        1. Let _B_ be the result of evaluating |Block|.
-        1. Let _F_ be the result of evaluating |Finally|.
+        1. Let _B_ be Evaluation of |Block|.
+        1. Let _F_ be Evaluation of |Finally|.
         1. If _F_.[[Type]] is ~normal~, set _F_ to _B_.
         1. Return ? UpdateEmpty(_F_, *undefined*).
       </emu-alg>
       <emu-grammar>TryStatement : `try` Block Catch Finally</emu-grammar>
       <emu-alg>
-        1. Let _B_ be the result of evaluating |Block|.
+        1. Let _B_ be Evaluation of |Block|.
         1. If _B_.[[Type]] is ~throw~, let _C_ be Completion(CatchClauseEvaluation of |Catch| with argument _B_.[[Value]]).
         1. Else, let _C_ be _B_.
-        1. Let _F_ be the result of evaluating |Finally|.
+        1. Let _F_ be Evaluation of |Finally|.
         1. If _F_.[[Type]] is ~normal~, set _F_ to _C_.
         1. Return ? UpdateEmpty(_F_, *undefined*).
       </emu-alg>
@@ -23325,7 +23325,7 @@
       <emu-grammar>FunctionBody : FunctionStatementList</emu-grammar>
       <emu-alg>
         1. Perform ? FunctionDeclarationInstantiation(_functionObject_, _argumentsList_).
-        1. Return the result of evaluating |FunctionStatementList|.
+        1. Return Evaluation of |FunctionStatementList|.
       </emu-alg>
     </emu-clause>
 
@@ -23508,7 +23508,7 @@
       <emu-grammar>ConciseBody : ExpressionBody</emu-grammar>
       <emu-alg>
         1. Perform ? FunctionDeclarationInstantiation(_functionObject_, _argumentsList_).
-        1. Return the result of evaluating |ExpressionBody|.
+        1. Return Evaluation of |ExpressionBody|.
       </emu-alg>
     </emu-clause>
 
@@ -23543,7 +23543,7 @@
       </emu-alg>
       <emu-grammar>ExpressionBody : AssignmentExpression</emu-grammar>
       <emu-alg>
-        1. Let _exprRef_ be the result of evaluating |AssignmentExpression|.
+        1. Let _exprRef_ be Evaluation of |AssignmentExpression|.
         1. Let _exprValue_ be ? GetValue(_exprRef_).
         1. Return Completion Record { [[Type]]: ~return~, [[Value]]: _exprValue_, [[Target]]: ~empty~ }.
       </emu-alg>
@@ -23660,7 +23660,7 @@
       </dl>
       <emu-grammar>MethodDefinition : ClassElementName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
-        1. Let _propKey_ be the result of evaluating |ClassElementName|.
+        1. Let _propKey_ be Evaluation of |ClassElementName|.
         1. ReturnIfAbrupt(_propKey_).
         1. Let _env_ be the running execution context's LexicalEnvironment.
         1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
@@ -23692,7 +23692,7 @@
       </emu-alg>
       <emu-grammar>MethodDefinition : `get` ClassElementName `(` `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
-        1. Let _propKey_ be the result of evaluating |ClassElementName|.
+        1. Let _propKey_ be Evaluation of |ClassElementName|.
         1. ReturnIfAbrupt(_propKey_).
         1. Let _env_ be the running execution context's LexicalEnvironment.
         1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
@@ -23710,7 +23710,7 @@
       </emu-alg>
       <emu-grammar>MethodDefinition : `set` ClassElementName `(` PropertySetParameterList `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
-        1. Let _propKey_ be the result of evaluating |ClassElementName|.
+        1. Let _propKey_ be Evaluation of |ClassElementName|.
         1. ReturnIfAbrupt(_propKey_).
         1. Let _env_ be the running execution context's LexicalEnvironment.
         1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
@@ -23727,7 +23727,7 @@
       </emu-alg>
       <emu-grammar>GeneratorMethod : `*` ClassElementName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
-        1. Let _propKey_ be the result of evaluating |ClassElementName|.
+        1. Let _propKey_ be Evaluation of |ClassElementName|.
         1. ReturnIfAbrupt(_propKey_).
         1. Let _env_ be the running execution context's LexicalEnvironment.
         1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
@@ -23743,7 +23743,7 @@
         AsyncGeneratorMethod : `async` `*` ClassElementName `(` UniqueFormalParameters `)` `{` AsyncGeneratorBody `}`
       </emu-grammar>
       <emu-alg>
-        1. Let _propKey_ be the result of evaluating |ClassElementName|.
+        1. Let _propKey_ be Evaluation of |ClassElementName|.
         1. ReturnIfAbrupt(_propKey_).
         1. Let _env_ be the running execution context's LexicalEnvironment.
         1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
@@ -23759,7 +23759,7 @@
         AsyncMethod : `async` ClassElementName `(` UniqueFormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
       <emu-alg>
-        1. Let _propKey_ be the result of evaluating |ClassElementName|.
+        1. Let _propKey_ be Evaluation of |ClassElementName|.
         1. ReturnIfAbrupt(_propKey_).
         1. Let _env_ be the LexicalEnvironment of the running execution context.
         1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
@@ -23967,14 +23967,14 @@
       </emu-alg>
       <emu-grammar>YieldExpression : `yield` AssignmentExpression</emu-grammar>
       <emu-alg>
-        1. Let _exprRef_ be the result of evaluating |AssignmentExpression|.
+        1. Let _exprRef_ be Evaluation of |AssignmentExpression|.
         1. Let _value_ be ? GetValue(_exprRef_).
         1. Return ? Yield(_value_).
       </emu-alg>
       <emu-grammar>YieldExpression : `yield` `*` AssignmentExpression</emu-grammar>
       <emu-alg>
         1. Let _generatorKind_ be GetGeneratorKind().
-        1. Let _exprRef_ be the result of evaluating |AssignmentExpression|.
+        1. Let _exprRef_ be Evaluation of |AssignmentExpression|.
         1. Let _value_ be ? GetValue(_exprRef_).
         1. Let _iteratorRecord_ be ? GetIterator(_value_, _generatorKind_).
         1. Let _iterator_ be _iteratorRecord_.[[Iterator]].
@@ -24666,7 +24666,7 @@
         FieldDefinition : ClassElementName Initializer?
       </emu-grammar>
       <emu-alg>
-        1. Let _name_ be the result of evaluating |ClassElementName|.
+        1. Let _name_ be Evaluation of |ClassElementName|.
         1. ReturnIfAbrupt(_name_).
         1. If |Initializer?| is present, then
           1. Let _formalParameterList_ be an instance of the production <emu-grammar>FormalParameters : [empty]</emu-grammar>.
@@ -24717,7 +24717,7 @@
       <emu-grammar>ClassStaticBlockBody : ClassStaticBlockStatementList</emu-grammar>
       <emu-alg>
         1. Perform ? FunctionDeclarationInstantiation(_functionObject_, &laquo; &raquo;).
-        1. Return the result of evaluating |ClassStaticBlockStatementList|.
+        1. Return Evaluation of |ClassStaticBlockStatementList|.
       </emu-alg>
     </emu-clause>
 
@@ -24796,7 +24796,7 @@
         1. Else,
           1. Set the running execution context's LexicalEnvironment to _classEnv_.
           1. NOTE: The running execution context's PrivateEnvironment is _outerPrivateEnvironment_ when evaluating |ClassHeritage|.
-          1. Let _superclassRef_ be the result of evaluating |ClassHeritage|.
+          1. Let _superclassRef_ be Evaluation of |ClassHeritage|.
           1. Set the running execution context's LexicalEnvironment to _env_.
           1. Let _superclass_ be ? GetValue(_superclassRef_).
           1. If _superclass_ is *null*, then
@@ -25133,7 +25133,7 @@
         AwaitExpression : `await` UnaryExpression
       </emu-grammar>
       <emu-alg>
-        1. Let _exprRef_ be the result of evaluating |UnaryExpression|.
+        1. Let _exprRef_ be Evaluation of |UnaryExpression|.
         1. Let _value_ be ? GetValue(_exprRef_).
         1. Return ? Await(_value_).
       </emu-alg>
@@ -25829,7 +25829,7 @@
         1. Let _script_ be _scriptRecord_.[[ECMAScriptCode]].
         1. Let _result_ be Completion(GlobalDeclarationInstantiation(_script_, _globalEnv_)).
         1. If _result_.[[Type]] is ~normal~, then
-          1. Set _result_ to the result of evaluating _script_.
+          1. Set _result_ to Evaluation of _script_.
         1. If _result_.[[Type]] is ~normal~ and _result_.[[Value]] is ~empty~, then
           1. Set _result_ to NormalCompletion(*undefined*).
         1. Suspend _scriptContext_ and remove it from the execution context stack.
@@ -27774,7 +27774,7 @@
             1. If _module_.[[HasTLA]] is *false*, then
               1. Assert: _capability_ is not present.
               1. Push _moduleContext_ onto the execution context stack; _moduleContext_ is now the running execution context.
-              1. Let _result_ be the result of evaluating _module_.[[ECMAScriptCode]].
+              1. Let _result_ be Evaluation of _module_.[[ECMAScriptCode]].
               1. Suspend _moduleContext_ and remove it from the execution context stack.
               1. Resume the context that is now on the top of the execution context stack as the running execution context.
               1. If _result_ is an abrupt completion, then
@@ -27943,16 +27943,16 @@
         </emu-alg>
         <emu-grammar>ModuleBody : ModuleItemList</emu-grammar>
         <emu-alg>
-          1. Let _result_ be the result of evaluating |ModuleItemList|.
+          1. Let _result_ be Evaluation of |ModuleItemList|.
           1. If _result_.[[Type]] is ~normal~ and _result_.[[Value]] is ~empty~, then
             1. Return *undefined*.
           1. Return ? _result_.
         </emu-alg>
         <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
         <emu-alg>
-          1. Let _sl_ be the result of evaluating |ModuleItemList|.
+          1. Let _sl_ be Evaluation of |ModuleItemList|.
           1. ReturnIfAbrupt(_sl_).
-          1. Let _s_ be the result of evaluating |ModuleItem|.
+          1. Let _s_ be Evaluation of |ModuleItem|.
           1. Return ? UpdateEmpty(_s_, _sl_).
         </emu-alg>
         <emu-note>
@@ -28468,15 +28468,15 @@
         </emu-alg>
         <emu-grammar>ExportDeclaration : `export` VariableStatement</emu-grammar>
         <emu-alg>
-          1. Return the result of evaluating |VariableStatement|.
+          1. Return Evaluation of |VariableStatement|.
         </emu-alg>
         <emu-grammar>ExportDeclaration : `export` Declaration</emu-grammar>
         <emu-alg>
-          1. Return the result of evaluating |Declaration|.
+          1. Return Evaluation of |Declaration|.
         </emu-alg>
         <emu-grammar>ExportDeclaration : `export` `default` HoistableDeclaration</emu-grammar>
         <emu-alg>
-          1. Return the result of evaluating |HoistableDeclaration|.
+          1. Return Evaluation of |HoistableDeclaration|.
         </emu-alg>
         <emu-grammar>ExportDeclaration : `export` `default` ClassDeclaration</emu-grammar>
         <emu-alg>
@@ -28492,7 +28492,7 @@
           1. If IsAnonymousFunctionDefinition(|AssignmentExpression|) is *true*, then
             1. Let _value_ be ? NamedEvaluation of |AssignmentExpression| with argument *"default"*.
           1. Else,
-            1. Let _rhs_ be the result of evaluating |AssignmentExpression|.
+            1. Let _rhs_ be Evaluation of |AssignmentExpression|.
             1. Let _value_ be ? GetValue(_rhs_).
           1. Let _env_ be the running execution context's LexicalEnvironment.
           1. Perform ? InitializeBoundName(*"\*default\*"*, _value_, _env_).
@@ -28695,7 +28695,7 @@
           1. Push _evalContext_ onto the execution context stack; _evalContext_ is now the running execution context.
           1. Let _result_ be Completion(EvalDeclarationInstantiation(_body_, _varEnv_, _lexEnv_, _privateEnv_, _strictEval_)).
           1. If _result_.[[Type]] is ~normal~, then
-            1. Set _result_ to the result of evaluating _body_.
+            1. Set _result_ to Evaluation of _body_.
           1. If _result_.[[Type]] is ~normal~ and _result_.[[Value]] is ~empty~, then
             1. Set _result_ to NormalCompletion(*undefined*).
           1. Suspend _evalContext_ and remove it from the execution context stack.
@@ -42396,7 +42396,7 @@ THH:mm:ss.sss
         1. [id="step-json-parse-parse"] Let _script_ be ParseText(StringToCodePoints(_scriptString_), |Script|).
         1. NOTE: The early error rules defined in <emu-xref href="#sec-object-initializer-static-semantics-early-errors"></emu-xref> have special handling for the above invocation of ParseText.
         1. Assert: _script_ is a Parse Node.
-        1. [id="step-json-parse-eval"] Let _completion_ be the result of <emu-meta suppress-effects="user-code">evaluating _script_</emu-meta>.
+        1. [id="step-json-parse-eval"] Let _completion_ be <emu-meta suppress-effects="user-code">Evaluation of _script_</emu-meta>.
         1. NOTE: The PropertyDefinitionEvaluation semantics defined in <emu-xref href="#sec-runtime-semantics-propertydefinitionevaluation"></emu-xref> have special handling for the above evaluation.
         1. Let _unfiltered_ be _completion_.[[Value]].
         1. [id="step-json-parse-assert-type"] Assert: _unfiltered_ is either a String, Number, Boolean, Null, or an Object that is defined by either an |ArrayLiteral| or an |ObjectLiteral|.
@@ -45034,7 +45034,7 @@ THH:mm:ss.sss
           1. Set the Generator component of _genContext_ to _generator_.
           1. [fence-effects="user-code"] Set the code evaluation state of _genContext_ such that when evaluation is resumed for that execution context the following steps will be performed:
             1. If _generatorBody_ is a Parse Node, then
-              1. Let _result_ be the result of evaluating _generatorBody_.
+              1. Let _result_ be Evaluation of _generatorBody_.
             1. Else,
               1. Assert: _generatorBody_ is an Abstract Closure with no parameters.
               1. Let _result_ be _generatorBody_().
@@ -45387,7 +45387,7 @@ THH:mm:ss.sss
           1. Set the Generator component of _genContext_ to _generator_.
           1. [fence-effects="user-code"] Set the code evaluation state of _genContext_ such that when evaluation is resumed for that execution context the following steps will be performed:
             1. If _generatorBody_ is a Parse Node, then
-              1. Let _result_ be the result of evaluating _generatorBody_.
+              1. Let _result_ be Evaluation of _generatorBody_.
             1. Else,
               1. Assert: _generatorBody_ is an Abstract Closure with no parameters.
               1. Let _result_ be Completion(_generatorBody_()).
@@ -45780,7 +45780,7 @@ THH:mm:ss.sss
           1. Assert: _promiseCapability_ is a PromiseCapability Record.
           1. Let _runningContext_ be the running execution context.
           1. [fence-effects="user-code"] Set the code evaluation state of _asyncContext_ such that when evaluation is resumed for that execution context the following steps will be performed:
-            1. Let _result_ be the result of evaluating _asyncBody_.
+            1. Let _result_ be Evaluation of _asyncBody_.
             1. Assert: If we return here, the async function either threw an exception or performed an implicit or explicit return; all awaiting is done.
             1. Remove _asyncContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
             1. If _result_.[[Type]] is ~normal~, then
@@ -48119,7 +48119,7 @@ THH:mm:ss.sss
         1. If IsAnonymousFunctionDefinition(|Initializer|) is *true*, then
           1. Let _value_ be ? NamedEvaluation of |Initializer| with argument _bindingId_.
         1. Else,
-          1. Let _rhs_ be the result of evaluating |Initializer|.
+          1. Let _rhs_ be Evaluation of |Initializer|.
           1. Let _value_ be ? GetValue(_rhs_).
         1. Perform ? PutValue(_lhs_, _value_).
         1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(&laquo; &raquo;, |Expression|, ~enumerate~).

--- a/spec.html
+++ b/spec.html
@@ -961,7 +961,6 @@
         <ul>
           <li>when the result of applying Completion, NormalCompletion, or ThrowCompletion is directly returned</li>
           <li>when the result of constructing a Completion Record is directly returned</li>
-          <li>when directly returning with the phrase "Evaluation of"</li>
         </ul>
         <p>It is an editorial error if a Completion Record is returned from such an abstract operation through any other means. For example, within these abstract operations,</p>
         <emu-alg example>
@@ -9662,7 +9661,7 @@
           1. If IsAnonymousFunctionDefinition(|Initializer|) is *true*, then
             1. Set _v_ to ? NamedEvaluation of |Initializer| with argument _bindingId_.
           1. Else,
-            1. Let _defaultValue_ be Evaluation of |Initializer|.
+            1. Let _defaultValue_ be ? Evaluation of |Initializer|.
             1. Set _v_ to ? GetValue(_defaultValue_).
         1. If _environment_ is *undefined*, return ? PutValue(_lhs_, _v_).
         1. Return ? InitializeReferencedBinding(_lhs_, _v_).
@@ -9680,7 +9679,7 @@
             1. If _v_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
             1. ReturnIfAbrupt(_v_).
         1. If |Initializer| is present and _v_ is *undefined*, then
-          1. Let _defaultValue_ be Evaluation of |Initializer|.
+          1. Let _defaultValue_ be ? Evaluation of |Initializer|.
           1. Set _v_ to ? GetValue(_defaultValue_).
         1. Return ? BindingInitialization of |BindingPattern| with arguments _v_ and _environment_.
       </emu-alg>
@@ -13381,7 +13380,7 @@
           1. If IsAnonymousFunctionDefinition(|AssignmentExpression|) is *true*, then
             1. Let _value_ be ? NamedEvaluation of |Initializer| with argument _functionObject_.[[ClassFieldInitializerName]].
           1. Else,
-            1. Let _rhs_ be Evaluation of |AssignmentExpression|.
+            1. Let _rhs_ be ? Evaluation of |AssignmentExpression|.
             1. Let _value_ be ? GetValue(_rhs_).
           1. Return Completion Record { [[Type]]: ~return~, [[Value]]: _value_, [[Target]]: ~empty~ }.
         </emu-alg>
@@ -18136,7 +18135,7 @@
         <emu-alg>
           1. If |Elision| is present, then
             1. Set _nextIndex_ to ? ArrayAccumulation of |Elision| with arguments _array_ and _nextIndex_.
-          1. Let _initResult_ be Evaluation of |AssignmentExpression|.
+          1. Let _initResult_ be ? Evaluation of |AssignmentExpression|.
           1. Let _initValue_ be ? GetValue(_initResult_).
           1. Let _created_ be ! CreateDataPropertyOrThrow(_array_, ! ToString(𝔽(_nextIndex_)), _initValue_).
           1. Return _nextIndex_ + 1.
@@ -18152,7 +18151,7 @@
           1. Set _nextIndex_ to ? ArrayAccumulation of |ElementList| with arguments _array_ and _nextIndex_.
           1. If |Elision| is present, then
             1. Set _nextIndex_ to ? ArrayAccumulation of |Elision| with arguments _array_ and _nextIndex_.
-          1. Let _initResult_ be Evaluation of |AssignmentExpression|.
+          1. Let _initResult_ be ? Evaluation of |AssignmentExpression|.
           1. Let _initValue_ be ? GetValue(_initResult_).
           1. Let _created_ be ! CreateDataPropertyOrThrow(_array_, ! ToString(𝔽(_nextIndex_)), _initValue_).
           1. Return _nextIndex_ + 1.
@@ -18166,7 +18165,7 @@
         </emu-alg>
         <emu-grammar>SpreadElement : `...` AssignmentExpression</emu-grammar>
         <emu-alg>
-          1. Let _spreadRef_ be Evaluation of |AssignmentExpression|.
+          1. Let _spreadRef_ be ? Evaluation of |AssignmentExpression|.
           1. Let _spreadObj_ be ? GetValue(_spreadRef_).
           1. Let _iteratorRecord_ be ? GetIterator(_spreadObj_).
           1. Repeat,
@@ -18355,7 +18354,7 @@
         </emu-alg>
         <emu-grammar>ComputedPropertyName : `[` AssignmentExpression `]`</emu-grammar>
         <emu-alg>
-          1. Let _exprValue_ be Evaluation of |AssignmentExpression|.
+          1. Let _exprValue_ be ? Evaluation of |AssignmentExpression|.
           1. Let _propName_ be ? GetValue(_exprValue_).
           1. Return ? ToPropertyKey(_propName_).
         </emu-alg>
@@ -18377,7 +18376,7 @@
         </emu-alg>
         <emu-grammar>PropertyDefinition : `...` AssignmentExpression</emu-grammar>
         <emu-alg>
-          1. Let _exprValue_ be Evaluation of |AssignmentExpression|.
+          1. Let _exprValue_ be ? Evaluation of |AssignmentExpression|.
           1. Let _fromValue_ be ? GetValue(_exprValue_).
           1. Let _excludedNames_ be a new empty List.
           1. Perform ? CopyDataProperties(_object_, _fromValue_, _excludedNames_).
@@ -18386,7 +18385,7 @@
         <emu-grammar>PropertyDefinition : IdentifierReference</emu-grammar>
         <emu-alg>
           1. Let _propName_ be StringValue of |IdentifierReference|.
-          1. Let _exprValue_ be Evaluation of |IdentifierReference|.
+          1. Let _exprValue_ be ? Evaluation of |IdentifierReference|.
           1. Let _propValue_ be ? GetValue(_exprValue_).
           1. Assert: _object_ is an ordinary, extensible object with no non-configurable properties.
           1. Perform ! CreateDataPropertyOrThrow(_object_, _propName_, _propValue_).
@@ -18394,8 +18393,7 @@
         </emu-alg>
         <emu-grammar>PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar>
         <emu-alg>
-          1. Let _propKey_ be Evaluation of |PropertyName|.
-          1. ReturnIfAbrupt(_propKey_).
+          1. Let _propKey_ be ? Evaluation of |PropertyName|.
           1. If this |PropertyDefinition| is contained within a |Script| that is being evaluated for JSON.parse (see step <emu-xref href="#step-json-parse-eval"></emu-xref> of <emu-xref href="#sec-json.parse">JSON.parse</emu-xref>), then
             1. Let _isProtoSetter_ be *false*.
           1. Else if _propKey_ is the String value *"__proto__"* and if IsComputedPropertyKey of |PropertyName| is *false*, then
@@ -18405,7 +18403,7 @@
           1. If IsAnonymousFunctionDefinition(|AssignmentExpression|) is *true* and _isProtoSetter_ is *false*, then
             1. Let _propValue_ be ? NamedEvaluation of |AssignmentExpression| with argument _propKey_.
           1. Else,
-            1. Let _exprValueRef_ be Evaluation of |AssignmentExpression|.
+            1. Let _exprValueRef_ be ? Evaluation of |AssignmentExpression|.
             1. Let _propValue_ be ? GetValue(_exprValueRef_).
           1. If _isProtoSetter_ is *true*, then
             1. If Type(_propValue_) is either Object or Null, then
@@ -18670,14 +18668,14 @@
         </emu-alg>
         <emu-grammar>TemplateMiddleList : TemplateMiddle Expression</emu-grammar>
         <emu-alg>
-          1. Let _subRef_ be Evaluation of |Expression|.
+          1. Let _subRef_ be ? Evaluation of |Expression|.
           1. Let _sub_ be ? GetValue(_subRef_).
           1. Return &laquo; _sub_ &raquo;.
         </emu-alg>
         <emu-grammar>TemplateMiddleList : TemplateMiddleList TemplateMiddle Expression</emu-grammar>
         <emu-alg>
           1. Let _preceding_ be ? SubstitutionEvaluation of |TemplateMiddleList|.
-          1. Let _nextRef_ be Evaluation of |Expression|.
+          1. Let _nextRef_ be ? Evaluation of |Expression|.
           1. Let _next_ be ? GetValue(_nextRef_).
           1. Return the list-concatenation of _preceding_ and &laquo; _next_ &raquo;.
         </emu-alg>
@@ -18692,11 +18690,10 @@
         <emu-grammar>SubstitutionTemplate : TemplateHead Expression TemplateSpans</emu-grammar>
         <emu-alg>
           1. Let _head_ be the TV of |TemplateHead| as defined in <emu-xref href="#sec-template-literal-lexical-components"></emu-xref>.
-          1. Let _subRef_ be Evaluation of |Expression|.
+          1. Let _subRef_ be ? Evaluation of |Expression|.
           1. Let _sub_ be ? GetValue(_subRef_).
           1. Let _middle_ be ? ToString(_sub_).
-          1. Let _tail_ be Evaluation of |TemplateSpans|.
-          1. ReturnIfAbrupt(_tail_).
+          1. Let _tail_ be ? Evaluation of |TemplateSpans|.
           1. Return the string-concatenation of _head_, _middle_, and _tail_.
         </emu-alg>
         <emu-note>
@@ -18708,15 +18705,14 @@
         </emu-alg>
         <emu-grammar>TemplateSpans : TemplateMiddleList TemplateTail</emu-grammar>
         <emu-alg>
-          1. Let _head_ be Evaluation of |TemplateMiddleList|.
-          1. ReturnIfAbrupt(_head_).
+          1. Let _head_ be ? Evaluation of |TemplateMiddleList|.
           1. Let _tail_ be the TV of |TemplateTail| as defined in <emu-xref href="#sec-template-literal-lexical-components"></emu-xref>.
           1. Return the string-concatenation of _head_ and _tail_.
         </emu-alg>
         <emu-grammar>TemplateMiddleList : TemplateMiddle Expression</emu-grammar>
         <emu-alg>
           1. Let _head_ be the TV of |TemplateMiddle| as defined in <emu-xref href="#sec-template-literal-lexical-components"></emu-xref>.
-          1. Let _subRef_ be Evaluation of |Expression|.
+          1. Let _subRef_ be ? Evaluation of |Expression|.
           1. Let _sub_ be ? GetValue(_subRef_).
           1. Let _middle_ be ? ToString(_sub_).
           1. Return the string-concatenation of _head_ and _middle_.
@@ -18726,10 +18722,9 @@
         </emu-note>
         <emu-grammar>TemplateMiddleList : TemplateMiddleList TemplateMiddle Expression</emu-grammar>
         <emu-alg>
-          1. Let _rest_ be Evaluation of |TemplateMiddleList|.
-          1. ReturnIfAbrupt(_rest_).
+          1. Let _rest_ be ? Evaluation of |TemplateMiddleList|.
           1. Let _middle_ be the TV of |TemplateMiddle| as defined in <emu-xref href="#sec-template-literal-lexical-components"></emu-xref>.
-          1. Let _subRef_ be Evaluation of |Expression|.
+          1. Let _subRef_ be ? Evaluation of |Expression|.
           1. Let _sub_ be ? GetValue(_subRef_).
           1. Let _last_ be ? ToString(_sub_).
           1. Return the string-concatenation of _rest_, _middle_, and _last_.
@@ -18758,11 +18753,11 @@
         <emu-grammar>PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
         <emu-alg>
           1. Let _expr_ be the |ParenthesizedExpression| that is covered by |CoverParenthesizedExpressionAndArrowParameterList|.
-          1. Return Evaluation of _expr_.
+          1. Return ? Evaluation of _expr_.
         </emu-alg>
         <emu-grammar>ParenthesizedExpression : `(` Expression `)`</emu-grammar>
         <emu-alg>
-          1. Return Evaluation of |Expression|. This may be of type Reference.
+          1. Return ? Evaluation of |Expression|. This may be of type Reference.
         </emu-alg>
         <emu-note>
           <p>This algorithm does not apply GetValue to Evaluation of |Expression|. The principal motivation for this is so that operators such as `delete` and `typeof` may be applied to parenthesized expressions.</p>
@@ -18940,42 +18935,42 @@
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>MemberExpression : MemberExpression `[` Expression `]`</emu-grammar>
         <emu-alg>
-          1. Let _baseReference_ be Evaluation of |MemberExpression|.
+          1. Let _baseReference_ be ? Evaluation of |MemberExpression|.
           1. Let _baseValue_ be ? GetValue(_baseReference_).
           1. If the source text matched by this |MemberExpression| is strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
           1. Return ? EvaluatePropertyAccessWithExpressionKey(_baseValue_, |Expression|, _strict_).
         </emu-alg>
         <emu-grammar>MemberExpression : MemberExpression `.` IdentifierName</emu-grammar>
         <emu-alg>
-          1. Let _baseReference_ be Evaluation of |MemberExpression|.
+          1. Let _baseReference_ be ? Evaluation of |MemberExpression|.
           1. Let _baseValue_ be ? GetValue(_baseReference_).
           1. If the source text matched by this |MemberExpression| is strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
           1. Return EvaluatePropertyAccessWithIdentifierKey(_baseValue_, |IdentifierName|, _strict_).
         </emu-alg>
         <emu-grammar>MemberExpression : MemberExpression `.` PrivateIdentifier</emu-grammar>
         <emu-alg>
-          1. Let _baseReference_ be Evaluation of |MemberExpression|.
+          1. Let _baseReference_ be ? Evaluation of |MemberExpression|.
           1. Let _baseValue_ be ? GetValue(_baseReference_).
           1. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
           1. Return MakePrivateReference(_baseValue_, _fieldNameString_).
         </emu-alg>
         <emu-grammar>CallExpression : CallExpression `[` Expression `]`</emu-grammar>
         <emu-alg>
-          1. Let _baseReference_ be Evaluation of |CallExpression|.
+          1. Let _baseReference_ be ? Evaluation of |CallExpression|.
           1. Let _baseValue_ be ? GetValue(_baseReference_).
           1. If the source text matched by this |CallExpression| is strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
           1. Return ? EvaluatePropertyAccessWithExpressionKey(_baseValue_, |Expression|, _strict_).
         </emu-alg>
         <emu-grammar>CallExpression : CallExpression `.` IdentifierName</emu-grammar>
         <emu-alg>
-          1. Let _baseReference_ be Evaluation of |CallExpression|.
+          1. Let _baseReference_ be ? Evaluation of |CallExpression|.
           1. Let _baseValue_ be ? GetValue(_baseReference_).
           1. If the source text matched by this |CallExpression| is strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
           1. Return EvaluatePropertyAccessWithIdentifierKey(_baseValue_, |IdentifierName|, _strict_).
         </emu-alg>
         <emu-grammar>CallExpression : CallExpression `.` PrivateIdentifier</emu-grammar>
         <emu-alg>
-          1. Let _baseReference_ be Evaluation of |CallExpression|.
+          1. Let _baseReference_ be ? Evaluation of |CallExpression|.
           1. Let _baseValue_ be ? GetValue(_baseReference_).
           1. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
           1. Return MakePrivateReference(_baseValue_, _fieldNameString_).
@@ -18994,7 +18989,7 @@
       <dl class="header">
       </dl>
       <emu-alg>
-        1. Let _propertyNameReference_ be Evaluation of _expression_.
+        1. Let _propertyNameReference_ be ? Evaluation of _expression_.
         1. Let _propertyNameValue_ be ? GetValue(_propertyNameReference_).
         1. Let _propertyKey_ be ? ToPropertyKey(_propertyNameValue_).
         1. Return the Reference Record { [[Base]]: _baseValue_, [[ReferencedName]]: _propertyKey_, [[Strict]]: _strict_, [[ThisValue]]: ~empty~ }.
@@ -19041,7 +19036,7 @@
           <dl class="header">
           </dl>
           <emu-alg>
-            1. Let _ref_ be Evaluation of _constructExpr_.
+            1. Let _ref_ be ? Evaluation of _constructExpr_.
             1. Let _constructor_ be ? GetValue(_ref_).
             1. If _arguments_ is ~empty~, let _argList_ be a new empty List.
             1. Else,
@@ -19063,7 +19058,7 @@
           1. Let _expr_ be the |CallMemberExpression| that is covered by |CoverCallExpressionAndAsyncArrowHead|.
           1. Let _memberExpr_ be the |MemberExpression| of _expr_.
           1. Let _arguments_ be the |Arguments| of _expr_.
-          1. Let _ref_ be Evaluation of _memberExpr_.
+          1. Let _ref_ be ? Evaluation of _memberExpr_.
           1. Let _func_ be ? GetValue(_ref_).
           1. If _ref_ is a Reference Record, IsPropertyReference(_ref_) is *false*, and _ref_.[[ReferencedName]] is *"eval"*, then
             1. If SameValue(_func_, %eval%) is *true*, then
@@ -19079,7 +19074,7 @@
         <p>A |CallExpression| evaluation that executes step <emu-xref href="#step-callexpression-evaluation-direct-eval"></emu-xref> is a <dfn variants="direct evals">direct eval</dfn>.</p>
         <emu-grammar>CallExpression : CallExpression Arguments</emu-grammar>
         <emu-alg>
-          1. Let _ref_ be Evaluation of |CallExpression|.
+          1. Let _ref_ be ? Evaluation of |CallExpression|.
           1. Let _func_ be ? GetValue(_ref_).
           1. Let _thisCall_ be this |CallExpression|.
           1. Let _tailCall_ be IsInTailPosition(_thisCall_).
@@ -19126,7 +19121,7 @@
         <emu-alg>
           1. Let _env_ be GetThisEnvironment().
           1. Let _actualThis_ be ? _env_.GetThisBinding().
-          1. Let _propertyNameReference_ be Evaluation of |Expression|.
+          1. Let _propertyNameReference_ be ? Evaluation of |Expression|.
           1. Let _propertyNameValue_ be ? GetValue(_propertyNameReference_).
           1. Let _propertyKey_ be ? ToPropertyKey(_propertyNameValue_).
           1. If the source text matched by this |SuperProperty| is strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
@@ -19206,14 +19201,14 @@
         </emu-alg>
         <emu-grammar>ArgumentList : AssignmentExpression</emu-grammar>
         <emu-alg>
-          1. Let _ref_ be Evaluation of |AssignmentExpression|.
+          1. Let _ref_ be ? Evaluation of |AssignmentExpression|.
           1. Let _arg_ be ? GetValue(_ref_).
           1. Return &laquo; _arg_ &raquo;.
         </emu-alg>
         <emu-grammar>ArgumentList : `...` AssignmentExpression</emu-grammar>
         <emu-alg>
           1. Let _list_ be a new empty List.
-          1. Let _spreadRef_ be Evaluation of |AssignmentExpression|.
+          1. Let _spreadRef_ be ? Evaluation of |AssignmentExpression|.
           1. Let _spreadObj_ be ? GetValue(_spreadRef_).
           1. Let _iteratorRecord_ be ? GetIterator(_spreadObj_).
           1. Repeat,
@@ -19225,14 +19220,14 @@
         <emu-grammar>ArgumentList : ArgumentList `,` AssignmentExpression</emu-grammar>
         <emu-alg>
           1. Let _precedingArgs_ be ? ArgumentListEvaluation of |ArgumentList|.
-          1. Let _ref_ be Evaluation of |AssignmentExpression|.
+          1. Let _ref_ be ? Evaluation of |AssignmentExpression|.
           1. Let _arg_ be ? GetValue(_ref_).
           1. Return the list-concatenation of _precedingArgs_ and &laquo; _arg_ &raquo;.
         </emu-alg>
         <emu-grammar>ArgumentList : ArgumentList `,` `...` AssignmentExpression</emu-grammar>
         <emu-alg>
           1. Let _precedingArgs_ be ? ArgumentListEvaluation of |ArgumentList|.
-          1. Let _spreadRef_ be Evaluation of |AssignmentExpression|.
+          1. Let _spreadRef_ be ? Evaluation of |AssignmentExpression|.
           1. Let _iteratorRecord_ be ? GetIterator(? GetValue(_spreadRef_)).
           1. Repeat,
             1. Let _next_ be ? IteratorStep(_iteratorRecord_).
@@ -19255,7 +19250,7 @@
         </emu-alg>
         <emu-grammar>SubstitutionTemplate : TemplateHead Expression TemplateSpans</emu-grammar>
         <emu-alg>
-          1. Let _firstSubRef_ be Evaluation of |Expression|.
+          1. Let _firstSubRef_ be ? Evaluation of |Expression|.
           1. Let _firstSub_ be ? GetValue(_firstSubRef_).
           1. Let _restSub_ be ? SubstitutionEvaluation of |TemplateSpans|.
           1. Assert: _restSub_ is a possibly empty List.
@@ -19275,7 +19270,7 @@
             MemberExpression OptionalChain
         </emu-grammar>
         <emu-alg>
-          1. Let _baseReference_ be Evaluation of |MemberExpression|.
+          1. Let _baseReference_ be ? Evaluation of |MemberExpression|.
           1. Let _baseValue_ be ? GetValue(_baseReference_).
           1. If _baseValue_ is *undefined* or *null*, then
             1. Return *undefined*.
@@ -19286,7 +19281,7 @@
             CallExpression OptionalChain
         </emu-grammar>
         <emu-alg>
-          1. Let _baseReference_ be Evaluation of |CallExpression|.
+          1. Let _baseReference_ be ? Evaluation of |CallExpression|.
           1. Let _baseValue_ be ? GetValue(_baseReference_).
           1. If _baseValue_ is *undefined* or *null*, then
             1. Return *undefined*.
@@ -19297,7 +19292,7 @@
             OptionalExpression OptionalChain
         </emu-grammar>
         <emu-alg>
-          1. Let _baseReference_ be Evaluation of |OptionalExpression|.
+          1. Let _baseReference_ be ? Evaluation of |OptionalExpression|.
           1. Let _baseValue_ be ? GetValue(_baseReference_).
           1. If _baseValue_ is *undefined* or *null*, then
             1. Return *undefined*.
@@ -19380,7 +19375,7 @@
         <emu-grammar>ImportCall : `import` `(` AssignmentExpression `)`</emu-grammar>
         <emu-alg>
           1. Let _referencingScriptOrModule_ be GetActiveScriptOrModule().
-          1. Let _argRef_ be Evaluation of |AssignmentExpression|.
+          1. Let _argRef_ be ? Evaluation of |AssignmentExpression|.
           1. Let _specifier_ be ? GetValue(_argRef_).
           1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
           1. Let _specifierString_ be Completion(ToString(_specifier_)).
@@ -19401,7 +19396,7 @@
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>MemberExpression : MemberExpression TemplateLiteral</emu-grammar>
         <emu-alg>
-          1. Let _tagRef_ be Evaluation of |MemberExpression|.
+          1. Let _tagRef_ be ? Evaluation of |MemberExpression|.
           1. Let _tagFunc_ be ? GetValue(_tagRef_).
           1. Let _thisCall_ be this |MemberExpression|.
           1. Let _tailCall_ be IsInTailPosition(_thisCall_).
@@ -19409,7 +19404,7 @@
         </emu-alg>
         <emu-grammar>CallExpression : CallExpression TemplateLiteral</emu-grammar>
         <emu-alg>
-          1. Let _tagRef_ be Evaluation of |CallExpression|.
+          1. Let _tagRef_ be ? Evaluation of |CallExpression|.
           1. Let _tagFunc_ be ? GetValue(_tagRef_).
           1. Let _thisCall_ be this |CallExpression|.
           1. Let _tailCall_ be IsInTailPosition(_thisCall_).
@@ -19536,7 +19531,7 @@
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>UpdateExpression : LeftHandSideExpression `++`</emu-grammar>
         <emu-alg>
-          1. Let _lhs_ be Evaluation of |LeftHandSideExpression|.
+          1. Let _lhs_ be ? Evaluation of |LeftHandSideExpression|.
           1. Let _oldValue_ be ? ToNumeric(? GetValue(_lhs_)).
           1. If Type(_oldValue_) is Number, then
             1. Let _newValue_ be Number::add(_oldValue_, *1*<sub>𝔽</sub>).
@@ -19556,7 +19551,7 @@
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>UpdateExpression : LeftHandSideExpression `--`</emu-grammar>
         <emu-alg>
-          1. Let _lhs_ be Evaluation of |LeftHandSideExpression|.
+          1. Let _lhs_ be ? Evaluation of |LeftHandSideExpression|.
           1. Let _oldValue_ be ? ToNumeric(? GetValue(_lhs_)).
           1. If Type(_oldValue_) is Number, then
             1. Let _newValue_ be Number::subtract(_oldValue_, *1*<sub>𝔽</sub>).
@@ -19576,7 +19571,7 @@
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>UpdateExpression : `++` UnaryExpression</emu-grammar>
         <emu-alg>
-          1. Let _expr_ be Evaluation of |UnaryExpression|.
+          1. Let _expr_ be ? Evaluation of |UnaryExpression|.
           1. Let _oldValue_ be ? ToNumeric(? GetValue(_expr_)).
           1. If Type(_oldValue_) is Number, then
             1. Let _newValue_ be Number::add(_oldValue_, *1*<sub>𝔽</sub>).
@@ -19596,7 +19591,7 @@
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>UpdateExpression : `--` UnaryExpression</emu-grammar>
         <emu-alg>
-          1. Let _expr_ be Evaluation of |UnaryExpression|.
+          1. Let _expr_ be ? Evaluation of |UnaryExpression|.
           1. Let _oldValue_ be ? ToNumeric(? GetValue(_expr_)).
           1. If Type(_oldValue_) is Number, then
             1. Let _newValue_ be Number::subtract(_oldValue_, *1*<sub>𝔽</sub>).
@@ -19653,8 +19648,7 @@
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>UnaryExpression : `delete` UnaryExpression</emu-grammar>
         <emu-alg>
-          1. Let _ref_ be Evaluation of |UnaryExpression|.
-          1. ReturnIfAbrupt(_ref_).
+          1. Let _ref_ be ? Evaluation of |UnaryExpression|.
           1. If _ref_ is not a Reference Record, return *true*.
           1. If IsUnresolvableReference(_ref_) is *true*, then
             1. Assert: _ref_.[[Strict]] is *false*.
@@ -19687,7 +19681,7 @@
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>UnaryExpression : `void` UnaryExpression</emu-grammar>
         <emu-alg>
-          1. Let _expr_ be Evaluation of |UnaryExpression|.
+          1. Let _expr_ be ? Evaluation of |UnaryExpression|.
           1. Perform ? GetValue(_expr_).
           1. Return *undefined*.
         </emu-alg>
@@ -19704,7 +19698,7 @@
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>UnaryExpression : `typeof` UnaryExpression</emu-grammar>
         <emu-alg>
-          1. Let _val_ be Evaluation of |UnaryExpression|.
+          1. Let _val_ be ? Evaluation of |UnaryExpression|.
           1. If _val_ is a Reference Record, then
             1. If IsUnresolvableReference(_val_) is *true*, return *"undefined"*.
           1. Set _val_ to ? GetValue(_val_).
@@ -19811,7 +19805,7 @@
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>UnaryExpression : `+` UnaryExpression</emu-grammar>
         <emu-alg>
-          1. Let _expr_ be Evaluation of |UnaryExpression|.
+          1. Let _expr_ be ? Evaluation of |UnaryExpression|.
           1. Return ? ToNumber(? GetValue(_expr_)).
         </emu-alg>
       </emu-clause>
@@ -19827,7 +19821,7 @@
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>UnaryExpression : `-` UnaryExpression</emu-grammar>
         <emu-alg>
-          1. Let _expr_ be Evaluation of |UnaryExpression|.
+          1. Let _expr_ be ? Evaluation of |UnaryExpression|.
           1. Let _oldValue_ be ? ToNumeric(? GetValue(_expr_)).
           1. Let _T_ be Type(_oldValue_).
           1. If Type(_oldValue_) is Number, then
@@ -19846,7 +19840,7 @@
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>UnaryExpression : `~` UnaryExpression</emu-grammar>
         <emu-alg>
-          1. Let _expr_ be Evaluation of |UnaryExpression|.
+          1. Let _expr_ be ? Evaluation of |UnaryExpression|.
           1. Let _oldValue_ be ? ToNumeric(? GetValue(_expr_)).
           1. Let _T_ be Type(_oldValue_).
           1. If Type(_oldValue_) is Number, then
@@ -19865,7 +19859,7 @@
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>UnaryExpression : `!` UnaryExpression</emu-grammar>
         <emu-alg>
-          1. Let _expr_ be Evaluation of |UnaryExpression|.
+          1. Let _expr_ be ? Evaluation of |UnaryExpression|.
           1. Let _oldValue_ be ToBoolean(? GetValue(_expr_)).
           1. If _oldValue_ is *true*, return *false*.
           1. Return *true*.
@@ -20047,53 +20041,53 @@
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>RelationalExpression : RelationalExpression `&lt;` ShiftExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be Evaluation of |RelationalExpression|.
+        1. Let _lref_ be ? Evaluation of |RelationalExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
-        1. Let _rref_ be Evaluation of |ShiftExpression|.
+        1. Let _rref_ be ? Evaluation of |ShiftExpression|.
         1. Let _rval_ be ? GetValue(_rref_).
         1. Let _r_ be ? IsLessThan(_lval_, _rval_, *true*).
         1. If _r_ is *undefined*, return *false*. Otherwise, return _r_.
       </emu-alg>
       <emu-grammar>RelationalExpression : RelationalExpression `&gt;` ShiftExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be Evaluation of |RelationalExpression|.
+        1. Let _lref_ be ? Evaluation of |RelationalExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
-        1. Let _rref_ be Evaluation of |ShiftExpression|.
+        1. Let _rref_ be ? Evaluation of |ShiftExpression|.
         1. Let _rval_ be ? GetValue(_rref_).
         1. Let _r_ be ? IsLessThan(_rval_, _lval_, *false*).
         1. If _r_ is *undefined*, return *false*. Otherwise, return _r_.
       </emu-alg>
       <emu-grammar>RelationalExpression : RelationalExpression `&lt;=` ShiftExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be Evaluation of |RelationalExpression|.
+        1. Let _lref_ be ? Evaluation of |RelationalExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
-        1. Let _rref_ be Evaluation of |ShiftExpression|.
+        1. Let _rref_ be ? Evaluation of |ShiftExpression|.
         1. Let _rval_ be ? GetValue(_rref_).
         1. Let _r_ be ? IsLessThan(_rval_, _lval_, *false*).
         1. If _r_ is *true* or *undefined*, return *false*. Otherwise, return *true*.
       </emu-alg>
       <emu-grammar>RelationalExpression : RelationalExpression `&gt;=` ShiftExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be Evaluation of |RelationalExpression|.
+        1. Let _lref_ be ? Evaluation of |RelationalExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
-        1. Let _rref_ be Evaluation of |ShiftExpression|.
+        1. Let _rref_ be ? Evaluation of |ShiftExpression|.
         1. Let _rval_ be ? GetValue(_rref_).
         1. Let _r_ be ? IsLessThan(_lval_, _rval_, *true*).
         1. If _r_ is *true* or *undefined*, return *false*. Otherwise, return *true*.
       </emu-alg>
       <emu-grammar>RelationalExpression : RelationalExpression `instanceof` ShiftExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be Evaluation of |RelationalExpression|.
+        1. Let _lref_ be ? Evaluation of |RelationalExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
-        1. Let _rref_ be Evaluation of |ShiftExpression|.
+        1. Let _rref_ be ? Evaluation of |ShiftExpression|.
         1. Let _rval_ be ? GetValue(_rref_).
         1. Return ? InstanceofOperator(_lval_, _rval_).
       </emu-alg>
       <emu-grammar>RelationalExpression : RelationalExpression `in` ShiftExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be Evaluation of |RelationalExpression|.
+        1. Let _lref_ be ? Evaluation of |RelationalExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
-        1. Let _rref_ be Evaluation of |ShiftExpression|.
+        1. Let _rref_ be ? Evaluation of |ShiftExpression|.
         1. Let _rval_ be ? GetValue(_rref_).
         1. If Type(_rval_) is not Object, throw a *TypeError* exception.
         1. Return ? HasProperty(_rval_, ? ToPropertyKey(_lval_)).
@@ -20101,7 +20095,7 @@
       <emu-grammar>RelationalExpression : PrivateIdentifier `in` ShiftExpression</emu-grammar>
       <emu-alg>
         1. Let _privateIdentifier_ be the StringValue of |PrivateIdentifier|.
-        1. Let _rref_ be Evaluation of |ShiftExpression|.
+        1. Let _rref_ be ? Evaluation of |ShiftExpression|.
         1. Let _rval_ be ? GetValue(_rref_).
         1. If Type(_rval_) is not Object, throw a *TypeError* exception.
         1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
@@ -20155,34 +20149,34 @@
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>EqualityExpression : EqualityExpression `==` RelationalExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be Evaluation of |EqualityExpression|.
+        1. Let _lref_ be ? Evaluation of |EqualityExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
-        1. Let _rref_ be Evaluation of |RelationalExpression|.
+        1. Let _rref_ be ? Evaluation of |RelationalExpression|.
         1. Let _rval_ be ? GetValue(_rref_).
         1. Return ? IsLooselyEqual(_rval_, _lval_).
       </emu-alg>
       <emu-grammar>EqualityExpression : EqualityExpression `!=` RelationalExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be Evaluation of |EqualityExpression|.
+        1. Let _lref_ be ? Evaluation of |EqualityExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
-        1. Let _rref_ be Evaluation of |RelationalExpression|.
+        1. Let _rref_ be ? Evaluation of |RelationalExpression|.
         1. Let _rval_ be ? GetValue(_rref_).
         1. Let _r_ be ? IsLooselyEqual(_rval_, _lval_).
         1. If _r_ is *true*, return *false*. Otherwise, return *true*.
       </emu-alg>
       <emu-grammar>EqualityExpression : EqualityExpression `===` RelationalExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be Evaluation of |EqualityExpression|.
+        1. Let _lref_ be ? Evaluation of |EqualityExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
-        1. Let _rref_ be Evaluation of |RelationalExpression|.
+        1. Let _rref_ be ? Evaluation of |RelationalExpression|.
         1. Let _rval_ be ? GetValue(_rref_).
         1. Return IsStrictlyEqual(_rval_, _lval_).
       </emu-alg>
       <emu-grammar>EqualityExpression : EqualityExpression `!==` RelationalExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be Evaluation of |EqualityExpression|.
+        1. Let _lref_ be ? Evaluation of |EqualityExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
-        1. Let _rref_ be Evaluation of |RelationalExpression|.
+        1. Let _rref_ be ? Evaluation of |RelationalExpression|.
         1. Let _rval_ be ? GetValue(_rref_).
         1. Let _r_ be IsStrictlyEqual(_rval_, _lval_).
         1. If _r_ is *true*, return *false*. Otherwise, return *true*.
@@ -20294,28 +20288,28 @@
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>LogicalANDExpression : LogicalANDExpression `&amp;&amp;` BitwiseORExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be Evaluation of |LogicalANDExpression|.
+        1. Let _lref_ be ? Evaluation of |LogicalANDExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
         1. Let _lbool_ be ToBoolean(_lval_).
         1. If _lbool_ is *false*, return _lval_.
-        1. Let _rref_ be Evaluation of |BitwiseORExpression|.
+        1. Let _rref_ be ? Evaluation of |BitwiseORExpression|.
         1. Return ? GetValue(_rref_).
       </emu-alg>
       <emu-grammar>LogicalORExpression : LogicalORExpression `||` LogicalANDExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be Evaluation of |LogicalORExpression|.
+        1. Let _lref_ be ? Evaluation of |LogicalORExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
         1. Let _lbool_ be ToBoolean(_lval_).
         1. If _lbool_ is *true*, return _lval_.
-        1. Let _rref_ be Evaluation of |LogicalANDExpression|.
+        1. Let _rref_ be ? Evaluation of |LogicalANDExpression|.
         1. Return ? GetValue(_rref_).
       </emu-alg>
       <emu-grammar>CoalesceExpression : CoalesceExpressionHead `??` BitwiseORExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be Evaluation of |CoalesceExpressionHead|.
+        1. Let _lref_ be ? Evaluation of |CoalesceExpressionHead|.
         1. Let _lval_ be ? GetValue(_lref_).
         1. If _lval_ is *undefined* or *null*, then
-          1. Let _rref_ be Evaluation of |BitwiseORExpression|.
+          1. Let _rref_ be ? Evaluation of |BitwiseORExpression|.
           1. Return ? GetValue(_rref_).
         1. Otherwise, return _lval_.
       </emu-alg>
@@ -20338,13 +20332,13 @@
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>ConditionalExpression : ShortCircuitExpression `?` AssignmentExpression `:` AssignmentExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be Evaluation of |ShortCircuitExpression|.
+        1. Let _lref_ be ? Evaluation of |ShortCircuitExpression|.
         1. Let _lval_ be ToBoolean(? GetValue(_lref_)).
         1. If _lval_ is *true*, then
-          1. Let _trueRef_ be Evaluation of the first |AssignmentExpression|.
+          1. Let _trueRef_ be ? Evaluation of the first |AssignmentExpression|.
           1. Return ? GetValue(_trueRef_).
         1. Else,
-          1. Let _falseRef_ be Evaluation of the second |AssignmentExpression|.
+          1. Let _falseRef_ be ? Evaluation of the second |AssignmentExpression|.
           1. Return ? GetValue(_falseRef_).
       </emu-alg>
     </emu-clause>
@@ -20404,26 +20398,25 @@
       <emu-grammar>AssignmentExpression : LeftHandSideExpression `=` AssignmentExpression</emu-grammar>
       <emu-alg>
         1. If |LeftHandSideExpression| is neither an |ObjectLiteral| nor an |ArrayLiteral|, then
-          1. Let _lref_ be Evaluation of |LeftHandSideExpression|.
-          1. ReturnIfAbrupt(_lref_).
+          1. Let _lref_ be ? Evaluation of |LeftHandSideExpression|.
           1. If IsAnonymousFunctionDefinition(|AssignmentExpression|) and IsIdentifierRef of |LeftHandSideExpression| are both *true*, then
             1. Let _rval_ be ? NamedEvaluation of |AssignmentExpression| with argument _lref_.[[ReferencedName]].
           1. Else,
-            1. Let _rref_ be Evaluation of |AssignmentExpression|.
+            1. Let _rref_ be ? Evaluation of |AssignmentExpression|.
             1. Let _rval_ be ? GetValue(_rref_).
           1. [id="step-assignmentexpression-evaluation-simple-putvalue"] Perform ? PutValue(_lref_, _rval_).
           1. Return _rval_.
         1. Let _assignmentPattern_ be the |AssignmentPattern| that is covered by |LeftHandSideExpression|.
-        1. Let _rref_ be Evaluation of |AssignmentExpression|.
+        1. Let _rref_ be ? Evaluation of |AssignmentExpression|.
         1. Let _rval_ be ? GetValue(_rref_).
         1. Perform ? DestructuringAssignmentEvaluation of _assignmentPattern_ with argument _rval_.
         1. Return _rval_.
       </emu-alg>
       <emu-grammar>AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be Evaluation of |LeftHandSideExpression|.
+        1. Let _lref_ be ? Evaluation of |LeftHandSideExpression|.
         1. [id="step-assignmentexpression-evaluation-compound-getvalue"] Let _lval_ be ? GetValue(_lref_).
-        1. Let _rref_ be Evaluation of |AssignmentExpression|.
+        1. Let _rref_ be ? Evaluation of |AssignmentExpression|.
         1. Let _rval_ be ? GetValue(_rref_).
         1. Let _assignmentOpText_ be the source text matched by |AssignmentOperator|.
         1. Let _opText_ be the sequence of Unicode code points associated with _assignmentOpText_ in the following table:
@@ -20451,41 +20444,41 @@
       </emu-alg>
       <emu-grammar>AssignmentExpression : LeftHandSideExpression `&amp;&amp;=` AssignmentExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be Evaluation of |LeftHandSideExpression|.
+        1. Let _lref_ be ? Evaluation of |LeftHandSideExpression|.
         1. [id="step-assignmentexpression-evaluation-lgcl-and-getvalue"] Let _lval_ be ? GetValue(_lref_).
         1. Let _lbool_ be ToBoolean(_lval_).
         1. If _lbool_ is *false*, return _lval_.
         1. If IsAnonymousFunctionDefinition(|AssignmentExpression|) is *true* and IsIdentifierRef of |LeftHandSideExpression| is *true*, then
           1. Let _rval_ be ? NamedEvaluation of |AssignmentExpression| with argument _lref_.[[ReferencedName]].
         1. Else,
-          1. Let _rref_ be Evaluation of |AssignmentExpression|.
+          1. Let _rref_ be ? Evaluation of |AssignmentExpression|.
           1. Let _rval_ be ? GetValue(_rref_).
         1. [id="step-assignmentexpression-evaluation-lgcl-and-putvalue"] Perform ? PutValue(_lref_, _rval_).
         1. Return _rval_.
       </emu-alg>
       <emu-grammar>AssignmentExpression : LeftHandSideExpression `||=` AssignmentExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be Evaluation of |LeftHandSideExpression|.
+        1. Let _lref_ be ? Evaluation of |LeftHandSideExpression|.
         1. [id="step-assignmentexpression-evaluation-lgcl-or-getvalue"] Let _lval_ be ? GetValue(_lref_).
         1. Let _lbool_ be ToBoolean(_lval_).
         1. If _lbool_ is *true*, return _lval_.
         1. If IsAnonymousFunctionDefinition(|AssignmentExpression|) is *true* and IsIdentifierRef of |LeftHandSideExpression| is *true*, then
           1. Let _rval_ be ? NamedEvaluation of |AssignmentExpression| with argument _lref_.[[ReferencedName]].
         1. Else,
-          1. Let _rref_ be Evaluation of |AssignmentExpression|.
+          1. Let _rref_ be ? Evaluation of |AssignmentExpression|.
           1. Let _rval_ be ? GetValue(_rref_).
         1. [id="step-assignmentexpression-evaluation-lgcl-or-putvalue"] Perform ? PutValue(_lref_, _rval_).
         1. Return _rval_.
       </emu-alg>
       <emu-grammar>AssignmentExpression : LeftHandSideExpression `??=` AssignmentExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be Evaluation of |LeftHandSideExpression|.
+        1. Let _lref_ be ? Evaluation of |LeftHandSideExpression|.
         1. [id="step-assignmentexpression-evaluation-lgcl-nullish-getvalue"] Let _lval_ be ? GetValue(_lref_).
         1. If _lval_ is neither *undefined* nor *null*, return _lval_.
         1. If IsAnonymousFunctionDefinition(|AssignmentExpression|) is *true* and IsIdentifierRef of |LeftHandSideExpression| is *true*, then
           1. Let _rval_ be ? NamedEvaluation of |AssignmentExpression| with argument _lref_.[[ReferencedName]].
         1. Else,
-          1. Let _rref_ be Evaluation of |AssignmentExpression|.
+          1. Let _rref_ be ? Evaluation of |AssignmentExpression|.
           1. Let _rval_ be ? GetValue(_rref_).
         1. [id="step-assignmentexpression-evaluation-lgcl-nullish-putvalue"] Perform ? PutValue(_lref_, _rval_).
         1. Return _rval_.
@@ -20572,9 +20565,9 @@
       <dl class="header">
       </dl>
       <emu-alg>
-        1. Let _lref_ be Evaluation of _leftOperand_.
+        1. Let _lref_ be ? Evaluation of _leftOperand_.
         1. Let _lval_ be ? GetValue(_lref_).
-        1. Let _rref_ be Evaluation of _rightOperand_.
+        1. Let _rref_ be ? Evaluation of _rightOperand_.
         1. Let _rval_ be ? GetValue(_rref_).
         1. Return ? ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
       </emu-alg>
@@ -20772,7 +20765,7 @@
             1. If IsAnonymousFunctionDefinition(|Initializer|) is *true*, then
               1. Set _v_ to ? NamedEvaluation of |Initializer| with argument _P_.
             1. Else,
-              1. Let _defaultValue_ be Evaluation of |Initializer|.
+              1. Let _defaultValue_ be ? Evaluation of |Initializer|.
               1. Set _v_ to ? GetValue(_defaultValue_).
           1. Perform ? PutValue(_lref_, _v_).
           1. Return &laquo; _P_ &raquo;.
@@ -20780,8 +20773,7 @@
 
         <emu-grammar>AssignmentProperty : PropertyName `:` AssignmentElement</emu-grammar>
         <emu-alg>
-          1. Let _name_ be Evaluation of |PropertyName|.
-          1. ReturnIfAbrupt(_name_).
+          1. Let _name_ be ? Evaluation of |PropertyName|.
           1. Perform ? KeyedDestructuringAssignmentEvaluation of |AssignmentElement| with arguments _value_ and _name_.
           1. Return &laquo; _name_ &raquo;.
         </emu-alg>
@@ -20798,8 +20790,7 @@
         </dl>
         <emu-grammar>AssignmentRestProperty : `...` DestructuringAssignmentTarget</emu-grammar>
         <emu-alg>
-          1. Let _lref_ be Evaluation of |DestructuringAssignmentTarget|.
-          1. ReturnIfAbrupt(_lref_).
+          1. Let _lref_ be ? Evaluation of |DestructuringAssignmentTarget|.
           1. Let _restObj_ be OrdinaryObjectCreate(%Object.prototype%).
           1. Perform ? CopyDataProperties(_restObj_, _value_, _excludedNames_).
           1. Return ? PutValue(_lref_, _restObj_).
@@ -20854,8 +20845,7 @@
         <emu-grammar>AssignmentElement : DestructuringAssignmentTarget Initializer?</emu-grammar>
         <emu-alg>
           1. If |DestructuringAssignmentTarget| is neither an |ObjectLiteral| nor an |ArrayLiteral|, then
-            1. Let _lref_ be Evaluation of |DestructuringAssignmentTarget|.
-            1. ReturnIfAbrupt(_lref_).
+            1. Let _lref_ be ? Evaluation of |DestructuringAssignmentTarget|.
           1. If _iteratorRecord_.[[Done]] is *false*, then
             1. Let _next_ be Completion(IteratorStep(_iteratorRecord_)).
             1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
@@ -20870,7 +20860,7 @@
             1. If IsAnonymousFunctionDefinition(|Initializer|) is *true* and IsIdentifierRef of |DestructuringAssignmentTarget| is *true*, then
               1. Let _v_ be ? NamedEvaluation of |Initializer| with argument _lref_.[[ReferencedName]].
             1. Else,
-              1. Let _defaultValue_ be Evaluation of |Initializer|.
+              1. Let _defaultValue_ be ? Evaluation of |Initializer|.
               1. Let _v_ be ? GetValue(_defaultValue_).
           1. Else, let _v_ be _value_.
           1. If |DestructuringAssignmentTarget| is an |ObjectLiteral| or an |ArrayLiteral|, then
@@ -20884,8 +20874,7 @@
         <emu-grammar>AssignmentRestElement : `...` DestructuringAssignmentTarget</emu-grammar>
         <emu-alg>
           1. If |DestructuringAssignmentTarget| is neither an |ObjectLiteral| nor an |ArrayLiteral|, then
-            1. Let _lref_ be Evaluation of |DestructuringAssignmentTarget|.
-            1. ReturnIfAbrupt(_lref_).
+            1. Let _lref_ be ? Evaluation of |DestructuringAssignmentTarget|.
           1. Let _A_ be ! ArrayCreate(0).
           1. Let _n_ be 0.
           1. Repeat, while _iteratorRecord_.[[Done]] is *false*,
@@ -20918,14 +20907,13 @@
         <emu-grammar>AssignmentElement : DestructuringAssignmentTarget Initializer?</emu-grammar>
         <emu-alg>
           1. If |DestructuringAssignmentTarget| is neither an |ObjectLiteral| nor an |ArrayLiteral|, then
-            1. Let _lref_ be Evaluation of |DestructuringAssignmentTarget|.
-            1. ReturnIfAbrupt(_lref_).
+            1. Let _lref_ be ? Evaluation of |DestructuringAssignmentTarget|.
           1. Let _v_ be ? GetV(_value_, _propertyName_).
           1. If |Initializer| is present and _v_ is *undefined*, then
             1. If IsAnonymousFunctionDefinition(|Initializer|) and IsIdentifierRef of |DestructuringAssignmentTarget| are both *true*, then
               1. Let _rhsValue_ be ? NamedEvaluation of |Initializer| with argument _lref_.[[ReferencedName]].
             1. Else,
-              1. Let _defaultValue_ be Evaluation of |Initializer|.
+              1. Let _defaultValue_ be ? Evaluation of |Initializer|.
               1. Let _rhsValue_ be ? GetValue(_defaultValue_).
           1. Else, let _rhsValue_ be _v_.
           1. If |DestructuringAssignmentTarget| is an |ObjectLiteral| or an |ArrayLiteral|, then
@@ -20950,9 +20938,9 @@
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>Expression : Expression `,` AssignmentExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be Evaluation of |Expression|.
+        1. Let _lref_ be ? Evaluation of |Expression|.
         1. Perform ? GetValue(_lref_).
-        1. Let _rref_ be Evaluation of |AssignmentExpression|.
+        1. Let _rref_ be ? Evaluation of |AssignmentExpression|.
         1. Return ? GetValue(_rref_).
       </emu-alg>
       <emu-note>
@@ -21016,7 +21004,7 @@
         HoistableDeclaration : FunctionDeclaration
       </emu-grammar>
       <emu-alg>
-        1. Return Evaluation of |FunctionDeclaration|.
+        1. Return ? Evaluation of |FunctionDeclaration|.
       </emu-alg>
       <emu-grammar>
         BreakableStatement :
@@ -21074,7 +21062,7 @@
         1. Let _blockEnv_ be NewDeclarativeEnvironment(_oldEnv_).
         1. Perform BlockDeclarationInstantiation(|StatementList|, _blockEnv_).
         1. Set the running execution context's LexicalEnvironment to _blockEnv_.
-        1. Let _blockValue_ be Evaluation of |StatementList|.
+        1. Let _blockValue_ be Completion(Evaluation of |StatementList|).
         1. Set the running execution context's LexicalEnvironment to _oldEnv_.
         1. Return _blockValue_.
       </emu-alg>
@@ -21083,9 +21071,8 @@
       </emu-note>
       <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
       <emu-alg>
-        1. Let _sl_ be Evaluation of |StatementList|.
-        1. ReturnIfAbrupt(_sl_).
-        1. Let _s_ be Evaluation of |StatementListItem|.
+        1. Let _sl_ be ? Evaluation of |StatementList|.
+        1. Let _s_ be Completion(Evaluation of |StatementListItem|).
         1. Return ? UpdateEmpty(_s_, _sl_).
       </emu-alg>
       <emu-note>
@@ -21185,15 +21172,13 @@
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>LexicalDeclaration : LetOrConst BindingList `;`</emu-grammar>
         <emu-alg>
-          1. Let _next_ be Evaluation of |BindingList|.
-          1. ReturnIfAbrupt(_next_).
+          1. Let _next_ be ? Evaluation of |BindingList|.
           1. Return ~empty~.
         </emu-alg>
         <emu-grammar>BindingList : BindingList `,` LexicalBinding</emu-grammar>
         <emu-alg>
-          1. Let _next_ be Evaluation of |BindingList|.
-          1. ReturnIfAbrupt(_next_).
-          1. Return Evaluation of |LexicalBinding|.
+          1. Let _next_ be ? Evaluation of |BindingList|.
+          1. Return ? Evaluation of |LexicalBinding|.
         </emu-alg>
         <emu-grammar>LexicalBinding : BindingIdentifier</emu-grammar>
         <emu-alg>
@@ -21211,14 +21196,14 @@
           1. If IsAnonymousFunctionDefinition(|Initializer|) is *true*, then
             1. Let _value_ be ? NamedEvaluation of |Initializer| with argument _bindingId_.
           1. Else,
-            1. Let _rhs_ be Evaluation of |Initializer|.
+            1. Let _rhs_ be ? Evaluation of |Initializer|.
             1. Let _value_ be ? GetValue(_rhs_).
           1. Perform ? InitializeReferencedBinding(_lhs_, _value_).
           1. Return ~empty~.
         </emu-alg>
         <emu-grammar>LexicalBinding : BindingPattern Initializer</emu-grammar>
         <emu-alg>
-          1. Let _rhs_ be Evaluation of |Initializer|.
+          1. Let _rhs_ be ? Evaluation of |Initializer|.
           1. Let _value_ be ? GetValue(_rhs_).
           1. Let _env_ be the running execution context's LexicalEnvironment.
           1. Return ? BindingInitialization of |BindingPattern| with arguments _value_ and _env_.
@@ -21249,15 +21234,13 @@
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>VariableStatement : `var` VariableDeclarationList `;`</emu-grammar>
         <emu-alg>
-          1. Let _next_ be Evaluation of |VariableDeclarationList|.
-          1. ReturnIfAbrupt(_next_).
+          1. Let _next_ be ? Evaluation of |VariableDeclarationList|.
           1. Return ~empty~.
         </emu-alg>
         <emu-grammar>VariableDeclarationList : VariableDeclarationList `,` VariableDeclaration</emu-grammar>
         <emu-alg>
-          1. Let _next_ be Evaluation of |VariableDeclarationList|.
-          1. ReturnIfAbrupt(_next_).
-          1. Return Evaluation of |VariableDeclaration|.
+          1. Let _next_ be ? Evaluation of |VariableDeclarationList|.
+          1. Return ? Evaluation of |VariableDeclaration|.
         </emu-alg>
         <emu-grammar>VariableDeclaration : BindingIdentifier</emu-grammar>
         <emu-alg>
@@ -21270,7 +21253,7 @@
           1. If IsAnonymousFunctionDefinition(|Initializer|) is *true*, then
             1. Let _value_ be ? NamedEvaluation of |Initializer| with argument _bindingId_.
           1. Else,
-            1. Let _rhs_ be Evaluation of |Initializer|.
+            1. Let _rhs_ be ? Evaluation of |Initializer|.
             1. Let _value_ be ? GetValue(_rhs_).
           1. [id="step-vardecllist-evaluation-putvalue"] Perform ? PutValue(_lhs_, _value_).
           1. Return ~empty~.
@@ -21280,7 +21263,7 @@
         </emu-note>
         <emu-grammar>VariableDeclaration : BindingPattern Initializer</emu-grammar>
         <emu-alg>
-          1. Let _rhs_ be Evaluation of |Initializer|.
+          1. Let _rhs_ be ? Evaluation of |Initializer|.
           1. Let _rval_ be ? GetValue(_rhs_).
           1. Return ? BindingInitialization of |BindingPattern| with arguments _rval_ and *undefined*.
         </emu-alg>
@@ -21363,8 +21346,7 @@
 
         <emu-grammar>BindingProperty : PropertyName `:` BindingElement</emu-grammar>
         <emu-alg>
-          1. Let _P_ be Evaluation of |PropertyName|.
-          1. ReturnIfAbrupt(_P_).
+          1. Let _P_ be ? Evaluation of |PropertyName|.
           1. Perform ? KeyedBindingInitialization of |BindingElement| with arguments _value_, _environment_, and _P_.
           1. Return &laquo; _P_ &raquo;.
         </emu-alg>
@@ -21407,7 +21389,7 @@
         <emu-alg>
           1. Let _v_ be ? GetV(_value_, _propertyName_).
           1. If |Initializer| is present and _v_ is *undefined*, then
-            1. Let _defaultValue_ be Evaluation of |Initializer|.
+            1. Let _defaultValue_ be ? Evaluation of |Initializer|.
             1. Set _v_ to ? GetValue(_defaultValue_).
           1. Return ? BindingInitialization of |BindingPattern| with arguments _v_ and _environment_.
         </emu-alg>
@@ -21420,7 +21402,7 @@
             1. If IsAnonymousFunctionDefinition(|Initializer|) is *true*, then
               1. Set _v_ to ? NamedEvaluation of |Initializer| with argument _bindingId_.
             1. Else,
-              1. Let _defaultValue_ be Evaluation of |Initializer|.
+              1. Let _defaultValue_ be ? Evaluation of |Initializer|.
               1. Set _v_ to ? GetValue(_defaultValue_).
           1. If _environment_ is *undefined*, return ? PutValue(_lhs_, _v_).
           1. Return ? InitializeReferencedBinding(_lhs_, _v_).
@@ -21461,7 +21443,7 @@
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>ExpressionStatement : Expression `;`</emu-grammar>
       <emu-alg>
-        1. Let _exprRef_ be Evaluation of |Expression|.
+        1. Let _exprRef_ be ? Evaluation of |Expression|.
         1. Return ? GetValue(_exprRef_).
       </emu-alg>
     </emu-clause>
@@ -21503,22 +21485,22 @@
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
       <emu-alg>
-        1. Let _exprRef_ be Evaluation of |Expression|.
+        1. Let _exprRef_ be ? Evaluation of |Expression|.
         1. Let _exprValue_ be ToBoolean(? GetValue(_exprRef_)).
         1. If _exprValue_ is *true*, then
-          1. Let _stmtCompletion_ be Evaluation of the first |Statement|.
+          1. Let _stmtCompletion_ be Completion(Evaluation of the first |Statement|).
         1. Else,
-          1. Let _stmtCompletion_ be Evaluation of the second |Statement|.
+          1. Let _stmtCompletion_ be Completion(Evaluation of the second |Statement|).
         1. Return ? UpdateEmpty(_stmtCompletion_, *undefined*).
       </emu-alg>
       <emu-grammar>IfStatement : `if` `(` Expression `)` Statement</emu-grammar>
       <emu-alg>
-        1. Let _exprRef_ be Evaluation of |Expression|.
+        1. Let _exprRef_ be ? Evaluation of |Expression|.
         1. Let _exprValue_ be ToBoolean(? GetValue(_exprRef_)).
         1. If _exprValue_ is *false*, then
           1. Return *undefined*.
         1. Else,
-          1. Let _stmtCompletion_ be Evaluation of |Statement|.
+          1. Let _stmtCompletion_ be Completion(Evaluation of |Statement|).
           1. Return ? UpdateEmpty(_stmtCompletion_, *undefined*).
       </emu-alg>
     </emu-clause>
@@ -21619,10 +21601,10 @@
         <emu-alg>
           1. Let _V_ be *undefined*.
           1. Repeat,
-            1. Let _stmtResult_ be Evaluation of |Statement|.
+            1. Let _stmtResult_ be Completion(Evaluation of |Statement|).
             1. If LoopContinues(_stmtResult_, _labelSet_) is *false*, return ? UpdateEmpty(_stmtResult_, _V_).
             1. If _stmtResult_.[[Value]] is not ~empty~, set _V_ to _stmtResult_.[[Value]].
-            1. Let _exprRef_ be Evaluation of |Expression|.
+            1. Let _exprRef_ be ? Evaluation of |Expression|.
             1. Let _exprValue_ be ? GetValue(_exprRef_).
             1. If ToBoolean(_exprValue_) is *false*, return _V_.
         </emu-alg>
@@ -21662,10 +21644,10 @@
         <emu-alg>
           1. Let _V_ be *undefined*.
           1. Repeat,
-            1. Let _exprRef_ be Evaluation of |Expression|.
+            1. Let _exprRef_ be ? Evaluation of |Expression|.
             1. Let _exprValue_ be ? GetValue(_exprRef_).
             1. If ToBoolean(_exprValue_) is *false*, return _V_.
-            1. Let _stmtResult_ be Evaluation of |Statement|.
+            1. Let _stmtResult_ be Completion(Evaluation of |Statement|).
             1. If LoopContinues(_stmtResult_, _labelSet_) is *false*, return ? UpdateEmpty(_stmtResult_, _V_).
             1. If _stmtResult_.[[Value]] is not ~empty~, set _V_ to _stmtResult_.[[Value]].
         </emu-alg>
@@ -21717,14 +21699,13 @@
         <emu-grammar>ForStatement : `for` `(` Expression? `;` Expression? `;` Expression? `)` Statement</emu-grammar>
         <emu-alg>
           1. If the first |Expression| is present, then
-            1. Let _exprRef_ be Evaluation of the first |Expression|.
+            1. Let _exprRef_ be ? Evaluation of the first |Expression|.
             1. Perform ? GetValue(_exprRef_).
           1. Return ? ForBodyEvaluation(the second |Expression|, the third |Expression|, |Statement|, &laquo; &raquo;, _labelSet_).
         </emu-alg>
         <emu-grammar>ForStatement : `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement</emu-grammar>
         <emu-alg>
-          1. Let _varDcl_ be Evaluation of |VariableDeclarationList|.
-          1. ReturnIfAbrupt(_varDcl_).
+          1. Let _varDcl_ be ? Evaluation of |VariableDeclarationList|.
           1. Return ? ForBodyEvaluation(the first |Expression|, the second |Expression|, |Statement|, &laquo; &raquo;, _labelSet_).
         </emu-alg>
         <emu-grammar>ForStatement : `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement</emu-grammar>
@@ -21739,7 +21720,7 @@
             1. Else,
               1. Perform ! _loopEnv_.CreateMutableBinding(_dn_, *false*).
           1. Set the running execution context's LexicalEnvironment to _loopEnv_.
-          1. Let _forDcl_ be Evaluation of |LexicalDeclaration|.
+          1. Let _forDcl_ be Completion(Evaluation of |LexicalDeclaration|).
           1. If _forDcl_ is an abrupt completion, then
             1. Set the running execution context's LexicalEnvironment to _oldEnv_.
             1. Return ? _forDcl_.
@@ -21767,15 +21748,15 @@
           1. Perform ? CreatePerIterationEnvironment(_perIterationBindings_).
           1. Repeat,
             1. If _test_ is not ~[empty]~, then
-              1. Let _testRef_ be Evaluation of _test_.
+              1. Let _testRef_ be ? Evaluation of _test_.
               1. Let _testValue_ be ? GetValue(_testRef_).
               1. If ToBoolean(_testValue_) is *false*, return _V_.
-            1. Let _result_ be Evaluation of _stmt_.
+            1. Let _result_ be Completion(Evaluation of _stmt_).
             1. If LoopContinues(_result_, _labelSet_) is *false*, return ? UpdateEmpty(_result_, _V_).
             1. If _result_.[[Value]] is not ~empty~, set _V_ to _result_.[[Value]].
             1. Perform ? CreatePerIterationEnvironment(_perIterationBindings_).
             1. If _increment_ is not ~[empty]~, then
-              1. Let _incRef_ be Evaluation of _increment_.
+              1. Let _incRef_ be ? Evaluation of _increment_.
               1. Perform ? GetValue(_incRef_).
         </emu-alg>
       </emu-clause>
@@ -22055,7 +22036,7 @@
             1. For each String _name_ of _uninitializedBoundNames_, do
               1. Perform ! _newEnv_.CreateMutableBinding(_name_, *false*).
             1. Set the running execution context's LexicalEnvironment to _newEnv_.
-          1. Let _exprRef_ be Evaluation of _expr_.
+          1. Let _exprRef_ be Completion(Evaluation of _expr_).
           1. Set the running execution context's LexicalEnvironment to _oldEnv_.
           1. Let _exprValue_ be ? GetValue(_exprRef_).
           1. If _iterationKind_ is ~enumerate~, then
@@ -22104,7 +22085,7 @@
             1. Let _nextValue_ be ? IteratorValue(_nextResult_).
             1. If _lhsKind_ is either ~assignment~ or ~varBinding~, then
               1. If _destructuring_ is *false*, then
-                1. Let _lhsRef_ be Evaluation of _lhs_. (It may be evaluated repeatedly.)
+                1. Let _lhsRef_ be Completion(Evaluation of _lhs_). (It may be evaluated repeatedly.)
             1. Else,
               1. Assert: _lhsKind_ is ~lexicalBinding~.
               1. Assert: _lhs_ is a |ForDeclaration|.
@@ -22140,7 +22121,7 @@
               1. Else,
                 1. Assert: _iterationKind_ is ~iterate~.
                 1. Return ? IteratorClose(_iteratorRecord_, _status_).
-            1. Let _result_ be Evaluation of _stmt_.
+            1. Let _result_ be Completion(Evaluation of _stmt_).
             1. Set the running execution context's LexicalEnvironment to _oldEnv_.
             1. If LoopContinues(_result_, _labelSet_) is *false*, then
               1. If _iterationKind_ is ~enumerate~, then
@@ -22440,7 +22421,7 @@
       </emu-alg>
       <emu-grammar>ReturnStatement : `return` Expression `;`</emu-grammar>
       <emu-alg>
-        1. Let _exprRef_ be Evaluation of |Expression|.
+        1. Let _exprRef_ be ? Evaluation of |Expression|.
         1. Let _exprValue_ be ? GetValue(_exprRef_).
         1. If GetGeneratorKind() is ~async~, set _exprValue_ to ? Await(_exprValue_).
         1. Return Completion Record { [[Type]]: ~return~, [[Value]]: _exprValue_, [[Target]]: ~empty~ }.
@@ -22483,12 +22464,12 @@
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>WithStatement : `with` `(` Expression `)` Statement</emu-grammar>
       <emu-alg>
-        1. Let _val_ be Evaluation of |Expression|.
+        1. Let _val_ be ? Evaluation of |Expression|.
         1. Let _obj_ be ? ToObject(? GetValue(_val_)).
         1. Let _oldEnv_ be the running execution context's LexicalEnvironment.
         1. Let _newEnv_ be NewObjectEnvironment(_obj_, *true*, _oldEnv_).
         1. Set the running execution context's LexicalEnvironment to _newEnv_.
-        1. Let _C_ be Evaluation of |Statement|.
+        1. Let _C_ be Completion(Evaluation of |Statement|).
         1. Set the running execution context's LexicalEnvironment to _oldEnv_.
         1. Return ? UpdateEmpty(_C_, *undefined*).
       </emu-alg>
@@ -22554,7 +22535,7 @@
           1. If _found_ is *false*, then
             1. Set _found_ to ? CaseClauseIsSelected(_C_, _input_).
           1. If _found_ is *true*, then
-            1. Let _R_ be Evaluation of _C_.
+            1. Let _R_ be Completion(Evaluation of _C_).
             1. If _R_.[[Value]] is not ~empty~, set _V_ to _R_.[[Value]].
             1. If _R_ is an abrupt completion, return ? UpdateEmpty(_R_, _V_).
         1. Return _V_.
@@ -22571,7 +22552,7 @@
           1. If _found_ is *false*, then
             1. Set _found_ to ? CaseClauseIsSelected(_C_, _input_).
           1. If _found_ is *true*, then
-            1. Let _R_ be Evaluation of _C_.
+            1. Let _R_ be Completion(Evaluation of _C_).
             1. If _R_.[[Value]] is not ~empty~, set _V_ to _R_.[[Value]].
             1. If _R_ is an abrupt completion, return ? UpdateEmpty(_R_, _V_).
         1. Let _foundInB_ be *false*.
@@ -22584,16 +22565,16 @@
             1. If _foundInB_ is *false*, then
               1. Set _foundInB_ to ? CaseClauseIsSelected(_C_, _input_).
             1. If _foundInB_ is *true*, then
-              1. Let _R_ be Evaluation of |CaseClause| _C_.
+              1. Let _R_ be Completion(Evaluation of |CaseClause| _C_).
               1. If _R_.[[Value]] is not ~empty~, set _V_ to _R_.[[Value]].
               1. If _R_ is an abrupt completion, return ? UpdateEmpty(_R_, _V_).
         1. If _foundInB_ is *true*, return _V_.
-        1. Let _R_ be Evaluation of |DefaultClause|.
+        1. Let _R_ be Completion(Evaluation of |DefaultClause|).
         1. If _R_.[[Value]] is not ~empty~, set _V_ to _R_.[[Value]].
         1. If _R_ is an abrupt completion, return ? UpdateEmpty(_R_, _V_).
         1. NOTE: The following is another complete iteration of the second |CaseClauses|.
         1. For each |CaseClause| _C_ of _B_, do
-          1. Let _R_ be Evaluation of |CaseClause| _C_.
+          1. Let _R_ be Completion(Evaluation of |CaseClause| _C_).
           1. If _R_.[[Value]] is not ~empty~, set _V_ to _R_.[[Value]].
           1. If _R_ is an abrupt completion, return ? UpdateEmpty(_R_, _V_).
         1. Return _V_.
@@ -22613,7 +22594,7 @@
       </dl>
       <emu-alg>
         1. Assert: _C_ is an instance of the production <emu-grammar>CaseClause : `case` Expression `:` StatementList?</emu-grammar>.
-        1. Let _exprRef_ be Evaluation of the |Expression| of _C_.
+        1. Let _exprRef_ be ? Evaluation of the |Expression| of _C_.
         1. Let _clauseSelector_ be ? GetValue(_exprRef_).
         1. Return IsStrictlyEqual(_input_, _clauseSelector_).
       </emu-alg>
@@ -22626,7 +22607,7 @@
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
       <emu-alg>
-        1. Let _exprRef_ be Evaluation of |Expression|.
+        1. Let _exprRef_ be ? Evaluation of |Expression|.
         1. Let _switchValue_ be ? GetValue(_exprRef_).
         1. Let _oldEnv_ be the running execution context's LexicalEnvironment.
         1. Let _blockEnv_ be NewDeclarativeEnvironment(_oldEnv_).
@@ -22645,7 +22626,7 @@
       </emu-alg>
       <emu-grammar>CaseClause : `case` Expression `:` StatementList</emu-grammar>
       <emu-alg>
-        1. Return Evaluation of |StatementList|.
+        1. Return ? Evaluation of |StatementList|.
       </emu-alg>
       <emu-grammar>DefaultClause : `default` `:`</emu-grammar>
       <emu-alg>
@@ -22653,7 +22634,7 @@
       </emu-alg>
       <emu-grammar>DefaultClause : `default` `:` StatementList</emu-grammar>
       <emu-alg>
-        1. Return Evaluation of |StatementList|.
+        1. Return ? Evaluation of |StatementList|.
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -22730,7 +22711,7 @@
       </emu-alg>
       <emu-grammar>BreakableStatement : SwitchStatement</emu-grammar>
       <emu-alg>
-        1. Let _stmtResult_ be Evaluation of |SwitchStatement|.
+        1. Let _stmtResult_ be Completion(Evaluation of |SwitchStatement|).
         1. If _stmtResult_.[[Type]] is ~break~, then
           1. If _stmtResult_.[[Target]] is ~empty~, then
             1. If _stmtResult_.[[Value]] is ~empty~, set _stmtResult_ to NormalCompletion(*undefined*).
@@ -22751,7 +22732,7 @@
       </emu-alg>
       <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
       <emu-alg>
-        1. Return Evaluation of |FunctionDeclaration|.
+        1. Return ? Evaluation of |FunctionDeclaration|.
       </emu-alg>
       <emu-grammar>
         Statement :
@@ -22769,7 +22750,7 @@
           DebuggerStatement
       </emu-grammar>
       <emu-alg>
-        1. Return Evaluation of |Statement|.
+        1. Return ? Evaluation of |Statement|.
       </emu-alg>
       <emu-note>
         <p>The only two productions of |Statement| which have special semantics for LabelledEvaluation are |BreakableStatement| and |LabelledStatement|.</p>
@@ -22789,7 +22770,7 @@
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>ThrowStatement : `throw` Expression `;`</emu-grammar>
       <emu-alg>
-        1. Let _exprRef_ be Evaluation of |Expression|.
+        1. Let _exprRef_ be ? Evaluation of |Expression|.
         1. Let _exprValue_ be ? GetValue(_exprRef_).
         1. Return ThrowCompletion(_exprValue_).
       </emu-alg>
@@ -22858,13 +22839,13 @@
         1. If _status_ is an abrupt completion, then
           1. Set the running execution context's LexicalEnvironment to _oldEnv_.
           1. Return ? _status_.
-        1. Let _B_ be Evaluation of |Block|.
+        1. Let _B_ be Completion(Evaluation of |Block|).
         1. Set the running execution context's LexicalEnvironment to _oldEnv_.
         1. Return ? _B_.
       </emu-alg>
       <emu-grammar>Catch : `catch` Block</emu-grammar>
       <emu-alg>
-        1. Return Evaluation of |Block|.
+        1. Return ? Evaluation of |Block|.
       </emu-alg>
       <emu-note>
         <p>No matter how control leaves the |Block| the LexicalEnvironment is always restored to its former state.</p>
@@ -22875,24 +22856,24 @@
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>TryStatement : `try` Block Catch</emu-grammar>
       <emu-alg>
-        1. Let _B_ be Evaluation of |Block|.
+        1. Let _B_ be Completion(Evaluation of |Block|).
         1. If _B_.[[Type]] is ~throw~, let _C_ be Completion(CatchClauseEvaluation of |Catch| with argument _B_.[[Value]]).
         1. Else, let _C_ be _B_.
         1. Return ? UpdateEmpty(_C_, *undefined*).
       </emu-alg>
       <emu-grammar>TryStatement : `try` Block Finally</emu-grammar>
       <emu-alg>
-        1. Let _B_ be Evaluation of |Block|.
-        1. Let _F_ be Evaluation of |Finally|.
+        1. Let _B_ be Completion(Evaluation of |Block|).
+        1. Let _F_ be Completion(Evaluation of |Finally|).
         1. If _F_.[[Type]] is ~normal~, set _F_ to _B_.
         1. Return ? UpdateEmpty(_F_, *undefined*).
       </emu-alg>
       <emu-grammar>TryStatement : `try` Block Catch Finally</emu-grammar>
       <emu-alg>
-        1. Let _B_ be Evaluation of |Block|.
+        1. Let _B_ be Completion(Evaluation of |Block|).
         1. If _B_.[[Type]] is ~throw~, let _C_ be Completion(CatchClauseEvaluation of |Catch| with argument _B_.[[Value]]).
         1. Else, let _C_ be _B_.
-        1. Let _F_ be Evaluation of |Finally|.
+        1. Let _F_ be Completion(Evaluation of |Finally|).
         1. If _F_.[[Type]] is ~normal~, set _F_ to _C_.
         1. Return ? UpdateEmpty(_F_, *undefined*).
       </emu-alg>
@@ -23325,7 +23306,7 @@
       <emu-grammar>FunctionBody : FunctionStatementList</emu-grammar>
       <emu-alg>
         1. Perform ? FunctionDeclarationInstantiation(_functionObject_, _argumentsList_).
-        1. Return Evaluation of |FunctionStatementList|.
+        1. Return ? Evaluation of |FunctionStatementList|.
       </emu-alg>
     </emu-clause>
 
@@ -23508,7 +23489,7 @@
       <emu-grammar>ConciseBody : ExpressionBody</emu-grammar>
       <emu-alg>
         1. Perform ? FunctionDeclarationInstantiation(_functionObject_, _argumentsList_).
-        1. Return Evaluation of |ExpressionBody|.
+        1. Return ? Evaluation of |ExpressionBody|.
       </emu-alg>
     </emu-clause>
 
@@ -23543,7 +23524,7 @@
       </emu-alg>
       <emu-grammar>ExpressionBody : AssignmentExpression</emu-grammar>
       <emu-alg>
-        1. Let _exprRef_ be Evaluation of |AssignmentExpression|.
+        1. Let _exprRef_ be ? Evaluation of |AssignmentExpression|.
         1. Let _exprValue_ be ? GetValue(_exprRef_).
         1. Return Completion Record { [[Type]]: ~return~, [[Value]]: _exprValue_, [[Target]]: ~empty~ }.
       </emu-alg>
@@ -23660,8 +23641,7 @@
       </dl>
       <emu-grammar>MethodDefinition : ClassElementName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
-        1. Let _propKey_ be Evaluation of |ClassElementName|.
-        1. ReturnIfAbrupt(_propKey_).
+        1. Let _propKey_ be ? Evaluation of |ClassElementName|.
         1. Let _env_ be the running execution context's LexicalEnvironment.
         1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
         1. If _functionPrototype_ is present, then
@@ -23692,8 +23672,7 @@
       </emu-alg>
       <emu-grammar>MethodDefinition : `get` ClassElementName `(` `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
-        1. Let _propKey_ be Evaluation of |ClassElementName|.
-        1. ReturnIfAbrupt(_propKey_).
+        1. Let _propKey_ be ? Evaluation of |ClassElementName|.
         1. Let _env_ be the running execution context's LexicalEnvironment.
         1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
         1. Let _sourceText_ be the source text matched by |MethodDefinition|.
@@ -23710,8 +23689,7 @@
       </emu-alg>
       <emu-grammar>MethodDefinition : `set` ClassElementName `(` PropertySetParameterList `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
-        1. Let _propKey_ be Evaluation of |ClassElementName|.
-        1. ReturnIfAbrupt(_propKey_).
+        1. Let _propKey_ be ? Evaluation of |ClassElementName|.
         1. Let _env_ be the running execution context's LexicalEnvironment.
         1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
         1. Let _sourceText_ be the source text matched by |MethodDefinition|.
@@ -23727,8 +23705,7 @@
       </emu-alg>
       <emu-grammar>GeneratorMethod : `*` ClassElementName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
-        1. Let _propKey_ be Evaluation of |ClassElementName|.
-        1. ReturnIfAbrupt(_propKey_).
+        1. Let _propKey_ be ? Evaluation of |ClassElementName|.
         1. Let _env_ be the running execution context's LexicalEnvironment.
         1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
         1. Let _sourceText_ be the source text matched by |GeneratorMethod|.
@@ -23743,8 +23720,7 @@
         AsyncGeneratorMethod : `async` `*` ClassElementName `(` UniqueFormalParameters `)` `{` AsyncGeneratorBody `}`
       </emu-grammar>
       <emu-alg>
-        1. Let _propKey_ be Evaluation of |ClassElementName|.
-        1. ReturnIfAbrupt(_propKey_).
+        1. Let _propKey_ be ? Evaluation of |ClassElementName|.
         1. Let _env_ be the running execution context's LexicalEnvironment.
         1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
         1. Let _sourceText_ be the source text matched by |AsyncGeneratorMethod|.
@@ -23759,8 +23735,7 @@
         AsyncMethod : `async` ClassElementName `(` UniqueFormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
       <emu-alg>
-        1. Let _propKey_ be Evaluation of |ClassElementName|.
-        1. ReturnIfAbrupt(_propKey_).
+        1. Let _propKey_ be ? Evaluation of |ClassElementName|.
         1. Let _env_ be the LexicalEnvironment of the running execution context.
         1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
         1. Let _sourceText_ be the source text matched by |AsyncMethod|.
@@ -23967,14 +23942,14 @@
       </emu-alg>
       <emu-grammar>YieldExpression : `yield` AssignmentExpression</emu-grammar>
       <emu-alg>
-        1. Let _exprRef_ be Evaluation of |AssignmentExpression|.
+        1. Let _exprRef_ be ? Evaluation of |AssignmentExpression|.
         1. Let _value_ be ? GetValue(_exprRef_).
         1. Return ? Yield(_value_).
       </emu-alg>
       <emu-grammar>YieldExpression : `yield` `*` AssignmentExpression</emu-grammar>
       <emu-alg>
         1. Let _generatorKind_ be GetGeneratorKind().
-        1. Let _exprRef_ be Evaluation of |AssignmentExpression|.
+        1. Let _exprRef_ be ? Evaluation of |AssignmentExpression|.
         1. Let _value_ be ? GetValue(_exprRef_).
         1. Let _iteratorRecord_ be ? GetIterator(_value_, _generatorKind_).
         1. Let _iterator_ be _iteratorRecord_.[[Iterator]].
@@ -24666,8 +24641,7 @@
         FieldDefinition : ClassElementName Initializer?
       </emu-grammar>
       <emu-alg>
-        1. Let _name_ be Evaluation of |ClassElementName|.
-        1. ReturnIfAbrupt(_name_).
+        1. Let _name_ be ? Evaluation of |ClassElementName|.
         1. If |Initializer?| is present, then
           1. Let _formalParameterList_ be an instance of the production <emu-grammar>FormalParameters : [empty]</emu-grammar>.
           1. Let _env_ be the LexicalEnvironment of the running execution context.
@@ -24717,7 +24691,7 @@
       <emu-grammar>ClassStaticBlockBody : ClassStaticBlockStatementList</emu-grammar>
       <emu-alg>
         1. Perform ? FunctionDeclarationInstantiation(_functionObject_, &laquo; &raquo;).
-        1. Return Evaluation of |ClassStaticBlockStatementList|.
+        1. Return ? Evaluation of |ClassStaticBlockStatementList|.
       </emu-alg>
     </emu-clause>
 
@@ -24796,7 +24770,7 @@
         1. Else,
           1. Set the running execution context's LexicalEnvironment to _classEnv_.
           1. NOTE: The running execution context's PrivateEnvironment is _outerPrivateEnvironment_ when evaluating |ClassHeritage|.
-          1. Let _superclassRef_ be Evaluation of |ClassHeritage|.
+          1. Let _superclassRef_ be Completion(Evaluation of |ClassHeritage|).
           1. Set the running execution context's LexicalEnvironment to _env_.
           1. Let _superclass_ be ? GetValue(_superclassRef_).
           1. If _superclass_ is *null*, then
@@ -25133,7 +25107,7 @@
         AwaitExpression : `await` UnaryExpression
       </emu-grammar>
       <emu-alg>
-        1. Let _exprRef_ be Evaluation of |UnaryExpression|.
+        1. Let _exprRef_ be ? Evaluation of |UnaryExpression|.
         1. Let _value_ be ? GetValue(_exprRef_).
         1. Return ? Await(_value_).
       </emu-alg>
@@ -25829,7 +25803,7 @@
         1. Let _script_ be _scriptRecord_.[[ECMAScriptCode]].
         1. Let _result_ be Completion(GlobalDeclarationInstantiation(_script_, _globalEnv_)).
         1. If _result_.[[Type]] is ~normal~, then
-          1. Set _result_ to Evaluation of _script_.
+          1. Set _result_ to Completion(Evaluation of _script_).
         1. If _result_.[[Type]] is ~normal~ and _result_.[[Value]] is ~empty~, then
           1. Set _result_ to NormalCompletion(*undefined*).
         1. Suspend _scriptContext_ and remove it from the execution context stack.
@@ -27774,7 +27748,7 @@
             1. If _module_.[[HasTLA]] is *false*, then
               1. Assert: _capability_ is not present.
               1. Push _moduleContext_ onto the execution context stack; _moduleContext_ is now the running execution context.
-              1. Let _result_ be Evaluation of _module_.[[ECMAScriptCode]].
+              1. Let _result_ be Completion(Evaluation of _module_.[[ECMAScriptCode]]).
               1. Suspend _moduleContext_ and remove it from the execution context stack.
               1. Resume the context that is now on the top of the execution context stack as the running execution context.
               1. If _result_ is an abrupt completion, then
@@ -27943,16 +27917,15 @@
         </emu-alg>
         <emu-grammar>ModuleBody : ModuleItemList</emu-grammar>
         <emu-alg>
-          1. Let _result_ be Evaluation of |ModuleItemList|.
+          1. Let _result_ be Completion(Evaluation of |ModuleItemList|).
           1. If _result_.[[Type]] is ~normal~ and _result_.[[Value]] is ~empty~, then
             1. Return *undefined*.
           1. Return ? _result_.
         </emu-alg>
         <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
         <emu-alg>
-          1. Let _sl_ be Evaluation of |ModuleItemList|.
-          1. ReturnIfAbrupt(_sl_).
-          1. Let _s_ be Evaluation of |ModuleItem|.
+          1. Let _sl_ be ? Evaluation of |ModuleItemList|.
+          1. Let _s_ be Completion(Evaluation of |ModuleItem|).
           1. Return ? UpdateEmpty(_s_, _sl_).
         </emu-alg>
         <emu-note>
@@ -28468,15 +28441,15 @@
         </emu-alg>
         <emu-grammar>ExportDeclaration : `export` VariableStatement</emu-grammar>
         <emu-alg>
-          1. Return Evaluation of |VariableStatement|.
+          1. Return ? Evaluation of |VariableStatement|.
         </emu-alg>
         <emu-grammar>ExportDeclaration : `export` Declaration</emu-grammar>
         <emu-alg>
-          1. Return Evaluation of |Declaration|.
+          1. Return ? Evaluation of |Declaration|.
         </emu-alg>
         <emu-grammar>ExportDeclaration : `export` `default` HoistableDeclaration</emu-grammar>
         <emu-alg>
-          1. Return Evaluation of |HoistableDeclaration|.
+          1. Return ? Evaluation of |HoistableDeclaration|.
         </emu-alg>
         <emu-grammar>ExportDeclaration : `export` `default` ClassDeclaration</emu-grammar>
         <emu-alg>
@@ -28492,7 +28465,7 @@
           1. If IsAnonymousFunctionDefinition(|AssignmentExpression|) is *true*, then
             1. Let _value_ be ? NamedEvaluation of |AssignmentExpression| with argument *"default"*.
           1. Else,
-            1. Let _rhs_ be Evaluation of |AssignmentExpression|.
+            1. Let _rhs_ be ? Evaluation of |AssignmentExpression|.
             1. Let _value_ be ? GetValue(_rhs_).
           1. Let _env_ be the running execution context's LexicalEnvironment.
           1. Perform ? InitializeBoundName(*"\*default\*"*, _value_, _env_).
@@ -28695,7 +28668,7 @@
           1. Push _evalContext_ onto the execution context stack; _evalContext_ is now the running execution context.
           1. Let _result_ be Completion(EvalDeclarationInstantiation(_body_, _varEnv_, _lexEnv_, _privateEnv_, _strictEval_)).
           1. If _result_.[[Type]] is ~normal~, then
-            1. Set _result_ to Evaluation of _body_.
+            1. Set _result_ to Completion(Evaluation of _body_).
           1. If _result_.[[Type]] is ~normal~ and _result_.[[Value]] is ~empty~, then
             1. Set _result_ to NormalCompletion(*undefined*).
           1. Suspend _evalContext_ and remove it from the execution context stack.
@@ -42396,7 +42369,7 @@ THH:mm:ss.sss
         1. [id="step-json-parse-parse"] Let _script_ be ParseText(StringToCodePoints(_scriptString_), |Script|).
         1. NOTE: The early error rules defined in <emu-xref href="#sec-object-initializer-static-semantics-early-errors"></emu-xref> have special handling for the above invocation of ParseText.
         1. Assert: _script_ is a Parse Node.
-        1. [id="step-json-parse-eval"] Let _completion_ be <emu-meta suppress-effects="user-code">Evaluation of _script_</emu-meta>.
+        1. [id="step-json-parse-eval"] Let _completion_ be Completion(<emu-meta suppress-effects="user-code">Evaluation of _script_</emu-meta>).
         1. NOTE: The PropertyDefinitionEvaluation semantics defined in <emu-xref href="#sec-runtime-semantics-propertydefinitionevaluation"></emu-xref> have special handling for the above evaluation.
         1. Let _unfiltered_ be _completion_.[[Value]].
         1. [id="step-json-parse-assert-type"] Assert: _unfiltered_ is either a String, Number, Boolean, Null, or an Object that is defined by either an |ArrayLiteral| or an |ObjectLiteral|.
@@ -45034,7 +45007,7 @@ THH:mm:ss.sss
           1. Set the Generator component of _genContext_ to _generator_.
           1. [fence-effects="user-code"] Set the code evaluation state of _genContext_ such that when evaluation is resumed for that execution context the following steps will be performed:
             1. If _generatorBody_ is a Parse Node, then
-              1. Let _result_ be Evaluation of _generatorBody_.
+              1. Let _result_ be Completion(Evaluation of _generatorBody_).
             1. Else,
               1. Assert: _generatorBody_ is an Abstract Closure with no parameters.
               1. Let _result_ be _generatorBody_().
@@ -45387,7 +45360,7 @@ THH:mm:ss.sss
           1. Set the Generator component of _genContext_ to _generator_.
           1. [fence-effects="user-code"] Set the code evaluation state of _genContext_ such that when evaluation is resumed for that execution context the following steps will be performed:
             1. If _generatorBody_ is a Parse Node, then
-              1. Let _result_ be Evaluation of _generatorBody_.
+              1. Let _result_ be Completion(Evaluation of _generatorBody_).
             1. Else,
               1. Assert: _generatorBody_ is an Abstract Closure with no parameters.
               1. Let _result_ be Completion(_generatorBody_()).
@@ -45780,7 +45753,7 @@ THH:mm:ss.sss
           1. Assert: _promiseCapability_ is a PromiseCapability Record.
           1. Let _runningContext_ be the running execution context.
           1. [fence-effects="user-code"] Set the code evaluation state of _asyncContext_ such that when evaluation is resumed for that execution context the following steps will be performed:
-            1. Let _result_ be Evaluation of _asyncBody_.
+            1. Let _result_ be Completion(Evaluation of _asyncBody_).
             1. Assert: If we return here, the async function either threw an exception or performed an implicit or explicit return; all awaiting is done.
             1. Remove _asyncContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
             1. If _result_.[[Type]] is ~normal~, then
@@ -48119,7 +48092,7 @@ THH:mm:ss.sss
         1. If IsAnonymousFunctionDefinition(|Initializer|) is *true*, then
           1. Let _value_ be ? NamedEvaluation of |Initializer| with argument _bindingId_.
         1. Else,
-          1. Let _rhs_ be Evaluation of |Initializer|.
+          1. Let _rhs_ be ? Evaluation of |Initializer|.
           1. Let _value_ be ? GetValue(_rhs_).
         1. Perform ? PutValue(_lhs_, _value_).
         1. Let _keyResult_ be ? ForIn/OfHeadEvaluation(&laquo; &raquo;, |Expression|, ~enumerate~).

--- a/spec.html
+++ b/spec.html
@@ -957,7 +957,7 @@
 
       <emu-clause id="sec-implicit-normal-completion" oldids="sec-implicit-completion-values">
         <h1>Implicit Normal Completion</h1>
-        <p>In algorithms within abstract operations which are declared to return a Completion Record, within the Evaluation syntax-directed operation, and within all built-in functions, the returned value is first passed to NormalCompletion, and the result is used instead. This rule does not apply within the Completion algorithm or when the value being returned is clearly marked as a Completion Record in that step; these cases are:</p>
+        <p>In algorithms within abstract operations which are declared to return a Completion Record, and within all built-in functions, the returned value is first passed to NormalCompletion, and the result is used instead. This rule does not apply within the Completion algorithm or when the value being returned is clearly marked as a Completion Record in that step; these cases are:</p>
         <ul>
           <li>when the result of applying Completion, NormalCompletion, or ThrowCompletion is directly returned</li>
           <li>when the result of constructing a Completion Record is directly returned</li>
@@ -7224,6 +7224,15 @@
 <emu-clause id="sec-syntax-directed-operations">
   <h1>Syntax-Directed Operations</h1>
   <p>In addition to those defined in this section, specialized syntax-directed operations are defined throughout this specification.</p>
+
+  <emu-clause id="sec-evaluation" type="sdo">
+    <h1>Runtime Semantics: Evaluation ( ): a Completion Record</h1>
+    <dl class="header">
+    </dl>
+    <emu-note>
+      The definitions for this operation are distributed over the "ECMAScript Language" sections of this specification. Each definition appears after the defining occurrence of the relevant productions.
+    </emu-note>
+  </emu-clause>
 
   <emu-clause id="sec-syntax-directed-operations-scope-analysis">
     <h1>Scope Analysis</h1>

--- a/spec.html
+++ b/spec.html
@@ -21064,7 +21064,7 @@
         1. Set the running execution context's LexicalEnvironment to _blockEnv_.
         1. Let _blockValue_ be Completion(Evaluation of |StatementList|).
         1. Set the running execution context's LexicalEnvironment to _oldEnv_.
-        1. Return _blockValue_.
+        1. Return ? _blockValue_.
       </emu-alg>
       <emu-note>
         <p>No matter how control leaves the |Block| the LexicalEnvironment is always restored to its former state.</p>


### PR DESCRIPTION
The `Evaluation` SDO is different from most SDOs in several ways, which this PR tries to reduce.

Each commit is a logically separate refactoring, but they should probably be squashed before merging.

The "spec bug" label is not to imply that treating `Evaluation` differently was a bug, but rather that this PR fixes some bugs along the way.

----

(1) The definitions of `Evaluation` are distributed over the "ECMAScript Language" sections of the spec rather than being gathered into one place (as established in PR #2271).

This PR does *not* consolidate the definitions of `Evaluation`.

However, the distributed definition has also meant that this SDO doesn't have a "home" section, so the first commit of this PR adds such a section. Now there will be a place to link to for "Evaluation", and a place (in the rendered spec) where you can find links to invocations of it. There could also be some prose that talks about Evaluation in general; suggestions welcome.

(The placement of the section, making it the new 8.1, was suggested by bakkot. To me, it seems odd to put a Runtime Semantics section before a Static Semantics section. I'd be inclined to reorganize section 8 into SS and RS, but I don't care too much.)

Note: Since Evaluation is now declared to return a Completion Record, it doesn't need to be special-cased in the first para of [Implicit Normal Completion](https://tc39.es/ecma262/#sec-implicit-normal-completion).

(Another aspect of Evaluation's distributed definition is that the multiple headings for its definitions don't conform to the 'structured header' conventions of PRs #2512 and #2547. I didn't try to change this, as bakkot thought that might confuse ecmarkup.)

----

(2) Currently, the invocations of Evaluation don't refer to it by that name, but are instead of the form "the result of evaluating X".

The second commit of this PR changes all such to "Evaluation of X".

Note that I left a few occurrences of the old form:
- In [[Call]] + [[Construct]] for a built-in function object, `the result of evaluating _F_` isn't a reference to the Evaluation SDO. (For one thing, the 'operand' is a function object, not a Parse Node.)
- Similarly in [Property Accessors](https://tc39.es/ecma262/#sec-property-accessors).
- In [Annex F](https://tc39.es/ecma262/#sec-additions-and-changes-that-introduce-incompatibilities-with-prior-editions), they *are* references to Evaluation, and could reasonably be changed. However, it's prose (where "the result of evaluating X" reads better), and it's an Annex, so I'm not sure there's a benefit. Let me know.

----

(3) Although Evaluation returns Completion Records, its invocations aren't currently marked with `!`, `?`, or `Completion()`.

To remove this difference, commit 3 starts by surrounding every invocation of Evaluation with `Completion()`, and then commits 4-8 gradually replace most of those with `?`.

(Commit 3 skips the two invocations of `Evaluation` in the chain rule example at the bottom of [5.2.2 Syntax-Directed Operations](https://tc39.es/ecma262/#sec-algorithm-conventions-syntax-directed-operations), because injecting "Completion()" would just confuse the reader. [Unfortunately, this omission causes ecmarkup to fail.] Perhaps the example should be rewritten to use an SDO that doesn't return a CR.)

Note: In commit 3, Implicit Normal Completion can drop the exception:
> when directly returning with the phrase "Evaluation of",

because all of those cases are now covered by the exception:
> when the result of applying Completion ... is directly returned.

Commits 4-8 have detailed commit messages; I'm not sure what I'll do with those if/when they get squashed.

----

Commit 9 is just a bonus bugfix.
