### PR TITLE
Editorial: Eliminate "unknown" as a parameter type

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -40848,7 +40848,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Assert: IsSharedArrayBuffer(_arrayBuffer_) is *false*.
           1. If _key_ is not present, set _key_ to *undefined*.
-          1. If SameValue(_arrayBuffer_.[[ArrayBufferDetachKey]], _key_) is *false*, throw a *TypeError* exception.
+          1. If _arrayBuffer_.[[ArrayBufferDetachKey]] is not _key_, throw a *TypeError* exception.
           1. Set _arrayBuffer_.[[ArrayBufferData]] to *null*.
           1. Set _arrayBuffer_.[[ArrayBufferByteLength]] to 0.
           1. Return ~unused~.

--- a/spec.html
+++ b/spec.html
@@ -4064,7 +4064,7 @@
       <emu-clause id="sec-normalcompletion" type="abstract operation">
         <h1>
           NormalCompletion (
-            _value_: unknown,
+            _value_: any value except a Completion Record,
           ): a normal completion
         </h1>
         <dl class="header">
@@ -4091,7 +4091,7 @@
         <h1>
           UpdateEmpty (
             _completionRecord_: a Completion Record,
-            _value_: unknown,
+            _value_: any value except a Completion Record,
           ): a Completion Record
         </h1>
         <dl class="header">
@@ -4256,7 +4256,7 @@
       <emu-clause id="sec-getthisvalue" type="abstract operation">
         <h1>
           GetThisValue (
-            _V_: unknown,
+            _V_: a Reference Record,
           ): an ECMAScript language value
         </h1>
         <dl class="header">
@@ -4387,7 +4387,7 @@
       <emu-clause id="sec-topropertydescriptor" type="abstract operation">
         <h1>
           ToPropertyDescriptor (
-            _Obj_: unknown,
+            _Obj_: an ECMAScript language value,
           ): either a normal completion containing a Property Descriptor or a throw completion
         </h1>
         <dl class="header">
@@ -4798,7 +4798,7 @@
     <emu-clause id="sec-toboolean" type="abstract operation">
       <h1>
         ToBoolean (
-          _argument_: unknown,
+          _argument_: an ECMAScript language value,
         ): a Boolean
       </h1>
       <dl class="header">
@@ -4889,7 +4889,7 @@
     <emu-clause id="sec-tonumeric" type="abstract operation">
       <h1>
         ToNumeric (
-          _value_: unknown,
+          _value_: an ECMAScript language value,
         ): either a normal completion containing either a Number or a BigInt, or a throw completion
       </h1>
       <dl class="header">
@@ -4906,7 +4906,7 @@
     <emu-clause id="sec-tonumber" type="abstract operation">
       <h1>
         ToNumber (
-          _argument_: unknown,
+          _argument_: an ECMAScript language value,
         ): either a normal completion containing a Number or a throw completion
       </h1>
       <dl class="header">
@@ -5173,7 +5173,7 @@
     <emu-clause id="sec-toint32" type="abstract operation">
       <h1>
         ToInt32 (
-          _argument_: unknown,
+          _argument_: an ECMAScript language value,
         ): either a normal completion containing an integral Number or a throw completion
       </h1>
       <dl class="header">
@@ -5206,7 +5206,7 @@
     <emu-clause id="sec-touint32" type="abstract operation">
       <h1>
         ToUint32 (
-          _argument_: unknown,
+          _argument_: an ECMAScript language value,
         ): either a normal completion containing an integral Number or a throw completion
       </h1>
       <dl class="header">
@@ -5242,7 +5242,7 @@
     <emu-clause id="sec-toint16" type="abstract operation">
       <h1>
         ToInt16 (
-          _argument_: unknown,
+          _argument_: an ECMAScript language value,
         ): either a normal completion containing an integral Number or a throw completion
       </h1>
       <dl class="header">
@@ -5261,7 +5261,7 @@
     <emu-clause id="sec-touint16" type="abstract operation">
       <h1>
         ToUint16 (
-          _argument_: unknown,
+          _argument_: an ECMAScript language value,
         ): either a normal completion containing an integral Number or a throw completion
       </h1>
       <dl class="header">
@@ -5291,7 +5291,7 @@
     <emu-clause id="sec-toint8" type="abstract operation">
       <h1>
         ToInt8 (
-          _argument_: unknown,
+          _argument_: an ECMAScript language value,
         ): either a normal completion containing an integral Number or a throw completion
       </h1>
       <dl class="header">
@@ -5310,7 +5310,7 @@
     <emu-clause id="sec-touint8" type="abstract operation">
       <h1>
         ToUint8 (
-          _argument_: unknown,
+          _argument_: an ECMAScript language value,
         ): either a normal completion containing an integral Number or a throw completion
       </h1>
       <dl class="header">
@@ -5329,7 +5329,7 @@
     <emu-clause id="sec-touint8clamp" type="abstract operation">
       <h1>
         ToUint8Clamp (
-          _argument_: unknown,
+          _argument_: an ECMAScript language value,
         ): either a normal completion containing an integral Number or a throw completion
       </h1>
       <dl class="header">
@@ -5355,7 +5355,7 @@
     <emu-clause id="sec-tobigint" type="abstract operation">
       <h1>
         ToBigInt (
-          _argument_: unknown,
+          _argument_: an ECMAScript language value,
         ): either a normal completion containing a BigInt or a throw completion
       </h1>
       <dl class="header">
@@ -5488,7 +5488,7 @@
     <emu-clause id="sec-tobigint64" type="abstract operation">
       <h1>
         ToBigInt64 (
-          _argument_: unknown,
+          _argument_: an ECMAScript language value,
         ): either a normal completion containing a BigInt or a throw completion
       </h1>
       <dl class="header">
@@ -5505,7 +5505,7 @@
     <emu-clause id="sec-tobiguint64" type="abstract operation">
       <h1>
         ToBigUint64 (
-          _argument_: unknown,
+          _argument_: an ECMAScript language value,
         ): either a normal completion containing a BigInt or a throw completion
       </h1>
       <dl class="header">
@@ -5522,7 +5522,7 @@
     <emu-clause id="sec-tostring" type="abstract operation">
       <h1>
         ToString (
-          _argument_: unknown,
+          _argument_: an ECMAScript language value,
         ): either a normal completion containing a String or a throw completion
       </h1>
       <dl class="header">
@@ -5615,7 +5615,7 @@
     <emu-clause id="sec-toobject" type="abstract operation">
       <h1>
         ToObject (
-          _argument_: unknown,
+          _argument_: an ECMAScript language value,
         ): either a normal completion containing an Object or a throw completion
       </h1>
       <dl class="header">
@@ -5703,7 +5703,7 @@
     <emu-clause id="sec-topropertykey" type="abstract operation">
       <h1>
         ToPropertyKey (
-          _argument_: unknown,
+          _argument_: an ECMAScript language value,
         ): either a normal completion containing a property key or a throw completion
       </h1>
       <dl class="header">
@@ -5783,7 +5783,7 @@
     <emu-clause id="sec-requireobjectcoercible" type="abstract operation">
       <h1>
         RequireObjectCoercible (
-          _argument_: unknown,
+          _argument_: an ECMAScript language value,
         ): either a normal completion containing an ECMAScript language value or a throw completion
       </h1>
       <dl class="header">
@@ -5871,7 +5871,7 @@
     <emu-clause id="sec-isarray" type="abstract operation">
       <h1>
         IsArray (
-          _argument_: unknown,
+          _argument_: an ECMAScript language value,
         ): either a normal completion containing a Boolean or a throw completion
       </h1>
       <dl class="header">
@@ -5939,7 +5939,7 @@
     <emu-clause id="sec-isintegralnumber" type="abstract operation" oldids="sec-isinteger">
       <h1>
         IsIntegralNumber (
-          _argument_: unknown,
+          _argument_: an ECMAScript language value,
         ): a Boolean
       </h1>
       <dl class="header">
@@ -5974,7 +5974,7 @@
     <emu-clause id="sec-isregexp" type="abstract operation">
       <h1>
         IsRegExp (
-          _argument_: unknown,
+          _argument_: an ECMAScript language value,
         ): either a normal completion containing a Boolean or a throw completion
       </h1>
       <dl class="header">
@@ -6480,7 +6480,7 @@
       <h1>
         Construct (
           _F_: a constructor,
-          optional _argumentsList_: unknown,
+          optional _argumentsList_: a List of ECMAScript language values,
           optional _newTarget_: a constructor,
         ): either a normal completion containing an Object or a throw completion
       </h1>
@@ -6601,7 +6601,7 @@
     <emu-clause id="sec-createlistfromarraylike" type="abstract operation">
       <h1>
         CreateListFromArrayLike (
-          _obj_: unknown,
+          _obj_: an ECMAScript language value,
           optional _elementTypes_: a List of names of ECMAScript Language Types,
         ): either a normal completion containing a List of ECMAScript language values or a throw completion
       </h1>
@@ -6649,7 +6649,7 @@
       <h1>
         OrdinaryHasInstance (
           _C_: an ECMAScript language value,
-          _O_: unknown,
+          _O_: an ECMAScript language value,
         ): either a normal completion containing a Boolean or a throw completion
       </h1>
       <dl class="header">
@@ -8414,7 +8414,7 @@
     <emu-clause id="sec-static-semantics-containsduplicatelabels" oldids="sec-statement-semantics-static-semantics-containsduplicatelabels,sec-block-static-semantics-containsduplicatelabels,sec-if-statement-static-semantics-containsduplicatelabels,sec-do-while-statement-static-semantics-containsduplicatelabels,sec-while-statement-static-semantics-containsduplicatelabels,sec-for-statement-static-semantics-containsduplicatelabels,sec-for-in-and-for-of-statements-static-semantics-containsduplicatelabels,sec-with-statement-static-semantics-containsduplicatelabels,sec-switch-statement-static-semantics-containsduplicatelabels,sec-labelled-statements-static-semantics-containsduplicatelabels,sec-try-statement-static-semantics-containsduplicatelabels,sec-function-definitions-static-semantics-containsduplicatelabels,sec-module-semantics-static-semantics-containsduplicatelabels" type="sdo">
       <h1>
         Static Semantics: ContainsDuplicateLabels (
-          _labelSet_: unknown,
+          _labelSet_: a List of Strings,
         ): a Boolean
       </h1>
       <dl class="header">
@@ -8586,7 +8586,7 @@
     <emu-clause id="sec-static-semantics-containsundefinedbreaktarget" oldids="sec-statement-semantics-static-semantics-containsundefinedbreaktarget,sec-block-static-semantics-containsundefinedbreaktarget,sec-if-statement-static-semantics-containsundefinedbreaktarget,sec-do-while-statement-static-semantics-containsundefinedbreaktarget,sec-while-statement-static-semantics-containsundefinedbreaktarget,sec-for-statement-static-semantics-containsundefinedbreaktarget,sec-for-in-and-for-of-statements-static-semantics-containsundefinedbreaktarget,sec-break-statement-static-semantics-containsundefinedbreaktarget,sec-with-statement-static-semantics-containsundefinedbreaktarget,sec-switch-statement-static-semantics-containsundefinedbreaktarget,sec-labelled-statements-static-semantics-containsundefinedbreaktarget,sec-try-statement-static-semantics-containsundefinedbreaktarget,sec-function-definitions-static-semantics-containsundefinedbreaktarget,sec-module-semantics-static-semantics-containsundefinedbreaktarget" type="sdo">
       <h1>
         Static Semantics: ContainsUndefinedBreakTarget (
-          _labelSet_: unknown,
+          _labelSet_: a List of Strings,
         ): a Boolean
       </h1>
       <dl class="header">
@@ -8765,8 +8765,8 @@
     <emu-clause id="sec-static-semantics-containsundefinedcontinuetarget" oldids="sec-statement-semantics-static-semantics-containsundefinedcontinuetarget,sec-block-static-semantics-containsundefinedcontinuetarget,sec-if-statement-static-semantics-containsundefinedcontinuetarget,sec-do-while-statement-static-semantics-containsundefinedcontinuetarget,sec-while-statement-static-semantics-containsundefinedcontinuetarget,sec-for-statement-static-semantics-containsundefinedcontinuetarget,sec-for-in-and-for-of-statements-static-semantics-containsundefinedcontinuetarget,sec-continue-statement-static-semantics-containsundefinedcontinuetarget,sec-with-statement-static-semantics-containsundefinedcontinuetarget,sec-switch-statement-static-semantics-containsundefinedcontinuetarget,sec-labelled-statements-static-semantics-containsundefinedcontinuetarget,sec-try-statement-static-semantics-containsundefinedcontinuetarget,sec-function-definitions-static-semantics-containsundefinedcontinuetarget,sec-module-semantics-static-semantics-containsundefinedcontinuetarget" type="sdo">
       <h1>
         Static Semantics: ContainsUndefinedContinueTarget (
-          _iterationSet_: unknown,
-          _labelSet_: unknown,
+          _iterationSet_: a List of Strings,
+          _labelSet_: a List of Strings,
         ): a Boolean
       </h1>
       <dl class="header">
@@ -9218,7 +9218,7 @@
     <emu-clause id="sec-runtime-semantics-namedevaluation" oldids="sec-grouping-operator-runtime-semantics-namedevaluation,sec-function-definitions-runtime-semantics-namedevaluation,sec-arrow-function-definitions-runtime-semantics-namedevaluation,sec-generator-function-definitions-runtime-semantics-namedevaluation,sec-asyncgenerator-definitions-namedevaluation,sec-class-definitions-runtime-semantics-namedevaluation,sec-async-function-definitions-runtime-semantics-namedevaluation,sec-async-arrow-function-definitions-runtime-semantics-namedevaluation" type="sdo">
       <h1>
         Runtime Semantics: NamedEvaluation (
-          _name_: unknown,
+          _name_: a property key or a Private Name,
         ): either a normal completion containing a function object or an abrupt completion
       </h1>
       <dl class="header">
@@ -9280,7 +9280,7 @@
     <emu-clause id="sec-static-semantics-contains" oldids="sec-object-initializer-static-semantics-contains,sec-static-semantics-static-semantics-contains,sec-function-definitions-static-semantics-contains,sec-arrow-function-definitions-static-semantics-contains,sec-generator-function-definitions-static-semantics-contains,sec-async-generator-function-definitions-static-semantics-contains,sec-class-definitions-static-semantics-contains,sec-async-function-definitions-static-semantics-Contains,sec-async-arrow-function-definitions-static-semantics-Contains" type="sdo">
       <h1>
         Static Semantics: Contains (
-          _symbol_: unknown,
+          _symbol_: a grammar symbol,
         ): a Boolean
       </h1>
       <dl class="header">
@@ -9416,7 +9416,7 @@
     <emu-clause id="sec-static-semantics-computedpropertycontains" oldids="sec-object-initializer-static-semantics-computedpropertycontains,sec-method-definitions-static-semantics-computedpropertycontains,sec-generator-function-definitions-static-semantics-computedpropertycontains,sec-async-generator-function-definitions-static-semantics-computedpropertycontains,sec-class-definitions-static-semantics-computedpropertycontains,sec-async-function-definitions-static-semantics-ComputedPropertyContains" type="sdo">
       <h1>
         Static Semantics: ComputedPropertyContains (
-          _symbol_: unknown,
+          _symbol_: a grammar symbol,
         ): a Boolean
       </h1>
       <dl class="header">
@@ -9486,8 +9486,8 @@
     <emu-clause id="sec-runtime-semantics-instantiatefunctionobject" type="sdo">
       <h1>
         Runtime Semantics: InstantiateFunctionObject (
-          _env_: unknown,
-          _privateEnv_: unknown,
+          _env_: an Environment Record,
+          _privateEnv_: a PrivateEnvironment Record or *null*,
         ): a function object
       </h1>
       <dl class="header">
@@ -9529,8 +9529,8 @@
     <emu-clause id="sec-runtime-semantics-bindinginitialization" oldids="sec-identifiers-runtime-semantics-bindinginitialization,sec-destructuring-binding-patterns-runtime-semantics-bindinginitialization" type="sdo">
       <h1>
         Runtime Semantics: BindingInitialization (
-          _value_: unknown,
-          _environment_: unknown,
+          _value_: an ECMAScript language value,
+          _environment_: an Environment Record or *undefined*,
         ): either a normal completion containing ~unused~ or an abrupt completion
       </h1>
       <dl class="header">
@@ -9591,8 +9591,8 @@
         <h1>
           InitializeBoundName (
             _name_: a String,
-            _value_: unknown,
-            _environment_: unknown,
+            _value_: an ECMAScript language value,
+            _environment_: an Environment Record or *undefined*,
           ): either a normal completion containing ~unused~ or an abrupt completion
         </h1>
         <dl class="header">
@@ -9611,8 +9611,8 @@
     <emu-clause id="sec-runtime-semantics-iteratorbindinginitialization" oldids="sec-destructuring-binding-patterns-runtime-semantics-iteratorbindinginitialization,sec-function-definitions-runtime-semantics-iteratorbindinginitialization,sec-arrow-function-definitions-runtime-semantics-iteratorbindinginitialization,sec-async-arrow-function-definitions-IteratorBindingInitialization" type="sdo">
       <h1>
         Runtime Semantics: IteratorBindingInitialization (
-          _iteratorRecord_: unknown,
-          _environment_: unknown,
+          _iteratorRecord_: an Iterator Record,
+          _environment_: an Environment Record or *undefined*,
         ): either a normal completion containing ~unused~ or an abrupt completion
       </h1>
       <dl class="header">
@@ -11498,8 +11498,8 @@
       <emu-clause id="sec-newglobalenvironment" type="abstract operation">
         <h1>
           NewGlobalEnvironment (
-            _G_: unknown,
-            _thisValue_: unknown,
+            _G_: an Object,
+            _thisValue_: an Object,
           ): a Global Environment Record
         </h1>
         <dl class="header">
@@ -11712,7 +11712,7 @@
     <emu-clause id="sec-createintrinsics" type="abstract operation">
       <h1>
         CreateIntrinsics (
-          _realmRec_: unknown,
+          _realmRec_: a Realm Record,
         ): ~unused~
       </h1>
       <dl class="header">
@@ -11728,9 +11728,9 @@
     <emu-clause id="sec-setrealmglobalobject" type="abstract operation">
       <h1>
         SetRealmGlobalObject (
-          _realmRec_: unknown,
+          _realmRec_: a Realm Record,
           _globalObj_: an Object or *undefined*,
-          _thisValue_: unknown,
+          _thisValue_: an Object or *undefined*,
         ): ~unused~
       </h1>
       <dl class="header">
@@ -11751,7 +11751,7 @@
     <emu-clause id="sec-setdefaultglobalbindings" type="abstract operation">
       <h1>
         SetDefaultGlobalBindings (
-          _realmRec_: unknown,
+          _realmRec_: a Realm Record,
         ): either a normal completion containing an Object or a throw completion
       </h1>
       <dl class="header">
@@ -13053,8 +13053,8 @@
     <emu-clause id="sec-requireinternalslot" type="abstract operation">
       <h1>
         RequireInternalSlot (
-          _O_: unknown,
-          _internalSlot_: unknown,
+          _O_: an ECMAScript language value,
+          _internalSlot_: an internal slot name,
         ): either a normal completion containing ~unused~ or a throw completion
       </h1>
       <dl class="header">
@@ -13347,7 +13347,7 @@
       <emu-clause id="sec-runtime-semantics-evaluatebody" type="sdo">
         <h1>
           Runtime Semantics: EvaluateBody (
-            _functionObject_: unknown,
+            _functionObject_: a function object,
             _argumentsList_: a List of ECMAScript language values,
           ): either a normal completion containing an ECMAScript language value or an abrupt completion
         </h1>
@@ -13672,7 +13672,7 @@
       <h1>
         FunctionDeclarationInstantiation (
           _func_: a function object,
-          _argumentsList_: unknown,
+          _argumentsList_: a List of ECMAScript language values,
         ): either a normal completion containing ~unused~ or an abrupt completion
       </h1>
       <dl class="header">
@@ -13870,7 +13870,7 @@
         CreateBuiltinFunction (
           _behaviour_: an Abstract Closure, a set of algorithm steps, or some other definition of a function's behaviour provided in this specification,
           _length_: a non-negative integer or +&infin;,
-          _name_: a property key,
+          _name_: a property key or a Private Name,
           _additionalInternalSlotsList_: a List of names of internal slots,
           optional _realm_: a Realm Record,
           optional _prototype_: an Object or *null*,
@@ -14077,7 +14077,7 @@
         <h1>
           ArrayCreate (
             _length_: a non-negative integer,
-            optional _proto_: unknown,
+            optional _proto_: an Object,
           ): either a normal completion containing an Array exotic object or a throw completion
         </h1>
         <dl class="header">
@@ -14098,7 +14098,7 @@
       <emu-clause id="sec-arrayspeciescreate" type="abstract operation">
         <h1>
           ArraySpeciesCreate (
-            _originalArray_: unknown,
+            _originalArray_: an Object,
             _length_: a non-negative integer,
           ): either a normal completion containing an Object or a throw completion
         </h1>
@@ -14248,7 +14248,7 @@
         <h1>
           StringCreate (
             _value_: a String,
-            _prototype_: unknown,
+            _prototype_: an Object,
           ): a String exotic object
         </h1>
         <dl class="header">
@@ -14444,7 +14444,7 @@
       <emu-clause id="sec-createunmappedargumentsobject" type="abstract operation">
         <h1>
           CreateUnmappedArgumentsObject (
-            _argumentsList_: unknown,
+            _argumentsList_: a List of ECMAScript language values,
           ): an ordinary object
         </h1>
         <dl class="header">
@@ -14710,7 +14710,7 @@
       <emu-clause id="sec-integerindexedobjectcreate" type="abstract operation">
         <h1>
           IntegerIndexedObjectCreate (
-            _prototype_: unknown,
+            _prototype_: an Object,
           ): an Integer-Indexed exotic object
         </h1>
         <dl class="header">
@@ -15083,7 +15083,7 @@
       <emu-clause id="sec-set-immutable-prototype" type="abstract operation">
         <h1>
           SetImmutablePrototype (
-            _O_: unknown,
+            _O_: an Object,
             _V_: an Object or *null*,
           ): either a normal completion containing a Boolean or a throw completion
         </h1>
@@ -15793,8 +15793,8 @@
     <emu-clause id="sec-proxycreate" type="abstract operation">
       <h1>
         ProxyCreate (
-          _target_: unknown,
-          _handler_: unknown,
+          _target_: an ECMAScript language value,
+          _handler_: an ECMAScript language value,
         ): either a normal completion containing a Proxy exotic object or a throw completion
       </h1>
       <dl class="header">
@@ -18403,7 +18403,7 @@
       <emu-clause id="sec-runtime-semantics-propertydefinitionevaluation" oldids="sec-object-initializer-runtime-semantics-propertydefinitionevaluation" type="sdo">
         <h1>
           Runtime Semantics: PropertyDefinitionEvaluation (
-            _object_: unknown,
+            _object_: an Object,
           ): either a normal completion containing ~unused~ or an abrupt completion
         </h1>
         <dl class="header">
@@ -18591,7 +18591,7 @@
       <emu-clause id="sec-static-semantics-templatestrings" type="sdo">
         <h1>
           Static Semantics: TemplateStrings (
-            _raw_: unknown,
+            _raw_: a Boolean,
           ): a List of Strings
         </h1>
         <dl class="header">
@@ -19209,9 +19209,9 @@
       <emu-clause id="sec-makesuperpropertyreference" type="abstract operation">
         <h1>
           MakeSuperPropertyReference (
-            _actualThis_: unknown,
-            _propertyKey_: unknown,
-            _strict_: unknown,
+            _actualThis_: an ECMAScript language value,
+            _propertyKey_: a property key,
+            _strict_: a Boolean,
           ): either a normal completion containing a Super Reference Record or a throw completion
         </h1>
         <dl class="header">
@@ -19343,8 +19343,8 @@
       <emu-clause id="sec-optional-chaining-chain-evaluation" type="sdo">
         <h1>
           Runtime Semantics: ChainEvaluation (
-            _baseValue_: unknown,
-            _baseReference_: unknown,
+            _baseValue_: an ECMAScript language value,
+            _baseReference_: an ECMAScript language value or a Reference Record,
           ): either a normal completion containing an ECMAScript language value or an abrupt completion
         </h1>
         <dl class="header">
@@ -20695,7 +20695,7 @@
       <emu-clause id="sec-runtime-semantics-destructuringassignmentevaluation" type="sdo">
         <h1>
           Runtime Semantics: DestructuringAssignmentEvaluation (
-            _value_: unknown,
+            _value_: an ECMAScript language value,
           ): either a normal completion containing ~unused~ or an abrupt completion
         </h1>
         <dl class="header">
@@ -20780,7 +20780,7 @@
       <emu-clause id="sec-runtime-semantics-propertydestructuringassignmentevaluation" type="sdo">
         <h1>
           Runtime Semantics: PropertyDestructuringAssignmentEvaluation (
-            _value_: unknown,
+            _value_: an ECMAScript language value,
           ): either a normal completion containing a List of property keys or an abrupt completion
         </h1>
         <dl class="header">
@@ -20820,8 +20820,8 @@
       <emu-clause id="sec-runtime-semantics-restdestructuringassignmentevaluation" type="sdo">
         <h1>
           Runtime Semantics: RestDestructuringAssignmentEvaluation (
-            _value_: unknown,
-            _excludedNames_: unknown,
+            _value_: an ECMAScript language value,
+            _excludedNames_: a List of property keys,
           ): either a normal completion containing ~unused~ or an abrupt completion
         </h1>
         <dl class="header">
@@ -20838,7 +20838,7 @@
       <emu-clause id="sec-runtime-semantics-iteratordestructuringassignmentevaluation" type="sdo">
         <h1>
           Runtime Semantics: IteratorDestructuringAssignmentEvaluation (
-            _iteratorRecord_: unknown,
+            _iteratorRecord_: an Iterator Record,
           ): either a normal completion containing ~unused~ or an abrupt completion
         </h1>
         <dl class="header">
@@ -20936,8 +20936,8 @@
       <emu-clause id="sec-runtime-semantics-keyeddestructuringassignmentevaluation" type="sdo">
         <h1>
           Runtime Semantics: KeyedDestructuringAssignmentEvaluation (
-            _value_: unknown,
-            _propertyName_: unknown,
+            _value_: an ECMAScript language value,
+            _propertyName_: a property key,
           ): either a normal completion containing ~unused~ or an abrupt completion
         </h1>
         <dl class="header">
@@ -21360,8 +21360,8 @@
       <emu-clause id="sec-destructuring-binding-patterns-runtime-semantics-propertybindinginitialization" type="sdo">
         <h1>
           Runtime Semantics: PropertyBindingInitialization (
-            _value_: unknown,
-            _environment_: unknown,
+            _value_: an ECMAScript language value,
+            _environment_: an Environment Record or *undefined*,
           ): either a normal completion containing a List of property keys or an abrupt completion
         </h1>
         <dl class="header">
@@ -21393,9 +21393,9 @@
       <emu-clause id="sec-destructuring-binding-patterns-runtime-semantics-restbindinginitialization" type="sdo">
         <h1>
           Runtime Semantics: RestBindingInitialization (
-            _value_: unknown,
-            _environment_: unknown,
-            _excludedNames_: unknown,
+            _value_: an ECMAScript language value,
+            _environment_: an Environment Record or *undefined*,
+            _excludedNames_: a List of property keys,
           ): either a normal completion containing ~unused~ or an abrupt completion
         </h1>
         <dl class="header">
@@ -21413,9 +21413,9 @@
       <emu-clause id="sec-runtime-semantics-keyedbindinginitialization" type="sdo">
         <h1>
           Runtime Semantics: KeyedBindingInitialization (
-            _value_: unknown,
-            _environment_: unknown,
-            _propertyName_: unknown,
+            _value_: an ECMAScript language value,
+            _environment_: an Environment Record or *undefined*,
+            _propertyName_: a property key,
           ): either a normal completion containing ~unused~ or an abrupt completion
         </h1>
         <dl class="header">
@@ -21561,8 +21561,8 @@
       <emu-clause id="sec-loopcontinues" type="abstract operation">
         <h1>
           LoopContinues (
-            _completion_: unknown,
-            _labelSet_: unknown,
+            _completion_: a Completion Record,
+            _labelSet_: a List of Strings,
           ): a Boolean
         </h1>
         <dl class="header">
@@ -21582,7 +21582,7 @@
       <emu-clause id="sec-runtime-semantics-loopevaluation" type="sdo">
         <h1>
           Runtime Semantics: LoopEvaluation (
-            _labelSet_: unknown,
+            _labelSet_: a List of Strings,
           ): either a normal completion containing an ECMAScript language value or an abrupt completion
         </h1>
         <dl class="header">
@@ -21630,7 +21630,7 @@
       <emu-clause id="sec-runtime-semantics-dowhileloopevaluation" oldids="sec-do-while-statement-runtime-semantics-labelledevaluation" type="sdo">
         <h1>
           Runtime Semantics: DoWhileLoopEvaluation (
-            _labelSet_: unknown,
+            _labelSet_: a List of Strings,
           ): either a normal completion containing an ECMAScript language value or an abrupt completion
         </h1>
         <dl class="header">
@@ -21673,7 +21673,7 @@
       <emu-clause id="sec-runtime-semantics-whileloopevaluation" oldids="sec-while-statement-runtime-semantics-labelledevaluation" type="sdo">
         <h1>
           Runtime Semantics: WhileLoopEvaluation (
-            _labelSet_: unknown,
+            _labelSet_: a List of Strings,
           ): either a normal completion containing an ECMAScript language value or an abrupt completion
         </h1>
         <dl class="header">
@@ -21729,7 +21729,7 @@
       <emu-clause id="sec-runtime-semantics-forloopevaluation" oldids="sec-for-statement-runtime-semantics-labelledevaluation" type="sdo">
         <h1>
           Runtime Semantics: ForLoopEvaluation (
-            _labelSet_: unknown,
+            _labelSet_: a List of Strings,
           ): either a normal completion containing an ECMAScript language value or an abrupt completion
         </h1>
         <dl class="header">
@@ -21778,11 +21778,11 @@
       <emu-clause id="sec-forbodyevaluation" type="abstract operation">
         <h1>
           ForBodyEvaluation (
-            _test_: unknown,
-            _increment_: unknown,
-            _stmt_: unknown,
-            _perIterationBindings_: unknown,
-            _labelSet_: unknown,
+            _test_: an |Expression| Parse Node or ~empty~,
+            _increment_: an |Expression| Parse Node or ~empty~,
+            _stmt_: a |Statement| Parse Node,
+            _perIterationBindings_: a List of Strings,
+            _labelSet_: a List of Strings,
           ): either a normal completion containing an ECMAScript language value or an abrupt completion
         </h1>
         <dl class="header">
@@ -21808,7 +21808,7 @@
       <emu-clause id="sec-createperiterationenvironment" type="abstract operation">
         <h1>
           CreatePerIterationEnvironment (
-            _perIterationBindings_: unknown,
+            _perIterationBindings_: a List of Strings,
           ): either a normal completion containing ~unused~ or a throw completion
         </h1>
         <dl class="header">
@@ -21963,8 +21963,8 @@
       <emu-clause id="sec-runtime-semantics-fordeclarationbindinginitialization" oldids="sec-for-in-and-for-of-statements-runtime-semantics-bindinginitialization" type="sdo">
         <h1>
           Runtime Semantics: ForDeclarationBindingInitialization (
-            _value_: unknown,
-            _environment_: unknown,
+            _value_: an ECMAScript language value,
+            _environment_: an Environment Record or *undefined*,
           ): either a normal completion containing ~unused~ or an abrupt completion
         </h1>
         <dl class="header">
@@ -21981,14 +21981,13 @@
       <emu-clause id="sec-runtime-semantics-fordeclarationbindinginstantiation" oldids="sec-runtime-semantics-bindinginstantiation" type="sdo">
         <h1>
           Runtime Semantics: ForDeclarationBindingInstantiation (
-            _environment_: unknown,
+            _environment_: a Declarative Environment Record,
           ): ~unused~
         </h1>
         <dl class="header">
         </dl>
         <emu-grammar>ForDeclaration : LetOrConst ForBinding</emu-grammar>
         <emu-alg>
-          1. Assert: _environment_ is a Declarative Environment Record.
           1. For each element _name_ of the BoundNames of |ForBinding|, do
             1. If IsConstantDeclaration of |LetOrConst| is *true*, then
               1. Perform ! _environment_.CreateImmutableBinding(_name_, *true*).
@@ -22001,7 +22000,7 @@
       <emu-clause id="sec-runtime-semantics-forinofloopevaluation" oldids="sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation" type="sdo">
         <h1>
           Runtime Semantics: ForInOfLoopEvaluation (
-            _labelSet_: unknown,
+            _labelSet_: a List of Strings,
           ): either a normal completion containing an ECMAScript language value or an abrupt completion
         </h1>
         <dl class="header">
@@ -22065,8 +22064,8 @@
       <emu-clause id="sec-runtime-semantics-forinofheadevaluation" type="abstract operation" oldids="sec-runtime-semantics-forin-div-ofheadevaluation-tdznames-expr-iterationkind">
         <h1>
           ForIn/OfHeadEvaluation (
-            _uninitializedBoundNames_: unknown,
-            _expr_: unknown,
+            _uninitializedBoundNames_: a List of Strings,
+            _expr_: an |Expression| Parse Node or an |AssignmentExpression| Parse Node,
             _iterationKind_: ~enumerate~, ~iterate~, or ~async-iterate~,
           ): either a normal completion containing an Iterator Record or an abrupt completion
         </h1>
@@ -22101,12 +22100,12 @@
       <emu-clause id="sec-runtime-semantics-forin-div-ofbodyevaluation-lhs-stmt-iterator-lhskind-labelset" type="abstract operation">
         <h1>
           ForIn/OfBodyEvaluation (
-            _lhs_: unknown,
-            _stmt_: unknown,
-            _iteratorRecord_: unknown,
-            _iterationKind_: unknown,
+            _lhs_: a Parse Node,
+            _stmt_: a |Statement| Parse Node,
+            _iteratorRecord_: an Iterator Record,
+            _iterationKind_: ~enumerate~ or ~iterate~,
             _lhsKind_: ~assignment~, ~varBinding~, or ~lexicalBinding~,
-            _labelSet_: unknown,
+            _labelSet_: a List of Strings,
             optional _iteratorKind_: ~sync~ or ~async~,
           ): either a normal completion containing an ECMAScript language value or an abrupt completion
         </h1>
@@ -22558,7 +22557,7 @@
     <emu-clause id="sec-runtime-semantics-caseblockevaluation" type="sdo">
       <h1>
         Runtime Semantics: CaseBlockEvaluation (
-          _input_: unknown,
+          _input_: an ECMAScript language value,
         ): either a normal completion containing an ECMAScript language value or an abrupt completion
       </h1>
       <dl class="header">
@@ -22711,7 +22710,7 @@
     <emu-clause id="sec-islabelledfunction" type="abstract operation">
       <h1>
         Static Semantics: IsLabelledFunction (
-          _stmt_: unknown,
+          _stmt_: a |Statement| Parse Node,
         ): a Boolean
       </h1>
       <dl class="header">
@@ -22736,7 +22735,7 @@
     <emu-clause id="sec-runtime-semantics-labelledevaluation" oldids="sec-statement-semantics-runtime-semantics-labelledevaluation,sec-labelled-statements-runtime-semantics-labelledevaluation" type="sdo">
       <h1>
         Runtime Semantics: LabelledEvaluation (
-          _labelSet_: unknown,
+          _labelSet_: a List of Strings,
         ): either a normal completion containing an ECMAScript language value or an abrupt completion
       </h1>
       <dl class="header">
@@ -22864,7 +22863,7 @@
     <emu-clause id="sec-runtime-semantics-catchclauseevaluation" type="sdo">
       <h1>
         Runtime Semantics: CatchClauseEvaluation (
-          _thrownValue_: unknown,
+          _thrownValue_: an ECMAScript language value,
         ): either a normal completion containing an ECMAScript language value or an abrupt completion
       </h1>
       <dl class="header">
@@ -23338,7 +23337,7 @@
     <emu-clause id="sec-runtime-semantics-evaluatefunctionbody" oldids="sec-function-definitions-runtime-semantics-evaluatebody" type="sdo">
       <h1>
         Runtime Semantics: EvaluateFunctionBody (
-          _functionObject_: unknown,
+          _functionObject_: a function object,
           _argumentsList_: a List of ECMAScript language values,
         ): either a normal completion containing an ECMAScript language value or an abrupt completion
       </h1>
@@ -23354,8 +23353,8 @@
     <emu-clause id="sec-runtime-semantics-instantiateordinaryfunctionobject" oldids="sec-function-definitions-runtime-semantics-instantiatefunctionobject" type="sdo">
       <h1>
         Runtime Semantics: InstantiateOrdinaryFunctionObject (
-          _env_: unknown,
-          _privateEnv_: unknown,
+          _env_: an Environment Record,
+          _privateEnv_: a PrivateEnvironment Record or *null*,
         ): a function object
       </h1>
       <dl class="header">
@@ -23385,7 +23384,7 @@
     <emu-clause id="sec-runtime-semantics-instantiateordinaryfunctionexpression" type="sdo">
       <h1>
         Runtime Semantics: InstantiateOrdinaryFunctionExpression (
-          optional _name_: unknown,
+          optional _name_: a property key or a Private Name,
         ): a function object
       </h1>
       <dl class="header">
@@ -23521,7 +23520,7 @@
     <emu-clause id="sec-runtime-semantics-evaluateconcisebody" oldids="sec-arrow-function-definitions-runtime-semantics-evaluatebody" type="sdo">
       <h1>
         Runtime Semantics: EvaluateConciseBody (
-          _functionObject_: unknown,
+          _functionObject_: a function object,
           _argumentsList_: a List of ECMAScript language values,
         ): either a normal completion containing an ECMAScript language value or an abrupt completion
       </h1>
@@ -23537,7 +23536,7 @@
     <emu-clause id="sec-runtime-semantics-instantiatearrowfunctionexpression" type="sdo">
       <h1>
         Runtime Semantics: InstantiateArrowFunctionExpression (
-          optional _name_: unknown,
+          optional _name_: a property key or a Private Name,
         ): a function object
       </h1>
       <dl class="header">
@@ -23674,8 +23673,8 @@
     <emu-clause id="sec-runtime-semantics-definemethod" type="sdo">
       <h1>
         Runtime Semantics: DefineMethod (
-          _object_: unknown,
-          optional _functionPrototype_: unknown,
+          _object_: an Object,
+          optional _functionPrototype_: an Object,
         ): either a normal completion containing a Record with fields [[Key]] (a property key) and [[Closure]] (a function object) or an abrupt completion
       </h1>
       <dl class="header">
@@ -23699,8 +23698,8 @@
     <emu-clause id="sec-runtime-semantics-methoddefinitionevaluation" oldids="sec-method-definitions-runtime-semantics-propertydefinitionevaluation,sec-generator-function-definitions-runtime-semantics-propertydefinitionevaluation,sec-asyncgenerator-definitions-propertydefinitionevaluation,sec-async-function-definitions-PropertyDefinitionEvaluation" type="sdo">
       <h1>
         Runtime Semantics: MethodDefinitionEvaluation (
-          _object_: unknown,
-          _enumerable_: unknown,
+          _object_: an Object,
+          _enumerable_: a Boolean,
         ): either a normal completion containing either a PrivateElement or ~unused~, or an abrupt completion
       </h1>
       <dl class="header">
@@ -23879,7 +23878,7 @@
     <emu-clause id="sec-runtime-semantics-evaluategeneratorbody" oldids="sec-generator-function-definitions-runtime-semantics-evaluatebody" type="sdo">
       <h1>
         Runtime Semantics: EvaluateGeneratorBody (
-          _functionObject_: unknown,
+          _functionObject_: a function object,
           _argumentsList_: a List of ECMAScript language values,
         ): a throw completion or a return completion
       </h1>
@@ -23898,8 +23897,8 @@
     <emu-clause id="sec-runtime-semantics-instantiategeneratorfunctionobject" oldids="sec-generator-function-definitions-runtime-semantics-instantiatefunctionobject" type="sdo">
       <h1>
         Runtime Semantics: InstantiateGeneratorFunctionObject (
-          _env_: unknown,
-          _privateEnv_: unknown,
+          _env_: an Environment Record,
+          _privateEnv_: a PrivateEnvironment Record or *null*,
         ): a function object
       </h1>
       <dl class="header">
@@ -23931,7 +23930,7 @@
     <emu-clause id="sec-runtime-semantics-instantiategeneratorfunctionexpression" type="sdo">
       <h1>
         Runtime Semantics: InstantiateGeneratorFunctionExpression (
-          optional _name_: unknown,
+          optional _name_: a property key or a Private Name,
         ): a function object
       </h1>
       <dl class="header">
@@ -24102,7 +24101,7 @@
     <emu-clause id="sec-runtime-semantics-evaluateasyncgeneratorbody" oldids="sec-asyncgenerator-definitions-evaluatebody" type="sdo">
       <h1>
         Runtime Semantics: EvaluateAsyncGeneratorBody (
-          _functionObject_: unknown,
+          _functionObject_: a function object,
           _argumentsList_: a List of ECMAScript language values,
         ): a throw completion or a return completion
       </h1>
@@ -24123,8 +24122,8 @@
     <emu-clause id="sec-runtime-semantics-instantiateasyncgeneratorfunctionobject" oldids="sec-asyncgenerator-definitions-instantiatefunctionobject" type="sdo">
       <h1>
         Runtime Semantics: InstantiateAsyncGeneratorFunctionObject (
-          _env_: unknown,
-          _privateEnv_: unknown,
+          _env_: an Environment Record,
+          _privateEnv_: a PrivateEnvironment Record or *null*,
         ): a function object
       </h1>
       <dl class="header">
@@ -24160,7 +24159,7 @@
     <emu-clause id="sec-runtime-semantics-instantiateasyncgeneratorfunctionexpression" type="sdo">
       <h1>
         Runtime Semantics: InstantiateAsyncGeneratorFunctionExpression (
-          optional _name_: unknown,
+          optional _name_: a property key or a Private Name,
         ): a function object
       </h1>
       <dl class="header">
@@ -24483,7 +24482,7 @@
     <emu-clause id="sec-static-semantics-allprivateidentifiersvalid" type="sdo">
       <h1>
         Static Semantics: AllPrivateIdentifiersValid (
-          _names_: unknown,
+          _names_: a List of Strings,
         ): a Boolean
       </h1>
       <dl class="header">
@@ -24673,7 +24672,7 @@
     <emu-clause id="sec-runtime-semantics-classfielddefinitionevaluation" type="sdo">
       <h1>
         Runtime Semantics: ClassFieldDefinitionEvaluation (
-          _homeObject_: unknown,
+          _homeObject_: an Object,
         ): either a normal completion containing a ClassFieldDefinition Record or an abrupt completion
       </h1>
       <dl class="header">
@@ -24703,7 +24702,7 @@
     <emu-clause id="sec-runtime-semantics-classstaticblockdefinitionevaluation" type="sdo">
       <h1>
         Runtime Semantics: ClassStaticBlockDefinitionEvaluation (
-          _homeObject_: unknown,
+          _homeObject_: an Object,
         ): a ClassStaticBlockDefinition Record
       </h1>
       <dl class="header">
@@ -24724,7 +24723,7 @@
     <emu-clause id="sec-runtime-semantics-evaluateclassstaticblockbody" type="sdo">
       <h1>
         Runtime Semantics: EvaluateClassStaticBlockBody (
-          _functionObject_: unknown,
+          _functionObject_: a function object,
         ): either a normal completion containing an ECMAScript language value or an abrupt completion
       </h1>
       <dl class="header">
@@ -24739,7 +24738,7 @@
     <emu-clause id="sec-static-semantics-classelementevaluation" type="sdo">
       <h1>
         Runtime Semantics: ClassElementEvaluation (
-          _object_: unknown,
+          _object_: an Object,
         ): either a normal completion containing either a ClassFieldDefinition Record, a ClassStaticBlockDefinition Record, a Private Name, or ~unused~, or an abrupt completion
       </h1>
       <dl class="header">
@@ -24779,8 +24778,8 @@
     <emu-clause id="sec-runtime-semantics-classdefinitionevaluation" oldids="sec-default-constructor-functions" type="sdo">
       <h1>
         Runtime Semantics: ClassDefinitionEvaluation (
-          _classBinding_: unknown,
-          _className_: unknown,
+          _classBinding_: a String or *undefined*,
+          _className_: a property key or a Private Name,
         ): either a normal completion containing a function object or an abrupt completion
       </h1>
       <dl class="header">
@@ -25044,8 +25043,8 @@
     <emu-clause id="sec-runtime-semantics-instantiateasyncfunctionobject" oldids="sec-async-function-definitions-InstantiateFunctionObject" type="sdo">
       <h1>
         Runtime Semantics: InstantiateAsyncFunctionObject (
-          _env_: unknown,
-          _privateEnv_: unknown,
+          _env_: an Environment Record,
+          _privateEnv_: a PrivateEnvironment Record or *null*,
         ): a function object
       </h1>
       <dl class="header">
@@ -25074,7 +25073,7 @@
     <emu-clause id="sec-runtime-semantics-instantiateasyncfunctionexpression" type="sdo">
       <h1>
         Runtime Semantics: InstantiateAsyncFunctionExpression (
-          optional _name_: unknown,
+          optional _name_: a property key or a Private Name,
         ): a function object
       </h1>
       <dl class="header">
@@ -25115,7 +25114,7 @@
     <emu-clause id="sec-runtime-semantics-evaluateasyncfunctionbody" oldids="sec-async-function-definitions-EvaluateBody" type="sdo">
       <h1>
         Runtime Semantics: EvaluateAsyncFunctionBody (
-          _functionObject_: unknown,
+          _functionObject_: a function object,
           _argumentsList_: a List of ECMAScript language values,
         ): a return completion
       </h1>
@@ -25222,7 +25221,7 @@
     <emu-clause id="sec-runtime-semantics-evaluateasyncconcisebody" oldids="sec-async-arrow-function-definitions-EvaluateBody" type="sdo">
       <h1>
         Runtime Semantics: EvaluateAsyncConciseBody (
-          _functionObject_: unknown,
+          _functionObject_: a function object,
           _argumentsList_: a List of ECMAScript language values,
         ): a return completion
       </h1>
@@ -25245,7 +25244,7 @@
     <emu-clause id="sec-runtime-semantics-instantiateasyncarrowfunctionexpression" type="sdo">
       <h1>
         Runtime Semantics: InstantiateAsyncArrowFunctionExpression (
-          optional _name_: unknown,
+          optional _name_: a property key or a Private Name,
         ): a function object
       </h1>
       <dl class="header">
@@ -25298,7 +25297,7 @@
     <emu-clause id="sec-isintailposition" type="abstract operation">
       <h1>
         Static Semantics: IsInTailPosition (
-          _call_: a Parse Node,
+          _call_: a |CallExpression| Parse Node, a |MemberExpression| Parse Node, or an |OptionalChain| Parse Node,
         ): a Boolean
       </h1>
       <dl class="header">
@@ -25321,7 +25320,7 @@
     <emu-clause id="sec-static-semantics-hascallintailposition" type="sdo">
       <h1>
         Static Semantics: HasCallInTailPosition (
-          _call_: unknown,
+          _call_: a |CallExpression| Parse Node, a |MemberExpression| Parse Node, or an |OptionalChain| Parse Node,
         ): a Boolean
       </h1>
       <dl class="header">
@@ -25802,8 +25801,8 @@
       <h1>
         ParseScript (
           _sourceText_: ECMAScript source text,
-          _realm_: unknown,
-          _hostDefined_: unknown,
+          _realm_: a Realm Record or *undefined*,
+          _hostDefined_: anything,
         ): a Script Record or a non-empty List of *SyntaxError* objects
       </h1>
       <dl class="header">
@@ -25824,7 +25823,7 @@
     <emu-clause id="sec-runtime-semantics-scriptevaluation" type="abstract operation">
       <h1>
         ScriptEvaluation (
-          _scriptRecord_: unknown,
+          _scriptRecord_: a Script Record,
         ): either a normal completion containing an ECMAScript language value or an abrupt completion
       </h1>
       <dl class="header">
@@ -26385,7 +26384,7 @@
             <h1>
               InnerModuleLinking (
                 _module_: a Module Record,
-                _stack_: unknown,
+                _stack_: a List of Cyclic Module Records,
                 _index_: a non-negative integer,
               ): either a normal completion containing a non-negative integer or a throw completion
             </h1>
@@ -26472,7 +26471,7 @@
             <h1>
               InnerModuleEvaluation (
                 _module_: a Module Record,
-                _stack_: unknown,
+                _stack_: a List of Cyclic Module Records,
                 _index_: a non-negative integer,
               ): either a normal completion containing a non-negative integer or a throw completion
             </h1>
@@ -27559,8 +27558,8 @@
           <h1>
             ParseModule (
               _sourceText_: ECMAScript source text,
-              _realm_: unknown,
-              _hostDefined_: unknown,
+              _realm_: a Realm Record,
+              _hostDefined_: anything,
             ): a Source Text Module Record or a non-empty List of *SyntaxError* objects
           </h1>
           <dl class="header">
@@ -27769,7 +27768,7 @@
         <emu-clause id="sec-source-text-module-record-execute-module" type="concrete method">
           <h1>
             ExecuteModule (
-              optional _capability_: unknown,
+              optional _capability_: a PromiseCapability Record,
             ): either a normal completion containing ~unused~ or a throw completion
           </h1>
           <dl class="header">
@@ -27891,10 +27890,10 @@
       <emu-clause id="sec-finishdynamicimport" type="abstract operation">
         <h1>
           FinishDynamicImport (
-            _referencingScriptOrModule_: unknown,
-            _specifier_: unknown,
+            _referencingScriptOrModule_: a Script Record, a Module Record, or *null*,
+            _specifier_: a String,
             _promiseCapability_: a PromiseCapability Record,
-            _innerPromise_: unknown,
+            _innerPromise_: a Promise,
           ): ~unused~
         </h1>
         <dl class="header">
@@ -28069,7 +28068,7 @@
       <emu-clause id="sec-static-semantics-importentriesformodule" type="sdo">
         <h1>
           Static Semantics: ImportEntriesForModule (
-            _module_: unknown,
+            _module_: a String,
           ): a List of ImportEntry Records
         </h1>
         <dl class="header">
@@ -28391,7 +28390,7 @@
       <emu-clause id="sec-static-semantics-exportentriesformodule" type="sdo">
         <h1>
           Static Semantics: ExportEntriesForModule (
-            _module_: unknown,
+            _module_: a String or *null*,
           ): a List of ExportEntry Records
         </h1>
         <dl class="header">
@@ -28650,9 +28649,9 @@
       <emu-clause id="sec-performeval" type="abstract operation" oldids="sec-performeval-rules-outside-functions,sec-performeval-rules-outside-methods,sec-performeval-rules-outside-constructors">
         <h1>
           PerformEval (
-            _x_: unknown,
-            _strictCaller_: unknown,
-            _direct_: unknown,
+            _x_: an ECMAScript language value,
+            _strictCaller_: a Boolean,
+            _direct_: a Boolean,
           ): either a normal completion containing an ECMAScript language value or a throw completion
         </h1>
         <dl class="header">
@@ -28741,11 +28740,11 @@
       <emu-clause id="sec-evaldeclarationinstantiation" type="abstract operation">
         <h1>
           EvalDeclarationInstantiation (
-            _body_: unknown,
-            _varEnv_: unknown,
-            _lexEnv_: unknown,
-            _privateEnv_: unknown,
-            _strict_: unknown,
+            _body_: a |ScriptBody| Parse Node,
+            _varEnv_: an Environment Record,
+            _lexEnv_: a Declarative Environment Record,
+            _privateEnv_: a PrivateEnvironment Record or *null*,
+            _strict_: a Boolean,
           ): either a normal completion containing ~unused~ or a throw completion
         </h1>
         <dl class="header">
@@ -29395,7 +29394,7 @@
           <h1>
             ObjectDefineProperties (
               _O_: an Object,
-              _Properties_: unknown,
+              _Properties_: an ECMAScript language value,
             ): either a normal completion containing an Object or a throw completion
           </h1>
           <dl class="header">
@@ -29516,7 +29515,7 @@
         <emu-clause id="sec-getownpropertykeys" type="abstract operation">
           <h1>
             GetOwnPropertyKeys (
-              _O_: unknown,
+              _O_: an ECMAScript language value,
               _type_: ~string~ or ~symbol~,
             ): either a normal completion containing a List of property keys or a throw completion
           </h1>
@@ -36016,7 +36015,7 @@ THH:mm:ss.sss
         <emu-clause id="sec-regexpalloc" type="abstract operation">
           <h1>
             RegExpAlloc (
-              _newTarget_: unknown,
+              _newTarget_: a constructor,
             ): either a normal completion containing an Object or a throw completion
           </h1>
           <dl class="header">
@@ -36107,8 +36106,8 @@ THH:mm:ss.sss
         <emu-clause id="sec-regexpcreate" type="abstract operation">
           <h1>
             RegExpCreate (
-              _P_: unknown,
-              _F_: unknown,
+              _P_: an ECMAScript language value,
+              _F_: a String or *undefined*,
             ): either a normal completion containing an Object or a throw completion
           </h1>
           <dl class="header">
@@ -36122,8 +36121,8 @@ THH:mm:ss.sss
         <emu-clause id="sec-escaperegexppattern" type="abstract operation">
           <h1>
             EscapeRegExpPattern (
-              _P_: unknown,
-              _F_: unknown,
+              _P_: a String,
+              _F_: a String,
             ): a String
           </h1>
           <dl class="header">
@@ -37140,7 +37139,7 @@ THH:mm:ss.sss
         <emu-clause id="sec-isconcatspreadable" type="abstract operation">
           <h1>
             IsConcatSpreadable (
-              _O_: unknown,
+              _O_: an ECMAScript language value,
             ): either a normal completion containing a Boolean or a throw completion
           </h1>
           <dl class="header">
@@ -37450,8 +37449,8 @@ THH:mm:ss.sss
               _sourceLen_: a non-negative integer,
               _start_: a non-negative integer,
               _depth_: a non-negative integer or +&infin;,
-              optional _mapperFunction_: unknown,
-              optional _thisArg_: unknown,
+              optional _mapperFunction_: a function object,
+              optional _thisArg_: an ECMAScript language value,
             ): either a normal completion containing a non-negative integer or a throw completion
           </h1>
           <dl class="header">
@@ -39504,7 +39503,7 @@ THH:mm:ss.sss
         <h1>
           TypedArraySpeciesCreate (
             _exemplar_: a TypedArray,
-            _argumentList_: unknown,
+            _argumentList_: a List of ECMAScript language values,
           ): either a normal completion containing a TypedArray or a throw completion
         </h1>
         <dl class="header">
@@ -39524,8 +39523,8 @@ THH:mm:ss.sss
       <emu-clause id="typedarray-create" type="abstract operation">
         <h1>
           TypedArrayCreate (
-            _constructor_: unknown,
-            _argumentList_: unknown,
+            _constructor_: a constructor,
+            _argumentList_: a List of ECMAScript language values,
           ): either a normal completion containing a TypedArray or a throw completion
         </h1>
         <dl class="header">
@@ -39544,7 +39543,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-validatetypedarray" type="abstract operation">
         <h1>
           ValidateTypedArray (
-            _O_: unknown,
+            _O_: an ECMAScript language value,
           ): either a normal completion containing ~unused~ or a throw completion
         </h1>
         <dl class="header">
@@ -39636,8 +39635,8 @@ THH:mm:ss.sss
           <h1>
             AllocateTypedArray (
               _constructorName_: a String which is the name of a TypedArray constructor in <emu-xref href="#table-the-typedarray-constructors"></emu-xref>,
-              _newTarget_: unknown,
-              _defaultProto_: unknown,
+              _newTarget_: a constructor,
+              _defaultProto_: a String,
               optional _length_: a non-negative integer,
             ): either a normal completion containing a TypedArray or a throw completion
           </h1>
@@ -39896,7 +39895,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-add-entries-from-iterable" type="abstract operation">
         <h1>
           AddEntriesFromIterable (
-            _target_: unknown,
+            _target_: an Object,
             _iterable_: an ECMAScript language value, but not *undefined* or *null*,
             _adder_: a function object,
           ): either a normal completion containing an ECMAScript language value or a throw completion
@@ -40805,7 +40804,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-allocatearraybuffer" type="abstract operation">
         <h1>
           AllocateArrayBuffer (
-            _constructor_: unknown,
+            _constructor_: a constructor,
             _byteLength_: a non-negative integer,
           ): either a normal completion containing an ArrayBuffer or a throw completion
         </h1>
@@ -40840,7 +40839,7 @@ THH:mm:ss.sss
         <h1>
           DetachArrayBuffer (
             _arrayBuffer_: an ArrayBuffer,
-            optional _key_: unknown,
+            optional _key_: anything,
           ): either a normal completion containing ~unused~ or a throw completion
         </h1>
         <dl class="header">
@@ -40883,7 +40882,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-isunsignedelementtype" type="abstract operation">
         <h1>
           IsUnsignedElementType (
-            _type_: unknown,
+            _type_: a TypedArray element type,
           ): a Boolean
         </h1>
         <dl class="header">
@@ -40899,7 +40898,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-isunclampedintegerelementtype" type="abstract operation">
         <h1>
           IsUnclampedIntegerElementType (
-            _type_: unknown,
+            _type_: a TypedArray element type,
           ): a Boolean
         </h1>
         <dl class="header">
@@ -40915,7 +40914,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-isbigintelementtype" type="abstract operation">
         <h1>
           IsBigIntElementType (
-            _type_: unknown,
+            _type_: a TypedArray element type,
           ): a Boolean
         </h1>
         <dl class="header">
@@ -40931,8 +40930,8 @@ THH:mm:ss.sss
       <emu-clause id="sec-isnotearconfiguration" type="abstract operation">
         <h1>
           IsNoTearConfiguration (
-            _type_: unknown,
-            _order_: unknown,
+            _type_: a TypedArray element type,
+            _order_: ~SeqCst~, ~Unordered~, or ~Init~,
           ): a Boolean
         </h1>
         <dl class="header">
@@ -41250,7 +41249,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-allocatesharedarraybuffer" type="abstract operation">
         <h1>
           AllocateSharedArrayBuffer (
-            _constructor_: unknown,
+            _constructor_: a constructor,
             _byteLength_: a non-negative integer,
           ): either a normal completion containing a SharedArrayBuffer or a throw completion
         </h1>
@@ -41422,10 +41421,10 @@ THH:mm:ss.sss
       <emu-clause id="sec-getviewvalue" type="abstract operation">
         <h1>
           GetViewValue (
-            _view_: unknown,
-            _requestIndex_: unknown,
-            _isLittleEndian_: unknown,
-            _type_: unknown,
+            _view_: an ECMAScript language value,
+            _requestIndex_: an ECMAScript language value,
+            _isLittleEndian_: an ECMAScript language value,
+            _type_: a TypedArray element type,
           ): either a normal completion containing either a Number or a BigInt, or a throw completion
         </h1>
         <dl class="header">
@@ -41451,11 +41450,11 @@ THH:mm:ss.sss
       <emu-clause id="sec-setviewvalue" type="abstract operation">
         <h1>
           SetViewValue (
-            _view_: unknown,
-            _requestIndex_: unknown,
-            _isLittleEndian_: unknown,
-            _type_: unknown,
-            _value_: unknown,
+            _view_: an ECMAScript language value,
+            _requestIndex_: an ECMAScript language value,
+            _isLittleEndian_: an ECMAScript language value,
+            _type_: a TypedArray element type,
+            _value_: an ECMAScript language value,
           ): either a normal completion containing *undefined* or a throw completion
         </h1>
         <dl class="header">
@@ -41826,7 +41825,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-validateintegertypedarray" type="abstract operation" oldids="sec-validatesharedintegertypedarray">
         <h1>
           ValidateIntegerTypedArray (
-            _typedArray_: unknown,
+            _typedArray_: an ECMAScript language value,
             optional _waitable_: a Boolean,
           ): either a normal completion containing either an ArrayBuffer or a SharedArrayBuffer, or a throw completion
         </h1>
@@ -41849,7 +41848,7 @@ THH:mm:ss.sss
         <h1>
           ValidateAtomicAccess (
             _typedArray_: a TypedArray,
-            _requestIndex_: unknown,
+            _requestIndex_: an ECMAScript language value,
           ): either a normal completion containing an integer or a throw completion
         </h1>
         <dl class="header">
@@ -42026,9 +42025,9 @@ THH:mm:ss.sss
       <emu-clause id="sec-atomicreadmodifywrite" type="abstract operation">
         <h1>
           AtomicReadModifyWrite (
-            _typedArray_: unknown,
-            _index_: unknown,
-            _value_: unknown,
+            _typedArray_: an ECMAScript language value,
+            _index_: an ECMAScript language value,
+            _value_: an ECMAScript language value,
             _op_: a read-modify-write modification function,
           ): either a normal completion containing either a Number or a BigInt, or a throw completion
         </h1>
@@ -42556,8 +42555,8 @@ THH:mm:ss.sss
         <h1>
           SerializeJSONProperty (
             _state_: a JSON Serialization Record,
-            _key_: unknown,
-            _holder_: unknown,
+            _key_: a String,
+            _holder_: an Object,
           ): either a normal completion containing either *undefined* or a String, or a throw completion
         </h1>
         <dl class="header">
@@ -43381,7 +43380,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-createasyncfromsynciterator" type="abstract operation">
         <h1>
           CreateAsyncFromSyncIterator (
-            _syncIteratorRecord_: unknown,
+            _syncIteratorRecord_: an Iterator Record,
           ): an Iterator Record
         </h1>
         <dl class="header">
@@ -43512,7 +43511,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-asyncfromsynciteratorcontinuation" type="abstract operation" oldids="sec-async-from-sync-iterator-value-unwrap-functions">
         <h1>
           AsyncFromSyncIteratorContinuation (
-            _result_: unknown,
+            _result_: an Object,
             _promiseCapability_: a PromiseCapability Record for an intrinsic %Promise%,
           ): a Promise
         </h1>
@@ -43686,7 +43685,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-createresolvingfunctions" type="abstract operation">
         <h1>
           CreateResolvingFunctions (
-            _promise_: unknown,
+            _promise_: a Promise,
           ): a Record with fields [[Resolve]] (a function object) and [[Reject]] (a function object)
         </h1>
         <dl class="header">
@@ -43761,8 +43760,8 @@ THH:mm:ss.sss
       <emu-clause id="sec-fulfillpromise" type="abstract operation">
         <h1>
           FulfillPromise (
-            _promise_: unknown,
-            _value_: unknown,
+            _promise_: a Promise,
+            _value_: an ECMAScript language value,
           ): ~unused~
         </h1>
         <dl class="header">
@@ -43782,7 +43781,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-newpromisecapability" type="abstract operation" oldids="sec-getcapabilitiesexecutor-functions">
         <h1>
           NewPromiseCapability (
-            _C_: unknown,
+            _C_: an ECMAScript language value,
           ): either a normal completion containing a PromiseCapability Record or a throw completion
         </h1>
         <dl class="header">
@@ -43814,7 +43813,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-ispromise" type="abstract operation">
         <h1>
           IsPromise (
-            _x_: unknown,
+            _x_: an ECMAScript language value,
           ): a Boolean
         </h1>
         <dl class="header">
@@ -43831,8 +43830,8 @@ THH:mm:ss.sss
       <emu-clause id="sec-rejectpromise" type="abstract operation">
         <h1>
           RejectPromise (
-            _promise_: unknown,
-            _reason_: unknown,
+            _promise_: a Promise,
+            _reason_: an ECMAScript language value,
           ): ~unused~
         </h1>
         <dl class="header">
@@ -43854,7 +43853,7 @@ THH:mm:ss.sss
         <h1>
           TriggerPromiseReactions (
             _reactions_: a List of PromiseReaction Records,
-            _argument_: unknown,
+            _argument_: an ECMAScript language value,
           ): ~unused~
         </h1>
         <dl class="header">
@@ -43910,7 +43909,7 @@ THH:mm:ss.sss
         <h1>
           NewPromiseReactionJob (
             _reaction_: a PromiseReaction Record,
-            _argument_: unknown,
+            _argument_: an ECMAScript language value,
           ): a Record with fields [[Job]] (a Job Abstract Closure) and [[Realm]] (a Realm Record or *null*)
         </h1>
         <dl class="header">
@@ -43949,9 +43948,9 @@ THH:mm:ss.sss
       <emu-clause id="sec-newpromiseresolvethenablejob" type="abstract operation" oldids="sec-promiseresolvethenablejob">
         <h1>
           NewPromiseResolveThenableJob (
-            _promiseToResolve_: unknown,
-            _thenable_: unknown,
-            _then_: unknown,
+            _promiseToResolve_: a Promise,
+            _thenable_: an Object,
+            _then_: a JobCallback Record,
           ): a Record with fields [[Job]] (a Job Abstract Closure) and [[Realm]] (a Realm Record)
         </h1>
         <dl class="header">
@@ -44058,7 +44057,7 @@ THH:mm:ss.sss
         <emu-clause id="sec-performpromiseall" type="abstract operation">
           <h1>
             PerformPromiseAll (
-              _iteratorRecord_: unknown,
+              _iteratorRecord_: an Iterator Record,
               _constructor_: a constructor,
               _resultCapability_: a PromiseCapability Record,
               _promiseResolve_: a function object,
@@ -44146,7 +44145,7 @@ THH:mm:ss.sss
         <emu-clause id="sec-performpromiseallsettled" type="abstract operation">
           <h1>
             PerformPromiseAllSettled (
-              _iteratorRecord_: unknown,
+              _iteratorRecord_: an Iterator Record,
               _constructor_: a constructor,
               _resultCapability_: a PromiseCapability Record,
               _promiseResolve_: a function object,
@@ -44273,7 +44272,7 @@ THH:mm:ss.sss
         <emu-clause id="sec-performpromiseany" type="abstract operation">
           <h1>
             PerformPromiseAny (
-              _iteratorRecord_: unknown,
+              _iteratorRecord_: an Iterator Record,
               _constructor_: a constructor,
               _resultCapability_: a PromiseCapability Record,
               _promiseResolve_: a function object,
@@ -44372,7 +44371,7 @@ THH:mm:ss.sss
         <emu-clause id="sec-performpromiserace" type="abstract operation">
           <h1>
             PerformPromiseRace (
-              _iteratorRecord_: unknown,
+              _iteratorRecord_: an Iterator Record,
               _constructor_: a constructor,
               _resultCapability_: a PromiseCapability Record,
               _promiseResolve_: a function object,
@@ -44528,9 +44527,9 @@ THH:mm:ss.sss
         <emu-clause id="sec-performpromisethen" type="abstract operation">
           <h1>
             PerformPromiseThen (
-              _promise_: unknown,
-              _onFulfilled_: unknown,
-              _onRejected_: unknown,
+              _promise_: a Promise,
+              _onFulfilled_: an ECMAScript language value,
+              _onRejected_: an ECMAScript language value,
               optional _resultCapability_: a PromiseCapability Record,
             ): an ECMAScript language value
           </h1>
@@ -44988,7 +44987,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-generatorstart" type="abstract operation">
         <h1>
           GeneratorStart (
-            _generator_: unknown,
+            _generator_: a Generator,
             _generatorBody_: a |FunctionBody| Parse Node or an Abstract Closure with no parameters,
           ): ~unused~
         </h1>
@@ -45023,8 +45022,8 @@ THH:mm:ss.sss
       <emu-clause id="sec-generatorvalidate" type="abstract operation">
         <h1>
           GeneratorValidate (
-            _generator_: unknown,
-            _generatorBrand_: unknown,
+            _generator_: an ECMAScript language value,
+            _generatorBrand_: a String or ~empty~,
           ): either a normal completion containing either ~suspendedStart~, ~suspendedYield~, or ~completed~, or a throw completion
         </h1>
         <dl class="header">
@@ -45043,9 +45042,9 @@ THH:mm:ss.sss
       <emu-clause id="sec-generatorresume" type="abstract operation">
         <h1>
           GeneratorResume (
-            _generator_: unknown,
-            _value_: unknown,
-            _generatorBrand_: unknown,
+            _generator_: an ECMAScript language value,
+            _value_: an ECMAScript language value or ~empty~,
+            _generatorBrand_: a String or ~empty~,
           ): either a normal completion containing an ECMAScript language value or a throw completion
         </h1>
         <dl class="header">
@@ -45068,9 +45067,9 @@ THH:mm:ss.sss
       <emu-clause id="sec-generatorresumeabrupt" type="abstract operation">
         <h1>
           GeneratorResumeAbrupt (
-            _generator_: unknown,
+            _generator_: an ECMAScript language value,
             _abruptCompletion_: a return completion or a throw completion,
-            _generatorBrand_: unknown,
+            _generatorBrand_: a String or ~empty~,
           ): either a normal completion containing an ECMAScript language value or a throw completion
         </h1>
         <dl class="header">
@@ -45152,7 +45151,7 @@ THH:mm:ss.sss
         <h1>
           CreateIteratorFromClosure (
             _closure_: an Abstract Closure with no parameters,
-            _generatorBrand_: unknown,
+            _generatorBrand_: a String or ~empty~,
             _generatorPrototype_: an Object,
           ): a Generator
         </h1>
@@ -45375,8 +45374,8 @@ THH:mm:ss.sss
       <emu-clause id="sec-asyncgeneratorvalidate" type="abstract operation">
         <h1>
           AsyncGeneratorValidate (
-            _generator_: unknown,
-            _generatorBrand_: unknown,
+            _generator_: an ECMAScript language value,
+            _generatorBrand_: a String or ~empty~,
           ): either a normal completion containing ~unused~ or a throw completion
         </h1>
         <dl class="header">
@@ -45484,7 +45483,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-asyncgeneratoryield" type="abstract operation">
         <h1>
           AsyncGeneratorYield (
-            _value_: unknown,
+            _value_: an ECMAScript language value,
           ): either a normal completion containing an ECMAScript language value or an abrupt completion
         </h1>
         <dl class="header">
@@ -45586,7 +45585,7 @@ THH:mm:ss.sss
         <h1>
           CreateAsyncIteratorFromClosure (
             _closure_: an Abstract Closure with no parameters,
-            _generatorBrand_: unknown,
+            _generatorBrand_: a String or ~empty~,
             _generatorPrototype_: an Object,
           ): an AsyncGenerator
         </h1>
@@ -45718,7 +45717,7 @@ THH:mm:ss.sss
         <h1>
           AsyncFunctionStart (
             _promiseCapability_: a PromiseCapability Record,
-            _asyncFunctionBody_: unknown,
+            _asyncFunctionBody_: a |FunctionBody| Parse Node or an |ExpressionBody| Parse Node,
           ): ~unused~
         </h1>
         <dl class="header">
@@ -47530,10 +47529,10 @@ THH:mm:ss.sss
         <emu-annex id="sec-createhtml" type="abstract operation">
           <h1>
             CreateHTML (
-              _string_: unknown,
+              _string_: an ECMAScript language value,
               _tag_: a String,
               _attribute_: a String,
-              _value_: unknown,
+              _value_: an ECMAScript language value,
             ): either a normal completion containing a String or a throw completion
           </h1>
           <dl class="header">


### PR DESCRIPTION
In the current spec, there are ~250~ 240 AO/SDO parameters with a type of "unknown". This PR replaces ~almost~ all of those unknowns with a reasonable type.

<strike>I say "almost all" because it skips:</strike>
- <strike>the 3 `_state_` parameters handled by PR #2741, and</strike>
- <strike>the 5 `_V_` and `_W_` parameters of GetValue, PutValue, and InitializeReferencedBinding, because they're weird, and need some attention before they can get sensible types.</strike>

(PR #2741 and PR #2842 have both been merged, so the above exceptions have already been dealt with.)

The PR is broken into commits according to what replaces "unknown", in case that helps review. Squash before merging.