### PR TITLE
Editorial: Make the steps of GetStringIndex more explicit

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -36418,16 +36418,24 @@ THH:mm:ss.sss
           <h1>
             GetStringIndex (
               _S_: a String,
-              _e_: a non-negative integer,
+              _codePointIndex_: a non-negative integer,
             ): a non-negative integer
           </h1>
           <dl class="header">
+            <dt>description</dt>
+            <dd>It interprets _S_ as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>, and returns the code unit index corresponding to code point index _codePointIndex_ when such an index exists. Otherwise, it returns the length of _S_.</dd>
           </dl>
           <emu-alg>
             1. If _S_ is the empty String, return 0.
-            1. Let _codepoints_ be StringToCodePoints(_S_).
-            1. Let _eUTF_ be the smallest index into _S_ that corresponds to the character at element _e_ of _codepoints_. If _e_ is greater than or equal to the number of elements in _codepoints_, then _eUTF_ is the length of _S_.
-            1. Return _eUTF_.
+            1. Let _len_ be the length of _S_.
+            1. Let _codeUnitCount_ be 0.
+            1. Let _codePointCount_ be 0.
+            1. Repeat, while _codeUnitCount_ &lt; _len_,
+              1. If _codePointCount_ = _codePointIndex_, return _codeUnitCount_.
+              1. Let _cp_ be CodePointAt(_S_, _codeUnitCount_).
+              1. Set _codeUnitCount_ to _codeUnitCount_ + _cp_.[[CodeUnitCount]].
+              1. Set _codePointCount_ to _codePointCount_ + 1.
+            1. Return _len_.
           </emu-alg>
         </emu-clause>
 


### PR DESCRIPTION
noticed as part of #2746 (which it extends; the first commit can be ignored)

Similar to #2737, this should simplify reading and help with KAIST-like efforts.