### PR TITLE
Editorial: Replace mixtures of spec aliases with language operators

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1856,7 +1856,7 @@
             1. Return an implementation-approximated Number value representing the result of raising ℝ(_base_) to the ℝ(_exponent_) power.
           </emu-alg>
           <emu-note>
-            <p>The result of _base_ `**` _exponent_ when _base_ is *1*<sub>𝔽</sub> or *-1*<sub>𝔽</sub> and _exponent_ is *+&infin;*<sub>𝔽</sub> or *-&infin;*<sub>𝔽</sub>, or when _base_ is *1*<sub>𝔽</sub> and _exponent_ is *NaN*, differs from IEEE 754-2019. The first edition of ECMAScript specified a result of *NaN* for this operation, whereas later versions of IEEE 754-2019 specified *1*<sub>𝔽</sub>. The historical ECMAScript behaviour is preserved for compatibility reasons.</p>
+            <p>The result of Number::exponentiate(_base_, _exponent_) when _base_ is *1*<sub>𝔽</sub> or *-1*<sub>𝔽</sub> and _exponent_ is *+&infin;*<sub>𝔽</sub> or *-&infin;*<sub>𝔽</sub>, or when _base_ is *1*<sub>𝔽</sub> and _exponent_ is *NaN*, differs from IEEE 754-2019. The first edition of ECMAScript specified a result of *NaN* for this operation, whereas later versions of IEEE 754-2019 specified *1*<sub>𝔽</sub>. The historical ECMAScript behaviour is preserved for compatibility reasons.</p>
           </emu-note>
         </emu-clause>
 
@@ -6156,7 +6156,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It provides the semantics for the comparison _x_ == _y_.</dd>
+        <dd>It provides the semantics for the `==` operator.</dd>
       </dl>
       <emu-alg>
         1. If Type(_x_) is the same as Type(_y_), then
@@ -6191,7 +6191,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It provides the semantics for the comparison _x_ === _y_.</dd>
+        <dd>It provides the semantics for the `===` operator.</dd>
       </dl>
       <emu-alg>
         1. If Type(_x_) is different from Type(_y_), return *false*.

--- a/spec.html
+++ b/spec.html
@@ -1856,7 +1856,7 @@
             1. Return an implementation-approximated Number value representing the result of raising ℝ(_base_) to the ℝ(_exponent_) power.
           </emu-alg>
           <emu-note>
-            <p>The result of Number::exponentiate(_base_, _exponent_) when _base_ is *1*<sub>𝔽</sub> or *-1*<sub>𝔽</sub> and _exponent_ is *+&infin;*<sub>𝔽</sub> or *-&infin;*<sub>𝔽</sub>, or when _base_ is *1*<sub>𝔽</sub> and _exponent_ is *NaN*, differs from IEEE 754-2019. The first edition of ECMAScript specified a result of *NaN* for this operation, whereas later versions of IEEE 754-2019 specified *1*<sub>𝔽</sub>. The historical ECMAScript behaviour is preserved for compatibility reasons.</p>
+            <p>The result of _base_ `**` _exponent_ when _base_ is *1*<sub>𝔽</sub> or *-1*<sub>𝔽</sub> and _exponent_ is *+&infin;*<sub>𝔽</sub> or *-&infin;*<sub>𝔽</sub>, or when _base_ is *1*<sub>𝔽</sub> and _exponent_ is *NaN*, differs from IEEE 754-2019. The first edition of ECMAScript specified a result of *NaN* for this operation, whereas later revisions of IEEE 754 specified *1*<sub>𝔽</sub>. The historical ECMAScript behaviour is preserved for compatibility reasons.</p>
           </emu-note>
         </emu-clause>
 


### PR DESCRIPTION
Fixes a few places that seem to incorrectly apply a language operator to a spec alias.

Also corrects a confusing use of "IEEE 754-2019" to refer to the entire IEEE 754 _series_.