### PR TITLE
Meta: bump ecmarkup to 12.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://tc39.es/ecma262/#sec-copyright-and-software-license",
       "dependencies": {
-        "ecmarkup": "^12.0.1"
+        "ecmarkup": "^12.0.3"
       },
       "devDependencies": {
         "glob": "^7.1.6",
@@ -720,9 +720,9 @@
       }
     },
     "node_modules/ecmarkup": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-12.0.1.tgz",
-      "integrity": "sha512-ER84eweK0LSlHpvtONUrQki0Wswq9OaXeTkv5HmfxmEueGRXhzCjUggkuWN93I0qFk8pqSNPN5R3GHczh1Ckmw==",
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-12.0.3.tgz",
+      "integrity": "sha512-iWn/8Az5izJqZzlNari7MONi+4bpUw7iuoktVf9mtxkxxg+da/vYdwk7G0pORM1moceJtVcdu7KEZnMEdgAj5A==",
       "dependencies": {
         "chalk": "^4.1.2",
         "command-line-args": "^5.2.0",
@@ -2935,9 +2935,9 @@
       }
     },
     "ecmarkup": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-12.0.1.tgz",
-      "integrity": "sha512-ER84eweK0LSlHpvtONUrQki0Wswq9OaXeTkv5HmfxmEueGRXhzCjUggkuWN93I0qFk8pqSNPN5R3GHczh1Ckmw==",
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-12.0.3.tgz",
+      "integrity": "sha512-iWn/8Az5izJqZzlNari7MONi+4bpUw7iuoktVf9mtxkxxg+da/vYdwk7G0pORM1moceJtVcdu7KEZnMEdgAj5A==",
       "requires": {
         "chalk": "^4.1.2",
         "command-line-args": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "license": "SEE LICENSE IN https://tc39.es/ecma262/#sec-copyright-and-software-license",
   "homepage": "https://tc39.es/ecma262/",
   "dependencies": {
-    "ecmarkup": "^12.0.1"
+    "ecmarkup": "^12.0.3"
   },
   "devDependencies": {
     "glob": "^7.1.6",


### PR DESCRIPTION
Some small tweaks, including a fix for which should un-break https://github.com/tc39/ecma262/pull/2744: https://github.com/tc39/ecmarkup/releases/tag/v12.0.3