### PR TITLE
Editorial: Specify Map/Set forEach more explicitly

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -40044,9 +40044,15 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_M_, [[MapData]]).
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
           1. Let _entries_ be the List that is _M_.[[MapData]].
-          1. For each Record { [[Key]], [[Value]] } _e_ of _entries_, do
+          1. Let _numEntries_ be the number of elements of _entries_.
+          1. Let _index_ be 0.
+          1. Repeat, while _index_ &lt; _numEntries_,
+            1. Let _e_ be the Record { [[Key]], [[Value]] } that is the value of _entries_[_index_].
+            1. Set _index_ to _index_ + 1.
             1. If _e_.[[Key]] is not ~empty~, then
               1. Perform ? Call(_callbackfn_, _thisArg_, &laquo; _e_.[[Value]], _e_.[[Key]], _M_ &raquo;).
+              1. NOTE: The number of elements in _entries_ may have increased during execution of _callbackfn_.
+              1. Set _numEntries_ to the number of elements of _entries_.
           1. Return *undefined*.
         </emu-alg>
         <emu-note>
@@ -40181,7 +40187,7 @@ THH:mm:ss.sss
                   1. Assert: _kind_ is ~key+value~.
                   1. Let _result_ be CreateArrayFromList(&laquo; _e_.[[Key]], _e_.[[Value]] &raquo;).
                 1. Perform ? GeneratorYield(CreateIterResultObject(_result_, *false*)).
-                1. NOTE: The number of elements in _entries_ may have changed while execution of this abstract operation was paused by Yield.
+                1. NOTE: The number of elements in _entries_ may have increased while execution of this abstract operation was paused by Yield.
                 1. Set _numEntries_ to the number of elements of _entries_.
             1. Return *undefined*.
           1. Return CreateIteratorFromClosure(_closure_, *"%MapIteratorPrototype%"*, %MapIteratorPrototype%).
@@ -40362,10 +40368,16 @@ THH:mm:ss.sss
           1. Let _S_ be the *this* value.
           1. Perform ? RequireInternalSlot(_S_, [[SetData]]).
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
-          1. Let _entries_ be the List that is _S_.[[SetData]].
-          1. For each element _e_ of _entries_, do
+          1. Let _entries_ be the List that is _set_.[[SetData]].
+          1. Let _numEntries_ be the number of elements of _entries_.
+          1. Let _index_ be 0.
+          1. Repeat, while _index_ &lt; _numEntries_,
+            1. Let _e_ be _entries_[_index_].
+            1. Set _index_ to _index_ + 1.
             1. If _e_ is not ~empty~, then
               1. Perform ? Call(_callbackfn_, _thisArg_, &laquo; _e_, _e_, _S_ &raquo;).
+              1. NOTE: The number of elements in _entries_ may have increased during execution of _callbackfn_.
+              1. Set _numEntries_ to the number of elements of _entries_.
           1. Return *undefined*.
         </emu-alg>
         <emu-note>
@@ -40470,7 +40482,7 @@ THH:mm:ss.sss
                 1. Else,
                   1. Assert: _kind_ is ~value~.
                   1. Perform ? GeneratorYield(CreateIterResultObject(_e_, *false*)).
-                1. NOTE: The number of elements in _entries_ may have changed while execution of this abstract operation was paused by Yield.
+                1. NOTE: The number of elements in _entries_ may have increased while execution of this abstract operation was paused by Yield.
                 1. Set _numEntries_ to the number of elements of _entries_.
             1. Return *undefined*.
           1. Return CreateIteratorFromClosure(_closure_, *"%SetIteratorPrototype%"*, %SetIteratorPrototype%).


### PR DESCRIPTION
@tabatkins [pointed out](https://matrixlogs.bakkot.com/TC39_General/2022-05-02#L16) that Map and Set iterators are specified with explicit indexing, whereas their `forEach` methods are specified with a "for each element of entries" style loop. The historical reason for that is probably path dependence (explicit indices were required for the iterators prior to the refactoring in https://github.com/tc39/ecma262/pull/2045), but there is now no particular reason they should be different.

I've chosen to make `forEach` match the iterators rather than the other way around because I think it makes it clearer that iteration is required to hit elements added to the list during iteration (either between calls to the iterator's `next` method or by the callback to `forEach`). We could go the other way, though.