### PR TITLE
Editorial: Fix incorrect SetMutableBinding infallibility assumption

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -11005,7 +11005,7 @@
           <emu-alg>
             1. Let _DclRec_ be _envRec_.[[DeclarativeRecord]].
             1. If ! _DclRec_.HasBinding(_N_) is *true*, then
-              1. Return ! _DclRec_.SetMutableBinding(_N_, _V_, _S_).
+              1. Return ? _DclRec_.SetMutableBinding(_N_, _V_, _S_).
             1. Let _ObjRec_ be _envRec_.[[ObjectRecord]].
             1. Return ? <emu-meta effects="user-code">_ObjRec_.SetMutableBinding</emu-meta>(_N_, _V_, _S_).
           </emu-alg>


### PR DESCRIPTION
Example where performing `SetMutableBinding` on `DclRec` would return a throw completion:

```js
function f() { x = 1; }
f(); // 💥
let x;
```

This is covered by 22 tests in test262 which fail when implemented as written.
