### PR TITLE
Editorial: Declare iteration aliases as close to iterations as practical

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -33955,8 +33955,8 @@ THH:mm:ss.sss
           <emu-alg>
             1. Let _stringLength_ be the length of _str_.
             1. Assert: _position_ &le; _stringLength_.
-            1. Let _templateRemainder_ be _replacementTemplate_.
             1. Let _result_ be the empty String.
+            1. Let _templateRemainder_ be _replacementTemplate_.
             1. Repeat, while _templateRemainder_ is not the empty String,
               1. NOTE: The following steps isolate _ref_ (a prefix of _templateRemainder_), determine _refReplacement_ (its replacement), and then append that replacement to _result_.
               1. If _templateRemainder_ starts with *"$$"*, then
@@ -34338,8 +34338,8 @@ THH:mm:ss.sss
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _s_ be ? ToString(_O_).
           1. Let _closure_ be a new Abstract Closure with no parameters that captures _s_ and performs the following steps when called:
-            1. Let _position_ be 0.
             1. Let _len_ be the length of _s_.
+            1. Let _position_ be 0.
             1. Repeat, while _position_ &lt; _len_,
               1. Let _cp_ be CodePointAt(_s_, _position_).
               1. Let _nextIndex_ be _position_ + _cp_.[[CodeUnitCount]].
@@ -36647,8 +36647,8 @@ THH:mm:ss.sss
             1. Let _matchLength_ be the length of _matched_.
             1. Let _position_ be ? ToIntegerOrInfinity(? Get(_result_, *"index"*)).
             1. Set _position_ to the result of clamping _position_ between 0 and _lengthS_.
-            1. Let _n_ be 1.
             1. Let _captures_ be a new empty List.
+            1. Let _n_ be 1.
             1. Repeat, while _n_ &le; _nCaptures_,
               1. Let _capN_ be ? Get(_result_, ! ToString(𝔽(_n_))).
               1. If _capN_ is not *undefined*, then
@@ -37123,9 +37123,9 @@ THH:mm:ss.sss
           1. For each element _E_ of _items_, do
             1. Let _spreadable_ be ? IsConcatSpreadable(_E_).
             1. If _spreadable_ is *true*, then
-              1. Let _k_ be 0.
               1. Let _len_ be ? LengthOfArrayLike(_E_).
               1. If _n_ + _len_ &gt; 2<sup>53</sup> - 1, throw a *TypeError* exception.
+              1. Let _k_ be 0.
               1. Repeat, while _k_ &lt; _len_,
                 1. Let _P_ be ! ToString(𝔽(_k_)).
                 1. Let _exists_ be ? HasProperty(_E_, _P_).
@@ -38872,8 +38872,8 @@ THH:mm:ss.sss
           1. Let _len_ be _O_.[[ArrayLength]].
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
           1. Let _kept_ be a new empty List.
-          1. Let _k_ be 0.
           1. Let _captured_ be 0.
+          1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_,
             1. Let _Pk_ be ! ToString(𝔽(_k_)).
             1. Let _kValue_ be ! Get(_O_, _Pk_).
@@ -39372,8 +39372,8 @@ THH:mm:ss.sss
               1. Let _elementSize_ be TypedArrayElementSize(_O_).
               1. NOTE: If _srcType_ and _targetType_ are the same, the transfer must be performed in a manner that preserves the bit-level encoding of the source data.
               1. Let _srcByteOffset_ be _O_.[[ByteOffset]].
-              1. Let _targetByteIndex_ be _A_.[[ByteOffset]].
               1. Let _srcByteIndex_ be (_k_ &times; _elementSize_) + _srcByteOffset_.
+              1. Let _targetByteIndex_ be _A_.[[ByteOffset]].
               1. Let _limit_ be _targetByteIndex_ + _count_ &times; _elementSize_.
               1. Repeat, while _targetByteIndex_ &lt; _limit_,
                 1. Let _value_ be GetValueFromBuffer(_srcBuffer_, _srcByteIndex_, ~Uint8~, *true*, ~Unordered~).
@@ -42399,8 +42399,8 @@ THH:mm:ss.sss
           1. If Type(_val_) is Object, then
             1. Let _isArray_ be ? IsArray(_val_).
             1. If _isArray_ is *true*, then
-              1. Let _I_ be 0.
               1. Let _len_ be ? LengthOfArrayLike(_val_).
+              1. Let _I_ be 0.
               1. Repeat, while _I_ &lt; _len_,
                 1. Let _prop_ be ! ToString(𝔽(_I_)).
                 1. Let _newElement_ be ? InternalizeJSONProperty(_val_, _prop_, _reviver_).


### PR DESCRIPTION
As observed at https://github.com/tc39/ecma262/pull/2766#discussion_r865008959 , it is very common for an iteration alias (i.e., a value that changes during iteration and effects its conclusion) to be declared immediately before its corresponding iteration. This updates a few deviations to conform more strongly with that convention.