### PR TITLE
Remove Job from Promise Resolve Functions

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -43600,7 +43600,7 @@ THH:mm:ss.sss
             1. Let _resolvingFunctions_ be CreateResolvingFunctions(_promise_).
             1. Let _thenCallResult_ be Completion(Call(_then_, _resolution_, &laquo; _resolvingFunctions_.[[Resolve]], _resolvingFunctions_.[[Reject]] &raquo;)).
             1. If _thenCallResult_ is an abrupt completion, then
-              1. Call(_resolvingFunctions_.[[Reject]], *undefined*, &laquo; _thenCallResult_.[[Value]] &raquo;).
+              1. Perform ! Call(_resolvingFunctions_.[[Reject]], *undefined*, &laquo; _thenCallResult_.[[Value]] &raquo;).
             1. Return *undefined*.
           </emu-alg>
           <p>The *"length"* property of a promise resolve function is *1*<sub>𝔽</sub>.</p>

--- a/spec.html
+++ b/spec.html
@@ -12126,7 +12126,7 @@
       </ul>
 
       <emu-note>
-        <p>The _realm_ for Jobs returned by NewPromiseResolveThenableJob is usually the result of calling GetFunctionRealm on the _then_ function object. The _realm_ for Jobs returned by NewPromiseReactionJob is usually the result of calling GetFunctionRealm on the handler if the handler is not *undefined*. If the handler is *undefined*, _realm_ is *null*. For both kinds of Jobs, when GetFunctionRealm completes abnormally (i.e. called on a revoked Proxy), _realm_ is the current Realm at the time of the GetFunctionRealm call. When the _realm_ is *null*, no user ECMAScript code will be evaluated and no new ECMAScript objects (e.g. Error objects) will be created. The WHATWG HTML specification (<a href="https://html.spec.whatwg.org/">https://html.spec.whatwg.org/</a>), for example, uses _realm_ to check for the ability to run script and for the <a href="https://html.spec.whatwg.org/#entry">entry</a> concept.</p>
+        <p>The _realm_ for Jobs returned by NewPromiseReactionJob is usually the result of calling GetFunctionRealm on the handler if the handler is not *undefined*. If the handler is *undefined*, _realm_ is *null*. When GetFunctionRealm completes abnormally (i.e. called on a revoked Proxy), _realm_ is the current Realm at the time of the GetFunctionRealm call. When the _realm_ is *null*, no user ECMAScript code will be evaluated and no new ECMAScript objects (e.g. Error objects) will be created. The WHATWG HTML specification (<a href="https://html.spec.whatwg.org/">https://html.spec.whatwg.org/</a>), for example, uses _realm_ to check for the ability to run script and for the <a href="https://html.spec.whatwg.org/#entry">entry</a> concept.</p>
       </emu-note>
     </emu-clause>
   </emu-clause>
@@ -43597,9 +43597,10 @@ THH:mm:ss.sss
             1. If IsCallable(_thenAction_) is *false*, then
               1. Perform FulfillPromise(_promise_, _resolution_).
               1. Return *undefined*.
-            1. Let _thenJobCallback_ be HostMakeJobCallback(_thenAction_).
-            1. Let _job_ be NewPromiseResolveThenableJob(_promise_, _resolution_, _thenJobCallback_).
-            1. Perform HostEnqueuePromiseJob(_job_.[[Job]], _job_.[[Realm]]).
+            1. Let _resolvingFunctions_ be CreateResolvingFunctions(_promise_).
+            1. Let _thenCallResult_ be Completion(Call(_then_, _resolution_, &laquo; _resolvingFunctions_.[[Resolve]], _resolvingFunctions_.[[Reject]] &raquo;)).
+            1. If _thenCallResult_ is an abrupt completion, then
+              1. Call(_resolvingFunctions_.[[Reject]], *undefined*, &laquo; _thenCallResult_.[[Value]] &raquo;).
             1. Return *undefined*.
           </emu-alg>
           <p>The *"length"* property of a promise resolve function is *1*<sub>𝔽</sub>.</p>
@@ -43792,34 +43793,6 @@ THH:mm:ss.sss
             1. NOTE: _handlerRealm_ is never *null* unless the handler is *undefined*. When the handler is a revoked Proxy and no ECMAScript code runs, _handlerRealm_ is used to create error objects.
           1. Return the Record { [[Job]]: _job_, [[Realm]]: _handlerRealm_ }.
         </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-newpromiseresolvethenablejob" type="abstract operation" oldids="sec-promiseresolvethenablejob">
-        <h1>
-          NewPromiseResolveThenableJob (
-            _promiseToResolve_: unknown,
-            _thenable_: unknown,
-            _then_: unknown,
-          ): a Record with fields [[Job]] (a Job Abstract Closure) and [[Realm]] (a Realm Record)
-        </h1>
-        <dl class="header">
-        </dl>
-        <emu-alg>
-          1. Let _job_ be a new Job Abstract Closure with no parameters that captures _promiseToResolve_, _thenable_, and _then_ and performs the following steps when called:
-            1. Let _resolvingFunctions_ be CreateResolvingFunctions(_promiseToResolve_).
-            1. Let _thenCallResult_ be Completion(HostCallJobCallback(_then_, _thenable_, &laquo; _resolvingFunctions_.[[Resolve]], _resolvingFunctions_.[[Reject]] &raquo;)).
-            1. If _thenCallResult_ is an abrupt completion, then
-              1. Return ? Call(_resolvingFunctions_.[[Reject]], *undefined*, &laquo; _thenCallResult_.[[Value]] &raquo;).
-            1. Return ? _thenCallResult_.
-          1. Let _getThenRealmResult_ be Completion(GetFunctionRealm(_then_.[[Callback]])).
-          1. If _getThenRealmResult_ is a normal completion, let _thenRealm_ be _getThenRealmResult_.[[Value]].
-          1. Else, let _thenRealm_ be the current Realm Record.
-          1. NOTE: _thenRealm_ is never *null*. When _then_.[[Callback]] is a revoked Proxy and no code runs, _thenRealm_ is used to create error objects.
-          1. Return the Record { [[Job]]: _job_, [[Realm]]: _thenRealm_ }.
-        </emu-alg>
-        <emu-note>
-          <p>This Job uses the supplied thenable and its `then` method to resolve the given promise. This process must take place as a Job to ensure that the evaluation of the `then` method occurs after evaluation of any surrounding code has completed.</p>
-        </emu-note>
       </emu-clause>
     </emu-clause>
 


### PR DESCRIPTION
This aligns the behavior of handling thenables with the Promises A+ spec, which says when the resolution value is a thenable, you're supposed to synchronously call `thenable.then(onRes, onRej)` ([Step 2.3.3.3][call-then]).

Given the example code:

```javascript
new Promise(resolve => {
  resolve(thenable)
});
```

The current behavior requires 2 ticks for the outer promise to fully resolve. One tick is created by the Promise Resolving Functions (and is removed in this PR), and one tick is created by the wrapping of the `onRes`/`onRej` callbacks passed to [`Promise.p.then`][then]. This made it noticeably slower to resolve with a thenable than to invoke the thenable's `.then` directly: `thenable.then(onRes, onRej)` only requires a single tick (for the wrapped `onRes`/`onRej`).

~~With this change, we could revert #1250 without slowing down `Await`.~~ Partially, I didn't see the 2nd promise allocation. This PR makes the pre-#1250 run in 2 ticks instead of 3. We still want 1 tick.

Fixes #2770.

[call-then]: https://promisesaplus.com/#point-56
[then]: https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-performpromisethen