### PR TITLE
Editorial: Improve the numeric string grammar summary

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -533,7 +533,7 @@
     <emu-clause id="sec-numeric-string-grammar">
       <h1>The Numeric String Grammar</h1>
       <p>Another grammar is used for translating Strings into numeric values. This grammar is similar to the part of the lexical grammar having to do with numeric literals and has as its terminal symbols |SourceCharacter|. This grammar appears in <emu-xref href="#sec-tonumber-applied-to-the-string-type"></emu-xref>.</p>
-      <p>Productions of the numeric string grammar are distinguished by having three colons &ldquo;<b>:::</b>&rdquo; as punctuation.</p>
+      <p>Productions of the numeric string grammar are distinguished by having three colons &ldquo;<b>:::</b>&rdquo; as punctuation, and are never used for parsing source text.</p>
     </emu-clause>
 
     <emu-clause id="sec-syntactic-grammar">

--- a/spec.html
+++ b/spec.html
@@ -532,7 +532,7 @@
 
     <emu-clause id="sec-numeric-string-grammar">
       <h1>The Numeric String Grammar</h1>
-      <p>Another grammar is used for translating Strings into numeric values. This grammar is similar to the part of the lexical grammar having to do with numeric literals and has as its terminal symbols |SourceCharacter|. This grammar appears in <emu-xref href="#sec-tonumber-applied-to-the-string-type"></emu-xref>.</p>
+      <p>A <em>numeric string grammar</em> appears in <emu-xref href="#sec-tonumber-applied-to-the-string-type"></emu-xref>. It has as its terminal symbols |SourceCharacter|, and is used for translating Strings into numeric values starting from the goal symbol |StringNumericLiteral| (which is similar to but distinct from the <emu-xref href="#sec-literals-numeric-literals">lexical grammar for numeric literals</emu-xref>).</p>
       <p>Productions of the numeric string grammar are distinguished by having three colons &ldquo;<b>:::</b>&rdquo; as punctuation, and are never used for parsing source text.</p>
     </emu-clause>
 


### PR DESCRIPTION
* Imply semantics for `:::` grammars (cf. https://github.com/tc39/proposal-temporal/issues/2190 ).
* Make the numeric string grammar summary more similar to other grammars.