### PR TITLE
Normative: Add missing `d` flag character to IsValidRegularExpressionLiteral

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -18463,7 +18463,7 @@
           <dd>It determines if its argument is a valid regular expression literal.</dd>
         </dl>
         <emu-alg>
-          1. If FlagText of _literal_ contains any code points other than `g`, `i`, `m`, `s`, `u`, or `y`, or if it contains the same code point more than once, return *false*.
+          1. If FlagText of _literal_ contains any code points other than `d`, `g`, `i`, `m`, `s`, `u`, or `y`, or if it contains the same code point more than once, return *false*.
           1. Let _patternText_ be BodyText of _literal_.
           1. If FlagText of _literal_ contains `u`, let _u_ be *true*; else let _u_ be *false*.
           1. If _u_ is *false*, then


### PR DESCRIPTION
This adds the `d` flag as a valid flag in IsValidRegularExpressionLiteral, which is currently missing. This was intended to be supported in the RegExp Match Indices proposal, but was overlooked when that proposal advanced to Stage 4.

Fixes #2778 