### PR TITLE
Normative: Use DefaultTimeZone to get the local time zone for Date

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1063,7 +1063,8 @@
       <p>The notation &ldquo;<emu-eqn id="eqn-modulo" aoid="modulo">_x_ modulo _y_</emu-eqn>&rdquo; (_y_ must be finite and non-zero) computes a value _k_ of the same sign as _y_ (or zero) such that <emu-eqn>abs(_k_) &lt; abs(_y_) and _x_ - _k_ = _q_ &times; _y_</emu-eqn> for some integer _q_.</p>
       <p>The phrase "the result of <dfn id="clamping">clamping</dfn> _x_ between _lower_ and _upper_" (where _x_ is an extended mathematical value and _lower_ and _upper_ are mathematical values such that _lower_ &le; _upper_) produces _lower_ if _x_ &lt; _lower_, produces _upper_ if _x_ &gt; _upper_, and otherwise produces _x_.</p>
       <p>The mathematical function <emu-eqn id="eqn-floor" aoid="floor">floor(_x_)</emu-eqn> produces the largest integer (closest to +&infin;) that is not larger than _x_.</p>
-      <p>Mathematical functions min, max, abs, and floor are not defined for Numbers and BigInts, and any usage of those methods that have non-mathematical value arguments would be an editorial error in this specification.</p>
+      <p>The mathematical function <emu-eqn id="eqn-truncate" aoid="truncate">truncate(_x_)</emu-eqn> removes the fractional part of _x_ by rounding towards zero, producing <emu-eqn>-floor(-_x_)</emu-eqn> if _x_ &lt; 0 and otherwise producing <emu-eqn>floor(_x_)</emu-eqn>.</p>
+      <p>Mathematical functions min, max, abs, floor, and truncate are not defined for Numbers and BigInts, and any usage of those methods that have non-mathematical value arguments would be an editorial error in this specification.</p>
       <emu-note>
         <p><emu-eqn>floor(_x_) = _x_ - (_x_ modulo 1)</emu-eqn>.</p>
       </emu-note>
@@ -32015,7 +32016,7 @@
 
       <emu-clause id="sec-time-values-and-time-range">
         <h1>Time Values and Time Range</h1>
-        <p>Time measurement in ECMAScript is analogous to time measurement in POSIX, in particular sharing definition in terms of the proleptic Gregorian calendar, an epoch of midnight at the beginning of 1 January 1970 UTC, and an accounting of every day as comprising exactly 86,400 seconds (each of which is 1000 milliseconds long).</p>
+        <p>Time measurement in ECMAScript is analogous to time measurement in POSIX, in particular sharing definition in terms of the proleptic Gregorian calendar, an <dfn id="epoch">epoch</dfn> of midnight at the beginning of 1 January 1970 UTC, and an accounting of every day as comprising exactly 86,400 seconds (each of which is 1000 milliseconds long).</p>
         <p>An ECMAScript <dfn variants="time values">time value</dfn> is a Number, either a finite integral Number representing an instant in time to millisecond precision or *NaN* representing no specific instant. A time value that is a multiple of <emu-eqn>24 &times; 60 &times; 60 &times; 1000 = 86,400,000</emu-eqn> (i.e., is equal to 86,400,000 &times; _d_ for some integer _d_) represents the instant at the start of the UTC day that follows the epoch by _d_ whole UTC days (preceding the epoch for negative _d_). Every other finite time value _t_ is defined relative to the greatest preceding time value _s_ that is such a multiple, and represents the instant that occurs within the same UTC day as _s_ but follows it by (_t_ - _s_) milliseconds.</p>
         <p>Time values do not account for UTC leap seconds&mdash;there are no time values representing instants within positive leap seconds, and there are time values representing instants removed from the UTC timeline by negative leap seconds. However, the definition of time values nonetheless yields piecewise alignment with UTC, with discontinuities only at leap second boundaries and zero difference outside of leap seconds.</p>
         <p>A Number can exactly represent all integers from -9,007,199,254,740,992 to 9,007,199,254,740,992 (<emu-xref href="#sec-number.min_safe_integer"></emu-xref> and <emu-xref href="#sec-number.max_safe_integer"></emu-xref>). A time value supports a slightly smaller range of -8,640,000,000,000,000 to 8,640,000,000,000,000 milliseconds. This yields a supported time value range of exactly -100,000,000 days to 100,000,000 days relative to midnight at the beginning of 1 January 1970 UTC.</p>
@@ -32109,43 +32110,141 @@
         <p>A weekday value of *+0*<sub>𝔽</sub> specifies Sunday; *1*<sub>𝔽</sub> specifies Monday; *2*<sub>𝔽</sub> specifies Tuesday; *3*<sub>𝔽</sub> specifies Wednesday; *4*<sub>𝔽</sub> specifies Thursday; *5*<sub>𝔽</sub> specifies Friday; and *6*<sub>𝔽</sub> specifies Saturday. Note that <emu-eqn>WeekDay(*+0*<sub>𝔽</sub>) = *4*<sub>𝔽</sub></emu-eqn>, corresponding to Thursday, 1 January 1970.</p>
       </emu-clause>
 
-      <emu-clause id="sec-local-time-zone-adjustment" type="implementation-defined abstract operation">
+      <emu-clause id="sec-getutcepochnanoseconds" type="abstract operation">
         <h1>
-          LocalTZA (
-            _t_: a Number,
-            _isUTC_: a Boolean,
-          ): an integral Number
+          GetUTCEpochNanoseconds (
+            _year_: an integer,
+            _month_: an integer in the inclusive interval from 1 to 12,
+            _day_: an integer in the inclusive interval from 1 to 31,
+            _hour_: an integer in the inclusive interval from 0 to 23,
+            _minute_: an integer in the inclusive interval from 0 to 59,
+            _second_: an integer in the inclusive interval from 0 to 59,
+            _millisecond_: an integer in the inclusive interval from 0 to 999,
+            _microsecond_: an integer in the inclusive interval from 0 to 999,
+            _nanosecond_: an integer in the inclusive interval from 0 to 999,
+          ): a BigInt
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>Its return value represents the local time zone adjustment, or offset, in milliseconds. The local political rules for standard time and daylight saving time in effect at _t_ should be used to determine the result in the way specified in this section.</dd>
+          <dd>The returned value represents a number of nanoseconds since the epoch that corresponds to the given ISO 8601 calendar date and wall-clock time in UTC.</dd>
         </dl>
-        <p>When _isUTC_ is true, <emu-eqn>LocalTZA( _t_<sub>UTC</sub>, true )</emu-eqn> should return the offset of the local time zone from UTC measured in milliseconds at time represented by time value <emu-eqn>_t_<sub>UTC</sub></emu-eqn>. When the result is added to <emu-eqn>_t_<sub>UTC</sub></emu-eqn>, it should yield the corresponding Number <emu-eqn>_t_<sub>local</sub></emu-eqn>.</p>
-        <p>When _isUTC_ is false, <emu-eqn>LocalTZA( _t_<sub>local</sub>, false )</emu-eqn> should return the offset of the local time zone from UTC measured in milliseconds at local time represented by Number <emu-eqn>_t_<sub>local</sub></emu-eqn>. When the result is subtracted from <emu-eqn>_t_<sub>local</sub></emu-eqn>, it should yield the corresponding time value <emu-eqn>_t_<sub>UTC</sub></emu-eqn>.</p>
-        <p>Input _t_ is nominally a time value but may be any Number value. This can occur when _isUTC_ is false and _t_<sub>local</sub> represents a time value that is already offset outside of the time value range at the range boundaries. The algorithm must not limit _t_<sub>local</sub> to the time value range, so that such inputs are supported.</p>
-        <p>When <emu-eqn>_t_<sub>local</sub></emu-eqn> represents local time repeating multiple times at a negative time zone transition (e.g. when the daylight saving time ends or the time zone offset is decreased due to a time zone rule change) or skipped local time at a positive time zone transitions (e.g. when the daylight saving time starts or the time zone offset is increased due to a time zone rule change), <emu-eqn>_t_<sub>local</sub></emu-eqn> must be interpreted using the time zone offset before the transition.</p>
-        <p>If an implementation does not support a conversion described above or if political rules for time _t_ are not available within the implementation, the result must be *+0*<sub>𝔽</sub>.</p>
+        <emu-alg>
+          1. Let _date_ be MakeDay(𝔽(_year_), 𝔽(_month_ - 1), 𝔽(_day_)).
+          1. Let _time_ be MakeTime(𝔽(_hour_), 𝔽(_minute_), 𝔽(_second_), 𝔽(_millisecond_)).
+          1. Let _ms_ be MakeDate(_date_, _time_).
+          1. Assert: _ms_ is an integral Number.
+          1. Return ℤ(ℝ(_ms_) &times; 10<sup>6</sup> + _microsecond_ &times; 10<sup>3</sup> + _nanosecond_).
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-getnamedtimezoneepochnanoseconds" type="implementation-defined abstract operation">
+        <h1>
+          GetNamedTimeZoneEpochNanoseconds (
+            _timeZoneIdentifier_: a String,
+            _year_: an integer,
+            _month_: an integer in the inclusive interval from 1 to 12,
+            _day_: an integer in the inclusive interval from 1 to 31,
+            _hour_: an integer in the inclusive interval from 0 to 23,
+            _minute_: an integer in the inclusive interval from 0 to 59,
+            _second_: an integer in the inclusive interval from 0 to 59,
+            _millisecond_: an integer in the inclusive interval from 0 to 999,
+            _microsecond_: an integer in the inclusive interval from 0 to 999,
+            _nanosecond_: an integer in the inclusive interval from 0 to 999,
+          ): a List of BigInts
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>
+            Each value in the returned List represents a number of nanoseconds since the epoch that corresponds to the given ISO 8601 calendar date and wall-clock time in the named time zone identified by _timeZoneIdentifier_.
+          </dd>
+        </dl>
+        <p>
+          When the input represents a local time occurring more than once because of a negative time zone transition (e.g. when daylight saving time ends or the time zone offset is decreased due to a time zone rule change), the returned List will have more than one element and will be sorted by ascending numerical value.
+          When the input represents a local time skipped because of a positive time zone transition (e.g. when daylight saving time begins or the time zone offset is increased due to a time zone rule change), the returned List will be empty.
+          Otherwise, the returned List will have one element.
+        </p>
+        <p>The default implementation of GetNamedTimeZoneEpochNanoseconds, to be used for ECMAScript implementations that do not include local political rules for any time zones, performs the following steps when called:</p>
+        <emu-alg>
+          1. Assert: _timeZoneIdentifier_ is *"UTC"*.
+          1. Let _epochNanoseconds_ be GetUTCEpochNanoseconds(_year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_).
+          1. Return &laquo; _epochNanoseconds_ &raquo;.
+        </emu-alg>
         <emu-note>
           <p>It is recommended that implementations use the time zone information of the IANA Time Zone Database <a href="https://www.iana.org/time-zones/">https://www.iana.org/time-zones/</a>.</p>
-          <p>1:30 AM on 5 November 2017 in America/New_York is repeated twice (fall backward), but it must be interpreted as 1:30 AM UTC-04 instead of 1:30 AM UTC-05. LocalTZA(TimeClip(MakeDate(MakeDay(2017, 10, 5), MakeTime(1, 30, 0, 0))), false) is <emu-eqn>-4 &times; msPerHour</emu-eqn>.</p>
-          <p>2:30 AM on 12 March 2017 in America/New_York does not exist, but it must be interpreted as 2:30 AM UTC-05 (equivalent to 3:30 AM UTC-04). LocalTZA(TimeClip(MakeDate(MakeDay(2017, 2, 12), MakeTime(2, 30, 0, 0))), false) is <emu-eqn>-5 &times; msPerHour</emu-eqn>.</p>
-          <p>Local time zone offset values may be positive <i>or</i> negative.</p>
+          <p>1:30 AM on 5 November 2017 in America/New_York is repeated twice, so GetNamedTimeZoneEpochNanoseconds(*"America/New_York"*, 2017, 11, 5, 1, 30, 0, 0, 0, 0) would return a List of length 2 in which the first element represents 05:30 UTC (corresponding with 01:30 US Eastern Daylight Time at UTC offset -04:00) and the second element represents 06:30 UTC (corresponding with 01:30 US Eastern Standard Time at UTC offset -05:00).</p>
+          <p>2:30 AM on 12 March 2017 in America/New_York does not exist, so GetNamedTimeZoneEpochNanoseconds(*"America/New_York"*, 2017, 3, 12, 2, 30, 0, 0, 0, 0) would return an empty List.</p>
+        </emu-note>
+      </emu-clause>
+
+      <emu-clause id="sec-getnamedtimezoneoffsetnanoseconds" oldids="sec-local-time-zone-adjustment" type="implementation-defined abstract operation">
+        <h1>
+          GetNamedTimeZoneOffsetNanoseconds (
+            _timeZoneIdentifier_: a String,
+            _epochNanoseconds_: a BigInt,
+          ): an integer
+        </h1>
+        <dl class="header">
+        </dl>
+        <p>The returned integer represents the offset from UTC of the named time zone identified by _timeZoneIdentifier_, at the instant corresponding with _epochNanoseconds_ relative to the epoch, both in nanoseconds.</p>
+        <p>The default implementation of GetNamedTimeZoneOffsetNanoseconds, to be used for ECMAScript implementations that do not include local political rules for any time zones, performs the following steps when called:</p>
+        <emu-alg>
+          1. Assert: _timeZoneIdentifier_ is *"UTC"*.
+          1. Return 0.
+        </emu-alg>
+        <emu-note>
+          <p>Time zone offset values may be positive or negative.</p>
+        </emu-note>
+      </emu-clause>
+
+      <emu-clause id="sec-defaulttimezone" type="implementation-defined abstract operation">
+        <h1>DefaultTimeZone ( ): a String</h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It returns a String value representing the host environment's current time zone, which is either a String representing a UTC offset for which IsTimeZoneOffsetString returns *true*, or a String identifier accepted by GetNamedTimeZoneEpochNanoseconds and GetNamedTimeZoneOffsetNanoseconds.</dd>
+        </dl>
+
+        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the DefaultTimeZone abstract operation as specified in the ECMA-402 specification.</p>
+        <p>The default implementation of DefaultTimeZone, to be used for ECMAScript implementations that do not include local political rules for any time zones, performs the following steps when called:</p>
+
+        <emu-alg>
+          1. Return *"UTC"*.
+        </emu-alg>
+
+        <emu-note>
+          <p>
+            To ensure the level of functionality that implementations commonly provide in the methods of the Date object, it is recommended that DefaultTimeZone return an IANA time zone name corresponding to the host environment's time zone setting, if such a thing exists.
+            GetNamedTimeZoneEpochNanoseconds and GetNamedTimeZoneOffsetNanoseconds must reflect the local political rules for standard time and daylight saving time in that time zone, if such rules exist.
+          </p>
+          <p>For example, if the host environment is a browser on a system where the user has chosen US Eastern Time as their time zone, DefaultTimeZone returns *"America/New_York"*.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-localtime" type="abstract operation">
         <h1>
           LocalTime (
-            _t_: a time value,
-          ): a Number
+            _t_: a finite time value,
+          ): an integral Number
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It converts _t_ from UTC to local time.</dd>
+          <dd>
+            It converts _t_ from UTC to local time.
+            The local political rules for standard time and daylight saving time in effect at _t_ should be used to determine the result in the way specified in this section.
+          </dd>
         </dl>
         <emu-alg>
-          1. Return _t_ + LocalTZA(_t_, *true*).
+          1. Let _localTimeZone_ be DefaultTimeZone().
+          1. If IsTimeZoneOffsetString(_localTimeZone_) is *true*, then
+            1. Let _offsetNs_ be ParseTimeZoneOffsetString(_localTimeZone_).
+          1. Else,
+            1. Let _offsetNs_ be GetNamedTimeZoneOffsetNanoseconds(_localTimeZone_, ℤ(ℝ(_t_) &times; 10<sup>6</sup>)).
+          1. Let _offsetMs_ be truncate(_offsetNs_ / 10<sup>6</sup>).
+          1. Return _t_ + 𝔽(_offsetMs_).
         </emu-alg>
+        <p>If political rules for the local time _t_ are not available within the implementation, the result is _t_ because DefaultTimeZone returns *"UTC"* and GetNamedTimeZoneOffsetNanoseconds returns 0.</p>
+        <emu-note>
+          <p>It is recommended that implementations use the time zone information of the IANA Time Zone Database <a href="https://www.iana.org/time-zones/">https://www.iana.org/time-zones/</a>.</p>
+        </emu-note>
         <emu-note>
           <p>Two different input time values <emu-eqn>_t_<sub>UTC</sub></emu-eqn> are converted to the same local time <emu-eqn>t<sub>local</sub></emu-eqn> at a negative time zone transition when there are repeated times (e.g. the daylight saving time ends or the time zone adjustment is decreased.).</p>
           <p><emu-eqn>LocalTime(UTC(_t_<sub>local</sub>))</emu-eqn> is not necessarily always equal to <emu-eqn>_t_<sub>local</sub></emu-eqn>. Correspondingly, <emu-eqn>UTC(LocalTime(_t_<sub>UTC</sub>))</emu-eqn> is not necessarily always equal to <emu-eqn>_t_<sub>UTC</sub></emu-eqn>.</p>
@@ -32160,11 +32259,46 @@
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It converts _t_ from local time to a UTC time value.</dd>
+          <dd>
+            It converts _t_ from local time to a UTC time value.
+            The local political rules for standard time and daylight saving time in effect at _t_ should be used to determine the result in the way specified in this section.
+          </dd>
         </dl>
         <emu-alg>
-          1. Return _t_ - LocalTZA(_t_, *false*).
+          1. Let _localTimeZone_ be DefaultTimeZone().
+          1. If IsTimeZoneOffsetString(_localTimeZone_) is *true*, then
+            1. Let _offsetNs_ be ParseTimeZoneOffsetString(_localTimeZone_).
+          1. Else,
+            1. Let _possibleInstants_ be GetNamedTimeZoneEpochNanoseconds(_localTimeZone_, ℝ(YearFromTime(_t_)), ℝ(MonthFromTime(_t_)) + 1, ℝ(DateFromTime(_t_)), ℝ(HourFromTime(_t_)), ℝ(MinFromTime(_t_)), ℝ(SecFromTime(_t_)), ℝ(msFromTime(_t_)), 0, 0).
+            1. NOTE: The following steps ensure that when _t_ represents local time repeating multiple times at a negative time zone transition (e.g. when the daylight saving time ends or the time zone offset is decreased due to a time zone rule change) or skipped local time at a positive time zone transition (e.g. when the daylight saving time starts or the time zone offset is increased due to a time zone rule change), _t_ is interpreted using the time zone offset before the transition.
+            1. If _possibleInstants_ is not empty, then
+              1. Let _disambiguatedInstant_ be _possibleInstants_[0].
+            1. Else,
+              1. NOTE: _t_ represents a local time skipped at a positive time zone transition (e.g. due to daylight saving time starting or a time zone rule change increasing the UTC offset).
+              1. Let _possibleInstantsBefore_ be GetNamedTimeZoneEpochNanoseconds(_localTimeZone_, ℝ(YearFromTime(_tBefore_)), ℝ(MonthFromTime(_tBefore_)) + 1, ℝ(DateFromTime(_tBefore_)), ℝ(HourFromTime(_tBefore_)), ℝ(MinFromTime(_tBefore_)), ℝ(SecFromTime(_tBefore_)), ℝ(msFromTime(_tBefore_)), 0, 0), where _tBefore_ is the largest integral Number &lt; _t_ for which _possibleInstantsBefore_ is not empty (i.e., _tBefore_ represents the last local time before the transition).
+              1. Let _disambiguatedInstant_ be the last element of _possibleInstantsBefore_.
+            1. Let _offsetNs_ be GetNamedTimeZoneOffsetNanoseconds(_localTimeZone_, _disambiguatedInstant_).
+          1. Let _offsetMs_ be truncate(_offsetNs_ / 10<sup>6</sup>).
+          1. Return _t_ - 𝔽(_offsetMs_).
         </emu-alg>
+        <p>
+          Input _t_ is nominally a time value but may be any Number value.
+          The algorithm must not limit _t_ to the time value range, so that inputs corresponding with a boundary of the time value range can be supported regardless of local UTC offset.
+          For example, the maximum time value is 8.64 &times; 10<sup>15</sup>, corresponding with *"+275760-09-13T00:00:00Z"*.
+          In an environment where the local time zone offset is ahead of UTC by 1 hour at that instant, it is represented by the larger input of 8.64 &times; 10<sup>15</sup> + 3.6 &times; 10<sup>6</sup>, corresponding with *"+275760-09-13T01:00:00+01:00"*.
+        </p>
+        <p>If political rules for the local time _t_ are not available within the implementation, the result is _t_ because DefaultTimeZone returns *"UTC"* and GetNamedTimeZoneOffsetNanoseconds returns 0.</p>
+        <emu-note>
+          <p>It is recommended that implementations use the time zone information of the IANA Time Zone Database <a href="https://www.iana.org/time-zones/">https://www.iana.org/time-zones/</a>.</p>
+          <p>
+            1:30 AM on 5 November 2017 in America/New_York is repeated twice (fall backward), but it must be interpreted as 1:30 AM UTC-04 instead of 1:30 AM UTC-05.
+            In UTC(TimeClip(MakeDate(MakeDay(2017, 10, 5), MakeTime(1, 30, 0, 0)))), the value of _offsetMs_ is <emu-eqn>-4 &times; msPerHour</emu-eqn>.
+          </p>
+          <p>
+            2:30 AM on 12 March 2017 in America/New_York does not exist, but it must be interpreted as 2:30 AM UTC-05 (equivalent to 3:30 AM UTC-04).
+            In UTC(TimeClip(MakeDate(MakeDay(2017, 2, 12), MakeTime(2, 30, 0, 0)))), the value of _offsetMs_ is <emu-eqn>-5 &times; msPerHour</emu-eqn>.
+          </p>
+        </emu-note>
         <emu-note>
           <p><emu-eqn>UTC(LocalTime(_t_<sub>UTC</sub>))</emu-eqn> is not necessarily always equal to <emu-eqn>_t_<sub>UTC</sub></emu-eqn>. Correspondingly, <emu-eqn>LocalTime(UTC(_t_<sub>local</sub>))</emu-eqn> is not necessarily always equal to <emu-eqn>_t_<sub>local</sub></emu-eqn>.</p>
         </emu-note>
@@ -32370,7 +32504,7 @@
                 `Z`
               </td>
               <td>
-                is the UTC offset representation specified as *"Z"* (for UTC with no offset) or an offset of either *"+"* or *"-"* followed by a time expression `HH:mm` (indicating local time ahead of or behind UTC, respectively)
+                is the UTC offset representation specified as *"Z"* (for UTC with no offset) or as either *"+"* or *"-"* followed by a time expression `HH:mm` (a subset of the <emu-xref href="#sec-time-zone-offset-strings">time zone offset string format</emu-xref> for indicating local time ahead of or behind UTC, respectively)
               </td>
             </tr>
           </table>
@@ -32433,6 +32567,156 @@ THH:mm:ss.sss
               </table>
             </figure>
           </emu-note>
+        </emu-clause>
+      </emu-clause>
+
+      <emu-clause id="sec-time-zone-offset-strings">
+        <h1>Time Zone Offset String Format</h1>
+
+        <p>
+          ECMAScript defines a string interchange format for UTC offsets, derived from ISO 8601.
+          The format is described by the following grammar.
+          The usage of Unicode code points in this grammar is listed in <emu-xref href="#table-time-zone-offset-string-code-points"></emu-xref>.
+        </p>
+
+        <emu-table id="table-time-zone-offset-string-code-points" caption="Time Zone Offset String Code Points">
+          <table>
+            <tr>
+              <th>
+                Code Point
+              </th>
+              <th>
+                Unicode Name
+              </th>
+              <th>
+                Abbreviation
+              </th>
+            </tr>
+            <tr>
+              <td>
+                `U+2212`
+              </td>
+              <td>
+                MINUS SIGN
+              </td>
+              <td>
+                &lt;MINUS&gt;
+              </td>
+            </tr>
+          </table>
+        </emu-table>
+
+        <emu-grammar type="definition">
+          UTCOffset :::
+            TemporalSign Hour
+            TemporalSign Hour HourSubcomponents[+Extended]
+            TemporalSign Hour HourSubcomponents[~Extended]
+
+          TemporalSign :::
+            ASCIISign
+            &lt;MINUS&gt;
+
+          ASCIISign ::: one of
+            `+` `-`
+
+          Hour :::
+            `0` DecimalDigit
+            `1` DecimalDigit
+            `20`
+            `21`
+            `22`
+            `23`
+
+          HourSubcomponents[Extended] :::
+            TimeSeparator[?Extended] MinuteSecond
+            TimeSeparator[?Extended] MinuteSecond TimeSeparator[?Extended] MinuteSecond TemporalDecimalFraction?
+
+          TimeSeparator[Extended] :::
+            [+Extended] `:`
+            [~Extended] [empty]
+
+          MinuteSecond :::
+            `0` DecimalDigit
+            `1` DecimalDigit
+            `2` DecimalDigit
+            `3` DecimalDigit
+            `4` DecimalDigit
+            `5` DecimalDigit
+
+          TemporalDecimalFraction :::
+            TemporalDecimalSeparator DecimalDigit
+            TemporalDecimalSeparator DecimalDigit DecimalDigit
+            TemporalDecimalSeparator DecimalDigit DecimalDigit DecimalDigit
+            TemporalDecimalSeparator DecimalDigit DecimalDigit DecimalDigit DecimalDigit
+            TemporalDecimalSeparator DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit
+            TemporalDecimalSeparator DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit
+            TemporalDecimalSeparator DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit
+            TemporalDecimalSeparator DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit
+            TemporalDecimalSeparator DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit
+
+          TemporalDecimalSeparator ::: one of
+            `.` `,`
+        </emu-grammar>
+
+        <emu-clause id="sec-istimezoneoffsetstring" type="abstract operation">
+          <h1>
+            IsTimeZoneOffsetString (
+              _offsetString_: a String,
+            ): a Boolean
+          </h1>
+          <dl class="header">
+            <dt>description</dt>
+            <dd>The return value indicates whether _offsetString_ conforms to the grammar given by |UTCOffset|.</dd>
+          </dl>
+          <emu-alg>
+            1. Let _parseResult_ be ParseText(StringToCodePoints(_offsetString_), |UTCOffset|).
+            1. If _parseResult_ is a List of errors, return *false*.
+            1. Return *true*.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-parsetimezoneoffsetstring" type="abstract operation">
+          <h1>
+            ParseTimeZoneOffsetString (
+              _offsetString_: a String,
+            ): an integer
+          </h1>
+          <dl class="header">
+            <dt>description</dt>
+            <dd>The return value is the UTC offset, as a number of nanoseconds, that corresponds to the String _offsetString_.</dd>
+          </dl>
+          <emu-alg>
+            1. Let _parseResult_ be ParseText(StringToCodePoints(_offsetString_), |UTCOffset|).
+            1. Assert: _parseResult_ is not a List of errors.
+            1. Assert: _parseResult_ contains a |TemporalSign| Parse Node.
+            1. Let _parsedSign_ be the source text matched by the |TemporalSign| Parse Node contained within _parseResult_.
+            1. If _parsedSign_ is the single code point U+002D (HYPHEN-MINUS) or U+2212 (MINUS SIGN), then
+              1. Let _sign_ be -1.
+            1. Else,
+              1. Let _sign_ be 1.
+            1. NOTE: Applications of StringToNumber below do not lose precision, since each of the parsed values is guaranteed to be a sufficiently short string of decimal digits.
+            1. Assert: _parseResult_ contains an |Hour| Parse Node.
+            1. Let _parsedHours_ be the source text matched by the |Hour| Parse Node contained within _parseResult_.
+            1. Let _hours_ be ℝ(StringToNumber(CodePointsToString(_parsedHours_))).
+            1. If _parseResult_ does not contain a |MinuteSecond| Parse Node, then
+              1. Let _minutes_ be 0.
+            1. Else,
+              1. Let _parsedMinutes_ be the source text matched by the first |MinuteSecond| Parse Node contained within _parseResult_.
+              1. Let _minutes_ be ℝ(StringToNumber(CodePointsToString(_parsedMinutes_))).
+            1. If _parseResult_ does not contain two |MinuteSecond| Parse Nodes, then
+              1. Let _seconds_ be 0.
+            1. Else,
+              1. Let _parsedSeconds_ be the source text matched by the second |MinuteSecond| Parse Node contained within _parseResult_.
+              1. Let _seconds_ be ℝ(StringToNumber(CodePointsToString(_parsedSeconds_))).
+            1. If _parseResult_ does not contain a |TemporalDecimalFraction| Parse Node, then
+              1. Let _nanoseconds_ be 0.
+            1. Else,
+              1. Let _parsedFraction_ be the source text matched by the |TemporalDecimalFraction| Parse Node contained within _parseResult_.
+              1. Let _fraction_ be the string-concatenation of CodePointsToString(_parsedFraction_) and *"000000000"*.
+              1. Let _nanosecondsString_ be the substring of _fraction_ from 1 to 10.
+              1. Let _nanoseconds_ be ℝ(StringToNumber(_nanosecondsString_)).
+            1. Return _sign_ &times; (((_hours_ &times; 60 + _minutes_) &times; 60 + _seconds_) &times; 10<sup>9</sup> + _nanoseconds_).
+          </emu-alg>
         </emu-clause>
       </emu-clause>
     </emu-clause>
@@ -33326,13 +33610,18 @@ THH:mm:ss.sss
         <emu-clause id="sec-timezoneestring" type="abstract operation">
           <h1>
             TimeZoneString (
-              _tv_: a Number, but not *NaN*,
+              _tv_: an integral Number,
             ): a String
           </h1>
           <dl class="header">
           </dl>
           <emu-alg>
-            1. Let _offset_ be LocalTZA(_tv_, *true*).
+            1. Let _localTimeZone_ be DefaultTimeZone().
+            1. If IsTimeZoneOffsetString(_localTimeZone_) is *true*, then
+              1. Let _offsetNs_ be ParseTimeZoneOffsetString(_localTimeZone_).
+            1. Else,
+              1. Let _offsetNs_ be GetNamedTimeZoneOffsetNanoseconds(_localTimeZone_, ℤ(ℝ(_tv_) &times; 10<sup>6</sup>)).
+            1. Let _offset_ be 𝔽(truncate(_offsetNs_ / 10<sup>6</sup>)).
             1. If _offset_ is *+0*<sub>𝔽</sub> or _offset_ &gt; *+0*<sub>𝔽</sub>, then
               1. Let _offsetSign_ be *"+"*.
               1. Let _absOffset_ be _offset_.
@@ -33349,7 +33638,7 @@ THH:mm:ss.sss
         <emu-clause id="sec-todatestring" type="abstract operation">
           <h1>
             ToDateString (
-              _tv_: a Number,
+              _tv_: an integral Number or *NaN*,
             ): a String
           </h1>
           <dl class="header">


### PR DESCRIPTION
Currently, it is technically possible for the following two operations to
result in different local times and different time zones:

```js
> date = new Date()
> date.toTimeString()
'13:43:47 GMT-0700 (Pacific Daylight Time)'
> new Intl.DateTimeFormat(undefined, {timeStyle: 'full'}).format(date)
'1:43:47 p.m. Pacific Daylight Time'
```

This is because Date gets its notion of the current system time zone from
the operation LocalTZA, while Intl.DateTimeFormat uses the operation
DefaultTimeZone from ECMA-402 to determine the current system time zone.

This is a normative change because there was previously no requirement for
these to be linked. However, they *should* definitely be linked, and no
implementation that includes ECMA-402 that I'm aware of has a discrepancy
between the two. This patch adds this requirement.

This is accomplished by removing LocalTZA (which was actually two
operations rolled into one, anyway) and redefining the LocalTime and UTC
operations in terms of DefaultTimeZone, which moves into ECMA-262, as well
as the two new operations GetNamedTimeZoneOffsetNanoseconds and
GetNamedTimeZoneEpochNanoseconds.

It essentially pushes the "implementation-definedness" of LocalTZA into
GetNamedTimeZoneOffsetNanoseconds, GetNamedTimeZoneEpochNanoseconds, and
DefaultTimeZone.

Although it is a normative change because it adds the requirement for Date
and Intl.DateTimeFormat to use the same default time zone, it should have
no other effects. Despite specifying what LocalTZA used to do in terms of
different operations, the observable effects are the same.

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
