### PR TITLE
Editorial: Fix remaining phrases using 'the number of code units in' for string length

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -14203,7 +14203,7 @@
 
     <emu-clause id="sec-string-exotic-objects">
       <h1>String Exotic Objects</h1>
-      <p>A String object is an exotic object that encapsulates a String value and exposes virtual integer-indexed data properties corresponding to the individual code unit elements of the String value. String exotic objects always have a data property named *"length"* whose value is the number of code unit elements in the encapsulated String value. Both the code unit data properties and the *"length"* property are non-writable and non-configurable.</p>
+      <p>A String object is an exotic object that encapsulates a String value and exposes virtual integer-indexed data properties corresponding to the individual code unit elements of the String value. String exotic objects always have a data property named *"length"* whose value is the length of the encapsulated String value. Both the code unit data properties and the *"length"* property are non-writable and non-configurable.</p>
 
       <p>An object is a <dfn id="string-exotic-object" variants="String exotic objects">String exotic object</dfn> (or simply, a String object) if its [[GetOwnProperty]], [[DefineOwnProperty]], and [[OwnPropertyKeys]] internal methods use the following implementations, and its other essential internal methods use the definitions found in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>. These methods are installed in StringCreate.</p>
 
@@ -14287,7 +14287,7 @@
           1. Set _S_.[[GetOwnProperty]] as specified in <emu-xref href="#sec-string-exotic-objects-getownproperty-p"></emu-xref>.
           1. Set _S_.[[DefineOwnProperty]] as specified in <emu-xref href="#sec-string-exotic-objects-defineownproperty-p-desc"></emu-xref>.
           1. Set _S_.[[OwnPropertyKeys]] as specified in <emu-xref href="#sec-string-exotic-objects-ownpropertykeys"></emu-xref>.
-          1. Let _length_ be the number of code unit elements in _value_.
+          1. Let _length_ be the length of _value_.
           1. Perform ! DefinePropertyOrThrow(_S_, *"length"*, PropertyDescriptor { [[Value]]: 𝔽(_length_), [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
           1. Return _S_.
         </emu-alg>
@@ -36689,7 +36689,7 @@ THH:mm:ss.sss
           1. Let _rx_ be the *this* value.
           1. If Type(_rx_) is not Object, throw a *TypeError* exception.
           1. Let _S_ be ? ToString(_string_).
-          1. Let _lengthS_ be the number of code unit elements in _S_.
+          1. Let _lengthS_ be the length of _S_.
           1. Let _functionalReplace_ be IsCallable(_replaceValue_).
           1. If _functionalReplace_ is *false*, then
             1. Set _replaceValue_ to ? ToString(_replaceValue_).


### PR DESCRIPTION
According to #2746, there are some inconsistent phrases that still use 'the number of code units in' for denoting the length of string value.

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
