### PR TITLE
Editorial: Consistify miscellaneous phrases

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -6630,7 +6630,7 @@
           1. Let _indexName_ be ! ToString(𝔽(_index_)).
           1. Let _next_ be ? Get(_obj_, _indexName_).
           1. If Type(_next_) is not an element of _elementTypes_, throw a *TypeError* exception.
-          1. Append _next_ as the last element of _list_.
+          1. Append _next_ to _list_.
           1. Set _index_ to _index_ + 1.
         1. Return _list_.
       </emu-alg>
@@ -7213,7 +7213,7 @@
           1. Set _next_ to ? IteratorStep(_iteratorRecord_).
           1. If _next_ is not *false*, then
             1. Let _nextValue_ be ? IteratorValue(_next_).
-            1. Append _nextValue_ to the end of the List _values_.
+            1. Append _nextValue_ to _values_.
         1. Return _values_.
       </emu-alg>
     </emu-clause>
@@ -12958,11 +12958,11 @@
         <emu-alg>
           1. Let _keys_ be a new empty List.
           1. For each own property key _P_ of _O_ such that _P_ is an array index, in ascending numeric index order, do
-            1. Add _P_ as the last element of _keys_.
+            1. Append _P_ to _keys_.
           1. For each own property key _P_ of _O_ such that Type(_P_) is String and _P_ is not an array index, in ascending chronological order of property creation, do
-            1. Add _P_ as the last element of _keys_.
+            1. Append _P_ to _keys_.
           1. For each own property key _P_ of _O_ such that Type(_P_) is Symbol, in ascending chronological order of property creation, do
-            1. Add _P_ as the last element of _keys_.
+            1. Append _P_ to _keys_.
           1. Return _keys_.
         </emu-alg>
       </emu-clause>
@@ -14220,13 +14220,13 @@
           1. Assert: Type(_str_) is String.
           1. Let _len_ be the length of _str_.
           1. For each integer _i_ starting with 0 such that _i_ &lt; _len_, in ascending order, do
-            1. Add ! ToString(𝔽(_i_)) as the last element of _keys_.
+            1. Append ! ToString(𝔽(_i_)) to _keys_.
           1. For each own property key _P_ of _O_ such that _P_ is an array index and ! ToIntegerOrInfinity(_P_) &ge; _len_, in ascending numeric index order, do
-            1. Add _P_ as the last element of _keys_.
+            1. Append _P_ to _keys_.
           1. For each own property key _P_ of _O_ such that Type(_P_) is String and _P_ is not an array index, in ascending chronological order of property creation, do
-            1. Add _P_ as the last element of _keys_.
+            1. Append _P_ to _keys_.
           1. For each own property key _P_ of _O_ such that Type(_P_) is Symbol, in ascending chronological order of property creation, do
-            1. Add _P_ as the last element of _keys_.
+            1. Append _P_ to _keys_.
           1. Return _keys_.
         </emu-alg>
       </emu-clause>
@@ -14488,7 +14488,7 @@
           1. Repeat, while _index_ &ge; 0,
             1. Let _name_ be _parameterNames_[_index_].
             1. If _name_ is not an element of _mappedNames_, then
-              1. Add _name_ as an element of the list _mappedNames_.
+              1. Append _name_ to _mappedNames_.
               1. If _index_ &lt; _len_, then
                 1. Let _g_ be MakeArgGetter(_name_, _env_).
                 1. Let _p_ be MakeArgSetter(_name_, _env_).
@@ -14683,11 +14683,11 @@
           1. Let _keys_ be a new empty List.
           1. If IsDetachedBuffer(_O_.[[ViewedArrayBuffer]]) is *false*, then
             1. For each integer _i_ starting with 0 such that _i_ &lt; _O_.[[ArrayLength]], in ascending order, do
-              1. Add ! ToString(𝔽(_i_)) as the last element of _keys_.
+              1. Append ! ToString(𝔽(_i_)) to _keys_.
           1. For each own property key _P_ of _O_ such that Type(_P_) is String and _P_ is not an integer index, in ascending chronological order of property creation, do
-            1. Add _P_ as the last element of _keys_.
+            1. Append _P_ to _keys_.
           1. For each own property key _P_ of _O_ such that Type(_P_) is Symbol, in ascending chronological order of property creation, do
-            1. Add _P_ as the last element of _keys_.
+            1. Append _P_ to _keys_.
           1. Return _keys_.
         </emu-alg>
       </emu-clause>
@@ -19215,7 +19215,7 @@
             1. Let _next_ be ? IteratorStep(_iteratorRecord_).
             1. If _next_ is *false*, return _list_.
             1. Let _nextArg_ be ? IteratorValue(_next_).
-            1. Append _nextArg_ as the last element of _list_.
+            1. Append _nextArg_ to _list_.
         </emu-alg>
         <emu-grammar>ArgumentList : ArgumentList `,` AssignmentExpression</emu-grammar>
         <emu-alg>
@@ -19233,7 +19233,7 @@
             1. Let _next_ be ? IteratorStep(_iteratorRecord_).
             1. If _next_ is *false*, return _precedingArgs_.
             1. Let _nextArg_ be ? IteratorValue(_next_).
-            1. Append _nextArg_ as the last element of _precedingArgs_.
+            1. Append _nextArg_ to _precedingArgs_.
         </emu-alg>
         <emu-grammar>TemplateLiteral : NoSubstitutionTemplate</emu-grammar>
         <emu-alg>
@@ -29536,7 +29536,7 @@
             1. Let _nameList_ be a new empty List.
             1. For each element _nextKey_ of _keys_, do
               1. If Type(_nextKey_) is Symbol and _type_ is ~symbol~ or Type(_nextKey_) is String and _type_ is ~string~, then
-                1. Append _nextKey_ as the last element of _nameList_.
+                1. Append _nextKey_ to _nameList_.
             1. Return _nameList_.
           </emu-alg>
         </emu-clause>
@@ -33433,7 +33433,7 @@ THH:mm:ss.sss
           1. Let _elements_ be a new empty List.
           1. For each element _next_ of _codeUnits_, do
             1. Let _nextCU_ be ℝ(? ToUint16(_next_)).
-            1. Append _nextCU_ to the end of _elements_.
+            1. Append _nextCU_ to _elements_.
           1. Return the String value whose code units are the elements in the List _elements_. If _codeUnits_ is empty, the empty String is returned.
         </emu-alg>
         <p>The *"length"* property of this function is *1*<sub>𝔽</sub>.</p>
@@ -34041,7 +34041,7 @@ THH:mm:ss.sss
           1. Let _matchPositions_ be a new empty List.
           1. Let _position_ be StringIndexOf(_string_, _searchString_, 0).
           1. Repeat, while _position_ is not -1,
-            1. Append _position_ to the end of _matchPositions_.
+            1. Append _position_ to _matchPositions_.
             1. Set _position_ to StringIndexOf(_string_, _searchString_, _position_ + _advanceBy_).
           1. Let _endOfLastMatch_ be 0.
           1. Let _result_ be the empty String.
@@ -34131,7 +34131,7 @@ THH:mm:ss.sss
           1. Let _j_ be StringIndexOf(_S_, _R_, 0).
           1. Repeat, while _j_ is not -1,
             1. Let _T_ be the substring of _S_ from _i_ to _j_.
-            1. Append _T_ as the last element of _substrings_.
+            1. Append _T_ to _substrings_.
             1. If the number of elements of _substrings_ is _lim_, return CreateArrayFromList(_substrings_).
             1. Set _i_ to _j_ + _separatorLength_.
             1. Set _j_ to StringIndexOf(_S_, _R_, _i_).
@@ -36636,7 +36636,7 @@ THH:mm:ss.sss
             1. Let _result_ be ? RegExpExec(_rx_, _S_).
             1. If _result_ is *null*, set _done_ to *true*.
             1. Else,
-              1. Append _result_ to the end of _results_.
+              1. Append _result_ to _results_.
               1. If _global_ is *false*, set _done_ to *true*.
               1. Else,
                 1. Let _matchStr_ be ? ToString(? Get(_result_, *"0"*)).
@@ -36659,7 +36659,7 @@ THH:mm:ss.sss
               1. Let _capN_ be ? Get(_result_, ! ToString(𝔽(_n_))).
               1. If _capN_ is not *undefined*, then
                 1. Set _capN_ to ? ToString(_capN_).
-              1. Append _capN_ as the last element of _captures_.
+              1. Append _capN_ to _captures_.
               1. NOTE: When _n_ = 1, the preceding step puts the first element into _captures_ (at index 0). More generally, the _n_<sup>th</sup> capture (the characters captured by the _n_<sup>th</sup> set of capturing parentheses) is at _captures_[_n_ - 1].
               1. Set _n_ to _n_ + 1.
             1. Let _namedCaptures_ be ? Get(_result_, *"groups"*).
@@ -36668,7 +36668,7 @@ THH:mm:ss.sss
               1. Append in List order the elements of _captures_ to the end of the List _replacerArgs_.
               1. Append 𝔽(_position_) and _S_ to _replacerArgs_.
               1. If _namedCaptures_ is not *undefined*, then
-                1. Append _namedCaptures_ as the last element of _replacerArgs_.
+                1. Append _namedCaptures_ to _replacerArgs_.
               1. Let _replValue_ be ? Call(_replaceValue_, *undefined*, _replacerArgs_).
               1. Let _replacement_ be ? ToString(_replValue_).
             1. Else,
@@ -38885,7 +38885,7 @@ THH:mm:ss.sss
             1. Let _kValue_ be ! Get(_O_, _Pk_).
             1. Let _selected_ be ToBoolean(? Call(_callbackfn_, _thisArg_, &laquo; _kValue_, 𝔽(_k_), _O_ &raquo;)).
             1. If _selected_ is *true*, then
-              1. Append _kValue_ to the end of _kept_.
+              1. Append _kValue_ to _kept_.
               1. Set _captured_ to _captured_ + 1.
             1. Set _k_ to _k_ + 1.
           1. Let _A_ be ? TypedArraySpeciesCreate(_O_, &laquo; 𝔽(_captured_) &raquo;).
@@ -40103,7 +40103,7 @@ THH:mm:ss.sss
               1. Return _M_.
           1. If _key_ is *-0*<sub>𝔽</sub>, set _key_ to *+0*<sub>𝔽</sub>.
           1. Let _p_ be the Record { [[Key]]: _key_, [[Value]]: _value_ }.
-          1. Append _p_ as the last element of _entries_.
+          1. Append _p_ to _entries_.
           1. Return _M_.
         </emu-alg>
       </emu-clause>
@@ -40297,7 +40297,7 @@ THH:mm:ss.sss
             1. If _e_ is not ~empty~ and SameValueZero(_e_, _value_) is *true*, then
               1. Return _S_.
           1. If _value_ is *-0*<sub>𝔽</sub>, set _value_ to *+0*<sub>𝔽</sub>.
-          1. Append _value_ as the last element of _entries_.
+          1. Append _value_ to _entries_.
           1. Return _S_.
         </emu-alg>
       </emu-clause>
@@ -40631,7 +40631,7 @@ THH:mm:ss.sss
               1. Set _p_.[[Value]] to _value_.
               1. Return _M_.
           1. Let _p_ be the Record { [[Key]]: _key_, [[Value]]: _value_ }.
-          1. Append _p_ as the last element of _entries_.
+          1. Append _p_ to _entries_.
           1. Return _M_.
         </emu-alg>
       </emu-clause>
@@ -40726,7 +40726,7 @@ THH:mm:ss.sss
           1. For each element _e_ of _entries_, do
             1. If _e_ is not ~empty~ and SameValue(_e_, _value_) is *true*, then
               1. Return _S_.
-          1. Append _value_ as the last element of _entries_.
+          1. Append _value_ to _entries_.
           1. Return _S_.
         </emu-alg>
       </emu-clause>
@@ -41945,7 +41945,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Assert: The surrounding agent is in the critical section for _WL_.
           1. Assert: _W_ is not on the list of waiters in any WaiterList.
-          1. Add _W_ to the end of the list of waiters in _WL_.
+          1. Append _W_ to _WL_.
           1. Return ~unused~.
         </emu-alg>
       </emu-clause>
@@ -41982,7 +41982,7 @@ THH:mm:ss.sss
           1. Let _S_ be a reference to the list of waiters in _WL_.
           1. Repeat, while _c_ &gt; 0 and _S_ is not empty,
             1. Let _W_ be the first waiter in _S_.
-            1. Add _W_ to the end of _L_.
+            1. Append _W_ to _L_.
             1. Remove _W_ from _S_.
             1. If _c_ is finite, set _c_ to _c_ - 1.
           1. Return _L_.
@@ -42077,7 +42077,7 @@ THH:mm:ss.sss
             1. Else if _op_ is `^`, let _resultByte_ be the result of applying the bitwise exclusive OR (XOR) operation to _xByte_ and _yByte_.
             1. Else, _op_ is `|`. Let _resultByte_ be the result of applying the bitwise inclusive OR operation to _xByte_ and _yByte_.
             1. Set _i_ to _i_ + 1.
-            1. Append _resultByte_ to the end of _result_.
+            1. Append _resultByte_ to _result_.
           1. Return _result_.
         </emu-alg>
       </emu-clause>
@@ -42459,7 +42459,7 @@ THH:mm:ss.sss
                 1. Else if Type(_v_) is Object, then
                   1. If _v_ has a [[StringData]] or [[NumberData]] internal slot, set _item_ to ? ToString(_v_).
                 1. If _item_ is not *undefined* and _item_ is not currently an element of _PropertyList_, then
-                  1. Append _item_ to the end of _PropertyList_.
+                  1. Append _item_ to _PropertyList_.
                 1. Set _k_ to _k_ + 1.
         1. If Type(_space_) is Object, then
           1. If _space_ has a [[NumberData]] internal slot, then
@@ -44560,8 +44560,8 @@ THH:mm:ss.sss
             1. Let _fulfillReaction_ be the PromiseReaction { [[Capability]]: _resultCapability_, [[Type]]: ~Fulfill~, [[Handler]]: _onFulfilledJobCallback_ }.
             1. Let _rejectReaction_ be the PromiseReaction { [[Capability]]: _resultCapability_, [[Type]]: ~Reject~, [[Handler]]: _onRejectedJobCallback_ }.
             1. If _promise_.[[PromiseState]] is ~pending~, then
-              1. Append _fulfillReaction_ as the last element of the List that is _promise_.[[PromiseFulfillReactions]].
-              1. Append _rejectReaction_ as the last element of the List that is _promise_.[[PromiseRejectReactions]].
+              1. Append _fulfillReaction_ to _promise_.[[PromiseFulfillReactions]].
+              1. Append _rejectReaction_ to _promise_.[[PromiseRejectReactions]].
             1. Else if _promise_.[[PromiseState]] is ~fulfilled~, then
               1. Let _value_ be _promise_.[[PromiseResult]].
               1. Let _fulfillJob_ be NewPromiseReactionJob(_fulfillReaction_, _value_).
@@ -45409,7 +45409,7 @@ THH:mm:ss.sss
         </dl>
         <emu-alg>
           1. Let _request_ be AsyncGeneratorRequest { [[Completion]]: _completion_, [[Capability]]: _promiseCapability_ }.
-          1. Append _request_ to the end of _generator_.[[AsyncGeneratorQueue]].
+          1. Append _request_ to _generator_.[[AsyncGeneratorQueue]].
           1. Return ~unused~.
         </emu-alg>
       </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -22030,7 +22030,7 @@
         </dl>
         <emu-alg>
           1. Let _oldEnv_ be the running execution context's LexicalEnvironment.
-          1. If _uninitializedBoundNames_ is not an empty List, then
+          1. If _uninitializedBoundNames_ is not empty, then
             1. Assert: _uninitializedBoundNames_ has no duplicate entries.
             1. Let _newEnv_ be NewDeclarativeEnvironment(_oldEnv_).
             1. For each String _name_ of _uninitializedBoundNames_, do
@@ -41980,7 +41980,7 @@ THH:mm:ss.sss
           1. Assert: The surrounding agent is in the critical section for _WL_.
           1. Let _L_ be a new empty List.
           1. Let _S_ be a reference to the list of waiters in _WL_.
-          1. Repeat, while _c_ &gt; 0 and _S_ is not an empty List,
+          1. Repeat, while _c_ &gt; 0 and _S_ is not empty,
             1. Let _W_ be the first waiter in _S_.
             1. Add _W_ to the end of _L_.
             1. Remove _W_ from _S_.
@@ -42317,7 +42317,7 @@ THH:mm:ss.sss
         1. Let _n_ be 0.
         1. Perform EnterCriticalSection(_WL_).
         1. Let _S_ be RemoveWaiters(_WL_, _c_).
-        1. Repeat, while _S_ is not an empty List,
+        1. Repeat, while _S_ is not empty,
           1. Let _W_ be the first agent in _S_.
           1. Remove _W_ from the front of _S_.
           1. Perform NotifyWaiter(_WL_, _W_).

--- a/spec.html
+++ b/spec.html
@@ -21339,7 +21339,7 @@
 
         <emu-grammar>BindingProperty : SingleNameBinding</emu-grammar>
         <emu-alg>
-          1. Let _name_ be the string that is the only element of BoundNames of |SingleNameBinding|.
+          1. Let _name_ be the sole element of the BoundNames of |SingleNameBinding|.
           1. Perform ? KeyedBindingInitialization of |SingleNameBinding| with arguments _value_, _environment_, and _name_.
           1. Return &laquo; _name_ &raquo;.
         </emu-alg>

--- a/spec.html
+++ b/spec.html
@@ -25798,7 +25798,7 @@
         1. Set the VariableEnvironment of _scriptContext_ to _globalEnv_.
         1. Set the LexicalEnvironment of _scriptContext_ to _globalEnv_.
         1. Set the PrivateEnvironment of _scriptContext_ to *null*.
-        1. Suspend the currently running execution context.
+        1. Suspend the running execution context.
         1. Push _scriptContext_ onto the execution context stack; _scriptContext_ is now the running execution context.
         1. Let _script_ be _scriptRecord_.[[ECMAScriptCode]].
         1. Let _result_ be Completion(GlobalDeclarationInstantiation(_script_, _globalEnv_)).
@@ -27744,7 +27744,7 @@
             1. Assert: _module_ has been linked and declarations in its module environment have been instantiated.
             1. Set the VariableEnvironment of _moduleContext_ to _module_.[[Environment]].
             1. Set the LexicalEnvironment of _moduleContext_ to _module_.[[Environment]].
-            1. Suspend the currently running execution context.
+            1. Suspend the running execution context.
             1. If _module_.[[HasTLA]] is *false*, then
               1. Assert: _capability_ is not present.
               1. Push _moduleContext_ onto the execution context stack; _moduleContext_ is now the running execution context.

--- a/spec.html
+++ b/spec.html
@@ -29338,7 +29338,7 @@
         <h1>Object ( [ _value_ ] )</h1>
         <p>This function performs the following steps when called:</p>
         <emu-alg>
-          1. If NewTarget is neither *undefined* nor the active function, then
+          1. If NewTarget is neither *undefined* nor the active function object, then
             1. Return ? OrdinaryCreateFromConstructor(NewTarget, *"%Object.prototype%"*).
           1. If _value_ is *undefined* or *null*, return OrdinaryObjectCreate(%Object.prototype%).
           1. Return ! ToObject(_value_).


### PR DESCRIPTION
I observed some phrases are written in inconsistent form:

- To extract the element from the list of length 1, other phrases use `the sole element of`.
- To check if the list is empty, other phrases use 'is empty' or 'is not empty'
- To reference some well-known objects, other phrases use `active function object` and `the running execution context`, respectively.
- To append an element to the end of list, other phrases use `append _element_ to _list_.`
- Removed unnecessary prefix 'the String' for denoting a string literal.

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
