### PR TITLE
Normative: Always check regular expression flags by "flags"

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -36555,12 +36555,11 @@ THH:mm:ss.sss
           1. Let _rx_ be the *this* value.
           1. If Type(_rx_) is not Object, throw a *TypeError* exception.
           1. Let _S_ be ? ToString(_string_).
-          1. Let _global_ be ToBoolean(? Get(_rx_, *"global"*)).
-          1. If _global_ is *false*, then
+          1. Let _flags_ be ? ToString(? Get(_rx_, *"flags"*)).
+          1. If _flags_ does not contain *"g"*, then
             1. Return ? RegExpExec(_rx_, _S_).
           1. Else,
-            1. Assert: _global_ is *true*.
-            1. Let _fullUnicode_ be ToBoolean(? Get(_rx_, *"unicode"*)).
+            1. If _flags_ contains *"u"*, let _fullUnicode_ be *true*. Otherwise, let _fullUnicode_ be *false*.
             1. Perform ? Set(_rx_, *"lastIndex"*, *+0*<sub>𝔽</sub>, *true*).
             1. Let _A_ be ! ArrayCreate(0).
             1. Let _n_ be 0.
@@ -36626,9 +36625,10 @@ THH:mm:ss.sss
           1. Let _functionalReplace_ be IsCallable(_replaceValue_).
           1. If _functionalReplace_ is *false*, then
             1. Set _replaceValue_ to ? ToString(_replaceValue_).
-          1. Let _global_ be ToBoolean(? Get(_rx_, *"global"*)).
+          1. Let _flags_ be ? ToString(? Get(_rx_, *"flags"*)).
+          1. If _flags_ contains *"g"*, let _global_ be *true*. Otherwise, let _global_ be *false*.
           1. If _global_ is *true*, then
-            1. Let _fullUnicode_ be ToBoolean(? Get(_rx_, *"unicode"*)).
+            1. If _flags_ contains *"u"*, let _fullUnicode_ be *true*. Otherwise, let _fullUnicode_ be *false*.
             1. Perform ? Set(_rx_, *"lastIndex"*, *+0*<sub>𝔽</sub>, *true*).
           1. Let _results_ be a new empty List.
           1. Let _done_ be *false*.


### PR DESCRIPTION
Discussion at https://github.com/tc39/ecma262/pull/2418#discussion_r876052820 uncovered a strange inconsistency: unlike other methods on or related to regular expressions, [RegExp.prototype[@@match]](https://tc39.es/ecma262/multipage/text-processing.html#sec-regexp.prototype-@@match) and [RegExp.prototype[@@replace]](https://tc39.es/ecma262/multipage/text-processing.html#sec-regexp.prototype-@@replace) bypass the "flags" property, instead reading directly (and only) from "global" and "unicode"—and doing so conditionally, checking the latter if and only if the former is coerced to boolean **true**. This is awkward for the introduction of v-mode regular expressions, which need to check a third flag in at least some cases and therefore require taking a position on when to get the property (which is observable).

But these are the only two methods that have such a problem... [String.prototype.matchAll](https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.matchall) and [String.prototype.replaceAll](https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.replaceall) and [RegExp.prototype[@@matchAll]](https://tc39.es/ecma262/multipage/text-processing.html#sec-regexp-prototype-matchall) and [RegExp.prototype[@@split]](https://tc39.es/ecma262/multipage/text-processing.html#sec-regexp.prototype-@@split) get "flags", coerce to string, and then check the result for "u"/"g"/etc. (and the built-in [RegExp.prototype.flags](https://tc39.es/ecma262/multipage/text-processing.html#sec-get-regexp.prototype.flags) itself performs an unconditional Get of each specific flag property in a stable order that is compatible with the deviant operations [i.e., "global" before "unicode"]).

I would like to fix the inconsistency and render the negotiation of https://github.com/tc39/ecma262/pull/2418#discussion_r876052820 moot by updating `@@match` and `@@replace` to align with the other methods in using "flags". This is a normative change, but one that seems likely to be web-compatible because any well-behaved regular expression analog is already required to support "flags" for the other methods, and deviation would actually require special effort—an author would need to copy the built-in `@@match` and/or `@@replace` but specifically remove or override the built-in `flags` getter to be inconsistent with independent `global`/`unicode` access. And if we _don't_ fix this now, then the problem is only going to get worse as more flags are added.