### PR TITLE
Editorial: Missing unwrapping of normal completion records

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -19051,6 +19051,7 @@
           1. Let _memberExpr_ be the |MemberExpression| of _expr_.
           1. Let _arguments_ be the |Arguments| of _expr_.
           1. Let _ref_ be the result of evaluating _memberExpr_.
+          1. ReturnIfAbrupt(_ref_).
           1. Let _func_ be ? GetValue(_ref_).
           1. If _ref_ is a Reference Record, IsPropertyReference(_ref_) is *false*, and _ref_.[[ReferencedName]] is *"eval"*, then
             1. If SameValue(_func_, %eval%) is *true*, then
@@ -19692,6 +19693,7 @@
         <emu-grammar>UnaryExpression : `typeof` UnaryExpression</emu-grammar>
         <emu-alg>
           1. Let _val_ be the result of evaluating |UnaryExpression|.
+          1. ReturnIfAbrupt(_val_).
           1. If _val_ is a Reference Record, then
             1. If IsUnresolvableReference(_val_) is *true*, return *"undefined"*.
           1. Set _val_ to ? GetValue(_val_).


### PR DESCRIPTION
In `Evaluation` SDOs of [13.6.6 Function Calls](https://tc39.es/ecma262/#sec-function-calls-runtime-semantics-evaluation) and [13.5.3 typeof Operator](https://tc39.es/ecma262/#sec-typeof-operator), explicit conversion from normal completion value, which is the result of evaluation, to its `[[Value]]` seem to be needed since it is used as a reference record in the condition of if step.