### PR TITLE
Editorial: Extend CopyDataProperties to support excluding properties by value

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -6763,7 +6763,8 @@
         CopyDataProperties (
           _target_: an Object,
           _source_: an ECMAScript language value,
-          _excludedItems_: a List of property keys,
+          _excludedKeys_: a List of property keys,
+          optional _excludedValues_: a List of ECMAScript language values,
         ): either a normal completion containing ~unused~ or a throw completion
       </h1>
       <dl class="header">
@@ -6774,14 +6775,18 @@
         1. Let _keys_ be ? <emu-meta effects="user-code">_from_.[[OwnPropertyKeys]]</emu-meta>().
         1. For each element _nextKey_ of _keys_, do
           1. Let _excluded_ be *false*.
-          1. For each element _e_ of _excludedItems_, do
+          1. For each property key _e_ of _excludedKeys_, do
             1. If SameValue(_e_, _nextKey_) is *true*, then
               1. Set _excluded_ to *true*.
           1. If _excluded_ is *false*, then
             1. Let _desc_ be ? <emu-meta effects="user-code">_from_.[[GetOwnProperty]]</emu-meta>(_nextKey_).
             1. If _desc_ is not *undefined* and _desc_.[[Enumerable]] is *true*, then
               1. Let _propValue_ be ? Get(_from_, _nextKey_).
-              1. Perform ! CreateDataPropertyOrThrow(_target_, _nextKey_, _propValue_).
+              1. If _excludedValues_ is present, then
+                1. For each value _e_ of _excludedValues_, do
+                  1. If SameValue(_e_, _propValue_) is *true*, then
+                    1. Set _excluded_ to *true*.
+              1. If _excluded_ is *false*, perform ! CreateDataPropertyOrThrow(_target_, _nextKey_, _propValue_).
         1. Return ~unused~.
       </emu-alg>
       <emu-note>


### PR DESCRIPTION
This is another Temporal pull-forward, primarily for treating as absent any property with *undefined* value (cf. https://github.com/tc39/proposal-temporal/pull/2245).