### PR TITLE
Editorial: Add an optional type restriction to IterableToList

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -6398,7 +6398,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It is used to create a List value whose elements are provided by the indexed properties of _obj_. _elementTypes_ contains the names of ECMAScript Language Types that are allowed for element values of the List that is created.</dd>
+        <dd>It is used to create a List whose elements are provided by the indexed properties of _obj_. If _elementTypes_ is present, all elements are required to be one of the types it contains.</dd>
       </dl>
       <emu-alg>
         1. If _elementTypes_ is not present, set _elementTypes_ to « Undefined, Null, Boolean, String, Symbol, Number, BigInt, Object ».
@@ -7000,10 +7000,13 @@
       <h1>
         IterableToList (
           _items_: an ECMAScript language value,
+          optional _elementTypes_: ~empty~ or a List of names of ECMAScript Language Types,
           optional _method_: a function object,
         ): either a normal completion containing a List of ECMAScript language values or a throw completion
       </h1>
       <dl class="header">
+        <dt>description</dt>
+        <dd>It is used to create a List whose elements are provided by the values of the iterable _items_, using method _method_ if present. If _elementTypes_ is present and not ~empty~, all elements are required to be one of the types it contains.</dd>
       </dl>
       <emu-alg>
         1. If _method_ is present, then
@@ -7016,6 +7019,9 @@
           1. Set _next_ to ? IteratorStep(_iteratorRecord_).
           1. If _next_ is not *false*, then
             1. Let _nextValue_ be ? IteratorValue(_next_).
+            1. If _elementTypes_ is not ~empty~ and Type(_nextValue_) is not an element of _elementTypes_, then
+              1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
+              1. Return ? IteratorClose(_iteratorRecord_, _error_).
             1. Append _nextValue_ to _values_.
         1. Return _values_.
       </emu-alg>
@@ -38831,7 +38837,7 @@ THH:mm:ss.sss
             1. Let _mapping_ be *true*.
           1. Let _usingIterator_ be ? GetMethod(_source_, @@iterator).
           1. If _usingIterator_ is not *undefined*, then
-            1. Let _values_ be ? IterableToList(_source_, _usingIterator_).
+            1. Let _values_ be ? IterableToList(_source_, ~empty~, _usingIterator_).
             1. Let _len_ be the number of elements in _values_.
             1. Let _targetObj_ be ? TypedArrayCreate(_C_, « 𝔽(_len_) »).
             1. Let _k_ be 0.
@@ -39842,7 +39848,7 @@ THH:mm:ss.sss
                 1. Assert: _firstArgument_ is an Object and _firstArgument_ does not have either a [[TypedArrayName]] or an [[ArrayBufferData]] internal slot.
                 1. Let _usingIterator_ be ? GetMethod(_firstArgument_, @@iterator).
                 1. If _usingIterator_ is not *undefined*, then
-                  1. Let _values_ be ? IterableToList(_firstArgument_, _usingIterator_).
+                  1. Let _values_ be ? IterableToList(_firstArgument_, ~empty~, _usingIterator_).
                   1. Perform ? InitializeTypedArrayFromList(_O_, _values_).
                 1. Else,
                   1. NOTE: _firstArgument_ is not an Iterable so assume it is already an array-like object.


### PR DESCRIPTION
Mirrors [CreateListFromArrayLike](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-createlistfromarraylike) and supports removal of [Temporal IterableToListOfType](https://tc39.es/proposal-temporal/#sec-iterabletolistoftype) and [ECMA-402 StringListFromIterable](https://tc39.es/ecma402/#sec-createstringlistfromiterable).