### PR TITLE
Editorial: Consistently capitalize List when refer to spec data structure

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -2699,7 +2699,7 @@
                 *undefined*
               </td>
               <td>
-                If the value is an Object it must be a function object. The function's [[Call]] internal method (<emu-xref href="#table-additional-essential-internal-methods-of-function-objects"></emu-xref>) is called with an empty arguments list to retrieve the property value each time a get access of the property is performed.
+                If the value is an Object it must be a function object. The function's [[Call]] internal method (<emu-xref href="#table-additional-essential-internal-methods-of-function-objects"></emu-xref>) is called with an empty arguments List to retrieve the property value each time a get access of the property is performed.
               </td>
             </tr>
             <tr>
@@ -2716,7 +2716,7 @@
                 *undefined*
               </td>
               <td>
-                If the value is an Object it must be a function object. The function's [[Call]] internal method (<emu-xref href="#table-additional-essential-internal-methods-of-function-objects"></emu-xref>) is called with an arguments list containing the assigned value as its sole argument each time a set access of the property is performed. The effect of a property's [[Set]] internal method may, but is not required to, have an effect on the value returned by subsequent calls to the property's [[Get]] internal method.
+                If the value is an Object it must be a function object. The function's [[Call]] internal method (<emu-xref href="#table-additional-essential-internal-methods-of-function-objects"></emu-xref>) is called with an arguments List containing the assigned value as its sole argument each time a set access of the property is performed. The effect of a property's [[Set]] internal method may, but is not required to, have an effect on the value returned by subsequent calls to the property's [[Get]] internal method.
               </td>
             </tr>
             <tr>
@@ -3903,7 +3903,7 @@
 
     <emu-clause id="sec-list-and-record-specification-type">
       <h1>The List and Record Specification Types</h1>
-      <p>The <dfn variants="Lists">List</dfn> type is used to explain the evaluation of argument lists (see <emu-xref href="#sec-argument-lists"></emu-xref>) in `new` expressions, in function calls, and in other algorithms where a simple ordered list of values is needed. Values of the List type are simply ordered sequences of list elements containing the individual values. These sequences may be of any length. The elements of a list may be randomly accessed using 0-origin indices. For notational convenience an array-like syntax can be used to access List elements. For example, _arguments_[2] is shorthand for saying the 3<sup>rd</sup> element of the List _arguments_.</p>
+      <p>The <dfn variants="Lists">List</dfn> type is used to explain the evaluation of argument lists (see <emu-xref href="#sec-argument-lists"></emu-xref>) in `new` expressions, in function calls, and in other algorithms where a simple ordered list of values is needed. Values of the List type are simply ordered sequences of list elements containing the individual values. These sequences may be of any length. The elements of a List may be randomly accessed using 0-origin indices. For notational convenience an array-like syntax can be used to access List elements. For example, _arguments_[2] is shorthand for saying the 3<sup>rd</sup> element of the List _arguments_.</p>
       <p>When an algorithm iterates over the elements of a List without specifying an order, the order used is the order of the elements in the List.</p>
       <p>For notational convenience within this specification, a literal syntax can be used to express a new List value. For example, &laquo; 1, 2 &raquo; defines a List value that has two elements each of which is initialized to a specific value. A new empty List can be expressed as &laquo; &raquo;.</p>
       <p>In this specification, the phrase "the <dfn id="list-concatenation">list-concatenation</dfn> of _A_, _B_, ..." (where each argument is a possibly empty List) denotes a new List value whose elements are the concatenation of the elements (in order) of each of the arguments (in order).</p>
@@ -6647,7 +6647,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It is used to call a method property of an ECMAScript language value. _V_ serves as both the lookup point for the property and the *this* value of the call. _argumentsList_ is the list of arguments values passed to the method. If _argumentsList_ is not present, a new empty List is used as its value.</dd>
+        <dd>It is used to call a method property of an ECMAScript language value. _V_ serves as both the lookup point for the property and the *this* value of the call. _argumentsList_ is the List of arguments values passed to the method. If _argumentsList_ is not present, a new empty List is used as its value.</dd>
       </dl>
 
       <emu-alg>
@@ -7190,7 +7190,7 @@
         1. Return the Iterator Record { [[Iterator]]: _iterator_, [[NextMethod]]: %GeneratorFunction.prototype.prototype.next%, [[Done]]: *false* }.
       </emu-alg>
       <emu-note>
-        <p>The list iterator object is never directly accessible to ECMAScript code.</p>
+        <p>The List iterator object is never directly accessible to ECMAScript code.</p>
       </emu-note>
     </emu-clause>
 
@@ -11657,7 +11657,7 @@
           </td>
           <td>
             <p>Template objects are canonicalized separately for each realm using its Realm Record's [[TemplateMap]]. Each [[Site]] value is a Parse Node that is a |TemplateLiteral|. The associated [[Array]] value is the corresponding template object that is passed to a tag function.</p>
-            <emu-note>Once a Parse Node becomes unreachable, the corresponding [[Array]] is also unreachable, and it would be unobservable if an implementation removed the pair from the [[TemplateMap]] list.</emu-note>
+            <emu-note>Once a Parse Node becomes unreachable, the corresponding [[Array]] is also unreachable, and it would be unobservable if an implementation removed the pair from the [[TemplateMap]] List.</emu-note>
           </td>
         </tr>
         <tr>
@@ -11698,7 +11698,7 @@
       </dl>
       <emu-alg>
         1. Set _realmRec_.[[Intrinsics]] to a new Record.
-        1. Set fields of _realmRec_.[[Intrinsics]] with the values listed in <emu-xref href="#table-well-known-intrinsic-objects"></emu-xref>. The field names are the names listed in column one of the table. The value of each field is a new object value fully and recursively populated with property values as defined by the specification of each object in clauses <emu-xref href="#sec-global-object"></emu-xref> through <emu-xref href="#sec-reflection"></emu-xref>. All object property values are newly created object values. All values that are built-in function objects are created by performing CreateBuiltinFunction(_steps_, _length_, _name_, _slots_, _realmRec_, _prototype_) where _steps_ is the definition of that function provided by this specification, _name_ is the initial value of the function's *"name"* property, _length_ is the initial value of the function's *"length"* property, _slots_ is a list of the names, if any, of the function's specified internal slots, and _prototype_ is the specified value of the function's [[Prototype]] internal slot. The creation of the intrinsics and their properties must be ordered to avoid any dependencies upon objects that have not yet been created.
+        1. Set fields of _realmRec_.[[Intrinsics]] with the values listed in <emu-xref href="#table-well-known-intrinsic-objects"></emu-xref>. The field names are the names listed in column one of the table. The value of each field is a new object value fully and recursively populated with property values as defined by the specification of each object in clauses <emu-xref href="#sec-global-object"></emu-xref> through <emu-xref href="#sec-reflection"></emu-xref>. All object property values are newly created object values. All values that are built-in function objects are created by performing CreateBuiltinFunction(_steps_, _length_, _name_, _slots_, _realmRec_, _prototype_) where _steps_ is the definition of that function provided by this specification, _name_ is the initial value of the function's *"name"* property, _length_ is the initial value of the function's *"length"* property, _slots_ is a List of the names, if any, of the function's specified internal slots, and _prototype_ is the specified value of the function's [[Prototype]] internal slot. The creation of the intrinsics and their properties must be ordered to avoid any dependencies upon objects that have not yet been created.
         1. Perform AddRestrictedFunctionProperties(_realmRec_.[[Intrinsics]].[[%Function.prototype%]], _realmRec_).
         1. Return ~unused~.
       </emu-alg>
@@ -12189,7 +12189,7 @@
         <tr>
           <td>[[KeptAlive]]</td>
           <td>a List of Objects</td>
-          <td>Initially a new empty List, representing the list of objects to be kept alive until the end of the current Job</td>
+          <td>Initially a new empty List, representing objects to be kept alive until the end of the current Job</td>
         </tr>
       </table>
     </emu-table>
@@ -12451,7 +12451,7 @@
       1. Return ~unused~.
     </emu-alg>
     <emu-note>
-      When the abstract operation AddToKeptObjects is called with a target object reference, it adds the target to a list that will point strongly at the target until ClearKeptObjects is called.
+      When the abstract operation AddToKeptObjects is called with a target object reference, it adds the target to a List that will point strongly at the target until ClearKeptObjects is called.
     </emu-note>
   </emu-clause>
 
@@ -13192,7 +13192,7 @@
             a List of ClassFieldDefinition Records
           </td>
           <td>
-            If the function is a class, this is a list of Records representing the non-static fields and corresponding initializers of the class.
+            If the function is a class, this is a List of Records representing the non-static fields and corresponding initializers of the class.
           </td>
         </tr>
         <tr>
@@ -13203,7 +13203,7 @@
             a List of PrivateElements
           </td>
           <td>
-            If the function is a class, this is a list representing the non-static private methods and accessors of the class.
+            If the function is a class, this is a List representing the non-static private methods and accessors of the class.
           </td>
         </tr>
         <tr>
@@ -13931,7 +13931,7 @@
               a List of ECMAScript language values
             </td>
             <td>
-              A list of values whose elements are used as the first arguments to any call to the wrapped function.
+              A List of values whose elements are used as the first arguments to any call to the wrapped function.
             </td>
           </tr>
         </table>
@@ -14476,7 +14476,7 @@
           1. Repeat, while _index_ &ge; 0,
             1. Let _name_ be _parameterNames_[_index_].
             1. If _name_ is not an element of _mappedNames_, then
-              1. Add _name_ as an element of the list _mappedNames_.
+              1. Add _name_ as an element of the List _mappedNames_.
               1. If _index_ &lt; _len_, then
                 1. Let _g_ be MakeArgGetter(_name_, _env_).
                 1. Let _p_ be MakeArgSetter(_name_, _env_).
@@ -14806,7 +14806,7 @@
               a List of Strings
             </td>
             <td>
-              A List whose elements are the String values of the exported names exposed as own properties of this object. The list is ordered as if an Array of those String values had been sorted using %Array.prototype.sort% using *undefined* as _comparefn_.
+              A List whose elements are the String values of the exported names exposed as own properties of this object. The List is ordered as if an Array of those String values had been sorted using %Array.prototype.sort% using *undefined* as _comparefn_.
             </td>
           </tr>
         </table>
@@ -15923,7 +15923,7 @@
       <emu-alg>
         1. Attempt to parse _sourceText_ using _goalSymbol_ as the goal symbol, and analyse the parse result for any early error conditions. Parsing and early error detection may be interleaved in an implementation-defined manner.
         1. If the parse succeeded and no early errors were found, return the Parse Node (an instance of _goalSymbol_) at the root of the parse tree resulting from the parse.
-        1. Otherwise, return a List of one or more *SyntaxError* objects representing the parsing errors and/or early errors. If more than one parsing error or early error is present, the number and ordering of error objects in the list is implementation-defined, but at least one must be present.
+        1. Otherwise, return a List of one or more *SyntaxError* objects representing the parsing errors and/or early errors. If more than one parsing error or early error is present, the number and ordering of error objects in the List is implementation-defined, but at least one must be present.
       </emu-alg>
       <emu-note>
         <p>Consider a text that has an early error at a particular point, and also a syntax error at a later point. An implementation that does a parse pass followed by an early errors pass might report the syntax error and not proceed to the early errors pass. An implementation that interleaves the two activities might report the early error and not proceed to find the syntax error. A third implementation might report both errors. All of these behaviours are conformant.</p>
@@ -17745,7 +17745,7 @@
         a = b + c
         (d + e).print()
       </code></pre>
-      <p>is <em>not</em> transformed by automatic semicolon insertion, because the parenthesized expression that begins the second line can be interpreted as an argument list for a function call:</p>
+      <p>is <em>not</em> transformed by automatic semicolon insertion, because the parenthesized expression that begins the second line can be interpreted as an argument List for a function call:</p>
       <pre><code class="javascript">a = b + c(d + e).print()</code></pre>
       <p>In the circumstance that an assignment statement must begin with a left parenthesis, it is a good idea for the programmer to provide an explicit semicolon at the end of the preceding statement rather than to rely on automatic semicolon insertion.</p>
     </emu-clause>
@@ -19180,7 +19180,7 @@
     <emu-clause id="sec-argument-lists">
       <h1>Argument Lists</h1>
       <emu-note>
-        <p>The evaluation of an argument list produces a List of values.</p>
+        <p>The evaluation of an argument List produces a List of values.</p>
       </emu-note>
 
       <emu-clause id="sec-runtime-semantics-argumentlistevaluation" oldids="sec-template-literals-runtime-semantics-argumentlistevaluation,sec-argument-lists-runtime-semantics-argumentlistevaluation" type="sdo">
@@ -20741,7 +20741,7 @@
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It collects a list of all destructured property keys.</dd>
+          <dd>It collects a List of all destructured property keys.</dd>
         </dl>
         <emu-grammar>AssignmentPropertyList : AssignmentPropertyList `,` AssignmentProperty</emu-grammar>
         <emu-alg>
@@ -21332,7 +21332,7 @@
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It collects a list of all bound property names.</dd>
+          <dd>It collects a List of all bound property names.</dd>
         </dl>
         <emu-grammar>BindingPropertyList : BindingPropertyList `,` BindingProperty</emu-grammar>
         <emu-alg>
@@ -26125,7 +26125,7 @@
                 GetExportedNames([_exportStarSet_])
               </td>
               <td>
-                Return a list of all names that are either directly or indirectly exported from this module.
+                Return a List of all names that are either directly or indirectly exported from this module.
               </td>
             </tr>
             <tr>
@@ -26565,7 +26565,7 @@
               1. Return ~unused~.
             </emu-alg>
             <emu-note>
-              <p>When an asynchronous execution for a root _module_ is fulfilled, this function determines the list of modules which are able to synchronously execute together on this completion, populating them in _execList_.</p>
+              <p>When an asynchronous execution for a root _module_ is fulfilled, this function determines the List of modules which are able to synchronously execute together on this completion, populating them in _execList_.</p>
             </emu-note>
           </emu-clause>
 
@@ -38070,7 +38070,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-array.prototype.unshift">
         <h1>Array.prototype.unshift ( ..._items_ )</h1>
-        <p>The arguments are prepended to the start of the array, such that their order within the array is the same as the order in which they appear in the argument list.</p>
+        <p>The arguments are prepended to the start of the array, such that their order within the array is the same as the order in which they appear in the argument List.</p>
         <p>When the `unshift` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
@@ -41642,10 +41642,10 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-waiterlist-objects">
       <h1>WaiterList Objects</h1>
-      <p>A <dfn variants="WaiterLists">WaiterList</dfn> is a semantic object that contains an ordered list of agent signifiers for those agents that are waiting on a location (_block_, _i_) in shared memory; _block_ is a Shared Data Block and _i_ a byte offset into the memory of _block_. A WaiterList object also optionally contains a Synchronize event denoting the previous leaving of its critical section.</p>
-      <p>Initially a WaiterList object has an empty list and no Synchronize event.</p>
+      <p>A <dfn variants="WaiterLists">WaiterList</dfn> is a semantic object that contains an ordered List of agent signifiers for those agents that are waiting on a location (_block_, _i_) in shared memory; _block_ is a Shared Data Block and _i_ a byte offset into the memory of _block_. A WaiterList object also optionally contains a Synchronize event denoting the previous leaving of its critical section.</p>
+      <p>Initially a WaiterList object has an empty List and no Synchronize event.</p>
       <p>The agent cluster has a store of WaiterList objects; the store is indexed by (_block_, _i_). WaiterLists are agent-independent: a lookup in the store of WaiterLists by (_block_, _i_) will result in the same WaiterList object in any agent in the agent cluster.</p>
-      <p>Each WaiterList has a <dfn variants="critical sections">critical section</dfn> that controls exclusive access to that WaiterList during evaluation. Only a single agent may enter a WaiterList's critical section at one time. Entering and leaving a WaiterList's critical section is controlled by the abstract operations EnterCriticalSection and LeaveCriticalSection. Operations on a WaiterList&mdash;adding and removing waiting agents, traversing the list of agents, suspending and notifying agents on the list, setting and retrieving the Synchronize event&mdash;may only be performed by agents that have entered the WaiterList's critical section.</p>
+      <p>Each WaiterList has a <dfn variants="critical sections">critical section</dfn> that controls exclusive access to that WaiterList during evaluation. Only a single agent may enter a WaiterList's critical section at one time. Entering and leaving a WaiterList's critical section is controlled by the abstract operations EnterCriticalSection and LeaveCriticalSection. Operations on a WaiterList&mdash;adding and removing waiting agents, traversing the List of agents, suspending and notifying agents on the list, setting and retrieving the Synchronize event&mdash;may only be performed by agents that have entered the WaiterList's critical section.</p>
     </emu-clause>
 
     <emu-clause id="sec-abstract-operations-for-atomics">
@@ -41765,8 +41765,8 @@ THH:mm:ss.sss
         </dl>
         <emu-alg>
           1. Assert: The surrounding agent is in the critical section for _WL_.
-          1. Assert: _W_ is not on the list of waiters in any WaiterList.
-          1. Add _W_ to the end of the list of waiters in _WL_.
+          1. Assert: _W_ is not on the List of waiters in any WaiterList.
+          1. Add _W_ to the end of the List of waiters in _WL_.
           1. Return ~unused~.
         </emu-alg>
       </emu-clause>
@@ -41782,8 +41782,8 @@ THH:mm:ss.sss
         </dl>
         <emu-alg>
           1. Assert: The surrounding agent is in the critical section for _WL_.
-          1. Assert: _W_ is on the list of waiters in _WL_.
-          1. Remove _W_ from the list of waiters in _WL_.
+          1. Assert: _W_ is on the List of waiters in _WL_.
+          1. Remove _W_ from the List of waiters in _WL_.
           1. Return ~unused~.
         </emu-alg>
       </emu-clause>
@@ -41800,7 +41800,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Assert: The surrounding agent is in the critical section for _WL_.
           1. Let _L_ be a new empty List.
-          1. Let _S_ be a reference to the list of waiters in _WL_.
+          1. Let _S_ be a reference to the List of waiters in _WL_.
           1. Repeat, while _c_ &gt; 0 and _S_ is not an empty List,
             1. Let _W_ be the first waiter in _S_.
             1. Add _W_ to the end of _L_.
@@ -41823,7 +41823,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Assert: The surrounding agent is in the critical section for _WL_.
           1. Assert: _W_ is equivalent to AgentSignifier().
-          1. Assert: _W_ is on the list of waiters in _WL_.
+          1. Assert: _W_ is on the List of waiters in _WL_.
           1. Assert: AgentCanSuspend() is *true*.
           1. Perform LeaveCriticalSection(_WL_) and suspend _W_ for up to _timeout_ milliseconds, performing the combined operation in such a way that a notification that arrives after the critical section is exited but before the suspension takes effect is not lost. _W_ can notify either because the timeout expired or because it was notified explicitly by another agent calling NotifyWaiter with arguments _WL_ and _W_, and not for any other reasons at all.
           1. Perform EnterCriticalSection(_WL_).
@@ -42111,7 +42111,7 @@ THH:mm:ss.sss
         1. Perform AddWaiter(_WL_, _W_).
         1. Let _notified_ be SuspendAgent(_WL_, _W_, _t_).
         1. If _notified_ is *true*, then
-          1. Assert: _W_ is not on the list of waiters in _WL_.
+          1. Assert: _W_ is not on the List of waiters in _WL_.
         1. Else,
           1. Perform RemoveWaiter(_WL_, _W_).
         1. Perform LeaveCriticalSection(_WL_).
@@ -45987,7 +45987,7 @@ THH:mm:ss.sss
         <tr>
           <td>[[EventList]]</td>
           <td>a List of events</td>
-          <td>Events are appended to the list during evaluation.</td>
+          <td>Events are appended to the List during evaluation.</td>
         </tr>
         <tr>
           <td>[[AgentSynchronizesWith]]</td>

--- a/spec.html
+++ b/spec.html
@@ -2699,7 +2699,7 @@
                 *undefined*
               </td>
               <td>
-                If the value is an Object it must be a function object. The function's [[Call]] internal method (<emu-xref href="#table-additional-essential-internal-methods-of-function-objects"></emu-xref>) is called with an empty arguments List to retrieve the property value each time a get access of the property is performed.
+                If the value is an Object it must be a function object. The function's [[Call]] internal method (<emu-xref href="#table-additional-essential-internal-methods-of-function-objects"></emu-xref>) is called with an empty arguments list to retrieve the property value each time a get access of the property is performed.
               </td>
             </tr>
             <tr>

--- a/spec.html
+++ b/spec.html
@@ -19180,7 +19180,7 @@
     <emu-clause id="sec-argument-lists">
       <h1>Argument Lists</h1>
       <emu-note>
-        <p>The evaluation of an argument List produces a List of values.</p>
+        <p>The evaluation of an argument list produces a List of values.</p>
       </emu-note>
 
       <emu-clause id="sec-runtime-semantics-argumentlistevaluation" oldids="sec-template-literals-runtime-semantics-argumentlistevaluation,sec-argument-lists-runtime-semantics-argumentlistevaluation" type="sdo">
@@ -38070,7 +38070,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-array.prototype.unshift">
         <h1>Array.prototype.unshift ( ..._items_ )</h1>
-        <p>The arguments are prepended to the start of the array, such that their order within the array is the same as the order in which they appear in the argument List.</p>
+        <p>The arguments are prepended to the start of the array, such that their order within the array is the same as the order in which they appear in the argument list.</p>
         <p>When the `unshift` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).

--- a/spec.html
+++ b/spec.html
@@ -2716,7 +2716,7 @@
                 *undefined*
               </td>
               <td>
-                If the value is an Object it must be a function object. The function's [[Call]] internal method (<emu-xref href="#table-additional-essential-internal-methods-of-function-objects"></emu-xref>) is called with an arguments List containing the assigned value as its sole argument each time a set access of the property is performed. The effect of a property's [[Set]] internal method may, but is not required to, have an effect on the value returned by subsequent calls to the property's [[Get]] internal method.
+                If the value is an Object it must be a function object. The function's [[Call]] internal method (<emu-xref href="#table-additional-essential-internal-methods-of-function-objects"></emu-xref>) is called with an arguments list containing the assigned value as its sole argument each time a set access of the property is performed. The effect of a property's [[Set]] internal method may, but is not required to, have an effect on the value returned by subsequent calls to the property's [[Get]] internal method.
               </td>
             </tr>
             <tr>
@@ -14806,7 +14806,7 @@
               a List of Strings
             </td>
             <td>
-              A List whose elements are the String values of the exported names exposed as own properties of this object. The List is ordered as if an Array of those String values had been sorted using %Array.prototype.sort% using *undefined* as _comparefn_.
+              A List whose elements are the String values of the exported names exposed as own properties of this object. The list is ordered as if an Array of those String values had been sorted using %Array.prototype.sort% using *undefined* as _comparefn_.
             </td>
           </tr>
         </table>
@@ -45987,7 +45987,7 @@ THH:mm:ss.sss
         <tr>
           <td>[[EventList]]</td>
           <td>a List of events</td>
-          <td>Events are appended to the List during evaluation.</td>
+          <td>Events are appended to the list during evaluation.</td>
         </tr>
         <tr>
           <td>[[AgentSynchronizesWith]]</td>

--- a/spec.html
+++ b/spec.html
@@ -41765,8 +41765,8 @@ THH:mm:ss.sss
         </dl>
         <emu-alg>
           1. Assert: The surrounding agent is in the critical section for _WL_.
-          1. Assert: _W_ is not on the List of waiters in any WaiterList.
-          1. Add _W_ to the end of the List of waiters in _WL_.
+          1. Assert: _W_ is not on the list of waiters in any WaiterList.
+          1. Add _W_ to the end of the list of waiters in _WL_.
           1. Return ~unused~.
         </emu-alg>
       </emu-clause>
@@ -41782,8 +41782,8 @@ THH:mm:ss.sss
         </dl>
         <emu-alg>
           1. Assert: The surrounding agent is in the critical section for _WL_.
-          1. Assert: _W_ is on the List of waiters in _WL_.
-          1. Remove _W_ from the List of waiters in _WL_.
+          1. Assert: _W_ is on the list of waiters in _WL_.
+          1. Remove _W_ from the list of waiters in _WL_.
           1. Return ~unused~.
         </emu-alg>
       </emu-clause>
@@ -41800,7 +41800,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Assert: The surrounding agent is in the critical section for _WL_.
           1. Let _L_ be a new empty List.
-          1. Let _S_ be a reference to the List of waiters in _WL_.
+          1. Let _S_ be a reference to the list of waiters in _WL_.
           1. Repeat, while _c_ &gt; 0 and _S_ is not an empty List,
             1. Let _W_ be the first waiter in _S_.
             1. Add _W_ to the end of _L_.
@@ -41823,7 +41823,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Assert: The surrounding agent is in the critical section for _WL_.
           1. Assert: _W_ is equivalent to AgentSignifier().
-          1. Assert: _W_ is on the List of waiters in _WL_.
+          1. Assert: _W_ is on the list of waiters in _WL_.
           1. Assert: AgentCanSuspend() is *true*.
           1. Perform LeaveCriticalSection(_WL_) and suspend _W_ for up to _timeout_ milliseconds, performing the combined operation in such a way that a notification that arrives after the critical section is exited but before the suspension takes effect is not lost. _W_ can notify either because the timeout expired or because it was notified explicitly by another agent calling NotifyWaiter with arguments _WL_ and _W_, and not for any other reasons at all.
           1. Perform EnterCriticalSection(_WL_).
@@ -42111,7 +42111,7 @@ THH:mm:ss.sss
         1. Perform AddWaiter(_WL_, _W_).
         1. Let _notified_ be SuspendAgent(_WL_, _W_, _t_).
         1. If _notified_ is *true*, then
-          1. Assert: _W_ is not on the List of waiters in _WL_.
+          1. Assert: _W_ is not on the list of waiters in _WL_.
         1. Else,
           1. Perform RemoveWaiter(_WL_, _W_).
         1. Perform LeaveCriticalSection(_WL_).


### PR DESCRIPTION
Fix https://github.com/tc39/ecma262/issues/2630

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
