### PR TITLE
Editorial: `HostImportModuleDynamically`'s specifier can be any string

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -27765,7 +27765,7 @@
         <h1>
           HostResolveImportedModule (
             _referencingScriptOrModule_: a Script Record, a Module Record, or *null*,
-            _specifier_: a |ModuleSpecifier| String,
+            _specifier_: a String,
           ): either a normal completion containing a Module Record or a throw completion
         </h1>
         <dl class="header">
@@ -27800,7 +27800,7 @@
         <h1>
           HostImportModuleDynamically (
             _referencingScriptOrModule_: a Script Record, a Module Record, or *null*,
-            _specifier_: a |ModuleSpecifier| String,
+            _specifier_: a String,
             _promiseCapability_: a PromiseCapability Record,
           ): ~unused~
         </h1>


### PR DESCRIPTION
`|ModuleSpecifier|` is the production used for the source in import declarations, but dynamic imports can use any runtime string.

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
