### PR TITLE
Editorial: Clarify that the `HostResolveImportedModule` cache is per-Realm

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -27790,7 +27790,7 @@
             If a Module Record corresponding to the pair _referencingScriptOrModule_, _specifier_ does not exist or cannot be created, an exception must be thrown.
           </li>
           <li>
-            Each time this operation is called with a specific _referencingScriptOrModule_, _specifier_ pair as arguments it must return the same Module Record instance if it completes normally.
+            Each time this operation is called, if it completes normally and the (_referencingScriptOrModule_, _specifier_, current Realm Record) triple is the same, it must return the same Module Record instance.
           </li>
         </ul>
         <p>Multiple different _referencingScriptOrModule_, _specifier_ pairs may map to the same Module Record instance. The actual mapping semantic is host-defined but typically a normalization process is applied to _specifier_ as part of the mapping process. A typical normalization process would include actions such as alphabetic case folding and expansion of relative and abbreviated path specifiers.</p>


### PR DESCRIPTION
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->

This commit clarifies that `HostResolveImportedModule` is required to return the same Module Record when called two times with the same (`null`, _specifier_) arguments only if the two calls are executed with the same current Realm.

Fixes https://github.com/tc39/ecma262/issues/2803.

I don't know if this is normative or editorial, because I don't know what is the current requirement:
- (Editorial) The cache is already implicitly per-Realm, as suggested by @dominic in https://github.com/tc39/ecma262/issues/2803#issuecomment-1164675594
- (Normative) If the referencing script/module is `null` there is currently no caching requirement, as suggested by @codehag in https://github.com/tc39/ecma262/issues/2803#issuecomment-1165251478
- (Normative) If `HostResolveImportedModule` is called with the same (`null`, _specifier_) arguments it must return the same Module Record even if it is in a different Realm, which was my understanding when reading the spec.

The HTML spec already follows the updated requirement proposed by this PR.

An alternative to this PR is https://github.com/nicolo-ribaudo/ecma262/commit/0877ff734cce3c8964cb92c890d54cfaa017834a, which has the same behavior but makes the caching behavior more explicit by moving it from a host requirement to an Abstract Operation that caches values in a per-Realm List.