### PR TITLE
Normative: allow host exotic objects to reject private fields

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -6816,6 +6816,8 @@
       <dl class="header">
       </dl>
       <emu-alg>
+        1. If the host is a web browser, then
+          1. Perform ? HostEnsureCanAddPrivateElement(_O_).
         1. Let _entry_ be PrivateElementFind(_O_, _P_).
         1. If _entry_ is not ~empty~, throw a *TypeError* exception.
         1. Append PrivateElement { [[Key]]: _P_, [[Kind]]: ~field~, [[Value]]: _value_ } to _O_.[[PrivateElements]].
@@ -6834,6 +6836,8 @@
       </dl>
       <emu-alg>
         1. Assert: _method_.[[Kind]] is either ~method~ or ~accessor~.
+        1. If the host is a web browser, then
+          1. Perform ? HostEnsureCanAddPrivateElement(_O_).
         1. Let _entry_ be PrivateElementFind(_O_, _method_.[[Key]]).
         1. If _entry_ is not ~empty~, throw a *TypeError* exception.
         1. Append _method_ to _O_.[[PrivateElements]].
@@ -6842,6 +6846,25 @@
       <emu-note>
         <p>The values for private methods and accessors are shared across instances. This operation does not create a new copy of the method or accessor.</p>
       </emu-note>
+    </emu-clause>
+
+    <emu-clause id="sec-hostensurecanaddprivateelement" type="host-defined abstract operation">
+      <h1>
+        HostEnsureCanAddPrivateElement (
+          _O_: an Object,
+        ): either a normal completion containing ~unused~ or a throw completion
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It allows host environments to prevent the addition of private elements to particular host-defined exotic objects.</dd>
+      </dl>
+      <p>An implementation of HostEnsureCanAddPrivateElement must conform to the following requirements:</p>
+      <ul>
+        <li>If _O_ is not a host-defined exotic object, this abstract operation must return NormalCompletion(~unused~) and perform no other steps.</li>
+        <li>Any two calls of this abstract operation with the same argument must return the same kind of Completion Record.</li>
+      </ul>
+      <p>The default implementation of HostEnsureCanAddPrivateElement is to return NormalCompletion(~unused~).</p>
+      <p>This abstract operation is only invoked by ECMAScript hosts that are web browsers.</p>
     </emu-clause>
 
     <emu-clause id="sec-privateget" type="abstract operation">

--- a/spec.html
+++ b/spec.html
@@ -48169,6 +48169,16 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-annex>
     </emu-annex>
+
+    <emu-annex id="sec-web-compat-host-make-job-callback">
+      <h1>Non-default behaviour in HostMakeJobCallback</h1>
+      <p>The HostMakeJobCallback abstract operation allows hosts which are web browsers to specify non-default behaviour.</p>
+    </emu-annex>
+
+    <emu-annex id="sec-web-compat-host-ensure-can-add-private-field">
+      <h1>Non-default behaviour in HostEnsureCanAddPrivateElement</h1>
+      <p>The HostEnsureCanAddPrivateElement abstract operation allows hosts which are web browsers to specify non-default behaviour.</p>
+    </emu-annex>
   </emu-annex>
 </emu-annex>
 


### PR DESCRIPTION
It is possible to add private fields to existing objects with the return override trick, although this is not good practice. This PR adds a new carveout allowing hosts such as HTML to reject the addition of private fields on exotic objects they define (by throwing). This is intended particularly for use with the [WindowProxy](https://html.spec.whatwg.org/multipage/window-object.html#the-windowproxy-exotic-object) exotic object, which is super weird. See discussion in https://github.com/whatwg/html/issues/7952 - the upshot is that supporting private fields on WindowProxy is a lot of potentially security-sensitive work in implementations for very little benefit.

It's conceivable that we would want to expose this ability to userland code at some point, or to non-browser hosts, but that can be done transparently on top of this if we ever decide to. This PR only exposes this functionality to web browser hosts, and only for host-defined exotic objects.