### PR TITLE
Normative: only coerce once in BigInt constructor

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -31249,7 +31249,7 @@
           1. If NewTarget is not *undefined*, throw a *TypeError* exception.
           1. Let _prim_ be ? ToPrimitive(_value_, ~number~).
           1. If Type(_prim_) is Number, return ? NumberToBigInt(_prim_).
-          1. Otherwise, return ? ToBigInt(_value_).
+          1. Otherwise, return ? <emu-meta suppress-effects="user-code">ToBigInt(_prim_)</emu-meta>.
         </emu-alg>
 
         <emu-clause id="sec-numbertobigint" type="abstract operation">


### PR DESCRIPTION
(This was raised on [the discourse](https://es.discourse.group/t/consider-rewriting-bigint-value-only-convert-to-a-primitive-once/1391).)

Consider

```js
let first = true;
let v = {
  [Symbol.toPrimitive]() {
    console.log('called');
    if (first) {
      first = false;
      return 'string';
    } else {
      return 0n;
    }
  }
};
BigInt(v);
```

Per spec this should print `called` twice and complete normally - step 3 of [the BigInt constructor](https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-bigint-constructor-number-value) will observe that the first call to `ToPrimitive` returns a value which is not a number and then step 4 will invoke [`ToBigInt`](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-tobigint) on the original, pre-coercion value, which will invoke `Symbol.toPrimitive` again.

In V8, SpiderMonkey, JavaScriptCore, and XS, this code will in fact only print `called` once and then throw a `TypeError` because the initial `'string'` can't be coerced to a BigInt - i.e., in step 4 they use the post-coercion value, not the pre-coercion value. That's the behavior proposed in this PR.

GraalJS and Engine262 implement the spec faithfully.