### PR TITLE
Editorial: Fix wrong assertion in 'DefineMethodProperty'

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -13576,17 +13576,18 @@
           _key_: a property key or Private Name,
           _closure_: a function object,
           _enumerable_: a Boolean,
-        ): a PrivateElement or ~unused~
+        ): either a normal completion containing either a PrivateElement or ~unused~, or an abrupt completion
       </h1>
       <dl class="header">
       </dl>
       <emu-alg>
-        1. Assert: _homeObject_ is an ordinary, extensible object with no non-configurable properties.
+        1. Assert: _homeObject_ is an ordinary, extensible object.
         1. If _key_ is a Private Name, then
           1. Return PrivateElement { [[Key]]: _key_, [[Kind]]: ~method~, [[Value]]: _closure_ }.
         1. Else,
           1. Let _desc_ be the PropertyDescriptor { [[Value]]: _closure_, [[Writable]]: *true*, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
-          1. Perform ! DefinePropertyOrThrow(_homeObject_, _key_, _desc_).
+          1. Perform ? DefinePropertyOrThrow(_homeObject_, _key_, _desc_).
+          1. NOTE: DefinePropertyOrThrow only returns an abrupt completion when attempting to define a class static method whose _key_ is *"prototype"*.
           1. Return ~unused~.
       </emu-alg>
     </emu-clause>
@@ -23809,7 +23810,7 @@
       <emu-alg>
         1. Let _methodDef_ be ? DefineMethod of |MethodDefinition| with argument _object_.
         1. Perform SetFunctionName(_methodDef_.[[Closure]], _methodDef_.[[Key]]).
-        1. Return DefineMethodProperty(_object_, _methodDef_.[[Key]], _methodDef_.[[Closure]], _enumerable_).
+        1. Return ? DefineMethodProperty(_object_, _methodDef_.[[Key]], _methodDef_.[[Closure]], _enumerable_).
       </emu-alg>
       <emu-grammar>MethodDefinition : `get` ClassElementName `(` `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
@@ -23855,7 +23856,7 @@
         1. Perform SetFunctionName(_closure_, _propKey_).
         1. Let _prototype_ be OrdinaryObjectCreate(%GeneratorFunction.prototype.prototype%).
         1. Perform ! DefinePropertyOrThrow(_closure_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
-        1. Return DefineMethodProperty(_object_, _propKey_, _closure_, _enumerable_).
+        1. Return ? DefineMethodProperty(_object_, _propKey_, _closure_, _enumerable_).
       </emu-alg>
       <emu-grammar>
         AsyncGeneratorMethod : `async` `*` ClassElementName `(` UniqueFormalParameters `)` `{` AsyncGeneratorBody `}`
@@ -23870,7 +23871,7 @@
         1. Perform SetFunctionName(_closure_, _propKey_).
         1. Let _prototype_ be OrdinaryObjectCreate(%AsyncGeneratorFunction.prototype.prototype%).
         1. Perform ! DefinePropertyOrThrow(_closure_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
-        1. Return DefineMethodProperty(_object_, _propKey_, _closure_, _enumerable_).
+        1. Return ? DefineMethodProperty(_object_, _propKey_, _closure_, _enumerable_).
       </emu-alg>
       <emu-grammar>
         AsyncMethod : `async` ClassElementName `(` UniqueFormalParameters `)` `{` AsyncFunctionBody `}`
@@ -23883,7 +23884,7 @@
         1. Let _closure_ be OrdinaryFunctionCreate(%AsyncFunction.prototype%, _sourceText_, |UniqueFormalParameters|, |AsyncFunctionBody|, ~non-lexical-this~, _env_, _privateEnv_).
         1. Perform MakeMethod(_closure_, _object_).
         1. Perform SetFunctionName(_closure_, _propKey_).
-        1. Return DefineMethodProperty(_object_, _propKey_, _closure_, _enumerable_).
+        1. Return ? DefineMethodProperty(_object_, _propKey_, _closure_, _enumerable_).
       </emu-alg>
     </emu-clause>
   </emu-clause>


### PR DESCRIPTION
`DefinePropertyOrThrow` invocation in [10.2.8 DefineMethodProperty](https://tc39.es/ecma262/#sec-definemethodproperty) can throw an abrupt completion. Consider following JavaScript code:

```js
class A {
  static * ['prototype'] () {}
}
```

- `prototype` property of `A` is defined in step 16 of [15.7.14 Runtime Semantics: ClassDefinitionEvaluation](https://tc39.es/ecma262/#sec-runtime-semantics-classdefinitionevaluation) with property descriptor `{[[Configurable]]: false, ... }`
- It tries to define static generator method `prototype` of `A` in [10.2.8 DefineMethodProperty](https://tc39.es/ecma262/#sec-definemethodproperty) with property descriptor `{[[Configurable]]: true, ...}`.
- Since `ValidateAndApplyPropertyDescriptor` return `false`, it throws a`TypeError` exception.