### PR TITLE
Editorial: Fix completion in GeneratorStart

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -7185,7 +7185,7 @@
         1. Let _closure_ be a new Abstract Closure with no parameters that captures _list_ and performs the following steps when called:
           1. For each element _E_ of _list_, do
             1. Perform ? GeneratorYield(CreateIterResultObject(_E_, *false*)).
-          1. Return *undefined*.
+          1. Return NormalCompletion(*undefined*).
         1. Let _iterator_ be CreateIteratorFromClosure(_closure_, ~empty~, %IteratorPrototype%).
         1. Return the Iterator Record { [[Iterator]]: _iterator_, [[NextMethod]]: %GeneratorFunction.prototype.prototype.next%, [[Done]]: *false* }.
       </emu-alg>
@@ -34344,7 +34344,7 @@ THH:mm:ss.sss
               1. Let _resultString_ be the substring of _s_ from _position_ to _nextIndex_.
               1. Set _position_ to _nextIndex_.
               1. Perform ? GeneratorYield(CreateIterResultObject(_resultString_, *false*)).
-            1. Return *undefined*.
+            1. Return NormalCompletion(*undefined*).
           1. Return CreateIteratorFromClosure(_closure_, *"%StringIteratorPrototype%"*, %StringIteratorPrototype%).
         </emu-alg>
         <p>The value of the *"name"* property of this function is *"[Symbol.iterator]"*.</p>
@@ -38254,7 +38254,7 @@ THH:mm:ss.sss
                 1. Let _len_ be _array_.[[ArrayLength]].
               1. Else,
                 1. Let _len_ be ? LengthOfArrayLike(_array_).
-              1. If _index_ &ge; _len_, return *undefined*.
+              1. If _index_ &ge; _len_, return NormalCompletion(*undefined*).
               1. If _kind_ is ~key~, perform ? GeneratorYield(CreateIterResultObject(𝔽(_index_), *false*)).
               1. Else,
                 1. Let _elementKey_ be ! ToString(𝔽(_index_)).
@@ -44902,7 +44902,7 @@ THH:mm:ss.sss
               1. Let _result_ be the result of evaluating _generatorBody_.
             1. Else,
               1. Assert: _generatorBody_ is an Abstract Closure with no parameters.
-              1. Let _result_ be _generatorBody_().
+              1. Let _result_ be Completion(_generatorBody_()).
             1. Assert: If we return here, the generator either threw an exception or performed either an implicit or explicit return.
             1. Remove _genContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
             1. Set _generator_.[[GeneratorState]] to ~completed~.


### PR DESCRIPTION
It seems that step 4.b.ii of [27.5.3.1 GeneratorStart](https://tc39.es/ecma262/#sec-generatorstart) needs to be wrapped with `Completion` for clarity as [27.6.3.2 AsyncGeneratorStart](https://tc39.es/ecma262/#sec-asyncgeneratorstart) since later steps assume that `result` is completion.

In addition, some abstract closures seem to return non-completion value, which violates `Completion` check in the fixed step in `GeneratorStart`. I'm not sure whether [conversion rules](https://tc39.es/ecma262/multipage/notational-conventions.html#sec-implicit-normal-completion) can be applied to those cases.