### PR TITLE
Editorial: IfAbrupt macros only take completion records

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -895,8 +895,9 @@
         </emu-alg>
         <p>mean the same thing as:</p>
         <emu-alg example>
+          1. Assert: _argument_ is a Completion Record.
           1. If _argument_ is an abrupt completion, return Completion(_argument_).
-          1. Else if _argument_ is a Completion Record, set _argument_ to _argument_.[[Value]].
+          1. Else, set _argument_ to _argument_.[[Value]].
         </emu-alg>
         <p>Algorithms steps that say or are otherwise equivalent to:</p>
         <emu-alg example>
@@ -905,8 +906,9 @@
         <p>mean the same thing as:</p>
         <emu-alg example>
           1. Let _hygienicTemp_ be AbstractOperation().
+          1. Assert: _hygienicTemp_ is a Completion Record.
           1. If _hygienicTemp_ is an abrupt completion, return Completion(_hygienicTemp_).
-          1. Else if _hygienicTemp_ is a Completion Record, set _hygienicTemp_ to _hygienicTemp_.[[Value]].
+          1. Else, set _hygienicTemp_ to _hygienicTemp_.[[Value]].
         </emu-alg>
         <p>Where _hygienicTemp_ is ephemeral and visible only in the steps pertaining to ReturnIfAbrupt.</p>
         <p>Algorithms steps that say or are otherwise equivalent to:</p>
@@ -915,8 +917,9 @@
         </emu-alg>
         <p>mean the same thing as:</p>
         <emu-alg example>
+          1. Assert: _argument_ is a Completion Record.
           1. If _argument_ is an abrupt completion, return Completion(_argument_).
-          1. If _argument_ is a Completion Record, set _argument_ to _argument_.[[Value]].
+          1. Else, set _argument_ to _argument_.[[Value]].
           1. Let _result_ be AbstractOperation(_argument_).
         </emu-alg>
       </emu-clause>
@@ -946,8 +949,8 @@
         <p>is equivalent to the following steps:</p>
         <emu-alg example>
           1. Let _val_ be OperationName().
-          1. Assert: _val_ is never an abrupt completion.
-          1. If _val_ is a Completion Record, set _val_ to _val_.[[Value]].
+          1. Assert: _val_ is a normal completion.
+          1. Set _val_ to _val_.[[Value]].
         </emu-alg>
         <p>Syntax-directed operations for runtime semantics make use of this shorthand by placing `!` or `?` before the invocation of the operation:</p>
         <emu-alg example>
@@ -7153,8 +7156,9 @@
       </emu-alg>
       <p>means the same thing as:</p>
       <emu-alg>
+        1. Assert: _value_ is a Completion Record.
         1. If _value_ is an abrupt completion, return ? IteratorClose(_iteratorRecord_, _value_).
-        1. Else if _value_ is a Completion Record, set _value_ to _value_.[[Value]].
+        1. Else, set _value_ to _value_.[[Value]].
       </emu-alg>
     </emu-clause>
 
@@ -43696,10 +43700,11 @@ THH:mm:ss.sss
           </emu-alg>
           <p>means the same thing as:</p>
           <emu-alg>
+            1. Assert: _value_ is a Completion Record.
             1. If _value_ is an abrupt completion, then
               1. Perform ? Call(_capability_.[[Reject]], *undefined*, &laquo; _value_.[[Value]] &raquo;).
               1. Return _capability_.[[Promise]].
-            1. Else if _value_ is a Completion Record, set _value_ to _value_.[[Value]].
+            1. Else, set _value_ to _value_.[[Value]].
           </emu-alg>
         </emu-clause>
       </emu-clause>


### PR DESCRIPTION
As of #2547 (edit: plus #2744 and #2842), it is always statically knowable whether a given expression at a given point is a Completion Record or not a Completion Record. So the various completion record unwrapping macros don't need to have a "what if it is not a completion record" case.