### PR TITLE
Normative: avoid triggering `throw` in corner case in async generators

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -7152,6 +7152,20 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-ifabruptcloseasynciterator" aoid="IfAbruptCloseAsyncIterator">
+      <h1>IfAbruptCloseAsyncIterator ( _value_, _iteratorRecord_ )</h1>
+      <p>IfAbruptCloseAsyncIterator is a shorthand for a sequence of algorithm steps that use an Iterator Record. An algorithm step of the form:</p>
+      <emu-alg>
+        1. IfAbruptCloseAsyncIterator(_value_, _iteratorRecord_).
+      </emu-alg>
+      <p>means the same thing as:</p>
+      <emu-alg>
+        1. Assert: _value_ is a Completion Record.
+        1. If _value_ is an abrupt completion, return ? AsyncIteratorClose(_iteratorRecord_, _value_).
+        1. Else, set _value_ to _value_.[[Value]].
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-createiterresultobject" type="abstract operation">
       <h1>
         CreateIterResultObject (
@@ -23974,7 +23988,11 @@
             1. Let _done_ be ? IteratorComplete(_innerResult_).
             1. If _done_ is *true*, then
               1. Return ? IteratorValue(_innerResult_).
-            1. If _generatorKind_ is ~async~, set _received_ to Completion(AsyncGeneratorYield(? IteratorValue(_innerResult_))).
+            1. If _generatorKind_ is ~async~, then
+              1. Set _value_ to ? IteratorValue(_innerResult_).
+              1. Let _unwrapped_ be Completion(Await(_value_)).
+              1. IfAbruptCloseAsyncIterator(_unwrapped_, _iteratorRecord_).
+              1. Set _received_ to Completion(AsyncGeneratorYield(_unwrapped_)).
             1. Else, set _received_ to Completion(GeneratorYield(_innerResult_)).
           1. Else if _received_.[[Type]] is ~throw~, then
             1. Let _throw_ be ? GetMethod(_iterator_, *"throw"*).
@@ -23986,7 +24004,11 @@
               1. Let _done_ be ? IteratorComplete(_innerResult_).
               1. If _done_ is *true*, then
                 1. Return ? IteratorValue(_innerResult_).
-              1. If _generatorKind_ is ~async~, set _received_ to Completion(AsyncGeneratorYield(? IteratorValue(_innerResult_))).
+              1. If _generatorKind_ is ~async~, then
+                1. Set _value_ to ? IteratorValue(_innerResult_).
+                1. Let _unwrapped_ be Completion(Await(_value_)).
+                1. IfAbruptCloseAsyncIterator(_unwrapped_, _iteratorRecord_).
+                1. Set _received_ to Completion(AsyncGeneratorYield(_unwrapped_)).
               1. Else, set _received_ to Completion(GeneratorYield(_innerResult_)).
             1. Else,
               1. NOTE: If _iterator_ does not have a `throw` method, this throw is going to terminate the `yield*` loop. But first we need to give _iterator_ a chance to clean up.
@@ -24008,7 +24030,11 @@
             1. If _done_ is *true*, then
               1. Let _value_ be ? IteratorValue(_innerReturnResult_).
               1. Return Completion Record { [[Type]]: ~return~, [[Value]]: _value_, [[Target]]: ~empty~ }.
-            1. If _generatorKind_ is ~async~, set _received_ to Completion(AsyncGeneratorYield(? IteratorValue(_innerReturnResult_))).
+            1. If _generatorKind_ is ~async~, then
+              1. Set _value_ to ? IteratorValue(_innerReturnResult_).
+              1. Let _unwrapped_ be Completion(Await(_value_)).
+              1. IfAbruptCloseAsyncIterator(_unwrapped_, _iteratorRecord_).
+              1. Set _received_ to Completion(AsyncGeneratorYield(_unwrapped_)).
             1. Else, set _received_ to Completion(GeneratorYield(_innerReturnResult_)).
       </emu-alg>
     </emu-clause>
@@ -45042,7 +45068,7 @@ THH:mm:ss.sss
         </dl>
         <emu-alg>
           1. Let _generatorKind_ be GetGeneratorKind().
-          1. If _generatorKind_ is ~async~, return ? AsyncGeneratorYield(_value_).
+          1. If _generatorKind_ is ~async~, return ? AsyncGeneratorYield(? Await(_value_)).
           1. Otherwise, return ? GeneratorYield(CreateIterResultObject(_value_, *false*)).
         </emu-alg>
       </emu-clause>
@@ -45393,7 +45419,6 @@ THH:mm:ss.sss
           1. Assert: _genContext_ is the execution context of a generator.
           1. Let _generator_ be the value of the Generator component of _genContext_.
           1. Assert: GetGeneratorKind() is ~async~.
-          1. Set _value_ to ? Await(_value_).
           1. Let _completion_ be NormalCompletion(_value_).
           1. Assert: The execution context stack has at least two elements.
           1. Let _previousContext_ be the second to top element of the execution context stack.


### PR DESCRIPTION
Fixes #2813.

The idea is that if you are doing `yield* m` on a manual async iterator `m` (i.e., one which is not an async generator), it is possible for the inner iterator to yield `{ next: promise, done: false }`. And if that promise rejects, it is treated as if someone had called `.throw` on the outer generator (the one doing `yield*`). That's inconsistent with the way the spec usually consumes iterators and is almost certainly a bug caused by the factoring of `AsyncGeneratorYield`. (Async generators await their result before yielding it, so it doesn't come up without a manually implemented iterator.)

There's only really three consistent options, that I can see.
1. treat this as a valid thing for a manual async iterator to do which happens to cause the outer generator to throw, in which case the inner iterator should be cleaned up before the exception propagates (which is what this PR does)
2. treat this as a protocol violation by the inner iterator, in which case neither `.throw` or `.return` should be called on the inner iterator (as if calling `.next` had thrown)
3. don't await the result from the inner iterator at all (which would mean it's possible for an async generator to yield a Promise without first unwrapping it, which is maybe surprising, but on the other hand is more consistent with treating `yield*` as being a completely transparent delegation to the inner iterator). This option would also reduce the number of microtask ticks entailed by async generators doing `yield*` in general. I've opened an alternative PR in https://github.com/tc39/ecma262/pull/2819 which implements this option.

This PR takes the first option.

I don't really like the second option, because `for await` does _not_ treat an async iterator yielding a promise as being a protocol violation - see [this snippet](https://github.com/tc39/proposal-array-from-async/issues/19#issuecomment-1175655515).

I actually kind of prefer the third option, but it has broader implications than this PR does, and so is more likely to break stuff. On the other hand, it also would improve the performance of async generators, which is nice.

---

As mentioned in the issue, this does not match any existing engine, but engines are inconsistent here, so the change in this PR is probably web compatible.