### PR TITLE
Normative: avoid mostly-redundant `await` in async `yield*`

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -45130,7 +45130,7 @@ THH:mm:ss.sss
         </dl>
         <emu-alg>
           1. Let _generatorKind_ be GetGeneratorKind().
-          1. If _generatorKind_ is ~async~, return ? AsyncGeneratorYield(_value_).
+          1. If _generatorKind_ is ~async~, return ? AsyncGeneratorYield(? Await(_value_)).
           1. Otherwise, return ? GeneratorYield(CreateIterResultObject(_value_, *false*)).
         </emu-alg>
       </emu-clause>
@@ -45481,7 +45481,6 @@ THH:mm:ss.sss
           1. Assert: _genContext_ is the execution context of a generator.
           1. Let _generator_ be the value of the Generator component of _genContext_.
           1. Assert: GetGeneratorKind() is ~async~.
-          1. Set _value_ to ? Await(_value_).
           1. Let _completion_ be NormalCompletion(_value_).
           1. Assert: The execution context stack has at least two elements.
           1. Let _previousContext_ be the second to top element of the execution context stack.


### PR DESCRIPTION
This is an alternative to #2818. See that PR for more context - this implements option 3 of the options listed there. Fixes https://github.com/tc39/ecma262/issues/2813.

The main effect of this PR would be that if you had

```js
let done = false;
let inner = {
  [Symbol.asyncIterator]: () => ({
    next() {
      if (done) {
        return Promise.resolve({ done: true });
      }
      done = true;
      return Promise.resolve({ done: false, value: Promise.resolve(0) });
    },
  }),
};

async function* outer() {
  yield* inner;
}

(async () => {
  for await (let x of outer()) {
    console.log(x);
  }
})().catch(e => {
  console.log('threw', e);
});
```
then you would see printed `Promise.resolve(0)` instead of, as currently, `0`. In other words, it would behave as if you'd written `for await (let x of inner)` instead of `of outer()`.

The other effect is a reduction in the number of promise ticks.

No difference (except in timing) would be observable without manually implementing `Symbol.asyncIterator` because async generators (and [the async-from-sync wrapper](https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-asyncfromsynciteratorcontinuation), see step 6) already `await` values before yielding or returning them.