### PR TITLE
Editorial: replace ECMAScript "code" with "source text" as appropriate

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1028,7 +1028,7 @@
 
     <emu-clause id="sec-value-notation">
       <h1>Value Notation</h1>
-      <p>In this specification, ECMAScript language values are displayed in *bold*. Examples include *null*, *true*, or *"hello"*. These are distinguished from longer ECMAScript code sequences such as `Function.prototype.apply` or `let n = 42;`.</p>
+      <p>In this specification, ECMAScript language values are displayed in *bold*. Examples include *null*, *true*, or *"hello"*. These are distinguished from ECMAScript source text such as `Function.prototype.apply` or `let n = 42;`.</p>
       <p>Values which are internal to the specification and not directly observable from ECMAScript code are indicated with a ~sans-serif~ typeface. For instance, a Completion Record's [[Type]] field takes on values like ~normal~, ~return~, or ~throw~.</p>
     </emu-clause>
   </emu-clause>
@@ -15815,7 +15815,7 @@
       SourceCharacter ::
         &gt; any Unicode code point
     </emu-grammar>
-    <p>ECMAScript code is expressed using Unicode. ECMAScript source text is a sequence of code points. All Unicode code point values from U+0000 to U+10FFFF, including surrogate code points, may occur in source text where permitted by the ECMAScript grammars. The actual encodings used to store and interchange ECMAScript source text is not relevant to this specification. Regardless of the external source text encoding, a conforming ECMAScript implementation processes the source text as if it was an equivalent sequence of |SourceCharacter| values, each |SourceCharacter| being a Unicode code point. Conforming ECMAScript implementations are not required to perform any normalization of source text, or behave as though they were performing normalization of source text.</p>
+    <p><dfn>ECMAScript source text</dfn> is a sequence of Unicode code points. All Unicode code point values from U+0000 to U+10FFFF, including surrogate code points, may occur in ECMAScript source text where permitted by the ECMAScript grammars. The actual encodings used to store and interchange ECMAScript source text is not relevant to this specification. Regardless of the external source text encoding, a conforming ECMAScript implementation processes the source text as if it was an equivalent sequence of |SourceCharacter| values, each |SourceCharacter| being a Unicode code point. Conforming ECMAScript implementations are not required to perform any normalization of source text, or behave as though they were performing normalization of source text.</p>
     <p>The components of a combining character sequence are treated as individual Unicode code points even though a user might think of the whole sequence as a single character.</p>
     <emu-note>
       <p>In string literals, regular expression literals, template literals and identifiers, any Unicode code point may also be expressed using Unicode escape sequences that explicitly express a code point's numeric value. Within a comment, such an escape sequence is effectively ignored as part of the comment.</p>
@@ -16018,7 +16018,7 @@
 
     <emu-clause id="sec-non-ecmascript-functions">
       <h1>Non-ECMAScript Functions</h1>
-      <p>An ECMAScript implementation may support the evaluation of function exotic objects whose evaluative behaviour is expressed in some host-defined form of executable code other than via ECMAScript code. Whether a function object is an ECMAScript code function or a non-ECMAScript function is not semantically observable from the perspective of an ECMAScript code function that calls or is called by such a non-ECMAScript function.</p>
+      <p>An ECMAScript implementation may support the evaluation of function exotic objects whose evaluative behaviour is expressed in some host-defined form of executable code other than ECMAScript source text. Whether a function object is defined within ECMAScript code or is a built-in function is not observable from the perspective of ECMAScript code that calls or is called by such a function object.</p>
     </emu-clause>
   </emu-clause>
 </emu-clause>
@@ -28690,7 +28690,7 @@
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It allows host environments to block certain ECMAScript functions which allow developers to compile strings into ECMAScript code.</dd>
+          <dd>It allows host environments to block certain ECMAScript functions which allow developers to interpret and evaluate strings as ECMAScript code.</dd>
         </dl>
         <p>An implementation of HostEnsureCanCompileStrings must conform to the following requirements:</p>
         <ul>
@@ -30163,7 +30163,7 @@
 
       <emu-clause id="sec-function-instances-name">
         <h1>name</h1>
-        <p>The value of the *"name"* property is a String that is descriptive of the function. The name has no semantic significance but is typically a variable or property name that is used to refer to the function at its point of definition in ECMAScript code. This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+        <p>The value of the *"name"* property is a String that is descriptive of the function. The name has no semantic significance but is typically a variable or property name that is used to refer to the function at its point of definition in ECMAScript source text. This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
         <p>Anonymous functions objects that do not have a contextual name associated with them by this specification use the empty String as the value of the *"name"* property.</p>
       </emu-clause>
 
@@ -30338,7 +30338,7 @@
           1. Append the Record { [[Key]]: _stringKey_, [[Symbol]]: _newSymbol_ } to the GlobalSymbolRegistry List.
           1. Return _newSymbol_.
         </emu-alg>
-        <p>The GlobalSymbolRegistry is a List that is globally available. It is shared by all realms. Prior to the evaluation of any ECMAScript code it is initialized as a new empty List. Elements of the GlobalSymbolRegistry are Records with the structure defined in <emu-xref href="#table-globalsymbolregistry-record-fields"></emu-xref>.</p>
+        <p>The GlobalSymbolRegistry is a List that is globally available. It is shared by all realms. Prior to the evaluation of any ECMAScript code, it is initialized as a new empty List. Elements of the GlobalSymbolRegistry are Records with the structure defined in <emu-xref href="#table-globalsymbolregistry-record-fields"></emu-xref>.</p>
         <emu-table id="table-globalsymbolregistry-record-fields" caption="GlobalSymbolRegistry Record Fields" oldids="table-44">
           <table>
             <tr>
@@ -47810,7 +47810,7 @@ THH:mm:ss.sss
 
     <emu-annex id="sec-block-level-function-declarations-web-legacy-compatibility-semantics">
       <h1>Block-Level Function Declarations Web Legacy Compatibility Semantics</h1>
-      <p>Prior to ECMAScript 2015, the ECMAScript specification did not define the occurrence of a |FunctionDeclaration| as an element of a |Block| statement's |StatementList|. However, support for that form of |FunctionDeclaration| was an allowable extension and most browser-hosted ECMAScript implementations permitted them. Unfortunately, the semantics of such declarations differ among those implementations. Because of these semantic differences, existing web ECMAScript code that uses |Block| level function declarations is only portable among browser implementations if the usage only depends upon the semantic intersection of all of the browser implementations for such declarations. The following are the use cases that fall within that intersection semantics:</p>
+      <p>Prior to ECMAScript 2015, the ECMAScript specification did not define the occurrence of a |FunctionDeclaration| as an element of a |Block| statement's |StatementList|. However, support for that form of |FunctionDeclaration| was an allowable extension and most browser-hosted ECMAScript implementations permitted them. Unfortunately, the semantics of such declarations differ among those implementations. Because of these semantic differences, existing web ECMAScript source text that uses |Block| level function declarations is only portable among browser implementations if the usage only depends upon the semantic intersection of all of the browser implementations for such declarations. The following are the use cases that fall within that intersection semantics:</p>
       <ol>
         <li>
           <p>A function is declared and only referenced within a single block.</p>
@@ -47864,7 +47864,7 @@ THH:mm:ss.sss
           </ul>
         </li>
       </ol>
-      <p>The first use case is interoperable with the semantics of |Block| level function declarations provided by ECMAScript 2015. Any pre-existing ECMAScript code that employs that use case will operate using the Block level function declarations semantics defined by clauses <emu-xref href="#sec-ordinary-and-exotic-objects-behaviours"></emu-xref>, <emu-xref href="#sec-ecmascript-language-statements-and-declarations"></emu-xref>, and <emu-xref href="#sec-ecmascript-language-functions-and-classes"></emu-xref>.</p>
+      <p>The first use case is interoperable with the semantics of |Block| level function declarations provided by ECMAScript 2015. Any pre-existing ECMAScript source text that employs that use case will operate using the Block level function declarations semantics defined by clauses <emu-xref href="#sec-ordinary-and-exotic-objects-behaviours"></emu-xref>, <emu-xref href="#sec-ecmascript-language-statements-and-declarations"></emu-xref>, and <emu-xref href="#sec-ecmascript-language-functions-and-classes"></emu-xref>.</p>
       <p>ECMAScript 2015 interoperability for the second and third use cases requires the following extensions to the clause <emu-xref href="#sec-ordinary-and-exotic-objects-behaviours"></emu-xref>, clause <emu-xref href="#sec-ecmascript-language-functions-and-classes"></emu-xref>, clause <emu-xref href="#sec-eval-x"></emu-xref> and clause <emu-xref href="#sec-globaldeclarationinstantiation"></emu-xref> semantics.</p>
       <p>If an ECMAScript implementation has a mechanism for reporting diagnostic warning messages, a warning should be produced when code contains a |FunctionDeclaration| for which these compatibility semantics are applied and introduce observable differences from non-compatibility semantics. For example, if a var binding is not introduced because its introduction would create an early error, a warning message should not be produced.</p>
 


### PR DESCRIPTION
The term "ECMAScript code" is used interchangeably to refer to "ECMAScript source text" and ECMAScript programs. This bothered me so I tried to separate the cases where it made sense. In addition, there actually is a `dfn` for "ECMAScript code", defining it to be any of 4 kinds of ECMAScript source text, but I don't think the majority of existing usages intended to refer to this term. Here's the remaining cases that I haven't changed as of opening this PR, which should therefore be interpreted roughly as a synonym for "ECMAScript source text". I'm open for suggestions for how to handle these cases (including leaving them as-is).

> spec.html:2883: Return the value of the property whose key is \_propertyKey\_ from this object. If any **ECMAScript code** must be executed to retrieve the property value, \_Receiver\_ is used as the \*this\* value when evaluating the code.

> spec.html:2894: Set the value of the property whose key is \_propertyKey\_ to \_value\_. If any **ECMAScript code** must be executed to set the property value, \_Receiver\_ is used as the \*this\* value when evaluating the code. Returns *true* if the property value was set or *false* if it could not be set.

> spec.html:3154: &lt;p>Within this specification a reference such as %name% means the intrinsic object, associated with the current realm, corresponding to the name. A reference such as %name.a.b% means, as if the *"b"* property of the value of the *"a"* property of the intrinsic object %name% was accessed prior to any **ECMAScript code** being evaluated. Determination of the current realm and its intrinsics is described in &lt;emu-xref href="#sec-execution-contexts">&lt;/emu-xref>. The well-known intrinsics are listed in &lt;emu-xref href="#table-well-known-intrinsic-objects">&lt;/emu-xref>.&lt;/p>

> spec.html:10010: &lt;p>&lt;dfn variants="Environment Records">Environment Record&lt;/dfn> is a specification type used to define the association of |Identifier|s to specific variables and functions, based upon the lexical nesting structure of **ECMAScript code**. Usually an Environment Record is associated with some specific syntactic structure of **ECMAScript code** such as a |FunctionDeclaration|, a |BlockStatement|, or a |Catch| clause of a |TryStatement|. Each time such code is evaluated, a new Environment Record is created to record the identifier bindings that are created by that code.&lt;/p>

> spec.html:10010: &lt;p>&lt;dfn variants="Environment Records">Environment Record&lt;/dfn> is a specification type used to define the association of |Identifier|s to specific variables and functions, based upon the lexical nesting structure of **ECMAScript code**. Usually an Environment Record is associated with some specific syntactic structure of **ECMAScript code** such as a |FunctionDeclaration|, a |BlockStatement|, or a |Catch| clause of a |TryStatement|. Each time such code is evaluated, a new Environment Record is created to record the identifier bindings that are created by that code.&lt;/p>

> spec.html:10254: &lt;p>An example of **ECMAScript code** that results in a missing binding at step &lt;emu-xref href="#step-setmutablebinding-missing-binding">&lt;/emu-xref> is:&lt;/p>

> spec.html:11518: &lt;p>A &lt;dfn id="privateenvironment-record" variants="PrivateEnvironment Records">PrivateEnvironment Record&lt;/dfn> is a specification mechanism used to track Private Names based upon the lexical nesting structure of |ClassDeclaration|s and |ClassExpression|s in **ECMAScript code**. They are similar to, but distinct from, Environment Records. Each PrivateEnvironment Record is associated with a |ClassDeclaration| or |ClassExpression|. Each time such a class is evaluated, a new PrivateEnvironment Record is created to record the Private Names declared by that class.&lt;/p>

> spec.html:11603: &lt;p>Before it is evaluated, an ECMAScript program must be associated with a &lt;dfn id="realm" variants="realms">realm&lt;/dfn>. Conceptually, a realm consists of a set of intrinsic objects, an ECMAScript global environment, all of the **ECMAScript code** that is loaded within the scope of that global environment, and other associated state and resources.&lt;/p>

> spec.html:11985: &lt;p>At any particular time, an execution is &lt;dfn id="job-preparedtoevaluatecode">prepared to evaluate **ECMAScript code**&lt;/dfn> if all of the following conditions are true:&lt;/p>

> spec.html:12105: &lt;li>If \_realm\_ is not \*null\*, each time \_job\_ is invoked the implementation must perform implementation-defined steps such that execution is &lt;emu-xref href="#job-preparedtoevaluatecode">prepared to evaluate **ECMAScript code**&lt;/emu-xref> at the time of \_job\_'s invocation.&lt;/li>

> spec.html:12111: &lt;p>The \_realm\_ for Jobs returned by NewPromiseResolveThenableJob is usually the result of calling GetFunctionRealm on the \_then\_ function object. The \_realm\_ for Jobs returned by NewPromiseReactionJob is usually the result of calling GetFunctionRealm on the handler if the handler is not \*undefined\*. If the handler is \*undefined\*, \_realm\_ is \*null\*. For both kinds of Jobs, when GetFunctionRealm completes abnormally (i.e. called on a revoked Proxy), \_realm\_ is the current Realm at the time of the GetFunctionRealm call. When the \_realm\_ is \*null\*, no **ECMAScript code** will be evaluated and no new ECMAScript objects (e.g. Error objects) will be created. The WHATWG HTML specification (&lt;a href="https\://html.spec.whatwg.org/">https\://html.spec.whatwg.org/&lt;/a>), for example, uses \_realm\_ to check for the ability to run script and for the &lt;a href="https\://html.spec.whatwg.org/#entry">entry&lt;/a> concept.&lt;/p>

> spec.html:12278: &lt;p>Prior to any evaluation of any **ECMAScript code** by any agent in a cluster, the [[CandidateExecution]] field of the Agent Record for all agents in the cluster is set to the initial candidate execution. The initial candidate execution is an empty candidate execution whose [[EventsRecords]] field is a List containing, for each agent, an Agent Events Record whose [[AgentSignifier]] field is that agent's agent signifier, and whose [[EventList]] and [[AgentSynchronizesWith]] fields are empty Lists.&lt;/p>

> spec.html:13051: &lt;p>ECMAScript function objects encapsulate parameterized **ECMAScript code** closed over a lexical environment and support the dynamic evaluation of that code. An ECMAScript function object is an ordinary object and has the same internal slots and the same internal methods as other ordinary objects. The code of an ECMAScript function object may be either strict mode code (&lt;emu-xref href="#sec-strict-mode-code">&lt;/emu-xref>) or non-strict code. An ECMAScript function object whose code is strict mode code is called a &lt;dfn id="strict-function" variants="strict functions">strict function&lt;/dfn>. One whose code is not strict mode code is called a &lt;dfn id="non-strict-function" variants="non-strict functions">non-strict function&lt;/dfn>.&lt;/p>

> spec.html:13785: &lt;p>The built-in function objects defined in this specification may be implemented as either ECMAScript function objects (&lt;emu-xref href="#sec-ecmascript-function-objects">&lt;/emu-xref>) whose behaviour is provided using **ECMAScript code** or as implementation provided function exotic objects whose behaviour is provided in some other manner. In either case, the effect of calling such functions must conform to their specifications. An implementation may also provide additional built-in function objects that are not defined in this specification.&lt;/p>

> spec.html:13789: &lt;p>The behaviour specified for each built-in function via algorithm steps or other means is the specification of the function body behaviour for both [[Call]] and [[Construct]] invocations of the function. However, [[Construct]] invocation is not supported by all built-in functions. For each built-in function, when invoked with [[Call]], the [[Call]] \_thisArgument\_ provides the \*this\* value, the [[Call]] \_argumentsList\_ provides the named parameters, and the NewTarget value is \*undefined\*. When invoked with [[Construct]], the \*this\* value is uninitialized, the [[Construct]] \_argumentsList\_ provides the named parameters, and the [[Construct]] \_newTarget\_ parameter provides the NewTarget value. If the built-in function is implemented as an ECMAScript function object then this specified behaviour must be implemented by the **ECMAScript code** that is the body of the function. Built-in functions that are ECMAScript function objects must be strict functions. If a built-in constructor has any [[Call]] behaviour other than throwing a *TypeError* exception, an ECMAScript implementation of the function must be done in a manner that does not cause the function's [[IsClassConstructor]] internal slot to have the value *true*.&lt;/p>

> spec.html:15076: &lt;p>A Proxy object is an exotic object whose essential internal methods are partially implemented using **ECMAScript code**. Every Proxy object has an internal slot called [[ProxyHandler]]. The value of [[ProxyHandler]] is an object, called the proxy's &lt;em>handler object&lt;/em>, or \*null\*. Methods (see &lt;emu-xref href="#table-proxy-handler-methods">&lt;/emu-xref>) of a handler object may be used to augment the implementation for one or more of the Proxy object's internal methods. Every Proxy object also has an internal slot called [[ProxyTarget]] whose value is either an object or the \*null\* value. This object is called the proxy's &lt;em>target object&lt;/em>.&lt;/p>

> spec.html:15198: &lt;p>Because Proxy objects permit the implementation of internal methods to be provided by arbitrary **ECMAScript code**, it is possible to define a Proxy object whose handler methods violates the invariants defined in &lt;emu-xref href="#sec-invariants-of-the-essential-internal-methods">&lt;/emu-xref>. Some of the internal method invariants defined in &lt;emu-xref href="#sec-invariants-of-the-essential-internal-methods">&lt;/emu-xref> are essential integrity invariants. These invariants are explicitly enforced by the Proxy object internal methods specified in this section. An ECMAScript implementation must be robust in the presence of all possible invariant violations.&lt;/p>

> spec.html:15939: &lt;p>There are four types of &lt;dfn>**ECMAScript code**&lt;/dfn>:&lt;/p>

> spec.html:16002: &lt;p>**ECMAScript code** that is not strict mode code is called &lt;dfn id="non-strict-code">non-strict code&lt;/dfn>.&lt;/p>

> spec.html:16007: &lt;p>An ECMAScript implementation may support the evaluation of function exotic objects whose evaluative behaviour is expressed in some host-defined form of executable code other than ECMAScript source text. Whether a function object is defined within **ECMAScript code** or is a built-in function is not observable from the perspective of **ECMAScript code** that calls or is called by such a function object.&lt;/p>

> spec.html:16007: &lt;p>An ECMAScript implementation may support the evaluation of function exotic objects whose evaluative behaviour is expressed in some host-defined form of executable code other than ECMAScript source text. Whether a function object is defined within **ECMAScript code** or is a built-in function is not observable from the perspective of **ECMAScript code** that calls or is called by such a function object.&lt;/p>

> spec.html:25638: 1. Assert: The current execution context will not subsequently be used for the evaluation of any **ECMAScript code** or built-in functions. The invocation of Call subsequent to the invocation of this abstract operation will create and push a new execution context before performing any such evaluation.

> spec.html:28704: &lt;dd>It allows host environments to block certain ECMAScript functions which allow developers to interpret strings as **ECMAScript code**.&lt;/dd>

> spec.html:30340: &lt;p>The GlobalSymbolRegistry is a List that is globally available. It is shared by all realms. Prior to the evaluation of any **ECMAScript code**, it is initialized as a new empty List. Elements of the GlobalSymbolRegistry are Records with the structure defined in &lt;emu-xref href="#table-globalsymbolregistry-record-fields">&lt;/emu-xref>.&lt;/p>

> spec.html:42820: &lt;p>If the WeakRef returns a \_target\_ Object that is not \*undefined\*, then this \_target\_ object should not be garbage collected until the current execution of **ECMAScript code** has completed. The AddToKeptObjects operation makes sure read consistency is maintained.&lt;/p>

> spec.html:43843: 1. NOTE: \_handlerRealm\_ is never \*null\* unless the handler is \*undefined\*. When the handler is a revoked Proxy and no **ECMAScript code** runs, \_handlerRealm\_ is used to create error objects.
