### PR TITLE
Editorial: Remove incorrect setting of the AsyncEvaluation state to false

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -26584,7 +26584,6 @@
               1. Assert: _module_.[[Status]] is ~evaluating-async~.
               1. Assert: _module_.[[AsyncEvaluation]] is *true*.
               1. Assert: _module_.[[EvaluationError]] is ~empty~.
-              1. Set _module_.[[AsyncEvaluation]] to *false*.
               1. Set _module_.[[Status]] to ~evaluated~.
               1. If _module_.[[TopLevelCapability]] is not ~empty~, then
                 1. Assert: _module_.[[CycleRoot]] is _module_.


### PR DESCRIPTION
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->

This change removes an extraneous line that was included when this was originally merged into the spec, but did not reflect the spec that had consensus. 

The line was removed (along with others) in this pr: https://github.com/tc39/proposal-top-level-await/commit/c2375dbd6ecb0d5e9a415f6a812fc0974a2935b7#diff-181371b08d71216599b0acccbaabd03c306da6de142ea6275c2135810999805aL697

Additionally, this is only set on the fulfilled state -- and not the rejected, so this is a mistake anyway. This could be seen as editorial or normative -- in either case this is a bug. 
