### PR TITLE
Editorial: `OrdinaryCreateFromConstructor`: correctly handle an omitted internalSlotsList

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -12987,7 +12987,7 @@
     <emu-clause id="sec-ordinarycreatefromconstructor" type="abstract operation">
       <h1>
         OrdinaryCreateFromConstructor (
-          _constructor_: unknown,
+          _constructor_: a constructor,
           _intrinsicDefaultProto_: a String,
           optional _internalSlotsList_: a List of names of internal slots,
         ): either a normal completion containing an Object or a throw completion
@@ -12999,7 +12999,9 @@
       <emu-alg>
         1. Assert: _intrinsicDefaultProto_ is this specification's name of an intrinsic object. The corresponding object must be an intrinsic that is intended to be used as the [[Prototype]] value of an object.
         1. Let _proto_ be ? GetPrototypeFromConstructor(_constructor_, _intrinsicDefaultProto_).
-        1. Return OrdinaryObjectCreate(_proto_, _internalSlotsList_).
+        1. If _internalSlotsList_ is present, let _slotsList_ be _internalSlotsList_.
+        1. Else, let _slotsList_ be a new empty List.
+        1. Return OrdinaryObjectCreate(_proto_, _slotsList_).
       </emu-alg>
     </emu-clause>
 


### PR DESCRIPTION
I noticed that when the list is omitted, it would be passing `undefined` to an AO that asserts that it receives a List.