### PR TITLE
Editorial: Fix ambiguities and type mismatches in Function.prototype.toString

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -30040,15 +30040,24 @@
         <emu-alg>
           1. Let _func_ be the *this* value.
           1. If _func_ is an Object, _func_ has a [[SourceText]] internal slot, _func_.[[SourceText]] is a sequence of Unicode code points, and HostHasSourceTextAvailable(_func_) is *true*, then
-            1. Return CodePointsToString(_func_.[[SourceText]]).
-          1. If _func_ is a <emu-xref href="#sec-built-in-function-objects">built-in function object</emu-xref>, return an implementation-defined String source code representation of _func_. The representation must have the syntax of a |NativeFunction|. Additionally, if _func_ has an [[InitialName]] internal slot and _func_.[[InitialName]] is a String, the portion of the returned String that would be matched by |NativeFunctionAccessor?| |PropertyName| must be the value of _func_.[[InitialName]].
-          1. If _func_ is an Object and IsCallable(_func_) is *true*, return an implementation-defined String source code representation of _func_. The representation must have the syntax of a |NativeFunction|.
-          1. Throw a *TypeError* exception.
+            1. Let _sourceText_ be _func_.[[SourceText]].
+          1. Else if _func_ is a <emu-xref href="#sec-built-in-function-objects">built-in function object</emu-xref>, then
+            1. NOTE: Every <emu-xref href="#sec-built-in-function-objects">built-in function object</emu-xref> has an [[InitialName]] internal slot with String value matching the initial value of its *"name"* property, which might be explicitly specified with contents that match the syntax of |ComputedPropertyName| rather than |LiteralPropertyName|. See <emu-xref href="#sec-ecmascript-standard-built-in-objects"></emu-xref>.
+            1. Let _sourceText_ be an implementation-defined sequence of Unicode code points that represents _func_ using the syntax of |NativeFunction| in which the portion of the sequence matched by |NativeFunctionName| is StringToCodePoints(_func_.[[InitialName]]).
+          1. Else if _func_ is an Object and IsCallable(_func_) is *true*, then
+            1. Let _sourceText_ be an implementation-defined sequence of Unicode code points that represents _func_ using the syntax of |NativeFunction|.
+          1. Else,
+            1. Throw a *TypeError* exception.
+          1. Return CodePointsToString(_sourceText_).
         </emu-alg>
 
         <emu-grammar type="definition">
           NativeFunction :
-            `function` NativeFunctionAccessor? PropertyName[~Yield, ~Await]? `(` FormalParameters[~Yield, ~Await] `)` `{` `[` `native` `code` `]` `}`
+            `function` NativeFunctionName `(` FormalParameters[~Yield, ~Await] `)` `{` `[` `native` `code` `]` `}`
+
+          NativeFunctionName :
+            [empty]
+            NativeFunctionAccessor? PropertyName[~Yield, ~Await]
 
           NativeFunctionAccessor :
             `get`

--- a/spec.html
+++ b/spec.html
@@ -30039,18 +30039,16 @@
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _func_ be the *this* value.
-          1. If _func_ is an Object, _func_ has a [[SourceText]] internal slot, _func_.[[SourceText]] is a sequence of Unicode code points, and HostHasSourceTextAvailable(_func_) is *true*, then
-            1. Let _sourceText_ be _func_.[[SourceText]].
-          1. Else if _func_ is a <emu-xref href="#sec-built-in-function-objects">built-in function object</emu-xref>, then
-            1. NOTE: Every <emu-xref href="#sec-built-in-function-objects">built-in function object</emu-xref> has an [[InitialName]] internal slot with String value matching the initial value of its *"name"* property, which might be explicitly specified with contents that match the syntax of |ComputedPropertyName| rather than |LiteralPropertyName|. See <emu-xref href="#sec-ecmascript-standard-built-in-objects"></emu-xref>.
-            1. Let _sourceText_ be an implementation-defined sequence of Unicode code points that represents _func_ using the syntax of |NativeFunction| in which the portion of the sequence matched by |NativeFunctionName| is StringToCodePoints(_func_.[[InitialName]]).
-          1. Else if _func_ is an Object and IsCallable(_func_) is *true*, then
-            1. Let _sourceText_ be an implementation-defined sequence of Unicode code points that represents _func_ using the syntax of |NativeFunction|.
-          1. Else,
-            1. Throw a *TypeError* exception.
+          1. If IsCallable(_func_) is *false*, throw a *TypeError* exception.
+          1. Assert: _func_ is an Object.
+          1. If _func_ has a [[SourceText]] internal slot, _func_.[[SourceText]] is a sequence of Unicode code points, and HostHasSourceTextAvailable(_func_) is *true*, then
+            1. Return CodePointsToString(_func_.[[SourceText]]).
+          1. Let _sourceText_ be an implementation-defined sequence of Unicode code points that represents _func_ using the syntax of |NativeFunction|. If _func_ is a <emu-xref href="#sec-built-in-function-objects">built-in function object</emu-xref>, the portion of _sourceText_ corresponding to |NativeFunctionName| must be StringToCodePoints(_func_.[[InitialName]]).
           1. Return CodePointsToString(_sourceText_).
         </emu-alg>
-
+        <emu-note>
+          <p>Every <emu-xref href="#sec-built-in-function-objects">built-in function object</emu-xref> has an [[InitialName]] internal slot with String value equal to the initial value of its *"name"* property, which for some functions is explicitly specified with contents that match the syntax of |ComputedPropertyName| rather than |LiteralPropertyName|. See <emu-xref href="#sec-ecmascript-standard-built-in-objects"></emu-xref>.</p>
+        </emu-note>
         <emu-grammar type="definition">
           NativeFunction :
             `function` NativeFunctionName `(` FormalParameters[~Yield, ~Await] `)` `{` `[` `native` `code` `]` `}`


### PR DESCRIPTION
This extracts the editorial fixes of #2695 and will serve as a rebase target for it.