### PR TITLE
Editorial: Fix typo in CharacterValue

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -34967,7 +34967,7 @@ THH:mm:ss.sss
           HexNonSurrogate :: Hex4Digits
         </emu-grammar>
         <emu-alg>
-          1. Return the MV of |HexDigits|.
+          1. Return the MV of |Hex4Digits|.
         </emu-alg>
         <emu-grammar>CharacterEscape :: IdentityEscape</emu-grammar>
         <emu-alg>


### PR DESCRIPTION
In [22.2.1.6 Static Semantics: CharacterValue](https://tc39.es/ecma262/#sec-patterns-static-semantics-character-value), it seems that `HexDigits` is typo and `Hex4Digits` is appropriate.