### PR TITLE
Editorial: remove unused capture in %TypedArray%.prototype.sort

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -39415,10 +39415,9 @@ THH:mm:ss.sss
           1. If _comparefn_ is not *undefined* and IsCallable(_comparefn_) is *false*, throw a *TypeError* exception.
           1. Let _obj_ be the *this* value.
           1. Perform ? ValidateTypedArray(_obj_).
-          1. Let _buffer_ be _obj_.[[ViewedArrayBuffer]].
           1. Let _len_ be _obj_.[[ArrayLength]].
           1. NOTE: The following closure performs a numeric comparison rather than the string comparison used in <emu-xref href="#sec-array.prototype.sort"></emu-xref>.
-          1. Let _SortCompare_ be a new Abstract Closure with parameters (_x_, _y_) that captures _comparefn_ and _buffer_ and performs the following steps when called:
+          1. Let _SortCompare_ be a new Abstract Closure with parameters (_x_, _y_) that captures _comparefn_ and performs the following steps when called:
             1. Assert: Both Type(_x_) and Type(_y_) are Number or both are BigInt.
             1. If _comparefn_ is not *undefined*, then
               1. Let _v_ be ? ToNumber(? Call(_comparefn_, *undefined*, &laquo; _x_, _y_ &raquo;)).


### PR DESCRIPTION
When the detached check was removed this seems to have been left behind.