### PR TITLE
Editorial: Consolidate use of ASCII subsets

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -569,7 +569,7 @@
 
     <emu-clause id="sec-grammar-notation" namespace="grammar-notation">
       <h1>Grammar Notation</h1>
-      <p>In the ECMAScript grammars, some terminal symbols are shown in `fixed-width` font. These are to appear in a source text exactly as written. All terminal symbol code points specified in this way are to be understood as the appropriate Unicode code points from the Basic Latin range, as opposed to any similar-looking code points from other Unicode ranges. A code point in a terminal symbol cannot be expressed by a `\\` |UnicodeEscapeSequence|.</p>
+      <p>In the ECMAScript grammars, some terminal symbols are shown in `fixed-width` font. These are to appear in a source text exactly as written. All terminal symbol code points specified in this way are to be understood as the appropriate Unicode code points from the Basic Latin block, as opposed to any similar-looking code points from other Unicode ranges. A code point in a terminal symbol cannot be expressed by a `\\` |UnicodeEscapeSequence|.</p>
       <p>In grammars whose terminal symbols are individual Unicode code points (i.e., the lexical, RegExp, and numeric string grammars), a contiguous run of multiple fixed-width code points appearing in a production is a simple shorthand for the same sequence of code points, written as standalone terminal symbols.</p>
       <p>For example, the production:</p>
       <emu-grammar type="definition" example>
@@ -35743,7 +35743,7 @@ THH:mm:ss.sss
             <pre><code class="javascript">["baaabaac", "ba", undefined, "abaac"]</code></pre>
           </emu-note>
           <emu-note>
-            <p>In case-insignificant matches when _rer_.[[Unicode]] is *true*, all characters are implicitly case-folded using the simple mapping provided by the Unicode Standard immediately before they are compared. The simple mapping always maps to a single code point, so it does not map, for example, `&szlig;` (U+00DF) to `SS`. It may however map a code point outside the Basic Latin range to a character within, for example, `&#x17f;` (U+017F) to `s`. Such characters are not mapped if _rer_.[[Unicode]] is *false*. This prevents Unicode code points such as U+017F and U+212A from matching regular expressions such as `/[a-z]/i`, but they will match `/[a-z]/ui`.</p>
+            <p>In case-insignificant matches when _rer_.[[Unicode]] is *true*, all characters are implicitly case-folded using the simple mapping provided by the Unicode Standard immediately before they are compared. The simple mapping always maps to a single code point, so it does not map, for example, `&szlig;` (U+00DF) to `SS`. It may however map a code point outside the Basic Latin block to a character within, for example, `&#x17f;` (U+017F) to `s`. Such characters are not mapped if _rer_.[[Unicode]] is *false*. This prevents Unicode code points such as U+017F and U+212A from matching regular expressions such as `/[a-z]/i`, but they will match `/[a-z]/ui`.</p>
           </emu-note>
         </emu-clause>
       </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -1090,7 +1090,7 @@
       <p>In this specification, the phrase "the <dfn id="string-concatenation">string-concatenation</dfn> of _A_, _B_, ..." (where each argument is a String value, a code unit, or a sequence of code units) denotes the String value whose sequence of code units is the concatenation of the code units (in order) of each of the arguments (in order).</p>
       <p>The phrase "the <dfn id="substring">substring</dfn> of _S_ from _inclusiveStart_ to _exclusiveEnd_" (where _S_ is a String value or a sequence of code units and _inclusiveStart_ and _exclusiveEnd_ are integers) denotes the String value consisting of the consecutive code units of _S_ beginning at index _inclusiveStart_ and ending immediately before index _exclusiveEnd_ (which is the empty String when _inclusiveStart_ = _exclusiveEnd_). If the "to" suffix is omitted, the length of _S_ is used as the value of _exclusiveEnd_.</p>
       <p>
-        The phrase "<dfn id="ASCII-word-characters">ASCII word characters</dfn>" denotes the following String value, which consists solely of every letter and number in the Unicode Basic Latin block along with U+005F (LOW LINE):<br>
+        The phrase "<dfn id="ASCII-word-characters">the ASCII word characters</dfn>" denotes the following String value, which consists solely of every letter and number in the Unicode Basic Latin block along with U+005F (LOW LINE):<br>
         *"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_"*.<br>
         For historical reasons, it has significance to various algorithms.
       </p>
@@ -28997,7 +28997,7 @@
         <emu-alg>
           1. Let _strLen_ be the length of _string_.
           1. Let _R_ be the empty String.
-          1. Let _alwaysUnescaped_ be the string-concatenation of ASCII word characters and *"-.!~\*'()"*.
+          1. Let _alwaysUnescaped_ be the string-concatenation of the ASCII word characters and *"-.!~\*'()"*.
           1. Let _unescapedSet_ be the string-concatenation of _alwaysUnescaped_ and _extraUnescaped_.
           1. Let _k_ be 0.
           1. Repeat,
@@ -36094,7 +36094,7 @@ THH:mm:ss.sss
             <dd>Returns a CharSet containing the characters considered "word characters" for the purposes of `\\b`, `\\B`, `\\w`, and `\\W`</dd>
           </dl>
           <emu-alg>
-            1. Let _basicWordChars_ be the CharSet containing every character in ASCII word characters.
+            1. Let _basicWordChars_ be the CharSet containing every character in the ASCII word characters.
             1. Let _extraWordChars_ be the CharSet containing all characters _c_ such that _c_ is not in _basicWordChars_ but Canonicalize(_rer_, _c_) is in _basicWordChars_.
             1. Assert: _extraWordChars_ is empty unless _rer_.[[Unicode]] and _rer_.[[IgnoreCase]] are both *true*.
             1. Return the union of _basicWordChars_ and _extraWordChars_.
@@ -47435,7 +47435,7 @@ THH:mm:ss.sss
           1. Set _string_ to ? ToString(_string_).
           1. Let _length_ be the length of _string_.
           1. Let _R_ be the empty String.
-          1. Let _unescapedSet_ be the string-concatenation of ASCII word characters and *"@\*+-./"*.
+          1. Let _unescapedSet_ be the string-concatenation of the ASCII word characters and *"@\*+-./"*.
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _length_,
             1. Let _char_ be the code unit at index _k_ within _string_.

--- a/spec.html
+++ b/spec.html
@@ -29012,10 +29012,8 @@
               1. Set _k_ to _k_ + _cp_.[[CodeUnitCount]].
               1. Let _Octets_ be the List of octets resulting by applying the UTF-8 transformation to _cp_.[[CodePoint]].
               1. For each element _octet_ of _Octets_, do
-                1. Set _R_ to the string-concatenation of:
-                  * _R_
-                  * *"%"*
-                  * the String representation of _octet_, formatted as a two-digit uppercase hexadecimal number, padded to the left with a zero if necessary
+                1. Let _hex_ be the String representation of _octet_, formatted as an uppercase hexadecimal number.
+                1. Set _R_ to the string-concatenation of _R_, *"%"*, and ! StringPad(_hex_, *2*<sub>𝔽</sub>, *"0"*, ~start~).
         </emu-alg>
         <emu-note>
           <p>Because percent-encoding is used to represent individual octets, a single code point may be expressed as multiple consecutive escape sequences (one for each of its 8-bit UTF-8 code units).</p>
@@ -47446,13 +47444,11 @@ THH:mm:ss.sss
             1. Else,
               1. Let _n_ be the numeric value of _char_.
               1. If _n_ &lt; 256, then
-                1. Let _S_ be the string-concatenation of:
-                  * *"%"*
-                  * the String representation of _n_, formatted as a two-digit uppercase hexadecimal number, padded to the left with a zero if necessary
+                1. Let _hex_ be the String representation of _n_, formatted as an uppercase hexadecimal number.
+                1. Let _S_ be the string-concatenation of *"%"* and ! StringPad(_hex_, *2*<sub>𝔽</sub>, *"0"*, ~start~).
               1. Else,
-                1. Let _S_ be the string-concatenation of:
-                  * *"%u"*
-                  * the String representation of _n_, formatted as a four-digit uppercase hexadecimal number, padded to the left with zeroes if necessary
+                1. Let _hex_ be the String representation of _n_, formatted as an uppercase hexadecimal number.
+                1. Let _S_ be the string-concatenation of *"%u"* and ! StringPad(_hex_, *4*<sub>𝔽</sub>, *"0"*, ~start~).
             1. Set _R_ to the string-concatenation of _R_ and _S_.
             1. Set _k_ to _k_ + 1.
           1. Return _R_.

--- a/spec.html
+++ b/spec.html
@@ -28920,7 +28920,7 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-uri-handling-functions">
+    <emu-clause id="sec-uri-handling-functions" oldids="sec-uri-syntax-and-semantics">
       <h1>URI Handling Functions</h1>
       <p>Uniform Resource Identifiers, or URIs, are Strings that identify resources (e.g. web pages or files) and transport protocols by which to access them (e.g. HTTP or FTP) on the Internet. The ECMAScript language itself does not provide any support for using URIs except for functions that encode and decode URIs as described in this section. `encodeURI` and `decodeURI` are intended to work with complete URIs; they assume that any reserved characters are intended to have special meaning (e.g., as delimiters) and so are not encoded. `encodeURIComponent` and `decodeURIComponent` are intended to work with the individual components of a URI; they assume that any reserved characters represent text and must be encoded to avoid special meaning when the component is part of a complete URI.</p>
       <emu-note>
@@ -28929,107 +28929,6 @@
       <emu-note>
         <p>Many implementations of ECMAScript provide additional functions and methods that manipulate web pages; these functions are beyond the scope of this standard.</p>
       </emu-note>
-
-      <emu-clause id="sec-uri-syntax-and-semantics">
-        <h1>URI Syntax and Semantics</h1>
-
-        <emu-clause id="sec-encode" type="abstract operation">
-          <h1>
-            Encode (
-              _string_: a String,
-              _extraUnescaped_: a String,
-            ): either a normal completion containing a String or a throw completion
-          </h1>
-          <dl class="header">
-            <dt>description</dt>
-            <dd>It performs URI encoding and escaping, interpreting _string_ as a sequence of UTF-16 encoded code points as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>. If a character is identified as unreserved in RFC 2396 or appears in _extraUnescaped_, it is not escaped.</dd>
-          </dl>
-          <emu-alg>
-            1. Let _strLen_ be the length of _string_.
-            1. Let _R_ be the empty String.
-            1. Let _alwaysUnescaped_ be the string-concatenation of ASCII word characters and *"-.!~\*'()"*.
-            1. Let _unescapedSet_ be the string-concatenation of _alwaysUnescaped_ and _extraUnescaped_.
-            1. Let _k_ be 0.
-            1. Repeat,
-              1. If _k_ = _strLen_, return _R_.
-              1. Let _C_ be the code unit at index _k_ within _string_.
-              1. If _C_ is in _unescapedSet_, then
-                1. Set _k_ to _k_ + 1.
-                1. Set _R_ to the string-concatenation of _R_ and _C_.
-              1. Else,
-                1. Let _cp_ be CodePointAt(_string_, _k_).
-                1. If _cp_.[[IsUnpairedSurrogate]] is *true*, throw a *URIError* exception.
-                1. Set _k_ to _k_ + _cp_.[[CodeUnitCount]].
-                1. Let _Octets_ be the List of octets resulting by applying the UTF-8 transformation to _cp_.[[CodePoint]].
-                1. For each element _octet_ of _Octets_, do
-                  1. Set _R_ to the string-concatenation of:
-                    * _R_
-                    * *"%"*
-                    * the String representation of _octet_, formatted as a two-digit uppercase hexadecimal number, padded to the left with a zero if necessary
-          </emu-alg>
-          <emu-note>
-            <p>Because percent-encoding is used to represent individual octets, a single code point may be expressed as multiple consecutive escape sequences (one for each of its 8-bit UTF-8 code units).</p>
-          </emu-note>
-        </emu-clause>
-
-        <emu-clause id="sec-decode" type="abstract operation">
-          <h1>
-            Decode (
-              _string_: a String,
-              _preserveEscapeSet_: a String,
-            ): either a normal completion containing a String or a throw completion
-          </h1>
-          <dl class="header">
-            <dt>description</dt>
-            <dd>It performs URI unescaping and decoding, preserving any escape sequences that correspond to Basic Latin characters in _preserveEscapeSet_.</dd>
-          </dl>
-          <emu-alg>
-            1. Let _strLen_ be the length of _string_.
-            1. Let _R_ be the empty String.
-            1. Let _k_ be 0.
-            1. Repeat,
-              1. If _k_ = _strLen_, return _R_.
-              1. Let _C_ be the code unit at index _k_ within _string_.
-              1. If _C_ is not the code unit 0x0025 (PERCENT SIGN), then
-                1. Let _S_ be the String value containing only the code unit _C_.
-              1. Else,
-                1. Let _start_ be _k_.
-                1. If _k_ + 2 &ge; _strLen_, throw a *URIError* exception.
-                1. If the code units at index (_k_ + 1) and (_k_ + 2) within _string_ do not represent hexadecimal digits, throw a *URIError* exception.
-                1. Let _B_ be the 8-bit value represented by the two hexadecimal digits at index (_k_ + 1) and (_k_ + 2).
-                1. Set _k_ to _k_ + 2.
-                1. Let _n_ be the number of leading 1 bits in _B_.
-                1. If _n_ = 0, then
-                  1. Let _C_ be the code unit whose value is _B_.
-                  1. If _C_ is not in _preserveEscapeSet_, then
-                    1. Let _S_ be the String value containing only the code unit _C_.
-                  1. Else,
-                    1. Let _S_ be the substring of _string_ from _start_ to _k_ + 1.
-                1. Else,
-                  1. If _n_ = 1 or _n_ &gt; 4, throw a *URIError* exception.
-                  1. If _k_ + (3 &times; (_n_ - 1)) &ge; _strLen_, throw a *URIError* exception.
-                  1. Let _Octets_ be &laquo; _B_ &raquo;.
-                  1. Let _j_ be 1.
-                  1. Repeat, while _j_ &lt; _n_,
-                    1. Set _k_ to _k_ + 1.
-                    1. If the code unit at index _k_ within _string_ is not the code unit 0x0025 (PERCENT SIGN), throw a *URIError* exception.
-                    1. If the code units at index (_k_ + 1) and (_k_ + 2) within _string_ do not represent hexadecimal digits, throw a *URIError* exception.
-                    1. Let _B_ be the 8-bit value represented by the two hexadecimal digits at index (_k_ + 1) and (_k_ + 2).
-                    1. Set _k_ to _k_ + 2.
-                    1. Append _B_ to _Octets_.
-                    1. Set _j_ to _j_ + 1.
-                  1. Assert: The length of _Octets_ is _n_.
-                  1. If _Octets_ does not contain a valid UTF-8 encoding of a Unicode code point, throw a *URIError* exception.
-                  1. Let _V_ be the code point obtained by applying the UTF-8 transformation to _Octets_, that is, from a List of octets into a 21-bit value.
-                  1. Let _S_ be UTF16EncodeCodePoint(_V_).
-              1. Set _R_ to the string-concatenation of _R_ and _S_.
-              1. Set _k_ to _k_ + 1.
-          </emu-alg>
-          <emu-note>
-            <p>RFC 3629 prohibits the decoding of invalid UTF-8 octet sequences. For example, the invalid sequence 0xC0 0x80 must not decode into the code unit 0x0000. Implementations of the Decode algorithm are required to throw a *URIError* when encountering such invalid sequences.</p>
-          </emu-note>
-        </emu-clause>
-      </emu-clause>
 
       <emu-clause id="sec-decodeuri-encodeduri">
         <h1>decodeURI ( _encodedURI_ )</h1>
@@ -29077,6 +28976,103 @@
           1. Let _extraUnescaped_ be the empty String.
           1. Return ? Encode(_componentString_, _extraUnescaped_).
         </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-encode" type="abstract operation">
+        <h1>
+          Encode (
+            _string_: a String,
+            _extraUnescaped_: a String,
+          ): either a normal completion containing a String or a throw completion
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It performs URI encoding and escaping, interpreting _string_ as a sequence of UTF-16 encoded code points as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>. If a character is identified as unreserved in RFC 2396 or appears in _extraUnescaped_, it is not escaped.</dd>
+        </dl>
+        <emu-alg>
+          1. Let _strLen_ be the length of _string_.
+          1. Let _R_ be the empty String.
+          1. Let _alwaysUnescaped_ be the string-concatenation of ASCII word characters and *"-.!~\*'()"*.
+          1. Let _unescapedSet_ be the string-concatenation of _alwaysUnescaped_ and _extraUnescaped_.
+          1. Let _k_ be 0.
+          1. Repeat,
+            1. If _k_ = _strLen_, return _R_.
+            1. Let _C_ be the code unit at index _k_ within _string_.
+            1. If _C_ is in _unescapedSet_, then
+              1. Set _k_ to _k_ + 1.
+              1. Set _R_ to the string-concatenation of _R_ and _C_.
+            1. Else,
+              1. Let _cp_ be CodePointAt(_string_, _k_).
+              1. If _cp_.[[IsUnpairedSurrogate]] is *true*, throw a *URIError* exception.
+              1. Set _k_ to _k_ + _cp_.[[CodeUnitCount]].
+              1. Let _Octets_ be the List of octets resulting by applying the UTF-8 transformation to _cp_.[[CodePoint]].
+              1. For each element _octet_ of _Octets_, do
+                1. Set _R_ to the string-concatenation of:
+                  * _R_
+                  * *"%"*
+                  * the String representation of _octet_, formatted as a two-digit uppercase hexadecimal number, padded to the left with a zero if necessary
+        </emu-alg>
+        <emu-note>
+          <p>Because percent-encoding is used to represent individual octets, a single code point may be expressed as multiple consecutive escape sequences (one for each of its 8-bit UTF-8 code units).</p>
+        </emu-note>
+      </emu-clause>
+
+      <emu-clause id="sec-decode" type="abstract operation">
+        <h1>
+          Decode (
+            _string_: a String,
+            _preserveEscapeSet_: a String,
+          ): either a normal completion containing a String or a throw completion
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It performs URI unescaping and decoding, preserving any escape sequences that correspond to Basic Latin characters in _preserveEscapeSet_.</dd>
+        </dl>
+        <emu-alg>
+          1. Let _strLen_ be the length of _string_.
+          1. Let _R_ be the empty String.
+          1. Let _k_ be 0.
+          1. Repeat,
+            1. If _k_ = _strLen_, return _R_.
+            1. Let _C_ be the code unit at index _k_ within _string_.
+            1. If _C_ is not the code unit 0x0025 (PERCENT SIGN), then
+              1. Let _S_ be the String value containing only the code unit _C_.
+            1. Else,
+              1. Let _start_ be _k_.
+              1. If _k_ + 2 &ge; _strLen_, throw a *URIError* exception.
+              1. If the code units at index (_k_ + 1) and (_k_ + 2) within _string_ do not represent hexadecimal digits, throw a *URIError* exception.
+              1. Let _B_ be the 8-bit value represented by the two hexadecimal digits at index (_k_ + 1) and (_k_ + 2).
+              1. Set _k_ to _k_ + 2.
+              1. Let _n_ be the number of leading 1 bits in _B_.
+              1. If _n_ = 0, then
+                1. Let _C_ be the code unit whose value is _B_.
+                1. If _C_ is not in _preserveEscapeSet_, then
+                  1. Let _S_ be the String value containing only the code unit _C_.
+                1. Else,
+                  1. Let _S_ be the substring of _string_ from _start_ to _k_ + 1.
+              1. Else,
+                1. If _n_ = 1 or _n_ &gt; 4, throw a *URIError* exception.
+                1. If _k_ + (3 &times; (_n_ - 1)) &ge; _strLen_, throw a *URIError* exception.
+                1. Let _Octets_ be &laquo; _B_ &raquo;.
+                1. Let _j_ be 1.
+                1. Repeat, while _j_ &lt; _n_,
+                  1. Set _k_ to _k_ + 1.
+                  1. If the code unit at index _k_ within _string_ is not the code unit 0x0025 (PERCENT SIGN), throw a *URIError* exception.
+                  1. If the code units at index (_k_ + 1) and (_k_ + 2) within _string_ do not represent hexadecimal digits, throw a *URIError* exception.
+                  1. Let _B_ be the 8-bit value represented by the two hexadecimal digits at index (_k_ + 1) and (_k_ + 2).
+                  1. Set _k_ to _k_ + 2.
+                  1. Append _B_ to _Octets_.
+                  1. Set _j_ to _j_ + 1.
+                1. Assert: The length of _Octets_ is _n_.
+                1. If _Octets_ does not contain a valid UTF-8 encoding of a Unicode code point, throw a *URIError* exception.
+                1. Let _V_ be the code point obtained by applying the UTF-8 transformation to _Octets_, that is, from a List of octets into a 21-bit value.
+                1. Let _S_ be UTF16EncodeCodePoint(_V_).
+            1. Set _R_ to the string-concatenation of _R_ and _S_.
+            1. Set _k_ to _k_ + 1.
+        </emu-alg>
+        <emu-note>
+          <p>RFC 3629 prohibits the decoding of invalid UTF-8 octet sequences. For example, the invalid sequence 0xC0 0x80 must not decode into the code unit 0x0000. Implementations of the Decode algorithm are required to throw a *URIError* when encountering such invalid sequences.</p>
+        </emu-note>
       </emu-clause>
     </emu-clause>
   </emu-clause>
@@ -47023,18 +47019,6 @@ THH:mm:ss.sss
     <p>All grammar symbols not explicitly defined by the |StringNumericLiteral| grammar have the definitions used in the <emu-xref href="#sec-literals-numeric-literals">Lexical Grammar for numeric literals</emu-xref>.</p>
     <emu-prodref name="StringIntegerLiteral"></emu-prodref>
     <emu-prodref name="StrIntegerLiteral"></emu-prodref>
-  </emu-annex>
-
-  <emu-annex id="sec-universal-resource-identifier-character-classes">
-    <h1>Universal Resource Identifier Character Classes</h1>
-    <emu-prodref name="uri"></emu-prodref>
-    <emu-prodref name="uriCharacters"></emu-prodref>
-    <emu-prodref name="uriCharacter"></emu-prodref>
-    <emu-prodref name="uriReserved"></emu-prodref>
-    <emu-prodref name="uriUnescaped"></emu-prodref>
-    <emu-prodref name="uriEscaped"></emu-prodref>
-    <emu-prodref name="uriAlpha"></emu-prodref>
-    <emu-prodref name="uriMark"></emu-prodref>
   </emu-annex>
 
   <emu-annex id="sec-regular-expressions">

--- a/spec.html
+++ b/spec.html
@@ -16440,6 +16440,11 @@
         &lt;ZWNJ&gt;
         &lt;ZWJ&gt;
 
+      // emu-format ignore
+      AsciiLetter :: one of
+        `a` `b` `c` `d` `e` `f` `g` `h` `i` `j` `k` `l` `m` `n` `o` `p` `q` `r` `s` `t` `u` `v` `w` `x` `y` `z`
+        `A` `B` `C` `D` `E` `F` `G` `H` `I` `J` `K` `L` `M` `N` `O` `P` `Q` `R` `S` `T` `U` `V` `W` `X` `Y` `Z`
+
       UnicodeIDStart ::
         &gt; any Unicode code point with the Unicode property &ldquo;ID_Start&rdquo;
 
@@ -34462,7 +34467,7 @@ THH:mm:ss.sss
 
         CharacterEscape[UnicodeMode] ::
           ControlEscape
-          `c` ControlLetter
+          `c` AsciiLetter
           `0` [lookahead &notin; DecimalDigit]
           HexEscapeSequence
           RegExpUnicodeEscapeSequence[?UnicodeMode]
@@ -34470,11 +34475,6 @@ THH:mm:ss.sss
 
         ControlEscape :: one of
           `f` `n` `r` `t` `v`
-
-        // emu-format ignore
-        ControlLetter :: one of
-          `a` `b` `c` `d` `e` `f` `g` `h` `i` `j` `k` `l` `m` `n` `o` `p` `q` `r` `s` `t` `u` `v` `w` `x` `y` `z`
-          `A` `B` `C` `D` `E` `F` `G` `H` `I` `J` `K` `L` `M` `N` `O` `P` `Q` `R` `S` `T` `U` `V` `W` `X` `Y` `Z`
 
         GroupSpecifier[UnicodeMode] ::
           `?` GroupName[?UnicodeMode]
@@ -34563,7 +34563,7 @@ THH:mm:ss.sss
           DecimalDigit
 
         UnicodePropertyNameCharacter ::
-          ControlLetter
+          AsciiLetter
           `_`
 
         CharacterClass[UnicodeMode] ::
@@ -34922,9 +34922,9 @@ THH:mm:ss.sss
             </tr>
           </table>
         </emu-table>
-        <emu-grammar>CharacterEscape :: `c` ControlLetter</emu-grammar>
+        <emu-grammar>CharacterEscape :: `c` AsciiLetter</emu-grammar>
         <emu-alg>
-          1. Let _ch_ be the code point matched by |ControlLetter|.
+          1. Let _ch_ be the code point matched by |AsciiLetter|.
           1. Let _i_ be the numeric value of _ch_.
           1. Return the remainder of dividing _i_ by 32.
         </emu-alg>
@@ -47036,7 +47036,6 @@ THH:mm:ss.sss
     <emu-prodref name="AtomEscape"></emu-prodref>
     <emu-prodref name="CharacterEscape"></emu-prodref>
     <emu-prodref name="ControlEscape"></emu-prodref>
-    <emu-prodref name="ControlLetter"></emu-prodref>
     <emu-prodref name="GroupSpecifier"></emu-prodref>
     <emu-prodref name="GroupName"></emu-prodref>
     <emu-prodref name="RegExpIdentifierName"></emu-prodref>
@@ -47192,7 +47191,7 @@ THH:mm:ss.sss
 
         CharacterEscape[UnicodeMode, N] ::
           ControlEscape
-          `c` ControlLetter
+          `c` AsciiLetter
           `0` [lookahead &notin; DecimalDigit]
           HexEscapeSequence
           RegExpUnicodeEscapeSequence[?UnicodeMode]

--- a/spec.html
+++ b/spec.html
@@ -1089,6 +1089,11 @@
       </emu-note>
       <p>In this specification, the phrase "the <dfn id="string-concatenation">string-concatenation</dfn> of _A_, _B_, ..." (where each argument is a String value, a code unit, or a sequence of code units) denotes the String value whose sequence of code units is the concatenation of the code units (in order) of each of the arguments (in order).</p>
       <p>The phrase "the <dfn id="substring">substring</dfn> of _S_ from _inclusiveStart_ to _exclusiveEnd_" (where _S_ is a String value or a sequence of code units and _inclusiveStart_ and _exclusiveEnd_ are integers) denotes the String value consisting of the consecutive code units of _S_ beginning at index _inclusiveStart_ and ending immediately before index _exclusiveEnd_ (which is the empty String when _inclusiveStart_ = _exclusiveEnd_). If the "to" suffix is omitted, the length of _S_ is used as the value of _exclusiveEnd_.</p>
+      <p>
+        The phrase "<dfn id="ASCII-word-characters">ASCII word characters</dfn>" denotes the following String value, which consists solely of every letter and number in the Unicode Basic Latin block along with U+005F (LOW LINE):<br>
+        *"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_"*.<br>
+        For historical reasons, it has significance to various algorithms.
+      </p>
 
       <emu-clause id="sec-stringindexof" type="abstract operation">
         <h1>
@@ -28929,51 +28934,14 @@
           <em>Scheme</em> `:` <em>First</em> `/` <em>Second</em> `;` <em>Third</em> `?` <em>Fourth</em>
         </div>
         <p>where the italicized names represent components and &ldquo;`:`&rdquo;, &ldquo;`/`&rdquo;, &ldquo;`;`&rdquo; and &ldquo;`?`&rdquo; are reserved for use as separators. The `encodeURI` and `decodeURI` functions are intended to work with complete URIs; they assume that any reserved code units in the URI are intended to have special meaning and so are not encoded. The `encodeURIComponent` and `decodeURIComponent` functions are intended to work with the individual component parts of a URI; they assume that any reserved code units represent text and so must be encoded so that they are not interpreted as reserved code units when the component is part of a complete URI.</p>
-        <p>The following lexical grammar specifies the form of encoded URIs.</p>
-        <h2>Syntax</h2>
-        <emu-grammar type="definition">
-          uri :::
-            uriCharacters?
-
-          uriCharacters :::
-            uriCharacter uriCharacters?
-
-          uriCharacter :::
-            uriReserved
-            uriUnescaped
-            uriEscaped
-
-          // emu-format ignore
-          uriReserved ::: one of
-            `;` `/` `?` `:` `@` `&amp;` `=` `+` `$` `,`
-
-          uriUnescaped :::
-            uriAlpha
-            DecimalDigit
-            uriMark
-
-          uriEscaped :::
-            `%` HexDigit HexDigit
-
-          // emu-format ignore
-          uriAlpha ::: one of
-            `a` `b` `c` `d` `e` `f` `g` `h` `i` `j` `k` `l` `m` `n` `o` `p` `q` `r` `s` `t` `u` `v` `w` `x` `y` `z`
-            `A` `B` `C` `D` `E` `F` `G` `H` `I` `J` `K` `L` `M` `N` `O` `P` `Q` `R` `S` `T` `U` `V` `W` `X` `Y` `Z`
-
-          uriMark ::: one of
-            `-` `_` `.` `!` `~` `*` `'` `(` `)`
-        </emu-grammar>
-        <emu-note>
-          <p>The above syntax is based upon RFC 2396 and does not reflect changes introduced by the more recent RFC 3986.</p>
-        </emu-note>
         <h2>Runtime Semantics</h2>
-        <p>When a code unit to be included in a URI is not listed above or is not intended to have the special meaning sometimes given to the reserved code units, that code unit must be encoded. The code unit is transformed into its UTF-8 encoding, with <emu-xref href="#surrogate-pair">surrogate pairs</emu-xref> first converted from UTF-16 to the corresponding code point value. (Note that for code units in the range [0, 127] this results in a single octet with the same value.) The resulting sequence of octets is then transformed into a String with each octet represented by an escape sequence of the form *"%xx"*.</p>
+        <p>When a code unit to be included in a URI must be encoded, it is transformed into its UTF-8 encoding, with <emu-xref href="#surrogate-pair">surrogate pairs</emu-xref> first converted from UTF-16 to the corresponding code point value (note that for code units in the range [0, 127] this results in a single octet with the same value) and the resulting sequence of octets is then transformed into a String with each octet represented by an escape sequence of the form *"%xx"*.</p>
 
         <emu-clause id="sec-encode" type="abstract operation">
           <h1>
             Encode (
               _string_: a String,
-              _unescapedSet_: a String,
+              _extraUnescaped_: a String,
             ): either a normal completion containing a String or a throw completion
           </h1>
           <dl class="header">
@@ -28983,6 +28951,8 @@
           <emu-alg>
             1. Let _strLen_ be the length of _string_.
             1. Let _R_ be the empty String.
+            1. Let _alwaysUnescaped_ be the string-concatenation of ASCII word characters and *"-.!~\*'()"*.
+            1. Let _unescapedSet_ be the string-concatenation of _alwaysUnescaped_ and _extraUnescaped_.
             1. Let _k_ be 0.
             1. Repeat,
               1. If _k_ = _strLen_, return _R_.
@@ -29070,7 +29040,7 @@
         <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _uriString_ be ? ToString(_encodedURI_).
-          1. Let _reservedURISet_ be a String containing one instance of each code unit valid in |uriReserved| plus *"#"*.
+          1. Let _reservedURISet_ be *";/?:@&=+$,#"*.
           1. Return ? Decode(_uriString_, _reservedURISet_).
         </emu-alg>
         <emu-note>
@@ -29097,8 +29067,8 @@
         <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _uriString_ be ? ToString(_uri_).
-          1. Let _unescapedURISet_ be a String containing one instance of each code unit valid in |uriReserved| and |uriUnescaped| plus *"#"*.
-          1. Return ? Encode(_uriString_, _unescapedURISet_).
+          1. Let _extraUnescaped_ be *";/?:@&=+$,#"*.
+          1. Return ? Encode(_uriString_, _extraUnescaped_).
         </emu-alg>
         <emu-note>
           <p>The code point `#` is not encoded to an escape sequence even though it is not a reserved or unescaped URI code point.</p>
@@ -29112,8 +29082,8 @@
         <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _componentString_ be ? ToString(_uriComponent_).
-          1. Let _unescapedURIComponentSet_ be a String containing one instance of each code unit valid in |uriUnescaped|.
-          1. Return ? Encode(_componentString_, _unescapedURIComponentSet_).
+          1. Let _extraUnescaped_ be the empty String.
+          1. Return ? Encode(_componentString_, _extraUnescaped_).
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -36138,8 +36108,7 @@ THH:mm:ss.sss
             <dd>Returns a CharSet containing the characters considered "word characters" for the purposes of `\\b`, `\\B`, `\\w`, and `\\W`</dd>
           </dl>
           <emu-alg>
-            1. Let _basicWordChars_ be the CharSet containing all sixty-three characters in *"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_"*.
-            1. NOTE: This is the letters, numbers, and U+005F (LOW LINE) in the Unicode Basic Latin block.
+            1. Let _basicWordChars_ be the CharSet containing every character in ASCII word characters.
             1. Let _extraWordChars_ be the CharSet containing all characters _c_ such that _c_ is not in _basicWordChars_ but Canonicalize(_rer_, _c_) is in _basicWordChars_.
             1. Assert: _extraWordChars_ is empty unless _rer_.[[Unicode]] and _rer_.[[IgnoreCase]] are both *true*.
             1. Return the union of _basicWordChars_ and _extraWordChars_.
@@ -47493,10 +47462,11 @@ THH:mm:ss.sss
           1. Set _string_ to ? ToString(_string_).
           1. Let _length_ be the length of _string_.
           1. Let _R_ be the empty String.
+          1. Let _unescapedSet_ be the string-concatenation of ASCII word characters and *"@\*+-./"*.
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _length_,
             1. Let _char_ be the code unit (represented as a 16-bit unsigned integer) at index _k_ within _string_.
-            1. If _char_ is one of the code units in *"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789@\*_+-./"*, then
+            1. If _char_ is in _unescapedSet_, then
               1. Let _S_ be the String value containing the single code unit _char_.
             1. Else if _char_ &ge; 256, then
               1. Let _n_ be the numeric value of _char_.

--- a/spec.html
+++ b/spec.html
@@ -47431,7 +47431,7 @@ THH:mm:ss.sss
       <emu-annex id="sec-escape-string">
         <h1>escape ( _string_ )</h1>
         <p>This function is a property of the global object. It computes a new version of a String value in which certain code units have been replaced by a hexadecimal escape sequence.</p>
-        <p>For those code units being replaced whose value is `0x00FF` or less, a two-digit escape sequence of the form <code>%<var>xx</var></code> is used. For those characters being replaced whose code unit value is greater than `0x00FF`, a four-digit escape sequence of the form <code>%u<var>xxxx</var></code> is used.</p>
+        <p>When replacing a code unit of numeric value less than or equal to 0x00FF, a two-digit escape sequence of the form <code>%<var>xx</var></code> is used. When replacing a code unit of numeric value greater than 0x00FF, a four-digit escape sequence of the form <code>%u<var>xxxx</var></code> is used.</p>
         <p>It is the <dfn>%escape%</dfn> intrinsic object.</p>
         <p>It performs the following steps when called:</p>
         <emu-alg>
@@ -47441,20 +47441,19 @@ THH:mm:ss.sss
           1. Let _unescapedSet_ be the string-concatenation of ASCII word characters and *"@\*+-./"*.
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _length_,
-            1. Let _char_ be the code unit (represented as a 16-bit unsigned integer) at index _k_ within _string_.
+            1. Let _char_ be the code unit at index _k_ within _string_.
             1. If _char_ is in _unescapedSet_, then
               1. Let _S_ be the String value containing the single code unit _char_.
-            1. Else if _char_ &ge; 256, then
-              1. Let _n_ be the numeric value of _char_.
-              1. Let _S_ be the string-concatenation of:
-                * *"%u"*
-                * the String representation of _n_, formatted as a four-digit uppercase hexadecimal number, padded to the left with zeroes if necessary
             1. Else,
-              1. Assert: _char_ &lt; 256.
               1. Let _n_ be the numeric value of _char_.
-              1. Let _S_ be the string-concatenation of:
-                * *"%"*
-                * the String representation of _n_, formatted as a two-digit uppercase hexadecimal number, padded to the left with a zero if necessary
+              1. If _n_ &lt; 256, then
+                1. Let _S_ be the string-concatenation of:
+                  * *"%"*
+                  * the String representation of _n_, formatted as a two-digit uppercase hexadecimal number, padded to the left with a zero if necessary
+              1. Else,
+                1. Let _S_ be the string-concatenation of:
+                  * *"%u"*
+                  * the String representation of _n_, formatted as a four-digit uppercase hexadecimal number, padded to the left with zeroes if necessary
             1. Set _R_ to the string-concatenation of _R_ and _S_.
             1. Set _k_ to _k_ + 1.
           1. Return _R_.

--- a/spec.html
+++ b/spec.html
@@ -28922,20 +28922,16 @@
 
     <emu-clause id="sec-uri-handling-functions">
       <h1>URI Handling Functions</h1>
-      <p>Uniform Resource Identifiers, or URIs, are Strings that identify resources (e.g. web pages or files) and transport protocols by which to access them (e.g. HTTP or FTP) on the Internet. The ECMAScript language itself does not provide any support for using URIs except for functions that encode and decode URIs as described in <emu-xref href="#sec-decodeuri-encodeduri"></emu-xref>, <emu-xref href="#sec-decodeuricomponent-encodeduricomponent"></emu-xref>, <emu-xref href="#sec-encodeuri-uri"></emu-xref> and <emu-xref href="#sec-encodeuricomponent-uricomponent"></emu-xref></p>
+      <p>Uniform Resource Identifiers, or URIs, are Strings that identify resources (e.g. web pages or files) and transport protocols by which to access them (e.g. HTTP or FTP) on the Internet. The ECMAScript language itself does not provide any support for using URIs except for functions that encode and decode URIs as described in this section. `encodeURI` and `decodeURI` are intended to work with complete URIs; they assume that any reserved characters are intended to have special meaning (e.g., as delimiters) and so are not encoded. `encodeURIComponent` and `decodeURIComponent` are intended to work with the individual components of a URI; they assume that any reserved characters represent text and must be encoded to avoid special meaning when the component is part of a complete URI.</p>
+      <emu-note>
+        <p>The set of reserved characters is based upon RFC 2396 and does not reflect changes introduced by the more recent RFC 3986.</p>
+      </emu-note>
       <emu-note>
         <p>Many implementations of ECMAScript provide additional functions and methods that manipulate web pages; these functions are beyond the scope of this standard.</p>
       </emu-note>
 
       <emu-clause id="sec-uri-syntax-and-semantics">
         <h1>URI Syntax and Semantics</h1>
-        <p>A URI is composed of a sequence of components separated by component separators. The general form is:</p>
-        <div class="rhs">
-          <em>Scheme</em> `:` <em>First</em> `/` <em>Second</em> `;` <em>Third</em> `?` <em>Fourth</em>
-        </div>
-        <p>where the italicized names represent components and &ldquo;`:`&rdquo;, &ldquo;`/`&rdquo;, &ldquo;`;`&rdquo; and &ldquo;`?`&rdquo; are reserved for use as separators. The `encodeURI` and `decodeURI` functions are intended to work with complete URIs; they assume that any reserved code units in the URI are intended to have special meaning and so are not encoded. The `encodeURIComponent` and `decodeURIComponent` functions are intended to work with the individual component parts of a URI; they assume that any reserved code units represent text and so must be encoded so that they are not interpreted as reserved code units when the component is part of a complete URI.</p>
-        <h2>Runtime Semantics</h2>
-        <p>When a code unit to be included in a URI must be encoded, it is transformed into its UTF-8 encoding, with <emu-xref href="#surrogate-pair">surrogate pairs</emu-xref> first converted from UTF-16 to the corresponding code point value (note that for code units in the range [0, 127] this results in a single octet with the same value) and the resulting sequence of octets is then transformed into a String with each octet represented by an escape sequence of the form *"%xx"*.</p>
 
         <emu-clause id="sec-encode" type="abstract operation">
           <h1>
@@ -28946,7 +28942,7 @@
           </h1>
           <dl class="header">
             <dt>description</dt>
-            <dd>It performs URI encoding and escaping.</dd>
+            <dd>It performs URI encoding and escaping, interpreting _string_ as a sequence of UTF-16 encoded code points as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>. If a character is identified as unreserved in RFC 2396 or appears in _extraUnescaped_, it is not escaped.</dd>
           </dl>
           <emu-alg>
             1. Let _strLen_ be the length of _string_.
@@ -28971,18 +28967,21 @@
                     * *"%"*
                     * the String representation of _octet_, formatted as a two-digit uppercase hexadecimal number, padded to the left with a zero if necessary
           </emu-alg>
+          <emu-note>
+            <p>Because percent-encoding is used to represent individual octets, a single code point may be expressed as multiple consecutive escape sequences (one for each of its 8-bit UTF-8 code units).</p>
+          </emu-note>
         </emu-clause>
 
         <emu-clause id="sec-decode" type="abstract operation">
           <h1>
             Decode (
               _string_: a String,
-              _reservedSet_: a String,
+              _preserveEscapeSet_: a String,
             ): either a normal completion containing a String or a throw completion
           </h1>
           <dl class="header">
             <dt>description</dt>
-            <dd>It performs URI unescaping and decoding.</dd>
+            <dd>It performs URI unescaping and decoding, preserving any escape sequences that correspond to Basic Latin characters in _preserveEscapeSet_.</dd>
           </dl>
           <emu-alg>
             1. Let _strLen_ be the length of _string_.
@@ -29002,7 +29001,7 @@
                 1. Let _n_ be the number of leading 1 bits in _B_.
                 1. If _n_ = 0, then
                   1. Let _C_ be the code unit whose value is _B_.
-                  1. If _C_ is not in _reservedSet_, then
+                  1. If _C_ is not in _preserveEscapeSet_, then
                     1. Let _S_ be the String value containing only the code unit _C_.
                   1. Else,
                     1. Let _S_ be the substring of _string_ from _start_ to _k_ + 1.
@@ -29027,42 +29026,38 @@
               1. Set _k_ to _k_ + 1.
           </emu-alg>
           <emu-note>
-            <p>This syntax of Uniform Resource Identifiers is based upon RFC 2396 and does not reflect the more recent RFC 3986 which replaces RFC 2396. A formal description and implementation of UTF-8 is given in RFC 3629.</p>
-            <p>RFC 3629 prohibits the decoding of invalid UTF-8 octet sequences. For example, the invalid sequence C0 80 must not decode into the code unit 0x0000. Implementations of the Decode algorithm are required to throw a *URIError* when encountering such invalid sequences.</p>
+            <p>RFC 3629 prohibits the decoding of invalid UTF-8 octet sequences. For example, the invalid sequence 0xC0 0x80 must not decode into the code unit 0x0000. Implementations of the Decode algorithm are required to throw a *URIError* when encountering such invalid sequences.</p>
           </emu-note>
         </emu-clause>
       </emu-clause>
 
       <emu-clause id="sec-decodeuri-encodeduri">
         <h1>decodeURI ( _encodedURI_ )</h1>
-        <p>This function computes a new version of a URI in which each escape sequence and UTF-8 encoding of the sort that might be introduced by the `encodeURI` function is replaced with the UTF-16 encoding of the code points that it represents. Escape sequences that could not have been introduced by `encodeURI` are not replaced.</p>
+        <p>This function computes a new version of a URI in which each escape sequence and UTF-8 encoding of the sort that might be introduced by the `encodeURI` function is replaced with the UTF-16 encoding of the code point that it represents. Escape sequences that could not have been introduced by `encodeURI` are not replaced.</p>
         <p>It is the <dfn>%decodeURI%</dfn> intrinsic object.</p>
         <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _uriString_ be ? ToString(_encodedURI_).
-          1. Let _reservedURISet_ be *";/?:@&=+$,#"*.
-          1. Return ? Decode(_uriString_, _reservedURISet_).
+          1. Let _preserveEscapeSet_ be *";/?:@&=+$,#"*.
+          1. Return ? Decode(_uriString_, _preserveEscapeSet_).
         </emu-alg>
-        <emu-note>
-          <p>The code point `#` is not decoded from escape sequences even though it is not a reserved URI code point.</p>
-        </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-decodeuricomponent-encodeduricomponent">
         <h1>decodeURIComponent ( _encodedURIComponent_ )</h1>
-        <p>This function computes a new version of a URI in which each escape sequence and UTF-8 encoding of the sort that might be introduced by the `encodeURIComponent` function is replaced with the UTF-16 encoding of the code points that it represents.</p>
+        <p>This function computes a new version of a URI in which each escape sequence and UTF-8 encoding of the sort that might be introduced by the `encodeURIComponent` function is replaced with the UTF-16 encoding of the code point that it represents.</p>
         <p>It is the <dfn>%decodeURIComponent%</dfn> intrinsic object.</p>
         <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _componentString_ be ? ToString(_encodedURIComponent_).
-          1. Let _reservedURIComponentSet_ be the empty String.
-          1. Return ? Decode(_componentString_, _reservedURIComponentSet_).
+          1. Let _preserveEscapeSet_ be the empty String.
+          1. Return ? Decode(_componentString_, _preserveEscapeSet_).
         </emu-alg>
       </emu-clause>
 
       <emu-clause id="sec-encodeuri-uri">
         <h1>encodeURI ( _uri_ )</h1>
-        <p>This function computes a new version of a UTF-16 encoded (<emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>) URI in which each instance of certain code points is replaced by one, two, three, or four escape sequences representing the UTF-8 encoding of the code points.</p>
+        <p>This function computes a new version of a UTF-16 encoded (<emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>) URI in which each instance of certain code points is replaced by one, two, three, or four escape sequences representing the UTF-8 encoding of the code point.</p>
         <p>It is the <dfn>%encodeURI%</dfn> intrinsic object.</p>
         <p>It performs the following steps when called:</p>
         <emu-alg>
@@ -29070,9 +29065,6 @@
           1. Let _extraUnescaped_ be *";/?:@&=+$,#"*.
           1. Return ? Encode(_uriString_, _extraUnescaped_).
         </emu-alg>
-        <emu-note>
-          <p>The code point `#` is not encoded to an escape sequence even though it is not a reserved or unescaped URI code point.</p>
-        </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-encodeuricomponent-uricomponent">


### PR DESCRIPTION
Fixes #2570

* Introduce a definition for ASCII word characters
* Refer to Unicode Basic Latin as "block" rather than "range"
* Refactor URI Handling Functions for clarity
* Refactor `escape` for clarity
* Replace |ControlLetter| with |AsciiLetter|