### PR TITLE
Normative: Set [[SourceText]] on classes before static blocks evaluate

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -9352,9 +9352,8 @@
       </emu-alg>
       <emu-grammar>ClassExpression : `class` ClassTail</emu-grammar>
       <emu-alg>
-        1. Let _value_ be ? ClassDefinitionEvaluation of |ClassTail| with arguments *undefined* and _name_.
-        1. Set _value_.[[SourceText]] to the source text matched by |ClassExpression|.
-        1. Return _value_.
+        1. Let _sourceText_ be the source text matched by |ClassExpression|.
+        1. Return ? ClassDefinitionEvaluation of |ClassTail| with arguments *undefined*, _name_, and _sourceText_.
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -25056,6 +25055,7 @@
         Runtime Semantics: ClassDefinitionEvaluation (
           _classBinding_: a String or *undefined*,
           _className_: a property key or a Private Name,
+          _sourceText_: ECMAScript source text,
         ): either a normal completion containing a function object or an abrupt completion
       </h1>
       <dl class="header">
@@ -25124,6 +25124,7 @@
           1. Let _F_ be _constructorInfo_.[[Closure]].
           1. Perform MakeClassConstructor(_F_).
           1. Perform SetFunctionName(_F_, _className_).
+        1. Set _F_.[[SourceText]] to _sourceText_.
         1. Perform MakeConstructor(_F_, *false*, _proto_).
         1. If |ClassHeritage| is present, set _F_.[[ConstructorKind]] to ~derived~.
         1. Perform ! DefineMethodProperty(_proto_, *"constructor"*, _F_, *false*).
@@ -25189,17 +25190,16 @@
       <emu-grammar>ClassDeclaration : `class` BindingIdentifier ClassTail</emu-grammar>
       <emu-alg>
         1. Let _className_ be the StringValue of |BindingIdentifier|.
-        1. Let _value_ be ? ClassDefinitionEvaluation of |ClassTail| with arguments _className_ and _className_.
-        1. Set _value_.[[SourceText]] to the source text matched by |ClassDeclaration|.
+        1. Let _sourceText_ be the source text matched by |ClassDeclaration|.
+        1. Let _value_ be ? ClassDefinitionEvaluation of |ClassTail| with arguments _className_, _className_, and _sourceText_.
         1. Let _env_ be the running execution context's LexicalEnvironment.
         1. Perform ? InitializeBoundName(_className_, _value_, _env_).
         1. Return _value_.
       </emu-alg>
       <emu-grammar>ClassDeclaration : `class` ClassTail</emu-grammar>
       <emu-alg>
-        1. Let _value_ be ? ClassDefinitionEvaluation of |ClassTail| with arguments *undefined* and *"default"*.
-        1. Set _value_.[[SourceText]] to the source text matched by |ClassDeclaration|.
-        1. Return _value_.
+        1. Let _sourceText_ be the source text matched by |ClassDeclaration|.
+        1. Return ? ClassDefinitionEvaluation of |ClassTail| with arguments *undefined*, *"default"*, and _sourceText_.
       </emu-alg>
       <emu-note>
         <p><emu-grammar>ClassDeclaration : `class` ClassTail</emu-grammar> only occurs as part of an |ExportDeclaration| and establishing its binding is handled as part of the evaluation action for that production. See <emu-xref href="#sec-exports-runtime-semantics-evaluation"></emu-xref>.</p>
@@ -25218,16 +25218,14 @@
       </emu-note>
       <emu-grammar>ClassExpression : `class` ClassTail</emu-grammar>
       <emu-alg>
-        1. Let _value_ be ? ClassDefinitionEvaluation of |ClassTail| with arguments *undefined* and *""*.
-        1. Set _value_.[[SourceText]] to the source text matched by |ClassExpression|.
-        1. Return _value_.
+        1. Let _sourceText_ be the source text matched by |ClassExpression|.
+        1. Return ? ClassDefinitionEvaluation of |ClassTail| with arguments *undefined*, *""*, and _sourceText_.
       </emu-alg>
       <emu-grammar>ClassExpression : `class` BindingIdentifier ClassTail</emu-grammar>
       <emu-alg>
         1. Let _className_ be the StringValue of |BindingIdentifier|.
-        1. Let _value_ be ? ClassDefinitionEvaluation of |ClassTail| with arguments _className_ and _className_.
-        1. Set _value_.[[SourceText]] to the source text matched by |ClassExpression|.
-        1. Return _value_.
+        1. Let _sourceText_ be the source text matched by |ClassExpression|.
+        1. Return ? ClassDefinitionEvaluation of |ClassTail| with arguments _className_, _className_, and _sourceText_.
       </emu-alg>
       <emu-grammar>ClassElementName : PrivateIdentifier</emu-grammar>
       <emu-alg>


### PR DESCRIPTION
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->

Test case: `class Foo { static { this.toString() } }`

This will require the `[[SourceText]]` of `Foo` to be set.