### PR TITLE
Editorial: GetValue and PutValue do not need to unwrap Completion Records

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -22100,7 +22100,7 @@
             1. Set the running execution context's LexicalEnvironment to _newEnv_.
           1. Let _exprRef_ be Completion(Evaluation of _expr_).
           1. Set the running execution context's LexicalEnvironment to _oldEnv_.
-          1. Let _exprValue_ be ? GetValue(_exprRef_).
+          1. Let _exprValue_ be ? GetValue(? _exprRef_).
           1. If _iterationKind_ is ~enumerate~, then
             1. If _exprValue_ is *undefined* or *null*, then
               1. Return Completion Record { [[Type]]: ~break~, [[Value]]: ~empty~, [[Target]]: ~empty~ }.
@@ -24831,7 +24831,7 @@
           1. NOTE: The running execution context's PrivateEnvironment is _outerPrivateEnvironment_ when evaluating |ClassHeritage|.
           1. Let _superclassRef_ be Completion(Evaluation of |ClassHeritage|).
           1. Set the running execution context's LexicalEnvironment to _env_.
-          1. Let _superclass_ be ? GetValue(_superclassRef_).
+          1. Let _superclass_ be ? GetValue(? _superclassRef_).
           1. If _superclass_ is *null*, then
             1. Let _protoParent_ be *null*.
             1. Let _constructorParent_ be %Function.prototype%.

--- a/spec.html
+++ b/spec.html
@@ -4218,13 +4218,12 @@
       <emu-clause id="sec-getvalue" type="abstract operation">
         <h1>
           GetValue (
-            _V_: unknown,
+            _V_: a Reference Record or an ECMAScript language value,
           ): either a normal completion containing an ECMAScript language value or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
         <emu-alg>
-          1. ReturnIfAbrupt(_V_).
           1. If _V_ is not a Reference Record, return _V_.
           1. If IsUnresolvableReference(_V_) is *true*, throw a *ReferenceError* exception.
           1. If IsPropertyReference(_V_) is *true*, then
@@ -4245,15 +4244,13 @@
       <emu-clause id="sec-putvalue" type="abstract operation">
         <h1>
           PutValue (
-            _V_: unknown,
-            _W_: unknown,
+            _V_: a Reference Record or an ECMAScript language value,
+            _W_: an ECMAScript language value,
           ): either a normal completion containing ~unused~ or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
         <emu-alg>
-          1. ReturnIfAbrupt(_V_).
-          1. ReturnIfAbrupt(_W_).
           1. If _V_ is not a Reference Record, throw a *ReferenceError* exception.
           1. If IsUnresolvableReference(_V_) is *true*, then
             1. If _V_.[[Strict]] is *true*, throw a *ReferenceError* exception.
@@ -4294,16 +4291,13 @@
       <emu-clause id="sec-initializereferencedbinding" type="abstract operation">
         <h1>
           InitializeReferencedBinding (
-            _V_: unknown,
-            _W_: unknown,
+            _V_: a Reference Record,
+            _W_: an ECMAScript language value,
           ): either a normal completion containing ~unused~ or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
         <emu-alg>
-          1. ReturnIfAbrupt(_V_).
-          1. ReturnIfAbrupt(_W_).
-          1. Assert: _V_ is a Reference Record.
           1. Assert: IsUnresolvableReference(_V_) is *false*.
           1. Let _base_ be _V_.[[Base]].
           1. Assert: _base_ is an Environment Record.

--- a/spec.html
+++ b/spec.html
@@ -21244,8 +21244,8 @@
         </emu-alg>
         <emu-grammar>LexicalBinding : BindingIdentifier</emu-grammar>
         <emu-alg>
-          1. Let _lhs_ be Completion(ResolveBinding(StringValue of |BindingIdentifier|)).
-          1. Perform ? InitializeReferencedBinding(_lhs_, *undefined*).
+          1. Let _lhs_ be ! ResolveBinding(StringValue of |BindingIdentifier|).
+          1. Perform ! InitializeReferencedBinding(_lhs_, *undefined*).
           1. Return ~empty~.
         </emu-alg>
         <emu-note>
@@ -21254,13 +21254,13 @@
         <emu-grammar>LexicalBinding : BindingIdentifier Initializer</emu-grammar>
         <emu-alg>
           1. Let _bindingId_ be StringValue of |BindingIdentifier|.
-          1. Let _lhs_ be Completion(ResolveBinding(_bindingId_)).
+          1. Let _lhs_ be ! ResolveBinding(_bindingId_).
           1. If IsAnonymousFunctionDefinition(|Initializer|) is *true*, then
             1. Let _value_ be ? NamedEvaluation of |Initializer| with argument _bindingId_.
           1. Else,
             1. Let _rhs_ be ? Evaluation of |Initializer|.
             1. Let _value_ be ? GetValue(_rhs_).
-          1. Perform ? InitializeReferencedBinding(_lhs_, _value_).
+          1. Perform ! InitializeReferencedBinding(_lhs_, _value_).
           1. Return ~empty~.
         </emu-alg>
         <emu-grammar>LexicalBinding : BindingPattern Initializer</emu-grammar>


### PR DESCRIPTION
https://github.com/tc39/ecma262/pull/2744 removed almost every case where GetValue or PutValue was passed a completion record, instead explicitly unwrapping on the previous line or lines. This removes the final three cases and then updates the definitions of those algorithms so that they do not need to handle being passed Completion Records.