### PR TITLE
Editorial: Revert unintentional normative change for String.prototype.substr

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -47505,10 +47505,10 @@ THH:mm:ss.sss
           1. Let _intStart_ be ? ToIntegerOrInfinity(_start_).
           1. If _intStart_ is -&infin;, set _intStart_ to 0.
           1. Else if _intStart_ &lt; 0, set _intStart_ to max(_size_ + _intStart_, 0).
+          1. Else, set _intStart_ to min(_intStart_, _size_).
           1. If _length_ is *undefined*, let _intLength_ be _size_; otherwise let _intLength_ be ? ToIntegerOrInfinity(_length_).
-          1. If _intStart_ is +&infin;, _intLength_ &le; 0, or _intLength_ is +&infin;, return the empty String.
+          1. Set _intLength_ to the result of clamping _intLength_ between 0 and _size_.
           1. Let _intEnd_ be min(_intStart_ + _intLength_, _size_).
-          1. If _intStart_ &ge; _intEnd_, return the empty String.
           1. Return the substring of _S_ from _intStart_ to _intEnd_.
         </emu-alg>
         <emu-note>


### PR DESCRIPTION
`"a".substr(0, Infinity)` should return `"a"`, but #2007 incorrectly changed the result to be `""`.

If we change `substr`'s algorithm to be more similar to `String.prototype.substring` and `String.prototype.slice`, we can easily fix this issue:

1. `min(intStart, size)` guarantees that `intStart` is now in `[0, size]`.
2. Clamping `intLength` guarantees it's also in `[0, size]`.

With these two changes, `intEnd = min(intStart + intLength, size)` is now in range `[intStart, size]`, so we no longer have to check for `intStart ≥ intEnd`, but instead can directly perform the `substring` operation.

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
