### PR TITLE
Editorial: Relocate some RegExp-related operations

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -35915,6 +35915,24 @@ THH:mm:ss.sss
           </emu-alg>
         </emu-clause>
 
+        <emu-clause id="sec-wordcharacters" type="abstract operation" oldids="sec-runtime-semantics-wordcharacters-abstract-operation">
+          <h1>
+            WordCharacters (
+              _rer_: a RegExp Record,
+            ): a CharSet
+          </h1>
+          <dl class="header">
+            <dt>description</dt>
+            <dd>Returns a CharSet containing the characters considered "word characters" for the purposes of `\\b`, `\\B`, `\\w`, and `\\W`</dd>
+          </dl>
+          <emu-alg>
+            1. Let _basicWordChars_ be the CharSet containing every character in the ASCII word characters.
+            1. Let _extraWordChars_ be the CharSet containing all characters _c_ such that _c_ is not in _basicWordChars_ but Canonicalize(_rer_, _c_) is in _basicWordChars_.
+            1. Assert: _extraWordChars_ is empty unless _rer_.[[Unicode]] and _rer_.[[IgnoreCase]] are both *true*.
+            1. Return the union of _basicWordChars_ and _extraWordChars_.
+          </emu-alg>
+        </emu-clause>
+
         <emu-clause id="sec-runtime-semantics-unicodematchproperty-p" type="abstract operation">
           <h1>
             UnicodeMatchProperty (
@@ -35968,6 +35986,98 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
+    <emu-clause id="sec-abstract-operations-for-regexp-creation" oldids="sec-abstract-operations-for-the-regexp-constructor">
+      <h1>Abstract Operations for RegExp Creation</h1>
+
+      <emu-clause id="sec-regexpcreate" type="abstract operation">
+        <h1>
+          RegExpCreate (
+            _P_: an ECMAScript language value,
+            _F_: a String or *undefined*,
+          ): either a normal completion containing an Object or a throw completion
+        </h1>
+        <dl class="header">
+        </dl>
+        <emu-alg>
+          1. Let _obj_ be ! RegExpAlloc(%RegExp%).
+          1. Return ? RegExpInitialize(_obj_, _P_, _F_).
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-regexpalloc" type="abstract operation">
+        <h1>
+          RegExpAlloc (
+            _newTarget_: a constructor,
+          ): either a normal completion containing an Object or a throw completion
+        </h1>
+        <dl class="header">
+        </dl>
+        <emu-alg>
+          1. Let _obj_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%RegExp.prototype%"*, &laquo; [[OriginalSource]], [[OriginalFlags]], [[RegExpRecord]], [[RegExpMatcher]] &raquo;).
+          1. Perform ! DefinePropertyOrThrow(_obj_, *"lastIndex"*, PropertyDescriptor { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
+          1. Return _obj_.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-regexpinitialize" type="abstract operation">
+        <h1>
+          RegExpInitialize (
+            _obj_: an Object,
+            _pattern_: an ECMAScript language value,
+            _flags_: an ECMAScript language value,
+          ): either a normal completion containing an Object or a throw completion
+        </h1>
+        <dl class="header">
+        </dl>
+        <emu-alg>
+          1. If _pattern_ is *undefined*, let _P_ be the empty String.
+          1. Else, let _P_ be ? ToString(_pattern_).
+          1. If _flags_ is *undefined*, let _F_ be the empty String.
+          1. Else, let _F_ be ? ToString(_flags_).
+          1. If _F_ contains any code unit other than *"d"*, *"g"*, *"i"*, *"m"*, *"s"*, *"u"*, or *"y"* or if it contains the same code unit more than once, throw a *SyntaxError* exception.
+          1. If _F_ contains *"i"*, let _i_ be *true*; else let _i_ be *false*.
+          1. If _F_ contains *"m"*, let _m_ be *true*; else let _m_ be *false*.
+          1. If _F_ contains *"s"*, let _s_ be *true*; else let _s_ be *false*.
+          1. If _F_ contains *"u"*, let _u_ be *true*; else let _u_ be *false*.
+          1. If _u_ is *true*, then
+            1. Let _patternText_ be StringToCodePoints(_P_).
+          1. Else,
+            1. Let _patternText_ be the result of interpreting each of _P_'s 16-bit elements as a Unicode BMP code point. UTF-16 decoding is not applied to the elements.
+          1. Let _parseResult_ be ParsePattern(_patternText_, _u_).
+          1. If _parseResult_ is a non-empty List of *SyntaxError* objects, throw a *SyntaxError* exception.
+          1. Assert: _parseResult_ is a |Pattern| Parse Node.
+          1. Set _obj_.[[OriginalSource]] to _P_.
+          1. Set _obj_.[[OriginalFlags]] to _F_.
+          1. Let _capturingGroupsCount_ be CountLeftCapturingParensWithin(_parseResult_).
+          1. Let _rer_ be the RegExp Record { [[IgnoreCase]]: _i_, [[Multiline]]: _m_, [[DotAll]]: _s_, [[Unicode]]: _u_, [[CapturingGroupsCount]]: _capturingGroupsCount_ }.
+          1. Set _obj_.[[RegExpRecord]] to _rer_.
+          1. Set _obj_.[[RegExpMatcher]] to CompilePattern of _parseResult_ with argument _rer_.
+          1. Perform ? Set(_obj_, *"lastIndex"*, *+0*<sub>𝔽</sub>, *true*).
+          1. Return _obj_.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-parsepattern" type="abstract operation">
+        <h1>
+          Static Semantics: ParsePattern (
+            _patternText_: a sequence of Unicode code points,
+            _u_: a Boolean,
+          ): a Parse Node or a non-empty List of *SyntaxError* objects
+        </h1>
+        <dl class="header">
+        </dl>
+        <emu-alg>
+          1. If _u_ is *true*, then
+            1. Let _parseResult_ be ParseText(_patternText_, |Pattern[+UnicodeMode, +N]|).
+          1. Else,
+            1. Let _parseResult_ be ParseText(_patternText_, |Pattern[~UnicodeMode, ~N]|).
+            1. If _parseResult_ is a Parse Node and _parseResult_ contains a |GroupName|, then
+              1. Set _parseResult_ to ParseText(_patternText_, |Pattern[~UnicodeMode, +N]|).
+          1. Return _parseResult_.
+        </emu-alg>
+      </emu-clause>
+    </emu-clause>
+
     <emu-clause id="sec-regexp-constructor">
       <h1>The RegExp Constructor</h1>
       <p>The RegExp constructor:</p>
@@ -36007,132 +36117,6 @@ THH:mm:ss.sss
         <emu-note>
           <p>If pattern is supplied using a |StringLiteral|, the usual escape sequence substitutions are performed before the String is processed by this function. If pattern must contain an escape sequence to be recognized by this function, any U+005C (REVERSE SOLIDUS) code points must be escaped within the |StringLiteral| to prevent them being removed when the contents of the |StringLiteral| are formed.</p>
         </emu-note>
-      </emu-clause>
-
-      <emu-clause id="sec-abstract-operations-for-the-regexp-constructor">
-        <h1>Abstract Operations for the RegExp Constructor</h1>
-
-        <emu-clause id="sec-regexpalloc" type="abstract operation">
-          <h1>
-            RegExpAlloc (
-              _newTarget_: a constructor,
-            ): either a normal completion containing an Object or a throw completion
-          </h1>
-          <dl class="header">
-          </dl>
-          <emu-alg>
-            1. Let _obj_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%RegExp.prototype%"*, &laquo; [[OriginalSource]], [[OriginalFlags]], [[RegExpRecord]], [[RegExpMatcher]] &raquo;).
-            1. Perform ! DefinePropertyOrThrow(_obj_, *"lastIndex"*, PropertyDescriptor { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
-            1. Return _obj_.
-          </emu-alg>
-        </emu-clause>
-
-        <emu-clause id="sec-regexpinitialize" type="abstract operation">
-          <h1>
-            RegExpInitialize (
-              _obj_: an Object,
-              _pattern_: an ECMAScript language value,
-              _flags_: an ECMAScript language value,
-            ): either a normal completion containing an Object or a throw completion
-          </h1>
-          <dl class="header">
-          </dl>
-          <emu-alg>
-            1. If _pattern_ is *undefined*, let _P_ be the empty String.
-            1. Else, let _P_ be ? ToString(_pattern_).
-            1. If _flags_ is *undefined*, let _F_ be the empty String.
-            1. Else, let _F_ be ? ToString(_flags_).
-            1. If _F_ contains any code unit other than *"d"*, *"g"*, *"i"*, *"m"*, *"s"*, *"u"*, or *"y"* or if it contains the same code unit more than once, throw a *SyntaxError* exception.
-            1. If _F_ contains *"i"*, let _i_ be *true*; else let _i_ be *false*.
-            1. If _F_ contains *"m"*, let _m_ be *true*; else let _m_ be *false*.
-            1. If _F_ contains *"s"*, let _s_ be *true*; else let _s_ be *false*.
-            1. If _F_ contains *"u"*, let _u_ be *true*; else let _u_ be *false*.
-            1. If _u_ is *true*, then
-              1. Let _patternText_ be StringToCodePoints(_P_).
-            1. Else,
-              1. Let _patternText_ be the result of interpreting each of _P_'s 16-bit elements as a Unicode BMP code point. UTF-16 decoding is not applied to the elements.
-            1. Let _parseResult_ be ParsePattern(_patternText_, _u_).
-            1. If _parseResult_ is a non-empty List of *SyntaxError* objects, throw a *SyntaxError* exception.
-            1. Assert: _parseResult_ is a |Pattern| Parse Node.
-            1. Set _obj_.[[OriginalSource]] to _P_.
-            1. Set _obj_.[[OriginalFlags]] to _F_.
-            1. Let _capturingGroupsCount_ be CountLeftCapturingParensWithin(_parseResult_).
-            1. Let _rer_ be the RegExp Record { [[IgnoreCase]]: _i_, [[Multiline]]: _m_, [[DotAll]]: _s_, [[Unicode]]: _u_, [[CapturingGroupsCount]]: _capturingGroupsCount_ }.
-            1. Set _obj_.[[RegExpRecord]] to _rer_.
-            1. Set _obj_.[[RegExpMatcher]] to CompilePattern of _parseResult_ with argument _rer_.
-            1. Perform ? Set(_obj_, *"lastIndex"*, *+0*<sub>𝔽</sub>, *true*).
-            1. Return _obj_.
-          </emu-alg>
-        </emu-clause>
-
-        <emu-clause id="sec-parsepattern" type="abstract operation">
-          <h1>
-            Static Semantics: ParsePattern (
-              _patternText_: a sequence of Unicode code points,
-              _u_: a Boolean,
-            ): a Parse Node or a non-empty List of *SyntaxError* objects
-          </h1>
-          <dl class="header">
-          </dl>
-          <emu-alg>
-            1. If _u_ is *true*, then
-              1. Let _parseResult_ be ParseText(_patternText_, |Pattern[+UnicodeMode, +N]|).
-            1. Else,
-              1. Let _parseResult_ be ParseText(_patternText_, |Pattern[~UnicodeMode, ~N]|).
-              1. If _parseResult_ is a Parse Node and _parseResult_ contains a |GroupName|, then
-                1. Set _parseResult_ to ParseText(_patternText_, |Pattern[~UnicodeMode, +N]|).
-            1. Return _parseResult_.
-          </emu-alg>
-        </emu-clause>
-
-        <emu-clause id="sec-wordcharacters" type="abstract operation" oldids="sec-runtime-semantics-wordcharacters-abstract-operation">
-          <h1>
-            WordCharacters (
-              _rer_: a RegExp Record,
-            ): a CharSet
-          </h1>
-          <dl class="header">
-            <dt>description</dt>
-            <dd>Returns a CharSet containing the characters considered "word characters" for the purposes of `\\b`, `\\B`, `\\w`, and `\\W`</dd>
-          </dl>
-          <emu-alg>
-            1. Let _basicWordChars_ be the CharSet containing every character in the ASCII word characters.
-            1. Let _extraWordChars_ be the CharSet containing all characters _c_ such that _c_ is not in _basicWordChars_ but Canonicalize(_rer_, _c_) is in _basicWordChars_.
-            1. Assert: _extraWordChars_ is empty unless _rer_.[[Unicode]] and _rer_.[[IgnoreCase]] are both *true*.
-            1. Return the union of _basicWordChars_ and _extraWordChars_.
-          </emu-alg>
-        </emu-clause>
-
-        <emu-clause id="sec-regexpcreate" type="abstract operation">
-          <h1>
-            RegExpCreate (
-              _P_: an ECMAScript language value,
-              _F_: a String or *undefined*,
-            ): either a normal completion containing an Object or a throw completion
-          </h1>
-          <dl class="header">
-          </dl>
-          <emu-alg>
-            1. Let _obj_ be ! RegExpAlloc(%RegExp%).
-            1. Return ? RegExpInitialize(_obj_, _P_, _F_).
-          </emu-alg>
-        </emu-clause>
-
-        <emu-clause id="sec-escaperegexppattern" type="abstract operation">
-          <h1>
-            EscapeRegExpPattern (
-              _P_: a String,
-              _F_: a String,
-            ): a String
-          </h1>
-          <dl class="header">
-          </dl>
-          <emu-alg>
-            1. Let _S_ be a String in the form of a |Pattern[~UnicodeMode]| (|Pattern[+UnicodeMode]| if _F_ contains *"u"*) equivalent to _P_ interpreted as UTF-16 encoded Unicode code points (<emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>), in which certain code points are escaped as described below. _S_ may or may not be identical to _P_; however, the Abstract Closure that would result from evaluating _S_ as a |Pattern[~UnicodeMode]| (|Pattern[+UnicodeMode]| if _F_ contains *"u"*) must behave identically to the Abstract Closure given by the constructed object's [[RegExpMatcher]] internal slot. Multiple calls to this abstract operation using the same values for _P_ and _F_ must produce identical results.
-            1. The code points `/` or any |LineTerminator| occurring in the pattern shall be escaped in _S_ as necessary to ensure that the string-concatenation of *"/"*, _S_, *"/"*, and _F_ can be parsed (in an appropriate lexical context) as a |RegularExpressionLiteral| that behaves identically to the constructed regular expression. For example, if _P_ is *"/"*, then _S_ could be *"\\/"* or *"\\u002F"*, among other possibilities, but not *"/"*, because `///` followed by _F_ would be parsed as a |SingleLineComment| rather than a |RegularExpressionLiteral|. If _P_ is the empty String, this specification can be met by letting _S_ be *"(?:)"*.
-            1. Return _S_.
-          </emu-alg>
-        </emu-clause>
       </emu-clause>
     </emu-clause>
 
@@ -36702,6 +36686,22 @@ THH:mm:ss.sss
           1. Let _flags_ be _R_.[[OriginalFlags]].
           1. Return EscapeRegExpPattern(_src_, _flags_).
         </emu-alg>
+
+        <emu-clause id="sec-escaperegexppattern" type="abstract operation">
+          <h1>
+            EscapeRegExpPattern (
+              _P_: a String,
+              _F_: a String,
+            ): a String
+          </h1>
+          <dl class="header">
+          </dl>
+          <emu-alg>
+            1. Let _S_ be a String in the form of a |Pattern[~UnicodeMode]| (|Pattern[+UnicodeMode]| if _F_ contains *"u"*) equivalent to _P_ interpreted as UTF-16 encoded Unicode code points (<emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>), in which certain code points are escaped as described below. _S_ may or may not be identical to _P_; however, the Abstract Closure that would result from evaluating _S_ as a |Pattern[~UnicodeMode]| (|Pattern[+UnicodeMode]| if _F_ contains *"u"*) must behave identically to the Abstract Closure given by the constructed object's [[RegExpMatcher]] internal slot. Multiple calls to this abstract operation using the same values for _P_ and _F_ must produce identical results.
+            1. The code points `/` or any |LineTerminator| occurring in the pattern shall be escaped in _S_ as necessary to ensure that the string-concatenation of *"/"*, _S_, *"/"*, and _F_ can be parsed (in an appropriate lexical context) as a |RegularExpressionLiteral| that behaves identically to the constructed regular expression. For example, if _P_ is *"/"*, then _S_ could be *"\\/"* or *"\\u002F"*, among other possibilities, but not *"/"*, because `///` followed by _F_ would be parsed as a |SingleLineComment| rather than a |RegularExpressionLiteral|. If _P_ is the empty String, this specification can be met by letting _S_ be *"(?:)"*.
+            1. Return _S_.
+          </emu-alg>
+        </emu-clause>
       </emu-clause>
 
       <emu-clause id="sec-regexp.prototype-@@split">

--- a/spec.html
+++ b/spec.html
@@ -36175,256 +36175,6 @@ THH:mm:ss.sss
           1. Let _S_ be ? ToString(_string_).
           1. Return ? RegExpBuiltinExec(_R_, _S_).
         </emu-alg>
-
-        <emu-clause id="sec-regexpexec" type="abstract operation">
-          <h1>
-            RegExpExec (
-              _R_: an Object,
-              _S_: a String,
-            ): either a normal completion containing either an Object or *null*, or a throw completion
-          </h1>
-          <dl class="header">
-          </dl>
-          <emu-alg>
-            1. Let _exec_ be ? Get(_R_, *"exec"*).
-            1. If IsCallable(_exec_) is *true*, then
-              1. Let _result_ be ? Call(_exec_, _R_, &laquo; _S_ &raquo;).
-              1. If _result_ is not an Object and _result_ is not *null*, throw a *TypeError* exception.
-              1. Return _result_.
-            1. Perform ? RequireInternalSlot(_R_, [[RegExpMatcher]]).
-            1. Return ? RegExpBuiltinExec(_R_, _S_).
-          </emu-alg>
-          <emu-note>
-            <p>If a callable *"exec"* property is not found this algorithm falls back to attempting to use the built-in RegExp matching algorithm. This provides compatible behaviour for code written for prior editions where most built-in algorithms that use regular expressions did not perform a dynamic property lookup of *"exec"*.</p>
-          </emu-note>
-        </emu-clause>
-
-        <emu-clause id="sec-regexpbuiltinexec" type="abstract operation">
-          <h1>
-            RegExpBuiltinExec (
-              _R_: an initialized RegExp instance,
-              _S_: a String,
-            ): either a normal completion containing either an Array exotic object or *null*, or a throw completion
-          </h1>
-          <dl class="header">
-          </dl>
-          <emu-alg>
-            1. Let _length_ be the length of _S_.
-            1. Let _lastIndex_ be ℝ(? ToLength(? Get(_R_, *"lastIndex"*))).
-            1. Let _flags_ be _R_.[[OriginalFlags]].
-            1. If _flags_ contains *"g"*, let _global_ be *true*; else let _global_ be *false*.
-            1. If _flags_ contains *"y"*, let _sticky_ be *true*; else let _sticky_ be *false*.
-            1. If _flags_ contains *"d"*, let _hasIndices_ be *true*; else let _hasIndices_ be *false*.
-            1. If _global_ is *false* and _sticky_ is *false*, set _lastIndex_ to 0.
-            1. Let _matcher_ be _R_.[[RegExpMatcher]].
-            1. If _flags_ contains *"u"*, let _fullUnicode_ be *true*; else let _fullUnicode_ be *false*.
-            1. Let _matchSucceeded_ be *false*.
-            1. If _fullUnicode_ is *true*, let _input_ be StringToCodePoints(_S_). Otherwise, let _input_ be a List whose elements are the code units that are the elements of _S_.
-            1. NOTE: Each element of _input_ is considered to be a character.
-            1. Repeat, while _matchSucceeded_ is *false*,
-              1. If _lastIndex_ &gt; _length_, then
-                1. If _global_ is *true* or _sticky_ is *true*, then
-                  1. Perform ? Set(_R_, *"lastIndex"*, *+0*<sub>𝔽</sub>, *true*).
-                1. Return *null*.
-              1. Let _inputIndex_ be the index into _input_ of the character that was obtained from element _lastIndex_ of _S_.
-              1. Let _r_ be _matcher_(_input_, _inputIndex_).
-              1. If _r_ is ~failure~, then
-                1. If _sticky_ is *true*, then
-                  1. Perform ? Set(_R_, *"lastIndex"*, *+0*<sub>𝔽</sub>, *true*).
-                  1. Return *null*.
-                1. Set _lastIndex_ to AdvanceStringIndex(_S_, _lastIndex_, _fullUnicode_).
-              1. Else,
-                1. Assert: _r_ is a State.
-                1. Set _matchSucceeded_ to *true*.
-            1. Let _e_ be _r_'s _endIndex_ value.
-            1. If _fullUnicode_ is *true*, set _e_ to GetStringIndex(_S_, _e_).
-            1. If _global_ is *true* or _sticky_ is *true*, then
-              1. Perform ? Set(_R_, *"lastIndex"*, 𝔽(_e_), *true*).
-            1. Let _n_ be the number of elements in _r_'s _captures_ List.
-            1. Assert: _n_ = _R_.[[RegExpRecord]].[[CapturingGroupsCount]].
-            1. Assert: _n_ &lt; 2<sup>32</sup> - 1.
-            1. Let _A_ be ! ArrayCreate(_n_ + 1).
-            1. Assert: The mathematical value of _A_'s *"length"* property is _n_ + 1.
-            1. Perform ! CreateDataPropertyOrThrow(_A_, *"index"*, 𝔽(_lastIndex_)).
-            1. Perform ! CreateDataPropertyOrThrow(_A_, *"input"*, _S_).
-            1. Let _match_ be the Match Record { [[StartIndex]]: _lastIndex_, [[EndIndex]]: _e_ }.
-            1. Let _indices_ be a new empty List.
-            1. Let _groupNames_ be a new empty List.
-            1. Append _match_ to _indices_.
-            1. Let _matchedSubstr_ be GetMatchString(_S_, _match_).
-            1. Perform ! CreateDataPropertyOrThrow(_A_, *"0"*, _matchedSubstr_).
-            1. If _R_ contains any |GroupName|, then
-              1. Let _groups_ be OrdinaryObjectCreate(*null*).
-              1. Let _hasGroups_ be *true*.
-            1. Else,
-              1. Let _groups_ be *undefined*.
-              1. Let _hasGroups_ be *false*.
-            1. Perform ! CreateDataPropertyOrThrow(_A_, *"groups"*, _groups_).
-            1. For each integer _i_ such that _i_ &ge; 1 and _i_ &le; _n_, in ascending order, do
-              1. Let _captureI_ be _i_<sup>th</sup> element of _r_'s _captures_ List.
-              1. If _captureI_ is *undefined*, then
-                1. Let _capturedValue_ be *undefined*.
-                1. Append *undefined* to _indices_.
-              1. Else,
-                1. Let _captureStart_ be _captureI_'s _startIndex_.
-                1. Let _captureEnd_ be _captureI_'s _endIndex_.
-                1. If _fullUnicode_ is *true*, then
-                  1. Set _captureStart_ to GetStringIndex(_S_, _captureStart_).
-                  1. Set _captureEnd_ to GetStringIndex(_S_, _captureEnd_).
-                1. Let _capture_ be the Match Record { [[StartIndex]]: _captureStart_, [[EndIndex]]: _captureEnd_ }.
-                1. Let _capturedValue_ be GetMatchString(_S_, _capture_).
-                1. Append _capture_ to _indices_.
-              1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_i_)), _capturedValue_).
-              1. If the _i_<sup>th</sup> capture of _R_ was defined with a |GroupName|, then
-                1. Let _s_ be the CapturingGroupName of that |GroupName|.
-                1. Perform ! CreateDataPropertyOrThrow(_groups_, _s_, _capturedValue_).
-                1. Append _s_ to _groupNames_.
-              1. Else,
-                1. Append *undefined* to _groupNames_.
-            1. If _hasIndices_ is *true*, then
-              1. Let _indicesArray_ be MakeMatchIndicesIndexPairArray(_S_, _indices_, _groupNames_, _hasGroups_).
-              1. Perform ! CreateDataPropertyOrThrow(_A_, *"indices"*, _indicesArray_).
-            1. Return _A_.
-          </emu-alg>
-        </emu-clause>
-
-        <emu-clause id="sec-advancestringindex" type="abstract operation">
-          <h1>
-            AdvanceStringIndex (
-              _S_: a String,
-              _index_: a non-negative integer,
-              _unicode_: a Boolean,
-            ): an integer
-          </h1>
-          <dl class="header">
-          </dl>
-          <emu-alg>
-            1. Assert: _index_ &le; 2<sup>53</sup> - 1.
-            1. If _unicode_ is *false*, return _index_ + 1.
-            1. Let _length_ be the length of _S_.
-            1. If _index_ + 1 &ge; _length_, return _index_ + 1.
-            1. Let _cp_ be CodePointAt(_S_, _index_).
-            1. Return _index_ + _cp_.[[CodeUnitCount]].
-          </emu-alg>
-        </emu-clause>
-
-        <emu-clause id="sec-getstringindex" type="abstract operation">
-          <h1>
-            GetStringIndex (
-              _S_: a String,
-              _codePointIndex_: a non-negative integer,
-            ): a non-negative integer
-          </h1>
-          <dl class="header">
-            <dt>description</dt>
-            <dd>It interprets _S_ as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>, and returns the code unit index corresponding to code point index _codePointIndex_ when such an index exists. Otherwise, it returns the length of _S_.</dd>
-          </dl>
-          <emu-alg>
-            1. If _S_ is the empty String, return 0.
-            1. Let _len_ be the length of _S_.
-            1. Let _codeUnitCount_ be 0.
-            1. Let _codePointCount_ be 0.
-            1. Repeat, while _codeUnitCount_ &lt; _len_,
-              1. If _codePointCount_ = _codePointIndex_, return _codeUnitCount_.
-              1. Let _cp_ be CodePointAt(_S_, _codeUnitCount_).
-              1. Set _codeUnitCount_ to _codeUnitCount_ + _cp_.[[CodeUnitCount]].
-              1. Set _codePointCount_ to _codePointCount_ + 1.
-            1. Return _len_.
-          </emu-alg>
-        </emu-clause>
-
-        <emu-clause id="sec-match-records">
-          <h1>Match Records</h1>
-          <p>A <dfn variants="Match Records">Match Record</dfn> is a Record value used to encapsulate the start and end indices of a regular expression match or capture.</p>
-          <p>Match Records have the fields listed in <emu-xref href="#table-match-record"></emu-xref>.</p>
-          <emu-table id="table-match-record" caption="Match Record Fields">
-            <table>
-              <tr>
-                <th>Field Name</th>
-                <th>Value</th>
-                <th>Meaning</th>
-              </tr>
-              <tr>
-                <td>[[StartIndex]]</td>
-                <td>a non-negative integer</td>
-                <td>The number of code units from the start of a string at which the match begins (inclusive).</td>
-              </tr>
-              <tr>
-                <td>[[EndIndex]]</td>
-                <td>an integer &ge; [[StartIndex]]</td>
-                <td>The number of code units from the start of a string at which the match ends (exclusive).</td>
-              </tr>
-            </table>
-          </emu-table>
-        </emu-clause>
-
-        <emu-clause id="sec-getmatchstring" type="abstract operation">
-          <h1>
-            GetMatchString (
-              _S_: a String,
-              _match_: a Match Record,
-            ): a String
-          </h1>
-          <dl class="header">
-          </dl>
-          <emu-alg>
-            1. Assert: _match_.[[StartIndex]] is a non-negative integer less than or equal to the length of _S_.
-            1. Assert: _match_.[[EndIndex]] is an integer between _match_.[[StartIndex]] and the length of _S_, inclusive.
-            1. Return the substring of _S_ from _match_.[[StartIndex]] to _match_.[[EndIndex]].
-          </emu-alg>
-        </emu-clause>
-
-        <emu-clause id="sec-getmatchindexpair" type="abstract operation">
-          <h1>
-            GetMatchIndexPair (
-              _S_: a String,
-              _match_: a Match Record,
-            ): an Array
-          </h1>
-          <dl class="header">
-          </dl>
-          <emu-alg>
-            1. Assert: _match_.[[StartIndex]] is a non-negative integer less than or equal to the length of _S_.
-            1. Assert: _match_.[[EndIndex]] is an integer between _match_.[[StartIndex]] and the length of _S_, inclusive.
-            1. Return CreateArrayFromList(&laquo; 𝔽(_match_.[[StartIndex]]), 𝔽(_match_.[[EndIndex]]) &raquo;).
-          </emu-alg>
-        </emu-clause>
-
-        <emu-clause id="sec-makematchindicesindexpairarray" type="abstract operation">
-          <h1>
-            MakeMatchIndicesIndexPairArray (
-              _S_: a String,
-              _indices_: a List of either Match Records or *undefined*,
-              _groupNames_: a List of either Strings or *undefined*,
-              _hasGroups_: a Boolean,
-            ): an Array
-          </h1>
-          <dl class="header">
-          </dl>
-          <emu-alg>
-            1. Let _n_ be the number of elements in _indices_.
-            1. Assert: _n_ &lt; 2<sup>32</sup> - 1.
-            1. Assert: _groupNames_ has _n_ - 1 elements.
-            1. NOTE: The _groupNames_ List contains elements aligned with the _indices_ List starting at _indices_[1].
-            1. Let _A_ be ! ArrayCreate(_n_).
-            1. If _hasGroups_ is *true*, then
-              1. Let _groups_ be OrdinaryObjectCreate(*null*).
-            1. Else,
-              1. Let _groups_ be *undefined*.
-            1. Perform ! CreateDataPropertyOrThrow(_A_, *"groups"*, _groups_).
-            1. For each integer _i_ starting with 0 such that _i_ &lt; _n_, in ascending order, do
-              1. Let _matchIndices_ be _indices_[_i_].
-              1. If _matchIndices_ is not *undefined*, then
-                1. Let _matchIndexPair_ be GetMatchIndexPair(_S_, _matchIndices_).
-              1. Else,
-                1. Let _matchIndexPair_ be *undefined*.
-              1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_i_)), _matchIndexPair_).
-              1. If _i_ &gt; 0 and _groupNames_[_i_ - 1] is not *undefined*, then
-                1. Assert: _groups_ is not *undefined*.
-                1. Perform ! CreateDataPropertyOrThrow(_groups_, _groupNames_[_i_ - 1], _matchIndexPair_).
-            1. Return _A_.
-          </emu-alg>
-        </emu-clause>
       </emu-clause>
 
       <emu-clause id="sec-get-regexp.prototype.dotAll">
@@ -36818,6 +36568,260 @@ THH:mm:ss.sss
           1. Let _R_ be the *this* value.
           1. Let _cu_ be the code unit 0x0075 (LATIN SMALL LETTER U).
           1. Return ? RegExpHasFlag(_R_, _cu_).
+        </emu-alg>
+      </emu-clause>
+    </emu-clause>
+
+    <emu-clause id="sec-abstract-operations-for-regexp-matching">
+      <h1>Abstract Operations for RegExp Matching</h1>
+
+      <emu-clause id="sec-regexpexec" type="abstract operation">
+        <h1>
+          RegExpExec (
+            _R_: an Object,
+            _S_: a String,
+          ): either a normal completion containing either an Object or *null*, or a throw completion
+        </h1>
+        <dl class="header">
+        </dl>
+        <emu-alg>
+          1. Let _exec_ be ? Get(_R_, *"exec"*).
+          1. If IsCallable(_exec_) is *true*, then
+            1. Let _result_ be ? Call(_exec_, _R_, &laquo; _S_ &raquo;).
+            1. If _result_ is not an Object and _result_ is not *null*, throw a *TypeError* exception.
+            1. Return _result_.
+          1. Perform ? RequireInternalSlot(_R_, [[RegExpMatcher]]).
+          1. Return ? RegExpBuiltinExec(_R_, _S_).
+        </emu-alg>
+        <emu-note>
+          <p>If a callable *"exec"* property is not found this algorithm falls back to attempting to use the built-in RegExp matching algorithm. This provides compatible behaviour for code written for prior editions where most built-in algorithms that use regular expressions did not perform a dynamic property lookup of *"exec"*.</p>
+        </emu-note>
+      </emu-clause>
+
+      <emu-clause id="sec-regexpbuiltinexec" type="abstract operation">
+        <h1>
+          RegExpBuiltinExec (
+            _R_: an initialized RegExp instance,
+            _S_: a String,
+          ): either a normal completion containing either an Array exotic object or *null*, or a throw completion
+        </h1>
+        <dl class="header">
+        </dl>
+        <emu-alg>
+          1. Let _length_ be the length of _S_.
+          1. Let _lastIndex_ be ℝ(? ToLength(? Get(_R_, *"lastIndex"*))).
+          1. Let _flags_ be _R_.[[OriginalFlags]].
+          1. If _flags_ contains *"g"*, let _global_ be *true*; else let _global_ be *false*.
+          1. If _flags_ contains *"y"*, let _sticky_ be *true*; else let _sticky_ be *false*.
+          1. If _flags_ contains *"d"*, let _hasIndices_ be *true*; else let _hasIndices_ be *false*.
+          1. If _global_ is *false* and _sticky_ is *false*, set _lastIndex_ to 0.
+          1. Let _matcher_ be _R_.[[RegExpMatcher]].
+          1. If _flags_ contains *"u"*, let _fullUnicode_ be *true*; else let _fullUnicode_ be *false*.
+          1. Let _matchSucceeded_ be *false*.
+          1. If _fullUnicode_ is *true*, let _input_ be StringToCodePoints(_S_). Otherwise, let _input_ be a List whose elements are the code units that are the elements of _S_.
+          1. NOTE: Each element of _input_ is considered to be a character.
+          1. Repeat, while _matchSucceeded_ is *false*,
+            1. If _lastIndex_ &gt; _length_, then
+              1. If _global_ is *true* or _sticky_ is *true*, then
+                1. Perform ? Set(_R_, *"lastIndex"*, *+0*<sub>𝔽</sub>, *true*).
+              1. Return *null*.
+            1. Let _inputIndex_ be the index into _input_ of the character that was obtained from element _lastIndex_ of _S_.
+            1. Let _r_ be _matcher_(_input_, _inputIndex_).
+            1. If _r_ is ~failure~, then
+              1. If _sticky_ is *true*, then
+                1. Perform ? Set(_R_, *"lastIndex"*, *+0*<sub>𝔽</sub>, *true*).
+                1. Return *null*.
+              1. Set _lastIndex_ to AdvanceStringIndex(_S_, _lastIndex_, _fullUnicode_).
+            1. Else,
+              1. Assert: _r_ is a State.
+              1. Set _matchSucceeded_ to *true*.
+          1. Let _e_ be _r_'s _endIndex_ value.
+          1. If _fullUnicode_ is *true*, set _e_ to GetStringIndex(_S_, _e_).
+          1. If _global_ is *true* or _sticky_ is *true*, then
+            1. Perform ? Set(_R_, *"lastIndex"*, 𝔽(_e_), *true*).
+          1. Let _n_ be the number of elements in _r_'s _captures_ List.
+          1. Assert: _n_ = _R_.[[RegExpRecord]].[[CapturingGroupsCount]].
+          1. Assert: _n_ &lt; 2<sup>32</sup> - 1.
+          1. Let _A_ be ! ArrayCreate(_n_ + 1).
+          1. Assert: The mathematical value of _A_'s *"length"* property is _n_ + 1.
+          1. Perform ! CreateDataPropertyOrThrow(_A_, *"index"*, 𝔽(_lastIndex_)).
+          1. Perform ! CreateDataPropertyOrThrow(_A_, *"input"*, _S_).
+          1. Let _match_ be the Match Record { [[StartIndex]]: _lastIndex_, [[EndIndex]]: _e_ }.
+          1. Let _indices_ be a new empty List.
+          1. Let _groupNames_ be a new empty List.
+          1. Append _match_ to _indices_.
+          1. Let _matchedSubstr_ be GetMatchString(_S_, _match_).
+          1. Perform ! CreateDataPropertyOrThrow(_A_, *"0"*, _matchedSubstr_).
+          1. If _R_ contains any |GroupName|, then
+            1. Let _groups_ be OrdinaryObjectCreate(*null*).
+            1. Let _hasGroups_ be *true*.
+          1. Else,
+            1. Let _groups_ be *undefined*.
+            1. Let _hasGroups_ be *false*.
+          1. Perform ! CreateDataPropertyOrThrow(_A_, *"groups"*, _groups_).
+          1. For each integer _i_ such that _i_ &ge; 1 and _i_ &le; _n_, in ascending order, do
+            1. Let _captureI_ be _i_<sup>th</sup> element of _r_'s _captures_ List.
+            1. If _captureI_ is *undefined*, then
+              1. Let _capturedValue_ be *undefined*.
+              1. Append *undefined* to _indices_.
+            1. Else,
+              1. Let _captureStart_ be _captureI_'s _startIndex_.
+              1. Let _captureEnd_ be _captureI_'s _endIndex_.
+              1. If _fullUnicode_ is *true*, then
+                1. Set _captureStart_ to GetStringIndex(_S_, _captureStart_).
+                1. Set _captureEnd_ to GetStringIndex(_S_, _captureEnd_).
+              1. Let _capture_ be the Match Record { [[StartIndex]]: _captureStart_, [[EndIndex]]: _captureEnd_ }.
+              1. Let _capturedValue_ be GetMatchString(_S_, _capture_).
+              1. Append _capture_ to _indices_.
+            1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_i_)), _capturedValue_).
+            1. If the _i_<sup>th</sup> capture of _R_ was defined with a |GroupName|, then
+              1. Let _s_ be the CapturingGroupName of that |GroupName|.
+              1. Perform ! CreateDataPropertyOrThrow(_groups_, _s_, _capturedValue_).
+              1. Append _s_ to _groupNames_.
+            1. Else,
+              1. Append *undefined* to _groupNames_.
+          1. If _hasIndices_ is *true*, then
+            1. Let _indicesArray_ be MakeMatchIndicesIndexPairArray(_S_, _indices_, _groupNames_, _hasGroups_).
+            1. Perform ! CreateDataPropertyOrThrow(_A_, *"indices"*, _indicesArray_).
+          1. Return _A_.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-advancestringindex" type="abstract operation">
+        <h1>
+          AdvanceStringIndex (
+            _S_: a String,
+            _index_: a non-negative integer,
+            _unicode_: a Boolean,
+          ): an integer
+        </h1>
+        <dl class="header">
+        </dl>
+        <emu-alg>
+          1. Assert: _index_ &le; 2<sup>53</sup> - 1.
+          1. If _unicode_ is *false*, return _index_ + 1.
+          1. Let _length_ be the length of _S_.
+          1. If _index_ + 1 &ge; _length_, return _index_ + 1.
+          1. Let _cp_ be CodePointAt(_S_, _index_).
+          1. Return _index_ + _cp_.[[CodeUnitCount]].
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-getstringindex" type="abstract operation">
+        <h1>
+          GetStringIndex (
+            _S_: a String,
+            _codePointIndex_: a non-negative integer,
+          ): a non-negative integer
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It interprets _S_ as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>, and returns the code unit index corresponding to code point index _codePointIndex_ when such an index exists. Otherwise, it returns the length of _S_.</dd>
+        </dl>
+        <emu-alg>
+          1. If _S_ is the empty String, return 0.
+          1. Let _len_ be the length of _S_.
+          1. Let _codeUnitCount_ be 0.
+          1. Let _codePointCount_ be 0.
+          1. Repeat, while _codeUnitCount_ &lt; _len_,
+            1. If _codePointCount_ = _codePointIndex_, return _codeUnitCount_.
+            1. Let _cp_ be CodePointAt(_S_, _codeUnitCount_).
+            1. Set _codeUnitCount_ to _codeUnitCount_ + _cp_.[[CodeUnitCount]].
+            1. Set _codePointCount_ to _codePointCount_ + 1.
+          1. Return _len_.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-match-records">
+        <h1>Match Records</h1>
+        <p>A <dfn variants="Match Records">Match Record</dfn> is a Record value used to encapsulate the start and end indices of a regular expression match or capture.</p>
+        <p>Match Records have the fields listed in <emu-xref href="#table-match-record"></emu-xref>.</p>
+        <emu-table id="table-match-record" caption="Match Record Fields">
+          <table>
+            <tr>
+              <th>Field Name</th>
+              <th>Value</th>
+              <th>Meaning</th>
+            </tr>
+            <tr>
+              <td>[[StartIndex]]</td>
+              <td>a non-negative integer</td>
+              <td>The number of code units from the start of a string at which the match begins (inclusive).</td>
+            </tr>
+            <tr>
+              <td>[[EndIndex]]</td>
+              <td>an integer &ge; [[StartIndex]]</td>
+              <td>The number of code units from the start of a string at which the match ends (exclusive).</td>
+            </tr>
+          </table>
+        </emu-table>
+      </emu-clause>
+
+      <emu-clause id="sec-getmatchstring" type="abstract operation">
+        <h1>
+          GetMatchString (
+            _S_: a String,
+            _match_: a Match Record,
+          ): a String
+        </h1>
+        <dl class="header">
+        </dl>
+        <emu-alg>
+          1. Assert: _match_.[[StartIndex]] is a non-negative integer less than or equal to the length of _S_.
+          1. Assert: _match_.[[EndIndex]] is an integer between _match_.[[StartIndex]] and the length of _S_, inclusive.
+          1. Return the substring of _S_ from _match_.[[StartIndex]] to _match_.[[EndIndex]].
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-getmatchindexpair" type="abstract operation">
+        <h1>
+          GetMatchIndexPair (
+            _S_: a String,
+            _match_: a Match Record,
+          ): an Array
+        </h1>
+        <dl class="header">
+        </dl>
+        <emu-alg>
+          1. Assert: _match_.[[StartIndex]] is a non-negative integer less than or equal to the length of _S_.
+          1. Assert: _match_.[[EndIndex]] is an integer between _match_.[[StartIndex]] and the length of _S_, inclusive.
+          1. Return CreateArrayFromList(&laquo; 𝔽(_match_.[[StartIndex]]), 𝔽(_match_.[[EndIndex]]) &raquo;).
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-makematchindicesindexpairarray" type="abstract operation">
+        <h1>
+          MakeMatchIndicesIndexPairArray (
+            _S_: a String,
+            _indices_: a List of either Match Records or *undefined*,
+            _groupNames_: a List of either Strings or *undefined*,
+            _hasGroups_: a Boolean,
+          ): an Array
+        </h1>
+        <dl class="header">
+        </dl>
+        <emu-alg>
+          1. Let _n_ be the number of elements in _indices_.
+          1. Assert: _n_ &lt; 2<sup>32</sup> - 1.
+          1. Assert: _groupNames_ has _n_ - 1 elements.
+          1. NOTE: The _groupNames_ List contains elements aligned with the _indices_ List starting at _indices_[1].
+          1. Let _A_ be ! ArrayCreate(_n_).
+          1. If _hasGroups_ is *true*, then
+            1. Let _groups_ be OrdinaryObjectCreate(*null*).
+          1. Else,
+            1. Let _groups_ be *undefined*.
+          1. Perform ! CreateDataPropertyOrThrow(_A_, *"groups"*, _groups_).
+          1. For each integer _i_ starting with 0 such that _i_ &lt; _n_, in ascending order, do
+            1. Let _matchIndices_ be _indices_[_i_].
+            1. If _matchIndices_ is not *undefined*, then
+              1. Let _matchIndexPair_ be GetMatchIndexPair(_S_, _matchIndices_).
+            1. Else,
+              1. Let _matchIndexPair_ be *undefined*.
+            1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_i_)), _matchIndexPair_).
+            1. If _i_ &gt; 0 and _groupNames_[_i_ - 1] is not *undefined*, then
+              1. Assert: _groups_ is not *undefined*.
+              1. Perform ! CreateDataPropertyOrThrow(_groups_, _groupNames_[_i_ - 1], _matchIndexPair_).
+          1. Return _A_.
         </emu-alg>
       </emu-clause>
     </emu-clause>


### PR DESCRIPTION
This was inspired by [my comment in PR #2843](https://github.com/tc39/ecma262/pull/2843#issuecomment-1204686524), but isn't exactly what I described there.

The first two commits move two AOs out of "Abstract Operations for the RegExp Constructor", where they don't really belong. I move them closer to their invocation(s).

- (1) WordCharacters: I was the one (in #2716) who put WordCharacters in its current location, but I have no idea why. Here, I move it to under [22.2.2.9 Runtime Semantics: CompileToCharSet](https://tc39.es/ecma262/#sec-compiletocharset), but it would also fit after [22.2.2.4.1 IsWordChar](https://tc39.es/ecma262/#sec-runtime-semantics-iswordchar-abstract-operation).

- (2) EscapeRegExpPattern (which isn't even invoked by the RegExp constructor): I move it to under its only invocation, in get `RegExp.prototype.source`.

That done, the remaining AOs in "Abstract Operations for the RegExp Constructor" are fairly cohesive. However, the title of the clause is suboptimal: although RegExpAll and RegExpInitialize (and, indirectly, ParsePattern) *are* invoked by the RegExp Constructor, that isn't the *only* way they're invoked; they're also invoked by RegExpCreate, which is in this clause even though it's never invoked by the RegExp Constructor. So (3) I propose changing the title of the clause to "Abstract Operations for RegExp Creation".

Also, (4) I move up `RegExpCreate`, so there's a top-down order to the clause.

The same reasoning for the name-change suggests that the clause should no longer be located within `The RegExp Constructor`. We could just 'promote' it where it is, but that would leave it between `The RegExp Constructor` and `Properties of The RegExp Constructor`, which would be odd. So (5) I propose moving it to before `The RegExp Constructor`.

----

Separately, there are all the AOs nested under `RegExp.prototype.exec`. These too are fairly cohesive, but they're not exclusive to that function (and RegExpExec isn't invoked by it at all). So (6) I propose splitting them off into their own clause, "Abstract Operations for RegExp Matching".

----

A final step could be to merge the two new clauses into a single clause "Abstract Operations for Regular Expressions". It wouldn't actually be *all* AOs for RegExps, since the ones under `Patterns`, `Pattern Semantics`, and `RegExp String Iterator Objects` would presumably stay where they are. But it could gather in `RegExpHasFlag` and possibly `EscapeRegExpPattern`, as described in https://github.com/tc39/ecma262/pull/2843#issuecomment-1204686524.

This PR doesn't have that merge, because I thought it would be easier to look at the PR as-is and imagine that last step, rather than vice versa. But I'll incorporate it if there's interest in seeing it.