### PR TITLE
Editorial: refactor ForIn/OfBodyEvaluation

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -22133,35 +22133,32 @@
             1. If _done_ is *true*, return _V_.
             1. Let _nextValue_ be ? IteratorValue(_nextResult_).
             1. If _lhsKind_ is either ~assignment~ or ~varBinding~, then
-              1. If _destructuring_ is *false*, then
+              1. If _destructuring_ is *true*, then
+                1. If _lhsKind_ is ~assignment~, then
+                  1. Let _status_ be Completion(DestructuringAssignmentEvaluation of _assignmentPattern_ with argument _nextValue_).
+                1. Else,
+                  1. Assert: _lhsKind_ is ~varBinding~.
+                  1. Assert: _lhs_ is a |ForBinding|.
+                  1. Let _status_ be Completion(BindingInitialization of _lhs_ with arguments _nextValue_ and *undefined*).
+              1. Else,
                 1. Let _lhsRef_ be Completion(Evaluation of _lhs_). (It may be evaluated repeatedly.)
+                1. If _lhsRef_ is an abrupt completion, then
+                  1. Let _status_ be _lhsRef_.
+                1. Else,
+                  1. Let _status_ be Completion(PutValue(_lhsRef_.[[Value]], _nextValue_)).
             1. Else,
               1. Assert: _lhsKind_ is ~lexicalBinding~.
               1. Assert: _lhs_ is a |ForDeclaration|.
               1. Let _iterationEnv_ be NewDeclarativeEnvironment(_oldEnv_).
               1. Perform ForDeclarationBindingInstantiation of _lhs_ with argument _iterationEnv_.
               1. Set the running execution context's LexicalEnvironment to _iterationEnv_.
-              1. If _destructuring_ is *false*, then
+              1. If _destructuring_ is *true*, then
+                1. Let _status_ be Completion(ForDeclarationBindingInitialization of _lhs_ with arguments _nextValue_ and _iterationEnv_).
+              1. Else,
                 1. Assert: _lhs_ binds a single name.
                 1. Let _lhsName_ be the sole element of BoundNames of _lhs_.
                 1. Let _lhsRef_ be ! ResolveBinding(_lhsName_).
-            1. If _destructuring_ is *false*, then
-              1. If _lhsRef_ is an abrupt completion, then
-                1. Let _status_ be _lhsRef_.
-              1. Else if _lhsKind_ is ~lexicalBinding~, then
                 1. Let _status_ be Completion(InitializeReferencedBinding(_lhsRef_, _nextValue_)).
-              1. Else,
-                1. Let _status_ be Completion(PutValue(_lhsRef_, _nextValue_)).
-            1. Else,
-              1. If _lhsKind_ is ~assignment~, then
-                1. Let _status_ be Completion(DestructuringAssignmentEvaluation of _assignmentPattern_ with argument _nextValue_).
-              1. Else if _lhsKind_ is ~varBinding~, then
-                1. Assert: _lhs_ is a |ForBinding|.
-                1. Let _status_ be Completion(BindingInitialization of _lhs_ with arguments _nextValue_ and *undefined*).
-              1. Else,
-                1. Assert: _lhsKind_ is ~lexicalBinding~.
-                1. Assert: _lhs_ is a |ForDeclaration|.
-                1. Let _status_ be Completion(ForDeclarationBindingInitialization of _lhs_ with arguments _nextValue_ and _iterationEnv_).
             1. If _status_ is an abrupt completion, then
               1. Set the running execution context's LexicalEnvironment to _oldEnv_.
               1. If _iteratorKind_ is ~async~, return ? AsyncIteratorClose(_iteratorRecord_, _status_).


### PR DESCRIPTION
Split out from #2842. This is a straight refactoring, just reording some `if`s. The only part which isn't totally obvious is that previously there was the following if-else chain:

```
1. If _destructuring_ is *false*, then
  1. If _lhsRef_ is an abrupt completion, then
    1. Let _status_ be _lhsRef_.
  1. Else if _lhsKind_ is ~lexicalBinding~, then
    1. Let _status_ be Completion(InitializeReferencedBinding(_lhsRef_, _nextValue_)).
  1. Else,
    1. Let _status_ be Completion(PutValue(_lhsRef_, _nextValue_)).
```

If you read the original carefully, the only place that could make `_lhsRef_` be an abrupt completion is this earlier bit:

```
1. If _lhsKind_ is either ~assignment~ or ~varBinding~, then
  1. If _destructuring_ is *false*, then
    1. Let _lhsRef_ be Completion(Evaluation of _lhs_). (It may be evaluated repeatedly.)
```

So it's safe to move the `Let _status_ be _lhsRef_` bit into the `~assignment~`/`~varBinding~` + `_destructuring_ is *false*` branch in the refactoring.

(The `Let _status_ be Completion(PutValue(_lhsRef_, _nextValue_)).` also gets moved into that branch, but that one's more obviously fine, since it's explicitly guarded on "not `~lexicalBinding~`" i.e. "is `~assignment~`/`~varBinding~`.)