### PR TITLE
Editorial: fix typo in Set.prototype.forEach

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -40414,7 +40414,7 @@ THH:mm:ss.sss
           1. Let _S_ be the *this* value.
           1. Perform ? RequireInternalSlot(_S_, [[SetData]]).
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
-          1. Let _entries_ be the List that is _set_.[[SetData]].
+          1. Let _entries_ be the List that is _S_.[[SetData]].
           1. Let _numEntries_ be the number of elements of _entries_.
           1. Let _index_ be 0.
           1. Repeat, while _index_ &lt; _numEntries_,


### PR DESCRIPTION
I introduced this typo in https://github.com/tc39/ecma262/pull/2766. Thanks to @jmdyck for the catch.