### PR TITLE
Editorial: Fix completion in CreateListIteratorRecord and CreateArrayIterator

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -7197,7 +7197,7 @@
         1. Let _closure_ be a new Abstract Closure with no parameters that captures _list_ and performs the following steps when called:
           1. For each element _E_ of _list_, do
             1. Perform ? GeneratorYield(CreateIterResultObject(_E_, *false*)).
-          1. Return *undefined*.
+          1. Return NormalCompletion(*undefined*).
         1. Let _iterator_ be CreateIteratorFromClosure(_closure_, ~empty~, %IteratorPrototype%).
         1. Return the Iterator Record { [[Iterator]]: _iterator_, [[NextMethod]]: %GeneratorFunction.prototype.prototype.next%, [[Done]]: *false* }.
       </emu-alg>
@@ -38298,7 +38298,7 @@ THH:mm:ss.sss
                 1. Let _len_ be _array_.[[ArrayLength]].
               1. Else,
                 1. Let _len_ be ? LengthOfArrayLike(_array_).
-              1. If _index_ &ge; _len_, return *undefined*.
+              1. If _index_ &ge; _len_, return NormalCompletion(*undefined*).
               1. If _kind_ is ~key~, perform ? GeneratorYield(CreateIterResultObject(𝔽(_index_), *false*)).
               1. Else,
                 1. Let _elementKey_ be ! ToString(𝔽(_index_)).


### PR DESCRIPTION
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->

An [Abstract Closure](https://tc39.es/ecma262/#sec-abstract-closure) is not an abstract operation. It is clear since this sentence in the section [Abstract Closure](https://tc39.es/ecma262/#sec-abstract-closure):
> Like [abstract operations](https://tc39.es/ecma262/#sec-algorithm-conventions-abstract-operations), invocations perform the algorithm steps described by the Abstract Closure.

However, [5.2.3.5 Implicit Normal Completion](https://tc39.es/ecma262/#sec-implicit-normal-completion) section only covers abstract operations and builtin functions, but not abstract closures. So, it is necessary to use `NormalCompletion` to return a normal completion wrapping a specific value.

Several abstract operations that create iterators (e.g., [CreateListIteratorRecord](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-createlistiteratorRecord) and [CreateArrayIterator](https://tc39.es/ecma262/multipage/indexed-collections.html#sec-createarrayiterator)) declares abstract closures. To represent the end of iteration, the abstract closures return the `undefined` value without the use of `NormalCompletion`. Therefore, they directly return the `undefined` value.

However, look at the step 4.b.ii. of [27.5.3.1. GeneratorStart](https://tc39.es/ecma262/#sec-generatorstart):
> 4.b.ii. Let result be generatorBody().

The `result` variable stores the return value of the `generatorBody` function. In this case, the `generatorBody` function might be one of abstract closures that I mentioned above. Therefore, the `result` variable might points to the `undefined` value not a completion record. It causes an error in the step 4.g. of [27.5.3.1. GeneratorStart](https://tc39.es/ecma262/#sec-generatorstart) because it tries to access the `[[Type]]` field of the `undefined` value:
> If result.[[Type]] is normal, let resultValue be undefined.

Therefore, I suggest to use the `NormalCompletion` to convert the `undefined` value to a nomal completion in such abstract closures declared in the abstract operations that creates iterators.