### PR TITLE
Editorial: replace implicit `~[empty]~` in ForBodyEvaluation with explicit `~empty~`

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -21757,12 +21757,16 @@
           1. If the first |Expression| is present, then
             1. Let _exprRef_ be ? Evaluation of the first |Expression|.
             1. Perform ? GetValue(_exprRef_).
-          1. Return ? ForBodyEvaluation(the second |Expression|, the third |Expression|, |Statement|, &laquo; &raquo;, _labelSet_).
+          1. If the second |Expression| is present, let _test_ be the second |Expression|; otherwise, let _test_ be ~empty~.
+          1. If the third |Expression| is present, let _increment_ be the third |Expression|; otherwise, let _increment_ be ~empty~.
+          1. Return ? ForBodyEvaluation(_test_, _increment_, |Statement|, &laquo; &raquo;, _labelSet_).
         </emu-alg>
         <emu-grammar>ForStatement : `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement</emu-grammar>
         <emu-alg>
           1. Let _varDcl_ be ? Evaluation of |VariableDeclarationList|.
-          1. Return ? ForBodyEvaluation(the first |Expression|, the second |Expression|, |Statement|, &laquo; &raquo;, _labelSet_).
+          1. If the first |Expression| is present, let _test_ be the first |Expression|; otherwise, let _test_ be ~empty~.
+          1. If the second |Expression| is present, let _increment_ be the second |Expression|; otherwise, let _increment_ be ~empty~.
+          1. Return ? ForBodyEvaluation(_test_, _increment_, |Statement|, &laquo; &raquo;, _labelSet_).
         </emu-alg>
         <emu-grammar>ForStatement : `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement</emu-grammar>
         <emu-alg>
@@ -21781,7 +21785,9 @@
             1. Set the running execution context's LexicalEnvironment to _oldEnv_.
             1. Return ? _forDcl_.
           1. If _isConst_ is *false*, let _perIterationLets_ be _boundNames_; otherwise let _perIterationLets_ be a new empty List.
-          1. Let _bodyResult_ be Completion(ForBodyEvaluation(the first |Expression|, the second |Expression|, |Statement|, _perIterationLets_, _labelSet_)).
+          1. If the first |Expression| is present, let _test_ be the first |Expression|; otherwise, let _test_ be ~empty~.
+          1. If the second |Expression| is present, let _increment_ be the second |Expression|; otherwise, let _increment_ be ~empty~.
+          1. Let _bodyResult_ be Completion(ForBodyEvaluation(_test_, _increment_, |Statement|, _perIterationLets_, _labelSet_)).
           1. Set the running execution context's LexicalEnvironment to _oldEnv_.
           1. Return ? _bodyResult_.
         </emu-alg>
@@ -21803,7 +21809,7 @@
           1. Let _V_ be *undefined*.
           1. Perform ? CreatePerIterationEnvironment(_perIterationBindings_).
           1. Repeat,
-            1. If _test_ is not ~[empty]~, then
+            1. If _test_ is not ~empty~, then
               1. Let _testRef_ be ? Evaluation of _test_.
               1. Let _testValue_ be ? GetValue(_testRef_).
               1. If ToBoolean(_testValue_) is *false*, return _V_.
@@ -21811,7 +21817,7 @@
             1. If LoopContinues(_result_, _labelSet_) is *false*, return ? UpdateEmpty(_result_, _V_).
             1. If _result_.[[Value]] is not ~empty~, set _V_ to _result_.[[Value]].
             1. Perform ? CreatePerIterationEnvironment(_perIterationBindings_).
-            1. If _increment_ is not ~[empty]~, then
+            1. If _increment_ is not ~empty~, then
               1. Let _incRef_ be ? Evaluation of _increment_.
               1. Perform ? GetValue(_incRef_).
         </emu-alg>


### PR DESCRIPTION
Previously we were acting as though the value of a missing parse node in an SDO definition was `~[empty]~` but that's not how it works as far as I'm aware. Now I explicitly test for their presence and pass the (more typical) enum `~empty~`.