### PR TITLE
Editorial: bugfix for exponentiation of Number and BigInt

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -2403,8 +2403,8 @@
           </dl>
           <emu-alg>
             1. If _y_ &lt; *0*<sub>ℤ</sub>, then
-              1. Return the BigInt value that represents ℝ(_x_) / 2<sup>-_y_</sup>, rounding down to the nearest integer, including for negative numbers.
-            1. Return the BigInt value that represents ℝ(_x_) &times; 2<sup>_y_</sup>.
+              1. Return the BigInt value that represents ℝ(_x_) / 2<sup>-ℝ(_y_)</sup>, rounding down to the nearest integer, including for negative numbers.
+            1. Return the BigInt value that represents ℝ(_x_) &times; 2<sup>ℝ(_y_)</sup>.
           </emu-alg>
           <emu-note>Semantics here should be equivalent to a bitwise shift, treating the BigInt as an infinite length string of binary two's complement digits.</emu-note>
         </emu-clause>


### PR DESCRIPTION
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
The `1. a.` step of [6.1.6.29 BigInt::leftShit(x, y)](https://tc39.es/ecma262/multipage/ecmascript-data-types-and-values.html#sec-numeric-types-bigint-leftShift) divides `ℝ(_x_)` by 2<sup>-y</sup>:

> 1. Return the BigInt value that represents ℝ(_x_) / 2<sup>-_y_</sup>, rounding down to the nearest integer, including for negative numbers.

Similarly, the step `2` in the same algorithm multiplies `ℝ(_x_)` by 2<sup>y</sup>:

> 1. Return the BigInt value that represents ℝ(_x_) &times; 2<sup>_y_</sup>.

However, there is no explicit rules for treating exponentiation of a _mathematical value_ base and a _BigInt_ exponent. Therefore, I suggest changing `_y_ ` into `ℝ(_y_)` to compute the exponentiation with mathematical base and exponent.

