### PR TITLE
Meta: bump ecmarkup to 14.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://tc39.es/ecma262/#sec-copyright-and-software-license",
       "dependencies": {
-        "ecmarkup": "^13.0.0"
+        "ecmarkup": "^14.1.1"
       },
       "devDependencies": {
         "glob": "^7.1.6",
@@ -724,9 +724,9 @@
       }
     },
     "node_modules/ecmarkup": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-13.0.0.tgz",
-      "integrity": "sha512-k3p1WL0PptR3PiBKpk1LzD/TszIfUb/MpDDWJ0XbK4DZHhzoEhYHaaytJxgQh8J5Lajo8bwo6+n/f0LWJ2as7w==",
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-14.1.1.tgz",
+      "integrity": "sha512-fS38NCH/v875qztGyhXnNh+SBoiXdnNkg7S/n76Jq98cDidLJ6iFg/UHCiLEduIZ0Tcr5yNngzvOLUdFEcvYHA==",
       "dependencies": {
         "chalk": "^4.1.2",
         "command-line-args": "^5.2.0",
@@ -740,6 +740,7 @@
         "html-escape": "^1.0.2",
         "js-yaml": "^3.13.1",
         "jsdom": "^19.0.0",
+        "nwsapi": "2.2.0",
         "parse5": "^6.0.1",
         "prex": "^0.4.7",
         "promise-debounce": "^1.0.1"
@@ -2939,9 +2940,9 @@
       }
     },
     "ecmarkup": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-13.0.0.tgz",
-      "integrity": "sha512-k3p1WL0PptR3PiBKpk1LzD/TszIfUb/MpDDWJ0XbK4DZHhzoEhYHaaytJxgQh8J5Lajo8bwo6+n/f0LWJ2as7w==",
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-14.1.1.tgz",
+      "integrity": "sha512-fS38NCH/v875qztGyhXnNh+SBoiXdnNkg7S/n76Jq98cDidLJ6iFg/UHCiLEduIZ0Tcr5yNngzvOLUdFEcvYHA==",
       "requires": {
         "chalk": "^4.1.2",
         "command-line-args": "^5.2.0",
@@ -2955,6 +2956,7 @@
         "html-escape": "^1.0.2",
         "js-yaml": "^3.13.1",
         "jsdom": "^19.0.0",
+        "nwsapi": "2.2.0",
         "parse5": "^6.0.1",
         "prex": "^0.4.7",
         "promise-debounce": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "license": "SEE LICENSE IN https://tc39.es/ecma262/#sec-copyright-and-software-license",
   "homepage": "https://tc39.es/ecma262/",
   "dependencies": {
-    "ecmarkup": "^13.0.0"
+    "ecmarkup": "^14.1.1"
   },
   "devDependencies": {
     "glob": "^7.1.6",


### PR DESCRIPTION
Should un-block https://github.com/tc39/ecma262/pull/2863 (except for the IPR), via inclusion of https://github.com/tc39/ecmarkup/pull/478.