### PR TITLE
Editorial: simplify IsNoTearConfiguration

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -41020,7 +41020,7 @@ THH:mm:ss.sss
         </dl>
         <emu-alg>
           1. If IsUnclampedIntegerElementType(_type_) is *true*, return *true*.
-          1. If IsBigIntElementType(_type_) is *true* and _order_ is not ~Init~ or ~Unordered~, return *true*.
+          1. If IsBigIntElementType(_type_) is *true* and _order_ is ~SeqCst~, return *true*.
           1. Return *false*.
         </emu-alg>
       </emu-clause>


### PR DESCRIPTION
The `open` parameter of `IsNoTearConfiguration` can only be `~SeqCst~`, `~Unordered~`, or `~Init~`.