### PR TITLE
Editorial: clarify BigInt.prototype.toString for non-decimal radices

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -2631,15 +2631,16 @@
           <h1>
             BigInt::toString (
               _x_: a BigInt,
+              _radix_: an integer in the inclusive interval from 2 to 36,
             ): a String
           </h1>
           <dl class="header">
             <dt>description</dt>
-            <dd>It converts _x_ to String format.</dd>
+            <dd>It represents _x_ as a String using a positional numeral system with radix _radix_. The digits used in the representation of a BigInt using radix _r_ are taken from the first _r_ code units of *"0123456789abcdefghijklmnopqrstuvwxyz"* in order. The representation of BigInts other than *0*<sub>ℤ</sub> never includes leading zeroes.</dd>
           </dl>
           <emu-alg>
-            1. If _x_ &lt; *0*<sub>ℤ</sub>, return the string-concatenation of the String *"-"* and BigInt::toString(-_x_).
-            1. Return the String value consisting of the code units of the digits of the decimal representation of _x_.
+            1. If _x_ &lt; *0*<sub>ℤ</sub>, return the string-concatenation of the String *"-"* and BigInt::toString(-_x_, _radix_).
+            1. Return the String value consisting of the representation of _x_ using radix _radix_.
           </emu-alg>
         </emu-clause>
       </emu-clause>
@@ -5622,7 +5623,7 @@
               BigInt
             </td>
             <td>
-              Return ! BigInt::toString(_argument_).
+              Return BigInt::toString(_argument_, 10).
             </td>
           </tr>
           <tr>
@@ -31415,9 +31416,8 @@
           1. Let _x_ be ? thisBigIntValue(*this* value).
           1. If _radix_ is *undefined*, let _radixMV_ be 10.
           1. Else, let _radixMV_ be ? ToIntegerOrInfinity(_radix_).
-          1. If _radixMV_ &lt; 2 or _radixMV_ &gt; 36, throw a *RangeError* exception.
-          1. If _radixMV_ = 10, return ! ToString(_x_).
-          1. Return the String representation of this Number value using the radix specified by _radixMV_. Letters `a`-`z` are used for digits with values 10 through 35. The precise algorithm is implementation-defined, however the algorithm should be a generalization of that specified in <emu-xref href="#sec-numeric-types-bigint-tostring"></emu-xref>.
+          1. If _radixMV_ is not in the inclusive interval from 2 to 36, throw a *RangeError* exception.
+          1. Return BigInt::toString(_x_, _radixMV_).
         </emu-alg>
         <p>This method is not generic; it throws a *TypeError* exception if its *this* value is not a BigInt or a BigInt object. Therefore, it cannot be transferred to other kinds of objects for use as a method.</p>
       </emu-clause>


### PR DESCRIPTION
Fixes #2860. Similar to what we did for `Number.prototype.toString` in #2854.

/cc @bathos