### PR TITLE
Editorial: get rid of BigInt::sameValue and BigInt::sameValueZero

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1627,21 +1627,16 @@
             <td>
               Number::sameValue
             </td>
-            <td rowspan="2">
+            <td>
               `Object.is(x, y)`
             </td>
-            <td rowspan="2">
+            <td>
               Object internal methods,
               via <emu-xref href="#sec-samevalue" title></emu-xref>,
               to test exact value equality
             </td>
-            <td rowspan="2">
-              Boolean
-            </td>
-          </tr>
-          <tr>
             <td>
-              BigInt::sameValue
+              Boolean
             </td>
           </tr>
 
@@ -1649,21 +1644,16 @@
             <td>
               Number::sameValueZero
             </td>
-            <td rowspan="2">
+            <td>
               `[x].includes(y)`
             </td>
-            <td rowspan="2">
+            <td>
               Array, Map, and Set methods,
               via <emu-xref href="#sec-samevaluezero" title></emu-xref>,
               to test value equality, ignoring the difference between *+0*<sub>𝔽</sub> and *-0*<sub>𝔽</sub>
             </td>
-            <td rowspan="2">
-              Boolean
-            </td>
-          </tr>
-          <tr>
             <td>
-              BigInt::sameValueZero
+              Boolean
             </td>
           </tr>
 
@@ -2459,7 +2449,7 @@
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-numeric-types-bigint-equal" type="numeric method">
+        <emu-clause id="sec-numeric-types-bigint-equal" type="numeric method" oldids="sec-numeric-types-bigint-sameValue,sec-numeric-types-bigint-sameValueZero">
           <h1>
             BigInt::equal (
               _x_: a BigInt,
@@ -2470,34 +2460,6 @@
           </dl>
           <emu-alg>
             1. If ℝ(_x_) = ℝ(_y_), return *true*; otherwise return *false*.
-          </emu-alg>
-        </emu-clause>
-
-        <emu-clause id="sec-numeric-types-bigint-sameValue" type="numeric method">
-          <h1>
-            BigInt::sameValue (
-              _x_: a BigInt,
-              _y_: a BigInt,
-            ): a Boolean
-          </h1>
-          <dl class="header">
-          </dl>
-          <emu-alg>
-            1. Return BigInt::equal(_x_, _y_).
-          </emu-alg>
-        </emu-clause>
-
-        <emu-clause id="sec-numeric-types-bigint-sameValueZero" type="numeric method">
-          <h1>
-            BigInt::sameValueZero (
-              _x_: a BigInt,
-              _y_: a BigInt,
-            ): a Boolean
-          </h1>
-          <dl class="header">
-          </dl>
-          <emu-alg>
-            1. Return BigInt::equal(_x_, _y_).
           </emu-alg>
         </emu-clause>
 
@@ -6054,9 +6016,7 @@
         1. If Type(_x_) is different from Type(_y_), return *false*.
         1. If Type(_x_) is Number, then
           1. Return Number::sameValue(_x_, _y_).
-        1. If Type(_x_) is BigInt, then
-          1. Return BigInt::sameValue(_x_, _y_).
-        1. Return SameValueNonNumeric(_x_, _y_).
+        1. Return SameValueNonNumber(_x_, _y_).
       </emu-alg>
       <emu-note>
         <p>This algorithm differs from the IsStrictlyEqual Algorithm by treating all *NaN* values as equivalent and by differentiating *+0*<sub>𝔽</sub> from *-0*<sub>𝔽</sub>.</p>
@@ -6078,26 +6038,26 @@
         1. If Type(_x_) is different from Type(_y_), return *false*.
         1. If Type(_x_) is Number, then
           1. Return Number::sameValueZero(_x_, _y_).
-        1. If Type(_x_) is BigInt, then
-          1. Return BigInt::sameValueZero(_x_, _y_).
-        1. Return SameValueNonNumeric(_x_, _y_).
+        1. Return SameValueNonNumber(_x_, _y_).
       </emu-alg>
       <emu-note>
         <p>SameValueZero differs from SameValue only in that it treats *+0*<sub>𝔽</sub> and *-0*<sub>𝔽</sub> as equivalent.</p>
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-samevaluenonnumeric" type="abstract operation" oldids="sec-samevaluenonnumber">
+    <emu-clause id="sec-samevaluenonnumber" type="abstract operation" oldids="sec-samevaluenonnumeric">
       <h1>
-        SameValueNonNumeric (
-          _x_: an ECMAScript language value, but not a Number or a BigInt,
-          _y_: an ECMAScript language value, but not a Number or a BigInt,
+        SameValueNonNumber (
+          _x_: an ECMAScript language value, but not a Number,
+          _y_: an ECMAScript language value, but not a Number,
         ): a Boolean
       </h1>
       <dl class="header">
       </dl>
       <emu-alg>
         1. Assert: Type(_x_) is the same as Type(_y_).
+        1. If Type(_x_) is BigInt, then
+          1. Return BigInt::equal(_x_, _y_).
         1. If Type(_x_) is Undefined, return *true*.
         1. If Type(_x_) is Null, return *true*.
         1. If Type(_x_) is String, then
@@ -6221,9 +6181,7 @@
         1. If Type(_x_) is different from Type(_y_), return *false*.
         1. If Type(_x_) is Number, then
           1. Return Number::equal(_x_, _y_).
-        1. If Type(_x_) is BigInt, then
-          1. Return BigInt::equal(_x_, _y_).
-        1. Return SameValueNonNumeric(_x_, _y_).
+        1. Return SameValueNonNumber(_x_, _y_).
       </emu-alg>
       <emu-note>
         <p>This algorithm differs from the SameValue Algorithm in its treatment of signed zeroes and NaNs.</p>
@@ -33701,7 +33659,8 @@ THH:mm:ss.sss
           1. Let _start_ be _end_ - _searchLength_.
           1. If _start_ &lt; 0, return *false*.
           1. Let _substring_ be the substring of _S_ from _start_ to _end_.
-          1. Return SameValueNonNumeric(_substring_, _searchStr_).
+          1. If _substring_ is _searchStr_, return *true*.
+          1. Return *false*.
         </emu-alg>
         <emu-note>
           <p>This method returns *true* if the sequence of code units of _searchString_ converted to a String is the same as the corresponding code units of this object (converted to a String) starting at _endPosition_ - length(this). Otherwise it returns *false*.</p>
@@ -34236,7 +34195,8 @@ THH:mm:ss.sss
           1. Let _end_ be _start_ + _searchLength_.
           1. If _end_ &gt; _len_, return *false*.
           1. Let _substring_ be the substring of _S_ from _start_ to _end_.
-          1. Return SameValueNonNumeric(_substring_, _searchStr_).
+          1. If _substring_ is _searchStr_, return *true*.
+          1. Return *false*.
         </emu-alg>
         <emu-note>
           <p>This method returns *true* if the sequence of code units of _searchString_ converted to a String is the same as the corresponding code units of this object (converted to a String) starting at index _position_. Otherwise it returns *false*.</p>


### PR DESCRIPTION
These were only added because we were doing dispatch on Number and BigInt which meant they needed matching AOs. We no longer do that.

We could also get rid of `BigInt::equal` by inlining it into the single call site you see here.