### PR TITLE
Editorial: use "is not finite" in more places where appropriate and add dfn for "finite" so they link

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1758,7 +1758,7 @@
           <p>The bit pattern that might be observed in an ArrayBuffer (see <emu-xref href="#sec-arraybuffer-objects"></emu-xref>) or a SharedArrayBuffer (see <emu-xref href="#sec-sharedarraybuffer-objects"></emu-xref>) after a Number value has been stored into it is not necessarily the same as the internal representation of that Number value used by the ECMAScript implementation.</p>
         </emu-note>
         <p>There are two other special values, called *positive Infinity* and *negative Infinity*. For brevity, these values are also referred to for expository purposes by the symbols *+&infin;*<sub>𝔽</sub> and *-&infin;*<sub>𝔽</sub>, respectively. (Note that these two infinite Number values are produced by the program expressions `+Infinity` (or simply `Infinity`) and `-Infinity`.)</p>
-        <p>The other 18,437,736,874,454,810,624 (that is, <emu-eqn>2<sup>64</sup> - 2<sup>53</sup></emu-eqn>) values are called the finite numbers. Half of these are positive numbers and half are negative numbers; for every finite positive Number value there is a corresponding negative value having the same magnitude.</p>
+        <p>The other 18,437,736,874,454,810,624 (that is, <emu-eqn>2<sup>64</sup> - 2<sup>53</sup></emu-eqn>) values are called the <dfn id="finite">finite</dfn> numbers. Half of these are positive numbers and half are negative numbers; for every finite positive Number value there is a corresponding negative value having the same magnitude.</p>
         <p>Note that there is both a *positive zero* and a *negative zero*. For brevity, these values are also referred to for expository purposes by the symbols *+0*<sub>𝔽</sub> and *-0*<sub>𝔽</sub>, respectively. (Note that these two different zero Number values are produced by the program expressions `+0` (or simply `0`) and `-0`.)</p>
         <p>The 18,437,736,874,454,810,622 (that is, <emu-eqn>2<sup>64</sup> - 2<sup>53</sup> - 2</emu-eqn>) finite non-zero values are of two kinds:</p>
         <p>18,428,729,675,200,069,632 (that is, <emu-eqn>2<sup>64</sup> - 2<sup>54</sup></emu-eqn>) of them are normalized, having the form</p>
@@ -5182,7 +5182,7 @@
       </dl>
       <emu-alg>
         1. Let _number_ be ? ToNumber(_argument_).
-        1. If _number_ is *NaN*, *+0*<sub>𝔽</sub>, *-0*<sub>𝔽</sub>, *+&infin;*<sub>𝔽</sub>, or *-&infin;*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
+        1. If _number_ is not finite or _number_ is either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
         1. Let _int_ be the mathematical value whose sign is the sign of _number_ and whose magnitude is floor(abs(ℝ(_number_))).
         1. Let _int32bit_ be _int_ modulo 2<sup>32</sup>.
         1. If _int32bit_ &ge; 2<sup>31</sup>, return 𝔽(_int32bit_ - 2<sup>32</sup>); otherwise return 𝔽(_int32bit_).
@@ -5215,7 +5215,7 @@
       </dl>
       <emu-alg>
         1. Let _number_ be ? ToNumber(_argument_).
-        1. If _number_ is *NaN*, *+0*<sub>𝔽</sub>, *-0*<sub>𝔽</sub>, *+&infin;*<sub>𝔽</sub>, or *-&infin;*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
+        1. If _number_ is not finite or _number_ is either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
         1. Let _int_ be the mathematical value whose sign is the sign of _number_ and whose magnitude is floor(abs(ℝ(_number_))).
         1. Let _int32bit_ be _int_ modulo 2<sup>32</sup>.
         1. [id="step-touint32-return"] Return 𝔽(_int32bit_).
@@ -5251,7 +5251,7 @@
       </dl>
       <emu-alg>
         1. Let _number_ be ? ToNumber(_argument_).
-        1. If _number_ is *NaN*, *+0*<sub>𝔽</sub>, *-0*<sub>𝔽</sub>, *+&infin;*<sub>𝔽</sub>, or *-&infin;*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
+        1. If _number_ is not finite or _number is either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
         1. Let _int_ be the mathematical value whose sign is the sign of _number_ and whose magnitude is floor(abs(ℝ(_number_))).
         1. Let _int16bit_ be _int_ modulo 2<sup>16</sup>.
         1. If _int16bit_ &ge; 2<sup>15</sup>, return 𝔽(_int16bit_ - 2<sup>16</sup>); otherwise return 𝔽(_int16bit_).
@@ -5270,7 +5270,7 @@
       </dl>
       <emu-alg>
         1. Let _number_ be ? ToNumber(_argument_).
-        1. If _number_ is *NaN*, *+0*<sub>𝔽</sub>, *-0*<sub>𝔽</sub>, *+&infin;*<sub>𝔽</sub>, or *-&infin;*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
+        1. If _number_ is not finite or _number_ is either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
         1. Let _int_ be the mathematical value whose sign is the sign of _number_ and whose magnitude is floor(abs(ℝ(_number_))).
         1. [id="step-touint16-mod"] Let _int16bit_ be _int_ modulo 2<sup>16</sup>.
         1. Return 𝔽(_int16bit_).
@@ -5300,7 +5300,7 @@
       </dl>
       <emu-alg>
         1. Let _number_ be ? ToNumber(_argument_).
-        1. If _number_ is *NaN*, *+0*<sub>𝔽</sub>, *-0*<sub>𝔽</sub>, *+&infin;*<sub>𝔽</sub>, or *-&infin;*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
+        1. If _number_ is not finite or _number_ is either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
         1. Let _int_ be the mathematical value whose sign is the sign of _number_ and whose magnitude is floor(abs(ℝ(_number_))).
         1. Let _int8bit_ be _int_ modulo 2<sup>8</sup>.
         1. If _int8bit_ &ge; 2<sup>7</sup>, return 𝔽(_int8bit_ - 2<sup>8</sup>); otherwise return 𝔽(_int8bit_).
@@ -5319,7 +5319,7 @@
       </dl>
       <emu-alg>
         1. Let _number_ be ? ToNumber(_argument_).
-        1. If _number_ is *NaN*, *+0*<sub>𝔽</sub>, *-0*<sub>𝔽</sub>, *+&infin;*<sub>𝔽</sub>, or *-&infin;*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
+        1. If _number_ is not finite or _number_ is either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
         1. Let _int_ be the mathematical value whose sign is the sign of _number_ and whose magnitude is floor(abs(ℝ(_number_))).
         1. Let _int8bit_ be _int_ modulo 2<sup>8</sup>.
         1. Return 𝔽(_int8bit_).
@@ -5948,7 +5948,7 @@
       </dl>
       <emu-alg>
         1. If _argument_ is not a Number, return *false*.
-        1. If _argument_ is *NaN*, *+&infin;*<sub>𝔽</sub>, or *-&infin;*<sub>𝔽</sub>, return *false*.
+        1. If _argument_ is not finite, return *false*.
         1. If floor(abs(ℝ(_argument_))) &ne; abs(ℝ(_argument_)), return *false*.
         1. Return *true*.
       </emu-alg>
@@ -6168,7 +6168,7 @@
         1. If _x_ is either a String, a Number, a BigInt, or a Symbol and _y_ is an Object, return ! IsLooselyEqual(_x_, ? ToPrimitive(_y_)).
         1. If _x_ is an Object and _y_ is either a String, a Number, a BigInt, or a Symbol, return ! IsLooselyEqual(? ToPrimitive(_x_), _y_).
         1. If _x_ is a BigInt and _y_ is a Number, or if _x_ is a Number and _y_ is a BigInt, then
-          1. If _x_ or _y_ are any of *NaN*, *+&infin;*<sub>𝔽</sub>, or *-&infin;*<sub>𝔽</sub>, return *false*.
+          1. If _x_ is not finite or _y_ is not finite, return *false*.
           1. If ℝ(_x_) = ℝ(_y_), return *true*; otherwise return *false*.
         1. Return *false*.
       </emu-alg>
@@ -28850,7 +28850,7 @@
       <p>It performs the following steps when called:</p>
       <emu-alg>
         1. Let _num_ be ? ToNumber(_number_).
-        1. If _num_ is *NaN*, *+&infin;*<sub>𝔽</sub>, or *-&infin;*<sub>𝔽</sub>, return *false*.
+        1. If _num_ is not finite, return *false*.
         1. Otherwise, return *true*.
       </emu-alg>
     </emu-clause>
@@ -30917,7 +30917,7 @@
         <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. If _number_ is not a Number, return *false*.
-          1. If _number_ is *NaN*, *+&infin;*<sub>𝔽</sub>, or *-&infin;*<sub>𝔽</sub>, return *false*.
+          1. If _number_ is not finite, return *false*.
           1. Otherwise, return *true*.
         </emu-alg>
       </emu-clause>
@@ -31506,7 +31506,7 @@
         <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
-          1. If _n_ is *NaN*, _n_ is *+0*<sub>𝔽</sub>, _n_ is *-0*<sub>𝔽</sub>, _n_ is *+&infin;*<sub>𝔽</sub>, or _n_ is *-&infin;*<sub>𝔽</sub>, return _n_.
+          1. If _n_ is not finite or _n_ is either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, return _n_.
           1. Return an implementation-approximated Number value representing the result of the inverse hyperbolic sine of ℝ(_n_).
         </emu-alg>
       </emu-clause>
@@ -31580,7 +31580,7 @@
         <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
-          1. If _n_ is *NaN*, _n_ is *+0*<sub>𝔽</sub>, _n_ is *-0*<sub>𝔽</sub>, _n_ is *+&infin;*<sub>𝔽</sub>, or _n_ is *-&infin;*<sub>𝔽</sub>, return _n_.
+          1. If _n_ is not finite or _n_ is either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, return _n_.
           1. Return an implementation-approximated Number value representing the result of the cube root of ℝ(_n_).
         </emu-alg>
       </emu-clause>
@@ -31591,7 +31591,7 @@
         <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
-          1. If _n_ is *NaN*, _n_ is *+0*<sub>𝔽</sub>, _n_ is *-0*<sub>𝔽</sub>, _n_ is *+&infin;*<sub>𝔽</sub>, or _n_ is *-&infin;*<sub>𝔽</sub>, return _n_.
+          1. If _n_ is not finite or _n_ is either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, return _n_.
           1. If _n_ &lt; *-0*<sub>𝔽</sub> and _n_ &gt; *-1*<sub>𝔽</sub>, return *-0*<sub>𝔽</sub>.
           1. If _n_ is an integral Number, return _n_.
           1. Return the smallest (closest to -&infin;) integral Number value that is not less than _n_.
@@ -31620,7 +31620,7 @@
         <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
-          1. If _n_ is *NaN*, _n_ is *+&infin;*<sub>𝔽</sub>, or _n_ is *-&infin;*<sub>𝔽</sub>, return *NaN*.
+          1. If _n_ is not finite, return *NaN*.
           1. If _n_ is *+0*<sub>𝔽</sub> or _n_ is *-0*<sub>𝔽</sub>, return *1*<sub>𝔽</sub>.
           1. Return an implementation-approximated Number value representing the result of the cosine of ℝ(_n_).
         </emu-alg>
@@ -31673,7 +31673,7 @@
         <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
-          1. If _n_ is *NaN*, _n_ is *+0*<sub>𝔽</sub>, _n_ is *-0*<sub>𝔽</sub>, _n_ is *+&infin;*<sub>𝔽</sub>, or _n_ is *-&infin;*<sub>𝔽</sub>, return _n_.
+          1. If _n_ is not finite or _n_ is either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, return _n_.
           1. If _n_ &lt; *1*<sub>𝔽</sub> and _n_ &gt; *+0*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
           1. If _n_ is an integral Number, return _n_.
           1. Return the greatest (closest to +&infin;) integral Number value that is not greater than _n_.
@@ -31852,7 +31852,7 @@
         <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
-          1. If _n_ is *NaN*, *+&infin;*<sub>𝔽</sub>, *-&infin;*<sub>𝔽</sub>, or an integral Number, return _n_.
+          1. If _n_ is not finite or _n_ is an integral Number, return _n_.
           1. If _n_ &lt; *0.5*<sub>𝔽</sub> and _n_ &gt; *+0*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
           1. If _n_ &lt; *-0*<sub>𝔽</sub> and _n_ &ge; *-0.5*<sub>𝔽</sub>, return *-0*<sub>𝔽</sub>.
           1. Return the integral Number closest to _n_, preferring the Number closer to +&infin; in the case of a tie.
@@ -31895,7 +31895,7 @@
         <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
-          1. If _n_ is *NaN*, _n_ is *+0*<sub>𝔽</sub>, _n_ is *-0*<sub>𝔽</sub>, _n_ is *+&infin;*<sub>𝔽</sub>, or _n_ is *-&infin;*<sub>𝔽</sub>, return _n_.
+          1. If _n_ is not finite or _n_ is either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, return _n_.
           1. Return an implementation-approximated Number value representing the result of the hyperbolic sine of ℝ(_n_).
         </emu-alg>
         <emu-note>
@@ -31949,7 +31949,7 @@
         <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
-          1. If _n_ is *NaN*, _n_ is *+0*<sub>𝔽</sub>, _n_ is *-0*<sub>𝔽</sub>, _n_ is *+&infin;*<sub>𝔽</sub>, or _n_ is *-&infin;*<sub>𝔽</sub>, return _n_.
+          1. If _n_ is not finite or _n_ is either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, return _n_.
           1. If _n_ &lt; *1*<sub>𝔽</sub> and _n_ &gt; *+0*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
           1. If _n_ &lt; *-0*<sub>𝔽</sub> and _n_ &gt; *-1*<sub>𝔽</sub>, return *-0*<sub>𝔽</sub>.
           1. Return the integral Number nearest _n_ in the direction of *+0*<sub>𝔽</sub>.


### PR DESCRIPTION
We already have 17 occurrences of "is not finite" and 7 occurrences of "is finite", so I've identified the remaining locations where "is not finite" can be used and changed those. I also added a `<dfn>` for "finite" so it links.