### PR TITLE
Editorial: define `\d` semantics in a similar way to `\s`, avoiding character range

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -35853,7 +35853,7 @@ THH:mm:ss.sss
         <!-- CharacterClassEscape -->
         <emu-grammar>CharacterClassEscape :: `d`</emu-grammar>
         <emu-alg>
-          1. Return the ten-element CharSet containing the characters `0` through `9` inclusive.
+          1. Return the ten-element CharSet containing the characters `0`, `1`, `2`, `3`, `4`, `5`, `6`, `7`, `8`, and `9`.
         </emu-alg>
         <emu-grammar>CharacterClassEscape :: `D`</emu-grammar>
         <emu-alg>


### PR DESCRIPTION
This avoids the ill-defined character range.