### PR TITLE
various editorial changes for comparisons

### DIFF
--- a/esmeta-ignore.json
+++ b/esmeta-ignore.json
@@ -26,7 +26,6 @@
   "ForIn/OfBodyEvaluation",
   "FunctionBody[0,0].EvaluateFunctionBody",
   "GeneratorBody[0,0].EvaluateGeneratorBody",
-  "GeneratorValidate",
   "GetGlobalObject",
   "GetMethod",
   "GetPromiseResolve",

--- a/spec.html
+++ b/spec.html
@@ -1160,11 +1160,11 @@
           1. Let _searchLen_ be the length of _searchValue_.
           1. For each integer _i_ such that _fromIndex_ ≤ _i_ ≤ _len_ - _searchLen_, in ascending order, do
             1. Let _candidate_ be the substring of _string_ from _i_ to _i_ + _searchLen_.
-            1. If _candidate_ is the same sequence of code units as _searchValue_, return _i_.
+            1. If _candidate_ is _searchValue_, return _i_.
           1. Return -1.
         </emu-alg>
         <emu-note>
-          <p>If _searchValue_ is the empty String and _fromIndex_ is less than or equal to the length of _string_, this algorithm returns _fromIndex_. The empty String is effectively found at every position within a string, including after the last code unit.</p>
+          <p>If _searchValue_ is the empty String and _fromIndex_ ≤ the length of _string_, this algorithm returns _fromIndex_. The empty String is effectively found at every position within a string, including after the last code unit.</p>
         </emu-note>
         <emu-note>
           <p>This algorithm always returns -1 if _fromIndex_ + the length of _searchValue_ > the length of _string_.</p>
@@ -1867,7 +1867,7 @@
           </dl>
           <emu-alg>
             1. If _exponent_ is *NaN*, return *NaN*.
-            1. If _exponent_ is *+0*<sub>𝔽</sub> or _exponent_ is *-0*<sub>𝔽</sub>, return *1*<sub>𝔽</sub>.
+            1. If _exponent_ is either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, return *1*<sub>𝔽</sub>.
             1. If _base_ is *NaN*, return *NaN*.
             1. If _base_ is *+∞*<sub>𝔽</sub>, then
               1. If _exponent_ > *+0*<sub>𝔽</sub>, return *+∞*<sub>𝔽</sub>. Otherwise, return *+0*<sub>𝔽</sub>.
@@ -1886,11 +1886,11 @@
             1. Assert: _base_ is finite and is neither *+0*<sub>𝔽</sub> nor *-0*<sub>𝔽</sub>.
             1. If _exponent_ is *+∞*<sub>𝔽</sub>, then
               1. If abs(ℝ(_base_)) > 1, return *+∞*<sub>𝔽</sub>.
-              1. If abs(ℝ(_base_)) is 1, return *NaN*.
+              1. If abs(ℝ(_base_)) = 1, return *NaN*.
               1. If abs(ℝ(_base_)) &lt; 1, return *+0*<sub>𝔽</sub>.
             1. If _exponent_ is *-∞*<sub>𝔽</sub>, then
               1. If abs(ℝ(_base_)) > 1, return *+0*<sub>𝔽</sub>.
-              1. If abs(ℝ(_base_)) is 1, return *NaN*.
+              1. If abs(ℝ(_base_)) = 1, return *NaN*.
               1. If abs(ℝ(_base_)) &lt; 1, return *+∞*<sub>𝔽</sub>.
             1. Assert: _exponent_ is finite and is neither *+0*<sub>𝔽</sub> nor *-0*<sub>𝔽</sub>.
             1. If _base_ &lt; *-0*<sub>𝔽</sub> and _exponent_ is not an integral Number, return *NaN*.
@@ -1914,12 +1914,12 @@
           </dl>
           <emu-alg>
             1. If _x_ is *NaN* or _y_ is *NaN*, return *NaN*.
-            1. If _x_ is *+∞*<sub>𝔽</sub> or _x_ is *-∞*<sub>𝔽</sub>, then
-              1. If _y_ is *+0*<sub>𝔽</sub> or _y_ is *-0*<sub>𝔽</sub>, return *NaN*.
+            1. If _x_ is either *+∞*<sub>𝔽</sub> or *-∞*<sub>𝔽</sub>, then
+              1. If _y_ is either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, return *NaN*.
               1. If _y_ > *+0*<sub>𝔽</sub>, return _x_.
               1. Return -_x_.
-            1. If _y_ is *+∞*<sub>𝔽</sub> or _y_ is *-∞*<sub>𝔽</sub>, then
-              1. If _x_ is *+0*<sub>𝔽</sub> or _x_ is *-0*<sub>𝔽</sub>, return *NaN*.
+            1. If _y_ is either *+∞*<sub>𝔽</sub> or *-∞*<sub>𝔽</sub>, then
+              1. If _x_ is either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, return *NaN*.
               1. If _x_ > *+0*<sub>𝔽</sub>, return _y_.
               1. Return -_y_.
             1. If _x_ is *-0*<sub>𝔽</sub>, then
@@ -1948,16 +1948,16 @@
           </dl>
           <emu-alg>
             1. If _x_ is *NaN* or _y_ is *NaN*, return *NaN*.
-            1. If _x_ is *+∞*<sub>𝔽</sub> or _x_ is *-∞*<sub>𝔽</sub>, then
-              1. If _y_ is *+∞*<sub>𝔽</sub> or _y_ is *-∞*<sub>𝔽</sub>, return *NaN*.
+            1. If _x_ is either *+∞*<sub>𝔽</sub> or *-∞*<sub>𝔽</sub>, then
+              1. If _y_ is either *+∞*<sub>𝔽</sub> or *-∞*<sub>𝔽</sub>, return *NaN*.
               1. If _y_ is *+0*<sub>𝔽</sub> or _y_ > *+0*<sub>𝔽</sub>, return _x_.
               1. Return -_x_.
             1. If _y_ is *+∞*<sub>𝔽</sub>, then
               1. If _x_ is *+0*<sub>𝔽</sub> or _x_ > *+0*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>. Otherwise, return *-0*<sub>𝔽</sub>.
             1. If _y_ is *-∞*<sub>𝔽</sub>, then
               1. If _x_ is *+0*<sub>𝔽</sub> or _x_ > *+0*<sub>𝔽</sub>, return *-0*<sub>𝔽</sub>. Otherwise, return *+0*<sub>𝔽</sub>.
-            1. If _x_ is *+0*<sub>𝔽</sub> or _x_ is *-0*<sub>𝔽</sub>, then
-              1. If _y_ is *+0*<sub>𝔽</sub> or _y_ is *-0*<sub>𝔽</sub>, return *NaN*.
+            1. If _x_ is either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, then
+              1. If _y_ is either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, return *NaN*.
               1. If _y_ > *+0*<sub>𝔽</sub>, return _x_.
               1. Return -_x_.
             1. If _y_ is *+0*<sub>𝔽</sub>, then
@@ -1981,15 +1981,15 @@
           </dl>
           <emu-alg>
             1. If _n_ is *NaN* or _d_ is *NaN*, return *NaN*.
-            1. If _n_ is *+∞*<sub>𝔽</sub> or _n_ is *-∞*<sub>𝔽</sub>, return *NaN*.
-            1. If _d_ is *+∞*<sub>𝔽</sub> or _d_ is *-∞*<sub>𝔽</sub>, return _n_.
-            1. If _d_ is *+0*<sub>𝔽</sub> or _d_ is *-0*<sub>𝔽</sub>, return *NaN*.
-            1. If _n_ is *+0*<sub>𝔽</sub> or _n_ is *-0*<sub>𝔽</sub>, return _n_.
+            1. If _n_ is either *+∞*<sub>𝔽</sub> or *-∞*<sub>𝔽</sub>, return *NaN*.
+            1. If _d_ is either *+∞*<sub>𝔽</sub> or *-∞*<sub>𝔽</sub>, return _n_.
+            1. If _d_ is either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, return *NaN*.
+            1. If _n_ is either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, return _n_.
             1. Assert: _n_ and _d_ are finite and non-zero.
             1. Let _quotient_ be ℝ(_n_) / ℝ(_d_).
             1. Let _q_ be truncate(_quotient_).
             1. Let _r_ be ℝ(_n_) - (ℝ(_d_) × _q_).
-            1. If _r_ is 0 and _n_ &lt; *-0*<sub>𝔽</sub>, return *-0*<sub>𝔽</sub>.
+            1. If _r_ = 0 and _n_ &lt; *-0*<sub>𝔽</sub>, return *-0*<sub>𝔽</sub>.
             1. Return 𝔽(_r_).
           </emu-alg>
           <emu-note>
@@ -2013,8 +2013,8 @@
             1. If _x_ is *NaN* or _y_ is *NaN*, return *NaN*.
             1. If _x_ is *+∞*<sub>𝔽</sub> and _y_ is *-∞*<sub>𝔽</sub>, return *NaN*.
             1. If _x_ is *-∞*<sub>𝔽</sub> and _y_ is *+∞*<sub>𝔽</sub>, return *NaN*.
-            1. If _x_ is *+∞*<sub>𝔽</sub> or _x_ is *-∞*<sub>𝔽</sub>, return _x_.
-            1. If _y_ is *+∞*<sub>𝔽</sub> or _y_ is *-∞*<sub>𝔽</sub>, return _y_.
+            1. If _x_ is either *+∞*<sub>𝔽</sub> or *-∞*<sub>𝔽</sub>, return _x_.
+            1. If _y_ is either *+∞*<sub>𝔽</sub> or *-∞*<sub>𝔽</sub>, return _y_.
             1. Assert: _x_ and _y_ are both finite.
             1. If _x_ is *-0*<sub>𝔽</sub> and _y_ is *-0*<sub>𝔽</sub>, return *-0*<sub>𝔽</sub>.
             1. Return 𝔽(ℝ(_x_) + ℝ(_y_)).
@@ -2106,7 +2106,7 @@
           <emu-alg>
             1. If _x_ is *NaN*, return *undefined*.
             1. If _y_ is *NaN*, return *undefined*.
-            1. If _x_ and _y_ are the same Number value, return *false*.
+            1. If _x_ is _y_, return *false*.
             1. If _x_ is *+0*<sub>𝔽</sub> and _y_ is *-0*<sub>𝔽</sub>, return *false*.
             1. If _x_ is *-0*<sub>𝔽</sub> and _y_ is *+0*<sub>𝔽</sub>, return *false*.
             1. If _x_ is *+∞*<sub>𝔽</sub>, return *false*.
@@ -2130,7 +2130,7 @@
           <emu-alg>
             1. If _x_ is *NaN*, return *false*.
             1. If _y_ is *NaN*, return *false*.
-            1. If _x_ is the same Number value as _y_, return *true*.
+            1. If _x_ is _y_, return *true*.
             1. If _x_ is *+0*<sub>𝔽</sub> and _y_ is *-0*<sub>𝔽</sub>, return *true*.
             1. If _x_ is *-0*<sub>𝔽</sub> and _y_ is *+0*<sub>𝔽</sub>, return *true*.
             1. Return *false*.
@@ -2150,7 +2150,7 @@
             1. If _x_ is *NaN* and _y_ is *NaN*, return *true*.
             1. If _x_ is *+0*<sub>𝔽</sub> and _y_ is *-0*<sub>𝔽</sub>, return *false*.
             1. If _x_ is *-0*<sub>𝔽</sub> and _y_ is *+0*<sub>𝔽</sub>, return *false*.
-            1. If _x_ is the same Number value as _y_, return *true*.
+            1. If _x_ is _y_, return *true*.
             1. Return *false*.
           </emu-alg>
         </emu-clause>
@@ -2168,7 +2168,7 @@
             1. If _x_ is *NaN* and _y_ is *NaN*, return *true*.
             1. If _x_ is *+0*<sub>𝔽</sub> and _y_ is *-0*<sub>𝔽</sub>, return *true*.
             1. If _x_ is *-0*<sub>𝔽</sub> and _y_ is *+0*<sub>𝔽</sub>, return *true*.
-            1. If _x_ is the same Number value as _y_, return *true*.
+            1. If _x_ is _y_, return *true*.
             1. Return *false*.
           </emu-alg>
         </emu-clause>
@@ -2250,7 +2250,7 @@
           </dl>
           <emu-alg>
             1. If _x_ is *NaN*, return *"NaN"*.
-            1. If _x_ is *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, return *"0"*.
+            1. If _x_ is either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, return *"0"*.
             1. If _x_ &lt; *-0*<sub>𝔽</sub>, return the string-concatenation of *"-"* and Number::toString(-_x_, _radix_).
             1. If _x_ is *+∞*<sub>𝔽</sub>, return *"Infinity"*.
             1. [id="step-number-tostring-intermediate-values"] Let _n_, _k_, and _s_ be integers such that _k_ ≥ 1, _radix_<sup>_k_ - 1</sup> ≤ _s_ &lt; _radix_<sup>_k_</sup>, 𝔽(_s_ × _radix_<sup>_n_ - _k_</sup>) is _x_, and _k_ is as small as possible. Note that _k_ is the number of digits in the representation of _s_ using radix _radix_, that _s_ is not divisible by _radix_, and that the least significant digit of _s_ is not necessarily uniquely determined by these criteria.
@@ -2277,7 +2277,7 @@
               1. Let _exponentSign_ be the code unit 0x002D (HYPHEN-MINUS).
             1. Else,
               1. Let _exponentSign_ be the code unit 0x002B (PLUS SIGN).
-            1. If _k_ is 1, then
+            1. If _k_ = 1, then
               1. Return the string-concatenation of:
                 * the code unit of the single digit of _s_
                 * the code unit 0x0065 (LATIN SMALL LETTER E)
@@ -2295,7 +2295,7 @@
             <p>The following observations may be useful as guidelines for implementations, but are not part of the normative requirements of this Standard:</p>
             <ul>
               <li>
-                If x is any Number value other than *-0*<sub>𝔽</sub>, then ToNumber(ToString(x)) is exactly the same Number value as x.
+                If x is any Number value other than *-0*<sub>𝔽</sub>, then ToNumber(ToString(x)) is x.
               </li>
               <li>
                 The least significant digit of s is not always uniquely determined by the requirements listed in step <emu-xref href="#step-number-tostring-intermediate-values"></emu-xref>.
@@ -2416,7 +2416,7 @@
             1. Let _q_ be ℤ(truncate(_quotient_)).
             1. Return _n_ - (_d_ × _q_).
           </emu-alg>
-          <emu-note>The sign of the result equals the sign of the dividend.</emu-note>
+          <emu-note>The sign of the result is the sign of the dividend.</emu-note>
         </emu-clause>
 
         <emu-clause id="sec-numeric-types-bigint-add" type="numeric method">
@@ -2530,7 +2530,7 @@
           <dl class="header">
           </dl>
           <emu-alg>
-            1. If _x_ is 1 and _y_ is 1, return 1.
+            1. If _x_ = 1 and _y_ = 1, return 1.
             1. Else, return 0.
           </emu-alg>
         </emu-clause>
@@ -2545,7 +2545,7 @@
           <dl class="header">
           </dl>
           <emu-alg>
-            1. If _x_ is 1 or _y_ is 1, return 1.
+            1. If _x_ = 1 or _y_ = 1, return 1.
             1. Else, return 0.
           </emu-alg>
         </emu-clause>
@@ -2560,8 +2560,8 @@
           <dl class="header">
           </dl>
           <emu-alg>
-            1. If _x_ is 1 and _y_ is 0, return 1.
-            1. Else if _x_ is 0 and _y_ is 1, return 1.
+            1. If _x_ = 1 and _y_ = 0, return 1.
+            1. Else if _x_ = 0 and _y_ = 1, return 1.
             1. Else, return 0.
           </emu-alg>
         </emu-clause>
@@ -3982,7 +3982,7 @@
         <li>
           <p>For all _a_, _b_, and _c_ in _R_'s domain:</p>
           <ul>
-            <li>_a_ is identical to _b_ or _a_ _R_ _b_ or _b_ _R_ _a_, and</li>
+            <li>_a_ is _b_ or _a_ _R_ _b_ or _b_ _R_ _a_, and</li>
             <li>It is not the case that _a_ _R_ _a_, and</li>
             <li>If _a_ _R_ _b_ and _b_ _R_ _c_, then _a_ _R_ _c_.</li>
           </ul>
@@ -4804,7 +4804,7 @@
       </dl>
       <emu-alg>
         1. If _argument_ is a Boolean, return _argument_.
-        1. If _argument_ is any of *undefined*, *null*, *+0*<sub>𝔽</sub>, *-0*<sub>𝔽</sub>, *NaN*, *0*<sub>ℤ</sub>, or the empty String, return *false*.
+        1. If _argument_ is one of *undefined*, *null*, *+0*<sub>𝔽</sub>, *-0*<sub>𝔽</sub>, *NaN*, *0*<sub>ℤ</sub>, or the empty String, return *false*.
         1. [id="step-to-boolean-web-compat-insertion-point"] NOTE: This step is replaced in section <emu-xref href="#sec-IsHTMLDDA-internal-slot-to-boolean"></emu-xref>.
         1. Return *true*.
       </emu-alg>
@@ -5014,7 +5014,7 @@
       </dl>
       <emu-alg>
         1. Let _number_ be ? ToNumber(_argument_).
-        1. If _number_ is *NaN*, *+0*<sub>𝔽</sub>, or *-0*<sub>𝔽</sub>, return 0.
+        1. If _number_ is one of *NaN*, *+0*<sub>𝔽</sub>, or *-0*<sub>𝔽</sub>, return 0.
         1. If _number_ is *+∞*<sub>𝔽</sub>, return +∞.
         1. If _number_ is *-∞*<sub>𝔽</sub>, return -∞.
         1. Return truncate(ℝ(_number_)).
@@ -5535,7 +5535,7 @@
       <emu-alg>
         1. If _argument_ is *"-0"*, return *-0*<sub>𝔽</sub>.
         1. Let _n_ be ! ToNumber(_argument_).
-        1. If SameValue(! ToString(_n_), _argument_) is *true*, return _n_.
+        1. If ! ToString(_n_) is _argument_, return _n_.
         1. Return *undefined*.
       </emu-alg>
       <p>A <dfn variants="canonical numeric strings">canonical numeric string</dfn> is any String value for which the CanonicalNumericIndexString abstract operation does not return *undefined*.</p>
@@ -5808,7 +5808,7 @@
         <dd>It determines whether or not the two arguments are the same value.</dd>
       </dl>
       <emu-alg>
-        1. If Type(_x_) is different from Type(_y_), return *false*.
+        1. If Type(_x_) is not Type(_y_), return *false*.
         1. If _x_ is a Number, then
           1. Return Number::sameValue(_x_, _y_).
         1. Return SameValueNonNumber(_x_, _y_).
@@ -5830,7 +5830,7 @@
         <dd>It determines whether or not the two arguments are the same value (ignoring the difference between *+0*<sub>𝔽</sub> and *-0*<sub>𝔽</sub>).</dd>
       </dl>
       <emu-alg>
-        1. If Type(_x_) is different from Type(_y_), return *false*.
+        1. If Type(_x_) is not Type(_y_), return *false*.
         1. If _x_ is a Number, then
           1. Return Number::sameValueZero(_x_, _y_).
         1. Return SameValueNonNumber(_x_, _y_).
@@ -5850,19 +5850,23 @@
       <dl class="header">
       </dl>
       <emu-alg>
-        1. Assert: Type(_x_) is the same as Type(_y_).
+        1. Assert: Type(_x_) is Type(_y_).
+        1. If _x_ is either *null* or *undefined*, return *true*.
         1. If _x_ is a BigInt, then
           1. Return BigInt::equal(_x_, _y_).
-        1. If _x_ is *undefined*, return *true*.
-        1. If _x_ is *null*, return *true*.
         1. If _x_ is a String, then
-          1. If _x_ and _y_ are exactly the same sequence of code units (same length and same code units at corresponding indices), return *true*; otherwise, return *false*.
+          1. If _x_ and _y_ have the same length and the same code units in the same positions, return *true*; otherwise, return *false*.
         1. If _x_ is a Boolean, then
           1. If _x_ and _y_ are both *true* or both *false*, return *true*; otherwise, return *false*.
-        1. If _x_ is a Symbol, then
-          1. If _x_ and _y_ are both the same Symbol value, return *true*; otherwise, return *false*.
-        1. If _x_ and _y_ are the same Object value, return *true*. Otherwise, return *false*.
+        1. NOTE: All other ECMAScript language values are compared by identity.
+        1. If _x_ is _y_, return *true*; otherwise, return *false*.
       </emu-alg>
+      <emu-note>
+        For expository purposes, some cases are handled separately within this algorithm even if it is unnecessary to do so.
+      </emu-note>
+      <emu-note>
+        The specifics of what "_x_ is _y_" means are detailed in <emu-xref href="#sec-identity"></emu-xref>.
+      </emu-note>
     </emu-clause>
 
     <emu-clause id="sec-islessthan" type="abstract operation" oldids="sec-abstract-relational-comparison">
@@ -5878,7 +5882,7 @@
         <dd>It provides the semantics for the comparison _x_ &lt; _y_, returning *true*, *false*, or *undefined* (which indicates that at least one operand is *NaN*). The _LeftFirst_ flag is used to control the order in which operations with potentially visible side-effects are performed upon _x_ and _y_. It is necessary because ECMAScript specifies left to right evaluation of expressions. If _LeftFirst_ is *true*, the _x_ parameter corresponds to an expression that occurs to the left of the _y_ parameter's corresponding expression. If _LeftFirst_ is *false*, the reverse is the case and operations must be performed upon _y_ before _x_.</dd>
       </dl>
       <emu-alg>
-        1. If the _LeftFirst_ flag is *true*, then
+        1. If _LeftFirst_ is *true*, then
           1. Let _px_ be ? ToPrimitive(_x_, ~number~).
           1. Let _py_ be ? ToPrimitive(_y_, ~number~).
         1. Else,
@@ -5889,8 +5893,8 @@
           1. Let _lx_ be the length of _px_.
           1. Let _ly_ be the length of _py_.
           1. For each integer _i_ such that 0 ≤ _i_ &lt; min(_lx_, _ly_), in ascending order, do
-            1. Let _cx_ be the integer that is the numeric value of the code unit at index _i_ within _px_.
-            1. Let _cy_ be the integer that is the numeric value of the code unit at index _i_ within _py_.
+            1. Let _cx_ be the numeric value of the code unit at index _i_ within _px_.
+            1. Let _cy_ be the numeric value of the code unit at index _i_ within _py_.
             1. If _cx_ &lt; _cy_, return *true*.
             1. If _cx_ > _cy_, return *false*.
           1. If _lx_ &lt; _ly_, return *true*. Otherwise, return *false*.
@@ -5906,7 +5910,7 @@
           1. NOTE: Because _px_ and _py_ are primitive values, evaluation order is not important.
           1. Let _nx_ be ? ToNumeric(_px_).
           1. Let _ny_ be ? ToNumeric(_py_).
-          1. If Type(_nx_) is the same as Type(_ny_), then
+          1. If Type(_nx_) is Type(_ny_), then
             1. If _nx_ is a Number, then
               1. Return Number::lessThan(_nx_, _ny_).
             1. Else,
@@ -5938,7 +5942,7 @@
         <dd>It provides the semantics for the `==` operator.</dd>
       </dl>
       <emu-alg>
-        1. If Type(_x_) is the same as Type(_y_), then
+        1. If Type(_x_) is Type(_y_), then
           1. Return IsStrictlyEqual(_x_, _y_).
         1. If _x_ is *null* and _y_ is *undefined*, return *true*.
         1. If _x_ is *undefined* and _y_ is *null*, return *true*.
@@ -5973,7 +5977,7 @@
         <dd>It provides the semantics for the `===` operator.</dd>
       </dl>
       <emu-alg>
-        1. If Type(_x_) is different from Type(_y_), return *false*.
+        1. If Type(_x_) is not Type(_y_), return *false*.
         1. If _x_ is a Number, then
           1. Return Number::equal(_x_, _y_).
         1. Return SameValueNonNumber(_x_, _y_).
@@ -6405,7 +6409,7 @@
         1. Repeat, while _index_ &lt; _len_,
           1. Let _indexName_ be ! ToString(𝔽(_index_)).
           1. Let _next_ be ? Get(_obj_, _indexName_).
-          1. If Type(_next_) is not an element of _elementTypes_, throw a *TypeError* exception.
+          1. If _elementTypes_ does not contain Type(_next_), throw a *TypeError* exception.
           1. Append _next_ to _list_.
           1. Set _index_ to _index_ + 1.
         1. Return _list_.
@@ -6544,7 +6548,7 @@
       <dl class="header">
       </dl>
       <emu-alg>
-        1. If _source_ is *undefined* or *null*, return ~unused~.
+        1. If _source_ is either *undefined* or *null*, return ~unused~.
         1. Let _from_ be ! ToObject(_source_).
         1. Let _keys_ be ? <emu-meta effects="user-code">_from_.[[OwnPropertyKeys]]</emu-meta>().
         1. For each element _nextKey_ of _keys_, do
@@ -6574,9 +6578,8 @@
       <dl class="header">
       </dl>
       <emu-alg>
-        1. If _O_.[[PrivateElements]] contains a PrivateElement whose [[Key]] is _P_, then
-          1. Let _entry_ be that PrivateElement.
-          1. Return _entry_.
+        1. If _O_.[[PrivateElements]] contains a PrivateElement _pe_ such that _pe_.[[Key]] is _P_, then
+          1. Return _pe_.
         1. Return ~empty~.
       </emu-alg>
     </emu-clause>
@@ -6655,7 +6658,7 @@
       <emu-alg>
         1. Let _entry_ be PrivateElementFind(_O_, _P_).
         1. If _entry_ is ~empty~, throw a *TypeError* exception.
-        1. If _entry_.[[Kind]] is ~field~ or ~method~, then
+        1. If _entry_.[[Kind]] is either ~field~ or ~method~, then
           1. Return _entry_.[[Value]].
         1. Assert: _entry_.[[Kind]] is ~accessor~.
         1. If _entry_.[[Get]] is *undefined*, throw a *TypeError* exception.
@@ -8318,7 +8321,7 @@
       <emu-grammar>LabelledStatement : LabelIdentifier `:` LabelledItem</emu-grammar>
       <emu-alg>
         1. Let _label_ be the StringValue of |LabelIdentifier|.
-        1. If _label_ is an element of _labelSet_, return *true*.
+        1. If _labelSet_ contains _label_, return *true*.
         1. Let _newLabelSet_ be the list-concatenation of _labelSet_ and « _label_ ».
         1. Return ContainsDuplicateLabels of |LabelledItem| with argument _newLabelSet_.
       </emu-alg>
@@ -8456,7 +8459,7 @@
       </emu-alg>
       <emu-grammar>BreakStatement : `break` LabelIdentifier `;`</emu-grammar>
       <emu-alg>
-        1. If the StringValue of |LabelIdentifier| is not an element of _labelSet_, return *true*.
+        1. If _labelSet_ does not contain the StringValue of |LabelIdentifier|, return *true*.
         1. Return *false*.
       </emu-alg>
       <emu-grammar>WithStatement : `with` `(` Expression `)` Statement</emu-grammar>
@@ -8645,7 +8648,7 @@
       </emu-alg>
       <emu-grammar>ContinueStatement : `continue` LabelIdentifier `;`</emu-grammar>
       <emu-alg>
-        1. If the StringValue of |LabelIdentifier| is not an element of _iterationSet_, return *true*.
+        1. If _iterationSet_ does not contain the StringValue of |LabelIdentifier|, return *true*.
         1. Return *false*.
       </emu-alg>
       <emu-grammar>WithStatement : `with` `(` Expression `)` Statement</emu-grammar>
@@ -9139,7 +9142,7 @@
       </emu-note>
       <emu-grammar>ArrowFunction : ArrowParameters `=>` ConciseBody</emu-grammar>
       <emu-alg>
-        1. If _symbol_ is not one of |NewTarget|, |SuperProperty|, |SuperCall|, `super` or `this`, return *false*.
+        1. If _symbol_ is not one of |NewTarget|, |SuperProperty|, |SuperCall|, `super`, or `this`, return *false*.
         1. If |ArrowParameters| Contains _symbol_ is *true*, return *true*.
         1. Return |ConciseBody| Contains _symbol_.
       </emu-alg>
@@ -9580,7 +9583,7 @@
       </dl>
       <emu-grammar>IdentifierReference : Identifier</emu-grammar>
       <emu-alg>
-        1. If this |IdentifierReference| is contained in strict mode code and StringValue of |Identifier| is *"eval"* or *"arguments"*, return ~invalid~.
+        1. If this |IdentifierReference| is contained in strict mode code and StringValue of |Identifier| is either *"eval"* or *"arguments"*, return ~invalid~.
         1. Return ~simple~.
       </emu-alg>
       <emu-grammar>
@@ -9962,7 +9965,7 @@
             <dd>It determines if the argument identifier is one of the identifiers bound by the record.</dd>
           </dl>
           <emu-alg>
-            1. If _envRec_ has a binding for the name that is the value of _N_, return *true*.
+            1. If _envRec_ has a binding for _N_, return *true*.
             1. Return *false*.
           </emu-alg>
         </emu-clause>
@@ -10021,7 +10024,7 @@
             <dd>a Declarative Environment Record _envRec_</dd>
 
             <dt>description</dt>
-            <dd>It is used to set the bound value of the current binding of the identifier whose name is the value of the argument _N_ to the value of argument _V_. An uninitialized binding for _N_ must already exist.</dd>
+            <dd>It is used to set the bound value of the current binding of the identifier whose name is _N_ to the value _V_. An uninitialized binding for _N_ must already exist.</dd>
           </dl>
           <emu-alg>
             1. Assert: _envRec_ must have an uninitialized binding for _N_.
@@ -10044,7 +10047,7 @@
             <dd>a Declarative Environment Record _envRec_</dd>
 
             <dt>description</dt>
-            <dd>It attempts to change the bound value of the current binding of the identifier whose name is the value of the argument _N_ to the value of argument _V_. A binding for _N_ normally already exists, but in rare cases it may not. If the binding is an immutable binding, a *TypeError* is thrown if _S_ is *true*.</dd>
+            <dd>It attempts to change the bound value of the current binding of the identifier whose name is _N_ to the value _V_. A binding for _N_ normally already exists, but in rare cases it may not. If the binding is an immutable binding, a *TypeError* is thrown if _S_ is *true*.</dd>
           </dl>
           <emu-alg>
             1. [id="step-setmutablebinding-missing-binding"] If _envRec_ does not have a binding for _N_, then
@@ -10078,7 +10081,7 @@
             <dd>a Declarative Environment Record _envRec_</dd>
 
             <dt>description</dt>
-            <dd>It returns the value of its bound identifier whose name is the value of the argument _N_. If the binding exists but is uninitialized a *ReferenceError* is thrown, regardless of the value of _S_.</dd>
+            <dd>It returns the value of its bound identifier whose name is _N_. If the binding exists but is uninitialized a *ReferenceError* is thrown, regardless of the value of _S_.</dd>
           </dl>
           <emu-alg>
             1. Assert: _envRec_ has a binding for _N_.
@@ -10101,7 +10104,7 @@
             <dd>It can only delete bindings that have been explicitly designated as being subject to deletion.</dd>
           </dl>
           <emu-alg>
-            1. Assert: _envRec_ has a binding for the name that is the value of _N_.
+            1. Assert: _envRec_ has a binding for _N_.
             1. If the binding for _N_ in _envRec_ cannot be deleted, return *false*.
             1. Remove the binding for _N_ from _envRec_.
             1. Return *true*.
@@ -10203,7 +10206,7 @@
             <dd>an Object Environment Record _envRec_</dd>
 
             <dt>description</dt>
-            <dd>It determines if its associated binding object has a property whose name is the value of the argument _N_.</dd>
+            <dd>It determines if its associated binding object has a property whose name is _N_.</dd>
           </dl>
           <emu-alg>
             1. Let _bindingObject_ be _envRec_.[[BindingObject]].
@@ -10230,7 +10233,7 @@
             <dd>an Object Environment Record _envRec_</dd>
 
             <dt>description</dt>
-            <dd>It creates in an Environment Record's associated binding object a property whose name is the String value and initializes it to the value *undefined*. If _D_ is *true*, the new property's [[Configurable]] attribute is set to *true*; otherwise it is set to *false*.</dd>
+            <dd>It creates in an Environment Record's associated binding object a property whose name is _N_ and initializes it to the value *undefined*. If _D_ is *true*, the new property's [[Configurable]] attribute is set to *true*; otherwise it is set to *false*.</dd>
           </dl>
           <emu-alg>
             1. Let _bindingObject_ be _envRec_.[[BindingObject]].
@@ -10259,7 +10262,7 @@
             <dd>an Object Environment Record _envRec_</dd>
 
             <dt>description</dt>
-            <dd>It is used to set the bound value of the current binding of the identifier whose name is the value of the argument _N_ to the value of argument _V_.</dd>
+            <dd>It is used to set the bound value of the current binding of the identifier whose name is _N_ to the value _V_.</dd>
           </dl>
           <emu-alg>
             1. Perform ? <emu-meta effects="user-code">_envRec_.SetMutableBinding</emu-meta>(_N_, _V_, *false*).
@@ -10283,7 +10286,7 @@
             <dd>an Object Environment Record _envRec_</dd>
 
             <dt>description</dt>
-            <dd>It attempts to set the value of the Environment Record's associated binding object's property whose name is the value of the argument _N_ to the value of argument _V_. A property named _N_ normally already exists but if it does not or is not currently writable, error handling is determined by _S_.</dd>
+            <dd>It attempts to set the value of the Environment Record's associated binding object's property whose name is _N_ to the value _V_. A property named _N_ normally already exists but if it does not or is not currently writable, error handling is determined by _S_.</dd>
           </dl>
           <emu-alg>
             1. Let _bindingObject_ be _envRec_.[[BindingObject]].
@@ -10306,7 +10309,7 @@
             <dd>an Object Environment Record _envRec_</dd>
 
             <dt>description</dt>
-            <dd>It returns the value of its associated binding object's property whose name is the String value of the argument identifier _N_. The property should already exist but if it does not the result depends upon _S_.</dd>
+            <dd>It returns the value of its associated binding object's property whose name is _N_. The property should already exist but if it does not the result depends upon _S_.</dd>
           </dl>
           <emu-alg>
             1. Let _bindingObject_ be _envRec_.[[BindingObject]].
@@ -10767,7 +10770,7 @@
             <dd>a Global Environment Record _envRec_</dd>
 
             <dt>description</dt>
-            <dd>It is used to set the bound value of the current binding of the identifier whose name is the value of the argument _N_ to the value of argument _V_. An uninitialized binding for _N_ must already exist.</dd>
+            <dd>It is used to set the bound value of the current binding of the identifier whose name is _N_ to the value _V_. An uninitialized binding for _N_ must already exist.</dd>
           </dl>
           <emu-alg>
             1. Let _DclRec_ be _envRec_.[[DeclarativeRecord]].
@@ -10792,7 +10795,7 @@
             <dd>a Global Environment Record _envRec_</dd>
 
             <dt>description</dt>
-            <dd>It attempts to change the bound value of the current binding of the identifier whose name is the value of the argument _N_ to the value of argument _V_. If the binding is an immutable binding, a *TypeError* is thrown if _S_ is *true*. A property named _N_ normally already exists but if it does not or is not currently writable, error handling is determined by _S_.</dd>
+            <dd>It attempts to change the bound value of the current binding of the identifier whose name is _N_ to the value _V_. If the binding is an immutable binding and _S_ is *true*, a *TypeError* is thrown. A property named _N_ normally already exists but if it does not or is not currently writable, error handling is determined by _S_.</dd>
           </dl>
           <emu-alg>
             1. Let _DclRec_ be _envRec_.[[DeclarativeRecord]].
@@ -10815,7 +10818,7 @@
             <dd>a Global Environment Record _envRec_</dd>
 
             <dt>description</dt>
-            <dd>It returns the value of its bound identifier whose name is the value of the argument _N_. If the binding is an uninitialized binding throw a *ReferenceError* exception. A property named _N_ normally already exists but if it does not or is not currently writable, error handling is determined by _S_.</dd>
+            <dd>It returns the value of its bound identifier whose name is _N_. If the binding is an uninitialized binding throw a *ReferenceError* exception. A property named _N_ normally already exists but if it does not or is not currently writable, error handling is determined by _S_.</dd>
           </dl>
           <emu-alg>
             1. Let _DclRec_ be _envRec_.[[DeclarativeRecord]].
@@ -10850,7 +10853,7 @@
               1. Let _status_ be ? <emu-meta effects="user-code">_ObjRec_.DeleteBinding</emu-meta>(_N_).
               1. If _status_ is *true*, then
                 1. Let _varNames_ be _envRec_.[[VarNames]].
-                1. If _N_ is an element of _varNames_, remove that element from the _varNames_.
+                1. If _varNames_ contains _N_, remove _N_ from _varNames_.
               1. Return _status_.
             1. Return *true*.
           </emu-alg>
@@ -11128,7 +11131,7 @@
             <dd>a Module Environment Record _envRec_</dd>
 
             <dt>description</dt>
-            <dd>It returns the value of its bound identifier whose name is the value of the argument _N_. However, if the binding is an indirect binding the value of the target binding is returned. If the binding exists but is uninitialized a *ReferenceError* is thrown.</dd>
+            <dd>It returns the value of its bound identifier whose name is _N_. However, if the binding is an indirect binding the value of the target binding is returned. If the binding exists but is uninitialized a *ReferenceError* is thrown.</dd>
           </dl>
           <emu-alg>
             1. Assert: _S_ is *true*.
@@ -11219,7 +11222,7 @@
         <dl class="header">
         </dl>
         <emu-alg>
-          1. If _env_ is the value *null*, then
+          1. If _env_ is *null*, then
             1. Return the Reference Record { [[Base]]: ~unresolvable~, [[ReferencedName]]: _name_, [[Strict]]: _strict_, [[ThisValue]]: ~empty~ }.
           1. Let _exists_ be ? <emu-meta effects="user-code">_env_.HasBinding</emu-meta>(_name_).
           1. If _exists_ is *true*, then
@@ -11396,13 +11399,12 @@
         </dl>
         <emu-alg>
           1. Let _names_ be _privEnv_.[[Names]].
-          1. If _names_ contains a Private Name whose [[Description]] is _identifier_, then
-            1. Let _name_ be that Private Name.
-            1. Return _name_.
-          1. Else,
-            1. Let _outerPrivEnv_ be _privEnv_.[[OuterPrivateEnvironment]].
-            1. Assert: _outerPrivEnv_ is not *null*.
-            1. Return ResolvePrivateIdentifier(_outerPrivEnv_, _identifier_).
+          1. For each Private Name _pn_ of _names_, do
+            1. If _pn_.[[Description]] is _identifier_, then
+              1. Return _pn_.
+          1. Let _outerPrivEnv_ be _privEnv_.[[OuterPrivateEnvironment]].
+          1. Assert: _outerPrivEnv_ is not *null*.
+          1. Return ResolvePrivateIdentifier(_outerPrivEnv_, _identifier_).
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -11709,7 +11711,7 @@
         <dd>It is used to determine the binding of _name_. _env_ can be used to explicitly provide the Environment Record that is to be searched for the binding.</dd>
       </dl>
       <emu-alg>
-        1. If _env_ is not present or if _env_ is *undefined*, then
+        1. If _env_ is not present or _env_ is *undefined*, then
           1. Set _env_ to the running execution context's LexicalEnvironment.
         1. Assert: _env_ is an Environment Record.
         1. If the source text matched by the syntactic production that is being evaluated is contained in strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
@@ -13133,7 +13135,7 @@
           1. Let _localEnv_ be the LexicalEnvironment of _calleeContext_.
           1. If _thisMode_ is ~strict~, let _thisValue_ be _thisArgument_.
           1. Else,
-            1. If _thisArgument_ is *undefined* or *null*, then
+            1. If _thisArgument_ is either *undefined* or *null*, then
               1. Let _globalEnv_ be _calleeRealm_.[[GlobalEnv]].
               1. Assert: _globalEnv_ is a Global Environment Record.
               1. Let _thisValue_ be _globalEnv_.[[GlobalThisValue]].
@@ -13509,7 +13511,7 @@
           1. If _d_ is neither a |VariableDeclaration| nor a |ForBinding| nor a |BindingIdentifier|, then
             1. Assert: _d_ is either a |FunctionDeclaration|, a |GeneratorDeclaration|, an |AsyncFunctionDeclaration|, or an |AsyncGeneratorDeclaration|.
             1. Let _fn_ be the sole element of the BoundNames of _d_.
-            1. If _fn_ is not an element of _functionNames_, then
+            1. If _functionNames_ does not contain _fn_, then
               1. Insert _fn_ as the first element of _functionNames_.
               1. NOTE: If there are multiple function declarations for the same name, the last declaration is used.
               1. Insert _d_ as the first element of _functionsToInitialize_.
@@ -13517,12 +13519,12 @@
         1. If _func_.[[ThisMode]] is ~lexical~, then
           1. NOTE: Arrow functions never have an arguments object.
           1. Set _argumentsObjectNeeded_ to *false*.
-        1. Else if *"arguments"* is an element of _parameterNames_, then
+        1. Else if _parameterNames_ contains *"arguments"*, then
           1. Set _argumentsObjectNeeded_ to *false*.
         1. Else if _hasParameterExpressions_ is *false*, then
-          1. If *"arguments"* is an element of _functionNames_ or if *"arguments"* is an element of _lexicalNames_, then
+          1. If _functionNames_ contains *"arguments"* or _lexicalNames_ contains *"arguments"*, then
             1. Set _argumentsObjectNeeded_ to *false*.
-        1. If _strict_ is *true* or if _hasParameterExpressions_ is *false*, then
+        1. If _strict_ is *true* or _hasParameterExpressions_ is *false*, then
           1. NOTE: Only a single Environment Record is needed for the parameters, since calls to `eval` in strict mode code cannot create new bindings which are visible outside of the `eval`.
           1. Let _env_ be the LexicalEnvironment of _calleeContext_.
         1. Else,
@@ -13539,7 +13541,7 @@
             1. If _hasDuplicates_ is *true*, then
               1. Perform ! _env_.InitializeBinding(_paramName_, *undefined*).
         1. If _argumentsObjectNeeded_ is *true*, then
-          1. If _strict_ is *true* or if _simpleParameterList_ is *false*, then
+          1. If _strict_ is *true* or _simpleParameterList_ is *false*, then
             1. Let _ao_ be CreateUnmappedArgumentsObject(_argumentsList_).
           1. Else,
             1. NOTE: A mapped argument object is only provided for non-strict functions that don't have a rest parameter, any parameter default value initializers, or any destructured parameters.
@@ -13562,7 +13564,7 @@
           1. NOTE: Only a single Environment Record is needed for the parameters and top-level vars.
           1. Let _instantiatedVarNames_ be a copy of the List _parameterBindings_.
           1. For each element _n_ of _varNames_, do
-            1. If _n_ is not an element of _instantiatedVarNames_, then
+            1. If _instantiatedVarNames_ does not contain _n_, then
               1. Append _n_ to _instantiatedVarNames_.
               1. Perform ! _env_.CreateMutableBinding(_n_, *false*).
               1. Perform ! _env_.InitializeBinding(_n_, *undefined*).
@@ -13573,10 +13575,10 @@
           1. Set the VariableEnvironment of _calleeContext_ to _varEnv_.
           1. Let _instantiatedVarNames_ be a new empty List.
           1. For each element _n_ of _varNames_, do
-            1. If _n_ is not an element of _instantiatedVarNames_, then
+            1. If _instantiatedVarNames_ does not contain _n_, then
               1. Append _n_ to _instantiatedVarNames_.
               1. Perform ! _varEnv_.CreateMutableBinding(_n_, *false*).
-              1. If _n_ is not an element of _parameterBindings_ or if _n_ is an element of _functionNames_, let _initialValue_ be *undefined*.
+              1. If _parameterBindings_ does not contain _n_, or if _functionNames_ contains _n_, let _initialValue_ be *undefined*.
               1. Else,
                 1. Let _initialValue_ be ! _env_.GetBindingValue(_n_, *false*).
               1. Perform ! _varEnv_.InitializeBinding(_n_, _initialValue_).
@@ -13836,9 +13838,9 @@
 
     <emu-clause id="sec-array-exotic-objects">
       <h1>Array Exotic Objects</h1>
-      <p>An Array is an exotic object that gives special treatment to array index property keys (see <emu-xref href="#sec-object-type"></emu-xref>). A property whose property name is an array index is also called an <em>element</em>. Every Array has a non-configurable *"length"* property whose value is always a non-negative integral Number whose mathematical value is less than 2<sup>32</sup>. The value of the *"length"* property is numerically greater than the name of every own property whose name is an array index; whenever an own property of an Array is created or changed, other properties are adjusted as necessary to maintain this invariant. Specifically, whenever an own property is added whose name is an array index, the value of the *"length"* property is changed, if necessary, to be one more than the numeric value of that array index; and whenever the value of the *"length"* property is changed, every own property whose name is an array index whose value is not smaller than the new length is deleted. This constraint applies only to own properties of an Array and is unaffected by *"length"* or array index properties that may be inherited from its prototypes.</p>
+      <p>An Array is an exotic object that gives special treatment to array index property keys (see <emu-xref href="#sec-object-type"></emu-xref>). A property whose property name is an array index is also called an <em>element</em>. Every Array has a non-configurable *"length"* property whose value is always a non-negative integral Number whose mathematical value is strictly less than 2<sup>32</sup>. The value of the *"length"* property is numerically greater than the name of every own property whose name is an array index; whenever an own property of an Array is created or changed, other properties are adjusted as necessary to maintain this invariant. Specifically, whenever an own property is added whose name is an array index, the value of the *"length"* property is changed, if necessary, to be one more than the numeric value of that array index; and whenever the value of the *"length"* property is changed, every own property whose name is an array index whose value is not smaller than the new length is deleted. This constraint applies only to own properties of an Array and is unaffected by *"length"* or array index properties that may be inherited from its prototypes.</p>
       <emu-note>
-        <p>A String property name _P_ is an <em>array index</em> if and only if ToString(ToUint32(_P_)) equals _P_ and ToUint32(_P_) is not the same value as 𝔽(<emu-eqn>2<sup>32</sup> - 1</emu-eqn>).</p>
+        <p>A String property name _P_ is an <em>array index</em> if and only if ToString(ToUint32(_P_)) is _P_ and ToUint32(_P_) is not 𝔽(<emu-eqn>2<sup>32</sup> - 1</emu-eqn>).</p>
       </emu-note>
 
       <p>An object is an <dfn id="array-exotic-object" variants="Array exotic objects">Array exotic object</dfn> (or simply, an Array) if its [[DefineOwnProperty]] internal method uses the following implementation, and its other essential internal methods use the definitions found in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>. These methods are installed in ArrayCreate.</p>
@@ -13961,7 +13963,7 @@
             1. Set _newLenDesc_.[[Writable]] to *true*.
           1. Let _succeeded_ be ! OrdinaryDefineOwnProperty(_A_, *"length"*, _newLenDesc_).
           1. If _succeeded_ is *false*, return *false*.
-          1. For each own property key _P_ of _A_ that is an array index, whose numeric value is greater than or equal to _newLen_, in descending numeric index order, do
+          1. For each own property key _P_ of _A_ such that _P_ is an array index and ! ToUint32(_P_) ≥ _newLen_, in descending numeric index order, do
             1. Let _deleteSucceeded_ be ! _A_.[[Delete]](_P_).
             1. If _deleteSucceeded_ is *false*, then
               1. Set _newLenDesc_.[[Value]] to ! ToUint32(_P_) + *1*<sub>𝔽</sub>.
@@ -14303,7 +14305,7 @@
           1. Set _index_ to _numberOfParameters_ - 1.
           1. Repeat, while _index_ ≥ 0,
             1. Let _name_ be _parameterNames_[_index_].
-            1. If _name_ is not an element of _mappedNames_, then
+            1. If _mappedNames_ does not contain _name_, then
               1. Append _name_ to _mappedNames_.
               1. If _index_ &lt; _len_, then
                 1. Let _g_ be MakeArgGetter(_name_, _env_).
@@ -14418,10 +14420,10 @@
             1. Let _numericIndex_ be CanonicalNumericIndexString(_P_).
             1. If _numericIndex_ is not *undefined*, then
               1. If IsValidIntegerIndex(_O_, _numericIndex_) is *false*, return *false*.
-              1. If _Desc_ has a [[Configurable]] field and if _Desc_.[[Configurable]] is *false*, return *false*.
-              1. If _Desc_ has an [[Enumerable]] field and if _Desc_.[[Enumerable]] is *false*, return *false*.
+              1. If _Desc_ has a [[Configurable]] field and _Desc_.[[Configurable]] is *false*, return *false*.
+              1. If _Desc_ has an [[Enumerable]] field and _Desc_.[[Enumerable]] is *false*, return *false*.
               1. If IsAccessorDescriptor(_Desc_) is *true*, return *false*.
-              1. If _Desc_ has a [[Writable]] field and if _Desc_.[[Writable]] is *false*, return *false*.
+              1. If _Desc_ has a [[Writable]] field and _Desc_.[[Writable]] is *false*, return *false*.
               1. If _Desc_ has a [[Value]] field, perform ? IntegerIndexedElementSet(_O_, _numericIndex_, _Desc_.[[Value]]).
               1. Return *true*.
           1. Return ! OrdinaryDefineOwnProperty(_O_, _P_, _Desc_).
@@ -14703,7 +14705,7 @@
         <emu-alg>
           1. If _P_ is a Symbol, return OrdinaryGetOwnProperty(_O_, _P_).
           1. Let _exports_ be _O_.[[Exports]].
-          1. If _P_ is not an element of _exports_, return *undefined*.
+          1. If _exports_ does not contain _P_, return *undefined*.
           1. Let _value_ be ? _O_.[[Get]](_P_, _O_).
           1. Return PropertyDescriptor { [[Value]]: _value_, [[Writable]]: *true*, [[Enumerable]]: *true*, [[Configurable]]: *false* }.
         </emu-alg>
@@ -14746,7 +14748,7 @@
         <emu-alg>
           1. If _P_ is a Symbol, return ! OrdinaryHasProperty(_O_, _P_).
           1. Let _exports_ be _O_.[[Exports]].
-          1. If _P_ is an element of _exports_, return *true*.
+          1. If _exports_ contains _P_, return *true*.
           1. Return *false*.
         </emu-alg>
       </emu-clause>
@@ -14766,7 +14768,7 @@
           1. If _P_ is a Symbol, then
             1. Return ! OrdinaryGet(_O_, _P_, _Receiver_).
           1. Let _exports_ be _O_.[[Exports]].
-          1. If _P_ is not an element of _exports_, return *undefined*.
+          1. If _exports_ does not contain _P_, return *undefined*.
           1. Let _m_ be _O_.[[Module]].
           1. Let _binding_ be _m_.ResolveExport(_P_).
           1. Assert: _binding_ is a ResolvedBinding Record.
@@ -14814,7 +14816,7 @@
           1. If _P_ is a Symbol, then
             1. Return ! OrdinaryDelete(_O_, _P_).
           1. Let _exports_ be _O_.[[Exports]].
-          1. If _P_ is an element of _exports_, return *false*.
+          1. If _exports_ contains _P_, return *false*.
           1. Return *true*.
         </emu-alg>
       </emu-clause>
@@ -15256,7 +15258,7 @@
         1. If _booleanTrapResult_ is *false*, return *false*.
         1. Let _targetDesc_ be ? <emu-meta effects="user-code">_target_.[[GetOwnProperty]]</emu-meta>(_P_).
         1. Let _extensibleTarget_ be ? IsExtensible(_target_).
-        1. If _Desc_ has a [[Configurable]] field and if _Desc_.[[Configurable]] is *false*, then
+        1. If _Desc_ has a [[Configurable]] field and _Desc_.[[Configurable]] is *false*, then
           1. Let _settingConfigFalse_ be *true*.
         1. Else, let _settingConfigFalse_ be *false*.
         1. If _targetDesc_ is *undefined*, then
@@ -15490,18 +15492,18 @@
         1. For each element _key_ of _targetKeys_, do
           1. Let _desc_ be ? <emu-meta effects="user-code">_target_.[[GetOwnProperty]]</emu-meta>(_key_).
           1. If _desc_ is not *undefined* and _desc_.[[Configurable]] is *false*, then
-            1. Append _key_ as an element of _targetNonconfigurableKeys_.
+            1. Append _key_ to _targetNonconfigurableKeys_.
           1. Else,
-            1. Append _key_ as an element of _targetConfigurableKeys_.
+            1. Append _key_ to _targetConfigurableKeys_.
         1. If _extensibleTarget_ is *true* and _targetNonconfigurableKeys_ is empty, then
           1. Return _trapResult_.
         1. Let _uncheckedResultKeys_ be a List whose elements are the elements of _trapResult_.
         1. For each element _key_ of _targetNonconfigurableKeys_, do
-          1. If _key_ is not an element of _uncheckedResultKeys_, throw a *TypeError* exception.
+          1. If _uncheckedResultKeys_ does not contain _key_, throw a *TypeError* exception.
           1. Remove _key_ from _uncheckedResultKeys_.
         1. If _extensibleTarget_ is *true*, return _trapResult_.
         1. For each element _key_ of _targetConfigurableKeys_, do
-          1. If _key_ is not an element of _uncheckedResultKeys_, throw a *TypeError* exception.
+          1. If _uncheckedResultKeys_ does not contain _key_, throw a *TypeError* exception.
           1. Remove _key_ from _uncheckedResultKeys_.
         1. If _uncheckedResultKeys_ is not empty, throw a *TypeError* exception.
         1. Return _trapResult_.
@@ -15723,8 +15725,8 @@
         1. Let _size_ be the length of _string_.
         1. Assert: _position_ ≥ 0 and _position_ &lt; _size_.
         1. Let _first_ be the code unit at index _position_ within _string_.
-        1. Let _cp_ be the code point whose numeric value is that of _first_.
-        1. If _first_ is not a <emu-xref href="#leading-surrogate"></emu-xref> or <emu-xref href="#trailing-surrogate"></emu-xref>, then
+        1. Let _cp_ be the code point whose numeric value is the numeric value of _first_.
+        1. If _first_ is neither a <emu-xref href="#leading-surrogate"></emu-xref> nor a <emu-xref href="#trailing-surrogate"></emu-xref>, then
           1. Return the Record { [[CodePoint]]: _cp_, [[CodeUnitCount]]: 1, [[IsUnpairedSurrogate]]: *false* }.
         1. If _first_ is a <emu-xref href="#trailing-surrogate"></emu-xref> or _position_ + 1 = _size_, then
           1. Return the Record { [[CodePoint]]: _cp_, [[CodeUnitCount]]: 1, [[IsUnpairedSurrogate]]: *true* }.
@@ -17287,7 +17289,7 @@
             The TV of <emu-grammar>TemplateTail :: `}` ```</emu-grammar> is the empty String.
           </li>
           <li>
-            The TV of <emu-grammar>TemplateCharacters :: TemplateCharacter TemplateCharacters</emu-grammar> is *undefined* if either the TV of |TemplateCharacter| is *undefined* or the TV of |TemplateCharacters| is *undefined*. Otherwise, it is the string-concatenation of the TV of |TemplateCharacter| and the TV of |TemplateCharacters|.
+            The TV of <emu-grammar>TemplateCharacters :: TemplateCharacter TemplateCharacters</emu-grammar> is *undefined* if the TV of |TemplateCharacter| is *undefined* or the TV of |TemplateCharacters| is *undefined*. Otherwise, it is the string-concatenation of the TV of |TemplateCharacter| and the TV of |TemplateCharacters|.
           </li>
           <li>
             The TV of <emu-grammar>TemplateCharacter :: SourceCharacter but not one of ``` or `\` or `$` or LineTerminator</emu-grammar> is the result of performing UTF16EncodeCodePoint on the code point matched by |SourceCharacter|.
@@ -17704,7 +17706,7 @@
       <emu-grammar>BindingIdentifier : Identifier</emu-grammar>
       <ul>
         <li>
-          It is a Syntax Error if the source text matched by this production is contained in strict mode code and the StringValue of |Identifier| is *"arguments"* or *"eval"*.
+          It is a Syntax Error if the source text matched by this production is contained in strict mode code and the StringValue of |Identifier| is either *"arguments"* or *"eval"*.
         </li>
       </ul>
       <emu-grammar>
@@ -17765,13 +17767,13 @@
       <emu-grammar>Identifier : IdentifierName but not ReservedWord</emu-grammar>
       <ul>
         <li>
-          It is a Syntax Error if this phrase is contained in strict mode code and the StringValue of |IdentifierName| is: *"implements"*, *"interface"*, *"let"*, *"package"*, *"private"*, *"protected"*, *"public"*, *"static"*, or *"yield"*.
+          It is a Syntax Error if this phrase is contained in strict mode code and the StringValue of |IdentifierName| is one of *"implements"*, *"interface"*, *"let"*, *"package"*, *"private"*, *"protected"*, *"public"*, *"static"*, or *"yield"*.
         </li>
         <li>
           It is a Syntax Error if the goal symbol of the syntactic grammar is |Module| and the StringValue of |IdentifierName| is *"await"*.
         </li>
         <li>
-          It is a Syntax Error if StringValue of |IdentifierName| is the same String value as the StringValue of any |ReservedWord| except for `yield` or `await`.
+          It is a Syntax Error if the StringValue of |IdentifierName| is the StringValue of any |ReservedWord| except for `yield` or `await`.
         </li>
       </ul>
       <emu-note>
@@ -18255,7 +18257,7 @@
           1. Let _propKey_ be ? Evaluation of |PropertyName|.
           1. If this |PropertyDefinition| is contained within a |Script| that is being evaluated for JSON.parse (see step <emu-xref href="#step-json-parse-eval"></emu-xref> of <emu-xref href="#sec-json.parse">JSON.parse</emu-xref>), then
             1. Let _isProtoSetter_ be *false*.
-          1. Else if _propKey_ is the String value *"__proto__"* and if IsComputedPropertyKey of |PropertyName| is *false*, then
+          1. Else if _propKey_ is *"__proto__"* and IsComputedPropertyKey of |PropertyName| is *false*, then
             1. Let _isProtoSetter_ be *true*.
           1. Else,
             1. Let _isProtoSetter_ be *false*.
@@ -18315,9 +18317,10 @@
           <dd>It determines if its argument is a valid regular expression literal.</dd>
         </dl>
         <emu-alg>
-          1. If FlagText of _literal_ contains any code points other than `d`, `g`, `i`, `m`, `s`, `u`, or `y`, or if it contains the same code point more than once, return *false*.
+          1. Let _flags_ be FlagText of _literal_.
+          1. If _flags_ contains any code points other than `d`, `g`, `i`, `m`, `s`, `u`, or `y`, or if _flags_ contains any code point more than once, return *false*.
+          1. If _flags_ contains `u`, let _u_ be *true*; else let _u_ be *false*.
           1. Let _patternText_ be BodyText of _literal_.
-          1. If FlagText of _literal_ contains `u`, let _u_ be *true*; else let _u_ be *false*.
           1. If _u_ is *false*, then
             1. Let _stringValue_ be CodePointsToString(_patternText_).
             1. Set _patternText_ to the sequence of code points resulting from interpreting each of the 16-bit elements of _stringValue_ as a Unicode BMP code point. UTF-16 decoding is not applied to the elements.
@@ -18373,7 +18376,7 @@
         </emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the number of elements in the result of TemplateStrings of |TemplateLiteral| with argument *false* is greater than 2<sup>32</sup> - 1.
+            It is a Syntax Error if the number of elements in the result of TemplateStrings of |TemplateLiteral| with argument *false* is greater than or equal to 2<sup>32</sup>.
           </li>
         </ul>
 
@@ -19128,7 +19131,7 @@
         <emu-alg>
           1. Let _baseReference_ be ? Evaluation of |MemberExpression|.
           1. Let _baseValue_ be ? GetValue(_baseReference_).
-          1. If _baseValue_ is *undefined* or *null*, then
+          1. If _baseValue_ is either *undefined* or *null*, then
             1. Return *undefined*.
           1. Return ? ChainEvaluation of |OptionalChain| with arguments _baseValue_ and _baseReference_.
         </emu-alg>
@@ -19139,7 +19142,7 @@
         <emu-alg>
           1. Let _baseReference_ be ? Evaluation of |CallExpression|.
           1. Let _baseValue_ be ? GetValue(_baseReference_).
-          1. If _baseValue_ is *undefined* or *null*, then
+          1. If _baseValue_ is either *undefined* or *null*, then
             1. Return *undefined*.
           1. Return ? ChainEvaluation of |OptionalChain| with arguments _baseValue_ and _baseReference_.
         </emu-alg>
@@ -19150,7 +19153,7 @@
         <emu-alg>
           1. Let _baseReference_ be ? Evaluation of |OptionalExpression|.
           1. Let _baseValue_ be ? GetValue(_baseReference_).
-          1. If _baseValue_ is *undefined* or *null*, then
+          1. If _baseValue_ is either *undefined* or *null*, then
             1. Return *undefined*.
           1. Return ? ChainEvaluation of |OptionalChain| with arguments _baseValue_ and _baseReference_.
         </emu-alg>
@@ -19881,7 +19884,7 @@
         1. Let _rref_ be ? Evaluation of |ShiftExpression|.
         1. Let _rval_ be ? GetValue(_rref_).
         1. Let _r_ be ? IsLessThan(_rval_, _lval_, *false*).
-        1. If _r_ is *true* or *undefined*, return *false*. Otherwise, return *true*.
+        1. If _r_ is either *true* or *undefined*, return *false*. Otherwise, return *true*.
       </emu-alg>
       <emu-grammar>RelationalExpression : RelationalExpression `&gt;=` ShiftExpression</emu-grammar>
       <emu-alg>
@@ -19890,7 +19893,7 @@
         1. Let _rref_ be ? Evaluation of |ShiftExpression|.
         1. Let _rval_ be ? GetValue(_rref_).
         1. Let _r_ be ? IsLessThan(_lval_, _rval_, *true*).
-        1. If _r_ is *true* or *undefined*, return *false*. Otherwise, return *true*.
+        1. If _r_ is either *true* or *undefined*, return *false*. Otherwise, return *true*.
       </emu-alg>
       <emu-grammar>RelationalExpression : RelationalExpression `instanceof` ShiftExpression</emu-grammar>
       <emu-alg>
@@ -20125,7 +20128,7 @@
       <emu-alg>
         1. Let _lref_ be ? Evaluation of |CoalesceExpressionHead|.
         1. Let _lval_ be ? GetValue(_lref_).
-        1. If _lval_ is *undefined* or *null*, then
+        1. If _lval_ is either *undefined* or *null*, then
           1. Let _rref_ be ? Evaluation of |BitwiseORExpression|.
           1. Return ? GetValue(_rref_).
         1. Otherwise, return _lval_.
@@ -20184,7 +20187,7 @@
     <emu-clause id="sec-assignment-operators-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
       <emu-grammar>AssignmentExpression : LeftHandSideExpression `=` AssignmentExpression</emu-grammar>
-      <p>If |LeftHandSideExpression| is an |ObjectLiteral| or an |ArrayLiteral|, the following Early Error rules are applied:</p>
+      <p>If |LeftHandSideExpression| is either an |ObjectLiteral| or an |ArrayLiteral|, the following Early Error rules are applied:</p>
       <ul>
         <li>
           |LeftHandSideExpression| must cover an |AssignmentPattern|.
@@ -20328,7 +20331,7 @@
         1. NOTE: At this point, it must be a numeric operation.
         1. Let _lnum_ be ? ToNumeric(_lval_).
         1. Let _rnum_ be ? ToNumeric(_rval_).
-        1. If Type(_lnum_) is different from Type(_rnum_), throw a *TypeError* exception.
+        1. If Type(_lnum_) is not Type(_rnum_), throw a *TypeError* exception.
         1. If _lnum_ is a BigInt, then
           1. If _opText_ is `**`, return ? BigInt::exponentiate(_lnum_, _rnum_).
           1. If _opText_ is `/`, return ? BigInt::divide(_lnum_, _rnum_).
@@ -20453,11 +20456,11 @@
         <emu-grammar>AssignmentRestProperty : `...` DestructuringAssignmentTarget</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if |DestructuringAssignmentTarget| is an |ArrayLiteral| or an |ObjectLiteral|.
+            It is a Syntax Error if |DestructuringAssignmentTarget| is either an |ArrayLiteral| or an |ObjectLiteral|.
           </li>
         </ul>
         <emu-grammar>DestructuringAssignmentTarget : LeftHandSideExpression</emu-grammar>
-        <p>If |LeftHandSideExpression| is an |ObjectLiteral| or an |ArrayLiteral|, the following Early Error rules are applied:</p>
+        <p>If |LeftHandSideExpression| is either an |ObjectLiteral| or an |ArrayLiteral|, the following Early Error rules are applied:</p>
         <ul>
           <li>
             |LeftHandSideExpression| must cover an |AssignmentPattern|.
@@ -20680,7 +20683,7 @@
               1. Let _defaultValue_ be ? Evaluation of |Initializer|.
               1. Let _v_ be ? GetValue(_defaultValue_).
           1. Else, let _v_ be _value_.
-          1. If |DestructuringAssignmentTarget| is an |ObjectLiteral| or an |ArrayLiteral|, then
+          1. If |DestructuringAssignmentTarget| is either an |ObjectLiteral| or an |ArrayLiteral|, then
             1. Let _nestedAssignmentPattern_ be the |AssignmentPattern| that is covered by |DestructuringAssignmentTarget|.
             1. Return ? DestructuringAssignmentEvaluation of _nestedAssignmentPattern_ with argument _v_.
           1. Return ? PutValue(_lref_, _v_).
@@ -20733,7 +20736,7 @@
               1. Let _defaultValue_ be ? Evaluation of |Initializer|.
               1. Let _rhsValue_ be ? GetValue(_defaultValue_).
           1. Else, let _rhsValue_ be _v_.
-          1. If |DestructuringAssignmentTarget| is an |ObjectLiteral| or an |ArrayLiteral|, then
+          1. If |DestructuringAssignmentTarget| is either an |ObjectLiteral| or an |ArrayLiteral|, then
             1. Let _assignmentPattern_ be the |AssignmentPattern| that is covered by |DestructuringAssignmentTarget|.
             1. Return ? DestructuringAssignmentEvaluation of _assignmentPattern_ with argument _rhsValue_.
           1. Return ? PutValue(_lref_, _rhsValue_).
@@ -20931,7 +20934,7 @@
               1. Perform ! _env_.CreateImmutableBinding(_dn_, *true*).
             1. Else,
               1. [id="step-blockdeclarationinstantiation-createmutablebinding"] Perform ! _env_.CreateMutableBinding(_dn_, *false*). NOTE: This step is replaced in section <emu-xref href="#sec-web-compat-blockdeclarationinstantiation"></emu-xref>.
-          1. If _d_ is a |FunctionDeclaration|, a |GeneratorDeclaration|, an |AsyncFunctionDeclaration|, or an |AsyncGeneratorDeclaration|, then
+          1. If _d_ is either a |FunctionDeclaration|, a |GeneratorDeclaration|, an |AsyncFunctionDeclaration|, or an |AsyncGeneratorDeclaration|, then
             1. Let _fn_ be the sole element of the BoundNames of _d_.
             1. Let _fo_ be InstantiateFunctionObject of _d_ with arguments _env_ and _privateEnv_.
             1. [id="step-blockdeclarationinstantiation-initializebinding"] Perform ! _env_.InitializeBinding(_fn_, _fo_). NOTE: This step is replaced in section <emu-xref href="#sec-web-compat-blockdeclarationinstantiation"></emu-xref>.
@@ -21350,7 +21353,7 @@
           1. If _completion_.[[Type]] is ~normal~, return *true*.
           1. If _completion_.[[Type]] is not ~continue~, return *false*.
           1. If _completion_.[[Target]] is ~empty~, return *true*.
-          1. If _completion_.[[Target]] is an element of _labelSet_, return *true*.
+          1. If _labelSet_ contains _completion_.[[Target]], return *true*.
           1. Return *false*.
         </emu-alg>
         <emu-note>
@@ -21862,14 +21865,14 @@
           1. Set the running execution context's LexicalEnvironment to _oldEnv_.
           1. Let _exprValue_ be ? GetValue(? _exprRef_).
           1. If _iterationKind_ is ~enumerate~, then
-            1. If _exprValue_ is *undefined* or *null*, then
+            1. If _exprValue_ is either *undefined* or *null*, then
               1. Return Completion Record { [[Type]]: ~break~, [[Value]]: ~empty~, [[Target]]: ~empty~ }.
             1. Let _obj_ be ! ToObject(_exprValue_).
             1. Let _iterator_ be EnumerateObjectProperties(_obj_).
             1. Let _nextMethod_ be ! GetV(_iterator_, *"next"*).
             1. Return the Iterator Record { [[Iterator]]: _iterator_, [[NextMethod]]: _nextMethod_, [[Done]]: *false* }.
           1. Else,
-            1. Assert: _iterationKind_ is ~iterate~ or ~async-iterate~.
+            1. Assert: _iterationKind_ is either ~iterate~ or ~async-iterate~.
             1. If _iterationKind_ is ~async-iterate~, let _iteratorHint_ be ~async~.
             1. Else, let _iteratorHint_ be ~sync~.
             1. Return ? GetIterator(_exprValue_, _iteratorHint_).
@@ -21895,7 +21898,7 @@
           1. Let _oldEnv_ be the running execution context's LexicalEnvironment.
           1. Let _V_ be *undefined*.
           1. Let _destructuring_ be IsDestructuring of _lhs_.
-          1. If _destructuring_ is *true* and if _lhsKind_ is ~assignment~, then
+          1. If _destructuring_ is *true* and _lhsKind_ is ~assignment~, then
             1. Assert: _lhs_ is a |LeftHandSideExpression|.
             1. Let _assignmentPattern_ be the |AssignmentPattern| that is covered by _lhs_.
           1. Repeat,
@@ -23059,7 +23062,7 @@
           If the source text matched by |FormalParameters| is strict mode code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.
         </li>
         <li>
-          If |BindingIdentifier| is present and the source text matched by |BindingIdentifier| is strict mode code, it is a Syntax Error if the StringValue of |BindingIdentifier| is *"eval"* or *"arguments"*.
+          If |BindingIdentifier| is present and the source text matched by |BindingIdentifier| is strict mode code, it is a Syntax Error if the StringValue of |BindingIdentifier| is either *"eval"* or *"arguments"*.
         </li>
         <li>
           It is a Syntax Error if FunctionBodyContainsUseStrict of |FunctionBody| is *true* and IsSimpleParameterList of |FormalParameters| is *false*.
@@ -23628,7 +23631,7 @@
           If the source text matched by |FormalParameters| is strict mode code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.
         </li>
         <li>
-          If |BindingIdentifier| is present and the source text matched by |BindingIdentifier| is strict mode code, it is a Syntax Error if the StringValue of |BindingIdentifier| is *"eval"* or *"arguments"*.
+          If |BindingIdentifier| is present and the source text matched by |BindingIdentifier| is strict mode code, it is a Syntax Error if the StringValue of |BindingIdentifier| is either *"eval"* or *"arguments"*.
         </li>
         <li>
           It is a Syntax Error if FunctionBodyContainsUseStrict of |GeneratorBody| is *true* and IsSimpleParameterList of |FormalParameters| is *false*.
@@ -23867,7 +23870,7 @@
       </emu-grammar>
       <ul>
         <li>If the source text matched by |FormalParameters| is strict mode code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.</li>
-        <li>If |BindingIdentifier| is present and the source text matched by |BindingIdentifier| is strict mode code, it is a Syntax Error if the StringValue of |BindingIdentifier| is *"eval"* or *"arguments"*.</li>
+        <li>If |BindingIdentifier| is present and the source text matched by |BindingIdentifier| is strict mode code, it is a Syntax Error if the StringValue of |BindingIdentifier| is either *"eval"* or *"arguments"*.</li>
         <li>It is a Syntax Error if FunctionBodyContainsUseStrict of |AsyncGeneratorBody| is *true* and IsSimpleParameterList of |FormalParameters| is *false*.</li>
         <li>It is a Syntax Error if any element of the BoundNames of |FormalParameters| also occurs in the LexicallyDeclaredNames of |AsyncGeneratorBody|.</li>
         <li>It is a Syntax Error if |FormalParameters| Contains |YieldExpression| is *true*.</li>
@@ -24094,7 +24097,7 @@
       <emu-grammar>ClassElement : `static` FieldDefinition `;`</emu-grammar>
       <ul>
         <li>
-          It is a Syntax Error if PropName of |FieldDefinition| is *"prototype"* or *"constructor"*.
+          It is a Syntax Error if PropName of |FieldDefinition| is either *"prototype"* or *"constructor"*.
         </li>
       </ul>
 
@@ -24580,10 +24583,10 @@
         1. Let _classPrivateEnvironment_ be NewPrivateEnvironment(_outerPrivateEnvironment_).
         1. If |ClassBody?| is present, then
           1. For each String _dn_ of the PrivateBoundIdentifiers of |ClassBody?|, do
-            1. If _classPrivateEnvironment_.[[Names]] contains a Private Name whose [[Description]] is _dn_, then
+            1. If _classPrivateEnvironment_.[[Names]] contains a Private Name _pn_ such that _pn_.[[Description]] is _dn_, then
               1. Assert: This is only possible for getter/setter pairs.
             1. Else,
-              1. Let _name_ be a new Private Name whose [[Description]] value is _dn_.
+              1. Let _name_ be a new Private Name whose [[Description]] is _dn_.
               1. Append _name_ to _classPrivateEnvironment_.[[Names]].
         1. If |ClassHeritage?| is not present, then
           1. Let _protoParent_ be %Object.prototype%.
@@ -24651,14 +24654,13 @@
             1. Assert: _element_.[[Kind]] is either ~method~ or ~accessor~.
             1. If IsStatic of _e_ is *false*, let _container_ be _instancePrivateMethods_.
             1. Else, let _container_ be _staticPrivateMethods_.
-            1. If _container_ contains a PrivateElement whose [[Key]] is _element_.[[Key]], then
-              1. Let _existing_ be that PrivateElement.
-              1. Assert: _element_.[[Kind]] and _existing_.[[Kind]] are both ~accessor~.
+            1. If _container_ contains a PrivateElement _pe_ such that _pe_.[[Key]] is _element_.[[Key]], then
+              1. Assert: _element_.[[Kind]] and _pe_.[[Kind]] are both ~accessor~.
               1. If _element_.[[Get]] is *undefined*, then
-                1. Let _combined_ be PrivateElement { [[Key]]: _element_.[[Key]], [[Kind]]: ~accessor~, [[Get]]: _existing_.[[Get]], [[Set]]: _element_.[[Set]] }.
+                1. Let _combined_ be PrivateElement { [[Key]]: _element_.[[Key]], [[Kind]]: ~accessor~, [[Get]]: _pe_.[[Get]], [[Set]]: _element_.[[Set]] }.
               1. Else,
-                1. Let _combined_ be PrivateElement { [[Key]]: _element_.[[Key]], [[Kind]]: ~accessor~, [[Get]]: _element_.[[Get]], [[Set]]: _existing_.[[Set]] }.
-              1. Replace _existing_ in _container_ with _combined_.
+                1. Let _combined_ be PrivateElement { [[Key]]: _element_.[[Key]], [[Kind]]: ~accessor~, [[Get]]: _element_.[[Get]], [[Set]]: _pe_.[[Set]] }.
+              1. Replace _pe_ in _container_ with _combined_.
             1. Else,
               1. Append _element_ to _container_.
           1. Else if _element_ is a ClassFieldDefinition Record, then
@@ -24812,7 +24814,7 @@
         <li>It is a Syntax Error if FunctionBodyContainsUseStrict of |AsyncFunctionBody| is *true* and IsSimpleParameterList of |FormalParameters| is *false*.</li>
         <li>It is a Syntax Error if |FormalParameters| Contains |AwaitExpression| is *true*.</li>
         <li>If the source text matched by |FormalParameters| is strict mode code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.</li>
-        <li>If |BindingIdentifier| is present and the source text matched by |BindingIdentifier| is strict mode code, it is a Syntax Error if the StringValue of |BindingIdentifier| is *"eval"* or *"arguments"*.</li>
+        <li>If |BindingIdentifier| is present and the source text matched by |BindingIdentifier| is strict mode code, it is a Syntax Error if the StringValue of |BindingIdentifier| is either *"eval"* or *"arguments"*.</li>
         <li>It is a Syntax Error if any element of the BoundNames of |FormalParameters| also occurs in the LexicallyDeclaredNames of |AsyncFunctionBody|.</li>
         <li>It is a Syntax Error if |FormalParameters| Contains |SuperProperty| is *true*.</li>
         <li>It is a Syntax Error if |AsyncFunctionBody| Contains |SuperProperty| is *true*.</li>
@@ -25085,7 +25087,7 @@
       </dl>
       <emu-alg>
         1. If the source text matched by _call_ is non-strict code, return *false*.
-        1. If _call_ is not contained within a |FunctionBody|, |ConciseBody|, or |AsyncConciseBody|, return *false*.
+        1. If _call_ is not contained within a |FunctionBody|, a |ConciseBody|, or an |AsyncConciseBody|, return *false*.
         1. Let _body_ be the |FunctionBody|, |ConciseBody|, or |AsyncConciseBody| that most closely contains _call_.
         1. If _body_ is the |FunctionBody| of a |GeneratorBody|, return *false*.
         1. If _body_ is the |FunctionBody| of an |AsyncFunctionBody|, return *false*.
@@ -25673,23 +25675,23 @@
         1. Let _functionsToInitialize_ be a new empty List.
         1. Let _declaredFunctionNames_ be a new empty List.
         1. For each element _d_ of _varDeclarations_, in reverse List order, do
-          1. If _d_ is neither a |VariableDeclaration| nor a |ForBinding| nor a |BindingIdentifier|, then
+          1. If _d_ is not either a |VariableDeclaration|, a |ForBinding|, or a |BindingIdentifier|, then
             1. Assert: _d_ is either a |FunctionDeclaration|, a |GeneratorDeclaration|, an |AsyncFunctionDeclaration|, or an |AsyncGeneratorDeclaration|.
             1. NOTE: If there are multiple function declarations for the same name, the last declaration is used.
             1. Let _fn_ be the sole element of the BoundNames of _d_.
-            1. If _fn_ is not an element of _declaredFunctionNames_, then
+            1. If _declaredFunctionNames_ does not contain _fn_, then
               1. Let _fnDefinable_ be ? _env_.CanDeclareGlobalFunction(_fn_).
               1. If _fnDefinable_ is *false*, throw a *TypeError* exception.
               1. Append _fn_ to _declaredFunctionNames_.
               1. Insert _d_ as the first element of _functionsToInitialize_.
         1. Let _declaredVarNames_ be a new empty List.
         1. For each element _d_ of _varDeclarations_, do
-          1. If _d_ is a |VariableDeclaration|, a |ForBinding|, or a |BindingIdentifier|, then
+          1. If _d_ is either a |VariableDeclaration|, a |ForBinding|, or a |BindingIdentifier|, then
             1. For each String _vn_ of the BoundNames of _d_, do
-              1. If _vn_ is not an element of _declaredFunctionNames_, then
+              1. If _declaredFunctionNames_ does not contain _vn_, then
                 1. Let _vnDefinable_ be ? _env_.CanDeclareGlobalVar(_vn_).
                 1. If _vnDefinable_ is *false*, throw a *TypeError* exception.
-                1. If _vn_ is not an element of _declaredVarNames_, then
+                1. If _declaredVarNames_ does not contain _vn_, then
                   1. Append _vn_ to _declaredVarNames_.
         1. NOTE: No abnormal terminations occur after this algorithm step if the global object is an ordinary object. However, if the global object is a Proxy exotic object it may exhibit behaviours that cause abnormal terminations in some of the following steps.
         1. [id="step-globaldeclarationinstantiation-web-compat-insertion-point"] NOTE: Annex <emu-xref href="#sec-web-compat-globaldeclarationinstantiation"></emu-xref> adds additional steps at this point.
@@ -25822,7 +25824,9 @@
         <emu-alg>
           1. Let _moduleNames_ be ModuleRequests of |ModuleItemList|.
           1. Let _additionalNames_ be ModuleRequests of |ModuleItem|.
-          1. Append to _moduleNames_ each element of _additionalNames_ that is not already an element of _moduleNames_.
+          1. For each String _name_ of _additionalNames_, do
+            1. If _moduleNames_ does not contain _name_, then
+              1. Append _name_ to _moduleNames_.
           1. Return _moduleNames_.
         </emu-alg>
         <emu-grammar>ModuleItem : StatementListItem</emu-grammar>
@@ -26029,7 +26033,7 @@
                 an integer or ~empty~
               </td>
               <td>
-                Auxiliary field used during Link and Evaluate only. If [[Status]] is ~linking~ or ~evaluating~, this non-negative number records the point at which the module was first visited during the depth-first traversal of the dependency graph.
+                Auxiliary field used during Link and Evaluate only. If [[Status]] is either ~linking~ or ~evaluating~, this non-negative number records the point at which the module was first visited during the depth-first traversal of the dependency graph.
               </td>
             </tr>
             <tr>
@@ -26040,7 +26044,7 @@
                 an integer or ~empty~
               </td>
               <td>
-                Auxiliary field used during Link and Evaluate only. If [[Status]] is ~linking~ or ~evaluating~, this is either the module's own [[DFSIndex]] or that of an "earlier" module in the same strongly connected component.
+                Auxiliary field used during Link and Evaluate only. If [[Status]] is either ~linking~ or ~evaluating~, this is either the module's own [[DFSIndex]] or that of an "earlier" module in the same strongly connected component.
               </td>
             </tr>
             <tr>
@@ -26073,7 +26077,7 @@
                 a Cyclic Module Record or ~empty~
               </td>
               <td>
-                The first visited module of the cycle, the root DFS ancestor of the strongly connected component. For a module not in a cycle this would be the module itself. Once Evaluate has completed, a module's [[DFSAncestorIndex]] is equal to the [[DFSIndex]] of its [[CycleRoot]].
+                The first visited module of the cycle, the root DFS ancestor of the strongly connected component. For a module not in a cycle, this would be the module itself. Once Evaluate has completed, a module's [[DFSAncestorIndex]] is the [[DFSIndex]] of its [[CycleRoot]].
               </td>
             </tr>
             <tr>
@@ -26334,7 +26338,7 @@
           </dl>
 
           <emu-alg>
-            1. Assert: _module_.[[Status]] is ~unlinked~, ~linked~, ~evaluating-async~, or ~evaluated~.
+            1. Assert: _module_.[[Status]] is one of ~unlinked~, ~linked~, ~evaluating-async~, or ~evaluated~.
             1. Let _stack_ be a new empty List.
             1. Let _result_ be Completion(InnerModuleLinking(_module_, _stack_, 0)).
             1. If _result_ is an abrupt completion, then
@@ -26343,7 +26347,7 @@
                 1. Set _m_.[[Status]] to ~unlinked~.
               1. Assert: _module_.[[Status]] is ~unlinked~.
               1. Return ? _result_.
-            1. Assert: _module_.[[Status]] is ~linked~, ~evaluating-async~, or ~evaluated~.
+            1. Assert: _module_.[[Status]] is one of ~linked~, ~evaluating-async~, or ~evaluated~.
             1. Assert: _stack_ is empty.
             1. Return ~unused~.
           </emu-alg>
@@ -26365,7 +26369,7 @@
               1. If _module_ is not a Cyclic Module Record, then
                 1. Perform ? _module_.Link().
                 1. Return _index_.
-              1. If _module_.[[Status]] is ~linking~, ~linked~, ~evaluating-async~, or ~evaluated~, then
+              1. If _module_.[[Status]] is one of ~linking~, ~linked~, ~evaluating-async~, or ~evaluated~, then
                 1. Return _index_.
               1. Assert: _module_.[[Status]] is ~unlinked~.
               1. Set _module_.[[Status]] to ~linking~.
@@ -26377,8 +26381,8 @@
                 1. Let _requiredModule_ be GetImportedModule(_module_, _required_).
                 1. Set _index_ to ? InnerModuleLinking(_requiredModule_, _stack_, _index_).
                 1. If _requiredModule_ is a Cyclic Module Record, then
-                  1. Assert: _requiredModule_.[[Status]] is either ~linking~, ~linked~, ~evaluating-async~, or ~evaluated~.
-                  1. Assert: _requiredModule_.[[Status]] is ~linking~ if and only if _requiredModule_ is in _stack_.
+                  1. Assert: _requiredModule_.[[Status]] is one of ~linking~, ~linked~, ~evaluating-async~, or ~evaluated~.
+                  1. Assert: _requiredModule_.[[Status]] is ~linking~ if and only if _stack_ contains _requiredModule_.
                   1. If _requiredModule_.[[Status]] is ~linking~, then
                     1. Set _module_.[[DFSAncestorIndex]] to min(_module_.[[DFSAncestorIndex]], _requiredModule_.[[DFSAncestorIndex]]).
               1. Perform ? _module_.InitializeEnvironment().
@@ -26409,8 +26413,8 @@
 
           <emu-alg>
             1. Assert: This call to Evaluate is not happening at the same time as another call to Evaluate within the surrounding agent.
-            1. Assert: _module_.[[Status]] is ~linked~, ~evaluating-async~, or ~evaluated~.
-            1. If _module_.[[Status]] is ~evaluating-async~ or ~evaluated~, set _module_ to _module_.[[CycleRoot]].
+            1. Assert: _module_.[[Status]] is one of ~linked~, ~evaluating-async~, or ~evaluated~.
+            1. If _module_.[[Status]] is either ~evaluating-async~ or ~evaluated~, set _module_ to _module_.[[CycleRoot]].
             1. If _module_.[[TopLevelCapability]] is not ~empty~, then
               1. Return _module_.[[TopLevelCapability]].[[Promise]].
             1. Let _stack_ be a new empty List.
@@ -26426,7 +26430,7 @@
               1. Assert: _module_.[[EvaluationError]] is _result_.
               1. Perform ! Call(_capability_.[[Reject]], *undefined*, « _result_.[[Value]] »).
             1. Else,
-              1. Assert: _module_.[[Status]] is ~evaluating-async~ or ~evaluated~.
+              1. Assert: _module_.[[Status]] is either ~evaluating-async~ or ~evaluated~.
               1. Assert: _module_.[[EvaluationError]] is ~empty~.
               1. If _module_.[[AsyncEvaluation]] is *false*, then
                 1. Assert: _module_.[[Status]] is ~evaluated~.
@@ -26455,7 +26459,7 @@
                 1. If _promise_.[[PromiseState]] is ~rejected~, then
                   1. Return ThrowCompletion(_promise_.[[PromiseResult]]).
                 1. Return _index_.
-              1. If _module_.[[Status]] is ~evaluating-async~ or ~evaluated~, then
+              1. If _module_.[[Status]] is either ~evaluating-async~ or ~evaluated~, then
                 1. If _module_.[[EvaluationError]] is ~empty~, return _index_.
                 1. Otherwise, return ? _module_.[[EvaluationError]].
               1. If _module_.[[Status]] is ~evaluating~, return _index_.
@@ -26470,13 +26474,13 @@
                 1. Let _requiredModule_ be GetImportedModule(_module_, _required_).
                 1. Set _index_ to ? InnerModuleEvaluation(_requiredModule_, _stack_, _index_).
                 1. If _requiredModule_ is a Cyclic Module Record, then
-                  1. Assert: _requiredModule_.[[Status]] is either ~evaluating~, ~evaluating-async~, or ~evaluated~.
-                  1. Assert: _requiredModule_.[[Status]] is ~evaluating~ if and only if _requiredModule_ is in _stack_.
+                  1. Assert: _requiredModule_.[[Status]] is one of ~evaluating~, ~evaluating-async~, or ~evaluated~.
+                  1. Assert: _requiredModule_.[[Status]] is ~evaluating~ if and only if _stack_ contains _requiredModule_.
                   1. If _requiredModule_.[[Status]] is ~evaluating~, then
                     1. Set _module_.[[DFSAncestorIndex]] to min(_module_.[[DFSAncestorIndex]], _requiredModule_.[[DFSAncestorIndex]]).
                   1. Else,
                     1. Set _requiredModule_ to _requiredModule_.[[CycleRoot]].
-                    1. Assert: _requiredModule_.[[Status]] is ~evaluating-async~ or ~evaluated~.
+                    1. Assert: _requiredModule_.[[Status]] is either ~evaluating-async~ or ~evaluated~.
                     1. If _requiredModule_.[[EvaluationError]] is not ~empty~, return ? _requiredModule_.[[EvaluationError]].
                   1. If _requiredModule_.[[AsyncEvaluation]] is *true*, then
                     1. Set _module_.[[PendingAsyncDependencies]] to _module_.[[PendingAsyncDependencies]] + 1.
@@ -26485,7 +26489,7 @@
                 1. Assert: _module_.[[AsyncEvaluation]] is *false* and was never previously set to *true*.
                 1. Set _module_.[[AsyncEvaluation]] to *true*.
                 1. NOTE: The order in which module records have their [[AsyncEvaluation]] fields transition to *true* is significant. (See <emu-xref href="#sec-async-module-execution-fulfilled"></emu-xref>.)
-                1. If _module_.[[PendingAsyncDependencies]] is 0, perform ExecuteAsyncModule(_module_).
+                1. If _module_.[[PendingAsyncDependencies]] = 0, perform ExecuteAsyncModule(_module_).
               1. Otherwise, perform ? <emu-meta effects="user-code">_module_.ExecuteModule()</emu-meta>.
               1. Assert: _module_ occurs exactly once in _stack_.
               1. Assert: _module_.[[DFSAncestorIndex]] ≤ _module_.[[DFSIndex]].
@@ -26519,7 +26523,7 @@
             </dl>
 
             <emu-alg>
-              1. Assert: _module_.[[Status]] is ~evaluating~ or ~evaluating-async~.
+              1. Assert: _module_.[[Status]] is either ~evaluating~ or ~evaluating-async~.
               1. Assert: _module_.[[HasTLA]] is *true*.
               1. Let _capability_ be ! NewPromiseCapability(%Promise%).
               1. Let _fulfilledClosure_ be a new Abstract Closure with no parameters that captures _module_ and performs the following steps when called:
@@ -27553,10 +27557,10 @@
             1. Let _exportEntries_ be ExportEntries of _body_.
             1. For each ExportEntry Record _ee_ of _exportEntries_, do
               1. If _ee_.[[ModuleRequest]] is *null*, then
-                1. If _ee_.[[LocalName]] is not an element of _importedBoundNames_, then
+                1. If _importedBoundNames_ does not contain _ee_.[[LocalName]], then
                   1. Append _ee_ to _localExportEntries_.
                 1. Else,
-                  1. Let _ie_ be the element of _importEntries_ whose [[LocalName]] is the same as _ee_.[[LocalName]].
+                  1. Let _ie_ be the element of _importEntries_ whose [[LocalName]] is _ee_.[[LocalName]].
                   1. If _ie_.[[ImportName]] is ~namespace-object~, then
                     1. NOTE: This is a re-export of an imported module namespace object.
                     1. Append _ee_ to _localExportEntries_.
@@ -27605,7 +27609,7 @@
               1. Let _starNames_ be _requestedModule_.GetExportedNames(_exportStarSet_).
               1. For each element _n_ of _starNames_, do
                 1. If SameValue(_n_, *"default"*) is *false*, then
-                  1. If _n_ is not an element of _exportedNames_, then
+                  1. If _exportedNames_ does not contain _n_, then
                     1. Append _n_ to _exportedNames_.
             1. Return _exportedNames_.
           </emu-alg>
@@ -27668,7 +27672,7 @@
                 1. Else,
                   1. Assert: There is more than one `*` import that includes the requested name.
                   1. If _resolution_.[[Module]] and _starResolution_.[[Module]] are not the same Module Record, return ~ambiguous~.
-                  1. If _resolution_.[[BindingName]] is ~namespace~ and _starResolution_.[[BindingName]] is not ~namespace~, or if _resolution_.[[BindingName]] is not ~namespace~ and _starResolution_.[[BindingName]] is ~namespace~, return ~ambiguous~.
+                  1. If _resolution_.[[BindingName]] is not _starResolution_.[[BindingName]] and either _resolution_.[[BindingName]] or _starResolution_.[[BindingName]] is ~namespace~, return ~ambiguous~.
                   1. If _resolution_.[[BindingName]] is a String, _starResolution_.[[BindingName]] is a String, and SameValue(_resolution_.[[BindingName]], _starResolution_.[[BindingName]]) is *false*, return ~ambiguous~.
             1. Return _starResolution_.
           </emu-alg>
@@ -27684,7 +27688,7 @@
           <emu-alg>
             1. For each ExportEntry Record _e_ of _module_.[[IndirectExportEntries]], do
               1. Let _resolution_ be _module_.ResolveExport(_e_.[[ExportName]]).
-              1. If _resolution_ is *null* or ~ambiguous~, throw a *SyntaxError* exception.
+              1. If _resolution_ is either *null* or ~ambiguous~, throw a *SyntaxError* exception.
               1. Assert: _resolution_ is a ResolvedBinding Record.
             1. Assert: All named exports from _module_ are resolvable.
             1. Let _realm_ be _module_.[[Realm]].
@@ -27699,7 +27703,7 @@
                 1. Perform ! _env_.InitializeBinding(_in_.[[LocalName]], _namespace_).
               1. Else,
                 1. Let _resolution_ be _importedModule_.ResolveExport(_in_.[[ImportName]]).
-                1. If _resolution_ is *null* or ~ambiguous~, throw a *SyntaxError* exception.
+                1. If _resolution_ is either *null* or ~ambiguous~, throw a *SyntaxError* exception.
                 1. If _resolution_.[[BindingName]] is ~namespace~, then
                   1. Let _namespace_ be GetModuleNamespace(_resolution_.[[Module]]).
                   1. Perform ! _env_.CreateImmutableBinding(_in_.[[LocalName]], *true*).
@@ -27721,7 +27725,7 @@
             1. Let _declaredVarNames_ be a new empty List.
             1. For each element _d_ of _varDeclarations_, do
               1. For each element _dn_ of the BoundNames of _d_, do
-                1. If _dn_ is not an element of _declaredVarNames_, then
+                1. If _declaredVarNames_ does not contain _dn_, then
                   1. Perform ! _env_.CreateMutableBinding(_dn_, *false*).
                   1. Perform ! _env_.InitializeBinding(_dn_, *undefined*).
                   1. Append _dn_ to _declaredVarNames_.
@@ -27733,7 +27737,7 @@
                   1. Perform ! _env_.CreateImmutableBinding(_dn_, *true*).
                 1. Else,
                   1. Perform ! _env_.CreateMutableBinding(_dn_, *false*).
-                1. If _d_ is a |FunctionDeclaration|, a |GeneratorDeclaration|, an |AsyncFunctionDeclaration|, or an |AsyncGeneratorDeclaration|, then
+                1. If _d_ is either a |FunctionDeclaration|, a |GeneratorDeclaration|, an |AsyncFunctionDeclaration|, or an |AsyncGeneratorDeclaration|, then
                   1. Let _fo_ be InstantiateFunctionObject of _d_ with arguments _env_ and _privateEnv_.
                   1. Perform ! _env_.InitializeBinding(_dn_, _fo_).
             1. Remove _moduleContext_ from the execution context stack.
@@ -28102,7 +28106,7 @@
             It is a Syntax Error if ReferencedBindings of |NamedExports| contains any |StringLiteral|s.
           </li>
           <li>
-            For each |IdentifierName| _n_ in ReferencedBindings of |NamedExports|: It is a Syntax Error if StringValue of _n_ is a |ReservedWord| or if the StringValue of _n_ is one of: *"implements"*, *"interface"*, *"let"*, *"package"*, *"private"*, *"protected"*, *"public"*, or *"static"*.
+            For each |IdentifierName| _n_ in ReferencedBindings of |NamedExports|: It is a Syntax Error if StringValue of _n_ is a |ReservedWord| or the StringValue of _n_ is one of *"implements"*, *"interface"*, *"let"*, *"package"*, *"private"*, *"protected"*, *"public"*, or *"static"*.
           </li>
         </ul>
         <emu-note>
@@ -28308,13 +28312,13 @@
         <emu-alg>
           1. Let _names_ be BoundNames of |HoistableDeclaration|.
           1. Let _localName_ be the sole element of _names_.
-          1. Return a List whose sole element is the ExportEntry Record { [[ModuleRequest]]: *null*, [[ImportName]]: *null*, [[LocalName]]: _localName_, [[ExportName]]: *"default"* }.
+          1. Return a List whose sole element is a new ExportEntry Record { [[ModuleRequest]]: *null*, [[ImportName]]: *null*, [[LocalName]]: _localName_, [[ExportName]]: *"default"* }.
         </emu-alg>
         <emu-grammar>ExportDeclaration : `export` `default` ClassDeclaration</emu-grammar>
         <emu-alg>
           1. Let _names_ be BoundNames of |ClassDeclaration|.
           1. Let _localName_ be the sole element of _names_.
-          1. Return a List whose sole element is the ExportEntry Record { [[ModuleRequest]]: *null*, [[ImportName]]: *null*, [[LocalName]]: _localName_, [[ExportName]]: *"default"* }.
+          1. Return a List whose sole element is a new ExportEntry Record { [[ModuleRequest]]: *null*, [[ImportName]]: *null*, [[LocalName]]: _localName_, [[ExportName]]: *"default"* }.
         </emu-alg>
         <emu-grammar>ExportDeclaration : `export` `default` AssignmentExpression `;`</emu-grammar>
         <emu-alg>
@@ -28364,7 +28368,7 @@
           1. Else,
             1. Let _localName_ be *null*.
             1. Let _importName_ be _sourceName_.
-          1. Return a List whose sole element is the ExportEntry Record { [[ModuleRequest]]: _module_, [[ImportName]]: _importName_, [[LocalName]]: _localName_, [[ExportName]]: _sourceName_ }.
+          1. Return a List whose sole element is a new ExportEntry Record { [[ModuleRequest]]: _module_, [[ImportName]]: _importName_, [[LocalName]]: _localName_, [[ExportName]]: _sourceName_ }.
         </emu-alg>
         <emu-grammar>ExportSpecifier : ModuleExportName `as` ModuleExportName</emu-grammar>
         <emu-alg>
@@ -28376,7 +28380,7 @@
           1. Else,
             1. Let _localName_ be *null*.
             1. Let _importName_ be _sourceName_.
-          1. Return a List whose sole element is the ExportEntry Record { [[ModuleRequest]]: _module_, [[ImportName]]: _importName_, [[LocalName]]: _localName_, [[ExportName]]: _exportName_ }.
+          1. Return a List whose sole element is a new ExportEntry Record { [[ModuleRequest]]: _module_, [[ImportName]]: _importName_, [[LocalName]]: _localName_, [[ExportName]]: _exportName_ }.
         </emu-alg>
       </emu-clause>
 
@@ -28526,7 +28530,7 @@
   <p>Unless otherwise specified every built-in prototype object has the Object prototype object, which is the initial value of the expression `Object.prototype` (<emu-xref href="#sec-properties-of-the-object-prototype-object"></emu-xref>), as the value of its [[Prototype]] internal slot, except the Object prototype object itself.</p>
   <p>Built-in function objects that are not identified as constructors do not implement the [[Construct]] internal method unless otherwise specified in the description of a particular function.</p>
   <p>Each built-in function defined in this specification is created by calling the CreateBuiltinFunction abstract operation (<emu-xref href="#sec-createbuiltinfunction"></emu-xref>). The values of the _length_ and _name_ parameters are the initial values of the *"length"* and *"name"* properties as discussed below. The values of the _prefix_ parameter are similarly discussed below.</p>
-  <p>Every built-in function object, including constructors, has a *"length"* property whose value is a non-negative integral Number. Unless otherwise specified, this value is equal to the number of required parameters shown in the subclause heading for the function description. Optional parameters and rest parameters are not included in the parameter count.</p>
+  <p>Every built-in function object, including constructors, has a *"length"* property whose value is a non-negative integral Number. Unless otherwise specified, this value is the number of required parameters shown in the subclause heading for the function description. Optional parameters and rest parameters are not included in the parameter count.</p>
   <emu-note>
     <p>For example, the function object that is the initial value of the *"map"* property of the Array prototype object is described under the subclause heading «Array.prototype.map (callbackFn [ , thisArg])» which shows the two named arguments callbackFn and thisArg, the latter being optional; therefore the value of the *"length"* property of that function object is *1*<sub>𝔽</sub>.</p>
   </emu-note>
@@ -28704,7 +28708,7 @@
                 1. NOTE: `eval` will not create a global var declaration that would be shadowed by a global lexical declaration.
             1. Let _thisEnv_ be _lexEnv_.
             1. Assert: The following loop will terminate.
-            1. Repeat, while _thisEnv_ is not the same as _varEnv_,
+            1. Repeat, while _thisEnv_ is not _varEnv_,
               1. If _thisEnv_ is not an Object Environment Record, then
                 1. NOTE: The environment of with statements cannot contain any lexical declaration so it doesn't need to be checked for var/let hoisting conflicts.
                 1. For each element _name_ of _varNames_, do
@@ -28723,11 +28727,11 @@
           1. Let _functionsToInitialize_ be a new empty List.
           1. Let _declaredFunctionNames_ be a new empty List.
           1. For each element _d_ of _varDeclarations_, in reverse List order, do
-            1. If _d_ is neither a |VariableDeclaration| nor a |ForBinding| nor a |BindingIdentifier|, then
+            1. If _d_ is not either a |VariableDeclaration|, a |ForBinding|, or a |BindingIdentifier|, then
               1. Assert: _d_ is either a |FunctionDeclaration|, a |GeneratorDeclaration|, an |AsyncFunctionDeclaration|, or an |AsyncGeneratorDeclaration|.
               1. NOTE: If there are multiple function declarations for the same name, the last declaration is used.
               1. Let _fn_ be the sole element of the BoundNames of _d_.
-              1. If _fn_ is not an element of _declaredFunctionNames_, then
+              1. If _declaredFunctionNames_ does not contain _fn_, then
                 1. If _varEnv_ is a Global Environment Record, then
                   1. Let _fnDefinable_ be ? _varEnv_.CanDeclareGlobalFunction(_fn_).
                   1. If _fnDefinable_ is *false*, throw a *TypeError* exception.
@@ -28736,13 +28740,13 @@
           1. [id="step-evaldeclarationinstantiation-web-compat-insertion-point"] NOTE: Annex <emu-xref href="#sec-web-compat-evaldeclarationinstantiation"></emu-xref> adds additional steps at this point.
           1. Let _declaredVarNames_ be a new empty List.
           1. For each element _d_ of _varDeclarations_, do
-            1. If _d_ is a |VariableDeclaration|, a |ForBinding|, or a |BindingIdentifier|, then
+            1. If _d_ is either a |VariableDeclaration|, a |ForBinding|, or a |BindingIdentifier|, then
               1. For each String _vn_ of the BoundNames of _d_, do
-                1. If _vn_ is not an element of _declaredFunctionNames_, then
+                1. If _declaredFunctionNames_ does not contain _vn_, then
                   1. If _varEnv_ is a Global Environment Record, then
                     1. Let _vnDefinable_ be ? _varEnv_.CanDeclareGlobalVar(_vn_).
                     1. If _vnDefinable_ is *false*, throw a *TypeError* exception.
-                  1. If _vn_ is not an element of _declaredVarNames_, then
+                  1. If _declaredVarNames_ does not contain _vn_, then
                     1. Append _vn_ to _declaredVarNames_.
           1. [id="step-evaldeclarationinstantiation-post-validation"] NOTE: No abnormal terminations occur after this algorithm step unless _varEnv_ is a Global Environment Record and the global object is a Proxy exotic object.
           1. Let _lexDeclarations_ be the LexicallyScopedDeclarations of _body_.
@@ -28804,7 +28808,7 @@
         1. Otherwise, return *false*.
       </emu-alg>
       <emu-note>
-        <p>A reliable way for ECMAScript code to test if a value `X` is a *NaN* is an expression of the form `X !== X`. The result will be *true* if and only if `X` is a *NaN*.</p>
+        <p>A reliable way for ECMAScript code to test if a value `X` is *NaN* is an expression of the form `X !== X`. The result will be *true* if and only if `X` is *NaN*.</p>
       </emu-note>
     </emu-clause>
 
@@ -28829,7 +28833,7 @@
 
     <emu-clause id="sec-parseint-string-radix">
       <h1>parseInt ( _string_, _radix_ )</h1>
-      <p>This function produces an integral Number dictated by interpretation of the contents of the _string_ argument according to the specified _radix_. Leading white space in _string_ is ignored. If _radix_ is *undefined* or 0, it is assumed to be 10 except when the number begins with the code unit pairs `0x` or `0X`, in which case a radix of 16 is assumed. If _radix_ is 16, the number may also optionally begin with the code unit pairs `0x` or `0X`.</p>
+      <p>This function produces an integral Number dictated by interpretation of the contents of _string_ according to the specified _radix_. Leading white space in _string_ is ignored. If _radix_ coerces to 0 (such as when it is *undefined*), it is assumed to be 10 except when the number representation begins with *"0x"* or *"0X"*, in which case it is assumed to be 16. If _radix_ is 16, the number representation may optionally begin with *"0x"* or *"0X"*.</p>
       <p>It is the <dfn>%parseInt%</dfn> intrinsic object.</p>
       <p>It performs the following steps when called:</p>
       <emu-alg>
@@ -28837,7 +28841,7 @@
         1. Let _S_ be ! TrimString(_inputString_, ~start~).
         1. Let _sign_ be 1.
         1. If _S_ is not empty and the first code unit of _S_ is the code unit 0x002D (HYPHEN-MINUS), set _sign_ to -1.
-        1. If _S_ is not empty and the first code unit of _S_ is the code unit 0x002B (PLUS SIGN) or the code unit 0x002D (HYPHEN-MINUS), set _S_ to the substring of _S_ from index 1.
+        1. If _S_ is not empty and the first code unit of _S_ is either the code unit 0x002B (PLUS SIGN) or the code unit 0x002D (HYPHEN-MINUS), set _S_ to the substring of _S_ from index 1.
         1. Let _R_ be ℝ(? ToInt32(_radix_)).
         1. Let _stripPrefix_ be *true*.
         1. If _R_ ≠ 0, then
@@ -28852,7 +28856,7 @@
         1. If _S_ contains a code unit that is not a radix-_R_ digit, let _end_ be the index within _S_ of the first such code unit; otherwise, let _end_ be the length of _S_.
         1. Let _Z_ be the substring of _S_ from 0 to _end_.
         1. If _Z_ is empty, return *NaN*.
-        1. Let _mathInt_ be the integer value that is represented by _Z_ in radix-_R_ notation, using the letters <b>A</b>-<b>Z</b> and <b>a</b>-<b>z</b> for digits with values 10 through 35. (However, if _R_ is 10 and _Z_ contains more than 20 significant digits, every significant digit after the 20th may be replaced by a 0 digit, at the option of the implementation; and if _R_ is not 2, 4, 8, 10, 16, or 32, then _mathInt_ may be an implementation-approximated integer representing the integer value denoted by _Z_ in radix-_R_ notation.)
+        1. Let _mathInt_ be the integer value that is represented by _Z_ in radix-_R_ notation, using the letters <b>A</b>-<b>Z</b> and <b>a</b>-<b>z</b> for digits with values 10 through 35. (However, if _R_ = 10 and _Z_ contains more than 20 significant digits, every significant digit after the 20th may be replaced by a 0 digit, at the option of the implementation; and if _R_ is not one of 2, 4, 8, 10, 16, or 32, then _mathInt_ may be an implementation-approximated integer representing the integer value denoted by _Z_ in radix-_R_ notation.)
         1. If _mathInt_ = 0, then
           1. If _sign_ = -1, return *-0*<sub>𝔽</sub>.
           1. Return *+0*<sub>𝔽</sub>.
@@ -28941,7 +28945,7 @@
           1. Repeat,
             1. If _k_ = _strLen_, return _R_.
             1. Let _C_ be the code unit at index _k_ within _string_.
-            1. If _C_ is in _unescapedSet_, then
+            1. If _unescapedSet_ contains _C_, then
               1. Set _k_ to _k_ + 1.
               1. Set _R_ to the string-concatenation of _R_ and _C_.
             1. Else,
@@ -29270,7 +29274,7 @@
         <emu-alg>
           1. If NewTarget is neither *undefined* nor the active function object, then
             1. Return ? OrdinaryCreateFromConstructor(NewTarget, *"%Object.prototype%"*).
-          1. If _value_ is *undefined* or *null*, return OrdinaryObjectCreate(%Object.prototype%).
+          1. If _value_ is either *undefined* or *null*, return OrdinaryObjectCreate(%Object.prototype%).
           1. Return ! ToObject(_value_).
         </emu-alg>
         <p>The *"length"* property of this function is *1*<sub>𝔽</sub>.</p>
@@ -29465,7 +29469,7 @@
             1. Let _keys_ be ? <emu-meta effects="user-code">_obj_.[[OwnPropertyKeys]]()</emu-meta>.
             1. Let _nameList_ be a new empty List.
             1. For each element _nextKey_ of _keys_, do
-              1. If _nextKey_ is a Symbol and _type_ is ~symbol~ or _nextKey_ is a String and _type_ is ~string~, then
+              1. If _nextKey_ is a Symbol and _type_ is ~symbol~, or if _nextKey_ is a String and _type_ is ~string~, then
                 1. Append _nextKey_ to _nameList_.
             1. Return _nameList_.
           </emu-alg>
@@ -29960,7 +29964,7 @@
         <emu-alg>
           1. Let _func_ be the *this* value.
           1. If IsCallable(_func_) is *false*, throw a *TypeError* exception.
-          1. If _argArray_ is *undefined* or *null*, then
+          1. If _argArray_ is either *undefined* or *null*, then
             1. Perform PrepareForTailCall().
             1. Return ? Call(_func_, _thisArg_).
           1. Let _argList_ be ? CreateListFromArrayLike(_argArray_).
@@ -29971,7 +29975,7 @@
           <p>The _thisArg_ value is passed without modification as the *this* value. This is a change from Edition 3, where an *undefined* or *null* _thisArg_ is replaced with the global object and ToObject is applied to all other values and that result is passed as the *this* value. Even though the _thisArg_ is passed without modification, non-strict functions still perform these transformations upon entry to the function.</p>
         </emu-note>
         <emu-note>
-          <p>If _func_ is an arrow function or a bound function exotic object then the _thisArg_ will be ignored by the function [[Call]] in step <emu-xref href="#step-function-proto-apply-call"></emu-xref>.</p>
+          <p>If _func_ is either an arrow function or a bound function exotic object, then the _thisArg_ will be ignored by the function [[Call]] in step <emu-xref href="#step-function-proto-apply-call"></emu-xref>.</p>
         </emu-note>
       </emu-clause>
 
@@ -30004,7 +30008,7 @@
           <p>Function objects created using `Function.prototype.bind` are exotic objects. They also do not have a *"prototype"* property.</p>
         </emu-note>
         <emu-note>
-          <p>If _Target_ is an arrow function or a bound function exotic object then the _thisArg_ passed to this method will not be used by subsequent calls to _F_.</p>
+          <p>If _Target_ is either an arrow function or a bound function exotic object, then the _thisArg_ passed to this method will not be used by subsequent calls to _F_.</p>
         </emu-note>
       </emu-clause>
 
@@ -30021,7 +30025,7 @@
           <p>The _thisArg_ value is passed without modification as the *this* value. This is a change from Edition 3, where an *undefined* or *null* _thisArg_ is replaced with the global object and ToObject is applied to all other values and that result is passed as the *this* value. Even though the _thisArg_ is passed without modification, non-strict functions still perform these transformations upon entry to the function.</p>
         </emu-note>
         <emu-note>
-          <p>If _func_ is an arrow function or a bound function exotic object then the _thisArg_ will be ignored by the function [[Call]] in step <emu-xref href="#step-function-proto-call-call"></emu-xref>.</p>
+          <p>If _func_ is either an arrow function or a bound function exotic object, then the _thisArg_ will be ignored by the function [[Call]] in step <emu-xref href="#step-function-proto-call-call"></emu-xref>.</p>
         </emu-note>
       </emu-clause>
 
@@ -30232,7 +30236,7 @@
           1. If NewTarget is not *undefined*, throw a *TypeError* exception.
           1. If _description_ is *undefined*, let _descString_ be *undefined*.
           1. Else, let _descString_ be ? ToString(_description_).
-          1. Return a new unique Symbol value whose [[Description]] value is _descString_.
+          1. Return a new Symbol whose [[Description]] is _descString_.
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -30259,7 +30263,7 @@
           1. For each element _e_ of the GlobalSymbolRegistry List, do
             1. If SameValue(_e_.[[Key]], _stringKey_) is *true*, return _e_.[[Symbol]].
           1. Assert: GlobalSymbolRegistry does not currently contain an entry for _stringKey_.
-          1. Let _newSymbol_ be a new unique Symbol value whose [[Description]] value is _stringKey_.
+          1. Let _newSymbol_ be a new Symbol whose [[Description]] is _stringKey_.
           1. Append the Record { [[Key]]: _stringKey_, [[Symbol]]: _newSymbol_ } to the GlobalSymbolRegistry List.
           1. Return _newSymbol_.
         </emu-alg>
@@ -31417,7 +31421,7 @@
         <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
-          1. If _n_ is *NaN* or _n_ is *+∞*<sub>𝔽</sub>, return _n_.
+          1. If _n_ is either *NaN* or *+∞*<sub>𝔽</sub>, return _n_.
           1. If _n_ is *1*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
           1. If _n_ &lt; *1*<sub>𝔽</sub>, return *NaN*.
           1. Return an implementation-approximated Number value representing the result of the inverse hyperbolic cosine of ℝ(_n_).
@@ -31430,7 +31434,7 @@
         <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
-          1. If _n_ is *NaN*, _n_ is *+0*<sub>𝔽</sub>, or _n_ is *-0*<sub>𝔽</sub>, return _n_.
+          1. If _n_ is one of *NaN*, *+0*<sub>𝔽</sub>, or *-0*<sub>𝔽</sub>, return _n_.
           1. If _n_ > *1*<sub>𝔽</sub> or _n_ &lt; *-1*<sub>𝔽</sub>, return *NaN*.
           1. Return an implementation-approximated Number value representing the result of the inverse sine of ℝ(_n_).
         </emu-alg>
@@ -31453,7 +31457,7 @@
         <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
-          1. If _n_ is *NaN*, _n_ is *+0*<sub>𝔽</sub>, or _n_ is *-0*<sub>𝔽</sub>, return _n_.
+          1. If _n_ is one of *NaN*, *+0*<sub>𝔽</sub>, or *-0*<sub>𝔽</sub>, return _n_.
           1. If _n_ is *+∞*<sub>𝔽</sub>, return an implementation-approximated Number value representing π / 2.
           1. If _n_ is *-∞*<sub>𝔽</sub>, return an implementation-approximated Number value representing -π / 2.
           1. Return an implementation-approximated Number value representing the result of the inverse tangent of ℝ(_n_).
@@ -31466,7 +31470,7 @@
         <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
-          1. If _n_ is *NaN*, _n_ is *+0*<sub>𝔽</sub>, or _n_ is *-0*<sub>𝔽</sub>, return _n_.
+          1. If _n_ is one of *NaN*, *+0*<sub>𝔽</sub>, or *-0*<sub>𝔽</sub>, return _n_.
           1. If _n_ > *1*<sub>𝔽</sub> or _n_ &lt; *-1*<sub>𝔽</sub>, return *NaN*.
           1. If _n_ is *1*<sub>𝔽</sub>, return *+∞*<sub>𝔽</sub>.
           1. If _n_ is *-1*<sub>𝔽</sub>, return *-∞*<sub>𝔽</sub>.
@@ -31500,11 +31504,11 @@
           1. If _ny_ > *+0*<sub>𝔽</sub>, then
             1. If _nx_ is *+∞*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
             1. If _nx_ is *-∞*<sub>𝔽</sub>, return an implementation-approximated Number value representing π.
-            1. If _nx_ is *+0*<sub>𝔽</sub> or _nx_ is *-0*<sub>𝔽</sub>, return an implementation-approximated Number value representing π / 2.
+            1. If _nx_ is either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, return an implementation-approximated Number value representing π / 2.
           1. If _ny_ &lt; *-0*<sub>𝔽</sub>, then
             1. If _nx_ is *+∞*<sub>𝔽</sub>, return *-0*<sub>𝔽</sub>.
             1. If _nx_ is *-∞*<sub>𝔽</sub>, return an implementation-approximated Number value representing -π.
-            1. If _nx_ is *+0*<sub>𝔽</sub> or _nx_ is *-0*<sub>𝔽</sub>, return an implementation-approximated Number value representing -π / 2.
+            1. If _nx_ is either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, return an implementation-approximated Number value representing -π / 2.
           1. Assert: _nx_ is finite and is neither *+0*<sub>𝔽</sub> nor *-0*<sub>𝔽</sub>.
           1. Return an implementation-approximated Number value representing the result of the inverse tangent of the quotient ℝ(_ny_) / ℝ(_nx_).
         </emu-alg>
@@ -31546,7 +31550,7 @@
           1. Return 𝔽(_p_).
         </emu-alg>
         <emu-note>
-          <p>If _n_ is *+0*<sub>𝔽</sub> or _n_ is *-0*<sub>𝔽</sub>, this method returns *32*<sub>𝔽</sub>. If the most significant bit of the 32-bit binary encoding of _n_ is 1, this method returns *+0*<sub>𝔽</sub>.</p>
+          <p>If _n_ is either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, this method returns *32*<sub>𝔽</sub>. If the most significant bit of the 32-bit binary encoding of _n_ is 1, this method returns *+0*<sub>𝔽</sub>.</p>
         </emu-note>
       </emu-clause>
 
@@ -31557,7 +31561,7 @@
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
           1. If _n_ is not finite, return *NaN*.
-          1. If _n_ is *+0*<sub>𝔽</sub> or _n_ is *-0*<sub>𝔽</sub>, return *1*<sub>𝔽</sub>.
+          1. If _n_ is either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, return *1*<sub>𝔽</sub>.
           1. Return an implementation-approximated Number value representing the result of the cosine of ℝ(_n_).
         </emu-alg>
       </emu-clause>
@@ -31569,8 +31573,8 @@
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
           1. If _n_ is *NaN*, return *NaN*.
-          1. If _n_ is *+∞*<sub>𝔽</sub> or _n_ is *-∞*<sub>𝔽</sub>, return *+∞*<sub>𝔽</sub>.
-          1. If _n_ is *+0*<sub>𝔽</sub> or _n_ is *-0*<sub>𝔽</sub>, return *1*<sub>𝔽</sub>.
+          1. If _n_ is either *+∞*<sub>𝔽</sub> or *-∞*<sub>𝔽</sub>, return *+∞*<sub>𝔽</sub>.
+          1. If _n_ is either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, return *1*<sub>𝔽</sub>.
           1. Return an implementation-approximated Number value representing the result of the hyperbolic cosine of ℝ(_n_).
         </emu-alg>
         <emu-note>
@@ -31584,8 +31588,8 @@
         <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
-          1. If _n_ is *NaN* or _n_ is *+∞*<sub>𝔽</sub>, return _n_.
-          1. If _n_ is *+0*<sub>𝔽</sub> or _n_ is *-0*<sub>𝔽</sub>, return *1*<sub>𝔽</sub>.
+          1. If _n_ is either *NaN* or *+∞*<sub>𝔽</sub>, return _n_.
+          1. If _n_ is either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, return *1*<sub>𝔽</sub>.
           1. If _n_ is *-∞*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
           1. Return an implementation-approximated Number value representing the result of the exponential function of ℝ(_n_).
         </emu-alg>
@@ -31597,7 +31601,7 @@
         <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
-          1. If _n_ is *NaN*, _n_ is *+0*<sub>𝔽</sub>, _n_ is *-0*<sub>𝔽</sub>, or _n_ is *+∞*<sub>𝔽</sub>, return _n_.
+          1. If _n_ is one of *NaN*, *+0*<sub>𝔽</sub>, *-0*<sub>𝔽</sub>, or *+∞*<sub>𝔽</sub>, return _n_.
           1. If _n_ is *-∞*<sub>𝔽</sub>, return *-1*<sub>𝔽</sub>.
           1. Return an implementation-approximated Number value representing the result of subtracting 1 from the exponential function of ℝ(_n_).
         </emu-alg>
@@ -31642,7 +31646,7 @@
             1. Let _n_ be ? ToNumber(_arg_).
             1. Append _n_ to _coerced_.
           1. For each element _number_ of _coerced_, do
-            1. If _number_ is *+∞*<sub>𝔽</sub> or _number_ is *-∞*<sub>𝔽</sub>, return *+∞*<sub>𝔽</sub>.
+            1. If _number_ is either *+∞*<sub>𝔽</sub> or *-∞*<sub>𝔽</sub>, return *+∞*<sub>𝔽</sub>.
           1. Let _onlyZero_ be *true*.
           1. For each element _number_ of _coerced_, do
             1. If _number_ is *NaN*, return *NaN*.
@@ -31673,9 +31677,9 @@
         <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
-          1. If _n_ is *NaN* or _n_ is *+∞*<sub>𝔽</sub>, return _n_.
+          1. If _n_ is either *NaN* or *+∞*<sub>𝔽</sub>, return _n_.
           1. If _n_ is *1*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
-          1. If _n_ is *+0*<sub>𝔽</sub> or _n_ is *-0*<sub>𝔽</sub>, return *-∞*<sub>𝔽</sub>.
+          1. If _n_ is either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, return *-∞*<sub>𝔽</sub>.
           1. If _n_ &lt; *-0*<sub>𝔽</sub>, return *NaN*.
           1. Return an implementation-approximated Number value representing the result of the natural logarithm of ℝ(_n_).
         </emu-alg>
@@ -31687,7 +31691,7 @@
         <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
-          1. If _n_ is *NaN*, _n_ is *+0*<sub>𝔽</sub>, _n_ is *-0*<sub>𝔽</sub>, or _n_ is *+∞*<sub>𝔽</sub>, return _n_.
+          1. If _n_ is one of *NaN*, *+0*<sub>𝔽</sub>, *-0*<sub>𝔽</sub>, or *+∞*<sub>𝔽</sub>, return _n_.
           1. If _n_ is *-1*<sub>𝔽</sub>, return *-∞*<sub>𝔽</sub>.
           1. If _n_ &lt; *-1*<sub>𝔽</sub>, return *NaN*.
           1. Return an implementation-approximated Number value representing the result of the natural logarithm of 1 + ℝ(_n_).
@@ -31700,9 +31704,9 @@
         <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
-          1. If _n_ is *NaN* or _n_ is *+∞*<sub>𝔽</sub>, return _n_.
+          1. If _n_ is either *NaN* or *+∞*<sub>𝔽</sub>, return _n_.
           1. If _n_ is *1*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
-          1. If _n_ is *+0*<sub>𝔽</sub> or _n_ is *-0*<sub>𝔽</sub>, return *-∞*<sub>𝔽</sub>.
+          1. If _n_ is either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, return *-∞*<sub>𝔽</sub>.
           1. If _n_ &lt; *-0*<sub>𝔽</sub>, return *NaN*.
           1. Return an implementation-approximated Number value representing the result of the base 10 logarithm of ℝ(_n_).
         </emu-alg>
@@ -31714,9 +31718,9 @@
         <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
-          1. If _n_ is *NaN* or _n_ is *+∞*<sub>𝔽</sub>, return _n_.
+          1. If _n_ is either *NaN* or *+∞*<sub>𝔽</sub>, return _n_.
           1. If _n_ is *1*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
-          1. If _n_ is *+0*<sub>𝔽</sub> or _n_ is *-0*<sub>𝔽</sub>, return *-∞*<sub>𝔽</sub>.
+          1. If _n_ is either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, return *-∞*<sub>𝔽</sub>.
           1. If _n_ &lt; *-0*<sub>𝔽</sub>, return *NaN*.
           1. Return an implementation-approximated Number value representing the result of the base 2 logarithm of ℝ(_n_).
         </emu-alg>
@@ -31797,7 +31801,7 @@
           <p>`Math.round(3.5)` returns 4, but `Math.round(-3.5)` returns -3.</p>
         </emu-note>
         <emu-note>
-          <p>The value of `Math.round(x)` is not always the same as the value of `Math.floor(x + 0.5)`. When `x` is *-0*<sub>𝔽</sub> or is less than *+0*<sub>𝔽</sub> but greater than or equal to *-0.5*<sub>𝔽</sub>, `Math.round(x)` returns *-0*<sub>𝔽</sub>, but `Math.floor(x + 0.5)` returns *+0*<sub>𝔽</sub>. `Math.round(x)` may also differ from the value of `Math.floor(x + 0.5)`because of internal rounding when computing `x + 0.5`.</p>
+          <p>The value of `Math.round(x)` is not always the same as the value of `Math.floor(x + 0.5)`. When `x` is *-0*<sub>𝔽</sub> or `x` is less than *+0*<sub>𝔽</sub> but greater than or equal to *-0.5*<sub>𝔽</sub>, `Math.round(x)` returns *-0*<sub>𝔽</sub>, but `Math.floor(x + 0.5)` returns *+0*<sub>𝔽</sub>. `Math.round(x)` may also differ from the value of `Math.floor(x + 0.5)`because of internal rounding when computing `x + 0.5`.</p>
         </emu-note>
       </emu-clause>
 
@@ -31807,7 +31811,7 @@
         <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
-          1. If _n_ is *NaN*, _n_ is *+0*<sub>𝔽</sub>, or _n_ is *-0*<sub>𝔽</sub>, return _n_.
+          1. If _n_ is one of *NaN*, *+0*<sub>𝔽</sub>, or *-0*<sub>𝔽</sub>, return _n_.
           1. If _n_ &lt; *-0*<sub>𝔽</sub>, return *-1*<sub>𝔽</sub>.
           1. Return *1*<sub>𝔽</sub>.
         </emu-alg>
@@ -31819,8 +31823,8 @@
         <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
-          1. If _n_ is *NaN*, _n_ is *+0*<sub>𝔽</sub>, or _n_ is *-0*<sub>𝔽</sub>, return _n_.
-          1. If _n_ is *+∞*<sub>𝔽</sub> or _n_ is *-∞*<sub>𝔽</sub>, return *NaN*.
+          1. If _n_ is one of *NaN*, *+0*<sub>𝔽</sub>, or *-0*<sub>𝔽</sub>, return _n_.
+          1. If _n_ is either *+∞*<sub>𝔽</sub> or *-∞*<sub>𝔽</sub>, return *NaN*.
           1. Return an implementation-approximated Number value representing the result of the sine of ℝ(_n_).
         </emu-alg>
       </emu-clause>
@@ -31845,7 +31849,7 @@
         <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
-          1. If _n_ is *NaN*, _n_ is *+0*<sub>𝔽</sub>, _n_ is *-0*<sub>𝔽</sub>, or _n_ is *+∞*<sub>𝔽</sub>, return _n_.
+          1. If _n_ is one of *NaN*, *+0*<sub>𝔽</sub>, *-0*<sub>𝔽</sub>, or *+∞*<sub>𝔽</sub>, return _n_.
           1. If _n_ &lt; *-0*<sub>𝔽</sub>, return *NaN*.
           1. Return an implementation-approximated Number value representing the result of the square root of ℝ(_n_).
         </emu-alg>
@@ -31857,8 +31861,8 @@
         <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
-          1. If _n_ is *NaN*, _n_ is *+0*<sub>𝔽</sub>, or _n_ is *-0*<sub>𝔽</sub>, return _n_.
-          1. If _n_ is *+∞*<sub>𝔽</sub>, or _n_ is *-∞*<sub>𝔽</sub>, return *NaN*.
+          1. If _n_ is one of *NaN*, *+0*<sub>𝔽</sub>, or *-0*<sub>𝔽</sub>, return _n_.
+          1. If _n_ is either *+∞*<sub>𝔽</sub> or *-∞*<sub>𝔽</sub>, return *NaN*.
           1. Return an implementation-approximated Number value representing the result of the tangent of ℝ(_n_).
         </emu-alg>
       </emu-clause>
@@ -31869,7 +31873,7 @@
         <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
-          1. If _n_ is *NaN*, _n_ is *+0*<sub>𝔽</sub>, or _n_ is *-0*<sub>𝔽</sub>, return _n_.
+          1. If _n_ is one of *NaN*, *+0*<sub>𝔽</sub>, or *-0*<sub>𝔽</sub>, return _n_.
           1. If _n_ is *+∞*<sub>𝔽</sub>, return *1*<sub>𝔽</sub>.
           1. If _n_ is *-∞*<sub>𝔽</sub>, return *-1*<sub>𝔽</sub>.
           1. Return an implementation-approximated Number value representing the result of the hyperbolic tangent of ℝ(_n_).
@@ -31904,7 +31908,7 @@
       <emu-clause id="sec-time-values-and-time-range">
         <h1>Time Values and Time Range</h1>
         <p>Time measurement in ECMAScript is analogous to time measurement in POSIX, in particular sharing definition in terms of the proleptic Gregorian calendar, an <dfn id="epoch">epoch</dfn> of midnight at the beginning of 1 January 1970 UTC, and an accounting of every day as comprising exactly 86,400 seconds (each of which is 1000 milliseconds long).</p>
-        <p>An ECMAScript <dfn variants="time values">time value</dfn> is a Number, either a finite integral Number representing an instant in time to millisecond precision or *NaN* representing no specific instant. A time value that is a multiple of <emu-eqn>24 × 60 × 60 × 1000 = 86,400,000</emu-eqn> (i.e., is equal to 86,400,000 × _d_ for some integer _d_) represents the instant at the start of the UTC day that follows the epoch by _d_ whole UTC days (preceding the epoch for negative _d_). Every other finite time value _t_ is defined relative to the greatest preceding time value _s_ that is such a multiple, and represents the instant that occurs within the same UTC day as _s_ but follows it by (_t_ - _s_) milliseconds.</p>
+        <p>An ECMAScript <dfn variants="time values">time value</dfn> is a Number, either a finite integral Number representing an instant in time to millisecond precision or *NaN* representing no specific instant. A time value that is a multiple of <emu-eqn>24 × 60 × 60 × 1000 = 86,400,000</emu-eqn> (i.e., is 86,400,000 × _d_ for some integer _d_) represents the instant at the start of the UTC day that follows the epoch by _d_ whole UTC days (preceding the epoch for negative _d_). Every other finite time value _t_ is defined relative to the greatest preceding time value _s_ that is such a multiple, and represents the instant that occurs within the same UTC day as _s_ but follows it by (_t_ - _s_) milliseconds.</p>
         <p>Time values do not account for UTC leap seconds—there are no time values representing instants within positive leap seconds, and there are time values representing instants removed from the UTC timeline by negative leap seconds. However, the definition of time values nonetheless yields piecewise alignment with UTC, with discontinuities only at leap second boundaries and zero difference outside of leap seconds.</p>
         <p>A Number can exactly represent all integers from -9,007,199,254,740,992 to 9,007,199,254,740,992 (<emu-xref href="#sec-number.min_safe_integer"></emu-xref> and <emu-xref href="#sec-number.max_safe_integer"></emu-xref>). A time value supports a slightly smaller range of -8,640,000,000,000,000 to 8,640,000,000,000,000 milliseconds. This yields a supported time value range of exactly -100,000,000 days to 100,000,000 days relative to midnight at the beginning of 1 January 1970 UTC.</p>
         <p>The exact moment of midnight at the beginning of 1 January 1970 UTC is represented by the time value *+0*<sub>𝔽</sub>.</p>
@@ -31942,8 +31946,8 @@
         <p>The leap-year function is *1*<sub>𝔽</sub> for a time within a leap year and otherwise is *+0*<sub>𝔽</sub>:</p>
         <emu-eqn id="eqn-InLeapYear" aoid="InLeapYear">
           InLeapYear(_t_)
-            = *+0*<sub>𝔽</sub> if DaysInYear(YearFromTime(_t_)) = *365*<sub>𝔽</sub>
-            = *1*<sub>𝔽</sub> if DaysInYear(YearFromTime(_t_)) = *366*<sub>𝔽</sub>
+            = *+0*<sub>𝔽</sub> if DaysInYear(YearFromTime(_t_)) is *365*<sub>𝔽</sub>
+            = *1*<sub>𝔽</sub> if DaysInYear(YearFromTime(_t_)) is *366*<sub>𝔽</sub>
         </emu-eqn>
       </emu-clause>
 
@@ -31975,18 +31979,18 @@
         <p>A date number is identified by an integral Number in the inclusive interval from *1*<sub>𝔽</sub> to *31*<sub>𝔽</sub>. The mapping DateFromTime(_t_) from a time value _t_ to a date number is defined by:</p>
         <emu-eqn aoid="DateFromTime">
           DateFromTime(_t_)
-            = DayWithinYear(_t_) + *1*<sub>𝔽</sub> if MonthFromTime(_t_) = *+0*<sub>𝔽</sub>
-            = DayWithinYear(_t_) - *30*<sub>𝔽</sub> if MonthFromTime(_t_) = *1*<sub>𝔽</sub>
-            = DayWithinYear(_t_) - *58*<sub>𝔽</sub> - InLeapYear(_t_) if MonthFromTime(_t_) = *2*<sub>𝔽</sub>
-            = DayWithinYear(_t_) - *89*<sub>𝔽</sub> - InLeapYear(_t_) if MonthFromTime(_t_) = *3*<sub>𝔽</sub>
-            = DayWithinYear(_t_) - *119*<sub>𝔽</sub> - InLeapYear(_t_) if MonthFromTime(_t_) = *4*<sub>𝔽</sub>
-            = DayWithinYear(_t_) - *150*<sub>𝔽</sub> - InLeapYear(_t_) if MonthFromTime(_t_) = *5*<sub>𝔽</sub>
-            = DayWithinYear(_t_) - *180*<sub>𝔽</sub> - InLeapYear(_t_) if MonthFromTime(_t_) = *6*<sub>𝔽</sub>
-            = DayWithinYear(_t_) - *211*<sub>𝔽</sub> - InLeapYear(_t_) if MonthFromTime(_t_) = *7*<sub>𝔽</sub>
-            = DayWithinYear(_t_) - *242*<sub>𝔽</sub> - InLeapYear(_t_) if MonthFromTime(_t_) = *8*<sub>𝔽</sub>
-            = DayWithinYear(_t_) - *272*<sub>𝔽</sub> - InLeapYear(_t_) if MonthFromTime(_t_) = *9*<sub>𝔽</sub>
-            = DayWithinYear(_t_) - *303*<sub>𝔽</sub> - InLeapYear(_t_) if MonthFromTime(_t_) = *10*<sub>𝔽</sub>
-            = DayWithinYear(_t_) - *333*<sub>𝔽</sub> - InLeapYear(_t_) if MonthFromTime(_t_) = *11*<sub>𝔽</sub>
+            = DayWithinYear(_t_) + *1*<sub>𝔽</sub> if MonthFromTime(_t_) is *+0*<sub>𝔽</sub>
+            = DayWithinYear(_t_) - *30*<sub>𝔽</sub> if MonthFromTime(_t_) is *1*<sub>𝔽</sub>
+            = DayWithinYear(_t_) - *58*<sub>𝔽</sub> - InLeapYear(_t_) if MonthFromTime(_t_) is *2*<sub>𝔽</sub>
+            = DayWithinYear(_t_) - *89*<sub>𝔽</sub> - InLeapYear(_t_) if MonthFromTime(_t_) is *3*<sub>𝔽</sub>
+            = DayWithinYear(_t_) - *119*<sub>𝔽</sub> - InLeapYear(_t_) if MonthFromTime(_t_) is *4*<sub>𝔽</sub>
+            = DayWithinYear(_t_) - *150*<sub>𝔽</sub> - InLeapYear(_t_) if MonthFromTime(_t_) is *5*<sub>𝔽</sub>
+            = DayWithinYear(_t_) - *180*<sub>𝔽</sub> - InLeapYear(_t_) if MonthFromTime(_t_) is *6*<sub>𝔽</sub>
+            = DayWithinYear(_t_) - *211*<sub>𝔽</sub> - InLeapYear(_t_) if MonthFromTime(_t_) is *7*<sub>𝔽</sub>
+            = DayWithinYear(_t_) - *242*<sub>𝔽</sub> - InLeapYear(_t_) if MonthFromTime(_t_) is *8*<sub>𝔽</sub>
+            = DayWithinYear(_t_) - *272*<sub>𝔽</sub> - InLeapYear(_t_) if MonthFromTime(_t_) is *9*<sub>𝔽</sub>
+            = DayWithinYear(_t_) - *303*<sub>𝔽</sub> - InLeapYear(_t_) if MonthFromTime(_t_) is *10*<sub>𝔽</sub>
+            = DayWithinYear(_t_) - *333*<sub>𝔽</sub> - InLeapYear(_t_) if MonthFromTime(_t_) is *11*<sub>𝔽</sub>
         </emu-eqn>
       </emu-clause>
 
@@ -32221,7 +32225,7 @@
           <dd>It calculates a number of milliseconds.</dd>
         </dl>
         <emu-alg>
-          1. If _hour_ is not finite or _min_ is not finite or _sec_ is not finite or _ms_ is not finite, return *NaN*.
+          1. If _hour_ is not finite, _min_ is not finite, _sec_ is not finite, or _ms_ is not finite, return *NaN*.
           1. Let _h_ be 𝔽(! ToIntegerOrInfinity(_hour_)).
           1. Let _m_ be 𝔽(! ToIntegerOrInfinity(_min_)).
           1. Let _s_ be 𝔽(! ToIntegerOrInfinity(_sec_)).
@@ -32244,14 +32248,14 @@
           <dd>It calculates a number of days.</dd>
         </dl>
         <emu-alg>
-          1. If _year_ is not finite or _month_ is not finite or _date_ is not finite, return *NaN*.
+          1. If _year_ is not finite, _month_ is not finite, or _date_ is not finite, return *NaN*.
           1. Let _y_ be 𝔽(! ToIntegerOrInfinity(_year_)).
           1. Let _m_ be 𝔽(! ToIntegerOrInfinity(_month_)).
           1. Let _dt_ be 𝔽(! ToIntegerOrInfinity(_date_)).
           1. Let _ym_ be _y_ + 𝔽(floor(ℝ(_m_) / 12)).
           1. If _ym_ is not finite, return *NaN*.
           1. Let _mn_ be 𝔽(ℝ(_m_) modulo 12).
-          1. Find a finite time value _t_ such that YearFromTime(_t_) is _ym_ and MonthFromTime(_t_) is _mn_ and DateFromTime(_t_) is *1*<sub>𝔽</sub>; but if this is not possible (because some argument is out of range), return *NaN*.
+          1. Find a finite time value _t_ such that YearFromTime(_t_) is _ym_, MonthFromTime(_t_) is _mn_, and DateFromTime(_t_) is *1*<sub>𝔽</sub>; but if this is not possible (because some argument is out of range), return *NaN*.
           1. Return Day(_t_) + _dt_ - *1*<sub>𝔽</sub>.
         </emu-alg>
       </emu-clause>
@@ -33584,7 +33588,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. If _O_ is not an Object, throw a *TypeError* exception.
-          1. If _hint_ is *"string"* or *"default"*, then
+          1. If _hint_ is either *"string"* or *"default"*, then
             1. Let _tryFirst_ be ~string~.
           1. Else if _hint_ is *"number"*, then
             1. Let _tryFirst_ be ~number~.
@@ -33875,7 +33879,7 @@ THH:mm:ss.sss
           1. Let _len_ be the length of _S_.
           1. Let _start_ be the result of clamping _pos_ between 0 and _len_.
           1. Let _index_ be StringIndexOf(_S_, _searchStr_, _start_).
-          1. If _index_ is not -1, return *true*.
+          1. If _index_ ≠ -1, return *true*.
           1. Return *false*.
         </emu-alg>
         <emu-note>
@@ -33929,7 +33933,7 @@ THH:mm:ss.sss
           1. If _searchStr_ is the empty String, return 𝔽(_start_).
           1. For each integer _i_ such that 0 ≤ _i_ ≤ _start_, in descending order, do
             1. Let _candidate_ be the substring of _S_ from _i_ to _i_ + _searchLen_.
-            1. If _candidate_ is the same sequence of code units as _searchStr_, return 𝔽(_i_).
+            1. If _candidate_ is _searchStr_, return 𝔽(_i_).
           1. Return *-1*<sub>𝔽</sub>.
         </emu-alg>
         <emu-note>
@@ -34114,8 +34118,8 @@ THH:mm:ss.sss
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
           1. Let _n_ be ? ToIntegerOrInfinity(_count_).
-          1. If _n_ &lt; 0 or _n_ is +∞, throw a *RangeError* exception.
-          1. If _n_ is 0, return the empty String.
+          1. If _n_ &lt; 0 or _n_ = +∞, throw a *RangeError* exception.
+          1. If _n_ = 0, return the empty String.
           1. Return the String value that is made from _n_ copies of _S_ appended together.
         </emu-alg>
         <emu-note>
@@ -34142,7 +34146,7 @@ THH:mm:ss.sss
             1. Set _replaceValue_ to ? ToString(_replaceValue_).
           1. Let _searchLength_ be the length of _searchString_.
           1. Let _position_ be StringIndexOf(_string_, _searchString_, 0).
-          1. If _position_ is -1, return _string_.
+          1. If _position_ = -1, return _string_.
           1. Let _preceding_ be the substring of _string_ from 0 to _position_.
           1. Let _following_ be the substring of _string_ from _position_ + _searchLength_.
           1. If _functionalReplace_ is *true*, then
@@ -34257,7 +34261,7 @@ THH:mm:ss.sss
           1. Let _advanceBy_ be max(1, _searchLength_).
           1. Let _matchPositions_ be a new empty List.
           1. Let _position_ be StringIndexOf(_string_, _searchString_, 0).
-          1. Repeat, while _position_ is not -1,
+          1. Repeat, while _position_ ≠ -1,
             1. Append _position_ to _matchPositions_.
             1. Set _position_ to StringIndexOf(_string_, _searchString_, _position_ + _advanceBy_).
           1. Let _endOfLastMatch_ be 0.
@@ -34305,11 +34309,11 @@ THH:mm:ss.sss
           1. Let _S_ be ? ToString(_O_).
           1. Let _len_ be the length of _S_.
           1. Let _intStart_ be ? ToIntegerOrInfinity(_start_).
-          1. If _intStart_ is -∞, let _from_ be 0.
+          1. If _intStart_ = -∞, let _from_ be 0.
           1. Else if _intStart_ &lt; 0, let _from_ be max(_len_ + _intStart_, 0).
           1. Else, let _from_ be min(_intStart_, _len_).
           1. If _end_ is *undefined*, let _intEnd_ be _len_; else let _intEnd_ be ? ToIntegerOrInfinity(_end_).
-          1. If _intEnd_ is -∞, let _to_ be 0.
+          1. If _intEnd_ = -∞, let _to_ be 0.
           1. Else if _intEnd_ &lt; 0, let _to_ be max(_len_ + _intEnd_, 0).
           1. Else, let _to_ be min(_intEnd_, _len_).
           1. If _from_ ≥ _to_, return the empty String.
@@ -34338,7 +34342,7 @@ THH:mm:ss.sss
           1. If _separator_ is *undefined*, then
             1. Return CreateArrayFromList(« _S_ »).
           1. Let _separatorLength_ be the length of _R_.
-          1. If _separatorLength_ is 0, then
+          1. If _separatorLength_ = 0, then
             1. Let _head_ be the substring of _S_ from 0 to _lim_.
             1. Let _codeUnits_ be a List consisting of the sequence of code units that are the elements of _head_.
             1. Return CreateArrayFromList(_codeUnits_).
@@ -34346,7 +34350,7 @@ THH:mm:ss.sss
           1. Let _substrings_ be a new empty List.
           1. Let _i_ be 0.
           1. Let _j_ be StringIndexOf(_S_, _R_, 0).
-          1. Repeat, while _j_ is not -1,
+          1. Repeat, while _j_ ≠ -1,
             1. Let _T_ be the substring of _S_ from _i_ to _j_.
             1. Append _T_ to _substrings_.
             1. If the number of elements in _substrings_ is _lim_, return CreateArrayFromList(_substrings_).
@@ -34400,8 +34404,8 @@ THH:mm:ss.sss
       <emu-clause id="sec-string.prototype.substring">
         <h1>String.prototype.substring ( _start_, _end_ )</h1>
         <p>This method returns a <emu-not-ref>substring</emu-not-ref> of the result of converting this object to a String, starting from index _start_ and running to, but not including, index _end_ of the String (or through the end of the String if _end_ is *undefined*). The result is a String value, not a String object.</p>
-        <p>If either argument is *NaN* or negative, it is replaced with zero; if either argument is larger than the length of the String, it is replaced with the length of the String.</p>
-        <p>If _start_ is larger than _end_, they are swapped.</p>
+        <p>If either argument is *NaN* or negative, it is replaced with zero; if either argument is strictly greater than the length of the String, it is replaced with the length of the String.</p>
+        <p>If _start_ is strictly greater than _end_, they are swapped.</p>
         <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
@@ -34844,7 +34848,7 @@ THH:mm:ss.sss
         <emu-grammar>QuantifierPrefix :: `{` DecimalDigits `,` DecimalDigits `}`</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the MV of the first |DecimalDigits| is larger than the MV of the second |DecimalDigits|.
+            It is a Syntax Error if the MV of the first |DecimalDigits| is strictly greater than the MV of the second |DecimalDigits|.
           </li>
         </ul>
         <emu-grammar>AtomEscape :: `k` GroupName</emu-grammar>
@@ -34856,7 +34860,7 @@ THH:mm:ss.sss
         <emu-grammar>AtomEscape :: DecimalEscape</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the CapturingGroupNumber of |DecimalEscape| is larger than CountLeftCapturingParensWithin(the |Pattern| containing |AtomEscape|).
+            It is a Syntax Error if the CapturingGroupNumber of |DecimalEscape| is strictly greater than CountLeftCapturingParensWithin(the |Pattern| containing |AtomEscape|).
           </li>
         </ul>
         <emu-grammar>NonemptyClassRanges :: ClassAtom `-` ClassAtom ClassRanges</emu-grammar>
@@ -34865,7 +34869,7 @@ THH:mm:ss.sss
             It is a Syntax Error if IsCharacterClass of the first |ClassAtom| is *true* or IsCharacterClass of the second |ClassAtom| is *true*.
           </li>
           <li>
-            It is a Syntax Error if IsCharacterClass of the first |ClassAtom| is *false* and IsCharacterClass of the second |ClassAtom| is *false* and the CharacterValue of the first |ClassAtom| is larger than the CharacterValue of the second |ClassAtom|.
+            It is a Syntax Error if IsCharacterClass of the first |ClassAtom| is *false*, IsCharacterClass of the second |ClassAtom| is *false*, and the CharacterValue of the first |ClassAtom| is strictly greater than the CharacterValue of the second |ClassAtom|.
           </li>
         </ul>
         <emu-grammar>NonemptyClassRangesNoDash :: ClassAtomNoDash `-` ClassAtom ClassRanges</emu-grammar>
@@ -34874,7 +34878,7 @@ THH:mm:ss.sss
             It is a Syntax Error if IsCharacterClass of |ClassAtomNoDash| is *true* or IsCharacterClass of |ClassAtom| is *true*.
           </li>
           <li>
-            It is a Syntax Error if IsCharacterClass of |ClassAtomNoDash| is *false* and IsCharacterClass of |ClassAtom| is *false* and the CharacterValue of |ClassAtomNoDash| is larger than the CharacterValue of |ClassAtom|.
+            It is a Syntax Error if IsCharacterClass of |ClassAtomNoDash| is *false*, IsCharacterClass of |ClassAtom| is *false*, and the CharacterValue of |ClassAtomNoDash| is strictly greater than the CharacterValue of |ClassAtom|.
           </li>
         </ul>
         <emu-grammar>RegExpIdentifierStart :: `\` RegExpUnicodeEscapeSequence</emu-grammar>
@@ -35208,7 +35212,7 @@ THH:mm:ss.sss
           1. Let _pattern_ be the |Pattern| containing _thisGroupName_.
           1. Let _result_ be a new empty List.
           1. For each |GroupSpecifier| _gs_ that _pattern_ contains, do
-            1. If the CapturingGroupName of _gs_ is the same value as _name_, then
+            1. If the CapturingGroupName of _gs_ is _name_, then
               1. Append _gs_ to _result_.
           1. Return _result_.
         </emu-alg>
@@ -35270,8 +35274,8 @@ THH:mm:ss.sss
           RegExpIdentifierPart :: UnicodeLeadSurrogate UnicodeTrailSurrogate
         </emu-grammar>
         <emu-alg>
-          1. Let _lead_ be the code unit whose numeric value is that of the code point matched by |UnicodeLeadSurrogate|.
-          1. Let _trail_ be the code unit whose numeric value is that of the code point matched by |UnicodeTrailSurrogate|.
+          1. Let _lead_ be the code unit whose numeric value is the numeric value of the code point matched by |UnicodeLeadSurrogate|.
+          1. Let _trail_ be the code unit whose numeric value is the numeric value of the code point matched by |UnicodeTrailSurrogate|.
           1. Return UTF16SurrogatePairToCodePoint(_lead_, _trail_).
         </emu-alg>
       </emu-clause>
@@ -35366,7 +35370,7 @@ THH:mm:ss.sss
           1. Let _m_ be CompileSubpattern of |Disjunction| with arguments _rer_ and ~forward~.
           1. Return a new Abstract Closure with parameters (_Input_, _index_) that captures _rer_ and _m_ and performs the following steps when called:
             1. Assert: _Input_ is a List of characters.
-            1. Assert: _index_ is a non-negative integer which is ≤ the number of elements in _Input_.
+            1. Assert: 0 ≤ _index_ ≤ the number of elements in _Input_.
             1. Let _c_ be a new MatcherContinuation with parameters (_y_) that captures nothing and performs the following steps when called:
               1. Assert: _y_ is a MatchState.
               1. Return _y_.
@@ -35496,7 +35500,7 @@ THH:mm:ss.sss
               1. Assert: _y_ is a MatchState.
               1. [id="step-repeatmatcher-done"] If _min_ = 0 and _y_'s _endIndex_ = _x_'s _endIndex_, return ~failure~.
               1. If _min_ = 0, let _min2_ be 0; otherwise let _min2_ be _min_ - 1.
-              1. If _max_ is +∞, let _max2_ be +∞; otherwise let _max2_ be _max_ - 1.
+              1. If _max_ = +∞, let _max2_ be +∞; otherwise let _max2_ be _max_ - 1.
               1. Return RepeatMatcher(_m_, _min2_, _max2_, _greedy_, _y_, _c_, _parenIndex_, _parenCount_).
             1. Let _cap_ be a copy of _x_'s _captures_ List.
             1. [id="step-repeatmatcher-clear-captures"] For each integer _k_ in the inclusive interval from _parenIndex_ + 1 to _parenIndex_ + _parenCount_, set _cap_[_k_] to *undefined*.
@@ -35573,7 +35577,7 @@ THH:mm:ss.sss
             1. Assert: _c_ is a MatcherContinuation.
             1. Let _Input_ be _x_'s _input_.
             1. Let _e_ be _x_'s _endIndex_.
-            1. If _e_ = 0, or if _rer_.[[Multiline]] is *true* and the character _Input_[_e_ - 1] is one of |LineTerminator|, then
+            1. If _e_ = 0, or if _rer_.[[Multiline]] is *true* and the character _Input_[_e_ - 1] is matched by |LineTerminator|, then
               1. Return _c_(_x_).
             1. Return ~failure~.
         </emu-alg>
@@ -35588,7 +35592,7 @@ THH:mm:ss.sss
             1. Let _Input_ be _x_'s _input_.
             1. Let _e_ be _x_'s _endIndex_.
             1. Let _InputLength_ be the number of elements in _Input_.
-            1. If _e_ = _InputLength_, or if _rer_.[[Multiline]] is *true* and the character _Input_[_e_] is one of |LineTerminator|, then
+            1. If _e_ = _InputLength_, or if _rer_.[[Multiline]] is *true* and the character _Input_[_e_] is matched by |LineTerminator|, then
               1. Return _c_(_x_).
             1. Return ~failure~.
         </emu-alg>
@@ -35691,9 +35695,9 @@ THH:mm:ss.sss
           </dl>
           <emu-alg>
             1. Let _InputLength_ be the number of elements in _Input_.
-            1. If _e_ = -1 or _e_ is _InputLength_, return *false*.
+            1. If _e_ = -1 or _e_ = _InputLength_, return *false*.
             1. Let _c_ be the character _Input_[_e_].
-            1. If _c_ is in WordCharacters(_rer_), return *true*.
+            1. If WordCharacters(_rer_) contains _c_, return *true*.
             1. Return *false*.
           </emu-alg>
         </emu-clause>
@@ -35903,7 +35907,7 @@ THH:mm:ss.sss
               1. Let _InputLength_ be the number of elements in _Input_.
               1. If _f_ &lt; 0 or _f_ > _InputLength_, return ~failure~.
               1. Let _g_ be min(_e_, _f_).
-              1. If there exists an integer _i_ in the interval from 0 (inclusive) to _len_ (exclusive) such that Canonicalize(_rer_, _Input_[_rs_ + _i_]) is not the same character value as Canonicalize(_rer_, _Input_[_g_ + _i_]), return ~failure~.
+              1. If there exists an integer _i_ in the interval from 0 (inclusive) to _len_ (exclusive) such that Canonicalize(_rer_, _Input_[_rs_ + _i_]) is not Canonicalize(_rer_, _Input_[_g_ + _i_]), return ~failure~.
               1. Let _y_ be the MatchState (_Input_, _f_, _cap_).
               1. Return _c_(_y_).
           </emu-alg>
@@ -35924,10 +35928,10 @@ THH:mm:ss.sss
               1. Return _ch_.
             1. If _rer_.[[IgnoreCase]] is *false*, return _ch_.
             1. Assert: _ch_ is a UTF-16 code unit.
-            1. Let _cp_ be the code point whose numeric value is that of _ch_.
+            1. Let _cp_ be the code point whose numeric value is the numeric value of _ch_.
             1. Let _u_ be the result of toUppercase(« _cp_ »), according to the Unicode Default Case Conversion algorithm.
             1. Let _uStr_ be CodePointsToString(_u_).
-            1. If _uStr_ does not consist of a single code unit, return _ch_.
+            1. If the length of _uStr_ ≠ 1, return _ch_.
             1. Let _cu_ be _uStr_'s single code unit element.
             1. If the numeric value of _ch_ ≥ 128 and the numeric value of _cu_ &lt; 128, return _ch_.
             1. Return _cu_.
@@ -36030,7 +36034,7 @@ THH:mm:ss.sss
           1. Return the union of _D_ and _C_.
         </emu-alg>
         <emu-note>
-          <p>|ClassRanges| can expand into a single |ClassAtom| and/or ranges of two |ClassAtom| separated by dashes. In the latter case the |ClassRanges| includes all characters between the first |ClassAtom| and the second |ClassAtom|, inclusive; an error occurs if either |ClassAtom| does not represent a single character (for example, if one is \w) or if the first |ClassAtom|'s character value is greater than the second |ClassAtom|'s character value.</p>
+          <p>|ClassRanges| can expand into a single |ClassAtom| and/or ranges of two |ClassAtom| separated by dashes. In the latter case the |ClassRanges| includes all characters between the first |ClassAtom| and the second |ClassAtom|, inclusive; an error occurs if either |ClassAtom| does not represent a single character (for example, if one is \w) or if the first |ClassAtom|'s character value is strictly greater than the second |ClassAtom|'s character value.</p>
         </emu-note>
         <emu-note>
           <p>Even if the pattern ignores case, the case of the two ends of a range is significant in determining which characters belong to the range. Thus, for example, the pattern `/[E-F]/i` matches only the letters `E`, `F`, `e`, and `f`, while the pattern `/[E-f]/i` matches all uppercase and lowercase letters in the Unicode Basic Latin block as well as the symbols `[`, `\\`, `]`, `^`, `_`, and <code>`</code>.</p>
@@ -36135,7 +36139,7 @@ THH:mm:ss.sss
             1. Let _i_ be the character value of character _a_.
             1. Let _j_ be the character value of character _b_.
             1. Assert: _i_ ≤ _j_.
-            1. Return the CharSet containing all characters with a character value greater than or equal to _i_ and less than or equal to _j_.
+            1. Return the CharSet containing all characters with a character value in the inclusive interval from _i_ to _j_.
           </emu-alg>
         </emu-clause>
 
@@ -36152,7 +36156,7 @@ THH:mm:ss.sss
           <emu-alg>
             1. Let _basicWordChars_ be the CharSet containing every character in the ASCII word characters.
             1. Let _extraWordChars_ be the CharSet containing all characters _c_ such that _c_ is not in _basicWordChars_ but Canonicalize(_rer_, _c_) is in _basicWordChars_.
-            1. Assert: _extraWordChars_ is empty unless _rer_.[[Unicode]] and _rer_.[[IgnoreCase]] are both *true*.
+            1. Assert: _extraWordChars_ is empty unless _rer_.[[Unicode]] is *true* and _rer_.[[IgnoreCase]] is *true*.
             1. Return the union of _basicWordChars_ and _extraWordChars_.
           </emu-alg>
         </emu-clause>
@@ -36258,7 +36262,7 @@ THH:mm:ss.sss
           1. Else, let _P_ be ? ToString(_pattern_).
           1. If _flags_ is *undefined*, let _F_ be the empty String.
           1. Else, let _F_ be ? ToString(_flags_).
-          1. If _F_ contains any code unit other than *"d"*, *"g"*, *"i"*, *"m"*, *"s"*, *"u"*, or *"y"* or if it contains the same code unit more than once, throw a *SyntaxError* exception.
+          1. If _F_ contains any code unit other than *"d"*, *"g"*, *"i"*, *"m"*, *"s"*, *"u"*, or *"y"*, or if _F_ contains any code unit more than once, throw a *SyntaxError* exception.
           1. If _F_ contains *"i"*, let _i_ be *true*; else let _i_ be *false*.
           1. If _F_ contains *"m"*, let _m_ be *true*; else let _m_ be *false*.
           1. If _F_ contains *"s"*, let _s_ be *true*; else let _s_ be *false*.
@@ -36669,7 +36673,7 @@ THH:mm:ss.sss
           <dl class="header">
           </dl>
           <emu-alg>
-            1. Let _S_ be a String in the form of a |Pattern[~UnicodeMode]| (|Pattern[+UnicodeMode]| if _F_ contains *"u"*) equivalent to _P_ interpreted as UTF-16 encoded Unicode code points (<emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>), in which certain code points are escaped as described below. _S_ may or may not be identical to _P_; however, the Abstract Closure that would result from evaluating _S_ as a |Pattern[~UnicodeMode]| (|Pattern[+UnicodeMode]| if _F_ contains *"u"*) must behave identically to the Abstract Closure given by the constructed object's [[RegExpMatcher]] internal slot. Multiple calls to this abstract operation using the same values for _P_ and _F_ must produce identical results.
+            1. Let _S_ be a String in the form of a |Pattern[~UnicodeMode]| (|Pattern[+UnicodeMode]| if _F_ contains *"u"*) equivalent to _P_ interpreted as UTF-16 encoded Unicode code points (<emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>), in which certain code points are escaped as described below. _S_ may or may not differ from _P_; however, the Abstract Closure that would result from evaluating _S_ as a |Pattern[~UnicodeMode]| (|Pattern[+UnicodeMode]| if _F_ contains *"u"*) must behave identically to the Abstract Closure given by the constructed object's [[RegExpMatcher]] internal slot. Multiple calls to this abstract operation using the same values for _P_ and _F_ must produce identical results.
             1. The code points `/` or any |LineTerminator| occurring in the pattern shall be escaped in _S_ as necessary to ensure that the string-concatenation of *"/"*, _S_, *"/"*, and _F_ can be parsed (in an appropriate lexical context) as a |RegularExpressionLiteral| that behaves identically to the constructed regular expression. For example, if _P_ is *"/"*, then _S_ could be *"\\/"* or *"\\u002F"*, among other possibilities, but not *"/"*, because `///` followed by _F_ would be parsed as a |SingleLineComment| rather than a |RegularExpressionLiteral|. If _P_ is the empty String, this specification can be met by letting _S_ be *"(?:)"*.
             1. Return _S_.
           </emu-alg>
@@ -36703,13 +36707,13 @@ THH:mm:ss.sss
           1. Let _A_ be ! ArrayCreate(0).
           1. Let _lengthA_ be 0.
           1. If _limit_ is *undefined*, let _lim_ be 2<sup>32</sup> - 1; else let _lim_ be ℝ(? ToUint32(_limit_)).
-          1. If _lim_ is 0, return _A_.
-          1. Let _size_ be the length of _S_.
-          1. If _size_ is 0, then
+          1. If _lim_ = 0, return _A_.
+          1. If _S_ is the empty String, then
             1. Let _z_ be ? RegExpExec(_splitter_, _S_).
             1. If _z_ is not *null*, return _A_.
             1. Perform ! CreateDataPropertyOrThrow(_A_, *"0"*, _S_).
             1. Return _A_.
+          1. Let _size_ be the length of _S_.
           1. Let _p_ be 0.
           1. Let _q_ be _p_.
           1. Repeat, while _q_ &lt; _size_,
@@ -36989,8 +36993,7 @@ THH:mm:ss.sss
         <dl class="header">
         </dl>
         <emu-alg>
-          1. Assert: _match_.[[StartIndex]] is a non-negative integer less than or equal to the length of _S_.
-          1. Assert: _match_.[[EndIndex]] is an integer in the inclusive interval from _match_.[[StartIndex]] to the length of _S_.
+          1. Assert: _match_.[[StartIndex]] ≤ _match_.[[EndIndex]] ≤ the length of _S_.
           1. Return the substring of _S_ from _match_.[[StartIndex]] to _match_.[[EndIndex]].
         </emu-alg>
       </emu-clause>
@@ -37005,8 +37008,7 @@ THH:mm:ss.sss
         <dl class="header">
         </dl>
         <emu-alg>
-          1. Assert: _match_.[[StartIndex]] is a non-negative integer less than or equal to the length of _S_.
-          1. Assert: _match_.[[EndIndex]] is an integer in the inclusive interval from _match_.[[StartIndex]] to the length of _S_.
+          1. Assert: _match_.[[StartIndex]] ≤ _match_.[[EndIndex]] ≤ the length of _S_.
           1. Return CreateArrayFromList(« 𝔽(_match_.[[StartIndex]]), 𝔽(_match_.[[EndIndex]]) »).
         </emu-alg>
       </emu-clause>
@@ -37397,15 +37399,15 @@ THH:mm:ss.sss
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
           1. Let _relativeTarget_ be ? ToIntegerOrInfinity(_target_).
-          1. If _relativeTarget_ is -∞, let _to_ be 0.
+          1. If _relativeTarget_ = -∞, let _to_ be 0.
           1. Else if _relativeTarget_ &lt; 0, let _to_ be max(_len_ + _relativeTarget_, 0).
           1. Else, let _to_ be min(_relativeTarget_, _len_).
           1. Let _relativeStart_ be ? ToIntegerOrInfinity(_start_).
-          1. If _relativeStart_ is -∞, let _from_ be 0.
+          1. If _relativeStart_ = -∞, let _from_ be 0.
           1. Else if _relativeStart_ &lt; 0, let _from_ be max(_len_ + _relativeStart_, 0).
           1. Else, let _from_ be min(_relativeStart_, _len_).
           1. If _end_ is *undefined*, let _relativeEnd_ be _len_; else let _relativeEnd_ be ? ToIntegerOrInfinity(_end_).
-          1. If _relativeEnd_ is -∞, let _final_ be 0.
+          1. If _relativeEnd_ = -∞, let _final_ be 0.
           1. Else if _relativeEnd_ &lt; 0, let _final_ be max(_len_ + _relativeEnd_, 0).
           1. Else, let _final_ be min(_relativeEnd_, _len_).
           1. Let _count_ be min(_final_ - _from_, _len_ - _to_).
@@ -37488,11 +37490,11 @@ THH:mm:ss.sss
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
           1. Let _relativeStart_ be ? ToIntegerOrInfinity(_start_).
-          1. If _relativeStart_ is -∞, let _k_ be 0.
+          1. If _relativeStart_ = -∞, let _k_ be 0.
           1. Else if _relativeStart_ &lt; 0, let _k_ be max(_len_ + _relativeStart_, 0).
           1. Else, let _k_ be min(_relativeStart_, _len_).
           1. If _end_ is *undefined*, let _relativeEnd_ be _len_; else let _relativeEnd_ be ? ToIntegerOrInfinity(_end_).
-          1. If _relativeEnd_ is -∞, let _final_ be 0.
+          1. If _relativeEnd_ = -∞, let _final_ be 0.
           1. Else if _relativeEnd_ &lt; 0, let _final_ be max(_len_ + _relativeEnd_, 0).
           1. Else, let _final_ be min(_relativeEnd_, _len_).
           1. Repeat, while _k_ &lt; _final_,
@@ -37696,7 +37698,7 @@ THH:mm:ss.sss
                 1. If _depth_ > 0, then
                   1. Set _shouldFlatten_ to ? IsArray(_element_).
                 1. If _shouldFlatten_ is *true*, then
-                  1. If _depth_ is +∞, let _newDepth_ be +∞.
+                  1. If _depth_ = +∞, let _newDepth_ be +∞.
                   1. Else, let _newDepth_ be _depth_ - 1.
                   1. Let _elementLen_ be ? LengthOfArrayLike(_element_).
                   1. Set _targetIndex_ to ? FlattenIntoArray(_target_, _element_, _elementLen_, _targetIndex_, _newDepth_).
@@ -37756,17 +37758,17 @@ THH:mm:ss.sss
         <h1>Array.prototype.includes ( _searchElement_ [ , _fromIndex_ ] )</h1>
         <emu-note>
           <p>This method compares _searchElement_ to the elements of the array, in ascending order, using the SameValueZero algorithm, and if found at any position, returns *true*; otherwise, it returns *false*.</p>
-          <p>The optional second argument _fromIndex_ defaults to *+0*<sub>𝔽</sub> (i.e. the whole array is searched). If it is greater than or equal to the length of the array, *false* is returned, i.e. the array will not be searched. If it is less than *+0*<sub>𝔽</sub>, it is used as the offset from the end of the array to compute _fromIndex_. If the computed index is less than *+0*<sub>𝔽</sub>, the whole array will be searched.</p>
+          <p>The optional second argument _fromIndex_ defaults to *+0*<sub>𝔽</sub> (i.e. the whole array is searched). If it is greater than or equal to the length of the array, *false* is returned, i.e. the array will not be searched. If it is less than *-0*<sub>𝔽</sub>, it is used as the offset from the end of the array to compute _fromIndex_. If the computed index is less than or equal to *+0*<sub>𝔽</sub>, the whole array will be searched.</p>
         </emu-note>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
-          1. If _len_ is 0, return *false*.
+          1. If _len_ = 0, return *false*.
           1. Let _n_ be ? ToIntegerOrInfinity(_fromIndex_).
           1. Assert: If _fromIndex_ is *undefined*, then _n_ is 0.
-          1. If _n_ is +∞, return *false*.
-          1. Else if _n_ is -∞, set _n_ to 0.
+          1. If _n_ = +∞, return *false*.
+          1. Else if _n_ = -∞, set _n_ to 0.
           1. If _n_ ≥ 0, then
             1. Let _k_ be _n_.
           1. Else,
@@ -37790,17 +37792,17 @@ THH:mm:ss.sss
         <h1>Array.prototype.indexOf ( _searchElement_ [ , _fromIndex_ ] )</h1>
         <p>This method compares _searchElement_ to the elements of the array, in ascending order, using the IsStrictlyEqual algorithm, and if found at one or more indices, returns the smallest such index; otherwise, it returns *-1*<sub>𝔽</sub>.</p>
         <emu-note>
-          <p>The optional second argument _fromIndex_ defaults to *+0*<sub>𝔽</sub> (i.e. the whole array is searched). If it is greater than or equal to the length of the array, *-1*<sub>𝔽</sub> is returned, i.e. the array will not be searched. If it is less than *+0*<sub>𝔽</sub>, it is used as the offset from the end of the array to compute _fromIndex_. If the computed index is less than *+0*<sub>𝔽</sub>, the whole array will be searched.</p>
+          <p>The optional second argument _fromIndex_ defaults to *+0*<sub>𝔽</sub> (i.e. the whole array is searched). If it is greater than or equal to the length of the array, *-1*<sub>𝔽</sub> is returned, i.e. the array will not be searched. If it is less than *-0*<sub>𝔽</sub>, it is used as the offset from the end of the array to compute _fromIndex_. If the computed index is less than or equal to *+0*<sub>𝔽</sub>, the whole array will be searched.</p>
         </emu-note>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
-          1. If _len_ is 0, return *-1*<sub>𝔽</sub>.
+          1. If _len_ = 0, return *-1*<sub>𝔽</sub>.
           1. Let _n_ be ? ToIntegerOrInfinity(_fromIndex_).
           1. Assert: If _fromIndex_ is *undefined*, then _n_ is 0.
-          1. If _n_ is +∞, return *-1*<sub>𝔽</sub>.
-          1. Else if _n_ is -∞, set _n_ to 0.
+          1. If _n_ = +∞, return *-1*<sub>𝔽</sub>.
+          1. Else if _n_ = -∞, set _n_ to 0.
           1. If _n_ ≥ 0, then
             1. Let _k_ be _n_.
           1. Else,
@@ -37810,8 +37812,7 @@ THH:mm:ss.sss
             1. Let _kPresent_ be ? HasProperty(_O_, ! ToString(𝔽(_k_))).
             1. If _kPresent_ is *true*, then
               1. Let _elementK_ be ? Get(_O_, ! ToString(𝔽(_k_))).
-              1. Let _same_ be IsStrictlyEqual(_searchElement_, _elementK_).
-              1. If _same_ is *true*, return 𝔽(_k_).
+              1. If IsStrictlyEqual(_searchElement_, _elementK_) is *true*, return 𝔽(_k_).
             1. Set _k_ to _k_ + 1.
           1. Return *-1*<sub>𝔽</sub>.
         </emu-alg>
@@ -37834,7 +37835,7 @@ THH:mm:ss.sss
           1. Repeat, while _k_ &lt; _len_,
             1. If _k_ > 0, set _R_ to the string-concatenation of _R_ and _sep_.
             1. Let _element_ be ? Get(_O_, ! ToString(𝔽(_k_))).
-            1. If _element_ is *undefined* or *null*, let _next_ be the empty String; otherwise, let _next_ be ? ToString(_element_).
+            1. If _element_ is either *undefined* or *null*, let _next_ be the empty String; otherwise, let _next_ be ? ToString(_element_).
             1. Set _R_ to the string-concatenation of _R_ and _next_.
             1. Set _k_ to _k_ + 1.
           1. Return _R_.
@@ -37857,15 +37858,15 @@ THH:mm:ss.sss
         <h1>Array.prototype.lastIndexOf ( _searchElement_ [ , _fromIndex_ ] )</h1>
         <emu-note>
           <p>This method compares _searchElement_ to the elements of the array in descending order using the IsStrictlyEqual algorithm, and if found at one or more indices, returns the largest such index; otherwise, it returns *-1*<sub>𝔽</sub>.</p>
-          <p>The optional second argument _fromIndex_ defaults to the array's length minus one (i.e. the whole array is searched). If it is greater than or equal to the length of the array, the whole array will be searched. If it is less than *+0*<sub>𝔽</sub>, it is used as the offset from the end of the array to compute _fromIndex_. If the computed index is less than *+0*<sub>𝔽</sub>, *-1*<sub>𝔽</sub> is returned.</p>
+          <p>The optional second argument _fromIndex_ defaults to the array's length minus one (i.e. the whole array is searched). If it is greater than or equal to the length of the array, the whole array will be searched. If it is less than *-0*<sub>𝔽</sub>, it is used as the offset from the end of the array to compute _fromIndex_. If the computed index is less than or equal to *+0*<sub>𝔽</sub>, *-1*<sub>𝔽</sub> is returned.</p>
         </emu-note>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
-          1. If _len_ is 0, return *-1*<sub>𝔽</sub>.
+          1. If _len_ = 0, return *-1*<sub>𝔽</sub>.
           1. If _fromIndex_ is present, let _n_ be ? ToIntegerOrInfinity(_fromIndex_); else let _n_ be _len_ - 1.
-          1. If _n_ is -∞, return *-1*<sub>𝔽</sub>.
+          1. If _n_ = -∞, return *-1*<sub>𝔽</sub>.
           1. If _n_ ≥ 0, then
             1. Let _k_ be min(_n_, _len_ - 1).
           1. Else,
@@ -37874,8 +37875,7 @@ THH:mm:ss.sss
             1. Let _kPresent_ be ? HasProperty(_O_, ! ToString(𝔽(_k_))).
             1. If _kPresent_ is *true*, then
               1. Let _elementK_ be ? Get(_O_, ! ToString(𝔽(_k_))).
-              1. Let _same_ be IsStrictlyEqual(_searchElement_, _elementK_).
-              1. If _same_ is *true*, return 𝔽(_k_).
+              1. If IsStrictlyEqual(_searchElement_, _elementK_) is *true*, return 𝔽(_k_).
             1. Set _k_ to _k_ - 1.
           1. Return *-1*<sub>𝔽</sub>.
         </emu-alg>
@@ -37968,7 +37968,7 @@ THH:mm:ss.sss
         <h1>Array.prototype.reduce ( _callbackfn_ [ , _initialValue_ ] )</h1>
         <emu-note>
           <p>_callbackfn_ should be a function that takes four arguments. `reduce` calls the callback, as a function, once for each element after the first element present in the array, in ascending order.</p>
-          <p>_callbackfn_ is called with four arguments: the _previousValue_ (value from the previous call to _callbackfn_), the _currentValue_ (value of the current element), the _currentIndex_, and the object being traversed. The first time that callback is called, the _previousValue_ and _currentValue_ can be one of two values. If an _initialValue_ was supplied in the call to `reduce`, then _previousValue_ will be equal to _initialValue_ and _currentValue_ will be equal to the first value in the array. If no _initialValue_ was supplied, then _previousValue_ will be equal to the first value in the array and _currentValue_ will be equal to the second. It is a *TypeError* if the array contains no elements and _initialValue_ is not provided.</p>
+          <p>_callbackfn_ is called with four arguments: the _previousValue_ (value from the previous call to _callbackfn_), the _currentValue_ (value of the current element), the _currentIndex_, and the object being traversed. The first time that callback is called, the _previousValue_ and _currentValue_ can be one of two values. If an _initialValue_ was supplied in the call to `reduce`, then _previousValue_ will be _initialValue_ and _currentValue_ will be the first value in the array. If no _initialValue_ was supplied, then _previousValue_ will be the first value in the array and _currentValue_ will be the second. It is a *TypeError* if the array contains no elements and _initialValue_ is not provided.</p>
           <p>`reduce` does not directly mutate the object on which it is called but the object may be mutated by the calls to _callbackfn_.</p>
           <p>The range of elements processed by `reduce` is set before the first call to _callbackfn_. Elements that are appended to the array after the call to `reduce` begins will not be visited by _callbackfn_. If existing elements of the array are changed, their value as passed to _callbackfn_ will be the value at the time `reduce` visits them; elements that are deleted after the call to `reduce` begins and before being visited are not visited.</p>
         </emu-note>
@@ -38009,7 +38009,7 @@ THH:mm:ss.sss
         <h1>Array.prototype.reduceRight ( _callbackfn_ [ , _initialValue_ ] )</h1>
         <emu-note>
           <p>_callbackfn_ should be a function that takes four arguments. `reduceRight` calls the callback, as a function, once for each element after the first element present in the array, in descending order.</p>
-          <p>_callbackfn_ is called with four arguments: the _previousValue_ (value from the previous call to _callbackfn_), the _currentValue_ (value of the current element), the _currentIndex_, and the object being traversed. The first time the function is called, the _previousValue_ and _currentValue_ can be one of two values. If an _initialValue_ was supplied in the call to `reduceRight`, then _previousValue_ will be equal to _initialValue_ and _currentValue_ will be equal to the last value in the array. If no _initialValue_ was supplied, then _previousValue_ will be equal to the last value in the array and _currentValue_ will be equal to the second-to-last value. It is a *TypeError* if the array contains no elements and _initialValue_ is not provided.</p>
+          <p>_callbackfn_ is called with four arguments: the _previousValue_ (value from the previous call to _callbackfn_), the _currentValue_ (value of the current element), the _currentIndex_, and the object being traversed. The first time the function is called, the _previousValue_ and _currentValue_ can be one of two values. If an _initialValue_ was supplied in the call to `reduceRight`, then _previousValue_ will be _initialValue_ and _currentValue_ will be the last value in the array. If no _initialValue_ was supplied, then _previousValue_ will be the last value in the array and _currentValue_ will be the second-to-last value. It is a *TypeError* if the array contains no elements and _initialValue_ is not provided.</p>
           <p>`reduceRight` does not directly mutate the object on which it is called but the object may be mutated by the calls to _callbackfn_.</p>
           <p>The range of elements processed by `reduceRight` is set before the first call to _callbackfn_. Elements that are appended to the array after the call to `reduceRight` begins will not be visited by _callbackfn_. If existing elements of the array are changed by _callbackfn_, their value as passed to _callbackfn_ will be the value at the time `reduceRight` visits them; elements that are deleted after the call to `reduceRight` begins and before being visited are not visited.</p>
         </emu-note>
@@ -38018,7 +38018,7 @@ THH:mm:ss.sss
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
-          1. If _len_ is 0 and _initialValue_ is not present, throw a *TypeError* exception.
+          1. If _len_ = 0 and _initialValue_ is not present, throw a *TypeError* exception.
           1. Let _k_ be _len_ - 1.
           1. Let _accumulator_ be *undefined*.
           1. If _initialValue_ is present, then
@@ -38127,11 +38127,11 @@ THH:mm:ss.sss
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
           1. Let _relativeStart_ be ? ToIntegerOrInfinity(_start_).
-          1. If _relativeStart_ is -∞, let _k_ be 0.
+          1. If _relativeStart_ = -∞, let _k_ be 0.
           1. Else if _relativeStart_ &lt; 0, let _k_ be max(_len_ + _relativeStart_, 0).
           1. Else, let _k_ be min(_relativeStart_, _len_).
           1. If _end_ is *undefined*, let _relativeEnd_ be _len_; else let _relativeEnd_ be ? ToIntegerOrInfinity(_end_).
-          1. If _relativeEnd_ is -∞, let _final_ be 0.
+          1. If _relativeEnd_ = -∞, let _final_ be 0.
           1. Else if _relativeEnd_ &lt; 0, let _final_ be max(_len_ + _relativeEnd_, 0).
           1. Else, let _final_ be min(_relativeEnd_, _len_).
           1. Let _count_ be max(_final_ - _k_, 0).
@@ -38303,7 +38303,7 @@ THH:mm:ss.sss
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
           1. Let _relativeStart_ be ? ToIntegerOrInfinity(_start_).
-          1. If _relativeStart_ is -∞, let _actualStart_ be 0.
+          1. If _relativeStart_ = -∞, let _actualStart_ be 0.
           1. Else if _relativeStart_ &lt; 0, let _actualStart_ be max(_len_ + _relativeStart_, 0).
           1. Else, let _actualStart_ be min(_relativeStart_, _len_).
           1. Let _itemCount_ be the number of elements in _items_.
@@ -38383,7 +38383,7 @@ THH:mm:ss.sss
             1. If _k_ > 0, then
               1. Set _R_ to the string-concatenation of _R_ and _separator_.
             1. Let _nextElement_ be ? Get(_array_, ! ToString(𝔽(_k_))).
-            1. If _nextElement_ is not *undefined* or *null*, then
+            1. If _nextElement_ is neither *undefined* nor *null*, then
               1. Let _S_ be ? ToString(? Invoke(_nextElement_, *"toLocaleString"*)).
               1. Set _R_ to the string-concatenation of _R_ and _S_.
             1. Set _k_ to _k_ + 1.
@@ -38980,15 +38980,15 @@ THH:mm:ss.sss
           1. Perform ? ValidateTypedArray(_O_).
           1. Let _len_ be _O_.[[ArrayLength]].
           1. Let _relativeTarget_ be ? ToIntegerOrInfinity(_target_).
-          1. If _relativeTarget_ is -∞, let _to_ be 0.
+          1. If _relativeTarget_ = -∞, let _to_ be 0.
           1. Else if _relativeTarget_ &lt; 0, let _to_ be max(_len_ + _relativeTarget_, 0).
           1. Else, let _to_ be min(_relativeTarget_, _len_).
           1. Let _relativeStart_ be ? ToIntegerOrInfinity(_start_).
-          1. If _relativeStart_ is -∞, let _from_ be 0.
+          1. If _relativeStart_ = -∞, let _from_ be 0.
           1. Else if _relativeStart_ &lt; 0, let _from_ be max(_len_ + _relativeStart_, 0).
           1. Else, let _from_ be min(_relativeStart_, _len_).
           1. If _end_ is *undefined*, let _relativeEnd_ be _len_; else let _relativeEnd_ be ? ToIntegerOrInfinity(_end_).
-          1. If _relativeEnd_ is -∞, let _final_ be 0.
+          1. If _relativeEnd_ = -∞, let _final_ be 0.
           1. Else if _relativeEnd_ &lt; 0, let _final_ be max(_len_ + _relativeEnd_, 0).
           1. Else, let _final_ be min(_relativeEnd_, _len_).
           1. Let _count_ be min(_final_ - _from_, _len_ - _to_).
@@ -39059,11 +39059,11 @@ THH:mm:ss.sss
           1. If _O_.[[ContentType]] is ~BigInt~, set _value_ to ? ToBigInt(_value_).
           1. Otherwise, set _value_ to ? ToNumber(_value_).
           1. Let _relativeStart_ be ? ToIntegerOrInfinity(_start_).
-          1. If _relativeStart_ is -∞, let _k_ be 0.
+          1. If _relativeStart_ = -∞, let _k_ be 0.
           1. Else if _relativeStart_ &lt; 0, let _k_ be max(_len_ + _relativeStart_, 0).
           1. Else, let _k_ be min(_relativeStart_, _len_).
           1. If _end_ is *undefined*, let _relativeEnd_ be _len_; else let _relativeEnd_ be ? ToIntegerOrInfinity(_end_).
-          1. If _relativeEnd_ is -∞, let _final_ be 0.
+          1. If _relativeEnd_ = -∞, let _final_ be 0.
           1. Else if _relativeEnd_ &lt; 0, let _final_ be max(_len_ + _relativeEnd_, 0).
           1. Else, let _final_ be min(_relativeEnd_, _len_).
           1. If IsDetachedBuffer(_O_.[[ViewedArrayBuffer]]) is *true*, throw a *TypeError* exception.
@@ -39217,11 +39217,11 @@ THH:mm:ss.sss
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
           1. Let _len_ be _O_.[[ArrayLength]].
-          1. If _len_ is 0, return *false*.
+          1. If _len_ = 0, return *false*.
           1. Let _n_ be ? ToIntegerOrInfinity(_fromIndex_).
           1. Assert: If _fromIndex_ is *undefined*, then _n_ is 0.
-          1. If _n_ is +∞, return *false*.
-          1. Else if _n_ is -∞, set _n_ to 0.
+          1. If _n_ = +∞, return *false*.
+          1. Else if _n_ = -∞, set _n_ to 0.
           1. If _n_ ≥ 0, then
             1. Let _k_ be _n_.
           1. Else,
@@ -39244,11 +39244,11 @@ THH:mm:ss.sss
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
           1. Let _len_ be _O_.[[ArrayLength]].
-          1. If _len_ is 0, return *-1*<sub>𝔽</sub>.
+          1. If _len_ = 0, return *-1*<sub>𝔽</sub>.
           1. Let _n_ be ? ToIntegerOrInfinity(_fromIndex_).
           1. Assert: If _fromIndex_ is *undefined*, then _n_ is 0.
-          1. If _n_ is +∞, return *-1*<sub>𝔽</sub>.
-          1. Else if _n_ is -∞, set _n_ to 0.
+          1. If _n_ = +∞, return *-1*<sub>𝔽</sub>.
+          1. Else if _n_ = -∞, set _n_ to 0.
           1. If _n_ ≥ 0, then
             1. Let _k_ be _n_.
           1. Else,
@@ -39258,8 +39258,7 @@ THH:mm:ss.sss
             1. Let _kPresent_ be ! HasProperty(_O_, ! ToString(𝔽(_k_))).
             1. If _kPresent_ is *true*, then
               1. Let _elementK_ be ! Get(_O_, ! ToString(𝔽(_k_))).
-              1. Let _same_ be IsStrictlyEqual(_searchElement_, _elementK_).
-              1. If _same_ is *true*, return 𝔽(_k_).
+              1. If IsStrictlyEqual(_searchElement_, _elementK_) is *true*, return 𝔽(_k_).
             1. Set _k_ to _k_ + 1.
           1. Return *-1*<sub>𝔽</sub>.
         </emu-alg>
@@ -39307,9 +39306,9 @@ THH:mm:ss.sss
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
           1. Let _len_ be _O_.[[ArrayLength]].
-          1. If _len_ is 0, return *-1*<sub>𝔽</sub>.
+          1. If _len_ = 0, return *-1*<sub>𝔽</sub>.
           1. If _fromIndex_ is present, let _n_ be ? ToIntegerOrInfinity(_fromIndex_); else let _n_ be _len_ - 1.
-          1. If _n_ is -∞, return *-1*<sub>𝔽</sub>.
+          1. If _n_ = -∞, return *-1*<sub>𝔽</sub>.
           1. If _n_ ≥ 0, then
             1. Let _k_ be min(_n_, _len_ - 1).
           1. Else,
@@ -39318,8 +39317,7 @@ THH:mm:ss.sss
             1. Let _kPresent_ be ! HasProperty(_O_, ! ToString(𝔽(_k_))).
             1. If _kPresent_ is *true*, then
               1. Let _elementK_ be ! Get(_O_, ! ToString(𝔽(_k_))).
-              1. Let _same_ be IsStrictlyEqual(_searchElement_, _elementK_).
-              1. If _same_ is *true*, return 𝔽(_k_).
+              1. If IsStrictlyEqual(_searchElement_, _elementK_) is *true*, return 𝔽(_k_).
             1. Set _k_ to _k_ - 1.
           1. Return *-1*<sub>𝔽</sub>.
         </emu-alg>
@@ -39400,7 +39398,7 @@ THH:mm:ss.sss
           1. Perform ? ValidateTypedArray(_O_).
           1. Let _len_ be _O_.[[ArrayLength]].
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
-          1. If _len_ is 0 and _initialValue_ is not present, throw a *TypeError* exception.
+          1. If _len_ = 0 and _initialValue_ is not present, throw a *TypeError* exception.
           1. Let _k_ be _len_ - 1.
           1. Let _accumulator_ be *undefined*.
           1. If _initialValue_ is present, then
@@ -39486,21 +39484,19 @@ THH:mm:ss.sss
             1. Let _srcElementSize_ be TypedArrayElementSize(_source_).
             1. Let _srcLength_ be _source_.[[ArrayLength]].
             1. Let _srcByteOffset_ be _source_.[[ByteOffset]].
-            1. If _targetOffset_ is +∞, throw a *RangeError* exception.
+            1. If _targetOffset_ = +∞, throw a *RangeError* exception.
             1. If _srcLength_ + _targetOffset_ > _targetLength_, throw a *RangeError* exception.
-            1. If _target_.[[ContentType]] ≠ _source_.[[ContentType]], throw a *TypeError* exception.
-            1. If both IsSharedArrayBuffer(_srcBuffer_) and IsSharedArrayBuffer(_targetBuffer_) are *true*, then
-              1. If _srcBuffer_.[[ArrayBufferData]] and _targetBuffer_.[[ArrayBufferData]] are the same Shared Data Block values, let _same_ be *true*; else let _same_ be *false*.
-            1. Else, let _same_ be SameValue(_srcBuffer_, _targetBuffer_).
-            1. If _same_ is *true*, then
+            1. If _target_.[[ContentType]] is not _source_.[[ContentType]], throw a *TypeError* exception.
+            1. If IsSharedArrayBuffer(_srcBuffer_) is *true*, IsSharedArrayBuffer(_targetBuffer_) is *true*, and _srcBuffer_.[[ArrayBufferData]] is _targetBuffer_.[[ArrayBufferData]], let _sameSharedArrayBuffer_ be *true*; otherwise, let _sameSharedArrayBuffer_ be *false*.
+            1. If SameValue(_srcBuffer_, _targetBuffer_) is *true* or _sameSharedArrayBuffer_ is *true*, then
               1. Let _srcByteLength_ be _source_.[[ByteLength]].
               1. Set _srcBuffer_ to ? CloneArrayBuffer(_srcBuffer_, _srcByteOffset_, _srcByteLength_).
               1. Let _srcByteIndex_ be 0.
             1. Else, let _srcByteIndex_ be _srcByteOffset_.
             1. Let _targetByteIndex_ be _targetOffset_ × _targetElementSize_ + _targetByteOffset_.
             1. Let _limit_ be _targetByteIndex_ + _targetElementSize_ × _srcLength_.
-            1. If _srcType_ is the same as _targetType_, then
-              1. NOTE: If _srcType_ and _targetType_ are the same, the transfer must be performed in a manner that preserves the bit-level encoding of the source data.
+            1. If _srcType_ is _targetType_, then
+              1. NOTE: The transfer must be performed in a manner that preserves the bit-level encoding of the source data.
               1. Repeat, while _targetByteIndex_ &lt; _limit_,
                 1. Let _value_ be GetValueFromBuffer(_srcBuffer_, _srcByteIndex_, ~Uint8~, *true*, ~Unordered~).
                 1. Perform SetValueInBuffer(_targetBuffer_, _targetByteIndex_, ~Uint8~, _value_, *true*, ~Unordered~).
@@ -39534,7 +39530,7 @@ THH:mm:ss.sss
             1. Let _targetLength_ be _target_.[[ArrayLength]].
             1. Let _src_ be ? ToObject(_source_).
             1. Let _srcLength_ be ? LengthOfArrayLike(_src_).
-            1. If _targetOffset_ is +∞, throw a *RangeError* exception.
+            1. If _targetOffset_ = +∞, throw a *RangeError* exception.
             1. If _srcLength_ + _targetOffset_ > _targetLength_, throw a *RangeError* exception.
             1. Let _k_ be 0.
             1. Repeat, while _k_ &lt; _srcLength_,
@@ -39557,11 +39553,11 @@ THH:mm:ss.sss
           1. Perform ? ValidateTypedArray(_O_).
           1. Let _len_ be _O_.[[ArrayLength]].
           1. Let _relativeStart_ be ? ToIntegerOrInfinity(_start_).
-          1. If _relativeStart_ is -∞, let _k_ be 0.
+          1. If _relativeStart_ = -∞, let _k_ be 0.
           1. Else if _relativeStart_ &lt; 0, let _k_ be max(_len_ + _relativeStart_, 0).
           1. Else, let _k_ be min(_relativeStart_, _len_).
           1. If _end_ is *undefined*, let _relativeEnd_ be _len_; else let _relativeEnd_ be ? ToIntegerOrInfinity(_end_).
-          1. If _relativeEnd_ is -∞, let _final_ be 0.
+          1. If _relativeEnd_ = -∞, let _final_ be 0.
           1. Else if _relativeEnd_ &lt; 0, let _final_ be max(_len_ + _relativeEnd_, 0).
           1. Else, let _final_ be min(_relativeEnd_, _len_).
           1. Let _count_ be max(_final_ - _k_, 0).
@@ -39570,19 +39566,11 @@ THH:mm:ss.sss
             1. If IsDetachedBuffer(_O_.[[ViewedArrayBuffer]]) is *true*, throw a *TypeError* exception.
             1. Let _srcType_ be TypedArrayElementType(_O_).
             1. Let _targetType_ be TypedArrayElementType(_A_).
-            1. If _srcType_ is different from _targetType_, then
-              1. Let _n_ be 0.
-              1. Repeat, while _k_ &lt; _final_,
-                1. Let _Pk_ be ! ToString(𝔽(_k_)).
-                1. Let _kValue_ be ! Get(_O_, _Pk_).
-                1. Perform ! Set(_A_, ! ToString(𝔽(_n_)), _kValue_, *true*).
-                1. Set _k_ to _k_ + 1.
-                1. Set _n_ to _n_ + 1.
-            1. Else,
+            1. If _srcType_ is _targetType_, then
+              1. NOTE: The transfer must be performed in a manner that preserves the bit-level encoding of the source data.
               1. Let _srcBuffer_ be _O_.[[ViewedArrayBuffer]].
               1. Let _targetBuffer_ be _A_.[[ViewedArrayBuffer]].
               1. Let _elementSize_ be TypedArrayElementSize(_O_).
-              1. NOTE: If _srcType_ and _targetType_ are the same, the transfer must be performed in a manner that preserves the bit-level encoding of the source data.
               1. Let _srcByteOffset_ be _O_.[[ByteOffset]].
               1. Let _srcByteIndex_ be (_k_ × _elementSize_) + _srcByteOffset_.
               1. Let _targetByteIndex_ be _A_.[[ByteOffset]].
@@ -39592,6 +39580,14 @@ THH:mm:ss.sss
                 1. Perform SetValueInBuffer(_targetBuffer_, _targetByteIndex_, ~Uint8~, _value_, *true*, ~Unordered~).
                 1. Set _srcByteIndex_ to _srcByteIndex_ + 1.
                 1. Set _targetByteIndex_ to _targetByteIndex_ + 1.
+            1. Else,
+              1. Let _n_ be 0.
+              1. Repeat, while _k_ &lt; _final_,
+                1. Let _Pk_ be ! ToString(𝔽(_k_)).
+                1. Let _kValue_ be ! Get(_O_, _Pk_).
+                1. Perform ! Set(_A_, ! ToString(𝔽(_n_)), _kValue_, *true*).
+                1. Set _k_ to _k_ + 1.
+                1. Set _n_ to _n_ + 1.
           1. Return _A_.
         </emu-alg>
         <p>This method is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
@@ -39652,7 +39648,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-%typedarray%.prototype.subarray">
         <h1>%TypedArray%.prototype.subarray ( _begin_, _end_ )</h1>
-        <p>This method returns a new _TypedArray_ whose element type is the same as this _TypedArray_ and whose ArrayBuffer is the same as the ArrayBuffer of this _TypedArray_, referencing the elements in the interval from _begin_ (inclusive) to _end_ (exclusive). If either _begin_ or _end_ is negative, it refers to an index from the end of the array, as opposed to from the beginning.</p>
+        <p>This method returns a new _TypedArray_ whose element type is the element type of this _TypedArray_ and whose ArrayBuffer is the ArrayBuffer of this _TypedArray_, referencing the elements in the interval from _begin_ (inclusive) to _end_ (exclusive). If either _begin_ or _end_ is negative, it refers to an index from the end of the array, as opposed to from the beginning.</p>
         <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
@@ -39661,11 +39657,11 @@ THH:mm:ss.sss
           1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
           1. Let _srcLength_ be _O_.[[ArrayLength]].
           1. Let _relativeBegin_ be ? ToIntegerOrInfinity(_begin_).
-          1. If _relativeBegin_ is -∞, let _beginIndex_ be 0.
+          1. If _relativeBegin_ = -∞, let _beginIndex_ be 0.
           1. Else if _relativeBegin_ &lt; 0, let _beginIndex_ be max(_srcLength_ + _relativeBegin_, 0).
           1. Else, let _beginIndex_ be min(_relativeBegin_, _srcLength_).
           1. If _end_ is *undefined*, let _relativeEnd_ be _srcLength_; else let _relativeEnd_ be ? ToIntegerOrInfinity(_end_).
-          1. If _relativeEnd_ is -∞, let _endIndex_ be 0.
+          1. If _relativeEnd_ = -∞, let _endIndex_ be 0.
           1. Else if _relativeEnd_ &lt; 0, let _endIndex_ be max(_srcLength_ + _relativeEnd_, 0).
           1. Else, let _endIndex_ be min(_relativeEnd_, _srcLength_).
           1. Let _newLength_ be max(_endIndex_ - _beginIndex_, 0).
@@ -39742,7 +39738,7 @@ THH:mm:ss.sss
           1. Let _constructor_ be ? SpeciesConstructor(_exemplar_, _defaultConstructor_).
           1. Let _result_ be ? TypedArrayCreate(_constructor_, _argumentList_).
           1. Assert: _result_ has [[TypedArrayName]] and [[ContentType]] internal slots.
-          1. If _result_.[[ContentType]] ≠ _exemplar_.[[ContentType]], throw a *TypeError* exception.
+          1. If _result_.[[ContentType]] is not _exemplar_.[[ContentType]], throw a *TypeError* exception.
           1. Return _result_.
         </emu-alg>
       </emu-clause>
@@ -39761,7 +39757,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _newTypedArray_ be ? Construct(_constructor_, _argumentList_).
           1. Perform ? ValidateTypedArray(_newTypedArray_).
-          1. If _argumentList_ is a List of a single Number, then
+          1. If the number of elements in _argumentList_ is 1 and _argumentList_[0] is a Number, then
             1. If _newTypedArray_.[[ArrayLength]] &lt; ℝ(_argumentList_[0]), throw a *TypeError* exception.
           1. Return _newTypedArray_.
         </emu-alg>
@@ -39876,7 +39872,7 @@ THH:mm:ss.sss
             1. Let _obj_ be IntegerIndexedObjectCreate(_proto_).
             1. Assert: _obj_.[[ViewedArrayBuffer]] is *undefined*.
             1. Set _obj_.[[TypedArrayName]] to _constructorName_.
-            1. If _constructorName_ is *"BigInt64Array"* or *"BigUint64Array"*, set _obj_.[[ContentType]] to ~BigInt~.
+            1. If _constructorName_ is either *"BigInt64Array"* or *"BigUint64Array"*, set _obj_.[[ContentType]] to ~BigInt~.
             1. Otherwise, set _obj_.[[ContentType]] to ~Number~.
             1. If _length_ is not present, then
               1. Set _obj_.[[ByteLength]] to 0.
@@ -39907,11 +39903,11 @@ THH:mm:ss.sss
             1. Let _srcByteOffset_ be _srcArray_.[[ByteOffset]].
             1. Let _elementLength_ be _srcArray_.[[ArrayLength]].
             1. Let _byteLength_ be _elementSize_ × _elementLength_.
-            1. If _elementType_ is the same as _srcType_, then
+            1. If _elementType_ is _srcType_, then
               1. Let _data_ be ? CloneArrayBuffer(_srcData_, _srcByteOffset_, _byteLength_).
             1. Else,
               1. Let _data_ be ? <emu-meta suppress-effects="user-code">AllocateArrayBuffer(%ArrayBuffer%, _byteLength_)</emu-meta>.
-              1. If _srcArray_.[[ContentType]] ≠ _O_.[[ContentType]], throw a *TypeError* exception.
+              1. If _srcArray_.[[ContentType]] is not _O_.[[ContentType]], throw a *TypeError* exception.
               1. Let _srcByteIndex_ be _srcByteOffset_.
               1. Let _targetByteIndex_ be 0.
               1. Let _count_ be _elementLength_.
@@ -40198,7 +40194,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _M_ be the *this* value.
           1. Perform ? RequireInternalSlot(_M_, [[MapData]]).
-          1. Let _entries_ be the List that is _M_.[[MapData]].
+          1. Let _entries_ be _M_.[[MapData]].
           1. For each Record { [[Key]], [[Value]] } _p_ of _entries_, do
             1. Set _p_.[[Key]] to ~empty~.
             1. Set _p_.[[Value]] to ~empty~.
@@ -40220,7 +40216,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _M_ be the *this* value.
           1. Perform ? RequireInternalSlot(_M_, [[MapData]]).
-          1. Let _entries_ be the List that is _M_.[[MapData]].
+          1. Let _entries_ be _M_.[[MapData]].
           1. For each Record { [[Key]], [[Value]] } _p_ of _entries_, do
             1. If _p_.[[Key]] is not ~empty~ and SameValueZero(_p_.[[Key]], _key_) is *true*, then
               1. Set _p_.[[Key]] to ~empty~.
@@ -40249,11 +40245,11 @@ THH:mm:ss.sss
           1. Let _M_ be the *this* value.
           1. Perform ? RequireInternalSlot(_M_, [[MapData]]).
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
-          1. Let _entries_ be the List that is _M_.[[MapData]].
+          1. Let _entries_ be _M_.[[MapData]].
           1. Let _numEntries_ be the number of elements in _entries_.
           1. Let _index_ be 0.
           1. Repeat, while _index_ &lt; _numEntries_,
-            1. Let _e_ be the Record { [[Key]], [[Value]] } that is the value of _entries_[_index_].
+            1. Let _e_ be _entries_[_index_].
             1. Set _index_ to _index_ + 1.
             1. If _e_.[[Key]] is not ~empty~, then
               1. Perform ? Call(_callbackfn_, _thisArg_, « _e_.[[Value]], _e_.[[Key]], _M_ »).
@@ -40275,7 +40271,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _M_ be the *this* value.
           1. Perform ? RequireInternalSlot(_M_, [[MapData]]).
-          1. Let _entries_ be the List that is _M_.[[MapData]].
+          1. Let _entries_ be _M_.[[MapData]].
           1. For each Record { [[Key]], [[Value]] } _p_ of _entries_, do
             1. If _p_.[[Key]] is not ~empty~ and SameValueZero(_p_.[[Key]], _key_) is *true*, return _p_.[[Value]].
           1. Return *undefined*.
@@ -40288,7 +40284,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _M_ be the *this* value.
           1. Perform ? RequireInternalSlot(_M_, [[MapData]]).
-          1. Let _entries_ be the List that is _M_.[[MapData]].
+          1. Let _entries_ be _M_.[[MapData]].
           1. For each Record { [[Key]], [[Value]] } _p_ of _entries_, do
             1. If _p_.[[Key]] is not ~empty~ and SameValueZero(_p_.[[Key]], _key_) is *true*, return *true*.
           1. Return *false*.
@@ -40310,7 +40306,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _M_ be the *this* value.
           1. Perform ? RequireInternalSlot(_M_, [[MapData]]).
-          1. Let _entries_ be the List that is _M_.[[MapData]].
+          1. Let _entries_ be _M_.[[MapData]].
           1. For each Record { [[Key]], [[Value]] } _p_ of _entries_, do
             1. If _p_.[[Key]] is not ~empty~ and SameValueZero(_p_.[[Key]], _key_) is *true*, then
               1. Set _p_.[[Value]] to _value_.
@@ -40328,7 +40324,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _M_ be the *this* value.
           1. Perform ? RequireInternalSlot(_M_, [[MapData]]).
-          1. Let _entries_ be the List that is _M_.[[MapData]].
+          1. Let _entries_ be _M_.[[MapData]].
           1. Let _count_ be 0.
           1. For each Record { [[Key]], [[Value]] } _p_ of _entries_, do
             1. If _p_.[[Key]] is not ~empty~, set _count_ to _count_ + 1.
@@ -40380,11 +40376,11 @@ THH:mm:ss.sss
         <emu-alg>
           1. Perform ? RequireInternalSlot(_map_, [[MapData]]).
           1. Let _closure_ be a new Abstract Closure with no parameters that captures _map_ and _kind_ and performs the following steps when called:
-            1. Let _entries_ be the List that is _map_.[[MapData]].
+            1. Let _entries_ be _map_.[[MapData]].
             1. Let _index_ be 0.
             1. Let _numEntries_ be the number of elements in _entries_.
             1. Repeat, while _index_ &lt; _numEntries_,
-              1. Let _e_ be the Record { [[Key]], [[Value]] } that is the value of _entries_[_index_].
+              1. Let _e_ be _entries_[_index_].
               1. Set _index_ to _index_ + 1.
               1. If _e_.[[Key]] is not ~empty~, then
                 1. If _kind_ is ~key~, let _result_ be _e_.[[Key]].
@@ -40506,7 +40502,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _S_ be the *this* value.
           1. Perform ? RequireInternalSlot(_S_, [[SetData]]).
-          1. Let _entries_ be the List that is _S_.[[SetData]].
+          1. Let _entries_ be _S_.[[SetData]].
           1. For each element _e_ of _entries_, do
             1. If _e_ is not ~empty~ and SameValueZero(_e_, _value_) is *true*, then
               1. Return _S_.
@@ -40522,7 +40518,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _S_ be the *this* value.
           1. Perform ? RequireInternalSlot(_S_, [[SetData]]).
-          1. Let _entries_ be the List that is _S_.[[SetData]].
+          1. Let _entries_ be _S_.[[SetData]].
           1. For each element _e_ of _entries_, do
             1. Replace the element of _entries_ whose value is _e_ with an element whose value is ~empty~.
           1. Return *undefined*.
@@ -40543,7 +40539,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _S_ be the *this* value.
           1. Perform ? RequireInternalSlot(_S_, [[SetData]]).
-          1. Let _entries_ be the List that is _S_.[[SetData]].
+          1. Let _entries_ be _S_.[[SetData]].
           1. For each element _e_ of _entries_, do
             1. If _e_ is not ~empty~ and SameValueZero(_e_, _value_) is *true*, then
               1. Replace the element of _entries_ whose value is _e_ with an element whose value is ~empty~.
@@ -40574,7 +40570,7 @@ THH:mm:ss.sss
           1. Let _S_ be the *this* value.
           1. Perform ? RequireInternalSlot(_S_, [[SetData]]).
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
-          1. Let _entries_ be the List that is _S_.[[SetData]].
+          1. Let _entries_ be _S_.[[SetData]].
           1. Let _numEntries_ be the number of elements in _entries_.
           1. Let _index_ be 0.
           1. Repeat, while _index_ &lt; _numEntries_,
@@ -40602,7 +40598,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _S_ be the *this* value.
           1. Perform ? RequireInternalSlot(_S_, [[SetData]]).
-          1. Let _entries_ be the List that is _S_.[[SetData]].
+          1. Let _entries_ be _S_.[[SetData]].
           1. For each element _e_ of _entries_, do
             1. If _e_ is not ~empty~ and SameValueZero(_e_, _value_) is *true*, return *true*.
           1. Return *false*.
@@ -40623,7 +40619,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _S_ be the *this* value.
           1. Perform ? RequireInternalSlot(_S_, [[SetData]]).
-          1. Let _entries_ be the List that is _S_.[[SetData]].
+          1. Let _entries_ be _S_.[[SetData]].
           1. Let _count_ be 0.
           1. For each element _e_ of _entries_, do
             1. If _e_ is not ~empty~, set _count_ to _count_ + 1.
@@ -40676,7 +40672,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_set_, [[SetData]]).
           1. Let _closure_ be a new Abstract Closure with no parameters that captures _set_ and _kind_ and performs the following steps when called:
             1. Let _index_ be 0.
-            1. Let _entries_ be the List that is _set_.[[SetData]].
+            1. Let _entries_ be _set_.[[SetData]].
             1. Let _numEntries_ be the number of elements in _entries_.
             1. Repeat, while _index_ &lt; _numEntries_,
               1. Let _e_ be _entries_[_index_].
@@ -40797,7 +40793,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _M_ be the *this* value.
           1. Perform ? RequireInternalSlot(_M_, [[WeakMapData]]).
-          1. Let _entries_ be the List that is _M_.[[WeakMapData]].
+          1. Let _entries_ be _M_.[[WeakMapData]].
           1. If _key_ is not an Object, return *false*.
           1. For each Record { [[Key]], [[Value]] } _p_ of _entries_, do
             1. If _p_.[[Key]] is not ~empty~ and SameValue(_p_.[[Key]], _key_) is *true*, then
@@ -40817,7 +40813,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _M_ be the *this* value.
           1. Perform ? RequireInternalSlot(_M_, [[WeakMapData]]).
-          1. Let _entries_ be the List that is _M_.[[WeakMapData]].
+          1. Let _entries_ be _M_.[[WeakMapData]].
           1. If _key_ is not an Object, return *undefined*.
           1. For each Record { [[Key]], [[Value]] } _p_ of _entries_, do
             1. If _p_.[[Key]] is not ~empty~ and SameValue(_p_.[[Key]], _key_) is *true*, return _p_.[[Value]].
@@ -40831,7 +40827,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _M_ be the *this* value.
           1. Perform ? RequireInternalSlot(_M_, [[WeakMapData]]).
-          1. Let _entries_ be the List that is _M_.[[WeakMapData]].
+          1. Let _entries_ be _M_.[[WeakMapData]].
           1. If _key_ is not an Object, return *false*.
           1. For each Record { [[Key]], [[Value]] } _p_ of _entries_, do
             1. If _p_.[[Key]] is not ~empty~ and SameValue(_p_.[[Key]], _key_) is *true*, return *true*.
@@ -40845,7 +40841,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _M_ be the *this* value.
           1. Perform ? RequireInternalSlot(_M_, [[WeakMapData]]).
-          1. Let _entries_ be the List that is _M_.[[WeakMapData]].
+          1. Let _entries_ be _M_.[[WeakMapData]].
           1. If _key_ is not an Object, throw a *TypeError* exception.
           1. For each Record { [[Key]], [[Value]] } _p_ of _entries_, do
             1. If _p_.[[Key]] is not ~empty~ and SameValue(_p_.[[Key]], _key_) is *true*, then
@@ -40943,7 +40939,7 @@ THH:mm:ss.sss
           1. Let _S_ be the *this* value.
           1. Perform ? RequireInternalSlot(_S_, [[WeakSetData]]).
           1. If _value_ is not an Object, throw a *TypeError* exception.
-          1. Let _entries_ be the List that is _S_.[[WeakSetData]].
+          1. Let _entries_ be _S_.[[WeakSetData]].
           1. For each element _e_ of _entries_, do
             1. If _e_ is not ~empty~ and SameValue(_e_, _value_) is *true*, then
               1. Return _S_.
@@ -40964,7 +40960,7 @@ THH:mm:ss.sss
           1. Let _S_ be the *this* value.
           1. Perform ? RequireInternalSlot(_S_, [[WeakSetData]]).
           1. If _value_ is not an Object, return *false*.
-          1. Let _entries_ be the List that is _S_.[[WeakSetData]].
+          1. Let _entries_ be _S_.[[WeakSetData]].
           1. For each element _e_ of _entries_, do
             1. If _e_ is not ~empty~ and SameValue(_e_, _value_) is *true*, then
               1. Replace the element of _entries_ whose value is _e_ with an element whose value is ~empty~.
@@ -40982,7 +40978,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _S_ be the *this* value.
           1. Perform ? RequireInternalSlot(_S_, [[WeakSetData]]).
-          1. Let _entries_ be the List that is _S_.[[WeakSetData]].
+          1. Let _entries_ be _S_.[[WeakSetData]].
           1. If _value_ is not an Object, return *false*.
           1. For each element _e_ of _entries_, do
             1. If _e_ is not ~empty~ and SameValue(_e_, _value_) is *true*, return *true*.
@@ -41119,7 +41115,7 @@ THH:mm:ss.sss
           <dd>It verifies if the argument _type_ is an unsigned TypedArray element type.</dd>
         </dl>
         <emu-alg>
-          1. If _type_ is ~Uint8~, ~Uint8C~, ~Uint16~, ~Uint32~, or ~BigUint64~, return *true*.
+          1. If _type_ is one of ~Uint8~, ~Uint8C~, ~Uint16~, ~Uint32~, or ~BigUint64~, return *true*.
           1. Return *false*.
         </emu-alg>
       </emu-clause>
@@ -41135,7 +41131,7 @@ THH:mm:ss.sss
           <dd>It verifies if the argument _type_ is an Integer TypedArray element type not including ~Uint8C~.</dd>
         </dl>
         <emu-alg>
-          1. If _type_ is ~Int8~, ~Uint8~, ~Int16~, ~Uint16~, ~Int32~, or ~Uint32~, return *true*.
+          1. If _type_ is one of ~Int8~, ~Uint8~, ~Int16~, ~Uint16~, ~Int32~, or ~Uint32~, return *true*.
           1. Return *false*.
         </emu-alg>
       </emu-clause>
@@ -41151,7 +41147,7 @@ THH:mm:ss.sss
           <dd>It verifies if the argument _type_ is a BigInt TypedArray element type.</dd>
         </dl>
         <emu-alg>
-          1. If _type_ is ~BigUint64~ or ~BigInt64~, return *true*.
+          1. If _type_ is either ~BigUint64~ or ~BigInt64~, return *true*.
           1. Return *false*.
         </emu-alg>
       </emu-clause>
@@ -41167,7 +41163,7 @@ THH:mm:ss.sss
         </dl>
         <emu-alg>
           1. If IsUnclampedIntegerElementType(_type_) is *true*, return *true*.
-          1. If IsBigIntElementType(_type_) is *true* and _order_ is not ~Init~ or ~Unordered~, return *true*.
+          1. If IsBigIntElementType(_type_) is *true* and _order_ is neither ~Init~ nor ~Unordered~, return *true*.
           1. Return *false*.
         </emu-alg>
       </emu-clause>
@@ -41431,11 +41427,11 @@ THH:mm:ss.sss
           1. If IsDetachedBuffer(_O_) is *true*, throw a *TypeError* exception.
           1. Let _len_ be _O_.[[ArrayBufferByteLength]].
           1. Let _relativeStart_ be ? ToIntegerOrInfinity(_start_).
-          1. If _relativeStart_ is -∞, let _first_ be 0.
+          1. If _relativeStart_ = -∞, let _first_ be 0.
           1. Else if _relativeStart_ &lt; 0, let _first_ be max(_len_ + _relativeStart_, 0).
           1. Else, let _first_ be min(_relativeStart_, _len_).
           1. If _end_ is *undefined*, let _relativeEnd_ be _len_; else let _relativeEnd_ be ? ToIntegerOrInfinity(_end_).
-          1. If _relativeEnd_ is -∞, let _final_ be 0.
+          1. If _relativeEnd_ = -∞, let _final_ be 0.
           1. Else if _relativeEnd_ &lt; 0, let _final_ be max(_len_ + _relativeEnd_, 0).
           1. Else, let _final_ be min(_relativeEnd_, _len_).
           1. Let _newLen_ be max(_final_ - _first_, 0).
@@ -41604,11 +41600,11 @@ THH:mm:ss.sss
           1. If IsSharedArrayBuffer(_O_) is *false*, throw a *TypeError* exception.
           1. Let _len_ be _O_.[[ArrayBufferByteLength]].
           1. Let _relativeStart_ be ? ToIntegerOrInfinity(_start_).
-          1. If _relativeStart_ is -∞, let _first_ be 0.
+          1. If _relativeStart_ = -∞, let _first_ be 0.
           1. Else if _relativeStart_ &lt; 0, let _first_ be max(_len_ + _relativeStart_, 0).
           1. Else, let _first_ be min(_relativeStart_, _len_).
           1. If _end_ is *undefined*, let _relativeEnd_ be _len_; else let _relativeEnd_ be ? ToIntegerOrInfinity(_end_).
-          1. If _relativeEnd_ is -∞, let _final_ be 0.
+          1. If _relativeEnd_ = -∞, let _final_ be 0.
           1. Else if _relativeEnd_ &lt; 0, let _final_ be max(_len_ + _relativeEnd_, 0).
           1. Else, let _final_ be min(_relativeEnd_, _len_).
           1. Let _newLen_ be max(_final_ - _first_, 0).
@@ -41616,7 +41612,7 @@ THH:mm:ss.sss
           1. Let _new_ be ? Construct(_ctor_, « 𝔽(_newLen_) »).
           1. Perform ? RequireInternalSlot(_new_, [[ArrayBufferData]]).
           1. If IsSharedArrayBuffer(_new_) is *false*, throw a *TypeError* exception.
-          1. If _new_.[[ArrayBufferData]] and _O_.[[ArrayBufferData]] are the same Shared Data Block values, throw a *TypeError* exception.
+          1. If _new_.[[ArrayBufferData]] is _O_.[[ArrayBufferData]], throw a *TypeError* exception.
           1. If _new_.[[ArrayBufferByteLength]] &lt; _newLen_, throw a *TypeError* exception.
           1. Let _fromBuf_ be _O_.[[ArrayBufferData]].
           1. Let _toBuf_ be _new_.[[ArrayBufferData]].
@@ -42066,7 +42062,7 @@ THH:mm:ss.sss
           1. Perform ? ValidateTypedArray(_typedArray_).
           1. Let _buffer_ be _typedArray_.[[ViewedArrayBuffer]].
           1. If _waitable_ is *true*, then
-            1. If _typedArray_.[[TypedArrayName]] is not *"Int32Array"* or *"BigInt64Array"*, throw a *TypeError* exception.
+            1. If _typedArray_.[[TypedArrayName]] is neither *"Int32Array"* nor *"BigInt64Array"*, throw a *TypeError* exception.
           1. Else,
             1. Let _type_ be TypedArrayElementType(_typedArray_).
             1. If IsUnclampedIntegerElementType(_type_) is *false* and IsBigIntElementType(_type_) is *false*, throw a *TypeError* exception.
@@ -42221,7 +42217,7 @@ THH:mm:ss.sss
         </dl>
         <emu-alg>
           1. Assert: The surrounding agent is in the critical section for _WL_.
-          1. Assert: _W_ is equivalent to AgentSignifier().
+          1. Assert: _W_ is AgentSignifier().
           1. Assert: _W_ is on the list of waiters in _WL_.
           1. Assert: AgentCanSuspend() is *true*.
           1. Let _additionalTimeout_ be an implementation-defined non-negative mathematical value.
@@ -42502,7 +42498,7 @@ THH:mm:ss.sss
         1. If _typedArray_.[[TypedArrayName]] is *"BigInt64Array"*, let _v_ be ? ToBigInt64(_value_).
         1. Otherwise, let _v_ be ? ToInt32(_value_).
         1. Let _q_ be ? ToNumber(_timeout_).
-        1. If _q_ is *NaN* or *+∞*<sub>𝔽</sub>, let _t_ be +∞; else if _q_ is *-∞*<sub>𝔽</sub>, let _t_ be 0; else let _t_ be max(ℝ(_q_), 0).
+        1. If _q_ is either *NaN* or *+∞*<sub>𝔽</sub>, let _t_ be +∞; else if _q_ is *-∞*<sub>𝔽</sub>, let _t_ be 0; else let _t_ be max(ℝ(_q_), 0).
         1. Let _B_ be AgentCanSuspend().
         1. If _B_ is *false*, throw a *TypeError* exception.
         1. Let _block_ be _buffer_.[[ArrayBufferData]].
@@ -42595,7 +42591,7 @@ THH:mm:ss.sss
         1. [id="step-json-parse-eval"] Let _completion_ be Completion(<emu-meta suppress-effects="user-code">Evaluation of _script_</emu-meta>).
         1. NOTE: The PropertyDefinitionEvaluation semantics defined in <emu-xref href="#sec-runtime-semantics-propertydefinitionevaluation"></emu-xref> have special handling for the above evaluation.
         1. Let _unfiltered_ be _completion_.[[Value]].
-        1. [id="step-json-parse-assert-type"] Assert: _unfiltered_ is either a String, Number, Boolean, Null, or an Object that is defined by either an |ArrayLiteral| or an |ObjectLiteral|.
+        1. [id="step-json-parse-assert-type"] Assert: _unfiltered_ is either a String, a Number, a Boolean, an Object that is defined by either an |ArrayLiteral| or an |ObjectLiteral|, or *null*.
         1. If IsCallable(_reviver_) is *true*, then
           1. Let _root_ be OrdinaryObjectCreate(%Object.prototype%).
           1. Let _rootName_ be the empty String.
@@ -42682,7 +42678,7 @@ THH:mm:ss.sss
                 1. Else if _v_ is a Number, set _item_ to ! ToString(_v_).
                 1. Else if _v_ is an Object, then
                   1. If _v_ has a [[StringData]] or [[NumberData]] internal slot, set _item_ to ? ToString(_v_).
-                1. If _item_ is not *undefined* and _item_ is not currently an element of _PropertyList_, then
+                1. If _item_ is not *undefined* and _PropertyList_ does not contain _item_, then
                   1. Append _item_ to _PropertyList_.
                 1. Set _k_ to _k_ + 1.
         1. If _space_ is an Object, then
@@ -42695,7 +42691,7 @@ THH:mm:ss.sss
           1. Set _spaceMV_ to min(10, _spaceMV_).
           1. If _spaceMV_ &lt; 1, let _gap_ be the empty String; otherwise let _gap_ be the String value containing _spaceMV_ occurrences of the code unit 0x0020 (SPACE).
         1. Else if _space_ is a String, then
-          1. If the length of _space_ is 10 or less, let _gap_ be _space_; otherwise let _gap_ be the substring of _space_ from 0 to 10.
+          1. If the length of _space_ ≤ 10, let _gap_ be _space_; otherwise let _gap_ be the substring of _space_ from 0 to 10.
         1. Else,
           1. Let _gap_ be the empty String.
         1. Let _wrapper_ be OrdinaryObjectCreate(%Object.prototype%).
@@ -42788,7 +42784,7 @@ THH:mm:ss.sss
             _state_: a JSON Serialization Record,
             _key_: a String,
             _holder_: an Object,
-          ): either a normal completion containing either *undefined* or a String, or a throw completion
+          ): either a normal completion containing either a String or *undefined*, or a throw completion
         </h1>
         <dl class="header">
         </dl>
@@ -42840,8 +42836,8 @@ THH:mm:ss.sss
           1. For each code point _C_ of StringToCodePoints(_value_), do
             1. If _C_ is listed in the “Code Point” column of <emu-xref href="#table-json-single-character-escapes"></emu-xref>, then
               1. Set _product_ to the string-concatenation of _product_ and the escape sequence for _C_ as specified in the “Escape Sequence” column of the corresponding row.
-            1. Else if _C_ has a numeric value less than 0x0020 (SPACE), or if _C_ has the same numeric value as a <emu-xref href="#leading-surrogate"></emu-xref> or <emu-xref href="#trailing-surrogate"></emu-xref>, then
-              1. Let _unit_ be the code unit whose numeric value is that of _C_.
+            1. Else if _C_ has a numeric value less than 0x0020 (SPACE) or _C_ has the same numeric value as a <emu-xref href="#leading-surrogate"></emu-xref> or <emu-xref href="#trailing-surrogate"></emu-xref>, then
+              1. Let _unit_ be the code unit whose numeric value is the numeric value of _C_.
               1. Set _product_ to the string-concatenation of _product_ and UnicodeEscape(_unit_).
             1. Else,
               1. Set _product_ to the string-concatenation of _product_ and UTF16EncodeCodePoint(_C_).
@@ -43293,7 +43289,7 @@ THH:mm:ss.sss
         </emu-alg>
 
         <emu-note>
-          <p>Based on the algorithms and definitions in this specification, _cell_.[[HeldValue]] is live when _cell_ is in _finalizationRegistry_.[[Cells]]; however, this does not necessarily mean that _cell_.[[UnregisterToken]] or _cell_.[[Target]] are live. For example, registering an object with itself as its unregister token would not keep the object alive forever.</p>
+          <p>Based on the algorithms and definitions in this specification, _cell_.[[HeldValue]] is live when _finalizationRegistry_.[[Cells]] contains _cell_; however, this does not necessarily mean that _cell_.[[UnregisterToken]] or _cell_.[[Target]] are live. For example, registering an object with itself as its unregister token would not keep the object alive forever.</p>
         </emu-note>
       </emu-clause>
 
@@ -44306,7 +44302,7 @@ THH:mm:ss.sss
               1. If _next_ is *false*, then
                 1. Set _iteratorRecord_.[[Done]] to *true*.
                 1. Set _remainingElementsCount_.[[Value]] to _remainingElementsCount_.[[Value]] - 1.
-                1. If _remainingElementsCount_.[[Value]] is 0, then
+                1. If _remainingElementsCount_.[[Value]] = 0, then
                   1. Let _valuesArray_ be CreateArrayFromList(_values_).
                   1. Perform ? Call(_resultCapability_.[[Resolve]], *undefined*, « _valuesArray_ »).
                 1. Return _resultCapability_.[[Promise]].
@@ -44343,7 +44339,7 @@ THH:mm:ss.sss
             1. Let _remainingElementsCount_ be _F_.[[RemainingElements]].
             1. Set _values_[_index_] to _x_.
             1. Set _remainingElementsCount_.[[Value]] to _remainingElementsCount_.[[Value]] - 1.
-            1. If _remainingElementsCount_.[[Value]] is 0, then
+            1. If _remainingElementsCount_.[[Value]] = 0, then
               1. Let _valuesArray_ be CreateArrayFromList(_values_).
               1. Return ? Call(_promiseCapability_.[[Resolve]], *undefined*, « _valuesArray_ »).
             1. Return *undefined*.
@@ -44394,7 +44390,7 @@ THH:mm:ss.sss
               1. If _next_ is *false*, then
                 1. Set _iteratorRecord_.[[Done]] to *true*.
                 1. Set _remainingElementsCount_.[[Value]] to _remainingElementsCount_.[[Value]] - 1.
-                1. If _remainingElementsCount_.[[Value]] is 0, then
+                1. If _remainingElementsCount_.[[Value]] = 0, then
                   1. Let _valuesArray_ be CreateArrayFromList(_values_).
                   1. Perform ? Call(_resultCapability_.[[Resolve]], *undefined*, « _valuesArray_ »).
                 1. Return _resultCapability_.[[Promise]].
@@ -44444,7 +44440,7 @@ THH:mm:ss.sss
             1. Perform ! CreateDataPropertyOrThrow(_obj_, *"value"*, _x_).
             1. Set _values_[_index_] to _obj_.
             1. Set _remainingElementsCount_.[[Value]] to _remainingElementsCount_.[[Value]] - 1.
-            1. If _remainingElementsCount_.[[Value]] is 0, then
+            1. If _remainingElementsCount_.[[Value]] = 0, then
               1. Let _valuesArray_ be CreateArrayFromList(_values_).
               1. Return ? Call(_promiseCapability_.[[Resolve]], *undefined*, « _valuesArray_ »).
             1. Return *undefined*.
@@ -44470,7 +44466,7 @@ THH:mm:ss.sss
             1. Perform ! CreateDataPropertyOrThrow(_obj_, *"reason"*, _x_).
             1. Set _values_[_index_] to _obj_.
             1. Set _remainingElementsCount_.[[Value]] to _remainingElementsCount_.[[Value]] - 1.
-            1. If _remainingElementsCount_.[[Value]] is 0, then
+            1. If _remainingElementsCount_.[[Value]] = 0, then
               1. Let _valuesArray_ be CreateArrayFromList(_values_).
               1. Return ? Call(_promiseCapability_.[[Resolve]], *undefined*, « _valuesArray_ »).
             1. Return *undefined*.
@@ -44521,7 +44517,7 @@ THH:mm:ss.sss
               1. If _next_ is *false*, then
                 1. Set _iteratorRecord_.[[Done]] to *true*.
                 1. Set _remainingElementsCount_.[[Value]] to _remainingElementsCount_.[[Value]] - 1.
-                1. If _remainingElementsCount_.[[Value]] is 0, then
+                1. If _remainingElementsCount_.[[Value]] = 0, then
                   1. Let _error_ be a newly created *AggregateError* object.
                   1. Perform ! DefinePropertyOrThrow(_error_, *"errors"*, PropertyDescriptor { [[Configurable]]: *true*, [[Enumerable]]: *false*, [[Writable]]: *true*, [[Value]]: CreateArrayFromList(_errors_) }).
                   1. Return ThrowCompletion(_error_).
@@ -44559,7 +44555,7 @@ THH:mm:ss.sss
             1. Let _remainingElementsCount_ be _F_.[[RemainingElements]].
             1. Set _errors_[_index_] to _x_.
             1. Set _remainingElementsCount_.[[Value]] to _remainingElementsCount_.[[Value]] - 1.
-            1. If _remainingElementsCount_.[[Value]] is 0, then
+            1. If _remainingElementsCount_.[[Value]] = 0, then
               1. Let _error_ be a newly created *AggregateError* object.
               1. Perform ! DefinePropertyOrThrow(_error_, *"errors"*, PropertyDescriptor { [[Configurable]]: *true*, [[Enumerable]]: *false*, [[Writable]]: *true*, [[Value]]: CreateArrayFromList(_errors_) }).
               1. Return ? Call(_promiseCapability_.[[Reject]], *undefined*, « _error_ »).
@@ -45257,14 +45253,14 @@ THH:mm:ss.sss
           GeneratorValidate (
             _generator_: an ECMAScript language value,
             _generatorBrand_: a String or ~empty~,
-          ): either a normal completion containing either ~suspendedStart~, ~suspendedYield~, or ~completed~, or a throw completion
+          ): either a normal completion containing one of ~suspendedStart~, ~suspendedYield~, or ~completed~, or a throw completion
         </h1>
         <dl class="header">
         </dl>
         <emu-alg>
           1. Perform ? RequireInternalSlot(_generator_, [[GeneratorState]]).
           1. Perform ? RequireInternalSlot(_generator_, [[GeneratorBrand]]).
-          1. If _generator_.[[GeneratorBrand]] is not the same value as _generatorBrand_, throw a *TypeError* exception.
+          1. If _generator_.[[GeneratorBrand]] is not _generatorBrand_, throw a *TypeError* exception.
           1. Assert: _generator_ also has a [[GeneratorContext]] internal slot.
           1. Let _state_ be _generator_.[[GeneratorState]].
           1. If _state_ is ~executing~, throw a *TypeError* exception.
@@ -45619,7 +45615,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_generator_, [[AsyncGeneratorContext]]).
           1. Perform ? RequireInternalSlot(_generator_, [[AsyncGeneratorState]]).
           1. Perform ? RequireInternalSlot(_generator_, [[AsyncGeneratorQueue]]).
-          1. If _generator_.[[GeneratorBrand]] is not the same value as _generatorBrand_, throw a *TypeError* exception.
+          1. If _generator_.[[GeneratorBrand]] is not _generatorBrand_, throw a *TypeError* exception.
           1. Return ~unused~.
         </emu-alg>
       </emu-clause>
@@ -46634,7 +46630,7 @@ THH:mm:ss.sss
       <h1>agent-order</h1>
       <p>For a candidate execution _execution_, _execution_.[[AgentOrder]] is a Relation on events that satisfies the following.</p>
       <ul>
-        <li>For each pair (_E_, _D_) in EventSet(_execution_), (_E_, _D_) is in _execution_.[[AgentOrder]] if there is some Agent Events Record _aer_ in _execution_.[[EventsRecords]] such that _E_ and _D_ are in _aer_.[[EventList]] and _E_ is before _D_ in List order of _aer_.[[EventList]].</li>
+        <li>For each pair (_E_, _D_) in EventSet(_execution_), _execution_.[[AgentOrder]] contains (_E_, _D_) if there is some Agent Events Record _aer_ in _execution_.[[EventsRecords]] such that _E_ and _D_ are in _aer_.[[EventList]] and _E_ is before _D_ in List order of _aer_.[[EventList]].</li>
       </ul>
 
       <emu-note>
@@ -46660,7 +46656,7 @@ THH:mm:ss.sss
       <h1>reads-from</h1>
       <p>For a candidate execution _execution_, _execution_.[[ReadsFrom]] is the least Relation on events that satisfies the following.</p>
       <ul>
-        <li>For each pair (_R_, _W_) in SharedDataBlockEventSet(_execution_), (_R_, _W_) is in _execution_.[[ReadsFrom]] if _W_ is in _execution_.[[ReadsBytesFrom]](_R_).</li>
+        <li>For each pair (_R_, _W_) in SharedDataBlockEventSet(_execution_), _execution_.[[ReadsFrom]] contains (_R_, _W_) if _execution_.[[ReadsBytesFrom]](_R_) contains _W_.</li>
       </ul>
     </emu-clause>
 
@@ -46668,7 +46664,7 @@ THH:mm:ss.sss
       <h1>host-synchronizes-with</h1>
       <p>For a candidate execution _execution_, _execution_.[[HostSynchronizesWith]] is a host-provided strict partial order on host-specific events that satisfies at least the following.</p>
       <ul>
-        <li>If (_E_, _D_) is in _execution_.[[HostSynchronizesWith]], _E_ and _D_ are in HostEventSet(_execution_).</li>
+        <li>If _execution_.[[HostSynchronizesWith]] contains (_E_, _D_), _E_ and _D_ are in HostEventSet(_execution_).</li>
         <li>There is no cycle in the union of _execution_.[[HostSynchronizesWith]] and _execution_.[[AgentOrder]].</li>
       </ul>
 
@@ -46685,15 +46681,15 @@ THH:mm:ss.sss
       <p>For a candidate execution _execution_, _execution_.[[SynchronizesWith]] is the least Relation on events that satisfies the following.</p>
       <ul>
         <li>
-          For each pair (_R_, _W_) in _execution_.[[ReadsFrom]], (_W_, _R_) is in _execution_.[[SynchronizesWith]] if _R_.[[Order]] is ~SeqCst~, _W_.[[Order]] is ~SeqCst~, and _R_ and _W_ have equal ranges.
+          For each pair (_R_, _W_) in _execution_.[[ReadsFrom]], _execution_.[[SynchronizesWith]] contains (_W_, _R_) if _R_.[[Order]] is ~SeqCst~, _W_.[[Order]] is ~SeqCst~, and _R_ and _W_ have equal ranges.
         </li>
         <li>
           For each element _eventsRecord_ of _execution_.[[EventsRecords]], the following is true.
           <ul>
-            <li>For each pair (_S_, _Sw_) in _eventsRecord_.[[AgentSynchronizesWith]], (_S_, _Sw_) is in _execution_.[[SynchronizesWith]].</li>
+            <li>For each pair (_S_, _Sw_) in _eventsRecord_.[[AgentSynchronizesWith]], _execution_.[[SynchronizesWith]] contains (_S_, _Sw_).</li>
           </ul>
         </li>
-        <li>For each pair (_E_, _D_) in _execution_.[[HostSynchronizesWith]], (_E_, _D_) is in _execution_.[[SynchronizesWith]].</li>
+        <li>For each pair (_E_, _D_) in _execution_.[[HostSynchronizesWith]], _execution_.[[SynchronizesWith]] contains (_E_, _D_).</li>
       </ul>
 
       <emu-note>
@@ -46718,10 +46714,10 @@ THH:mm:ss.sss
       <p>For a candidate execution _execution_, _execution_.[[HappensBefore]] is the least Relation on events that satisfies the following.</p>
 
       <ul>
-        <li>For each pair (_E_, _D_) in _execution_.[[AgentOrder]], (_E_, _D_) is in _execution_.[[HappensBefore]].</li>
-        <li>For each pair (_E_, _D_) in _execution_.[[SynchronizesWith]], (_E_, _D_) is in _execution_.[[HappensBefore]].</li>
-        <li>For each pair (_E_, _D_) in SharedDataBlockEventSet(_execution_), (_E_, _D_) is in _execution_.[[HappensBefore]] if _E_.[[Order]] is ~Init~ and _E_ and _D_ have overlapping ranges.</li>
-        <li>For each pair (_E_, _D_) in EventSet(_execution_), (_E_, _D_) is in _execution_.[[HappensBefore]] if there is an event _F_ such that the pairs (_E_, _F_) and (_F_, _D_) are in _execution_.[[HappensBefore]].</li>
+        <li>For each pair (_E_, _D_) in _execution_.[[AgentOrder]], _execution_.[[HappensBefore]] contains (_E_, _D_).</li>
+        <li>For each pair (_E_, _D_) in _execution_.[[SynchronizesWith]], _execution_.[[HappensBefore]] contains (_E_, _D_).</li>
+        <li>For each pair (_E_, _D_) in SharedDataBlockEventSet(_execution_), _execution_.[[HappensBefore]] contains (_E_, _D_) if _E_.[[Order]] is ~Init~ and _E_ and _D_ have overlapping ranges.</li>
+        <li>For each pair (_E_, _D_) in EventSet(_execution_), _execution_.[[HappensBefore]] contains (_E_, _D_) if there is an event _F_ such that the pairs (_E_, _F_) and (_F_, _D_) are in _execution_.[[HappensBefore]].</li>
       </ul>
 
       <emu-note>
@@ -46759,7 +46755,7 @@ THH:mm:ss.sss
           1. Let _Ws_ be _execution_.[[ReadsBytesFrom]](_R_).
           1. Let _byteLocation_ be _R_.[[ByteIndex]].
           1. For each element _W_ of _Ws_, do
-            1. If (_R_, _W_) is in _execution_.[[HappensBefore]], then
+            1. If _execution_.[[HappensBefore]] contains (_R_, _W_), then
               1. Return *false*.
             1. If there exists a WriteSharedMemory or ReadModifyWriteSharedMemory event _V_ that has _byteLocation_ in its range such that the pairs (_W_, _V_) and (_V_, _R_) are in _execution_.[[HappensBefore]], then
               1. Return *false*.
@@ -46775,8 +46771,8 @@ THH:mm:ss.sss
         1. For each ReadSharedMemory or ReadModifyWriteSharedMemory event _R_ of SharedDataBlockEventSet(_execution_), do
           1. If _R_.[[NoTear]] is *true*, then
             1. Assert: The remainder of dividing _R_.[[ByteIndex]] by _R_.[[ElementSize]] is 0.
-            1. For each event _W_ such that (_R_, _W_) is in _execution_.[[ReadsFrom]] and _W_.[[NoTear]] is *true*, do
-              1. If _R_ and _W_ have equal ranges and there exists an event _V_ such that _V_ and _W_ have equal ranges, _V_.[[NoTear]] is *true*, _W_ is not _V_, and (_R_, _V_) is in _execution_.[[ReadsFrom]], then
+            1. For each event _W_ such that _execution_.[[ReadsFrom]] contains (_R_, _W_) and _W_.[[NoTear]] is *true*, do
+              1. If _R_ and _W_ have equal ranges and there exists an event _V_ such that _V_ and _W_ have equal ranges, _V_.[[NoTear]] is *true*, _W_ is not _V_, and _execution_.[[ReadsFrom]] contains (_R_, _V_), then
                 1. Return *false*.
         1. Return *true*.
       </emu-alg>
@@ -46795,7 +46791,7 @@ THH:mm:ss.sss
         <li>
           <p>For each pair (_R_, _W_) in _execution_.[[ReadsFrom]], there is no WriteSharedMemory or ReadModifyWriteSharedMemory event _V_ in SharedDataBlockEventSet(_execution_) such that _V_.[[Order]] is ~SeqCst~, the pairs (_W_, _V_) and (_V_, _R_) are in memory-order, and any of the following conditions are true.</p>
           <ul>
-            <li>The pair (_W_, _R_) is in _execution_.[[SynchronizesWith]], and _V_ and _R_ have equal ranges.</li>
+            <li>_execution_.[[SynchronizesWith]] contains the pair (_W_, _R_), and _V_ and _R_ have equal ranges.</li>
             <li>The pairs (_W_, _R_) and (_V_, _R_) are in _execution_.[[HappensBefore]], _W_.[[Order]] is ~SeqCst~, and _W_ and _V_ have equal ranges.</li>
             <li>The pairs (_W_, _R_) and (_W_, _V_) are in _execution_.[[HappensBefore]], _R_.[[Order]] is ~SeqCst~, and _V_ and _R_ have equal ranges.</li>
           </ul>
@@ -46840,7 +46836,7 @@ THH:mm:ss.sss
         1. If the pairs (_E_, _D_) and (_D_, _E_) are not in _execution_.[[HappensBefore]], then
           1. If _E_ and _D_ are both WriteSharedMemory or ReadModifyWriteSharedMemory events and _E_ and _D_ do not have disjoint ranges, then
             1. Return *true*.
-          1. If either (_E_, _D_) or (_D_, _E_) is in _execution_.[[ReadsFrom]], then
+          1. If _execution_.[[ReadsFrom]] contains either (_E_, _D_) or (_D_, _E_), then
             1. Return *true*.
       1. Return *false*.
     </emu-alg>
@@ -47528,7 +47524,7 @@ THH:mm:ss.sss
             It is a Syntax Error if IsCharacterClass of the first |ClassAtom| is *true* or IsCharacterClass of the second |ClassAtom| is *true* <ins>and this production has a <sub>[UnicodeMode]</sub> parameter</ins>.
           </li>
           <li>
-            It is a Syntax Error if IsCharacterClass of the first |ClassAtom| is *false* and IsCharacterClass of the second |ClassAtom| is *false* and the CharacterValue of the first |ClassAtom| is larger than the CharacterValue of the second |ClassAtom|.
+            It is a Syntax Error if IsCharacterClass of the first |ClassAtom| is *false*, IsCharacterClass of the second |ClassAtom| is *false*, and the CharacterValue of the first |ClassAtom| is strictly greater than the CharacterValue of the second |ClassAtom|.
           </li>
         </ul>
         <emu-grammar>NonemptyClassRangesNoDash :: ClassAtomNoDash `-` ClassAtom ClassRanges</emu-grammar>
@@ -47537,7 +47533,7 @@ THH:mm:ss.sss
             It is a Syntax Error if IsCharacterClass of |ClassAtomNoDash| is *true* or IsCharacterClass of |ClassAtom| is *true* <ins>and this production has a <sub>[UnicodeMode]</sub> parameter</ins>.
           </li>
           <li>
-            It is a Syntax Error if IsCharacterClass of |ClassAtomNoDash| is *false* and IsCharacterClass of |ClassAtom| is *false* and the CharacterValue of |ClassAtomNoDash| is larger than the CharacterValue of |ClassAtom|.
+            It is a Syntax Error if IsCharacterClass of |ClassAtomNoDash| is *false*, IsCharacterClass of |ClassAtom| is *false*, and the CharacterValue of |ClassAtomNoDash| is strictly greater than the CharacterValue of |ClassAtom|.
           </li>
         </ul>
       </emu-annex>
@@ -47715,7 +47711,7 @@ THH:mm:ss.sss
       <emu-annex id="sec-escape-string">
         <h1>escape ( _string_ )</h1>
         <p>This function is a property of the global object. It computes a new version of a String value in which certain code units have been replaced by a hexadecimal escape sequence.</p>
-        <p>When replacing a code unit of numeric value less than or equal to 0x00FF, a two-digit escape sequence of the form <code>%<var>xx</var></code> is used. When replacing a code unit of numeric value greater than 0x00FF, a four-digit escape sequence of the form <code>%u<var>xxxx</var></code> is used.</p>
+        <p>When replacing a code unit of numeric value less than or equal to 0x00FF, a two-digit escape sequence of the form <code>%<var>xx</var></code> is used. When replacing a code unit of numeric value strictly greater than 0x00FF, a four-digit escape sequence of the form <code>%u<var>xxxx</var></code> is used.</p>
         <p>It is the <dfn>%escape%</dfn> intrinsic object.</p>
         <p>It performs the following steps when called:</p>
         <emu-alg>
@@ -47726,7 +47722,7 @@ THH:mm:ss.sss
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _length_,
             1. Let _char_ be the code unit at index _k_ within _string_.
-            1. If _char_ is in _unescapedSet_, then
+            1. If _unescapedSet_ contains _char_, then
               1. Let _S_ be the String value containing the single code unit _char_.
             1. Else,
               1. Let _n_ be the numeric value of _char_.
@@ -47790,7 +47786,7 @@ THH:mm:ss.sss
           1. Let _S_ be ? ToString(_O_).
           1. Let _size_ be the length of _S_.
           1. Let _intStart_ be ? ToIntegerOrInfinity(_start_).
-          1. If _intStart_ is -∞, set _intStart_ to 0.
+          1. If _intStart_ = -∞, set _intStart_ to 0.
           1. Else if _intStart_ &lt; 0, set _intStart_ to max(_size_ + _intStart_, 0).
           1. Else, set _intStart_ to min(_intStart_, _size_).
           1. If _length_ is *undefined*, let _intLength_ be _size_; otherwise let _intLength_ be ? ToIntegerOrInfinity(_length_).
@@ -48127,7 +48123,7 @@ THH:mm:ss.sss
           1. If _strict_ is *false*, then
             1. For each |FunctionDeclaration| _f_ that is directly contained in the |StatementList| of a |Block|, |CaseClause|, or |DefaultClause|, do
               1. Let _F_ be StringValue of the |BindingIdentifier| of _f_.
-              1. If replacing the |FunctionDeclaration| _f_ with a |VariableStatement| that has _F_ as a |BindingIdentifier| would not produce any Early Errors for _func_ and _F_ is not an element of _parameterNames_, then
+              1. If replacing the |FunctionDeclaration| _f_ with a |VariableStatement| that has _F_ as a |BindingIdentifier| would not produce any Early Errors for _func_ and _parameterNames_ does not contain _F_, then
                 1. NOTE: A var binding for _F_ is only instantiated here if it is neither a VarDeclaredName, the name of a formal parameter, or another |FunctionDeclaration|.
                 1. If _initializedBindings_ does not contain _F_ and _F_ is not *"arguments"*, then
                   1. Perform ! _varEnv_.CreateMutableBinding(_F_, *false*).
@@ -48181,7 +48177,7 @@ THH:mm:ss.sss
                 1. Let _bindingExists_ be *false*.
                 1. Let _thisEnv_ be _lexEnv_.
                 1. Assert: The following loop will terminate.
-                1. Repeat, while _thisEnv_ is not the same as _varEnv_,
+                1. Repeat, while _thisEnv_ is not _varEnv_,
                   1. If _thisEnv_ is not an Object Environment Record, then
                     1. If ! _thisEnv_.HasBinding(_F_) is *true*, then
                       1. [id="step-evaldeclarationinstantiation-web-compat-bindingexists"] Let _bindingExists_ be *true*.
@@ -48439,13 +48435,13 @@ THH:mm:ss.sss
       For strict functions, if an arguments object is created the binding of the local identifier `arguments` to the arguments object is immutable and hence may not be the target of an assignment expression. (<emu-xref href="#sec-functiondeclarationinstantiation"></emu-xref>).
     </li>
     <li>
-      It is a *SyntaxError* if the StringValue of a |BindingIdentifier| is *"eval"* or *"arguments"* within strict mode code (<emu-xref href="#sec-identifiers-static-semantics-early-errors"></emu-xref>).
+      It is a *SyntaxError* if the StringValue of a |BindingIdentifier| is either *"eval"* or *"arguments"* within strict mode code (<emu-xref href="#sec-identifiers-static-semantics-early-errors"></emu-xref>).
     </li>
     <li>
       Strict mode eval code cannot instantiate variables or functions in the variable environment of the caller to eval. Instead, a new variable environment is created and that environment is used for declaration binding instantiation for the eval code (<emu-xref href="#sec-eval-x"></emu-xref>).
     </li>
     <li>
-      If *this* is evaluated within strict mode code, then the *this* value is not coerced to an object. A *this* value of *undefined* or *null* is not converted to the global object and primitive values are not converted to wrapper objects. The *this* value passed via a function call (including calls made using `Function.prototype.apply` and `Function.prototype.call`) do not coerce the passed *this* value to an object (<emu-xref href="#sec-ordinarycallbindthis"></emu-xref>, <emu-xref href="#sec-function.prototype.apply"></emu-xref>, <emu-xref href="#sec-function.prototype.call"></emu-xref>).
+      If *this* is evaluated within strict mode code, then the *this* value is not coerced to an object. A *this* value of either *undefined* or *null* is not converted to the global object and primitive values are not converted to wrapper objects. The *this* value passed via a function call (including calls made using `Function.prototype.apply` and `Function.prototype.call`) do not coerce the passed *this* value to an object (<emu-xref href="#sec-ordinarycallbindthis"></emu-xref>, <emu-xref href="#sec-function.prototype.apply"></emu-xref>, <emu-xref href="#sec-function.prototype.call"></emu-xref>).
     </li>
     <li>
       When a `delete` operator occurs within strict mode code, a *SyntaxError* is thrown if its |UnaryExpression| is a direct reference to a variable, function argument, or function name (<emu-xref href="#sec-delete-operator-static-semantics-early-errors"></emu-xref>).


### PR DESCRIPTION
Extracted from #2821. Fixes #2794.

### Editorial choices included in this PR
* use `=`, <code>&ne;</code>, `<`, <code>&le;</code>, `>`, and <code>&ge;</code> for mathematical value and bigint comparisons (except in asserts); prefer `=` over <code>&ne;</code>
* use `is`, `is not`, `<`, <code>&le;</code>, `>`, and <code>&ge;</code> for number comparisons
* use `SameValue(..., ...) is *true*` for equality comparison of symbols (except well-known) / objects / unknown ECMAScript language values
* use `is` and `is not` for equality comparison of all other values, including booleans, strings, well-known symbols, null, undefined, enums, etc; avoid "is different from" or "is the same as"
* prefer "if a is either b or c" over "if a is b or a is c"; use "any of" in place of "either" when more than 2 options
* prefer "if a is c and b is c" over "if a and b are both c"
* presence in a List is tested with `_list_ contains _element_` or `_list_ does not contain _element_`, not `_element_ is an element of _list_` or `_element_ is in _list_`
* don't say `the value of _a_`; just use `_a_`
* prefer "if a or b" over "if a or if b"; prefer "if a and b" over "if a and if b"
* prefer "whose _ is _" over "whose _ is that of _"

### Other editorial choices (still to do, not as part of this PR)
* use `a`/`an`/`a new` for creating and referencing values with identity
* use `the` for referencing values without identity

<!--
* ~prefer "a is b" to "a is the same X as b" or "a and b are the same X"; similar for "is not" and "not the same"~
-->