### PR TITLE
Editorial: refactor String.fromCharCode to build a String directly

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -33456,11 +33456,11 @@ THH:mm:ss.sss
         <p>This function may be called with any number of arguments which form the rest parameter _codeUnits_.</p>
         <p>It performs the following steps when called:</p>
         <emu-alg>
-          1. Let _elements_ be a new empty List.
+          1. Let _result_ be the empty String.
           1. For each element _next_ of _codeUnits_, do
-            1. Let _nextCU_ be ℝ(? ToUint16(_next_)).
-            1. Append _nextCU_ to _elements_.
-          1. Return the String value whose code units are the elements in the List _elements_. If _codeUnits_ is empty, the empty String is returned.
+            1. Let _nextCU_ be the code unit whose numeric value is ℝ(? ToUint16(_next_)).
+            1. Set _result_ to the string-concatenation of _result_ and _nextCU_.
+          1. Return _result_.
         </emu-alg>
         <p>The *"length"* property of this function is *1*<sub>𝔽</sub>.</p>
       </emu-clause>


### PR DESCRIPTION
I think this is simpler, more idiomatic, and reads better.