### PR TITLE
Editorial: turn "no action is required" step in Array reverse into note

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -37906,7 +37906,7 @@ THH:mm:ss.sss
               1. Perform ? Set(_O_, _upperP_, _lowerValue_, *true*).
             1. Else,
               1. Assert: _lowerExists_ and _upperExists_ are both *false*.
-              1. No action is required.
+              1. NOTE: No action is required.
             1. Set _lower_ to _lower_ + 1.
           1. Return _O_.
         </emu-alg>


### PR DESCRIPTION
Alternatively we could make it a note, but I don't think it's needed given the assert.