### PR TITLE
Editorial: Use the execution context created by InitializeEnvironment

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -28701,13 +28701,8 @@
             </dl>
 
             <emu-alg>
-              1. Let _moduleContext_ be a new ECMAScript code execution context.
-              1. Set the Function of _moduleContext_ to *null*.
-              1. Set the Realm of _moduleContext_ to _module_.[[Realm]].
-              1. Set the ScriptOrModule of _moduleContext_ to _module_.
               1. Assert: _module_ has been linked and declarations in its module environment have been instantiated.
-              1. Set the VariableEnvironment of _moduleContext_ to _module_.[[Environment]].
-              1. Set the LexicalEnvironment of _moduleContext_ to _module_.[[Environment]].
+              1. Let _moduleContext_ be _module_.[[Context]].
               1. Suspend the running execution context.
               1. If _module_.[[HasTLA]] is *false*, then
                 1. Assert: _capability_ is not present.


### PR DESCRIPTION
In `ExecuteModule`, use the execution context that `InitializeEnvironment` created and put in `_module_.[[Context]]`.

See issue #2660 for backstory.

Resolves #2660.

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
