### PR TITLE
Editorial: Eliminate mutable String values

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -28898,7 +28898,7 @@
         1. Let _S_ be ! TrimString(_inputString_, ~start~).
         1. Let _sign_ be 1.
         1. If _S_ is not empty and the first code unit of _S_ is the code unit 0x002D (HYPHEN-MINUS), set _sign_ to -1.
-        1. If _S_ is not empty and the first code unit of _S_ is the code unit 0x002B (PLUS SIGN) or the code unit 0x002D (HYPHEN-MINUS), remove the first code unit from _S_.
+        1. If _S_ is not empty and the first code unit of _S_ is the code unit 0x002B (PLUS SIGN) or the code unit 0x002D (HYPHEN-MINUS), set _S_ to the substring of _S_ from index 1.
         1. Let _R_ be ℝ(? ToInt32(_radix_)).
         1. Let _stripPrefix_ be *true*.
         1. If _R_ &ne; 0, then
@@ -28908,7 +28908,7 @@
           1. Set _R_ to 10.
         1. If _stripPrefix_ is *true*, then
           1. If the length of _S_ is at least 2 and the first two code units of _S_ are either *"0x"* or *"0X"*, then
-            1. Remove the first two code units from _S_.
+            1. Set _S_ to the substring of _S_ from index 2.
             1. Set _R_ to 16.
         1. If _S_ contains a code unit that is not a radix-_R_ digit, let _end_ be the index within _S_ of the first such code unit; otherwise, let _end_ be the length of _S_.
         1. Let _Z_ be the substring of _S_ from 0 to _end_.
@@ -36459,22 +36459,22 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _R_ be the *this* value.
           1. If _R_ is not an Object, throw a *TypeError* exception.
-          1. Let _result_ be the empty String.
+          1. Let _codeUnits_ be a new empty List.
           1. Let _hasIndices_ be ToBoolean(? Get(_R_, *"hasIndices"*)).
-          1. If _hasIndices_ is *true*, append the code unit 0x0064 (LATIN SMALL LETTER D) as the last code unit of _result_.
+          1. If _hasIndices_ is *true*, append the code unit 0x0064 (LATIN SMALL LETTER D) to _codeUnits_.
           1. Let _global_ be ToBoolean(? Get(_R_, *"global"*)).
-          1. If _global_ is *true*, append the code unit 0x0067 (LATIN SMALL LETTER G) as the last code unit of _result_.
+          1. If _global_ is *true*, append the code unit 0x0067 (LATIN SMALL LETTER G) to _codeUnits_.
           1. Let _ignoreCase_ be ToBoolean(? Get(_R_, *"ignoreCase"*)).
-          1. If _ignoreCase_ is *true*, append the code unit 0x0069 (LATIN SMALL LETTER I) as the last code unit of _result_.
+          1. If _ignoreCase_ is *true*, append the code unit 0x0069 (LATIN SMALL LETTER I) to _codeUnits_.
           1. Let _multiline_ be ToBoolean(? Get(_R_, *"multiline"*)).
-          1. If _multiline_ is *true*, append the code unit 0x006D (LATIN SMALL LETTER M) as the last code unit of _result_.
+          1. If _multiline_ is *true*, append the code unit 0x006D (LATIN SMALL LETTER M) to _codeUnits_.
           1. Let _dotAll_ be ToBoolean(? Get(_R_, *"dotAll"*)).
-          1. If _dotAll_ is *true*, append the code unit 0x0073 (LATIN SMALL LETTER S) as the last code unit of _result_.
+          1. If _dotAll_ is *true*, append the code unit 0x0073 (LATIN SMALL LETTER S) to _codeUnits_.
           1. Let _unicode_ be ToBoolean(? Get(_R_, *"unicode"*)).
-          1. If _unicode_ is *true*, append the code unit 0x0075 (LATIN SMALL LETTER U) as the last code unit of _result_.
+          1. If _unicode_ is *true*, append the code unit 0x0075 (LATIN SMALL LETTER U) to _codeUnits_.
           1. Let _sticky_ be ToBoolean(? Get(_R_, *"sticky"*)).
-          1. If _sticky_ is *true*, append the code unit 0x0079 (LATIN SMALL LETTER Y) as the last code unit of _result_.
-          1. Return _result_.
+          1. If _sticky_ is *true*, append the code unit 0x0079 (LATIN SMALL LETTER Y) to _codeUnits_.
+          1. Return the String value whose code units are the elements in the List _codeUnits_. If _codeUnits_ has no elements, the empty String is returned.
         </emu-alg>
 
         <emu-clause id="sec-regexphasflag" type="abstract operation">


### PR DESCRIPTION
There are a couple of algorithms in the spec (`parseInt` and `get RegExp.prototype.flags`) that treat String values as if they're mutable, removing and appending code units.

Modify these algorithms to treat String values as immutable.

(I'm pretty sure these are the only ones, but it's possible I missed something.)