### PR TITLE
Editorial: Subdivide the "Grammar Notation" section

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -569,240 +569,280 @@
 
     <emu-clause id="sec-grammar-notation" namespace="grammar-notation">
       <h1>Grammar Notation</h1>
-      <p>In the ECMAScript grammars, some terminal symbols are shown in `fixed-width` font. These are to appear in a source text exactly as written. All terminal symbol code points specified in this way are to be understood as the appropriate Unicode code points from the Basic Latin block, as opposed to any similar-looking code points from other Unicode ranges. A code point in a terminal symbol cannot be expressed by a `\\` |UnicodeEscapeSequence|.</p>
-      <p>In grammars whose terminal symbols are individual Unicode code points (i.e., the lexical, RegExp, and numeric string grammars), a contiguous run of multiple fixed-width code points appearing in a production is a simple shorthand for the same sequence of code points, written as standalone terminal symbols.</p>
-      <p>For example, the production:</p>
-      <emu-grammar type="definition" example>
-        HexIntegerLiteral :: `0x` HexDigits
-      </emu-grammar>
-      <p>is a shorthand for:</p>
-      <emu-grammar type="example">
-        HexIntegerLiteral :: `0` `x` HexDigits
-      </emu-grammar>
-      <p>In contrast, in the syntactic grammar, a contiguous run of fixed-width code points is a single terminal symbol.</p>
-      <p>Terminal symbols come in two other forms:</p>
-      <ul>
-        <li>In the lexical and RegExp grammars, Unicode code points without a conventional printed representation are instead shown in the form "&lt;ABBREV&gt;" where "ABBREV" is a mnemonic for the code point. These forms are defined in <emu-xref href="#sec-unicode-format-control-characters" title></emu-xref> and <emu-xref href="#sec-white-space" title></emu-xref>.</li>
-        <li>In the syntactic grammar, certain terminal symbols (e.g. |IdentifierName| and |RegularExpressionLiteral|) are shown in italics, as they refer to the nonterminals of the same name in the lexical grammar.</li>
-      </ul>
-      <p>Nonterminal symbols are shown in <i>italic</i> type. The definition of a nonterminal (also called a &ldquo;production&rdquo;) is introduced by the name of the nonterminal being defined followed by one or more colons. (The number of colons indicates to which grammar the production belongs.) One or more alternative right-hand sides for the nonterminal then follow on succeeding lines. For example, the syntactic definition:</p>
-      <emu-grammar type="definition" example>
-        WhileStatement :
-          `while` `(` Expression `)` Statement
-      </emu-grammar>
-      <p>states that the nonterminal |WhileStatement| represents the token `while`, followed by a left parenthesis token, followed by an |Expression|, followed by a right parenthesis token, followed by a |Statement|. The occurrences of |Expression| and |Statement| are themselves nonterminals. As another example, the syntactic definition:</p>
-      <emu-grammar type="definition" example>
-        ArgumentList :
-          AssignmentExpression
-          ArgumentList `,` AssignmentExpression
-      </emu-grammar>
-      <p>states that an |ArgumentList| may represent either a single |AssignmentExpression| or an |ArgumentList|, followed by a comma, followed by an |AssignmentExpression|. This definition of |ArgumentList| is recursive, that is, it is defined in terms of itself. The result is that an |ArgumentList| may contain any positive number of arguments, separated by commas, where each argument expression is an |AssignmentExpression|. Such recursive definitions of nonterminals are common.</p>
-      <p>The subscripted suffix &ldquo;<sub>opt</sub>&rdquo;, which may appear after a terminal or nonterminal, indicates an optional symbol. The alternative containing the optional symbol actually specifies two right-hand sides, one that omits the optional element and one that includes it. This means that:</p>
-      <emu-grammar type="definition" example>
-        VariableDeclaration :
-          BindingIdentifier Initializer?
-      </emu-grammar>
-      <p>is a convenient abbreviation for:</p>
-      <emu-grammar type="definition" example>
-        VariableDeclaration :
-          BindingIdentifier
-          BindingIdentifier Initializer
-      </emu-grammar>
-      <p>and that:</p>
-      <emu-grammar type="definition" example>
-        ForStatement :
-          `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement
-      </emu-grammar>
-      <p>is a convenient abbreviation for:</p>
-      <emu-grammar type="definition" example>
-        ForStatement :
-          `for` `(` LexicalDeclaration `;` Expression? `)` Statement
-          `for` `(` LexicalDeclaration Expression `;` Expression? `)` Statement
-      </emu-grammar>
-      <p>which in turn is an abbreviation for:</p>
-      <emu-grammar type="definition" example>
-        ForStatement :
-          `for` `(` LexicalDeclaration `;` `)` Statement
-          `for` `(` LexicalDeclaration `;` Expression `)` Statement
-          `for` `(` LexicalDeclaration Expression `;` `)` Statement
-          `for` `(` LexicalDeclaration Expression `;` Expression `)` Statement
-      </emu-grammar>
-      <p>so, in this example, the nonterminal |ForStatement| actually has four alternative right-hand sides.</p>
-      <p>A production may be parameterized by a subscripted annotation of the form &ldquo;<sub>[parameters]</sub>&rdquo;, which may appear as a suffix to the nonterminal symbol defined by the production. &ldquo;<sub>parameters</sub>&rdquo; may be either a single name or a comma separated list of names. A parameterized production is shorthand for a set of productions defining all combinations of the parameter names, preceded by an underscore, appended to the parameterized nonterminal symbol. This means that:</p>
-      <emu-grammar type="definition" example>
-        StatementList[Return] :
-          ReturnStatement
-          ExpressionStatement
-      </emu-grammar>
-      <p>is a convenient abbreviation for:</p>
-      <emu-grammar type="definition" example>
-        StatementList :
-          ReturnStatement
-          ExpressionStatement
 
-        StatementList_Return :
-          ReturnStatement
-          ExpressionStatement
-      </emu-grammar>
-      <p>and that:</p>
-      <emu-grammar type="definition" example>
-        StatementList[Return, In] :
-          ReturnStatement
-          ExpressionStatement
-      </emu-grammar>
-      <p>is an abbreviation for:</p>
-      <emu-grammar type="definition" example>
-        StatementList :
-          ReturnStatement
-          ExpressionStatement
+      <emu-clause id="sec-terminal-symbols">
+        <h1>Terminal Symbols</h1>
+        <p>In the ECMAScript grammars, some terminal symbols are shown in `fixed-width` font. These are to appear in a source text exactly as written. All terminal symbol code points specified in this way are to be understood as the appropriate Unicode code points from the Basic Latin block, as opposed to any similar-looking code points from other Unicode ranges. A code point in a terminal symbol cannot be expressed by a `\\` |UnicodeEscapeSequence|.</p>
+        <p>In grammars whose terminal symbols are individual Unicode code points (i.e., the lexical, RegExp, and numeric string grammars), a contiguous run of multiple fixed-width code points appearing in a production is a simple shorthand for the same sequence of code points, written as standalone terminal symbols.</p>
+        <p>For example, the production:</p>
+        <emu-grammar type="definition" example>
+          HexIntegerLiteral :: `0x` HexDigits
+        </emu-grammar>
+        <p>is a shorthand for:</p>
+        <emu-grammar type="example">
+          HexIntegerLiteral :: `0` `x` HexDigits
+        </emu-grammar>
+        <p>In contrast, in the syntactic grammar, a contiguous run of fixed-width code points is a single terminal symbol.</p>
+        <p>Terminal symbols come in two other forms:</p>
+        <ul>
+          <li>In the lexical and RegExp grammars, Unicode code points without a conventional printed representation are instead shown in the form "&lt;ABBREV&gt;" where "ABBREV" is a mnemonic for the code point. These forms are defined in <emu-xref href="#sec-unicode-format-control-characters" title></emu-xref> and <emu-xref href="#sec-white-space" title></emu-xref>.</li>
+          <li>In the syntactic grammar, certain terminal symbols (e.g. |IdentifierName| and |RegularExpressionLiteral|) are shown in italics, as they refer to the nonterminals of the same name in the lexical grammar.</li>
+        </ul>
+      </emu-clause>
 
-        StatementList_Return :
-          ReturnStatement
-          ExpressionStatement
+      <emu-clause id="sec-nonterminal-symbols-and-productions">
+        <h1>Nonterminal Symbols and Productions</h1>
+        <p>Nonterminal symbols are shown in <i>italic</i> type. The definition of a nonterminal (also called a &ldquo;production&rdquo;) is introduced by the name of the nonterminal being defined followed by one or more colons. (The number of colons indicates to which grammar the production belongs.) One or more alternative right-hand sides for the nonterminal then follow on succeeding lines. For example, the syntactic definition:</p>
+        <emu-grammar type="definition" example>
+          WhileStatement :
+            `while` `(` Expression `)` Statement
+        </emu-grammar>
+        <p>states that the nonterminal |WhileStatement| represents the token `while`, followed by a left parenthesis token, followed by an |Expression|, followed by a right parenthesis token, followed by a |Statement|. The occurrences of |Expression| and |Statement| are themselves nonterminals. As another example, the syntactic definition:</p>
+        <emu-grammar type="definition" example>
+          ArgumentList :
+            AssignmentExpression
+            ArgumentList `,` AssignmentExpression
+        </emu-grammar>
+        <p>states that an |ArgumentList| may represent either a single |AssignmentExpression| or an |ArgumentList|, followed by a comma, followed by an |AssignmentExpression|. This definition of |ArgumentList| is recursive, that is, it is defined in terms of itself. The result is that an |ArgumentList| may contain any positive number of arguments, separated by commas, where each argument expression is an |AssignmentExpression|. Such recursive definitions of nonterminals are common.</p>
+      </emu-clause>
 
-        StatementList_In :
-          ReturnStatement
-          ExpressionStatement
+      <emu-clause id="sec-optional-symbols">
+        <h1>Optional Symbols</h1>
+        <p>The subscripted suffix &ldquo;<sub>opt</sub>&rdquo;, which may appear after a terminal or nonterminal, indicates an optional symbol. The alternative containing the optional symbol actually specifies two right-hand sides, one that omits the optional element and one that includes it. This means that:</p>
+        <emu-grammar type="definition" example>
+          VariableDeclaration :
+            BindingIdentifier Initializer?
+        </emu-grammar>
+        <p>is a convenient abbreviation for:</p>
+        <emu-grammar type="definition" example>
+          VariableDeclaration :
+            BindingIdentifier
+            BindingIdentifier Initializer
+        </emu-grammar>
+        <p>and that:</p>
+        <emu-grammar type="definition" example>
+          ForStatement :
+            `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement
+        </emu-grammar>
+        <p>is a convenient abbreviation for:</p>
+        <emu-grammar type="definition" example>
+          ForStatement :
+            `for` `(` LexicalDeclaration `;` Expression? `)` Statement
+            `for` `(` LexicalDeclaration Expression `;` Expression? `)` Statement
+        </emu-grammar>
+        <p>which in turn is an abbreviation for:</p>
+        <emu-grammar type="definition" example>
+          ForStatement :
+            `for` `(` LexicalDeclaration `;` `)` Statement
+            `for` `(` LexicalDeclaration `;` Expression `)` Statement
+            `for` `(` LexicalDeclaration Expression `;` `)` Statement
+            `for` `(` LexicalDeclaration Expression `;` Expression `)` Statement
+        </emu-grammar>
+        <p>so, in this example, the nonterminal |ForStatement| actually has four alternative right-hand sides.</p>
+      </emu-clause>
 
-        StatementList_Return_In :
-          ReturnStatement
-          ExpressionStatement
-      </emu-grammar>
-      <p>Multiple parameters produce a combinatory number of productions, not all of which are necessarily referenced in a complete grammar.</p>
-      <p>References to nonterminals on the right-hand side of a production can also be parameterized. For example:</p>
-      <emu-grammar type="definition" example>
-        StatementList :
-          ReturnStatement
-          ExpressionStatement[+In]
-      </emu-grammar>
-      <p>is equivalent to saying:</p>
-      <emu-grammar type="definition" example>
-        StatementList :
-          ReturnStatement
-          ExpressionStatement_In
-      </emu-grammar>
-      <p>and:</p>
-      <emu-grammar type="definition" example>
-        StatementList :
-          ReturnStatement
-          ExpressionStatement[~In]
-      </emu-grammar>
-      <p>is equivalent to:</p>
-      <emu-grammar type="definition" example>
-        StatementList :
-          ReturnStatement
-          ExpressionStatement
-      </emu-grammar>
-      <p>A nonterminal reference may have both a parameter list and an &ldquo;<sub>opt</sub>&rdquo; suffix. For example:</p>
-      <emu-grammar type="definition" example>
-        VariableDeclaration :
-          BindingIdentifier Initializer[+In]?
-      </emu-grammar>
-      <p>is an abbreviation for:</p>
-      <emu-grammar type="definition" example>
-        VariableDeclaration :
-          BindingIdentifier
-          BindingIdentifier Initializer_In
-      </emu-grammar>
-      <p>Prefixing a parameter name with &ldquo;<sub>?</sub>&rdquo; on a right-hand side nonterminal reference makes that parameter value dependent upon the occurrence of the parameter name on the reference to the current production's left-hand side symbol. For example:</p>
-      <emu-grammar type="definition" example>
-        VariableDeclaration[In] :
-          BindingIdentifier Initializer[?In]
-      </emu-grammar>
-      <p>is an abbreviation for:</p>
-      <emu-grammar type="definition" example>
-        VariableDeclaration :
-          BindingIdentifier Initializer
+      <emu-clause id="sec-grammatical-parameters">
+        <h1>Grammatical Parameters</h1>
+        <p>A production may be parameterized by a subscripted annotation of the form &ldquo;<sub>[parameters]</sub>&rdquo;, which may appear as a suffix to the nonterminal symbol defined by the production. &ldquo;<sub>parameters</sub>&rdquo; may be either a single name or a comma separated list of names. A parameterized production is shorthand for a set of productions defining all combinations of the parameter names, preceded by an underscore, appended to the parameterized nonterminal symbol. This means that:</p>
+        <emu-grammar type="definition" example>
+          StatementList[Return] :
+            ReturnStatement
+            ExpressionStatement
+        </emu-grammar>
+        <p>is a convenient abbreviation for:</p>
+        <emu-grammar type="definition" example>
+          StatementList :
+            ReturnStatement
+            ExpressionStatement
 
-        VariableDeclaration_In :
-          BindingIdentifier Initializer_In
-      </emu-grammar>
-      <p>If a right-hand side alternative is prefixed with &ldquo;[+parameter]&rdquo; that alternative is only available if the named parameter was used in referencing the production's nonterminal symbol. If a right-hand side alternative is prefixed with &ldquo;[\~parameter]&rdquo; that alternative is only available if the named parameter was <em>not</em> used in referencing the production's nonterminal symbol. This means that:</p>
-      <emu-grammar type="definition" example>
-        StatementList[Return] :
-          [+Return] ReturnStatement
-          ExpressionStatement
-      </emu-grammar>
-      <p>is an abbreviation for:</p>
-      <emu-grammar type="definition" example>
-        StatementList :
-          ExpressionStatement
+          StatementList_Return :
+            ReturnStatement
+            ExpressionStatement
+        </emu-grammar>
+        <p>and that:</p>
+        <emu-grammar type="definition" example>
+          StatementList[Return, In] :
+            ReturnStatement
+            ExpressionStatement
+        </emu-grammar>
+        <p>is an abbreviation for:</p>
+        <emu-grammar type="definition" example>
+          StatementList :
+            ReturnStatement
+            ExpressionStatement
 
-        StatementList_Return :
-          ReturnStatement
-          ExpressionStatement
-      </emu-grammar>
-      <p>and that:</p>
-      <emu-grammar type="definition" example>
-        StatementList[Return] :
-          [~Return] ReturnStatement
-          ExpressionStatement
-      </emu-grammar>
-      <p>is an abbreviation for:</p>
-      <emu-grammar type="definition" example>
-        StatementList :
-          ReturnStatement
-          ExpressionStatement
+          StatementList_Return :
+            ReturnStatement
+            ExpressionStatement
 
-        StatementList_Return :
-          ExpressionStatement
-      </emu-grammar>
-      <p>When the words &ldquo;<b>one of</b>&rdquo; follow the colon(s) in a grammar definition, they signify that each of the terminal symbols on the following line or lines is an alternative definition. For example, the lexical grammar for ECMAScript contains the production:</p>
-      <emu-grammar type="definition" example>
-        NonZeroDigit :: one of
-          `1` `2` `3` `4` `5` `6` `7` `8` `9`
-      </emu-grammar>
-      <p>which is merely a convenient abbreviation for:</p>
-      <emu-grammar type="definition" example>
-        NonZeroDigit ::
-          `1`
-          `2`
-          `3`
-          `4`
-          `5`
-          `6`
-          `7`
-          `8`
-          `9`
-      </emu-grammar>
-      <p>If the phrase &ldquo;[empty]&rdquo; appears as the right-hand side of a production, it indicates that the production's right-hand side contains no terminals or nonterminals.</p>
-      <p>If the phrase &ldquo;[lookahead = _seq_]&rdquo; appears in the right-hand side of a production, it indicates that the production may only be used if the token sequence _seq_ is a prefix of the immediately following input token sequence. Similarly, &ldquo;[lookahead &isin; _set_]&rdquo;, where _set_ is a finite non-empty set of token sequences, indicates that the production may only be used if some element of _set_ is a prefix of the immediately following token sequence. For convenience, the set can also be written as a nonterminal, in which case it represents the set of all token sequences to which that nonterminal could expand. It is considered an editorial error if the nonterminal could expand to infinitely many distinct token sequences.</p>
-      <p>These conditions may be negated. &ldquo;[lookahead &ne; _seq_]&rdquo; indicates that the containing production may only be used if _seq_ is <em>not</em> a prefix of the immediately following input token sequence, and &ldquo;[lookahead &notin; _set_]&rdquo; indicates that the production may only be used if <em>no</em> element of _set_ is a prefix of the immediately following token sequence.</p>
-      <p>As an example, given the definitions:</p>
-      <emu-grammar type="definition" example>
-        DecimalDigit :: one of
-          `0` `1` `2` `3` `4` `5` `6` `7` `8` `9`
+          StatementList_In :
+            ReturnStatement
+            ExpressionStatement
 
-        DecimalDigits ::
-          DecimalDigit
-          DecimalDigits DecimalDigit
-      </emu-grammar>
-      <p>the definition:</p>
-      <emu-grammar type="definition" example>
-        LookaheadExample ::
-          `n` [lookahead &notin; { `1`, `3`, `5`, `7`, `9` }] DecimalDigits
-          DecimalDigit [lookahead &notin; DecimalDigit]
-      </emu-grammar>
-      <p>matches either the letter `n` followed by one or more decimal digits the first of which is even, or a decimal digit not followed by another decimal digit.</p>
-      <p>Note that when these phrases are used in the syntactic grammar, it may not be possible to unambiguously identify the immediately following token sequence because determining later tokens requires knowing which lexical goal symbol to use at later positions. As such, when these are used in the syntactic grammar, it is considered an editorial error for a token sequence _seq_ to appear in a lookahead restriction (including as part of a set of sequences) if the choices of lexical goal symbols to use could change whether or not _seq_ would be a prefix of the resulting token sequence.</p>
-      <p>If the phrase &ldquo;[no |LineTerminator| here]&rdquo; appears in the right-hand side of a production of the syntactic grammar, it indicates that the production is <em>a restricted production</em>: it may not be used if a |LineTerminator| occurs in the input stream at the indicated position. For example, the production:</p>
-      <emu-grammar type="definition" example>
-        ThrowStatement :
-          `throw` [no LineTerminator here] Expression `;`
-      </emu-grammar>
-      <p>indicates that the production may not be used if a |LineTerminator| occurs in the script between the `throw` token and the |Expression|.</p>
-      <p>Unless the presence of a |LineTerminator| is forbidden by a restricted production, any number of occurrences of |LineTerminator| may appear between any two consecutive tokens in the stream of input elements without affecting the syntactic acceptability of the script.</p>
-      <p>The right-hand side of a production may specify that certain expansions are not permitted by using the phrase &ldquo;<b>but not</b>&rdquo; and then indicating the expansions to be excluded. For example, the production:</p>
-      <emu-grammar type="definition" example>
-        Identifier ::
-          IdentifierName but not ReservedWord
-      </emu-grammar>
-      <p>means that the nonterminal |Identifier| may be replaced by any sequence of code points that could replace |IdentifierName| provided that the same sequence of code points could not replace |ReservedWord|.</p>
-      <p>Finally, a few nonterminal symbols are described by a descriptive phrase in sans-serif type in cases where it would be impractical to list all the alternatives:</p>
-      <emu-grammar type="definition" example>
-        SourceCharacter ::
-          &gt; any Unicode code point
-      </emu-grammar>
+          StatementList_Return_In :
+            ReturnStatement
+            ExpressionStatement
+        </emu-grammar>
+        <p>Multiple parameters produce a combinatory number of productions, not all of which are necessarily referenced in a complete grammar.</p>
+        <p>References to nonterminals on the right-hand side of a production can also be parameterized. For example:</p>
+        <emu-grammar type="definition" example>
+          StatementList :
+            ReturnStatement
+            ExpressionStatement[+In]
+        </emu-grammar>
+        <p>is equivalent to saying:</p>
+        <emu-grammar type="definition" example>
+          StatementList :
+            ReturnStatement
+            ExpressionStatement_In
+        </emu-grammar>
+        <p>and:</p>
+        <emu-grammar type="definition" example>
+          StatementList :
+            ReturnStatement
+            ExpressionStatement[~In]
+        </emu-grammar>
+        <p>is equivalent to:</p>
+        <emu-grammar type="definition" example>
+          StatementList :
+            ReturnStatement
+            ExpressionStatement
+        </emu-grammar>
+        <p>A nonterminal reference may have both a parameter list and an &ldquo;<sub>opt</sub>&rdquo; suffix. For example:</p>
+        <emu-grammar type="definition" example>
+          VariableDeclaration :
+            BindingIdentifier Initializer[+In]?
+        </emu-grammar>
+        <p>is an abbreviation for:</p>
+        <emu-grammar type="definition" example>
+          VariableDeclaration :
+            BindingIdentifier
+            BindingIdentifier Initializer_In
+        </emu-grammar>
+        <p>Prefixing a parameter name with &ldquo;<sub>?</sub>&rdquo; on a right-hand side nonterminal reference makes that parameter value dependent upon the occurrence of the parameter name on the reference to the current production's left-hand side symbol. For example:</p>
+        <emu-grammar type="definition" example>
+          VariableDeclaration[In] :
+            BindingIdentifier Initializer[?In]
+        </emu-grammar>
+        <p>is an abbreviation for:</p>
+        <emu-grammar type="definition" example>
+          VariableDeclaration :
+            BindingIdentifier Initializer
+
+          VariableDeclaration_In :
+            BindingIdentifier Initializer_In
+        </emu-grammar>
+        <p>If a right-hand side alternative is prefixed with &ldquo;[+parameter]&rdquo; that alternative is only available if the named parameter was used in referencing the production's nonterminal symbol. If a right-hand side alternative is prefixed with &ldquo;[\~parameter]&rdquo; that alternative is only available if the named parameter was <em>not</em> used in referencing the production's nonterminal symbol. This means that:</p>
+        <emu-grammar type="definition" example>
+          StatementList[Return] :
+            [+Return] ReturnStatement
+            ExpressionStatement
+        </emu-grammar>
+        <p>is an abbreviation for:</p>
+        <emu-grammar type="definition" example>
+          StatementList :
+            ExpressionStatement
+
+          StatementList_Return :
+            ReturnStatement
+            ExpressionStatement
+        </emu-grammar>
+        <p>and that:</p>
+        <emu-grammar type="definition" example>
+          StatementList[Return] :
+            [~Return] ReturnStatement
+            ExpressionStatement
+        </emu-grammar>
+        <p>is an abbreviation for:</p>
+        <emu-grammar type="definition" example>
+          StatementList :
+            ReturnStatement
+            ExpressionStatement
+
+          StatementList_Return :
+            ExpressionStatement
+        </emu-grammar>
+      </emu-clause>
+
+      <emu-clause id="sec-one-of">
+        <h1>one of</h1>
+        <p>When the words &ldquo;<b>one of</b>&rdquo; follow the colon(s) in a grammar definition, they signify that each of the terminal symbols on the following line or lines is an alternative definition. For example, the lexical grammar for ECMAScript contains the production:</p>
+        <emu-grammar type="definition" example>
+          NonZeroDigit :: one of
+            `1` `2` `3` `4` `5` `6` `7` `8` `9`
+        </emu-grammar>
+        <p>which is merely a convenient abbreviation for:</p>
+        <emu-grammar type="definition" example>
+          NonZeroDigit ::
+            `1`
+            `2`
+            `3`
+            `4`
+            `5`
+            `6`
+            `7`
+            `8`
+            `9`
+        </emu-grammar>
+      </emu-clause>
+
+      <emu-clause id="sec-empty">
+        <h1>[empty]</h1>
+        <p>If the phrase &ldquo;[empty]&rdquo; appears as the right-hand side of a production, it indicates that the production's right-hand side contains no terminals or nonterminals.</p>
+      </emu-clause>
+
+      <emu-clause id="sec-lookahead-restrictions">
+        <h1>Lookahead Restrictions</h1>
+        <p>If the phrase &ldquo;[lookahead = _seq_]&rdquo; appears in the right-hand side of a production, it indicates that the production may only be used if the token sequence _seq_ is a prefix of the immediately following input token sequence. Similarly, &ldquo;[lookahead &isin; _set_]&rdquo;, where _set_ is a finite non-empty set of token sequences, indicates that the production may only be used if some element of _set_ is a prefix of the immediately following token sequence. For convenience, the set can also be written as a nonterminal, in which case it represents the set of all token sequences to which that nonterminal could expand. It is considered an editorial error if the nonterminal could expand to infinitely many distinct token sequences.</p>
+        <p>These conditions may be negated. &ldquo;[lookahead &ne; _seq_]&rdquo; indicates that the containing production may only be used if _seq_ is <em>not</em> a prefix of the immediately following input token sequence, and &ldquo;[lookahead &notin; _set_]&rdquo; indicates that the production may only be used if <em>no</em> element of _set_ is a prefix of the immediately following token sequence.</p>
+        <p>As an example, given the definitions:</p>
+        <emu-grammar type="definition" example>
+          DecimalDigit :: one of
+            `0` `1` `2` `3` `4` `5` `6` `7` `8` `9`
+
+          DecimalDigits ::
+            DecimalDigit
+            DecimalDigits DecimalDigit
+        </emu-grammar>
+        <p>the definition:</p>
+        <emu-grammar type="definition" example>
+          LookaheadExample ::
+            `n` [lookahead &notin; { `1`, `3`, `5`, `7`, `9` }] DecimalDigits
+            DecimalDigit [lookahead &notin; DecimalDigit]
+        </emu-grammar>
+        <p>matches either the letter `n` followed by one or more decimal digits the first of which is even, or a decimal digit not followed by another decimal digit.</p>
+        <p>Note that when these phrases are used in the syntactic grammar, it may not be possible to unambiguously identify the immediately following token sequence because determining later tokens requires knowing which lexical goal symbol to use at later positions. As such, when these are used in the syntactic grammar, it is considered an editorial error for a token sequence _seq_ to appear in a lookahead restriction (including as part of a set of sequences) if the choices of lexical goal symbols to use could change whether or not _seq_ would be a prefix of the resulting token sequence.</p>
+      </emu-clause>
+
+      <emu-clause id="sec-no-lineterminator-here">
+        <h1>[no |LineTerminator| here]</h1>
+        <p>If the phrase &ldquo;[no |LineTerminator| here]&rdquo; appears in the right-hand side of a production of the syntactic grammar, it indicates that the production is <em>a restricted production</em>: it may not be used if a |LineTerminator| occurs in the input stream at the indicated position. For example, the production:</p>
+        <emu-grammar type="definition" example>
+          ThrowStatement :
+            `throw` [no LineTerminator here] Expression `;`
+        </emu-grammar>
+        <p>indicates that the production may not be used if a |LineTerminator| occurs in the script between the `throw` token and the |Expression|.</p>
+        <p>Unless the presence of a |LineTerminator| is forbidden by a restricted production, any number of occurrences of |LineTerminator| may appear between any two consecutive tokens in the stream of input elements without affecting the syntactic acceptability of the script.</p>
+      </emu-clause>
+
+      <emu-clause id="sec-but-not">
+        <h1>but not</h1>
+        <p>The right-hand side of a production may specify that certain expansions are not permitted by using the phrase &ldquo;<b>but not</b>&rdquo; and then indicating the expansions to be excluded. For example, the production:</p>
+        <emu-grammar type="definition" example>
+          Identifier ::
+            IdentifierName but not ReservedWord
+        </emu-grammar>
+        <p>means that the nonterminal |Identifier| may be replaced by any sequence of code points that could replace |IdentifierName| provided that the same sequence of code points could not replace |ReservedWord|.</p>
+      </emu-clause>
+
+      <emu-clause id="sec-descriptive-phrases">
+        <h1>Descriptive Phrases</h1>
+        <p>Finally, a few nonterminal symbols are described by a descriptive phrase in sans-serif type in cases where it would be impractical to list all the alternatives:</p>
+        <emu-grammar type="definition" example>
+          SourceCharacter ::
+            &gt; any Unicode code point
+        </emu-grammar>
+      </emu-clause>
     </emu-clause>
   </emu-clause>
 


### PR DESCRIPTION
[5.1.5 Grammar Notation](https://tc39.es/ecma262/#sec-grammar-notation) is a long section that covers lots of subtopics with no aids to navigation. This PR breaks it up into subsections, which I think makes it more digestible, and provides more precise anchors for links.

(The bulk of the diff is caused by having to indent the existing text of the section. I recommend viewing the diff with "Hide whitespace" checked.)