### PR TITLE
Editorial: Minimize use of the term "callable"

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -4693,12 +4693,12 @@
           1. Let _hasGet_ be ? HasProperty(_obj_, *"get"*).
           1. If _hasGet_ is *true*, then
             1. Let _getter_ be ? Get(_obj_, *"get"*).
-            1. If IsCallable(_getter_) is *false* and _getter_ is not *undefined*, throw a *TypeError* exception.
+            1. If IsFunction(_getter_) is *false* and _getter_ is not *undefined*, throw a *TypeError* exception.
             1. Set _desc_.[[Get]] to _getter_.
           1. Let _hasSet_ be ? HasProperty(_obj_, *"set"*).
           1. If _hasSet_ is *true*, then
             1. Let _setter_ be ? Get(_obj_, *"set"*).
-            1. If IsCallable(_setter_) is *false* and _setter_ is not *undefined*, throw a *TypeError* exception.
+            1. If IsFunction(_setter_) is *false* and _setter_ is not *undefined*, throw a *TypeError* exception.
             1. Set _desc_.[[Set]] to _setter_.
           1. If _desc_ has a [[Get]] field or _desc_ has a [[Set]] field, then
             1. If _desc_ has a [[Value]] field or _desc_ has a [[Writable]] field, throw a *TypeError* exception.
@@ -5077,7 +5077,7 @@
             1. Let _methodNames_ be « *"valueOf"*, *"toString"* ».
           1. For each element _name_ of _methodNames_, do
             1. Let _method_ be ? Get(_obj_, _name_).
-            1. If IsCallable(_method_) is *true*, then
+            1. If IsFunction(_method_) is *true*, then
               1. Let _result_ be ? Call(_method_, _obj_).
               1. If _result_ is not an Object, return _result_.
           1. Throw a *TypeError* exception.
@@ -5823,15 +5823,15 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-iscallable" type="abstract operation">
+    <emu-clause id="sec-isfunction" type="abstract operation" oldids="sec-iscallable">
       <h1>
-        IsCallable (
+        IsFunction (
           _argument_: an ECMAScript language value,
         ): a Boolean
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It determines if _argument_ is a callable function with a [[Call]] internal method.</dd>
+        <dd>It determines if _argument_ is a function (i.e., an Object with a [[Call]] internal method).</dd>
       </dl>
       <emu-alg>
         1. If _argument_ is not an Object, return *false*.
@@ -6333,7 +6333,7 @@
       <emu-alg>
         1. Let _func_ be ? GetV(_value_, _propertyKey_).
         1. If _func_ is either *undefined* or *null*, return *undefined*.
-        1. If IsCallable(_func_) is *false*, throw a *TypeError* exception.
+        1. If IsFunction(_func_) is *false*, throw a *TypeError* exception.
         1. Return _func_.
       </emu-alg>
     </emu-clause>
@@ -6386,7 +6386,7 @@
       </dl>
       <emu-alg>
         1. If _argumentsList_ is not present, set _argumentsList_ to a new empty List.
-        1. If IsCallable(_func_) is *false*, throw a *TypeError* exception.
+        1. If IsFunction(_func_) is *false*, throw a *TypeError* exception.
         1. Return ? <emu-meta effects="user-code">_func_.[[Call]](_thisValue_, _argumentsList_)</emu-meta>.
       </emu-alg>
     </emu-clause>
@@ -6572,7 +6572,7 @@
         <dd>It implements the default algorithm for determining if _instance_ inherits from the instance object inheritance path provided by _constructor_.</dd>
       </dl>
       <emu-alg>
-        1. If IsCallable(_constructor_) is *false*, return *false*.
+        1. If IsFunction(_constructor_) is *false*, return *false*.
         1. If _constructor_ has a [[BoundTargetFunction]] internal slot, then
           1. Let _boundConstructor_ be _constructor_.[[BoundTargetFunction]].
           1. Return ? InstanceofOperator(_instance_, _boundConstructor_).
@@ -6898,7 +6898,7 @@
       </dl>
       <emu-alg>
         1. Perform ? RequireObjectCoercible(_items_).
-        1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+        1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
         1. Let _groups_ be a new empty List.
         1. Let _iteratorRecord_ be ? GetIterator(_items_, ~sync~).
         1. Let _k_ be 0.
@@ -12141,7 +12141,7 @@
       </emu-note>
       <p>The default implementation of HostCallJobCallback performs the following steps when called:</p>
       <emu-alg>
-        1. Assert: IsCallable(_jobCallback_.[[Callback]]) is *true*.
+        1. Assert: IsFunction(_jobCallback_.[[Callback]]) is *true*.
         1. Return ? Call(_jobCallback_.[[Callback]], _value_, _argumentsList_).
       </emu-alg>
       <p>ECMAScript hosts that are not web browsers must use the default implementation of HostCallJobCallback.</p>
@@ -16160,7 +16160,7 @@
         1. If _handler_ is not an Object, throw a *TypeError* exception.
         1. Let _proxy_ be MakeBasicObject(« [[ProxyHandler]], [[ProxyTarget]] »).
         1. Set _proxy_'s essential internal methods, except for [[Call]] and [[Construct]], to the definitions specified in <emu-xref href="#sec-proxy-object-internal-methods-and-internal-slots"></emu-xref>.
-        1. If IsCallable(_target_) is *true*, then
+        1. If IsFunction(_target_) is *true*, then
           1. Set _proxy_.[[Call]] as specified in <emu-xref href="#sec-proxy-object-internal-methods-and-internal-slots-call-thisargument-argumentslist"></emu-xref>.
           1. If IsConstructor(_target_) is *true*, then
             1. Set _proxy_.[[Construct]] as specified in <emu-xref href="#sec-proxy-object-internal-methods-and-internal-slots-construct-argumentslist-newtarget"></emu-xref>.
@@ -19483,7 +19483,7 @@
             1. Let _thisValue_ be *undefined*.
           1. Let _argList_ be ? ArgumentListEvaluation of _arguments_.
           1. If _func_ is not an Object, throw a *TypeError* exception.
-          1. If IsCallable(_func_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_func_) is *false*, throw a *TypeError* exception.
           1. If _tailPosition_ is *true*, perform PrepareForTailCall().
           1. Return ? Call(_func_, _thisValue_, _argList_).
         </emu-alg>
@@ -20504,7 +20504,7 @@
         1. Let _instOfHandler_ be ? GetMethod(_target_, %Symbol.hasInstance%).
         1. If _instOfHandler_ is not *undefined*, then
           1. Return ToBoolean(? Call(_instOfHandler_, _target_, « _value_ »)).
-        1. [id="step-instanceof-check-function"] If IsCallable(_target_) is *false*, throw a *TypeError* exception.
+        1. [id="step-instanceof-check-function"] If IsFunction(_target_) is *false*, throw a *TypeError* exception.
         1. [id="step-instanceof-fallback"] Return ? OrdinaryHasInstance(_target_, _value_).
       </emu-alg>
       <emu-note>
@@ -31040,7 +31040,7 @@
           <p>This method performs the following steps when called:</p>
           <emu-alg>
             1. Let _obj_ be ? ToObject(*this* value).
-            1. If IsCallable(_getter_) is *false*, throw a *TypeError* exception.
+            1. If IsFunction(_getter_) is *false*, throw a *TypeError* exception.
             1. Let _desc_ be PropertyDescriptor { [[Get]]: _getter_, [[Enumerable]]: *true*, [[Configurable]]: *true* }.
             1. Let _key_ be ? ToPropertyKey(_propertyKey_).
             1. Perform ? DefinePropertyOrThrow(_obj_, _key_, _desc_).
@@ -31053,7 +31053,7 @@
           <p>This method performs the following steps when called:</p>
           <emu-alg>
             1. Let _obj_ be ? ToObject(*this* value).
-            1. If IsCallable(_setter_) is *false*, throw a *TypeError* exception.
+            1. If IsFunction(_setter_) is *false*, throw a *TypeError* exception.
             1. Let _desc_ be PropertyDescriptor { [[Set]]: _setter_, [[Enumerable]]: *true*, [[Configurable]]: *true* }.
             1. Let _key_ be ? ToPropertyKey(_propertyKey_).
             1. Perform ? DefinePropertyOrThrow(_obj_, _key_, _desc_).
@@ -31261,7 +31261,7 @@
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _func_ be the *this* value.
-          1. If IsCallable(_func_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_func_) is *false*, throw a *TypeError* exception.
           1. If _argArray_ is either *undefined* or *null*, then
             1. Perform PrepareForTailCall().
             1. Return ? Call(_func_, _thisArg_).
@@ -31282,7 +31282,7 @@
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _target_ be the *this* value.
-          1. If IsCallable(_target_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_target_) is *false*, throw a *TypeError* exception.
           1. Let _boundFunc_ be ? BoundFunctionCreate(_target_, _thisArg_, _args_).
           1. Let _length_ be 0.
           1. Let _targetHasLength_ be ? HasOwnProperty(_target_, *"length"*).
@@ -31317,7 +31317,7 @@
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _func_ be the *this* value.
-          1. If IsCallable(_func_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_func_) is *false*, throw a *TypeError* exception.
           1. Perform PrepareForTailCall().
           1. [id="step-function-proto-call-call"] Return ? Call(_func_, _thisArg_, _args_).
         </emu-alg>
@@ -31342,7 +31342,7 @@
           1. If _func_ is an Object, _func_ has a [[SourceText]] internal slot, _func_.[[SourceText]] is a sequence of Unicode code points, and HostHasSourceTextAvailable(_func_) is *true*, then
             1. Return CodePointsToString(_func_.[[SourceText]]).
           1. If _func_ is a <emu-xref href="#sec-built-in-function-objects">built-in function object</emu-xref>, return an implementation-defined String source code representation of _func_. The representation must have the syntax of a |NativeFunction|. Additionally, if _func_ has an [[InitialName]] internal slot and _func_.[[InitialName]] is a String, the portion of the returned String that would be matched by |NativeFunctionAccessor?| |PropertyName| must be _func_.[[InitialName]].
-          1. If _func_ is an Object and IsCallable(_func_) is *true*, return an implementation-defined String source code representation of _func_. The representation must have the syntax of a |NativeFunction|.
+          1. If _func_ is an Object and IsFunction(_func_) is *true*, return an implementation-defined String source code representation of _func_. The representation must have the syntax of a |NativeFunction|.
           1. Throw a *TypeError* exception.
         </emu-alg>
 
@@ -35952,7 +35952,7 @@ THH:mm:ss.sss
               1. Return ? Call(_replacer_, _searchValue_, « _thisValue_, _replaceValue_ »).
           1. Let _string_ be ? ToString(_thisValue_).
           1. Let _searchString_ be ? ToString(_searchValue_).
-          1. Let _functionalReplace_ be IsCallable(_replaceValue_).
+          1. Let _functionalReplace_ be IsFunction(_replaceValue_).
           1. If _functionalReplace_ is *false*, then
             1. Set _replaceValue_ to ? ToString(_replaceValue_).
           1. Let _searchLength_ be the length of _searchString_.
@@ -36071,7 +36071,7 @@ THH:mm:ss.sss
               1. Return ? Call(_replacer_, _searchValue_, « _thisValue_, _replaceValue_ »).
           1. Let _string_ be ? ToString(_thisValue_).
           1. Let _searchString_ be ? ToString(_searchValue_).
-          1. Let _functionalReplace_ be IsCallable(_replaceValue_).
+          1. Let _functionalReplace_ be IsFunction(_replaceValue_).
           1. If _functionalReplace_ is *false*, then
             1. Set _replaceValue_ to ? ToString(_replaceValue_).
           1. Let _searchLength_ be the length of _searchString_.
@@ -39109,7 +39109,7 @@ THH:mm:ss.sss
           1. If _regexp_ is not an Object, throw a *TypeError* exception.
           1. Let _str_ be ? ToString(_string_).
           1. Let _lengthS_ be the length of _str_.
-          1. Let _functionalReplace_ be IsCallable(_replaceValue_).
+          1. Let _functionalReplace_ be IsFunction(_replaceValue_).
           1. If _functionalReplace_ is *false*, then
             1. Set _replaceValue_ to ? ToString(_replaceValue_).
           1. Let _flags_ be ? ToString(? Get(_regexp_, *"flags"*)).
@@ -39382,7 +39382,7 @@ THH:mm:ss.sss
         </dl>
         <emu-alg>
           1. Let _exec_ be ? Get(_regexp_, *"exec"*).
-          1. If IsCallable(_exec_) is *true*, then
+          1. If IsFunction(_exec_) is *true*, then
             1. Let _result_ be ? Call(_exec_, _regexp_, « _str_ »).
             1. If _result_ is not an Object and _result_ is not *null*, throw a *TypeError* exception.
             1. Return _result_.
@@ -39828,7 +39828,7 @@ THH:mm:ss.sss
           1. If _mapper_ is *undefined*, then
             1. Let _mapping_ be *false*.
           1. Else,
-            1. If IsCallable(_mapper_) is *false*, throw a *TypeError* exception.
+            1. If IsFunction(_mapper_) is *false*, throw a *TypeError* exception.
             1. Let _mapping_ be *true*.
           1. Let _usingIterator_ be ? GetMethod(_items_, %Symbol.iterator%).
           1. If _usingIterator_ is not *undefined*, then
@@ -39888,7 +39888,7 @@ THH:mm:ss.sss
           1. Let _constructor_ be the *this* value.
           1. Let _mapping_ be *false*.
           1. If _mapper_ is not *undefined*, then
-            1. If IsCallable(_mapper_) is *false*, throw a *TypeError* exception.
+            1. If IsFunction(_mapper_) is *false*, throw a *TypeError* exception.
             1. Set _mapping_ to *true*.
           1. Let _iteratorRecord_ be *undefined*.
           1. Let _usingAsyncIterator_ be ? GetMethod(_items_, %Symbol.asyncIterator%).
@@ -40169,7 +40169,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _obj_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_obj_).
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_,
             1. Let _propertyKey_ be ! ToString(𝔽(_k_)).
@@ -40231,7 +40231,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _obj_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_obj_).
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. Let _array_ be ? ArraySpeciesCreate(_obj_, 0).
           1. Let _k_ be 0.
           1. Let _to_ be 0.
@@ -40344,7 +40344,7 @@ THH:mm:ss.sss
             </dd>
           </dl>
           <emu-alg>
-            1. If IsCallable(_predicate_) is *false*, throw a *TypeError* exception.
+            1. If IsFunction(_predicate_) is *false*, throw a *TypeError* exception.
             1. If _direction_ is ~ascending~, then
               1. Let _indices_ be a List of the integers in the interval from 0 (inclusive) to _len_ (exclusive), in ascending order.
             1. Else,
@@ -40390,7 +40390,7 @@ THH:mm:ss.sss
           <dl class="header">
           </dl>
           <emu-alg>
-            1. Assert: If _mapperFunction_ is present, then IsCallable(_mapperFunction_) is *true*, _thisArg_ is present, and _depth_ is 1.
+            1. Assert: If _mapperFunction_ is present, then IsFunction(_mapperFunction_) is *true*, _thisArg_ is present, and _depth_ is 1.
             1. Let _targetIndex_ be _start_.
             1. Let _sourceIndex_ be *+0*<sub>𝔽</sub>.
             1. Repeat, while ℝ(_sourceIndex_) &lt; _sourceLen_,
@@ -40424,7 +40424,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _obj_ be ? ToObject(*this* value).
           1. Let _sourceLen_ be ? LengthOfArrayLike(_obj_).
-          1. If IsCallable(_mapperFunction_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_mapperFunction_) is *false*, throw a *TypeError* exception.
           1. Let _array_ be ? ArraySpeciesCreate(_obj_, 0).
           1. Perform ? FlattenIntoArray(_array_, _obj_, _sourceLen_, 0, 1, _mapperFunction_, _thisArg_).
           1. Return _array_.
@@ -40444,7 +40444,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _obj_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_obj_).
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_,
             1. Let _propertyKey_ be ! ToString(𝔽(_k_)).
@@ -40606,7 +40606,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _obj_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_obj_).
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. Let _array_ be ? ArraySpeciesCreate(_obj_, _len_).
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_,
@@ -40684,7 +40684,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _obj_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_obj_).
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. If _len_ = 0 and _initialValue_ is not present, throw a *TypeError* exception.
           1. Let _k_ be 0.
           1. Let _accumulator_ be *undefined*.
@@ -40725,7 +40725,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _obj_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_obj_).
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. If _len_ = 0 and _initialValue_ is not present, throw a *TypeError* exception.
           1. Let _k_ be _len_ - 1.
           1. Let _accumulator_ be *undefined*.
@@ -40877,7 +40877,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _obj_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_obj_).
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_,
             1. Let _propertyKey_ be ! ToString(𝔽(_k_)).
@@ -40899,7 +40899,7 @@ THH:mm:ss.sss
         <p>This method sorts the elements of this array. If _comparator_ is not *undefined*, it should be a function that accepts two arguments _x_ and _y_ and returns a negative Number if _x_ &lt; _y_, a positive Number if _x_ > _y_, or a zero otherwise.</p>
         <p>It performs the following steps when called:</p>
         <emu-alg>
-          1. [id="step-array-sort-comparefn"] If _comparator_ is not *undefined* and IsCallable(_comparator_) is *false*, throw a *TypeError* exception.
+          1. [id="step-array-sort-comparefn"] If _comparator_ is not *undefined* and IsFunction(_comparator_) is *false*, throw a *TypeError* exception.
           1. Let _obj_ be ? ToObject(*this* value).
           1. [id="step-array-sort-len"] Let _len_ be ? LengthOfArrayLike(_obj_).
           1. Let _sortCompare_ be a new Abstract Closure with parameters (_x_, _y_) that captures _comparator_ and performs the following steps when called:
@@ -41151,7 +41151,7 @@ THH:mm:ss.sss
         <h1>Array.prototype.toSorted ( _comparator_ )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. If _comparator_ is not *undefined* and IsCallable(_comparator_) is *false*, throw a *TypeError* exception.
+          1. If _comparator_ is not *undefined* and IsFunction(_comparator_) is *false*, throw a *TypeError* exception.
           1. Let _obj_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_obj_).
           1. Let _array_ be ? ArrayCreate(_len_).
@@ -41215,7 +41215,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _array_ be ? ToObject(*this* value).
           1. Let _func_ be ? Get(_array_, *"join"*).
-          1. If IsCallable(_func_) is *false*, set _func_ to the intrinsic function %Object.prototype.toString%.
+          1. If IsFunction(_func_) is *false*, set _func_ to the intrinsic function %Object.prototype.toString%.
           1. Return ? Call(_func_, _array_).
         </emu-alg>
         <emu-note>
@@ -41751,7 +41751,7 @@ THH:mm:ss.sss
           1. If _mapper_ is *undefined*, then
             1. Let _mapping_ be *false*.
           1. Else,
-            1. If IsCallable(_mapper_) is *false*, throw a *TypeError* exception.
+            1. If IsFunction(_mapper_) is *false*, throw a *TypeError* exception.
             1. Let _mapping_ be *true*.
           1. Let _usingIterator_ be ? GetMethod(_source_, %Symbol.iterator%).
           1. If _usingIterator_ is not *undefined*, then
@@ -41965,7 +41965,7 @@ THH:mm:ss.sss
           1. Let _obj_ be the *this* value.
           1. Let _taRecord_ be ? ValidateTypedArray(_obj_, ~seq-cst~).
           1. Let _len_ be TypedArrayLength(_taRecord_).
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_,
             1. Let _propertyKey_ be ! ToString(𝔽(_k_)).
@@ -42017,7 +42017,7 @@ THH:mm:ss.sss
           1. Let _obj_ be the *this* value.
           1. Let _taRecord_ be ? ValidateTypedArray(_obj_, ~seq-cst~).
           1. Let _len_ be TypedArrayLength(_taRecord_).
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. Let _kept_ be a new empty List.
           1. Let _captured_ be 0.
           1. Let _k_ be 0.
@@ -42103,7 +42103,7 @@ THH:mm:ss.sss
           1. Let _obj_ be the *this* value.
           1. Let _taRecord_ be ? ValidateTypedArray(_obj_, ~seq-cst~).
           1. Let _len_ be TypedArrayLength(_taRecord_).
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_,
             1. Let _propertyKey_ be ! ToString(𝔽(_k_)).
@@ -42256,7 +42256,7 @@ THH:mm:ss.sss
           1. Let _obj_ be the *this* value.
           1. Let _taRecord_ be ? ValidateTypedArray(_obj_, ~seq-cst~).
           1. Let _len_ be TypedArrayLength(_taRecord_).
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. Let _resultTypedArray_ be ? TypedArraySpeciesCreate(_obj_, « 𝔽(_len_) »).
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_,
@@ -42278,7 +42278,7 @@ THH:mm:ss.sss
           1. Let _obj_ be the *this* value.
           1. Let _taRecord_ be ? ValidateTypedArray(_obj_, ~seq-cst~).
           1. Let _len_ be TypedArrayLength(_taRecord_).
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. If _len_ = 0 and _initialValue_ is not present, throw a *TypeError* exception.
           1. Let _k_ be 0.
           1. Let _accumulator_ be *undefined*.
@@ -42306,7 +42306,7 @@ THH:mm:ss.sss
           1. Let _obj_ be the *this* value.
           1. Let _taRecord_ be ? ValidateTypedArray(_obj_, ~seq-cst~).
           1. Let _len_ be TypedArrayLength(_taRecord_).
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. If _len_ = 0 and _initialValue_ is not present, throw a *TypeError* exception.
           1. Let _k_ be _len_ - 1.
           1. Let _accumulator_ be *undefined*.
@@ -42517,7 +42517,7 @@ THH:mm:ss.sss
           1. Let _obj_ be the *this* value.
           1. Let _taRecord_ be ? ValidateTypedArray(_obj_, ~seq-cst~).
           1. Let _len_ be TypedArrayLength(_taRecord_).
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_,
             1. Let _propertyKey_ be ! ToString(𝔽(_k_)).
@@ -42536,7 +42536,7 @@ THH:mm:ss.sss
         <p>This method is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
         <p>It performs the following steps when called:</p>
         <emu-alg>
-          1. If _comparator_ is not *undefined* and IsCallable(_comparator_) is *false*, throw a *TypeError* exception.
+          1. If _comparator_ is not *undefined* and IsFunction(_comparator_) is *false*, throw a *TypeError* exception.
           1. Let _obj_ be the *this* value.
           1. Let _taRecord_ be ? ValidateTypedArray(_obj_, ~seq-cst~).
           1. Let _len_ be TypedArrayLength(_taRecord_).
@@ -42622,7 +42622,7 @@ THH:mm:ss.sss
         <h1>%TypedArray%.prototype.toSorted ( _comparator_ )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. If _comparator_ is not *undefined* and IsCallable(_comparator_) is *false*, throw a *TypeError* exception.
+          1. If _comparator_ is not *undefined* and IsFunction(_comparator_) is *false*, throw a *TypeError* exception.
           1. Let _obj_ be the *this* value.
           1. Let _taRecord_ be ? ValidateTypedArray(_obj_, ~seq-cst~).
           1. Let _len_ be TypedArrayLength(_taRecord_).
@@ -43530,7 +43530,7 @@ THH:mm:ss.sss
           1. Set _map_.[[MapData]] to a new empty List.
           1. If _iterable_ is either *undefined* or *null*, return _map_.
           1. Let _adder_ be ? Get(_map_, *"set"*).
-          1. If IsCallable(_adder_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_adder_) is *false*, throw a *TypeError* exception.
           1. Return ? AddEntriesFromIterable(_map_, _iterable_, _adder_).
         </emu-alg>
         <emu-note>
@@ -43682,7 +43682,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _map_ be the *this* value.
           1. Perform ? RequireInternalSlot(_map_, [[MapData]]).
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. Let _entries_ be _map_.[[MapData]].
           1. Let _numEntries_ be the number of elements in _entries_.
           1. Let _index_ be 0.
@@ -43737,7 +43737,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _map_ be the *this* value.
           1. Perform ? RequireInternalSlot(_map_, [[MapData]]).
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. Set _key_ to CanonicalizeKeyedCollectionKey(_key_).
           1. For each Record { [[Key]], [[Value]] } _entry_ of _map_.[[MapData]], do
             1. If _entry_.[[Key]] is not ~empty~ and SameValue(_entry_.[[Key]], _key_) is *true*, return _entry_.[[Value]].
@@ -43987,9 +43987,9 @@ THH:mm:ss.sss
           1. Let _intSize_ be ! ToIntegerOrInfinity(_numSize_).
           1. If _intSize_ &lt; 0, throw a *RangeError* exception.
           1. Let _has_ be ? Get(_obj_, *"has"*).
-          1. If IsCallable(_has_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_has_) is *false*, throw a *TypeError* exception.
           1. Let _keys_ be ? Get(_obj_, *"keys"*).
-          1. If IsCallable(_keys_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_keys_) is *false*, throw a *TypeError* exception.
           1. Return a new Set Record { [[SetObject]]: _obj_, [[Size]]: _intSize_, [[Has]]: _has_, [[Keys]]: _keys_ }.
         </emu-alg>
       </emu-clause>
@@ -44068,7 +44068,7 @@ THH:mm:ss.sss
           1. Set _set_.[[SetData]] to a new empty List.
           1. If _iterable_ is either *undefined* or *null*, return _set_.
           1. Let _adder_ be ? Get(_set_, *"add"*).
-          1. If IsCallable(_adder_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_adder_) is *false*, throw a *TypeError* exception.
           1. Let _iteratorRecord_ be ? GetIterator(_iterable_, ~sync~).
           1. Repeat,
             1. Let _next_ be ? IteratorStepValue(_iteratorRecord_).
@@ -44221,7 +44221,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _set_ be the *this* value.
           1. Perform ? RequireInternalSlot(_set_, [[SetData]]).
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. Let _entries_ be _set_.[[SetData]].
           1. Let _numEntries_ be the number of elements in _entries_.
           1. Let _index_ be 0.
@@ -44558,7 +44558,7 @@ THH:mm:ss.sss
           1. Set _map_.[[WeakMapData]] to a new empty List.
           1. If _iterable_ is either *undefined* or *null*, return _map_.
           1. Let _adder_ be ? Get(_map_, *"set"*).
-          1. If IsCallable(_adder_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_adder_) is *false*, throw a *TypeError* exception.
           1. Return ? AddEntriesFromIterable(_map_, _iterable_, _adder_).
         </emu-alg>
         <emu-note>
@@ -44651,7 +44651,7 @@ THH:mm:ss.sss
           1. Let _weakMap_ be the *this* value.
           1. Perform ? RequireInternalSlot(_weakMap_, [[WeakMapData]]).
           1. If CanBeHeldWeakly(_key_) is *false*, throw a *TypeError* exception.
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. For each Record { [[Key]], [[Value]] } _entry_ of _weakMap_.[[WeakMapData]], do
             1. If _entry_.[[Key]] is not ~empty~ and SameValue(_entry_.[[Key]], _key_) is *true*, return _entry_.[[Value]].
           1. Let _value_ be ? Call(_callback_, *undefined*, « _key_ »).
@@ -44738,7 +44738,7 @@ THH:mm:ss.sss
           1. Set _set_.[[WeakSetData]] to a new empty List.
           1. If _iterable_ is either *undefined* or *null*, return _set_.
           1. Let _adder_ be ? Get(_set_, *"add"*).
-          1. If IsCallable(_adder_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_adder_) is *false*, throw a *TypeError* exception.
           1. Let _iteratorRecord_ be ? GetIterator(_iterable_, ~sync~).
           1. Repeat,
             1. Let _next_ be ? IteratorStepValue(_iteratorRecord_).
@@ -47261,7 +47261,7 @@ THH:mm:ss.sss
         1. Let _jsonString_ be ? ToString(_text_).
         1. Let _parseResult_ be ? ParseJSON(_jsonString_).
         1. Let _unfiltered_ be _parseResult_.[[Value]].
-        1. If IsCallable(_reviver_) is *false*, return _unfiltered_.
+        1. If IsFunction(_reviver_) is *false*, return _unfiltered_.
         1. Let _root_ be OrdinaryObjectCreate(%Object.prototype%).
         1. Let _rootName_ be the empty String.
         1. Perform ! CreateDataPropertyOrThrow(_root_, _rootName_, _unfiltered_).
@@ -47555,7 +47555,7 @@ THH:mm:ss.sss
         1. Let _propertyList_ be *undefined*.
         1. Let _replacerFunction_ be *undefined*.
         1. If _replacer_ is an Object, then
-          1. If IsCallable(_replacer_) is *true*, then
+          1. If IsFunction(_replacer_) is *true*, then
             1. Set _replacerFunction_ to _replacer_.
           1. Else,
             1. Let _isArray_ be ? IsArray(_replacer_).
@@ -47689,7 +47689,7 @@ THH:mm:ss.sss
           1. Let _value_ be ? Get(_holder_, _key_).
           1. If _value_ is an Object or _value_ is a BigInt, then
             1. Let _toJSON_ be ? GetV(_value_, *"toJSON"*).
-            1. If IsCallable(_toJSON_) is *true*, then
+            1. If IsFunction(_toJSON_) is *true*, then
               1. Set _value_ to ? Call(_toJSON_, _value_, « _key_ »).
           1. If _state_.[[ReplacerFunction]] is not *undefined*, then
             1. Set _value_ to ? Call(_state_.[[ReplacerFunction]], _holder_, « _key_, _value_ »).
@@ -47714,7 +47714,7 @@ THH:mm:ss.sss
             1. If _value_ is finite, return ! ToString(_value_).
             1. Return *"null"*.
           1. If _value_ is a BigInt, throw a *TypeError* exception.
-          1. If _value_ is an Object and IsCallable(_value_) is *false*, then
+          1. If _value_ is an Object and IsFunction(_value_) is *false*, then
             1. Let _isArray_ be ? IsArray(_value_).
             1. If _isArray_ is *true*, return ? SerializeJSONArray(_state_, _value_).
             1. Return ? SerializeJSONObject(_state_, _value_).
@@ -48126,7 +48126,7 @@ THH:mm:ss.sss
         <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
-          1. If IsCallable(_cleanupCallback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_cleanupCallback_) is *false*, throw a *TypeError* exception.
           1. Let _finalizationRegistry_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%FinalizationRegistry.prototype%"*, « [[Realm]], [[CleanupCallback]], [[Cells]] »).
           1. Let _fn_ be the active function object.
           1. Set _finalizationRegistry_.[[Realm]] to _fn_.[[Realm]].
@@ -48711,7 +48711,7 @@ THH:mm:ss.sss
             1. Let _obj_ be the *this* value.
             1. If _obj_ is not an Object, throw a *TypeError* exception.
             1. Let _iterated_ be the Iterator Record { [[Iterator]]: _obj_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
-            1. If IsCallable(_predicate_) is *false*, then
+            1. If IsFunction(_predicate_) is *false*, then
               1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
               1. Return ? IteratorClose(_iterated_, _error_).
             1. Set _iterated_ to ? GetIteratorDirect(_obj_).
@@ -48733,7 +48733,7 @@ THH:mm:ss.sss
             1. Let _obj_ be the *this* value.
             1. If _obj_ is not an Object, throw a *TypeError* exception.
             1. Let _iterated_ be the Iterator Record { [[Iterator]]: _obj_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
-            1. If IsCallable(_predicate_) is *false*, then
+            1. If IsFunction(_predicate_) is *false*, then
               1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
               1. Return ? IteratorClose(_iterated_, _error_).
             1. Set _iterated_ to ? GetIteratorDirect(_obj_).
@@ -48761,7 +48761,7 @@ THH:mm:ss.sss
             1. Let _obj_ be the *this* value.
             1. If _obj_ is not an Object, throw a *TypeError* exception.
             1. Let _iterated_ be the Iterator Record { [[Iterator]]: _obj_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
-            1. If IsCallable(_predicate_) is *false*, then
+            1. If IsFunction(_predicate_) is *false*, then
               1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
               1. Return ? IteratorClose(_iterated_, _error_).
             1. Set _iterated_ to ? GetIteratorDirect(_obj_).
@@ -48783,7 +48783,7 @@ THH:mm:ss.sss
             1. Let _obj_ be the *this* value.
             1. If _obj_ is not an Object, throw a *TypeError* exception.
             1. Let _iterated_ be the Iterator Record { [[Iterator]]: _obj_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
-            1. If IsCallable(_mapper_) is *false*, then
+            1. If IsFunction(_mapper_) is *false*, then
               1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
               1. Return ? IteratorClose(_iterated_, _error_).
             1. Set _iterated_ to ? GetIteratorDirect(_obj_).
@@ -48822,7 +48822,7 @@ THH:mm:ss.sss
             1. Let _obj_ be the *this* value.
             1. If _obj_ is not an Object, throw a *TypeError* exception.
             1. Let _iterated_ be the Iterator Record { [[Iterator]]: _obj_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
-            1. If IsCallable(_procedure_) is *false*, then
+            1. If IsFunction(_procedure_) is *false*, then
               1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
               1. Return ? IteratorClose(_iterated_, _error_).
             1. Set _iterated_ to ? GetIteratorDirect(_obj_).
@@ -48843,7 +48843,7 @@ THH:mm:ss.sss
             1. Let _obj_ be the *this* value.
             1. If _obj_ is not an Object, throw a *TypeError* exception.
             1. Let _iterated_ be the Iterator Record { [[Iterator]]: _obj_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
-            1. If IsCallable(_mapper_) is *false*, then
+            1. If IsFunction(_mapper_) is *false*, then
               1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
               1. Return ? IteratorClose(_iterated_, _error_).
             1. Set _iterated_ to ? GetIteratorDirect(_obj_).
@@ -48870,7 +48870,7 @@ THH:mm:ss.sss
             1. Let _obj_ be the *this* value.
             1. If _obj_ is not an Object, throw a *TypeError* exception.
             1. Let _iterated_ be the Iterator Record { [[Iterator]]: _obj_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
-            1. If IsCallable(_reducer_) is *false*, then
+            1. If IsFunction(_reducer_) is *false*, then
               1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
               1. Return ? IteratorClose(_iterated_, _error_).
             1. Set _iterated_ to ? GetIteratorDirect(_obj_).
@@ -48898,7 +48898,7 @@ THH:mm:ss.sss
             1. Let _obj_ be the *this* value.
             1. If _obj_ is not an Object, throw a *TypeError* exception.
             1. Let _iterated_ be the Iterator Record { [[Iterator]]: _obj_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
-            1. If IsCallable(_predicate_) is *false*, then
+            1. If IsFunction(_predicate_) is *false*, then
               1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
               1. Return ? IteratorClose(_iterated_, _error_).
             1. Set _iterated_ to ? GetIteratorDirect(_obj_).
@@ -49379,7 +49379,7 @@ THH:mm:ss.sss
               1. Perform RejectPromise(_promise_, _then_.[[Value]]).
               1. Return *undefined*.
             1. Let _thenAction_ be _then_.[[Value]].
-            1. If IsCallable(_thenAction_) is *false*, then
+            1. If IsFunction(_thenAction_) is *false*, then
               1. Perform FulfillPromise(_promise_, _resolution_).
               1. Return *undefined*.
             1. Let _thenJobCallback_ be HostMakeJobCallback(_thenAction_).
@@ -49441,8 +49441,8 @@ THH:mm:ss.sss
             1. Return NormalCompletion(*undefined*).
           1. Let _executor_ be CreateBuiltinFunction(_executorClosure_, 2, *""*, « »).
           1. Let _promise_ be ? Construct(_constructor_, « _executor_ »).
-          1. If IsCallable(_resolvingFunctions_.[[Resolve]]) is *false*, throw a *TypeError* exception.
-          1. If IsCallable(_resolvingFunctions_.[[Reject]]) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_resolvingFunctions_.[[Resolve]]) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_resolvingFunctions_.[[Reject]]) is *false*, throw a *TypeError* exception.
           1. Return the PromiseCapability Record { [[Promise]]: _promise_, [[Resolve]]: _resolvingFunctions_.[[Resolve]], [[Reject]]: _resolvingFunctions_.[[Reject]] }.
         </emu-alg>
         <emu-note>
@@ -49627,7 +49627,7 @@ THH:mm:ss.sss
         <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
-          1. If IsCallable(_executor_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_executor_) is *false*, throw a *TypeError* exception.
           1. Let _promise_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Promise.prototype%"*, « [[PromiseState]], [[PromiseResult]], [[PromiseFulfillReactions]], [[PromiseRejectReactions]], [[PromiseIsHandled]] »).
           1. Set _promise_.[[PromiseState]] to ~pending~.
           1. Set _promise_.[[PromiseResult]] to ~empty~.
@@ -49687,7 +49687,7 @@ THH:mm:ss.sss
           </dl>
           <emu-alg>
             1. Let _promiseResolve_ be ? Get(_promiseConstructor_, *"resolve"*).
-            1. If IsCallable(_promiseResolve_) is *false*, throw a *TypeError* exception.
+            1. If IsFunction(_promiseResolve_) is *false*, throw a *TypeError* exception.
             1. Return _promiseResolve_.
           </emu-alg>
         </emu-clause>
@@ -50073,7 +50073,7 @@ THH:mm:ss.sss
           1. If _promise_ is not an Object, throw a *TypeError* exception.
           1. Let _constructor_ be ? SpeciesConstructor(_promise_, %Promise%).
           1. Assert: IsConstructor(_constructor_) is *true*.
-          1. If IsCallable(_onFinally_) is *false*, then
+          1. If IsFunction(_onFinally_) is *false*, then
             1. Let _thenFinally_ be _onFinally_.
             1. Let _catchFinally_ be _onFinally_.
           1. Else,
@@ -50125,11 +50125,11 @@ THH:mm:ss.sss
             1. Assert: IsPromise(_promise_) is *true*.
             1. If _resultCapability_ is not present, then
               1. Set _resultCapability_ to *undefined*.
-            1. If IsCallable(_onFulfilled_) is *false*, then
+            1. If IsFunction(_onFulfilled_) is *false*, then
               1. Let _onFulfilledJobCallback_ be ~empty~.
             1. Else,
               1. Let _onFulfilledJobCallback_ be HostMakeJobCallback(_onFulfilled_).
-            1. If IsCallable(_onRejected_) is *false*, then
+            1. If IsFunction(_onRejected_) is *false*, then
               1. Let _onRejectedJobCallback_ be ~empty~.
             1. Else,
               1. Let _onRejectedJobCallback_ be HostMakeJobCallback(_onRejected_).
@@ -51385,7 +51385,7 @@ THH:mm:ss.sss
       <h1>Reflect.apply ( _target_, _thisArgument_, _argumentsList_ )</h1>
       <p>This function performs the following steps when called:</p>
       <emu-alg>
-        1. If IsCallable(_target_) is *false*, throw a *TypeError* exception.
+        1. If IsFunction(_target_) is *false*, throw a *TypeError* exception.
         1. Let _args_ be ? CreateListFromArrayLike(_argumentsList_).
         1. Perform PrepareForTailCall().
         1. Return ? Call(_target_, _thisArgument_, _args_).

--- a/spec.html
+++ b/spec.html
@@ -52150,7 +52150,7 @@ THH:mm:ss.sss
     <emu-alg>
       1. If _eventA_ and _eventB_ are not the same Shared Data Block event, then
         1. If it is not the case that both _eventA_ happens-before _eventB_ in _execution_ and _eventB_ happens-before _eventA_ in _execution_, then
-          1. If _eventA_ and _eventB_ are both WriteSharedMemory or ReadModifyWriteSharedMemory events and _eventA_ and _eventB_ do not have disjoint memory ranges, then
+          1. If _eventA_ is either a WriteSharedMemory or ReadModifyWriteSharedMemory event, _eventB_ is either a WriteSharedMemory or ReadModifyWriteSharedMemory event, and _eventA_ and _eventB_ do not have disjoint memory ranges, then
             1. Return *true*.
           1. If _eventA_ reads-from _eventB_ in _execution_ or _eventB_ reads-from _eventA_ in _execution_, then
             1. Return *true*.

--- a/spec.html
+++ b/spec.html
@@ -3186,7 +3186,7 @@
                 (<em>any</em>, a List of <em>any</em>) <b>→</b> <em>any</em>
               </td>
               <td>
-                Executes code associated with this object. Invoked via a function call expression. The arguments to the internal method are a *this* value and a List whose elements are the arguments passed to the function by a call expression. Objects that implement this internal method are <em>callable</em>.
+                Executes code associated with this object. Invoked via a function call expression. The arguments to the internal method are a *this* value and a List whose elements are the arguments passed to the function by a call expression. Objects that implement this internal method are functions.
               </td>
             </tr>
             <tr>
@@ -4316,8 +4316,8 @@
         <li><dfn variants="abrupt completions">abrupt completion</dfn> refers to any Completion Record with a [[Type]] value other than ~normal~.</li>
         <li>a <dfn variants="normal completions containing">normal completion containing</dfn> some type of value refers to a normal completion that has a value of that type in its [[Value]] field.</li>
       </ul>
-      <p>Callable objects that are defined in this specification only return a normal completion or a throw completion. Returning any other kind of Completion Record is considered an editorial error.</p>
-      <p>Implementation-defined callable objects must return either a normal completion or a throw completion.</p>
+      <p>Functions that are defined in this specification only return a normal completion or a throw completion. Returning any other kind of Completion Record is considered an editorial error.</p>
+      <p>Implementation-defined functions must return either a normal completion or a throw completion.</p>
 
       <emu-clause id="sec-normalcompletion" type="abstract operation">
         <h1>
@@ -14074,7 +14074,7 @@
               [[BoundTargetFunction]]
             </td>
             <td>
-              a callable Object
+              a function object
             </td>
             <td>
               The wrapped function object.
@@ -29739,7 +29739,7 @@
 <emu-clause id="sec-ecmascript-standard-built-in-objects">
   <h1>ECMAScript Standard Built-in Objects</h1>
   <p>There are certain built-in objects available whenever an ECMAScript |Script| or |Module| begins execution. One, the global object, is part of the global environment of the executing program. Others are accessible as initial properties of the global object or indirectly as properties of accessible built-in objects.</p>
-  <p>Unless specified otherwise, a built-in object that is callable as a function is a built-in function object with the characteristics described in <emu-xref href="#sec-built-in-function-objects"></emu-xref>. Unless specified otherwise, the [[Extensible]] internal slot of a built-in object initially has the value *true*. Every built-in function object has a [[Realm]] internal slot whose value is the Realm Record of the realm for which the object was initially created.</p>
+  <p>Unless specified otherwise, a built-in object that is a function is a built-in function object with the characteristics described in <emu-xref href="#sec-built-in-function-objects"></emu-xref>. Unless specified otherwise, the [[Extensible]] internal slot of a built-in object initially has the value *true*. Every built-in function object has a [[Realm]] internal slot whose value is the Realm Record of the realm for which the object was initially created.</p>
   <p>Many built-in objects are functions: they can be invoked with arguments. Some of them furthermore are constructors: they are functions intended for use with the `new` operator. For each built-in function, this specification describes the arguments required by that function and the properties of that function object. For each built-in constructor, this specification furthermore describes properties of the prototype object of that constructor and properties of specific object instances returned by a `new` expression that invokes that constructor.</p>
   <p>Unless otherwise specified in the description of a particular function, if a built-in function or constructor is given fewer arguments than the function is specified to require, the function or constructor shall behave exactly as if it had been given sufficient additional arguments, each such argument being the *undefined* value. Such missing arguments are considered to be “not present” and may be identified in that manner by specification algorithms. In the description of a particular function, the terms “*this* value” and “NewTarget” have the meanings given in <emu-xref href="#sec-built-in-function-objects"></emu-xref>.</p>
   <p>Unless otherwise specified in the description of a particular function, if a built-in function or constructor described is given more arguments than the function is specified to allow, the extra arguments are evaluated by the call and then ignored by the function. However, an implementation may define implementation specific behaviour relating to such arguments as long as the behaviour is not the throwing of a *TypeError* exception that is predicated simply on the presence of an extra argument.</p>

--- a/spec.html
+++ b/spec.html
@@ -3171,7 +3171,7 @@
                 (<em>any</em>, a List of <em>any</em>) <b>→</b> <em>any</em>
               </td>
               <td>
-                Executes code associated with this object. Invoked via a function call expression. The arguments to the internal method are a *this* value and a List whose elements are the arguments passed to the function by a call expression. Objects that implement this internal method are <em>callable</em>.
+                Executes code associated with this object. Invoked via a function call expression. The arguments to the internal method are a *this* value and a List whose elements are the arguments passed to the function by a call expression. Objects that implement this internal method are functions.
               </td>
             </tr>
             <tr>
@@ -4334,8 +4334,8 @@
         <li><dfn variants="abrupt completions">abrupt completion</dfn> refers to any Completion Record with a [[Type]] value other than ~normal~.</li>
         <li>a <dfn variants="normal completions containing">normal completion containing</dfn> some type of value refers to a normal completion that has a value of that type in its [[Value]] field.</li>
       </ul>
-      <p>Callable objects that are defined in this specification only return a normal completion or a throw completion. Returning any other kind of Completion Record is considered an editorial error.</p>
-      <p>Implementation-defined callable objects must return either a normal completion or a throw completion.</p>
+      <p>Functions that are defined in this specification only return a normal completion or a throw completion. Returning any other kind of Completion Record is considered an editorial error.</p>
+      <p>Implementation-defined functions must return either a normal completion or a throw completion.</p>
 
       <emu-clause id="sec-normalcompletion" type="abstract operation">
         <h1>
@@ -14466,7 +14466,7 @@
               [[BoundTargetFunction]]
             </td>
             <td>
-              a callable Object
+              a function object
             </td>
             <td>
               The wrapped function object.
@@ -30320,7 +30320,7 @@
 <emu-clause id="sec-ecmascript-standard-built-in-objects">
   <h1>ECMAScript Standard Built-in Objects</h1>
   <p>There are certain built-in objects available whenever an ECMAScript |Script| or |Module| begins execution. One, the global object, is part of the global environment of the executing program. Others are accessible as initial properties of the global object or indirectly as properties of accessible built-in objects.</p>
-  <p>Unless specified otherwise, a built-in object that is callable as a function is a built-in function object with the characteristics described in <emu-xref href="#sec-built-in-function-objects"></emu-xref>. Unless specified otherwise, the [[Extensible]] internal slot of a built-in object initially has the value *true*. Every built-in function object has a [[Realm]] internal slot whose value is the Realm Record of the realm for which the object was initially created.</p>
+  <p>Unless specified otherwise, a built-in object that is a function is a built-in function object with the characteristics described in <emu-xref href="#sec-built-in-function-objects"></emu-xref>. Unless specified otherwise, the [[Extensible]] internal slot of a built-in object initially has the value *true*. Every built-in function object has a [[Realm]] internal slot whose value is the Realm Record of the realm for which the object was initially created.</p>
   <p>Many built-in objects are functions: they can be invoked with arguments. Some of them furthermore are constructors: they are functions intended for use with the `new` operator. For each built-in function, this specification describes the arguments required by that function and the properties of that function object. For each built-in constructor, this specification furthermore describes properties of the prototype object of that constructor and properties of specific object instances returned by a `new` expression that invokes that constructor.</p>
   <p>Unless otherwise specified in the description of a particular function, if a built-in function or constructor is given fewer arguments than the function is specified to require, the function or constructor shall behave exactly as if it had been given sufficient additional arguments, each such argument being the *undefined* value. Such missing arguments are considered to be “not present” and may be identified in that manner by specification algorithms. In the description of a particular function, the terms “*this* value” and “NewTarget” have the meanings given in <emu-xref href="#sec-built-in-function-objects"></emu-xref>.</p>
   <p>Unless otherwise specified in the description of a particular function, if a built-in function or constructor described is given more arguments than the function is specified to allow, the extra arguments are evaluated by the call and then ignored by the function. However, an implementation may define implementation specific behaviour relating to such arguments as long as the behaviour is not the throwing of a *TypeError* exception that is predicated simply on the presence of an extra argument.</p>

--- a/spec.html
+++ b/spec.html
@@ -4711,12 +4711,12 @@
           1. Let _hasGet_ be ? HasProperty(_obj_, *"get"*).
           1. If _hasGet_ is *true*, then
             1. Let _getter_ be ? Get(_obj_, *"get"*).
-            1. If IsCallable(_getter_) is *false* and _getter_ is not *undefined*, throw a *TypeError* exception.
+            1. If IsFunction(_getter_) is *false* and _getter_ is not *undefined*, throw a *TypeError* exception.
             1. Set _propertyDesc_.[[Getter]] to _getter_.
           1. Let _hasSet_ be ? HasProperty(_obj_, *"set"*).
           1. If _hasSet_ is *true*, then
             1. Let _setter_ be ? Get(_obj_, *"set"*).
-            1. If IsCallable(_setter_) is *false* and _setter_ is not *undefined*, throw a *TypeError* exception.
+            1. If IsFunction(_setter_) is *false* and _setter_ is not *undefined*, throw a *TypeError* exception.
             1. Set _propertyDesc_.[[Setter]] to _setter_.
           1. If _propertyDesc_ has a [[Getter]] field or _propertyDesc_ has a [[Setter]] field, then
             1. If _propertyDesc_ has a [[Value]] field or _propertyDesc_ has a [[Writable]] field, throw a *TypeError* exception.
@@ -5095,7 +5095,7 @@
             1. Let _methodNames_ be « *"valueOf"*, *"toString"* ».
           1. For each element _name_ of _methodNames_, do
             1. Let _method_ be ? Get(_obj_, _name_).
-            1. If IsCallable(_method_) is *true*, then
+            1. If IsFunction(_method_) is *true*, then
               1. Let _result_ be ? Call(_method_, _obj_).
               1. If _result_ is not an Object, return _result_.
           1. Throw a *TypeError* exception.
@@ -5805,15 +5805,15 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-iscallable" type="abstract operation">
+    <emu-clause id="sec-isfunction" type="abstract operation" oldids="sec-iscallable">
       <h1>
-        IsCallable (
+        IsFunction (
           _arg_: an ECMAScript language value,
         ): a Boolean
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It determines if _arg_ is a callable function with a [[Call]] internal method.</dd>
+        <dd>It determines if _arg_ is a function (i.e., an Object with a [[Call]] internal method).</dd>
       </dl>
       <emu-alg>
         1. If _arg_ is not an Object, return *false*.
@@ -6315,7 +6315,7 @@
       <emu-alg>
         1. Let _func_ be ? GetV(_value_, _propertyKey_).
         1. If _func_ is either *undefined* or *null*, return *undefined*.
-        1. If IsCallable(_func_) is *false*, throw a *TypeError* exception.
+        1. If IsFunction(_func_) is *false*, throw a *TypeError* exception.
         1. Return _func_.
       </emu-alg>
     </emu-clause>
@@ -6368,7 +6368,7 @@
       </dl>
       <emu-alg>
         1. If _argList_ is not present, set _argList_ to a new empty List.
-        1. If IsCallable(_func_) is *false*, throw a *TypeError* exception.
+        1. If IsFunction(_func_) is *false*, throw a *TypeError* exception.
         1. Return ? <emu-meta effects="user-code">_func_.[[Call]](_thisValue_, _argList_)</emu-meta>.
       </emu-alg>
     </emu-clause>
@@ -6554,7 +6554,7 @@
         <dd>It implements the default algorithm for determining if _instance_ inherits from the instance object inheritance path provided by _ctor_.</dd>
       </dl>
       <emu-alg>
-        1. If IsCallable(_ctor_) is *false*, return *false*.
+        1. If IsFunction(_ctor_) is *false*, return *false*.
         1. If _ctor_ has a [[BoundTargetFunction]] internal slot, then
           1. Let _boundCtor_ be _ctor_.[[BoundTargetFunction]].
           1. Return ? InstanceofOperator(_instance_, _boundCtor_).
@@ -6880,7 +6880,7 @@
       </dl>
       <emu-alg>
         1. Perform ? RequireObjectCoercible(_items_).
-        1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+        1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
         1. Let _groups_ be a new empty List.
         1. Let _iteratorRecord_ be ? GetIterator(_items_, ~sync~).
         1. Let _k_ be 0.
@@ -12524,7 +12524,7 @@
       </emu-note>
       <p>The default implementation of HostCallJobCallback performs the following steps when called:</p>
       <emu-alg>
-        1. Assert: IsCallable(_jobCallback_.[[Callback]]) is *true*.
+        1. Assert: IsFunction(_jobCallback_.[[Callback]]) is *true*.
         1. Return ? Call(_jobCallback_.[[Callback]], _thisValue_, _argList_).
       </emu-alg>
       <p>ECMAScript hosts that are not web browsers must use the default implementation of HostCallJobCallback.</p>
@@ -16552,7 +16552,7 @@
         1. If _handler_ is not an Object, throw a *TypeError* exception.
         1. Let _proxy_ be MakeBasicObject(« [[ProxyHandler]], [[ProxyTarget]] »).
         1. Set _proxy_'s essential internal methods, except for [[Call]] and [[Construct]], to the definitions specified in <emu-xref href="#sec-proxy-object-internal-methods-and-internal-slots"></emu-xref>.
-        1. If IsCallable(_target_) is *true*, then
+        1. If IsFunction(_target_) is *true*, then
           1. Set _proxy_.[[Call]] as specified in <emu-xref href="#sec-proxy-object-internal-methods-and-internal-slots-call-thisargument-argumentslist"></emu-xref>.
           1. If IsConstructor(_target_) is *true*, then
             1. Set _proxy_.[[Construct]] as specified in <emu-xref href="#sec-proxy-object-internal-methods-and-internal-slots-construct-argumentslist-newtarget"></emu-xref>.
@@ -19894,7 +19894,7 @@
             1. Let _thisValue_ be *undefined*.
           1. Let _argList_ be ? ArgumentListEvaluation of _argumentListNode_.
           1. If _func_ is not an Object, throw a *TypeError* exception.
-          1. If IsCallable(_func_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_func_) is *false*, throw a *TypeError* exception.
           1. If _tailPosition_ is *true*, perform PrepareForTailCall().
           1. Return ? Call(_func_, _thisValue_, _argList_).
         </emu-alg>
@@ -20929,7 +20929,7 @@
         1. Let _instOfHandler_ be ? GetMethod(_target_, %Symbol.hasInstance%).
         1. If _instOfHandler_ is not *undefined*, then
           1. Return ToBoolean(? Call(_instOfHandler_, _target_, « _value_ »)).
-        1. [id="step-instanceof-check-function"] If IsCallable(_target_) is *false*, throw a *TypeError* exception.
+        1. [id="step-instanceof-check-function"] If IsFunction(_target_) is *false*, throw a *TypeError* exception.
         1. [id="step-instanceof-fallback"] Return ? OrdinaryHasInstance(_target_, _value_).
       </emu-alg>
       <emu-note>
@@ -31637,7 +31637,7 @@
           <p>This method performs the following steps when called:</p>
           <emu-alg>
             1. Let _obj_ be ? ToObject(*this* value).
-            1. If IsCallable(_getter_) is *false*, throw a *TypeError* exception.
+            1. If IsFunction(_getter_) is *false*, throw a *TypeError* exception.
             1. Let _propertyDesc_ be PropertyDescriptor { [[Getter]]: _getter_, [[Enumerable]]: *true*, [[Configurable]]: *true* }.
             1. Let _propertyKey_ be ? ToPropertyKey(_key_).
             1. Perform ? DefinePropertyOrThrow(_obj_, _propertyKey_, _propertyDesc_).
@@ -31650,7 +31650,7 @@
           <p>This method performs the following steps when called:</p>
           <emu-alg>
             1. Let _obj_ be ? ToObject(*this* value).
-            1. If IsCallable(_setter_) is *false*, throw a *TypeError* exception.
+            1. If IsFunction(_setter_) is *false*, throw a *TypeError* exception.
             1. Let _propertyDesc_ be PropertyDescriptor { [[Setter]]: _setter_, [[Enumerable]]: *true*, [[Configurable]]: *true* }.
             1. Let _propertyKey_ be ? ToPropertyKey(_key_).
             1. Perform ? DefinePropertyOrThrow(_obj_, _propertyKey_, _propertyDesc_).
@@ -31858,7 +31858,7 @@
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _func_ be the *this* value.
-          1. If IsCallable(_func_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_func_) is *false*, throw a *TypeError* exception.
           1. If _argArray_ is either *undefined* or *null*, then
             1. Perform PrepareForTailCall().
             1. Return ? Call(_func_, _thisArg_).
@@ -31879,7 +31879,7 @@
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _target_ be the *this* value.
-          1. If IsCallable(_target_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_target_) is *false*, throw a *TypeError* exception.
           1. Let _boundFunc_ be ? BoundFunctionCreate(_target_, _thisArg_, _args_).
           1. Let _length_ be 0.
           1. Let _targetHasLength_ be ? HasOwnProperty(_target_, *"length"*).
@@ -31914,7 +31914,7 @@
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _func_ be the *this* value.
-          1. If IsCallable(_func_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_func_) is *false*, throw a *TypeError* exception.
           1. Perform PrepareForTailCall().
           1. [id="step-function-proto-call-call"] Return ? Call(_func_, _thisArg_, _args_).
         </emu-alg>
@@ -31939,7 +31939,7 @@
           1. If _func_ is an Object, _func_ has a [[SourceText]] internal slot, _func_.[[SourceText]] is a sequence of Unicode code points, and HostHasSourceTextAvailable(_func_) is *true*, then
             1. Return CodePointsToString(_func_.[[SourceText]]).
           1. If _func_ is a <emu-xref href="#sec-built-in-function-objects">built-in function object</emu-xref>, return an implementation-defined String source code representation of _func_. The representation must have the syntax of a |NativeFunction|. Additionally, if _func_ has an [[InitialName]] internal slot and _func_.[[InitialName]] is a String, the portion of the returned String that would be matched by |NativeFunctionAccessor?| |PropertyName| must be _func_.[[InitialName]].
-          1. If _func_ is an Object and IsCallable(_func_) is *true*, return an implementation-defined String source code representation of _func_. The representation must have the syntax of a |NativeFunction|.
+          1. If _func_ is an Object and IsFunction(_func_) is *true*, return an implementation-defined String source code representation of _func_. The representation must have the syntax of a |NativeFunction|.
           1. Throw a *TypeError* exception.
         </emu-alg>
 
@@ -36615,7 +36615,7 @@ THH:mm:ss.sss
               1. Return ? Call(_replacer_, _searchValue_, « _thisValue_, _replaceValue_ »).
           1. Let _string_ be ? ToString(_thisValue_).
           1. Let _searchString_ be ? ToString(_searchValue_).
-          1. Let _functionalReplace_ be IsCallable(_replaceValue_).
+          1. Let _functionalReplace_ be IsFunction(_replaceValue_).
           1. If _functionalReplace_ is *false*, then
             1. Set _replaceValue_ to ? ToString(_replaceValue_).
           1. Let _searchLength_ be the length of _searchString_.
@@ -36734,7 +36734,7 @@ THH:mm:ss.sss
               1. Return ? Call(_replacer_, _searchValue_, « _thisValue_, _replaceValue_ »).
           1. Let _string_ be ? ToString(_thisValue_).
           1. Let _searchString_ be ? ToString(_searchValue_).
-          1. Let _functionalReplace_ be IsCallable(_replaceValue_).
+          1. Let _functionalReplace_ be IsFunction(_replaceValue_).
           1. If _functionalReplace_ is *false*, then
             1. Set _replaceValue_ to ? ToString(_replaceValue_).
           1. Let _searchLength_ be the length of _searchString_.
@@ -39772,7 +39772,7 @@ THH:mm:ss.sss
           1. If _regexp_ is not an Object, throw a *TypeError* exception.
           1. Set _string_ to ? ToString(_string_).
           1. Let _stringLength_ be the length of _string_.
-          1. Let _functionalReplace_ be IsCallable(_replaceValue_).
+          1. Let _functionalReplace_ be IsFunction(_replaceValue_).
           1. If _functionalReplace_ is *false*, then
             1. Set _replaceValue_ to ? ToString(_replaceValue_).
           1. Let _flags_ be ? ToString(? Get(_regexp_, *"flags"*)).
@@ -40045,7 +40045,7 @@ THH:mm:ss.sss
         </dl>
         <emu-alg>
           1. Let _exec_ be ? Get(_regexp_, *"exec"*).
-          1. If IsCallable(_exec_) is *true*, then
+          1. If IsFunction(_exec_) is *true*, then
             1. Let _result_ be ? Call(_exec_, _regexp_, « _string_ »).
             1. If _result_ is not an Object and _result_ is not *null*, throw a *TypeError* exception.
             1. Return _result_.
@@ -40491,7 +40491,7 @@ THH:mm:ss.sss
           1. If _mapper_ is *undefined*, then
             1. Let _mapping_ be *false*.
           1. Else,
-            1. If IsCallable(_mapper_) is *false*, throw a *TypeError* exception.
+            1. If IsFunction(_mapper_) is *false*, throw a *TypeError* exception.
             1. Let _mapping_ be *true*.
           1. Let _usingIterator_ be ? GetMethod(_items_, %Symbol.iterator%).
           1. If _usingIterator_ is not *undefined*, then
@@ -40551,7 +40551,7 @@ THH:mm:ss.sss
           1. Let _ctor_ be the *this* value.
           1. Let _mapping_ be *false*.
           1. If _mapper_ is not *undefined*, then
-            1. If IsCallable(_mapper_) is *false*, throw a *TypeError* exception.
+            1. If IsFunction(_mapper_) is *false*, throw a *TypeError* exception.
             1. Set _mapping_ to *true*.
           1. Let _iteratorRecord_ be *undefined*.
           1. Let _usingAsyncIterator_ be ? GetMethod(_items_, %Symbol.asyncIterator%).
@@ -40832,7 +40832,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _obj_ be ? ToObject(*this* value).
           1. Let _length_ be ? LengthOfArrayLike(_obj_).
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _length_,
             1. Let _propertyKey_ be ! ToString(𝔽(_k_)).
@@ -40894,7 +40894,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _obj_ be ? ToObject(*this* value).
           1. Let _length_ be ? LengthOfArrayLike(_obj_).
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. Let _array_ be ? ArraySpeciesCreate(_obj_, 0).
           1. Let _k_ be 0.
           1. Let _to_ be 0.
@@ -41007,7 +41007,7 @@ THH:mm:ss.sss
             </dd>
           </dl>
           <emu-alg>
-            1. If IsCallable(_predicate_) is *false*, throw a *TypeError* exception.
+            1. If IsFunction(_predicate_) is *false*, throw a *TypeError* exception.
             1. If _direction_ is ~ascending~, then
               1. Let _indices_ be a List of the integers in the interval from 0 (inclusive) to _length_ (exclusive), in ascending order.
             1. Else,
@@ -41053,7 +41053,7 @@ THH:mm:ss.sss
           <dl class="header">
           </dl>
           <emu-alg>
-            1. Assert: If _mapperFunc_ is present, then IsCallable(_mapperFunc_) is *true*, _thisArg_ is present, and _depth_ is 1.
+            1. Assert: If _mapperFunc_ is present, then IsFunction(_mapperFunc_) is *true*, _thisArg_ is present, and _depth_ is 1.
             1. Let _targetIndex_ be _start_.
             1. Let _sourceIndex_ be *+0*<sub>𝔽</sub>.
             1. Repeat, while ℝ(_sourceIndex_) &lt; _sourceLength_,
@@ -41087,7 +41087,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _obj_ be ? ToObject(*this* value).
           1. Let _sourceLength_ be ? LengthOfArrayLike(_obj_).
-          1. If IsCallable(_mapperFunc_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_mapperFunc_) is *false*, throw a *TypeError* exception.
           1. Let _array_ be ? ArraySpeciesCreate(_obj_, 0).
           1. Perform ? FlattenIntoArray(_array_, _obj_, _sourceLength_, 0, 1, _mapperFunc_, _thisArg_).
           1. Return _array_.
@@ -41107,7 +41107,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _obj_ be ? ToObject(*this* value).
           1. Let _length_ be ? LengthOfArrayLike(_obj_).
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _length_,
             1. Let _propertyKey_ be ! ToString(𝔽(_k_)).
@@ -41269,7 +41269,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _obj_ be ? ToObject(*this* value).
           1. Let _length_ be ? LengthOfArrayLike(_obj_).
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. Let _array_ be ? ArraySpeciesCreate(_obj_, _length_).
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _length_,
@@ -41347,7 +41347,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _obj_ be ? ToObject(*this* value).
           1. Let _length_ be ? LengthOfArrayLike(_obj_).
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. If _length_ = 0 and _initialValue_ is not present, throw a *TypeError* exception.
           1. Let _k_ be 0.
           1. Let _accumulator_ be *undefined*.
@@ -41388,7 +41388,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _obj_ be ? ToObject(*this* value).
           1. Let _length_ be ? LengthOfArrayLike(_obj_).
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. If _length_ = 0 and _initialValue_ is not present, throw a *TypeError* exception.
           1. Let _k_ be _length_ - 1.
           1. Let _accumulator_ be *undefined*.
@@ -41540,7 +41540,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _obj_ be ? ToObject(*this* value).
           1. Let _length_ be ? LengthOfArrayLike(_obj_).
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _length_,
             1. Let _propertyKey_ be ! ToString(𝔽(_k_)).
@@ -41562,7 +41562,7 @@ THH:mm:ss.sss
         <p>This method sorts the elements of this array. If _comparator_ is not *undefined*, it should be a function that accepts two arguments _x_ and _y_ and returns a negative Number if _x_ &lt; _y_, a positive Number if _x_ > _y_, or a zero otherwise.</p>
         <p>It performs the following steps when called:</p>
         <emu-alg>
-          1. [id="step-array-sort-comparefn"] If _comparator_ is not *undefined* and IsCallable(_comparator_) is *false*, throw a *TypeError* exception.
+          1. [id="step-array-sort-comparefn"] If _comparator_ is not *undefined* and IsFunction(_comparator_) is *false*, throw a *TypeError* exception.
           1. Let _obj_ be ? ToObject(*this* value).
           1. [id="step-array-sort-len"] Let _length_ be ? LengthOfArrayLike(_obj_).
           1. Let _sortCompare_ be a new Abstract Closure with parameters (_x_, _y_) that captures _comparator_ and performs the following steps when called:
@@ -41814,7 +41814,7 @@ THH:mm:ss.sss
         <h1>Array.prototype.toSorted ( _comparator_ )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. If _comparator_ is not *undefined* and IsCallable(_comparator_) is *false*, throw a *TypeError* exception.
+          1. If _comparator_ is not *undefined* and IsFunction(_comparator_) is *false*, throw a *TypeError* exception.
           1. Let _obj_ be ? ToObject(*this* value).
           1. Let _length_ be ? LengthOfArrayLike(_obj_).
           1. Let _array_ be ? ArrayCreate(_length_).
@@ -41878,7 +41878,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _array_ be ? ToObject(*this* value).
           1. Let _func_ be ? Get(_array_, *"join"*).
-          1. If IsCallable(_func_) is *false*, set _func_ to the intrinsic function %Object.prototype.toString%.
+          1. If IsFunction(_func_) is *false*, set _func_ to the intrinsic function %Object.prototype.toString%.
           1. Return ? Call(_func_, _array_).
         </emu-alg>
         <emu-note>
@@ -42414,7 +42414,7 @@ THH:mm:ss.sss
           1. If _mapper_ is *undefined*, then
             1. Let _mapping_ be *false*.
           1. Else,
-            1. If IsCallable(_mapper_) is *false*, throw a *TypeError* exception.
+            1. If IsFunction(_mapper_) is *false*, throw a *TypeError* exception.
             1. Let _mapping_ be *true*.
           1. Let _usingIterator_ be ? GetMethod(_source_, %Symbol.iterator%).
           1. If _usingIterator_ is not *undefined*, then
@@ -42628,7 +42628,7 @@ THH:mm:ss.sss
           1. Let _obj_ be the *this* value.
           1. Let _taRecord_ be ? ValidateTypedArray(_obj_, ~seq-cst~).
           1. Let _length_ be TypedArrayLength(_taRecord_).
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _length_,
             1. Let _propertyKey_ be ! ToString(𝔽(_k_)).
@@ -42680,7 +42680,7 @@ THH:mm:ss.sss
           1. Let _obj_ be the *this* value.
           1. Let _taRecord_ be ? ValidateTypedArray(_obj_, ~seq-cst~).
           1. Let _length_ be TypedArrayLength(_taRecord_).
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. Let _kept_ be a new empty List.
           1. Let _captured_ be 0.
           1. Let _k_ be 0.
@@ -42766,7 +42766,7 @@ THH:mm:ss.sss
           1. Let _obj_ be the *this* value.
           1. Let _taRecord_ be ? ValidateTypedArray(_obj_, ~seq-cst~).
           1. Let _length_ be TypedArrayLength(_taRecord_).
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _length_,
             1. Let _propertyKey_ be ! ToString(𝔽(_k_)).
@@ -42919,7 +42919,7 @@ THH:mm:ss.sss
           1. Let _obj_ be the *this* value.
           1. Let _taRecord_ be ? ValidateTypedArray(_obj_, ~seq-cst~).
           1. Let _length_ be TypedArrayLength(_taRecord_).
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. Let _result_ be ? TypedArraySpeciesCreate(_obj_, « 𝔽(_length_) »).
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _length_,
@@ -42941,7 +42941,7 @@ THH:mm:ss.sss
           1. Let _obj_ be the *this* value.
           1. Let _taRecord_ be ? ValidateTypedArray(_obj_, ~seq-cst~).
           1. Let _length_ be TypedArrayLength(_taRecord_).
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. If _length_ = 0 and _initialValue_ is not present, throw a *TypeError* exception.
           1. Let _k_ be 0.
           1. Let _accumulator_ be *undefined*.
@@ -42969,7 +42969,7 @@ THH:mm:ss.sss
           1. Let _obj_ be the *this* value.
           1. Let _taRecord_ be ? ValidateTypedArray(_obj_, ~seq-cst~).
           1. Let _length_ be TypedArrayLength(_taRecord_).
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. If _length_ = 0 and _initialValue_ is not present, throw a *TypeError* exception.
           1. Let _k_ be _length_ - 1.
           1. Let _accumulator_ be *undefined*.
@@ -43180,7 +43180,7 @@ THH:mm:ss.sss
           1. Let _obj_ be the *this* value.
           1. Let _taRecord_ be ? ValidateTypedArray(_obj_, ~seq-cst~).
           1. Let _length_ be TypedArrayLength(_taRecord_).
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _length_,
             1. Let _propertyKey_ be ! ToString(𝔽(_k_)).
@@ -43199,7 +43199,7 @@ THH:mm:ss.sss
         <p>This method is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
         <p>It performs the following steps when called:</p>
         <emu-alg>
-          1. If _comparator_ is not *undefined* and IsCallable(_comparator_) is *false*, throw a *TypeError* exception.
+          1. If _comparator_ is not *undefined* and IsFunction(_comparator_) is *false*, throw a *TypeError* exception.
           1. Let _obj_ be the *this* value.
           1. Let _taRecord_ be ? ValidateTypedArray(_obj_, ~seq-cst~).
           1. Let _length_ be TypedArrayLength(_taRecord_).
@@ -43285,7 +43285,7 @@ THH:mm:ss.sss
         <h1>%TypedArray%.prototype.toSorted ( _comparator_ )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. If _comparator_ is not *undefined* and IsCallable(_comparator_) is *false*, throw a *TypeError* exception.
+          1. If _comparator_ is not *undefined* and IsFunction(_comparator_) is *false*, throw a *TypeError* exception.
           1. Let _obj_ be the *this* value.
           1. Let _taRecord_ be ? ValidateTypedArray(_obj_, ~seq-cst~).
           1. Let _length_ be TypedArrayLength(_taRecord_).
@@ -44194,7 +44194,7 @@ THH:mm:ss.sss
           1. Set _map_.[[MapData]] to a new empty List.
           1. If _iterable_ is either *undefined* or *null*, return _map_.
           1. Let _adder_ be ? Get(_map_, *"set"*).
-          1. If IsCallable(_adder_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_adder_) is *false*, throw a *TypeError* exception.
           1. Return ? AddEntriesFromIterable(_map_, _iterable_, _adder_).
         </emu-alg>
         <emu-note>
@@ -44346,7 +44346,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _map_ be the *this* value.
           1. Perform ? RequireInternalSlot(_map_, [[MapData]]).
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. Let _entries_ be _map_.[[MapData]].
           1. Let _entriesCount_ be the number of elements in _entries_.
           1. Let _index_ be 0.
@@ -44401,7 +44401,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _map_ be the *this* value.
           1. Perform ? RequireInternalSlot(_map_, [[MapData]]).
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. Set _key_ to CanonicalizeKeyedCollectionKey(_key_).
           1. For each Record { [[Key]], [[Value]] } _entry_ of _map_.[[MapData]], do
             1. If _entry_.[[Key]] is not ~empty~ and SameValue(_entry_.[[Key]], _key_) is *true*, return _entry_.[[Value]].
@@ -44651,9 +44651,9 @@ THH:mm:ss.sss
           1. Let _intSize_ be ! ToIntegerOrInfinity(_numberSize_).
           1. If _intSize_ &lt; 0, throw a *RangeError* exception.
           1. Let _has_ be ? Get(_obj_, *"has"*).
-          1. If IsCallable(_has_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_has_) is *false*, throw a *TypeError* exception.
           1. Let _keys_ be ? Get(_obj_, *"keys"*).
-          1. If IsCallable(_keys_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_keys_) is *false*, throw a *TypeError* exception.
           1. Return a new Set Record { [[SetObject]]: _obj_, [[Size]]: _intSize_, [[Has]]: _has_, [[Keys]]: _keys_ }.
         </emu-alg>
       </emu-clause>
@@ -44732,7 +44732,7 @@ THH:mm:ss.sss
           1. Set _set_.[[SetData]] to a new empty List.
           1. If _iterable_ is either *undefined* or *null*, return _set_.
           1. Let _adder_ be ? Get(_set_, *"add"*).
-          1. If IsCallable(_adder_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_adder_) is *false*, throw a *TypeError* exception.
           1. Let _iteratorRecord_ be ? GetIterator(_iterable_, ~sync~).
           1. Repeat,
             1. Let _next_ be ? IteratorStepValue(_iteratorRecord_).
@@ -44885,7 +44885,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _set_ be the *this* value.
           1. Perform ? RequireInternalSlot(_set_, [[SetData]]).
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. Let _entries_ be _set_.[[SetData]].
           1. Let _entriesCount_ be the number of elements in _entries_.
           1. Let _index_ be 0.
@@ -45222,7 +45222,7 @@ THH:mm:ss.sss
           1. Set _map_.[[WeakMapData]] to a new empty List.
           1. If _iterable_ is either *undefined* or *null*, return _map_.
           1. Let _adder_ be ? Get(_map_, *"set"*).
-          1. If IsCallable(_adder_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_adder_) is *false*, throw a *TypeError* exception.
           1. Return ? AddEntriesFromIterable(_map_, _iterable_, _adder_).
         </emu-alg>
         <emu-note>
@@ -45315,7 +45315,7 @@ THH:mm:ss.sss
           1. Let _weakMap_ be the *this* value.
           1. Perform ? RequireInternalSlot(_weakMap_, [[WeakMapData]]).
           1. If CanBeHeldWeakly(_key_) is *false*, throw a *TypeError* exception.
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. For each Record { [[Key]], [[Value]] } _entry_ of _weakMap_.[[WeakMapData]], do
             1. If _entry_.[[Key]] is not ~empty~ and SameValue(_entry_.[[Key]], _key_) is *true*, return _entry_.[[Value]].
           1. Let _value_ be ? Call(_callback_, *undefined*, « _key_ »).
@@ -45402,7 +45402,7 @@ THH:mm:ss.sss
           1. Set _set_.[[WeakSetData]] to a new empty List.
           1. If _iterable_ is either *undefined* or *null*, return _set_.
           1. Let _adder_ be ? Get(_set_, *"add"*).
-          1. If IsCallable(_adder_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_adder_) is *false*, throw a *TypeError* exception.
           1. Let _iteratorRecord_ be ? GetIterator(_iterable_, ~sync~).
           1. Repeat,
             1. Let _next_ be ? IteratorStepValue(_iteratorRecord_).
@@ -47943,7 +47943,7 @@ THH:mm:ss.sss
         1. Let _jsonString_ be ? ToString(_text_).
         1. Let _parseResult_ be ? ParseJSON(_jsonString_).
         1. Let _unfiltered_ be _parseResult_.[[Value]].
-        1. If IsCallable(_reviver_) is *false*, return _unfiltered_.
+        1. If IsFunction(_reviver_) is *false*, return _unfiltered_.
         1. Let _root_ be OrdinaryObjectCreate(%Object.prototype%).
         1. Let _rootName_ be the empty String.
         1. Perform ! CreateDataPropertyOrThrow(_root_, _rootName_, _unfiltered_).
@@ -48237,7 +48237,7 @@ THH:mm:ss.sss
         1. Let _propertyList_ be *undefined*.
         1. Let _replacerFunc_ be *undefined*.
         1. If _replacer_ is an Object, then
-          1. If IsCallable(_replacer_) is *true*, then
+          1. If IsFunction(_replacer_) is *true*, then
             1. Set _replacerFunc_ to _replacer_.
           1. Else,
             1. Let _isArray_ be ? IsArray(_replacer_).
@@ -48371,7 +48371,7 @@ THH:mm:ss.sss
           1. Let _value_ be ? Get(_holder_, _key_).
           1. If _value_ is an Object or _value_ is a BigInt, then
             1. Let _toJSON_ be ? GetV(_value_, *"toJSON"*).
-            1. If IsCallable(_toJSON_) is *true*, then
+            1. If IsFunction(_toJSON_) is *true*, then
               1. Set _value_ to ? Call(_toJSON_, _value_, « _key_ »).
           1. If _state_.[[ReplacerFunction]] is not *undefined*, then
             1. Set _value_ to ? Call(_state_.[[ReplacerFunction]], _holder_, « _key_, _value_ »).
@@ -48396,7 +48396,7 @@ THH:mm:ss.sss
             1. If _value_ is finite, return ! ToString(_value_).
             1. Return *"null"*.
           1. If _value_ is a BigInt, throw a *TypeError* exception.
-          1. If _value_ is an Object and IsCallable(_value_) is *false*, then
+          1. If _value_ is an Object and IsFunction(_value_) is *false*, then
             1. Let _isArray_ be ? IsArray(_value_).
             1. If _isArray_ is *true*, then
               1. Return ? SerializeJSONArray(_state_, _value_).
@@ -48809,7 +48809,7 @@ THH:mm:ss.sss
         <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
-          1. If IsCallable(_cleanupCallback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_cleanupCallback_) is *false*, throw a *TypeError* exception.
           1. Let _finalizationRegistry_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%FinalizationRegistry.prototype%"*, « [[Realm]], [[CleanupCallback]], [[Cells]] »).
           1. Let _activeFunc_ be the active function object.
           1. Set _finalizationRegistry_.[[Realm]] to _activeFunc_.[[Realm]].
@@ -49493,7 +49493,7 @@ THH:mm:ss.sss
             1. Let _obj_ be the *this* value.
             1. If _obj_ is not an Object, throw a *TypeError* exception.
             1. Let _iterated_ be the Iterator Record { [[Iterator]]: _obj_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
-            1. If IsCallable(_predicate_) is *false*, then
+            1. If IsFunction(_predicate_) is *false*, then
               1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
               1. Return ? IteratorClose(_iterated_, _error_).
             1. Set _iterated_ to ? GetIteratorDirect(_obj_).
@@ -49515,7 +49515,7 @@ THH:mm:ss.sss
             1. Let _obj_ be the *this* value.
             1. If _obj_ is not an Object, throw a *TypeError* exception.
             1. Let _iterated_ be the Iterator Record { [[Iterator]]: _obj_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
-            1. If IsCallable(_predicate_) is *false*, then
+            1. If IsFunction(_predicate_) is *false*, then
               1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
               1. Return ? IteratorClose(_iterated_, _error_).
             1. Set _iterated_ to ? GetIteratorDirect(_obj_).
@@ -49543,7 +49543,7 @@ THH:mm:ss.sss
             1. Let _obj_ be the *this* value.
             1. If _obj_ is not an Object, throw a *TypeError* exception.
             1. Let _iterated_ be the Iterator Record { [[Iterator]]: _obj_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
-            1. If IsCallable(_predicate_) is *false*, then
+            1. If IsFunction(_predicate_) is *false*, then
               1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
               1. Return ? IteratorClose(_iterated_, _error_).
             1. Set _iterated_ to ? GetIteratorDirect(_obj_).
@@ -49565,7 +49565,7 @@ THH:mm:ss.sss
             1. Let _obj_ be the *this* value.
             1. If _obj_ is not an Object, throw a *TypeError* exception.
             1. Let _iterated_ be the Iterator Record { [[Iterator]]: _obj_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
-            1. If IsCallable(_mapper_) is *false*, then
+            1. If IsFunction(_mapper_) is *false*, then
               1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
               1. Return ? IteratorClose(_iterated_, _error_).
             1. Set _iterated_ to ? GetIteratorDirect(_obj_).
@@ -49604,7 +49604,7 @@ THH:mm:ss.sss
             1. Let _obj_ be the *this* value.
             1. If _obj_ is not an Object, throw a *TypeError* exception.
             1. Let _iterated_ be the Iterator Record { [[Iterator]]: _obj_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
-            1. If IsCallable(_procedure_) is *false*, then
+            1. If IsFunction(_procedure_) is *false*, then
               1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
               1. Return ? IteratorClose(_iterated_, _error_).
             1. Set _iterated_ to ? GetIteratorDirect(_obj_).
@@ -49625,7 +49625,7 @@ THH:mm:ss.sss
             1. Let _obj_ be the *this* value.
             1. If _obj_ is not an Object, throw a *TypeError* exception.
             1. Let _iterated_ be the Iterator Record { [[Iterator]]: _obj_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
-            1. If IsCallable(_mapper_) is *false*, then
+            1. If IsFunction(_mapper_) is *false*, then
               1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
               1. Return ? IteratorClose(_iterated_, _error_).
             1. Set _iterated_ to ? GetIteratorDirect(_obj_).
@@ -49652,7 +49652,7 @@ THH:mm:ss.sss
             1. Let _obj_ be the *this* value.
             1. If _obj_ is not an Object, throw a *TypeError* exception.
             1. Let _iterated_ be the Iterator Record { [[Iterator]]: _obj_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
-            1. If IsCallable(_reducer_) is *false*, then
+            1. If IsFunction(_reducer_) is *false*, then
               1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
               1. Return ? IteratorClose(_iterated_, _error_).
             1. Set _iterated_ to ? GetIteratorDirect(_obj_).
@@ -49680,7 +49680,7 @@ THH:mm:ss.sss
             1. Let _obj_ be the *this* value.
             1. If _obj_ is not an Object, throw a *TypeError* exception.
             1. Let _iterated_ be the Iterator Record { [[Iterator]]: _obj_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
-            1. If IsCallable(_predicate_) is *false*, then
+            1. If IsFunction(_predicate_) is *false*, then
               1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
               1. Return ? IteratorClose(_iterated_, _error_).
             1. Set _iterated_ to ? GetIteratorDirect(_obj_).
@@ -50226,7 +50226,7 @@ THH:mm:ss.sss
           1. Let _disposableStack_ be the *this* value.
           1. Perform ? RequireInternalSlot(_disposableStack_, [[DisposableState]]).
           1. If _disposableStack_.[[DisposableState]] is ~disposed~, throw a *ReferenceError* exception.
-          1. If IsCallable(_onDispose_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_onDispose_) is *false*, throw a *TypeError* exception.
           1. Let _closure_ be a new Abstract Closure with no parameters that captures _value_ and _onDispose_ and performs the following steps when called:
             1. Return ? Call(_onDispose_, *undefined*, « _value_ »).
           1. Let _func_ be CreateBuiltinFunction(_closure_, 0, *""*, « »).
@@ -50247,7 +50247,7 @@ THH:mm:ss.sss
           1. Let _disposableStack_ be the *this* value.
           1. Perform ? RequireInternalSlot(_disposableStack_, [[DisposableState]]).
           1. If _disposableStack_.[[DisposableState]] is ~disposed~, throw a *ReferenceError* exception.
-          1. If IsCallable(_onDispose_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_onDispose_) is *false*, throw a *TypeError* exception.
           1. Perform ? AddDisposableResource(_disposableStack_.[[DisposableResourceStack]], *undefined*, ~sync-dispose~, _onDispose_).
           1. Return *undefined*.
         </emu-alg>
@@ -50420,7 +50420,7 @@ THH:mm:ss.sss
           1. Let _asyncDisposableStack_ be the *this* value.
           1. Perform ? RequireInternalSlot(_asyncDisposableStack_, [[AsyncDisposableState]]).
           1. If _asyncDisposableStack_.[[AsyncDisposableState]] is ~disposed~, throw a *ReferenceError* exception.
-          1. If IsCallable(_onDisposeAsync_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_onDisposeAsync_) is *false*, throw a *TypeError* exception.
           1. Let _closure_ be a new Abstract Closure with no parameters that captures _value_ and _onDisposeAsync_ and performs the following steps when called:
             1. Return ? Call(_onDisposeAsync_, *undefined*, « _value_ »).
           1. Let _func_ be CreateBuiltinFunction(_closure_, 0, *""*, « »).
@@ -50441,7 +50441,7 @@ THH:mm:ss.sss
           1. Let _asyncDisposableStack_ be the *this* value.
           1. Perform ? RequireInternalSlot(_asyncDisposableStack_, [[AsyncDisposableState]]).
           1. If _asyncDisposableStack_.[[AsyncDisposableState]] is ~disposed~, throw a *ReferenceError* exception.
-          1. If IsCallable(_onDisposeAsync_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_onDisposeAsync_) is *false*, throw a *TypeError* exception.
           1. Perform ? AddDisposableResource(_asyncDisposableStack_.[[DisposableResourceStack]], *undefined*, ~async-dispose~, _onDisposeAsync_).
           1. Return *undefined*.
         </emu-alg>
@@ -50728,7 +50728,7 @@ THH:mm:ss.sss
               1. Perform RejectPromise(_promise_, _then_.[[Value]]).
               1. Return *undefined*.
             1. Let _thenAction_ be _then_.[[Value]].
-            1. If IsCallable(_thenAction_) is *false*, then
+            1. If IsFunction(_thenAction_) is *false*, then
               1. Perform FulfillPromise(_promise_, _resolution_).
               1. Return *undefined*.
             1. Let _thenJobCallback_ be HostMakeJobCallback(_thenAction_).
@@ -50790,8 +50790,8 @@ THH:mm:ss.sss
             1. Return NormalCompletion(*undefined*).
           1. Let _executor_ be CreateBuiltinFunction(_executorClosure_, 2, *""*, « »).
           1. Let _promise_ be ? Construct(_ctor_, « _executor_ »).
-          1. If IsCallable(_resolvingFuncs_.[[Resolve]]) is *false*, throw a *TypeError* exception.
-          1. If IsCallable(_resolvingFuncs_.[[Reject]]) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_resolvingFuncs_.[[Resolve]]) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_resolvingFuncs_.[[Reject]]) is *false*, throw a *TypeError* exception.
           1. Return the PromiseCapability Record { [[Promise]]: _promise_, [[Resolve]]: _resolvingFuncs_.[[Resolve]], [[Reject]]: _resolvingFuncs_.[[Reject]] }.
         </emu-alg>
         <emu-note>
@@ -50976,7 +50976,7 @@ THH:mm:ss.sss
         <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
-          1. If IsCallable(_executor_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_executor_) is *false*, throw a *TypeError* exception.
           1. Let _promise_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Promise.prototype%"*, « [[PromiseState]], [[PromiseResult]], [[PromiseFulfillReactions]], [[PromiseRejectReactions]], [[PromiseIsHandled]] »).
           1. Set _promise_.[[PromiseState]] to ~pending~.
           1. Set _promise_.[[PromiseResult]] to ~empty~.
@@ -51036,7 +51036,7 @@ THH:mm:ss.sss
           </dl>
           <emu-alg>
             1. Let _promiseResolve_ be ? Get(_promiseCtor_, *"resolve"*).
-            1. If IsCallable(_promiseResolve_) is *false*, throw a *TypeError* exception.
+            1. If IsFunction(_promiseResolve_) is *false*, throw a *TypeError* exception.
             1. Return _promiseResolve_.
           </emu-alg>
         </emu-clause>
@@ -51422,7 +51422,7 @@ THH:mm:ss.sss
           1. If _promise_ is not an Object, throw a *TypeError* exception.
           1. Let _ctor_ be ? SpeciesConstructor(_promise_, %Promise%).
           1. Assert: IsConstructor(_ctor_) is *true*.
-          1. If IsCallable(_onFinally_) is *false*, then
+          1. If IsFunction(_onFinally_) is *false*, then
             1. Let _thenFinally_ be _onFinally_.
             1. Let _catchFinally_ be _onFinally_.
           1. Else,
@@ -51474,11 +51474,11 @@ THH:mm:ss.sss
             1. Assert: IsPromise(_promise_) is *true*.
             1. If _resultCapability_ is not present, then
               1. Set _resultCapability_ to *undefined*.
-            1. If IsCallable(_onFulfilled_) is *false*, then
+            1. If IsFunction(_onFulfilled_) is *false*, then
               1. Let _onFulfilledJobCallback_ be ~empty~.
             1. Else,
               1. Let _onFulfilledJobCallback_ be HostMakeJobCallback(_onFulfilled_).
-            1. If IsCallable(_onRejected_) is *false*, then
+            1. If IsFunction(_onRejected_) is *false*, then
               1. Let _onRejectedJobCallback_ be ~empty~.
             1. Else,
               1. Let _onRejectedJobCallback_ be HostMakeJobCallback(_onRejected_).
@@ -52698,7 +52698,7 @@ THH:mm:ss.sss
       <h1>Reflect.apply ( _target_, _thisArg_, _args_ )</h1>
       <p>This function performs the following steps when called:</p>
       <emu-alg>
-        1. If IsCallable(_target_) is *false*, throw a *TypeError* exception.
+        1. If IsFunction(_target_) is *false*, throw a *TypeError* exception.
         1. Let _argList_ be ? CreateListFromArrayLike(_args_).
         1. Perform PrepareForTailCall().
         1. Return ? Call(_target_, _thisArg_, _argList_).

--- a/spec.html
+++ b/spec.html
@@ -4740,12 +4740,12 @@
           1. Let _hasGet_ be ? HasProperty(_obj_, *"get"*).
           1. If _hasGet_ is *true*, then
             1. Let _getter_ be ? Get(_obj_, *"get"*).
-            1. If IsCallable(_getter_) is *false* and _getter_ is not *undefined*, throw a *TypeError* exception.
+            1. If IsFunction(_getter_) is *false* and _getter_ is not *undefined*, throw a *TypeError* exception.
             1. Set _propertyDesc_.[[Getter]] to _getter_.
           1. Let _hasSet_ be ? HasProperty(_obj_, *"set"*).
           1. If _hasSet_ is *true*, then
             1. Let _setter_ be ? Get(_obj_, *"set"*).
-            1. If IsCallable(_setter_) is *false* and _setter_ is not *undefined*, throw a *TypeError* exception.
+            1. If IsFunction(_setter_) is *false* and _setter_ is not *undefined*, throw a *TypeError* exception.
             1. Set _propertyDesc_.[[Setter]] to _setter_.
           1. If _propertyDesc_ has a [[Getter]] field or _propertyDesc_ has a [[Setter]] field, then
             1. If _propertyDesc_ has a [[Value]] field or _propertyDesc_ has a [[Writable]] field, throw a *TypeError* exception.
@@ -5124,7 +5124,7 @@
             1. Let _methodNames_ be « *"valueOf"*, *"toString"* ».
           1. For each element _name_ of _methodNames_, do
             1. Let _method_ be ? Get(_obj_, _name_).
-            1. If IsCallable(_method_) is *true*, then
+            1. If IsFunction(_method_) is *true*, then
               1. Let _result_ be ? Call(_method_, _obj_).
               1. If _result_ is not an Object, return _result_.
           1. Throw a *TypeError* exception.
@@ -5894,15 +5894,15 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-iscallable" type="abstract operation">
+    <emu-clause id="sec-isfunction" type="abstract operation" oldids="sec-iscallable">
       <h1>
-        IsCallable (
+        IsFunction (
           _arg_: an ECMAScript language value,
         ): a Boolean
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It determines if _arg_ is a callable function with a [[Call]] internal method.</dd>
+        <dd>It determines if _arg_ is a function (i.e., an Object with a [[Call]] internal method).</dd>
       </dl>
       <emu-alg>
         1. If _arg_ is not an Object, return *false*.
@@ -6404,7 +6404,7 @@
       <emu-alg>
         1. Let _func_ be ? GetV(_value_, _propertyKey_).
         1. If _func_ is either *undefined* or *null*, return *undefined*.
-        1. If IsCallable(_func_) is *false*, throw a *TypeError* exception.
+        1. If IsFunction(_func_) is *false*, throw a *TypeError* exception.
         1. Return _func_.
       </emu-alg>
     </emu-clause>
@@ -6457,7 +6457,7 @@
       </dl>
       <emu-alg>
         1. If _argList_ is not present, set _argList_ to a new empty List.
-        1. If IsCallable(_func_) is *false*, throw a *TypeError* exception.
+        1. If IsFunction(_func_) is *false*, throw a *TypeError* exception.
         1. Return ? <emu-meta effects="user-code">_func_.[[Call]](_thisValue_, _argList_)</emu-meta>.
       </emu-alg>
     </emu-clause>
@@ -6643,7 +6643,7 @@
         <dd>It implements the default algorithm for determining if _instance_ inherits from the instance object inheritance path provided by _ctor_.</dd>
       </dl>
       <emu-alg>
-        1. If IsCallable(_ctor_) is *false*, return *false*.
+        1. If IsFunction(_ctor_) is *false*, return *false*.
         1. If _ctor_ has a [[BoundTargetFunction]] internal slot, then
           1. Let _boundCtor_ be _ctor_.[[BoundTargetFunction]].
           1. Return ? InstanceofOperator(_instance_, _boundCtor_).
@@ -6969,7 +6969,7 @@
       </dl>
       <emu-alg>
         1. Perform ? RequireObjectCoercible(_items_).
-        1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+        1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
         1. Let _groups_ be a new empty List.
         1. Let _iteratorRecord_ be ? GetIterator(_items_, ~sync~).
         1. Let _k_ be 0.
@@ -12607,7 +12607,7 @@
       </emu-note>
       <p>The default implementation of HostCallJobCallback performs the following steps when called:</p>
       <emu-alg>
-        1. Assert: IsCallable(_jobCallback_.[[Callback]]) is *true*.
+        1. Assert: IsFunction(_jobCallback_.[[Callback]]) is *true*.
         1. Return ? Call(_jobCallback_.[[Callback]], _thisValue_, _argList_).
       </emu-alg>
       <p>ECMAScript hosts that are not web browsers must use the default implementation of HostCallJobCallback.</p>
@@ -16636,7 +16636,7 @@
         1. If _handler_ is not an Object, throw a *TypeError* exception.
         1. Let _proxy_ be MakeBasicObject(« [[ProxyHandler]], [[ProxyTarget]] »).
         1. Set _proxy_'s essential internal methods, except for [[Call]] and [[Construct]], to the definitions specified in <emu-xref href="#sec-proxy-object-internal-methods-and-internal-slots"></emu-xref>.
-        1. If IsCallable(_target_) is *true*, then
+        1. If IsFunction(_target_) is *true*, then
           1. Set _proxy_.[[Call]] as specified in <emu-xref href="#sec-proxy-object-internal-methods-and-internal-slots-call-thisargument-argumentslist"></emu-xref>.
           1. If IsConstructor(_target_) is *true*, then
             1. Set _proxy_.[[Construct]] as specified in <emu-xref href="#sec-proxy-object-internal-methods-and-internal-slots-construct-argumentslist-newtarget"></emu-xref>.
@@ -19942,7 +19942,7 @@
             1. Let _thisValue_ be *undefined*.
           1. Let _argList_ be ? ArgumentListEvaluation of _argumentListNode_.
           1. If _func_ is not an Object, throw a *TypeError* exception.
-          1. If IsCallable(_func_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_func_) is *false*, throw a *TypeError* exception.
           1. If _tailPosition_ is *true*, perform PrepareForTailCall().
           1. Return ? Call(_func_, _thisValue_, _argList_).
         </emu-alg>
@@ -20977,7 +20977,7 @@
         1. Let _instOfHandler_ be ? GetMethod(_target_, %Symbol.hasInstance%).
         1. If _instOfHandler_ is not *undefined*, then
           1. Return ToBoolean(? Call(_instOfHandler_, _target_, « _value_ »)).
-        1. [id="step-instanceof-check-function"] If IsCallable(_target_) is *false*, throw a *TypeError* exception.
+        1. [id="step-instanceof-check-function"] If IsFunction(_target_) is *false*, throw a *TypeError* exception.
         1. [id="step-instanceof-fallback"] Return ? OrdinaryHasInstance(_target_, _value_).
       </emu-alg>
       <emu-note>
@@ -31681,7 +31681,7 @@
           <p>This method performs the following steps when called:</p>
           <emu-alg>
             1. Let _obj_ be ? ToObject(*this* value).
-            1. If IsCallable(_getter_) is *false*, throw a *TypeError* exception.
+            1. If IsFunction(_getter_) is *false*, throw a *TypeError* exception.
             1. Let _propertyDesc_ be PropertyDescriptor { [[Getter]]: _getter_, [[Enumerable]]: *true*, [[Configurable]]: *true* }.
             1. Let _propertyKey_ be ? ToPropertyKey(_key_).
             1. Perform ? DefinePropertyOrThrow(_obj_, _propertyKey_, _propertyDesc_).
@@ -31694,7 +31694,7 @@
           <p>This method performs the following steps when called:</p>
           <emu-alg>
             1. Let _obj_ be ? ToObject(*this* value).
-            1. If IsCallable(_setter_) is *false*, throw a *TypeError* exception.
+            1. If IsFunction(_setter_) is *false*, throw a *TypeError* exception.
             1. Let _propertyDesc_ be PropertyDescriptor { [[Setter]]: _setter_, [[Enumerable]]: *true*, [[Configurable]]: *true* }.
             1. Let _propertyKey_ be ? ToPropertyKey(_key_).
             1. Perform ? DefinePropertyOrThrow(_obj_, _propertyKey_, _propertyDesc_).
@@ -31902,7 +31902,7 @@
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _func_ be the *this* value.
-          1. If IsCallable(_func_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_func_) is *false*, throw a *TypeError* exception.
           1. If _argArray_ is either *undefined* or *null*, then
             1. Perform PrepareForTailCall().
             1. Return ? Call(_func_, _thisArg_).
@@ -31923,7 +31923,7 @@
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _target_ be the *this* value.
-          1. If IsCallable(_target_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_target_) is *false*, throw a *TypeError* exception.
           1. Let _boundFunc_ be ? BoundFunctionCreate(_target_, _thisArg_, _args_).
           1. Let _length_ be 0.
           1. Let _targetHasLength_ be ? HasOwnProperty(_target_, *"length"*).
@@ -31957,7 +31957,7 @@
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _func_ be the *this* value.
-          1. If IsCallable(_func_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_func_) is *false*, throw a *TypeError* exception.
           1. Perform PrepareForTailCall().
           1. [id="step-function-proto-call-call"] Return ? Call(_func_, _thisArg_, _args_).
         </emu-alg>
@@ -31982,7 +31982,7 @@
           1. If _func_ is an Object, _func_ has a [[SourceText]] internal slot, _func_.[[SourceText]] is a sequence of Unicode code points, and HostHasSourceTextAvailable(_func_) is *true*, then
             1. Return CodePointsToString(_func_.[[SourceText]]).
           1. If _func_ is a <emu-xref href="#sec-built-in-function-objects">built-in function object</emu-xref>, return an implementation-defined String source code representation of _func_. The representation must have the syntax of a |NativeFunction|. Additionally, if _func_ has an [[InitialName]] internal slot and _func_.[[InitialName]] is a String, the portion of the returned String that would be matched by |NativeFunctionAccessor?| |PropertyName| must be _func_.[[InitialName]].
-          1. If _func_ is an Object and IsCallable(_func_) is *true*, return an implementation-defined String source code representation of _func_. The representation must have the syntax of a |NativeFunction|.
+          1. If _func_ is an Object and IsFunction(_func_) is *true*, return an implementation-defined String source code representation of _func_. The representation must have the syntax of a |NativeFunction|.
           1. Throw a *TypeError* exception.
         </emu-alg>
 
@@ -36658,7 +36658,7 @@ THH:mm:ss.sss
               1. Return ? Call(_replacer_, _searchValue_, « _thisValue_, _replaceValue_ »).
           1. Let _string_ be ? ToString(_thisValue_).
           1. Let _searchString_ be ? ToString(_searchValue_).
-          1. Let _functionalReplace_ be IsCallable(_replaceValue_).
+          1. Let _functionalReplace_ be IsFunction(_replaceValue_).
           1. If _functionalReplace_ is *false*, then
             1. Set _replaceValue_ to ? ToString(_replaceValue_).
           1. Let _searchLength_ be the length of _searchString_.
@@ -36777,7 +36777,7 @@ THH:mm:ss.sss
               1. Return ? Call(_replacer_, _searchValue_, « _thisValue_, _replaceValue_ »).
           1. Let _string_ be ? ToString(_thisValue_).
           1. Let _searchString_ be ? ToString(_searchValue_).
-          1. Let _functionalReplace_ be IsCallable(_replaceValue_).
+          1. Let _functionalReplace_ be IsFunction(_replaceValue_).
           1. If _functionalReplace_ is *false*, then
             1. Set _replaceValue_ to ? ToString(_replaceValue_).
           1. Let _searchLength_ be the length of _searchString_.
@@ -39822,7 +39822,7 @@ THH:mm:ss.sss
           1. If _regexp_ is not an Object, throw a *TypeError* exception.
           1. Set _string_ to ? ToString(_string_).
           1. Let _stringLength_ be the length of _string_.
-          1. Let _functionalReplace_ be IsCallable(_replaceValue_).
+          1. Let _functionalReplace_ be IsFunction(_replaceValue_).
           1. If _functionalReplace_ is *false*, then
             1. Set _replaceValue_ to ? ToString(_replaceValue_).
           1. Let _flags_ be ? ToString(? Get(_regexp_, *"flags"*)).
@@ -40095,7 +40095,7 @@ THH:mm:ss.sss
         </dl>
         <emu-alg>
           1. Let _exec_ be ? Get(_regexp_, *"exec"*).
-          1. If IsCallable(_exec_) is *true*, then
+          1. If IsFunction(_exec_) is *true*, then
             1. Let _result_ be ? Call(_exec_, _regexp_, « _string_ »).
             1. If _result_ is not an Object and _result_ is not *null*, throw a *TypeError* exception.
             1. Return _result_.
@@ -40541,7 +40541,7 @@ THH:mm:ss.sss
           1. If _mapper_ is *undefined*, then
             1. Let _mapping_ be *false*.
           1. Else,
-            1. If IsCallable(_mapper_) is *false*, throw a *TypeError* exception.
+            1. If IsFunction(_mapper_) is *false*, throw a *TypeError* exception.
             1. Let _mapping_ be *true*.
           1. Let _usingIterator_ be ? GetMethod(_items_, %Symbol.iterator%).
           1. If _usingIterator_ is not *undefined*, then
@@ -40601,7 +40601,7 @@ THH:mm:ss.sss
           1. Let _ctor_ be the *this* value.
           1. Let _mapping_ be *false*.
           1. If _mapper_ is not *undefined*, then
-            1. If IsCallable(_mapper_) is *false*, throw a *TypeError* exception.
+            1. If IsFunction(_mapper_) is *false*, throw a *TypeError* exception.
             1. Set _mapping_ to *true*.
           1. Let _iteratorRecord_ be *undefined*.
           1. Let _usingAsyncIterator_ be ? GetMethod(_items_, %Symbol.asyncIterator%).
@@ -40869,7 +40869,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _obj_ be ? ToObject(*this* value).
           1. Let _length_ be ? LengthOfArrayLike(_obj_).
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _length_,
             1. Let _propertyKey_ be ! ToString(𝔽(_k_)).
@@ -40925,7 +40925,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _obj_ be ? ToObject(*this* value).
           1. Let _length_ be ? LengthOfArrayLike(_obj_).
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. Let _array_ be ? ArraySpeciesCreate(_obj_, 0).
           1. Let _k_ be 0.
           1. Let _to_ be 0.
@@ -41038,7 +41038,7 @@ THH:mm:ss.sss
             </dd>
           </dl>
           <emu-alg>
-            1. If IsCallable(_predicate_) is *false*, throw a *TypeError* exception.
+            1. If IsFunction(_predicate_) is *false*, throw a *TypeError* exception.
             1. If _direction_ is ~ascending~, then
               1. Let _indices_ be a List of the integers in the interval from 0 (inclusive) to _length_ (exclusive), in ascending order.
             1. Else,
@@ -41084,7 +41084,7 @@ THH:mm:ss.sss
           <dl class="header">
           </dl>
           <emu-alg>
-            1. Assert: If _mapperFunc_ is present, then IsCallable(_mapperFunc_) is *true*, _thisArg_ is present, and _depth_ is 1.
+            1. Assert: If _mapperFunc_ is present, then IsFunction(_mapperFunc_) is *true*, _thisArg_ is present, and _depth_ is 1.
             1. Let _targetIndex_ be _start_.
             1. Let _sourceIndex_ be 0.
             1. Repeat, while _sourceIndex_ &lt; _sourceLength_,
@@ -41118,7 +41118,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _obj_ be ? ToObject(*this* value).
           1. Let _sourceLength_ be ? LengthOfArrayLike(_obj_).
-          1. If IsCallable(_mapperFunc_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_mapperFunc_) is *false*, throw a *TypeError* exception.
           1. Let _array_ be ? ArraySpeciesCreate(_obj_, 0).
           1. Perform ? FlattenIntoArray(_array_, _obj_, _sourceLength_, 0, 1, _mapperFunc_, _thisArg_).
           1. Return _array_.
@@ -41138,7 +41138,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _obj_ be ? ToObject(*this* value).
           1. Let _length_ be ? LengthOfArrayLike(_obj_).
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _length_,
             1. Let _propertyKey_ be ! ToString(𝔽(_k_)).
@@ -41279,7 +41279,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _obj_ be ? ToObject(*this* value).
           1. Let _length_ be ? LengthOfArrayLike(_obj_).
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. Let _array_ be ? ArraySpeciesCreate(_obj_, _length_).
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _length_,
@@ -41357,7 +41357,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _obj_ be ? ToObject(*this* value).
           1. Let _length_ be ? LengthOfArrayLike(_obj_).
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. If _length_ = 0 and _initialValue_ is not present, throw a *TypeError* exception.
           1. Let _k_ be 0.
           1. Let _accumulator_ be *undefined*.
@@ -41398,7 +41398,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _obj_ be ? ToObject(*this* value).
           1. Let _length_ be ? LengthOfArrayLike(_obj_).
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. If _length_ = 0 and _initialValue_ is not present, throw a *TypeError* exception.
           1. Let _k_ be _length_ - 1.
           1. Let _accumulator_ be *undefined*.
@@ -41544,7 +41544,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _obj_ be ? ToObject(*this* value).
           1. Let _length_ be ? LengthOfArrayLike(_obj_).
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _length_,
             1. Let _propertyKey_ be ! ToString(𝔽(_k_)).
@@ -41566,7 +41566,7 @@ THH:mm:ss.sss
         <p>This method sorts the elements of this array. If _comparator_ is not *undefined*, it should be a function that accepts two arguments _x_ and _y_ and returns a negative Number if _x_ &lt; _y_, a positive Number if _x_ > _y_, or a zero otherwise.</p>
         <p>It performs the following steps when called:</p>
         <emu-alg>
-          1. [id="step-array-sort-comparefn"] If _comparator_ is not *undefined* and IsCallable(_comparator_) is *false*, throw a *TypeError* exception.
+          1. [id="step-array-sort-comparefn"] If _comparator_ is not *undefined* and IsFunction(_comparator_) is *false*, throw a *TypeError* exception.
           1. Let _obj_ be ? ToObject(*this* value).
           1. [id="step-array-sort-len"] Let _length_ be ? LengthOfArrayLike(_obj_).
           1. Let _sortCompare_ be a new Abstract Closure with parameters (_x_, _y_) that captures _comparator_ and performs the following steps when called:
@@ -41816,7 +41816,7 @@ THH:mm:ss.sss
         <h1>Array.prototype.toSorted ( _comparator_ )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. If _comparator_ is not *undefined* and IsCallable(_comparator_) is *false*, throw a *TypeError* exception.
+          1. If _comparator_ is not *undefined* and IsFunction(_comparator_) is *false*, throw a *TypeError* exception.
           1. Let _obj_ be ? ToObject(*this* value).
           1. Let _length_ be ? LengthOfArrayLike(_obj_).
           1. Let _array_ be ? ArrayCreate(_length_).
@@ -41878,7 +41878,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _array_ be ? ToObject(*this* value).
           1. Let _func_ be ? Get(_array_, *"join"*).
-          1. If IsCallable(_func_) is *false*, set _func_ to the intrinsic function %Object.prototype.toString%.
+          1. If IsFunction(_func_) is *false*, set _func_ to the intrinsic function %Object.prototype.toString%.
           1. Return ? Call(_func_, _array_).
         </emu-alg>
         <emu-note>
@@ -42411,7 +42411,7 @@ THH:mm:ss.sss
           1. If _mapper_ is *undefined*, then
             1. Let _mapping_ be *false*.
           1. Else,
-            1. If IsCallable(_mapper_) is *false*, throw a *TypeError* exception.
+            1. If IsFunction(_mapper_) is *false*, throw a *TypeError* exception.
             1. Let _mapping_ be *true*.
           1. Let _usingIterator_ be ? GetMethod(_source_, %Symbol.iterator%).
           1. If _usingIterator_ is not *undefined*, then
@@ -42610,7 +42610,7 @@ THH:mm:ss.sss
           1. Let _obj_ be the *this* value.
           1. Let _taRecord_ be ? ValidateTypedArray(_obj_, ~seq-cst~).
           1. Let _length_ be TypedArrayLength(_taRecord_).
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _length_,
             1. Let _propertyKey_ be ! ToString(𝔽(_k_)).
@@ -42655,7 +42655,7 @@ THH:mm:ss.sss
           1. Let _obj_ be the *this* value.
           1. Let _taRecord_ be ? ValidateTypedArray(_obj_, ~seq-cst~).
           1. Let _length_ be TypedArrayLength(_taRecord_).
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. Let _kept_ be a new empty List.
           1. Let _captured_ be 0.
           1. Let _k_ be 0.
@@ -42741,7 +42741,7 @@ THH:mm:ss.sss
           1. Let _obj_ be the *this* value.
           1. Let _taRecord_ be ? ValidateTypedArray(_obj_, ~seq-cst~).
           1. Let _length_ be TypedArrayLength(_taRecord_).
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _length_,
             1. Let _propertyKey_ be ! ToString(𝔽(_k_)).
@@ -42873,7 +42873,7 @@ THH:mm:ss.sss
           1. Let _obj_ be the *this* value.
           1. Let _taRecord_ be ? ValidateTypedArray(_obj_, ~seq-cst~).
           1. Let _length_ be TypedArrayLength(_taRecord_).
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. Let _result_ be ? TypedArraySpeciesCreate(_obj_, « 𝔽(_length_) »).
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _length_,
@@ -42895,7 +42895,7 @@ THH:mm:ss.sss
           1. Let _obj_ be the *this* value.
           1. Let _taRecord_ be ? ValidateTypedArray(_obj_, ~seq-cst~).
           1. Let _length_ be TypedArrayLength(_taRecord_).
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. If _length_ = 0 and _initialValue_ is not present, throw a *TypeError* exception.
           1. Let _k_ be 0.
           1. Let _accumulator_ be *undefined*.
@@ -42923,7 +42923,7 @@ THH:mm:ss.sss
           1. Let _obj_ be the *this* value.
           1. Let _taRecord_ be ? ValidateTypedArray(_obj_, ~seq-cst~).
           1. Let _length_ be TypedArrayLength(_taRecord_).
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. If _length_ = 0 and _initialValue_ is not present, throw a *TypeError* exception.
           1. Let _k_ be _length_ - 1.
           1. Let _accumulator_ be *undefined*.
@@ -43124,7 +43124,7 @@ THH:mm:ss.sss
           1. Let _obj_ be the *this* value.
           1. Let _taRecord_ be ? ValidateTypedArray(_obj_, ~seq-cst~).
           1. Let _length_ be TypedArrayLength(_taRecord_).
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _length_,
             1. Let _propertyKey_ be ! ToString(𝔽(_k_)).
@@ -43143,7 +43143,7 @@ THH:mm:ss.sss
         <p>This method is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
         <p>It performs the following steps when called:</p>
         <emu-alg>
-          1. If _comparator_ is not *undefined* and IsCallable(_comparator_) is *false*, throw a *TypeError* exception.
+          1. If _comparator_ is not *undefined* and IsFunction(_comparator_) is *false*, throw a *TypeError* exception.
           1. Let _obj_ be the *this* value.
           1. Let _taRecord_ be ? ValidateTypedArray(_obj_, ~seq-cst~).
           1. Let _length_ be TypedArrayLength(_taRecord_).
@@ -43221,7 +43221,7 @@ THH:mm:ss.sss
         <h1>%TypedArray%.prototype.toSorted ( _comparator_ )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. If _comparator_ is not *undefined* and IsCallable(_comparator_) is *false*, throw a *TypeError* exception.
+          1. If _comparator_ is not *undefined* and IsFunction(_comparator_) is *false*, throw a *TypeError* exception.
           1. Let _obj_ be the *this* value.
           1. Let _taRecord_ be ? ValidateTypedArray(_obj_, ~seq-cst~).
           1. Let _length_ be TypedArrayLength(_taRecord_).
@@ -44138,7 +44138,7 @@ THH:mm:ss.sss
           1. Set _map_.[[MapData]] to a new empty List.
           1. If _iterable_ is either *undefined* or *null*, return _map_.
           1. Let _adder_ be ? Get(_map_, *"set"*).
-          1. If IsCallable(_adder_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_adder_) is *false*, throw a *TypeError* exception.
           1. Return ? AddEntriesFromIterable(_map_, _iterable_, _adder_).
         </emu-alg>
         <emu-note>
@@ -44290,7 +44290,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _map_ be the *this* value.
           1. Perform ? RequireInternalSlot(_map_, [[MapData]]).
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. Let _entries_ be _map_.[[MapData]].
           1. Let _entriesCount_ be the number of elements in _entries_.
           1. Let _index_ be 0.
@@ -44345,7 +44345,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _map_ be the *this* value.
           1. Perform ? RequireInternalSlot(_map_, [[MapData]]).
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. Set _key_ to CanonicalizeKeyedCollectionKey(_key_).
           1. For each Record { [[Key]], [[Value]] } _entry_ of _map_.[[MapData]], do
             1. If _entry_.[[Key]] is not ~empty~ and SameValue(_entry_.[[Key]], _key_) is *true*, return _entry_.[[Value]].
@@ -44595,9 +44595,9 @@ THH:mm:ss.sss
           1. Let _intSize_ be ! ToIntegerOrInfinity(_numberSize_).
           1. If _intSize_ &lt; 0, throw a *RangeError* exception.
           1. Let _has_ be ? Get(_obj_, *"has"*).
-          1. If IsCallable(_has_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_has_) is *false*, throw a *TypeError* exception.
           1. Let _keys_ be ? Get(_obj_, *"keys"*).
-          1. If IsCallable(_keys_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_keys_) is *false*, throw a *TypeError* exception.
           1. Return a new Set Record { [[SetObject]]: _obj_, [[Size]]: _intSize_, [[Has]]: _has_, [[Keys]]: _keys_ }.
         </emu-alg>
       </emu-clause>
@@ -44676,7 +44676,7 @@ THH:mm:ss.sss
           1. Set _set_.[[SetData]] to a new empty List.
           1. If _iterable_ is either *undefined* or *null*, return _set_.
           1. Let _adder_ be ? Get(_set_, *"add"*).
-          1. If IsCallable(_adder_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_adder_) is *false*, throw a *TypeError* exception.
           1. Let _iteratorRecord_ be ? GetIterator(_iterable_, ~sync~).
           1. Repeat,
             1. Let _next_ be ? IteratorStepValue(_iteratorRecord_).
@@ -44829,7 +44829,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _set_ be the *this* value.
           1. Perform ? RequireInternalSlot(_set_, [[SetData]]).
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. Let _entries_ be _set_.[[SetData]].
           1. Let _entriesCount_ be the number of elements in _entries_.
           1. Let _index_ be 0.
@@ -45166,7 +45166,7 @@ THH:mm:ss.sss
           1. Set _map_.[[WeakMapData]] to a new empty List.
           1. If _iterable_ is either *undefined* or *null*, return _map_.
           1. Let _adder_ be ? Get(_map_, *"set"*).
-          1. If IsCallable(_adder_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_adder_) is *false*, throw a *TypeError* exception.
           1. Return ? AddEntriesFromIterable(_map_, _iterable_, _adder_).
         </emu-alg>
         <emu-note>
@@ -45259,7 +45259,7 @@ THH:mm:ss.sss
           1. Let _weakMap_ be the *this* value.
           1. Perform ? RequireInternalSlot(_weakMap_, [[WeakMapData]]).
           1. If CanBeHeldWeakly(_key_) is *false*, throw a *TypeError* exception.
-          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_callback_) is *false*, throw a *TypeError* exception.
           1. For each Record { [[Key]], [[Value]] } _entry_ of _weakMap_.[[WeakMapData]], do
             1. If _entry_.[[Key]] is not ~empty~ and SameValue(_entry_.[[Key]], _key_) is *true*, return _entry_.[[Value]].
           1. Let _value_ be ? Call(_callback_, *undefined*, « _key_ »).
@@ -45346,7 +45346,7 @@ THH:mm:ss.sss
           1. Set _set_.[[WeakSetData]] to a new empty List.
           1. If _iterable_ is either *undefined* or *null*, return _set_.
           1. Let _adder_ be ? Get(_set_, *"add"*).
-          1. If IsCallable(_adder_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_adder_) is *false*, throw a *TypeError* exception.
           1. Let _iteratorRecord_ be ? GetIterator(_iterable_, ~sync~).
           1. Repeat,
             1. Let _next_ be ? IteratorStepValue(_iteratorRecord_).
@@ -47874,7 +47874,7 @@ THH:mm:ss.sss
         1. Let _jsonString_ be ? ToString(_text_).
         1. Let _parseResult_ be ? ParseJSON(_jsonString_).
         1. Let _unfiltered_ be _parseResult_.[[Value]].
-        1. If IsCallable(_reviver_) is *false*, return _unfiltered_.
+        1. If IsFunction(_reviver_) is *false*, return _unfiltered_.
         1. Let _root_ be OrdinaryObjectCreate(%Object.prototype%).
         1. Let _rootName_ be the empty String.
         1. Perform ! CreateDataPropertyOrThrow(_root_, _rootName_, _unfiltered_).
@@ -48168,7 +48168,7 @@ THH:mm:ss.sss
         1. Let _propertyList_ be *undefined*.
         1. Let _replacerFunc_ be *undefined*.
         1. If _replacer_ is an Object, then
-          1. If IsCallable(_replacer_) is *true*, then
+          1. If IsFunction(_replacer_) is *true*, then
             1. Set _replacerFunc_ to _replacer_.
           1. Else,
             1. Let _isArray_ be ? IsArray(_replacer_).
@@ -48302,7 +48302,7 @@ THH:mm:ss.sss
           1. Let _value_ be ? Get(_holder_, _key_).
           1. If _value_ is an Object or _value_ is a BigInt, then
             1. Let _toJSON_ be ? GetV(_value_, *"toJSON"*).
-            1. If IsCallable(_toJSON_) is *true*, then
+            1. If IsFunction(_toJSON_) is *true*, then
               1. Set _value_ to ? Call(_toJSON_, _value_, « _key_ »).
           1. If _state_.[[ReplacerFunction]] is not *undefined*, then
             1. Set _value_ to ? Call(_state_.[[ReplacerFunction]], _holder_, « _key_, _value_ »).
@@ -48327,7 +48327,7 @@ THH:mm:ss.sss
             1. If _value_ is finite, return ! ToString(_value_).
             1. Return *"null"*.
           1. If _value_ is a BigInt, throw a *TypeError* exception.
-          1. If _value_ is an Object and IsCallable(_value_) is *false*, then
+          1. If _value_ is an Object and IsFunction(_value_) is *false*, then
             1. Let _isArray_ be ? IsArray(_value_).
             1. If _isArray_ is *true*, then
               1. Return ? SerializeJSONArray(_state_, _value_).
@@ -48740,7 +48740,7 @@ THH:mm:ss.sss
         <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
-          1. If IsCallable(_cleanupCallback_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_cleanupCallback_) is *false*, throw a *TypeError* exception.
           1. Let _finalizationRegistry_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%FinalizationRegistry.prototype%"*, « [[Realm]], [[CleanupCallback]], [[Cells]] »).
           1. Let _activeFunc_ be the active function object.
           1. Set _finalizationRegistry_.[[Realm]] to _activeFunc_.[[Realm]].
@@ -49426,7 +49426,7 @@ THH:mm:ss.sss
             1. Let _obj_ be the *this* value.
             1. If _obj_ is not an Object, throw a *TypeError* exception.
             1. Let _iterated_ be the Iterator Record { [[Iterator]]: _obj_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
-            1. If IsCallable(_predicate_) is *false*, then
+            1. If IsFunction(_predicate_) is *false*, then
               1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
               1. Return ? IteratorClose(_iterated_, _error_).
             1. Set _iterated_ to ? GetIteratorDirect(_obj_).
@@ -49449,7 +49449,7 @@ THH:mm:ss.sss
             1. Let _obj_ be the *this* value.
             1. If _obj_ is not an Object, throw a *TypeError* exception.
             1. Let _iterated_ be the Iterator Record { [[Iterator]]: _obj_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
-            1. If IsCallable(_predicate_) is *false*, then
+            1. If IsFunction(_predicate_) is *false*, then
               1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
               1. Return ? IteratorClose(_iterated_, _error_).
             1. Set _iterated_ to ? GetIteratorDirect(_obj_).
@@ -49478,7 +49478,7 @@ THH:mm:ss.sss
             1. Let _obj_ be the *this* value.
             1. If _obj_ is not an Object, throw a *TypeError* exception.
             1. Let _iterated_ be the Iterator Record { [[Iterator]]: _obj_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
-            1. If IsCallable(_predicate_) is *false*, then
+            1. If IsFunction(_predicate_) is *false*, then
               1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
               1. Return ? IteratorClose(_iterated_, _error_).
             1. Set _iterated_ to ? GetIteratorDirect(_obj_).
@@ -49501,7 +49501,7 @@ THH:mm:ss.sss
             1. Let _obj_ be the *this* value.
             1. If _obj_ is not an Object, throw a *TypeError* exception.
             1. Let _iterated_ be the Iterator Record { [[Iterator]]: _obj_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
-            1. If IsCallable(_mapper_) is *false*, then
+            1. If IsFunction(_mapper_) is *false*, then
               1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
               1. Return ? IteratorClose(_iterated_, _error_).
             1. Set _iterated_ to ? GetIteratorDirect(_obj_).
@@ -49541,7 +49541,7 @@ THH:mm:ss.sss
             1. Let _obj_ be the *this* value.
             1. If _obj_ is not an Object, throw a *TypeError* exception.
             1. Let _iterated_ be the Iterator Record { [[Iterator]]: _obj_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
-            1. If IsCallable(_procedure_) is *false*, then
+            1. If IsFunction(_procedure_) is *false*, then
               1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
               1. Return ? IteratorClose(_iterated_, _error_).
             1. Set _iterated_ to ? GetIteratorDirect(_obj_).
@@ -49563,7 +49563,7 @@ THH:mm:ss.sss
             1. Let _obj_ be the *this* value.
             1. If _obj_ is not an Object, throw a *TypeError* exception.
             1. Let _iterated_ be the Iterator Record { [[Iterator]]: _obj_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
-            1. If IsCallable(_mapper_) is *false*, then
+            1. If IsFunction(_mapper_) is *false*, then
               1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
               1. Return ? IteratorClose(_iterated_, _error_).
             1. Set _iterated_ to ? GetIteratorDirect(_obj_).
@@ -49591,7 +49591,7 @@ THH:mm:ss.sss
             1. Let _obj_ be the *this* value.
             1. If _obj_ is not an Object, throw a *TypeError* exception.
             1. Let _iterated_ be the Iterator Record { [[Iterator]]: _obj_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
-            1. If IsCallable(_reducer_) is *false*, then
+            1. If IsFunction(_reducer_) is *false*, then
               1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
               1. Return ? IteratorClose(_iterated_, _error_).
             1. Set _iterated_ to ? GetIteratorDirect(_obj_).
@@ -49620,7 +49620,7 @@ THH:mm:ss.sss
             1. Let _obj_ be the *this* value.
             1. If _obj_ is not an Object, throw a *TypeError* exception.
             1. Let _iterated_ be the Iterator Record { [[Iterator]]: _obj_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
-            1. If IsCallable(_predicate_) is *false*, then
+            1. If IsFunction(_predicate_) is *false*, then
               1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
               1. Return ? IteratorClose(_iterated_, _error_).
             1. Set _iterated_ to ? GetIteratorDirect(_obj_).
@@ -50169,7 +50169,7 @@ THH:mm:ss.sss
           1. Let _disposableStack_ be the *this* value.
           1. Perform ? RequireInternalSlot(_disposableStack_, [[DisposableState]]).
           1. If _disposableStack_.[[DisposableState]] is ~disposed~, throw a *ReferenceError* exception.
-          1. If IsCallable(_onDispose_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_onDispose_) is *false*, throw a *TypeError* exception.
           1. Let _closure_ be a new Abstract Closure with no parameters that captures _value_ and _onDispose_ and performs the following steps when called:
             1. Return ? Call(_onDispose_, *undefined*, « _value_ »).
           1. Let _func_ be CreateBuiltinFunction(_closure_, 0, *""*, « »).
@@ -50190,7 +50190,7 @@ THH:mm:ss.sss
           1. Let _disposableStack_ be the *this* value.
           1. Perform ? RequireInternalSlot(_disposableStack_, [[DisposableState]]).
           1. If _disposableStack_.[[DisposableState]] is ~disposed~, throw a *ReferenceError* exception.
-          1. If IsCallable(_onDispose_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_onDispose_) is *false*, throw a *TypeError* exception.
           1. Perform ? AddDisposableResource(_disposableStack_.[[DisposableResourceStack]], *undefined*, ~sync-dispose~, _onDispose_).
           1. Return *undefined*.
         </emu-alg>
@@ -50363,7 +50363,7 @@ THH:mm:ss.sss
           1. Let _asyncDisposableStack_ be the *this* value.
           1. Perform ? RequireInternalSlot(_asyncDisposableStack_, [[AsyncDisposableState]]).
           1. If _asyncDisposableStack_.[[AsyncDisposableState]] is ~disposed~, throw a *ReferenceError* exception.
-          1. If IsCallable(_onDisposeAsync_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_onDisposeAsync_) is *false*, throw a *TypeError* exception.
           1. Let _closure_ be a new Abstract Closure with no parameters that captures _value_ and _onDisposeAsync_ and performs the following steps when called:
             1. Return ? Call(_onDisposeAsync_, *undefined*, « _value_ »).
           1. Let _func_ be CreateBuiltinFunction(_closure_, 0, *""*, « »).
@@ -50384,7 +50384,7 @@ THH:mm:ss.sss
           1. Let _asyncDisposableStack_ be the *this* value.
           1. Perform ? RequireInternalSlot(_asyncDisposableStack_, [[AsyncDisposableState]]).
           1. If _asyncDisposableStack_.[[AsyncDisposableState]] is ~disposed~, throw a *ReferenceError* exception.
-          1. If IsCallable(_onDisposeAsync_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_onDisposeAsync_) is *false*, throw a *TypeError* exception.
           1. Perform ? AddDisposableResource(_asyncDisposableStack_.[[DisposableResourceStack]], *undefined*, ~async-dispose~, _onDisposeAsync_).
           1. Return *undefined*.
         </emu-alg>
@@ -50672,7 +50672,7 @@ THH:mm:ss.sss
               1. Perform RejectPromise(_promise_, _then_.[[Value]]).
               1. Return *undefined*.
             1. Let _thenAction_ be _then_.[[Value]].
-            1. If IsCallable(_thenAction_) is *false*, then
+            1. If IsFunction(_thenAction_) is *false*, then
               1. Perform FulfillPromise(_promise_, _resolution_).
               1. Return *undefined*.
             1. Let _thenJobCallback_ be HostMakeJobCallback(_thenAction_).
@@ -50734,8 +50734,8 @@ THH:mm:ss.sss
             1. Return NormalCompletion(*undefined*).
           1. Let _executor_ be CreateBuiltinFunction(_executorClosure_, 2, *""*, « »).
           1. Let _promise_ be ? Construct(_ctor_, « _executor_ »).
-          1. If IsCallable(_resolvingFuncs_.[[Resolve]]) is *false*, throw a *TypeError* exception.
-          1. If IsCallable(_resolvingFuncs_.[[Reject]]) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_resolvingFuncs_.[[Resolve]]) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_resolvingFuncs_.[[Reject]]) is *false*, throw a *TypeError* exception.
           1. Return the PromiseCapability Record { [[Promise]]: _promise_, [[Resolve]]: _resolvingFuncs_.[[Resolve]], [[Reject]]: _resolvingFuncs_.[[Reject]] }.
         </emu-alg>
         <emu-note>
@@ -50920,7 +50920,7 @@ THH:mm:ss.sss
         <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
-          1. If IsCallable(_executor_) is *false*, throw a *TypeError* exception.
+          1. If IsFunction(_executor_) is *false*, throw a *TypeError* exception.
           1. Let _promise_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Promise.prototype%"*, « [[PromiseState]], [[PromiseResult]], [[PromiseFulfillReactions]], [[PromiseRejectReactions]], [[PromiseIsHandled]] »).
           1. Set _promise_.[[PromiseState]] to ~pending~.
           1. Set _promise_.[[PromiseResult]] to ~empty~.
@@ -50980,7 +50980,7 @@ THH:mm:ss.sss
           </dl>
           <emu-alg>
             1. Let _promiseResolve_ be ? Get(_promiseCtor_, *"resolve"*).
-            1. If IsCallable(_promiseResolve_) is *false*, throw a *TypeError* exception.
+            1. If IsFunction(_promiseResolve_) is *false*, throw a *TypeError* exception.
             1. Return _promiseResolve_.
           </emu-alg>
         </emu-clause>
@@ -51366,7 +51366,7 @@ THH:mm:ss.sss
           1. If _promise_ is not an Object, throw a *TypeError* exception.
           1. Let _ctor_ be ? SpeciesConstructor(_promise_, %Promise%).
           1. Assert: IsConstructor(_ctor_) is *true*.
-          1. If IsCallable(_onFinally_) is *false*, then
+          1. If IsFunction(_onFinally_) is *false*, then
             1. Let _thenFinally_ be _onFinally_.
             1. Let _catchFinally_ be _onFinally_.
           1. Else,
@@ -51418,11 +51418,11 @@ THH:mm:ss.sss
             1. Assert: IsPromise(_promise_) is *true*.
             1. If _resultCapability_ is not present, then
               1. Set _resultCapability_ to *undefined*.
-            1. If IsCallable(_onFulfilled_) is *false*, then
+            1. If IsFunction(_onFulfilled_) is *false*, then
               1. Let _onFulfilledJobCallback_ be ~empty~.
             1. Else,
               1. Let _onFulfilledJobCallback_ be HostMakeJobCallback(_onFulfilled_).
-            1. If IsCallable(_onRejected_) is *false*, then
+            1. If IsFunction(_onRejected_) is *false*, then
               1. Let _onRejectedJobCallback_ be ~empty~.
             1. Else,
               1. Let _onRejectedJobCallback_ be HostMakeJobCallback(_onRejected_).
@@ -52649,7 +52649,7 @@ THH:mm:ss.sss
       <h1>Reflect.apply ( _target_, _thisArg_, _args_ )</h1>
       <p>This function performs the following steps when called:</p>
       <emu-alg>
-        1. If IsCallable(_target_) is *false*, throw a *TypeError* exception.
+        1. If IsFunction(_target_) is *false*, throw a *TypeError* exception.
         1. Let _argList_ be ? CreateListFromArrayLike(_args_).
         1. Perform PrepareForTailCall().
         1. Return ? Call(_target_, _thisArg_, _argList_).

--- a/spec.html
+++ b/spec.html
@@ -3192,7 +3192,7 @@
                 ): either a normal completion containing an ECMAScript language value or a throw completion
               </td>
               <td>
-                It executes code associated with this object. Invoked via a function call expression. The arguments to the internal method are a *this* value and a List whose elements are the arguments passed to the function by a call expression. Objects that implement this internal method are <em>callable</em>.
+                It executes code associated with this object. Invoked via a function call expression. The arguments to the internal method are a *this* value and a List whose elements are the arguments passed to the function by a call expression. Objects that implement this internal method are functions.
               </td>
               <td>
                 Within this specification it has definitions in the following types; hosts may provide additional types with their own definitions:
@@ -4363,8 +4363,8 @@
         <li><dfn variants="abrupt completions">abrupt completion</dfn> refers to any Completion Record with a [[Type]] value other than ~normal~.</li>
         <li>a <dfn variants="normal completions containing">normal completion containing</dfn> some type of value refers to a normal completion that has a value of that type in its [[Value]] field.</li>
       </ul>
-      <p>Callable objects that are defined in this specification only return a normal completion or a throw completion. Returning any other kind of Completion Record is considered an editorial error.</p>
-      <p>Implementation-defined callable objects must return either a normal completion or a throw completion.</p>
+      <p>Functions that are defined in this specification only return a normal completion or a throw completion. Returning any other kind of Completion Record is considered an editorial error.</p>
+      <p>Implementation-defined functions must return either a normal completion or a throw completion.</p>
 
       <emu-clause id="sec-normalcompletion" type="abstract operation">
         <h1>
@@ -14550,7 +14550,7 @@
               [[BoundTargetFunction]]
             </td>
             <td>
-              a callable Object
+              a function object
             </td>
             <td>
               The wrapped function object.
@@ -30364,7 +30364,7 @@
 <emu-clause id="sec-ecmascript-standard-built-in-objects">
   <h1>ECMAScript Standard Built-in Objects</h1>
   <p>There are certain built-in objects available whenever an ECMAScript |Script| or |Module| begins execution. One, the global object, is part of the global environment of the executing program. Others are accessible as initial properties of the global object or indirectly as properties of accessible built-in objects.</p>
-  <p>Unless specified otherwise, a built-in object that is callable as a function is a built-in function object with the characteristics described in <emu-xref href="#sec-built-in-function-objects"></emu-xref>. Unless specified otherwise, the [[Extensible]] internal slot of a built-in object initially has the value *true*. Every built-in function object has a [[Realm]] internal slot whose value is the Realm Record of the realm for which the object was initially created.</p>
+  <p>Unless specified otherwise, a built-in object that is a function is a built-in function object with the characteristics described in <emu-xref href="#sec-built-in-function-objects"></emu-xref>. Unless specified otherwise, the [[Extensible]] internal slot of a built-in object initially has the value *true*. Every built-in function object has a [[Realm]] internal slot whose value is the Realm Record of the realm for which the object was initially created.</p>
   <p>Many built-in objects are functions: they can be invoked with arguments. Some of them furthermore are constructors: they are functions intended for use with the `new` operator. For each built-in function, this specification describes the arguments required by that function and the properties of that function object. For each built-in constructor, this specification furthermore describes properties of the prototype object of that constructor and properties of specific object instances returned by a `new` expression that invokes that constructor.</p>
   <p>Unless otherwise specified in the description of a particular function, if a built-in function or constructor is given fewer arguments than the function is specified to require, the function or constructor shall behave exactly as if it had been given sufficient additional arguments, each such argument being the *undefined* value. Such missing arguments are considered to be “not present” and may be identified in that manner by specification algorithms. In the description of a particular function, the terms “*this* value” and “NewTarget” have the meanings given in <emu-xref href="#sec-built-in-function-objects"></emu-xref>.</p>
   <p>Unless otherwise specified in the description of a particular function, if a built-in function or constructor described is given more arguments than the function is specified to allow, the extra arguments are evaluated by the call and then ignored by the function. However, an implementation may define implementation specific behaviour relating to such arguments as long as the behaviour is not the throwing of a *TypeError* exception that is predicated simply on the presence of an extra argument.</p>


### PR DESCRIPTION
In the ECMAScript spec, the term "callable" (as a noun) is synonymous with "function", but that might not be obvious to the reader. (There are languages in which callables are a superset of functions.)

This PR mostly eliminates the word "callable". (I left a few occurrences, e.g. "a function is a callable object" is an informal way to relate concepts.)

The first commit just renames `IsCallable` to `IsFunction`. The second commit handles other occurrences. They can probably be squashed for merging.