### PR TITLE
Editorial: Expand on "a List"

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -6598,7 +6598,7 @@
         CreateListFromArrayLike (
           _obj_: unknown,
           optional _elementTypes_: a List of names of ECMAScript Language Types,
-        ): either a normal completion containing a List or a throw completion
+        ): either a normal completion containing a List of ECMAScript language values or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -6693,7 +6693,7 @@
         EnumerableOwnPropertyNames (
           _O_: an Object,
           _kind_: ~key~, ~value~, or ~key+value~,
-        ): either a normal completion containing a List or a throw completion
+        ): either a normal completion containing a List of ECMAScript language values or a throw completion
       </h1>
       <dl class="header">
       </dl>
@@ -7181,7 +7181,7 @@
     <emu-clause id="sec-createlistiteratorRecord" type="abstract operation" oldids="sec-createlistiterator,sec-listiteratornext-functions,sec-listiterator-next">
       <h1>
         CreateListIteratorRecord (
-          _list_: a List,
+          _list_: a List of ECMAScript language values,
         ): an Iterator Record
       </h1>
       <dl class="header">
@@ -7206,7 +7206,7 @@
         IterableToList (
           _items_: an ECMAScript language value,
           optional _method_: a function object,
-        ): either a normal completion containing a List or a throw completion
+        ): either a normal completion containing a List of ECMAScript language values or a throw completion
       </h1>
       <dl class="header">
       </dl>
@@ -13343,7 +13343,7 @@
         <h1>
           Runtime Semantics: EvaluateBody (
             _functionObject_: unknown,
-            _argumentsList_: a List,
+            _argumentsList_: a List of ECMAScript language values,
           ): either a normal completion containing an ECMAScript language value or an abrupt completion
         </h1>
         <dl class="header">
@@ -13408,7 +13408,7 @@
         <h1>
           OrdinaryCallEvaluateBody (
             _F_: a function object,
-            _argumentsList_: a List,
+            _argumentsList_: a List of ECMAScript language values,
           ): either a normal completion containing an ECMAScript language value or an abrupt completion
         </h1>
         <dl class="header">
@@ -14465,7 +14465,7 @@
           CreateMappedArgumentsObject (
             _func_: an Object,
             _formals_: a Parse Node,
-            _argumentsList_: a List,
+            _argumentsList_: a List of ECMAScript language values,
             _env_: an Environment Record,
           ): an arguments exotic object
         </h1>
@@ -23329,7 +23329,7 @@
       <h1>
         Runtime Semantics: EvaluateFunctionBody (
           _functionObject_: unknown,
-          _argumentsList_: a List,
+          _argumentsList_: a List of ECMAScript language values,
         ): either a normal completion containing an ECMAScript language value or an abrupt completion
       </h1>
       <dl class="header">
@@ -23512,7 +23512,7 @@
       <h1>
         Runtime Semantics: EvaluateConciseBody (
           _functionObject_: unknown,
-          _argumentsList_: a List,
+          _argumentsList_: a List of ECMAScript language values,
         ): either a normal completion containing an ECMAScript language value or an abrupt completion
       </h1>
       <dl class="header">
@@ -23870,7 +23870,7 @@
       <h1>
         Runtime Semantics: EvaluateGeneratorBody (
           _functionObject_: unknown,
-          _argumentsList_: a List,
+          _argumentsList_: a List of ECMAScript language values,
         ): a throw completion or a return completion
       </h1>
       <dl class="header">
@@ -24093,7 +24093,7 @@
       <h1>
         Runtime Semantics: EvaluateAsyncGeneratorBody (
           _functionObject_: unknown,
-          _argumentsList_: a List,
+          _argumentsList_: a List of ECMAScript language values,
         ): a throw completion or a return completion
       </h1>
       <dl class="header">
@@ -25106,7 +25106,7 @@
       <h1>
         Runtime Semantics: EvaluateAsyncFunctionBody (
           _functionObject_: unknown,
-          _argumentsList_: a List,
+          _argumentsList_: a List of ECMAScript language values,
         ): a return completion
       </h1>
       <dl class="header">
@@ -25213,7 +25213,7 @@
       <h1>
         Runtime Semantics: EvaluateAsyncConciseBody (
           _functionObject_: unknown,
-          _argumentsList_: a List,
+          _argumentsList_: a List of ECMAScript language values,
         ): a return completion
       </h1>
       <dl class="header">
@@ -40990,7 +40990,7 @@ THH:mm:ss.sss
         <h1>
           RawBytesToNumeric (
             _type_: a TypedArray element type,
-            _rawBytes_: a List,
+            _rawBytes_: a List of byte values,
             _isLittleEndian_: a Boolean,
           ): a Number or a BigInt
         </h1>
@@ -46124,7 +46124,7 @@ THH:mm:ss.sss
         </tr>
         <tr>
           <td>[[Payload]]</td>
-          <td>a List</td>
+          <td>a List of byte values</td>
           <td>The List of byte values to be read by other events.</td>
         </tr>
       </table>
@@ -46164,7 +46164,7 @@ THH:mm:ss.sss
         </tr>
         <tr>
           <td>[[Payload]]</td>
-          <td>a List</td>
+          <td>a List of byte values</td>
           <td>The List of byte values to be passed to [[ModifyOp]].</td>
         </tr>
         <tr>


### PR DESCRIPTION
In the definition of:
- an operation parameter,
- an operation return, or
- a record field,

don't just say "a List", say "a List of [element type]".

(In this PR, it's mostly "a List of ECMAScript language values", plus 3 cases of "a List of byte values".)