### PR TITLE
Editorial: Have NewGlobalEnvironment invoke NewDeclarativeEnvironment

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -11492,7 +11492,7 @@
       <emu-clause id="sec-newdeclarativeenvironment" type="abstract operation">
         <h1>
           NewDeclarativeEnvironment (
-            _E_: an Environment Record,
+            _E_: an Environment Record or *null*,
           ): a Declarative Environment Record
         </h1>
         <dl class="header">
@@ -11554,7 +11554,7 @@
         </dl>
         <emu-alg>
           1. Let _objRec_ be NewObjectEnvironment(_G_, *false*, *null*).
-          1. Let _dclRec_ be a new Declarative Environment Record containing no bindings.
+          1. Let _dclRec_ be NewDeclarativeEnvironment(*null*).
           1. Let _env_ be a new Global Environment Record.
           1. Set _env_.[[ObjectRecord]] to _objRec_.
           1. Set _env_.[[GlobalThisValue]] to _thisValue_.


### PR DESCRIPTION
In NewDeclarativeEnvironment, allow parameter `_E_` to be `*null*`,
and in NewGlobalEnvironment, change
`a new declarative Environment Record containing no bindings`
to
`NewDeclarativeEnvironment(*null*)`

History: `NewDeclarativeEnvironment(*null*)` used to have different semantics, which would have been wrong for NewGlobalEnvironment, so the latter used `a new declarative Environment Record containing no bindings` instead. But the merge of PR #1697 changed the semantics of NewDeclarativeEnvironment, and now it makes sense for NewGlobalEnvironment to call it.

The first commit in PR #2287 did something analogous for NewObjectEnvironment and NewGlobalEnvironment's call to it.

(prompted by https://github.com/engine262/engine262/issues/166)
