### PR TITLE
Editorial: Change CreateDataPropertyOrThrow's normal return

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -6323,7 +6323,7 @@
           _O_: an Object,
           _P_: a property key,
           _V_: an ECMAScript language value,
-        ): either a normal completion containing a Boolean or a throw completion
+        ): either a normal completion containing ~unused~ or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -6332,7 +6332,7 @@
       <emu-alg>
         1. Let _success_ be ? CreateDataProperty(_O_, _P_, _V_).
         1. If _success_ is *false*, throw a *TypeError* exception.
-        1. Return _success_.
+        1. Return ~unused~.
       </emu-alg>
       <emu-note>
         <p>This abstract operation creates a property whose attributes are set to the same defaults used for properties created by the ECMAScript language assignment operator. Normally, the property will not already exist. If it does exist and is not configurable or if _O_ is not extensible, [[DefineOwnProperty]] will return *false* causing this operation to throw a *TypeError* exception.</p>
@@ -18167,7 +18167,7 @@
             1. Set _nextIndex_ to ? ArrayAccumulation of |Elision| with arguments _array_ and _nextIndex_.
           1. Let _initResult_ be ? Evaluation of |AssignmentExpression|.
           1. Let _initValue_ be ? GetValue(_initResult_).
-          1. Let _created_ be ! CreateDataPropertyOrThrow(_array_, ! ToString(𝔽(_nextIndex_)), _initValue_).
+          1. Perform ! CreateDataPropertyOrThrow(_array_, ! ToString(𝔽(_nextIndex_)), _initValue_).
           1. Return _nextIndex_ + 1.
         </emu-alg>
         <emu-grammar>ElementList : Elision? SpreadElement</emu-grammar>
@@ -18183,7 +18183,7 @@
             1. Set _nextIndex_ to ? ArrayAccumulation of |Elision| with arguments _array_ and _nextIndex_.
           1. Let _initResult_ be ? Evaluation of |AssignmentExpression|.
           1. Let _initValue_ be ? GetValue(_initResult_).
-          1. Let _created_ be ! CreateDataPropertyOrThrow(_array_, ! ToString(𝔽(_nextIndex_)), _initValue_).
+          1. Perform ! CreateDataPropertyOrThrow(_array_, ! ToString(𝔽(_nextIndex_)), _initValue_).
           1. Return _nextIndex_ + 1.
         </emu-alg>
         <emu-grammar>ElementList : ElementList `,` Elision? SpreadElement</emu-grammar>


### PR DESCRIPTION
... from Boolean to `~unused~`.

When CreateDataPropertyOrThrow returns a normal completion, the `[[Value]]` of that completion is never used (because the only thing it can be is `*true*`, so why bother looking?). So change it to `~unused~`.

Downstream:
- Intl API uses CreateDataPropertyOrThrow lots, but always with "Perform".
- No uses in Web IDL or HTML.