### PR TITLE
Editorial: Refactor TemplateStrings SDO

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -18646,54 +18646,51 @@
         </dl>
         <emu-grammar>TemplateLiteral : NoSubstitutionTemplate</emu-grammar>
         <emu-alg>
-          1. If _raw_ is *false*, then
-            1. Let _string_ be the TV of |NoSubstitutionTemplate|.
-          1. Else,
-            1. Let _string_ be the TRV of |NoSubstitutionTemplate|.
-          1. Return &laquo; _string_ &raquo;.
+          1. Return &laquo; TemplateString(|NoSubstitutionTemplate|, _raw_) &raquo;.
         </emu-alg>
         <emu-grammar>SubstitutionTemplate : TemplateHead Expression TemplateSpans</emu-grammar>
         <emu-alg>
-          1. If _raw_ is *false*, then
-            1. Let _head_ be the TV of |TemplateHead|.
-          1. Else,
-            1. Let _head_ be the TRV of |TemplateHead|.
+          1. Let _head_ be &laquo; TemplateString(|TemplateHead|, _raw_) &raquo;.
           1. Let _tail_ be TemplateStrings of |TemplateSpans| with argument _raw_.
-          1. Return the list-concatenation of &laquo; _head_ &raquo; and _tail_.
+          1. Return the list-concatenation of _head_ and _tail_.
         </emu-alg>
         <emu-grammar>TemplateSpans : TemplateTail</emu-grammar>
         <emu-alg>
-          1. If _raw_ is *false*, then
-            1. Let _tail_ be the TV of |TemplateTail|.
-          1. Else,
-            1. Let _tail_ be the TRV of |TemplateTail|.
-          1. Return &laquo; _tail_ &raquo;.
+          1. Return &laquo; TemplateString(|TemplateTail|, _raw_) &raquo;.
         </emu-alg>
         <emu-grammar>TemplateSpans : TemplateMiddleList TemplateTail</emu-grammar>
         <emu-alg>
           1. Let _middle_ be TemplateStrings of |TemplateMiddleList| with argument _raw_.
-          1. If _raw_ is *false*, then
-            1. Let _tail_ be the TV of |TemplateTail|.
-          1. Else,
-            1. Let _tail_ be the TRV of |TemplateTail|.
-          1. Return the list-concatenation of _middle_ and &laquo; _tail_ &raquo;.
+          1. Let _tail_ be &laquo; TemplateString(|TemplateTail|, _raw_) &raquo;.
+          1. Return the list-concatenation of _middle_ and _tail_.
         </emu-alg>
         <emu-grammar>TemplateMiddleList : TemplateMiddle Expression</emu-grammar>
         <emu-alg>
-          1. If _raw_ is *false*, then
-            1. Let _string_ be the TV of |TemplateMiddle|.
-          1. Else,
-            1. Let _string_ be the TRV of |TemplateMiddle|.
-          1. Return &laquo; _string_ &raquo;.
+          1. Return &laquo; TemplateString(|TemplateMiddle|, _raw_) &raquo;.
         </emu-alg>
         <emu-grammar>TemplateMiddleList : TemplateMiddleList TemplateMiddle Expression</emu-grammar>
         <emu-alg>
           1. Let _front_ be TemplateStrings of |TemplateMiddleList| with argument _raw_.
-          1. If _raw_ is *false*, then
-            1. Let _last_ be the TV of |TemplateMiddle|.
+          1. Let _last_ be &laquo; TemplateString(|TemplateMiddle|, _raw_) &raquo;.
+          1. Return the list-concatenation of _front_ and _last_.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-templatestring" type="abstract operation">
+        <h1>
+          Static Semantics: TemplateString (
+            _templateToken_: a |NoSubstitutionTemplate| Parse Node, a |TemplateHead| Parse Node, a |TemplateMiddle| Parse Node, or a |TemplateTail| Parse Node,
+            _raw_: a Boolean,
+          ): a String
+        </h1>
+        <dl class="header">
+        </dl>
+        <emu-alg>
+          1. If _raw_ is *true*, then
+            1. Let _string_ be the TRV of _templateToken_.
           1. Else,
-            1. Let _last_ be the TRV of |TemplateMiddle|.
-          1. Return the list-concatenation of _front_ and &laquo; _last_ &raquo;.
+            1. Let _string_ be the TV of _templateToken_.
+          1. Return _string_.
         </emu-alg>
       </emu-clause>
 


### PR DESCRIPTION
... to separately handle
- NoSubstitutionTemplate,
- TemplateHead,
- TemplateMiddle, and
- TemplateTail.

This separates all the `_raw_/TV/TRV` stuff from the list-concatenation stuff, which I think makes it easier to see what's going on.

~(I don't think GitHub's diff is very helpful for this one.)~