### PR TITLE
Editorial: Tweak ScriptEvaluation

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -25845,8 +25845,8 @@
         1. Let _result_ be Completion(GlobalDeclarationInstantiation(_script_, _globalEnv_)).
         1. If _result_.[[Type]] is ~normal~, then
           1. Set _result_ to Completion(Evaluation of _script_).
-        1. If _result_.[[Type]] is ~normal~ and _result_.[[Value]] is ~empty~, then
-          1. Set _result_ to NormalCompletion(*undefined*).
+          1. If _result_.[[Type]] is ~normal~ and _result_.[[Value]] is ~empty~, then
+            1. Set _result_ to NormalCompletion(*undefined*).
         1. Suspend _scriptContext_ and remove it from the execution context stack.
         1. Assert: The execution context stack is not empty.
         1. Resume the context that is now on the top of the execution context stack as the running execution context.


### PR DESCRIPTION
If the test at step 13 fails (i.e., `_result_.[[Type]]` isn't `~normal~`), then execution immediately goes to step 14, where `_result_.[[Type]]` *still* isn't `~normal~`, and the test will fail.

I.e. step 14's test can succeed only if step 13's test succeeds, so step 14 might as well be indented under step 13.

(This goes back to ES6.)