### PR TITLE
Editorial: combine the two subclauses for HasCallInTailPosition

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -25365,7 +25365,7 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-static-semantics-hascallintailposition" type="sdo">
+    <emu-clause id="sec-static-semantics-hascallintailposition" type="sdo" oldids="sec-statement-rules,sec-expression-rules">
       <h1>
         Static Semantics: HasCallInTailPosition (
           _call_: a |CallExpression| Parse Node, a |MemberExpression| Parse Node, or an |OptionalChain| Parse Node,
@@ -25376,333 +25376,327 @@
       <emu-note>
         <p>_call_ is a Parse Node that represents a specific range of source text. When the following algorithms compare _call_ to another Parse Node, it is a test of whether they represent the same source text.</p>
       </emu-note>
+      <emu-note>
+        <p>A potential tail position call that is immediately followed by return GetValue of the call result is also a possible tail position call. A function call cannot return a Reference Record, so such a GetValue operation will always return the same value as the actual function call result.</p>
+      </emu-note>
 
-      <emu-clause id="sec-statement-rules">
-        <h1>Statement Rules</h1>
-        <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
-        <emu-alg>
-          1. Let _has_ be HasCallInTailPosition of |StatementList| with argument _call_.
-          1. If _has_ is *true*, return *true*.
-          1. Return HasCallInTailPosition of |StatementListItem| with argument _call_.
-        </emu-alg>
-        <emu-grammar>
-          FunctionStatementList :
-            [empty]
+      <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
+      <emu-alg>
+        1. Let _has_ be HasCallInTailPosition of |StatementList| with argument _call_.
+        1. If _has_ is *true*, return *true*.
+        1. Return HasCallInTailPosition of |StatementListItem| with argument _call_.
+      </emu-alg>
+      <emu-grammar>
+        FunctionStatementList :
+          [empty]
 
-          StatementListItem :
-            Declaration
+        StatementListItem :
+          Declaration
 
-          Statement :
-            VariableStatement
-            EmptyStatement
-            ExpressionStatement
-            ContinueStatement
-            BreakStatement
-            ThrowStatement
-            DebuggerStatement
+        Statement :
+          VariableStatement
+          EmptyStatement
+          ExpressionStatement
+          ContinueStatement
+          BreakStatement
+          ThrowStatement
+          DebuggerStatement
 
-          Block :
-            `{` `}`
+        Block :
+          `{` `}`
 
-          ReturnStatement :
-            `return` `;`
+        ReturnStatement :
+          `return` `;`
 
-          LabelledItem :
-            FunctionDeclaration
+        LabelledItem :
+          FunctionDeclaration
 
-          ForInOfStatement :
-            `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
-            `for` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
-            `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement
+        ForInOfStatement :
+          `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
+          `for` `(` `var` ForBinding `of` AssignmentExpression `)` Statement
+          `for` `(` ForDeclaration `of` AssignmentExpression `)` Statement
 
-          CaseBlock :
-            `{` `}`
-        </emu-grammar>
-        <emu-alg>
-          1. Return *false*.
-        </emu-alg>
-        <emu-grammar>IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
-        <emu-alg>
-          1. Let _has_ be HasCallInTailPosition of the first |Statement| with argument _call_.
-          1. If _has_ is *true*, return *true*.
-          1. Return HasCallInTailPosition of the second |Statement| with argument _call_.
-        </emu-alg>
-        <emu-grammar>
-          IfStatement :
-            `if` `(` Expression `)` Statement
+        CaseBlock :
+          `{` `}`
+      </emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
+      <emu-alg>
+        1. Let _has_ be HasCallInTailPosition of the first |Statement| with argument _call_.
+        1. If _has_ is *true*, return *true*.
+        1. Return HasCallInTailPosition of the second |Statement| with argument _call_.
+      </emu-alg>
+      <emu-grammar>
+        IfStatement :
+          `if` `(` Expression `)` Statement
 
-          DoWhileStatement :
-            `do` Statement `while` `(` Expression `)` `;`
+        DoWhileStatement :
+          `do` Statement `while` `(` Expression `)` `;`
 
-          WhileStatement :
-            `while` `(` Expression `)` Statement
+        WhileStatement :
+          `while` `(` Expression `)` Statement
 
-          ForStatement :
-            `for` `(` Expression? `;` Expression? `;` Expression? `)` Statement
-            `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement
-            `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement
+        ForStatement :
+          `for` `(` Expression? `;` Expression? `;` Expression? `)` Statement
+          `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement
+          `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement
 
-          ForInOfStatement :
-            `for` `(` LeftHandSideExpression `in` Expression `)` Statement
-            `for` `(` `var` ForBinding `in` Expression `)` Statement
-            `for` `(` ForDeclaration `in` Expression `)` Statement
+        ForInOfStatement :
+          `for` `(` LeftHandSideExpression `in` Expression `)` Statement
+          `for` `(` `var` ForBinding `in` Expression `)` Statement
+          `for` `(` ForDeclaration `in` Expression `)` Statement
 
-          WithStatement :
-            `with` `(` Expression `)` Statement
-        </emu-grammar>
-        <emu-alg>
-          1. Return HasCallInTailPosition of |Statement| with argument _call_.
-        </emu-alg>
-        <emu-grammar>
-          LabelledStatement :
-            LabelIdentifier `:` LabelledItem
-        </emu-grammar>
-        <emu-alg>
-          1. Return HasCallInTailPosition of |LabelledItem| with argument _call_.
-        </emu-alg>
-        <emu-grammar>ReturnStatement : `return` Expression `;`</emu-grammar>
-        <emu-alg>
-          1. Return HasCallInTailPosition of |Expression| with argument _call_.
-        </emu-alg>
-        <emu-grammar>SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
-        <emu-alg>
-          1. Return HasCallInTailPosition of |CaseBlock| with argument _call_.
-        </emu-alg>
-        <emu-grammar>CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
-        <emu-alg>
-          1. Let _has_ be *false*.
-          1. If the first |CaseClauses| is present, let _has_ be HasCallInTailPosition of the first |CaseClauses| with argument _call_.
-          1. If _has_ is *true*, return *true*.
-          1. Let _has_ be HasCallInTailPosition of |DefaultClause| with argument _call_.
-          1. If _has_ is *true*, return *true*.
-          1. If the second |CaseClauses| is present, let _has_ be HasCallInTailPosition of the second |CaseClauses| with argument _call_.
-          1. Return _has_.
-        </emu-alg>
-        <emu-grammar>CaseClauses : CaseClauses CaseClause</emu-grammar>
-        <emu-alg>
-          1. Let _has_ be HasCallInTailPosition of |CaseClauses| with argument _call_.
-          1. If _has_ is *true*, return *true*.
-          1. Return HasCallInTailPosition of |CaseClause| with argument _call_.
-        </emu-alg>
-        <emu-grammar>
-          CaseClause : `case` Expression `:` StatementList?
+        WithStatement :
+          `with` `(` Expression `)` Statement
+      </emu-grammar>
+      <emu-alg>
+        1. Return HasCallInTailPosition of |Statement| with argument _call_.
+      </emu-alg>
+      <emu-grammar>
+        LabelledStatement :
+          LabelIdentifier `:` LabelledItem
+      </emu-grammar>
+      <emu-alg>
+        1. Return HasCallInTailPosition of |LabelledItem| with argument _call_.
+      </emu-alg>
+      <emu-grammar>ReturnStatement : `return` Expression `;`</emu-grammar>
+      <emu-alg>
+        1. Return HasCallInTailPosition of |Expression| with argument _call_.
+      </emu-alg>
+      <emu-grammar>SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
+      <emu-alg>
+        1. Return HasCallInTailPosition of |CaseBlock| with argument _call_.
+      </emu-alg>
+      <emu-grammar>CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
+      <emu-alg>
+        1. Let _has_ be *false*.
+        1. If the first |CaseClauses| is present, let _has_ be HasCallInTailPosition of the first |CaseClauses| with argument _call_.
+        1. If _has_ is *true*, return *true*.
+        1. Let _has_ be HasCallInTailPosition of |DefaultClause| with argument _call_.
+        1. If _has_ is *true*, return *true*.
+        1. If the second |CaseClauses| is present, let _has_ be HasCallInTailPosition of the second |CaseClauses| with argument _call_.
+        1. Return _has_.
+      </emu-alg>
+      <emu-grammar>CaseClauses : CaseClauses CaseClause</emu-grammar>
+      <emu-alg>
+        1. Let _has_ be HasCallInTailPosition of |CaseClauses| with argument _call_.
+        1. If _has_ is *true*, return *true*.
+        1. Return HasCallInTailPosition of |CaseClause| with argument _call_.
+      </emu-alg>
+      <emu-grammar>
+        CaseClause : `case` Expression `:` StatementList?
 
-          DefaultClause : `default` `:` StatementList?
-        </emu-grammar>
-        <emu-alg>
-          1. If |StatementList| is present, return HasCallInTailPosition of |StatementList| with argument _call_.
-          1. Return *false*.
-        </emu-alg>
-        <emu-grammar>TryStatement : `try` Block Catch</emu-grammar>
-        <emu-alg>
-          1. Return HasCallInTailPosition of |Catch| with argument _call_.
-        </emu-alg>
-        <emu-grammar>
-          TryStatement :
-            `try` Block Finally
-            `try` Block Catch Finally
-        </emu-grammar>
-        <emu-alg>
-          1. Return HasCallInTailPosition of |Finally| with argument _call_.
-        </emu-alg>
-        <emu-grammar>Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
-        <emu-alg>
-          1. Return HasCallInTailPosition of |Block| with argument _call_.
-        </emu-alg>
-      </emu-clause>
+        DefaultClause : `default` `:` StatementList?
+      </emu-grammar>
+      <emu-alg>
+        1. If |StatementList| is present, return HasCallInTailPosition of |StatementList| with argument _call_.
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>TryStatement : `try` Block Catch</emu-grammar>
+      <emu-alg>
+        1. Return HasCallInTailPosition of |Catch| with argument _call_.
+      </emu-alg>
+      <emu-grammar>
+        TryStatement :
+          `try` Block Finally
+          `try` Block Catch Finally
+      </emu-grammar>
+      <emu-alg>
+        1. Return HasCallInTailPosition of |Finally| with argument _call_.
+      </emu-alg>
+      <emu-grammar>Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
+      <emu-alg>
+        1. Return HasCallInTailPosition of |Block| with argument _call_.
+      </emu-alg>
 
-      <emu-clause id="sec-expression-rules">
-        <h1>Expression Rules</h1>
-        <emu-note>
-          <p>A potential tail position call that is immediately followed by return GetValue of the call result is also a possible tail position call. A function call cannot return a Reference Record, so such a GetValue operation will always return the same value as the actual function call result.</p>
-        </emu-note>
-        <emu-grammar>
-          AssignmentExpression :
-            YieldExpression
-            ArrowFunction
-            AsyncArrowFunction
-            LeftHandSideExpression `=` AssignmentExpression
-            LeftHandSideExpression AssignmentOperator AssignmentExpression
-            LeftHandSideExpression `&amp;&amp;=` AssignmentExpression
-            LeftHandSideExpression `||=` AssignmentExpression
-            LeftHandSideExpression `??=` AssignmentExpression
+      <emu-grammar>
+        AssignmentExpression :
+          YieldExpression
+          ArrowFunction
+          AsyncArrowFunction
+          LeftHandSideExpression `=` AssignmentExpression
+          LeftHandSideExpression AssignmentOperator AssignmentExpression
+          LeftHandSideExpression `&amp;&amp;=` AssignmentExpression
+          LeftHandSideExpression `||=` AssignmentExpression
+          LeftHandSideExpression `??=` AssignmentExpression
 
-          BitwiseANDExpression :
-            BitwiseANDExpression `&amp;` EqualityExpression
+        BitwiseANDExpression :
+          BitwiseANDExpression `&amp;` EqualityExpression
 
-          BitwiseXORExpression :
-            BitwiseXORExpression `^` BitwiseANDExpression
+        BitwiseXORExpression :
+          BitwiseXORExpression `^` BitwiseANDExpression
 
-          BitwiseORExpression :
-            BitwiseORExpression `|` BitwiseXORExpression
+        BitwiseORExpression :
+          BitwiseORExpression `|` BitwiseXORExpression
 
-          EqualityExpression :
-            EqualityExpression `==` RelationalExpression
-            EqualityExpression `!=` RelationalExpression
-            EqualityExpression `===` RelationalExpression
-            EqualityExpression `!==` RelationalExpression
+        EqualityExpression :
+          EqualityExpression `==` RelationalExpression
+          EqualityExpression `!=` RelationalExpression
+          EqualityExpression `===` RelationalExpression
+          EqualityExpression `!==` RelationalExpression
 
-          RelationalExpression :
-            RelationalExpression `&lt;` ShiftExpression
-            RelationalExpression `&gt;` ShiftExpression
-            RelationalExpression `&lt;=` ShiftExpression
-            RelationalExpression `&gt;=` ShiftExpression
-            RelationalExpression `instanceof` ShiftExpression
-            RelationalExpression `in` ShiftExpression
-            PrivateIdentifier `in` ShiftExpression
+        RelationalExpression :
+          RelationalExpression `&lt;` ShiftExpression
+          RelationalExpression `&gt;` ShiftExpression
+          RelationalExpression `&lt;=` ShiftExpression
+          RelationalExpression `&gt;=` ShiftExpression
+          RelationalExpression `instanceof` ShiftExpression
+          RelationalExpression `in` ShiftExpression
+          PrivateIdentifier `in` ShiftExpression
 
-          ShiftExpression :
-            ShiftExpression `&lt;&lt;` AdditiveExpression
-            ShiftExpression `&gt;&gt;` AdditiveExpression
-            ShiftExpression `&gt;&gt;&gt;` AdditiveExpression
+        ShiftExpression :
+          ShiftExpression `&lt;&lt;` AdditiveExpression
+          ShiftExpression `&gt;&gt;` AdditiveExpression
+          ShiftExpression `&gt;&gt;&gt;` AdditiveExpression
 
-          AdditiveExpression :
-            AdditiveExpression `+` MultiplicativeExpression
-            AdditiveExpression `-` MultiplicativeExpression
+        AdditiveExpression :
+          AdditiveExpression `+` MultiplicativeExpression
+          AdditiveExpression `-` MultiplicativeExpression
 
-          MultiplicativeExpression :
-            MultiplicativeExpression MultiplicativeOperator ExponentiationExpression
+        MultiplicativeExpression :
+          MultiplicativeExpression MultiplicativeOperator ExponentiationExpression
 
-          ExponentiationExpression :
-            UpdateExpression `**` ExponentiationExpression
+        ExponentiationExpression :
+          UpdateExpression `**` ExponentiationExpression
 
-          UpdateExpression :
-            LeftHandSideExpression `++`
-            LeftHandSideExpression `--`
-            `++` UnaryExpression
-            `--` UnaryExpression
+        UpdateExpression :
+          LeftHandSideExpression `++`
+          LeftHandSideExpression `--`
+          `++` UnaryExpression
+          `--` UnaryExpression
 
-          UnaryExpression :
-            `delete` UnaryExpression
-            `void` UnaryExpression
-            `typeof` UnaryExpression
-            `+` UnaryExpression
-            `-` UnaryExpression
-            `~` UnaryExpression
-            `!` UnaryExpression
-            AwaitExpression
+        UnaryExpression :
+          `delete` UnaryExpression
+          `void` UnaryExpression
+          `typeof` UnaryExpression
+          `+` UnaryExpression
+          `-` UnaryExpression
+          `~` UnaryExpression
+          `!` UnaryExpression
+          AwaitExpression
 
-          CallExpression :
-            SuperCall
-            CallExpression `[` Expression `]`
-            CallExpression `.` IdentifierName
-            CallExpression `.` PrivateIdentifier
+        CallExpression :
+          SuperCall
+          CallExpression `[` Expression `]`
+          CallExpression `.` IdentifierName
+          CallExpression `.` PrivateIdentifier
 
-          NewExpression :
-            `new` NewExpression
+        NewExpression :
+          `new` NewExpression
 
-          MemberExpression :
-            MemberExpression `[` Expression `]`
-            MemberExpression `.` IdentifierName
-            SuperProperty
-            MetaProperty
-            `new` MemberExpression Arguments
-            MemberExpression `.` PrivateIdentifier
+        MemberExpression :
+          MemberExpression `[` Expression `]`
+          MemberExpression `.` IdentifierName
+          SuperProperty
+          MetaProperty
+          `new` MemberExpression Arguments
+          MemberExpression `.` PrivateIdentifier
 
-          PrimaryExpression :
-            `this`
-            IdentifierReference
-            Literal
-            ArrayLiteral
-            ObjectLiteral
-            FunctionExpression
-            ClassExpression
-            GeneratorExpression
-            AsyncFunctionExpression
-            AsyncGeneratorExpression
-            RegularExpressionLiteral
-            TemplateLiteral
-        </emu-grammar>
-        <emu-alg>
-          1. Return *false*.
-        </emu-alg>
-        <emu-grammar>
-          Expression :
-            AssignmentExpression
-            Expression `,` AssignmentExpression
-        </emu-grammar>
-        <emu-alg>
-          1. Return HasCallInTailPosition of |AssignmentExpression| with argument _call_.
-        </emu-alg>
-        <emu-grammar>ConditionalExpression : ShortCircuitExpression `?` AssignmentExpression `:` AssignmentExpression</emu-grammar>
-        <emu-alg>
-          1. Let _has_ be HasCallInTailPosition of the first |AssignmentExpression| with argument _call_.
-          1. If _has_ is *true*, return *true*.
-          1. Return HasCallInTailPosition of the second |AssignmentExpression| with argument _call_.
-        </emu-alg>
-        <emu-grammar>LogicalANDExpression : LogicalANDExpression `&amp;&amp;` BitwiseORExpression</emu-grammar>
-        <emu-alg>
-          1. Return HasCallInTailPosition of |BitwiseORExpression| with argument _call_.
-        </emu-alg>
-        <emu-grammar>LogicalORExpression : LogicalORExpression `||` LogicalANDExpression</emu-grammar>
-        <emu-alg>
-          1. Return HasCallInTailPosition of |LogicalANDExpression| with argument _call_.
-        </emu-alg>
-        <emu-grammar>CoalesceExpression : CoalesceExpressionHead `??` BitwiseORExpression</emu-grammar>
-        <emu-alg>
-          1. Return HasCallInTailPosition of |BitwiseORExpression| with argument _call_.
-        </emu-alg>
-        <emu-grammar>
-          CallExpression :
-            CoverCallExpressionAndAsyncArrowHead
-            CallExpression Arguments
-            CallExpression TemplateLiteral
-        </emu-grammar>
-        <emu-alg>
-          1. If this |CallExpression| is _call_, return *true*.
-          1. Return *false*.
-        </emu-alg>
-        <emu-grammar>
-          OptionalExpression :
-            MemberExpression OptionalChain
-            CallExpression OptionalChain
-            OptionalExpression OptionalChain
-        </emu-grammar>
-        <emu-alg>
-          1. Return HasCallInTailPosition of |OptionalChain| with argument _call_.
-        </emu-alg>
-        <emu-grammar>
-          OptionalChain :
-            `?.` `[` Expression `]`
-            `?.` IdentifierName
-            `?.` PrivateIdentifier
-            OptionalChain `[` Expression `]`
-            OptionalChain `.` IdentifierName
-            OptionalChain `.` PrivateIdentifier
-        </emu-grammar>
-        <emu-alg>
-          1. Return *false*.
-        </emu-alg>
-        <emu-grammar>
-          OptionalChain :
-            `?.` Arguments
-            OptionalChain Arguments
-        </emu-grammar>
-        <emu-alg>
-          1. If this |OptionalChain| is _call_, return *true*.
-          1. Return *false*.
-        </emu-alg>
-        <emu-grammar>
-          MemberExpression :
-            MemberExpression TemplateLiteral
-        </emu-grammar>
-        <emu-alg>
-          1. If this |MemberExpression| is _call_, return *true*.
-          1. Return *false*.
-        </emu-alg>
-        <emu-grammar>PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
-        <emu-alg>
-          1. Let _expr_ be the |ParenthesizedExpression| that is covered by |CoverParenthesizedExpressionAndArrowParameterList|.
-          1. Return HasCallInTailPosition of _expr_ with argument _call_.
-        </emu-alg>
-        <emu-grammar>
-          ParenthesizedExpression :
-            `(` Expression `)`
-        </emu-grammar>
-        <emu-alg>
-          1. Return HasCallInTailPosition of |Expression| with argument _call_.
-        </emu-alg>
-      </emu-clause>
+        PrimaryExpression :
+          `this`
+          IdentifierReference
+          Literal
+          ArrayLiteral
+          ObjectLiteral
+          FunctionExpression
+          ClassExpression
+          GeneratorExpression
+          AsyncFunctionExpression
+          AsyncGeneratorExpression
+          RegularExpressionLiteral
+          TemplateLiteral
+      </emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>
+        Expression :
+          AssignmentExpression
+          Expression `,` AssignmentExpression
+      </emu-grammar>
+      <emu-alg>
+        1. Return HasCallInTailPosition of |AssignmentExpression| with argument _call_.
+      </emu-alg>
+      <emu-grammar>ConditionalExpression : ShortCircuitExpression `?` AssignmentExpression `:` AssignmentExpression</emu-grammar>
+      <emu-alg>
+        1. Let _has_ be HasCallInTailPosition of the first |AssignmentExpression| with argument _call_.
+        1. If _has_ is *true*, return *true*.
+        1. Return HasCallInTailPosition of the second |AssignmentExpression| with argument _call_.
+      </emu-alg>
+      <emu-grammar>LogicalANDExpression : LogicalANDExpression `&amp;&amp;` BitwiseORExpression</emu-grammar>
+      <emu-alg>
+        1. Return HasCallInTailPosition of |BitwiseORExpression| with argument _call_.
+      </emu-alg>
+      <emu-grammar>LogicalORExpression : LogicalORExpression `||` LogicalANDExpression</emu-grammar>
+      <emu-alg>
+        1. Return HasCallInTailPosition of |LogicalANDExpression| with argument _call_.
+      </emu-alg>
+      <emu-grammar>CoalesceExpression : CoalesceExpressionHead `??` BitwiseORExpression</emu-grammar>
+      <emu-alg>
+        1. Return HasCallInTailPosition of |BitwiseORExpression| with argument _call_.
+      </emu-alg>
+      <emu-grammar>
+        CallExpression :
+          CoverCallExpressionAndAsyncArrowHead
+          CallExpression Arguments
+          CallExpression TemplateLiteral
+      </emu-grammar>
+      <emu-alg>
+        1. If this |CallExpression| is _call_, return *true*.
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>
+        OptionalExpression :
+          MemberExpression OptionalChain
+          CallExpression OptionalChain
+          OptionalExpression OptionalChain
+      </emu-grammar>
+      <emu-alg>
+        1. Return HasCallInTailPosition of |OptionalChain| with argument _call_.
+      </emu-alg>
+      <emu-grammar>
+        OptionalChain :
+          `?.` `[` Expression `]`
+          `?.` IdentifierName
+          `?.` PrivateIdentifier
+          OptionalChain `[` Expression `]`
+          OptionalChain `.` IdentifierName
+          OptionalChain `.` PrivateIdentifier
+      </emu-grammar>
+      <emu-alg>
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>
+        OptionalChain :
+          `?.` Arguments
+          OptionalChain Arguments
+      </emu-grammar>
+      <emu-alg>
+        1. If this |OptionalChain| is _call_, return *true*.
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>
+        MemberExpression :
+          MemberExpression TemplateLiteral
+      </emu-grammar>
+      <emu-alg>
+        1. If this |MemberExpression| is _call_, return *true*.
+        1. Return *false*.
+      </emu-alg>
+      <emu-grammar>PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
+      <emu-alg>
+        1. Let _expr_ be the |ParenthesizedExpression| that is covered by |CoverParenthesizedExpressionAndArrowParameterList|.
+        1. Return HasCallInTailPosition of _expr_ with argument _call_.
+      </emu-alg>
+      <emu-grammar>
+        ParenthesizedExpression :
+          `(` Expression `)`
+      </emu-grammar>
+      <emu-alg>
+        1. Return HasCallInTailPosition of |Expression| with argument _call_.
+      </emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-preparefortailcall" type="abstract operation">


### PR DESCRIPTION
HasCallInTailPosition was defined in one place even prior to the more general [SDO consolidation](https://github.com/tc39/ecma262/pull/2271).

But that one place was split up into two subclauses. Prior to SDO consolidation that wasn't remarkable, but afterwards it was, since no other SDO split its parts into subclauses like this. Plus it makes static analysis harder. So remove the subclauses.

I recommend reviewing this PR [with whitespace changes suppressed](https://github.com/tc39/ecma262/pull/2896/files?w=1).