### PR TITLE
Editorial: rename EnumerableOwnPropertyNames to EnumerableOwnProperties

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -6688,9 +6688,9 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-enumerableownpropertynames" type="abstract operation" oldids="sec-enumerableownproperties">
+    <emu-clause id="sec-enumerableownproperties" type="abstract operation" oldids="sec-enumerableownpropertynames">
       <h1>
-        EnumerableOwnPropertyNames (
+        EnumerableOwnProperties (
           _O_: an Object,
           _kind_: ~key~, ~value~, or ~key+value~,
         ): either a normal completion containing a List of ECMAScript language values or a throw completion
@@ -6699,20 +6699,20 @@
       </dl>
       <emu-alg>
         1. Let _ownKeys_ be ? <emu-meta effects="user-code">_O_.[[OwnPropertyKeys]]</emu-meta>().
-        1. Let _properties_ be a new empty List.
+        1. Let _results_ be a new empty List.
         1. For each element _key_ of _ownKeys_, do
           1. If _key_ is a String, then
             1. Let _desc_ be ? <emu-meta effects="user-code">_O_.[[GetOwnProperty]]</emu-meta>(_key_).
             1. If _desc_ is not *undefined* and _desc_.[[Enumerable]] is *true*, then
-              1. If _kind_ is ~key~, append _key_ to _properties_.
+              1. If _kind_ is ~key~, append _key_ to _results_.
               1. Else,
                 1. Let _value_ be ? Get(_O_, _key_).
-                1. If _kind_ is ~value~, append _value_ to _properties_.
+                1. If _kind_ is ~value~, append _value_ to _results_.
                 1. Else,
                   1. Assert: _kind_ is ~key+value~.
                   1. Let _entry_ be CreateArrayFromList(&laquo; _key_, _value_ &raquo;).
-                  1. Append _entry_ to _properties_.
-        1. Return _properties_.
+                  1. Append _entry_ to _results_.
+        1. Return _results_.
       </emu-alg>
     </emu-clause>
 
@@ -29476,8 +29476,8 @@
         <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. Let _obj_ be ? ToObject(_O_).
-          1. Let _nameList_ be ? EnumerableOwnPropertyNames(_obj_, ~key+value~).
-          1. Return CreateArrayFromList(_nameList_).
+          1. Let _entryList_ be ? EnumerableOwnProperties(_obj_, ~key+value~).
+          1. Return CreateArrayFromList(_entryList_).
         </emu-alg>
       </emu-clause>
 
@@ -29632,8 +29632,8 @@
         <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. Let _obj_ be ? ToObject(_O_).
-          1. Let _nameList_ be ? EnumerableOwnPropertyNames(_obj_, ~key~).
-          1. Return CreateArrayFromList(_nameList_).
+          1. Let _keyList_ be ? EnumerableOwnProperties(_obj_, ~key~).
+          1. Return CreateArrayFromList(_keyList_).
         </emu-alg>
       </emu-clause>
 
@@ -29683,8 +29683,8 @@
         <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. Let _obj_ be ? ToObject(_O_).
-          1. Let _nameList_ be ? EnumerableOwnPropertyNames(_obj_, ~value~).
-          1. Return CreateArrayFromList(_nameList_).
+          1. Let _valueList_ be ? EnumerableOwnProperties(_obj_, ~value~).
+          1. Return CreateArrayFromList(_valueList_).
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -42452,7 +42452,7 @@ THH:mm:ss.sss
                   1. Perform ? CreateDataProperty(_val_, _prop_, _newElement_).
                 1. Set _I_ to _I_ + 1.
             1. Else,
-              1. Let _keys_ be ? EnumerableOwnPropertyNames(_val_, ~key~).
+              1. Let _keys_ be ? EnumerableOwnProperties(_val_, ~key~).
               1. For each String _P_ of _keys_, do
                 1. Let _newElement_ be ? InternalizeJSONProperty(_val_, _P_, _reviver_).
                 1. If _newElement_ is *undefined*, then
@@ -42791,7 +42791,7 @@ THH:mm:ss.sss
           1. If _state_.[[PropertyList]] is not *undefined*, then
             1. Let _K_ be _state_.[[PropertyList]].
           1. Else,
-            1. Let _K_ be ? EnumerableOwnPropertyNames(_value_, ~key~).
+            1. Let _K_ be ? EnumerableOwnProperties(_value_, ~key~).
           1. Let _partial_ be a new empty List.
           1. For each element _P_ of _K_, do
             1. Let _strP_ be ? SerializeJSONProperty(_state_, _P_, _value_).


### PR DESCRIPTION
Since this AO takes a `kind` where 2 of the 3 values cause it to *not* return names, I felt `EnumerableOwnPropertyNames` was a poor name for it.