### PR TITLE
Editorial: split variable declarations into their own lines in JSON.stringify

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -42475,7 +42475,8 @@ THH:mm:ss.sss
       <emu-alg>
         1. Let _stack_ be a new empty List.
         1. Let _indent_ be the empty String.
-        1. Let _PropertyList_ and _ReplacerFunction_ be *undefined*.
+        1. Let _PropertyList_ be *undefined*.
+        1. Let _ReplacerFunction_ be *undefined*.
         1. If _replacer_ is an Object, then
           1. If IsCallable(_replacer_) is *true*, then
             1. Set _ReplacerFunction_ to _replacer_.


### PR DESCRIPTION
Just for consistency's sake. There's a few other places we declare multiple variables on one line, but those seem motivated by the algorithm's structure; this does not.