### PR TITLE
Editorial: Tweak the parameter list of Function constructors

### DIFF
--- a/.github/workflows/esmeta-typecheck.yml
+++ b/.github/workflows/esmeta-typecheck.yml
@@ -24,7 +24,7 @@ jobs:
           cd "${ESMETA_HOME}"
           git init
           git remote add origin https://github.com/es-meta/esmeta.git
-          git fetch --depth 1 origin 568abcfc85534c661bba3576815badffe185d334 ;# v0.1.0-rc5
+          git fetch --depth 1 origin 502c7e927cac67e369d6dd611034505124b9a2ce ;# v0.1.0-rc6
           git checkout FETCH_HEAD
       - name: build esmeta
         run: |

--- a/spec.html
+++ b/spec.html
@@ -29575,13 +29575,13 @@
       </ul>
 
       <emu-clause id="sec-function-p1-p2-pn-body">
-        <h1>Function ( _p1_, _p2_, … , _pn_, _body_ )</h1>
+        <h1>Function ( ..._parameterArgs_, _bodyArg_ )</h1>
         <p>The last argument (if any) specifies the body (executable code) of a function; any preceding arguments specify formal parameters.</p>
         <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. Let _C_ be the active function object.
-          1. [declared="argumentsList"] Let _args_ be the _argumentsList_ that was passed to this function by [[Call]] or [[Construct]].
-          1. Return ? CreateDynamicFunction(_C_, NewTarget, ~normal~, _args_).
+          1. If _bodyArg_ is not present, set _bodyArg_ to the empty String.
+          1. Return ? CreateDynamicFunction(_C_, NewTarget, ~normal~, _parameterArgs_, _bodyArg_).
         </emu-alg>
         <emu-note>
           <p>It is permissible but not necessary to have one argument for each formal parameter to be specified. For example, all three of the following expressions produce the same result:</p>
@@ -29598,12 +29598,13 @@
               _constructor_: a constructor,
               _newTarget_: a constructor,
               _kind_: ~normal~, ~generator~, ~async~, or ~asyncGenerator~,
-              _args_: a List of ECMAScript language values,
+              _parameterArgs_: a List of ECMAScript language values,
+              _bodyArg_: an ECMAScript language value,
             ): either a normal completion containing a function object or a throw completion
           </h1>
           <dl class="header">
             <dt>description</dt>
-            <dd>_constructor_ is the constructor function that is performing this action. _newTarget_ is the constructor that `new` was initially applied to. _args_ is the argument values that were passed to _constructor_.</dd>
+            <dd>_constructor_ is the constructor function that is performing this action. _newTarget_ is the constructor that `new` was initially applied to. _parameterArgs_ and _bodyArg_ reflect the argument values that were passed to _constructor_.</dd>
           </dl>
           <emu-alg>
             1. Let _currentRealm_ be the current Realm Record.
@@ -29634,21 +29635,17 @@
               1. Let _bodySym_ be the grammar symbol |AsyncGeneratorBody|.
               1. Let _parameterSym_ be the grammar symbol |FormalParameters[+Yield, +Await]|.
               1. Let _fallbackProto_ be *"%AsyncGeneratorFunction.prototype%"*.
-            1. Let _argCount_ be the number of elements in _args_.
+            1. Let _argCount_ be the number of elements in _parameterArgs_.
             1. Let _P_ be the empty String.
-            1. If _argCount_ = 0, let _bodyArg_ be the empty String.
-            1. Else if _argCount_ = 1, let _bodyArg_ be _args_[0].
-            1. Else,
-              1. Assert: _argCount_ > 1.
-              1. Let _firstArg_ be _args_[0].
+            1. If _argCount_ > 0, then
+              1. Let _firstArg_ be _parameterArgs_[0].
               1. Set _P_ to ? ToString(_firstArg_).
               1. Let _k_ be 1.
-              1. Repeat, while _k_ &lt; _argCount_ - 1,
-                1. Let _nextArg_ be _args_[_k_].
+              1. Repeat, while _k_ &lt; _argCount_,
+                1. Let _nextArg_ be _parameterArgs_[_k_].
                 1. Let _nextArgString_ be ? ToString(_nextArg_).
                 1. Set _P_ to the string-concatenation of _P_, *","* (a comma), and _nextArgString_.
                 1. Set _k_ to _k_ + 1.
-              1. Let _bodyArg_ be _args_[_k_].
             1. Let _bodyString_ be the string-concatenation of 0x000A (LINE FEED), ? ToString(_bodyArg_), and 0x000A (LINE FEED).
             1. Let _sourceString_ be the string-concatenation of _prefix_, *" anonymous("*, _P_, 0x000A (LINE FEED), *") {"*, _bodyString_, and *"}"*.
             1. Let _sourceText_ be StringToCodePoints(_sourceString_).
@@ -44666,13 +44663,13 @@ THH:mm:ss.sss
       </ul>
 
       <emu-clause id="sec-generatorfunction">
-        <h1>GeneratorFunction ( _p1_, _p2_, … , _pn_, _body_ )</h1>
+        <h1>GeneratorFunction ( ..._parameterArgs_, _bodyArg_ )</h1>
         <p>The last argument (if any) specifies the body (executable code) of a generator function; any preceding arguments specify formal parameters.</p>
         <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. Let _C_ be the active function object.
-          1. [declared="argumentsList"] Let _args_ be the _argumentsList_ that was passed to this function by [[Call]] or [[Construct]].
-          1. Return ? CreateDynamicFunction(_C_, NewTarget, ~generator~, _args_).
+          1. If _bodyArg_ is not present, set _bodyArg_ to the empty String.
+          1. Return ? CreateDynamicFunction(_C_, NewTarget, ~generator~, _parameterArgs_, _bodyArg_).
         </emu-alg>
         <emu-note>
           <p>See NOTE for <emu-xref href="#sec-function-p1-p2-pn-body"></emu-xref>.</p>
@@ -44772,13 +44769,13 @@ THH:mm:ss.sss
       </ul>
 
       <emu-clause id="sec-asyncgeneratorfunction">
-        <h1>AsyncGeneratorFunction ( _p1_, _p2_, … , _pn_, _body_ )</h1>
+        <h1>AsyncGeneratorFunction ( ..._parameterArgs_, _bodyArg_ )</h1>
         <p>The last argument (if any) specifies the body (executable code) of an async generator function; any preceding arguments specify formal parameters.</p>
         <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. Let _C_ be the active function object.
-          1. [declared="argumentsList"] Let _args_ be the _argumentsList_ that was passed to this function by [[Call]] or [[Construct]].
-          1. Return ? CreateDynamicFunction(_C_, NewTarget, ~asyncGenerator~, _args_).
+          1. If _bodyArg_ is not present, set _bodyArg_ to the empty String.
+          1. Return ? CreateDynamicFunction(_C_, NewTarget, ~asyncGenerator~, _parameterArgs_, _bodyArg_).
         </emu-alg>
         <emu-note>
           <p>See NOTE for <emu-xref href="#sec-function-p1-p2-pn-body"></emu-xref>.</p>
@@ -45618,14 +45615,14 @@ THH:mm:ss.sss
       </ul>
 
       <emu-clause id="sec-async-function-constructor-arguments">
-        <h1>AsyncFunction ( _p1_, _p2_, … , _pn_, _body_ )</h1>
+        <h1>AsyncFunction ( ..._parameterArgs_, _bodyArg_ )</h1>
         <p>The last argument (if any) specifies the body (executable code) of an async function. Any preceding arguments specify formal parameters.</p>
         <p>This function performs the following steps when called:</p>
 
         <emu-alg>
           1. Let _C_ be the active function object.
-          1. [declared="argumentsList"] Let _args_ be the _argumentsList_ that was passed to this function by [[Call]] or [[Construct]].
-          1. Return ? CreateDynamicFunction(_C_, NewTarget, ~async~, _args_).
+          1. If _bodyArg_ is not present, set _bodyArg_ to the empty String.
+          1. Return ? CreateDynamicFunction(_C_, NewTarget, ~async~, _parameterArgs_, _bodyArg_).
         </emu-alg>
 
         <emu-note>See NOTE for <emu-xref href="#sec-function-p1-p2-pn-body"></emu-xref>.</emu-note>


### PR DESCRIPTION
In the specification of each of the constructors:
- Function
- GeneratorFunction
- AsyncGeneratorFunction
- AsyncFunction

the parameter list is given as
`( _p1_, _p2_, &hellip; , _pn_, _body_ )`

Note that these specific parameters are not referenced by the preamble or the algorithm. The preamble used to refer to them, before PR #2592; I don't think the algorithm has ever referred to them. Instead, the algorithm currently says:
```
Let _args_ be the _argumentsList_ that was passed
   to this function by [[Call]] or [[Construct]].
```

The wording of this step is problematic:
- It refers to an alias that is defined in another algorithm (which is prompting some special-casing in PR #2901).
- It says that `[[Call]]` or `[[Construct]]` is passing something to this function, which is incongruous. (`[[Call]]` and `[[Construct]]` deal with an arguments list that has already *been* passed to the function.)

To resolve all of the above, this PR changes the parameter list to:
`( ..._args_ )`
and just deletes the `Let _args_ be ...` step.