### PR TITLE
Layering: Add HostLoadImportedModule hook

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -11474,6 +11474,20 @@
         </tr>
         <tr>
           <td>
+            [[LoadedModules]]
+          </td>
+          <td>
+            a List of Records with fields [[Specifier]] (a String) and [[Module]] (a Module Record)
+          </td>
+          <td>
+            <p>A map from the specifier strings imported by this realm to the resolved Module Record. The list does not contain two different Records with the same [[Specifier]].</p>
+            <emu-note>
+              As mentioned in HostLoadImportedModule (<emu-xref href="#note-HostLoadImportedModule-referrer-Realm-Record"></emu-xref>), [[LoadedModules]] in Realm Records is only used when running an `import()` expression in a context where there is no active script or module.
+            </emu-note>
+          </td>
+        </tr>
+        <tr>
+          <td>
             [[HostDefined]]
           </td>
           <td>
@@ -14756,12 +14770,12 @@
           1. Let _exports_ be _O_.[[Exports]].
           1. If _P_ is not an element of _exports_, return *undefined*.
           1. Let _m_ be _O_.[[Module]].
-          1. Let _binding_ be ! _m_.ResolveExport(_P_).
+          1. Let _binding_ be _m_.ResolveExport(_P_).
           1. Assert: _binding_ is a ResolvedBinding Record.
           1. Let _targetModule_ be _binding_.[[Module]].
           1. Assert: _targetModule_ is not *undefined*.
           1. If _binding_.[[BindingName]] is ~namespace~, then
-            1. Return ? GetModuleNamespace(_targetModule_).
+            1. Return GetModuleNamespace(_targetModule_).
           1. Let _targetEnv_ be _targetModule_.[[Environment]].
           1. If _targetEnv_ is ~empty~, throw a *ReferenceError* exception.
           1. Return ? _targetEnv_.GetBindingValue(_binding_.[[BindingName]], *true*).
@@ -19201,15 +19215,56 @@
 
         <emu-grammar>ImportCall : `import` `(` AssignmentExpression `)`</emu-grammar>
         <emu-alg>
-          1. Let _referencingScriptOrModule_ be GetActiveScriptOrModule().
+          1. Let _referrer_ be GetActiveScriptOrModule().
+          1. If _referrer_ is *null*, set _referrer_ to the current Realm Record.
           1. Let _argRef_ be ? Evaluation of |AssignmentExpression|.
           1. Let _specifier_ be ? GetValue(_argRef_).
           1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
           1. Let _specifierString_ be Completion(ToString(_specifier_)).
           1. IfAbruptRejectPromise(_specifierString_, _promiseCapability_).
-          1. Perform HostImportModuleDynamically(_referencingScriptOrModule_, _specifierString_, _promiseCapability_).
+          1. Perform HostLoadImportedModule(_referrer_, _specifierString_, ~empty~, _promiseCapability_).
           1. Return _promiseCapability_.[[Promise]].
         </emu-alg>
+
+        <emu-clause id="sec-ContinueDynamicImport" type="abstract operation">
+          <h1>
+            ContinueDynamicImport (
+              _promiseCapability_: a PromiseCapability Record,
+              _moduleCompletion_: either a normal completion containing a Module Record or a throw completion,
+            ): ~unused~
+          </h1>
+          <dl class="header">
+            <dt>description</dt>
+            <dd>It completes the process of a dynamic import originally started by an <emu-xref href="#sec-import-calls">`import()`</emu-xref> call, resolving or rejecting the promise returned by that call as appropriate.</dd>
+          </dl>
+          <emu-alg>
+            1. If _moduleCompletion_ is an abrupt completion, then
+              1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, « _moduleCompletion_.[[Value]] »).
+              1. Return ~unused~.
+            1. Let _module_ be _moduleCompletion_.[[Value]].
+            1. Let _loadPromise_ be _module_.LoadRequestedModules().
+            1. Let _rejectedClosure_ be a new Abstract Closure with parameters (_reason_) that captures _promiseCapability_ and performs the following steps when called:
+              1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, « _reason_ »).
+              1. Return ~unused~.
+            1. Let _onRejected_ be CreateBuiltinFunction(_rejectedClosure_, 1, *""*, « »).
+            1. Let _linkAndEvaluateClosure_ be a new Abstract Closure with no parameters that captures _module_, _promiseCapability_, and _onRejected_ and performs the following steps when called:
+              1. Let _link_ be Completion(_module_.Link()).
+              1. If _link_ is an abrupt completion, then
+                1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, « _link_.[[Value]] »).
+                1. Return ~unused~.
+              1. Let _evaluatePromise_ be _module_.Evaluate().
+              1. Let _fulfilledClosure_ be a new Abstract Closure with no parameters that captures _module_ and _promiseCapability_ and performs the following steps when called:
+                1. Let _namespace_ be GetModuleNamespace(_module_).
+                1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, « _namespace_ »).
+                1. Return ~unused~.
+              1. Let _onFulfilled_ be CreateBuiltinFunction(_fulfilledClosure_, 0, *""*, « »).
+              1. Perform PerformPromiseThen(_evaluatePromise_, _onFulfilled_, _onRejected_).
+              1. Return ~unused~.
+            1. Let _linkAndEvaluate_ be CreateBuiltinFunction(_linkAndEvaluateClosure_, 0, *""*, « »).
+            1. Perform PerformPromiseThen(_loadPromise_, _linkAndEvaluate_, _onRejected_).
+            1. Return ~unused~.
+          </emu-alg>
+        </emu-clause>
       </emu-clause>
     </emu-clause>
 
@@ -25487,6 +25542,17 @@
           </tr>
           <tr>
             <td>
+              [[LoadedModules]]
+            </td>
+            <td>
+              a List of Records with fields [[Specifier]] (a String) and [[Module]] (a Module Record)
+            </td>
+            <td>
+              A map from the specifier strings imported by this script to the resolved Module Record. The list does not contain two different Records with the same [[Specifier]].
+            </td>
+          </tr>
+          <tr>
+            <td>
               [[HostDefined]]
             </td>
             <td>
@@ -25516,7 +25582,7 @@
       <emu-alg>
         1. Let _script_ be ParseText(_sourceText_, |Script|).
         1. If _script_ is a List of errors, return _script_.
-        1. Return Script Record { [[Realm]]: _realm_, [[ECMAScriptCode]]: _script_, [[HostDefined]]: _hostDefined_ }.
+        1. Return Script Record { [[Realm]]: _realm_, [[ECMAScriptCode]]: _script_, [[LoadedModules]]: « », [[HostDefined]]: _hostDefined_ }.
       </emu-alg>
       <emu-note>
         <p>An implementation may parse script source text and analyse it for Early Error conditions prior to evaluation of ParseScript for that script source text. However, the reporting of any errors must be deferred until the point where this specification actually performs ParseScript upon that source text.</p>
@@ -25852,10 +25918,19 @@
             </tr>
             <tr>
               <td>
+                LoadRequestedModules( [ _hostDefined_ ] )
+              </td>
+              <td>
+                <p>Prepares the module for linking by recursively loading all its dependencies, and returns a promise.</p>
+              </td>
+            </tr>
+            <tr>
+              <td>
                 GetExportedNames([_exportStarSet_])
               </td>
               <td>
-                Return a list of all names that are either directly or indirectly exported from this module.
+                <p>Return a list of all names that are either directly or indirectly exported from this module.</p>
+                <p>LoadRequestedModules must have completed successfully prior to invoking this method.</p>
               </td>
             </tr>
             <tr>
@@ -25864,7 +25939,8 @@
               </td>
               <td>
                 <p>Return the binding of a name exported by this module. Bindings are represented by a <dfn id="resolvedbinding-record" variants="ResolvedBinding Records">ResolvedBinding Record</dfn>, of the form { [[Module]]: Module Record, [[BindingName]]: String | ~namespace~ }. If the export is a Module Namespace Object without a direct binding in any module, [[BindingName]] will be set to ~namespace~. Return *null* if the name cannot be resolved, or ~ambiguous~ if multiple bindings were found.</p>
-                <p>Each time this operation is called with a specific _exportName_, _resolveSet_ pair as arguments it must return the same result if it completes normally.</p>
+                <p>Each time this operation is called with a specific _exportName_, _resolveSet_ pair as arguments it must return the same result.</p>
+                <p>LoadRequestedModules must have completed successfully prior to invoking this method.</p>
               </td>
             </tr>
             <tr>
@@ -25873,6 +25949,7 @@
               </td>
               <td>
                 <p>Prepare the module for evaluation by transitively resolving all module dependencies and creating a Module Environment Record.</p>
+                <p>LoadRequestedModules must have completed successfully prior to invoking this method.</p>
               </td>
             </tr>
             <tr>
@@ -25910,10 +25987,10 @@
                 [[Status]]
               </td>
               <td>
-                ~unlinked~, ~linking~, ~linked~, ~evaluating~, ~evaluating-async~, or ~evaluated~
+                ~new~, ~unlinked~, ~linking~, ~linked~, ~evaluating~, ~evaluating-async~, or ~evaluated~
               </td>
               <td>
-                Initially ~unlinked~. Transitions to ~linking~, ~linked~, ~evaluating~, possibly ~evaluating-async~, ~evaluated~ (in that order) as the module progresses throughout its lifecycle. ~evaluating-async~ indicates this module is queued to execute on completion of its asynchronous dependencies or it is a module whose [[HasTLA]] field is *true* that has been executed and is pending top-level completion.
+                Initially ~new~. Transitions to ~unlinked~, ~linking~, ~linked~, ~evaluating~, possibly ~evaluating-async~, ~evaluated~ (in that order) as the module progresses throughout its lifecycle. ~evaluating-async~ indicates this module is queued to execute on completion of its asynchronous dependencies or it is a module whose [[HasTLA]] field is *true* that has been executed and is pending top-level completion.
               </td>
             </tr>
             <tr>
@@ -25958,6 +26035,17 @@
               </td>
               <td>
                 A List of all the |ModuleSpecifier| strings used by the module represented by this record to request the importation of a module. The List is in source text occurrence order.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                [[LoadedModules]]
+              </td>
+              <td>
+                a List of Records with fields [[Specifier]] (a String) and [[Module]] (a Module Record)
+              </td>
+              <td>
+                A map from the specifier strings used by the module represented by this record to request the importation of a module to the resolved Module Record. The list does not contain two different Records with the same [[Specifier]].
               </td>
             </tr>
             <tr>
@@ -26058,6 +26146,166 @@
           </table>
         </emu-table>
 
+        <p>A <dfn id="graphloadingstate-record" variants="GraphLoadingState Records">GraphLoadingState Record</dfn> is a Record that contains information about the loading process of a module graph. It's used to continue loading after a call to HostLoadImportedModule. Each GraphLoadingState Record has the fields defined in <emu-xref href="#table-graphloadingstate-record-fields"></emu-xref>:</p>
+        <emu-table id="table-graphloadingstate-record-fields" caption="GraphLoadingState Record Fields">
+          <table>
+            <tr>
+              <th>
+                Field Name
+              </th>
+              <th>
+                Value Type
+              </th>
+              <th>
+                Meaning
+              </th>
+            </tr>
+            <tr>
+              <td>
+                [[PromiseCapability]]
+              </td>
+              <td>
+                a PromiseCapability Record
+              </td>
+              <td>
+                The promise to resolve when the loading process finishes.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                [[IsLoading]]
+              </td>
+              <td>
+                a Boolean
+              </td>
+              <td>
+                It is true if the loading process has not finished yet, neither successfully nor with an error.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                [[PendingModulesCount]]
+              </td>
+              <td>
+                a non-negative integer
+              </td>
+              <td>
+                It tracks the number of pending HostLoadImportedModule calls.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                [[Visited]]
+              </td>
+              <td>
+                a List of Cyclic Module Records
+              </td>
+              <td>
+                It is a list of the Cyclic Module Records that have been already loaded by the current loading process, to avoid infinite loops with circular dependencies.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                [[HostDefined]]
+              </td>
+              <td>
+                anything (default value is ~empty~)
+              </td>
+              <td>
+                It contains host-defined data to pass from the LoadRequestedModules caller to HostLoadImportedModule.
+              </td>
+            </tr>
+          </table>
+        </emu-table>
+
+        <emu-clause id="sec-LoadRequestedModules" type="concrete method">
+          <h1>
+            LoadRequestedModules (
+              optional _hostDefined_: anything,
+            ): a Promise
+          </h1>
+          <dl class="header">
+            <dt>for</dt>
+            <dd>a Cyclic Module Record _module_</dd>
+
+            <dt>description</dt>
+            <dd>It populates the [[LoadedModules]] of all the Module Records in the dependency graph of _module_ (most of the work is done by the auxiliary function InnerModuleLoading). It takes an optional _hostDefined_ parameter that is passed to the HostLoadImportedModule hook.</dd>
+          </dl>
+
+          <emu-alg>
+            1. If _hostDefined_ is not present, let _hostDefined_ be ~empty~.
+            1. Let _pc_ be ! NewPromiseCapability(%Promise%).
+            1. Let _state_ be the GraphLoadingState Record { [[IsLoading]]: *true*, [[PendingModulesCount]]: 1, [[Visited]]: « », [[PromiseCapability]]: _pc_, [[HostDefined]]: _hostDefined_ }.
+            1. Perform InnerModuleLoading(_state_, _module_).
+            1. Return _pc_.[[Promise]].
+          </emu-alg>
+
+          <emu-note>
+            The _hostDefined_ parameter can be used to pass additional information necessary to fetch the imported modules. It is used, for example, by HTML to set the correct fetch destination for <code>&lt;link rel="preload" as="..."&gt;</code> tags.
+            <code>import()</code> expressions never set the _hostDefined_ parameter.
+          </emu-note>
+
+          <emu-clause id="sec-InnerModuleLoading" type="abstract operation">
+            <h1>
+              InnerModuleLoading (
+                _state_: a GraphLoadingState Record,
+                _module_: a Module Record,
+              ): ~unused~
+            </h1>
+            <dl class="header">
+              <dt>description</dt>
+              <dd>It is used by LoadRequestedModules to recursively perform the actual loading process for _module_'s dependency graph.</dd>
+            </dl>
+
+            <emu-alg>
+              1. Assert: _state_.[[IsLoading]] is *true*.
+              1. If _module_ is a Cyclic Module Record, _module_.[[Status]] is ~new~, and _state_.[[Visited]] does not contain _module_, then
+                1. Append _module_ to _state_.[[Visited]].
+                1. Let _requestedModulesCount_ be the number of elements in _module_.[[RequestedModules]].
+                1. Set _state_.[[PendingModulesCount]] to _state_.[[PendingModulesCount]] + _requestedModulesCount_.
+                1. For each String _required_ of _module_.[[RequestedModules]], do
+                  1. If _module_.[[LoadedModules]] contains a Record whose [[Specifier]] is _required_, then
+                    1. Let _record_ be that Record.
+                    1. Perform InnerModuleLoading(_state_, _record_.[[Module]]).
+                  1. Else,
+                    1. Perform HostLoadImportedModule(_module_, _required_, _state_.[[HostDefined]], _state_).
+                    1. NOTE: HostLoadImportedModule will call FinishLoadingImportedModule, which re-enters the graph loading process through ContinueModuleLoading.
+                  1. If _state_.[[IsLoading]] is *false*, return ~unused~.
+              1. Assert: _state_.[[PendingModulesCount]] ≥ 1.
+              1. Set _state_.[[PendingModulesCount]] to _state_.[[PendingModulesCount]] - 1.
+              1. If _state_.[[PendingModulesCount]] = 0, then
+                1. Set _state_.[[IsLoading]] to *false*.
+                1. For each Cyclic Module Record _loaded_ of _state_.[[Visited]], do
+                  1. If _loaded_.[[Status]] is ~new~, set _loaded_.[[Status]] to ~unlinked~.
+                1. Perform ! Call(_state_.[[PromiseCapability]].[[Resolve]], *undefined*, « *undefined* »).
+              1. Return ~unused~.
+            </emu-alg>
+          </emu-clause>
+
+          <emu-clause id="sec-ContinueModuleLoading" type="abstract operation">
+            <h1>
+              ContinueModuleLoading (
+                _state_: a GraphLoadingState Record,
+                _moduleCompletion_: either a normal completion containing a Module Record or a throw completion,
+              ): ~unused~
+            </h1>
+            <dl class="header">
+              <dt>description</dt>
+              <dd>It is used to re-enter the loading process after a call to HostLoadImportedModule.</dd>
+            </dl>
+
+            <emu-alg>
+              1. If _state_.[[IsLoading]] is *false*, return ~unused~.
+              1. If _moduleCompletion_ is a normal completion, then
+                1. Perform InnerModuleLoading(_state_, _moduleCompletion_.[[Value]]).
+              1. Else,
+                1. Set _state_.[[IsLoading]] to *false*.
+                1. Perform ! Call(_state_.[[PromiseCapability]].[[Reject]], *undefined*, « _moduleCompletion_.[[Value]] »).
+              1. Return ~unused~.
+            </emu-alg>
+          </emu-clause>
+        </emu-clause>
+
         <emu-clause id="sec-moduledeclarationlinking" type="concrete method" oldids="sec-moduledeclarationinstantiation">
           <h1>Link ( ): either a normal completion containing ~unused~ or a throw completion</h1>
           <dl class="header">
@@ -26069,7 +26317,7 @@
           </dl>
 
           <emu-alg>
-            1. Assert: _module_.[[Status]] is not ~linking~ or ~evaluating~.
+            1. Assert: _module_.[[Status]] is ~unlinked~, ~linked~, ~evaluating-async~, or ~evaluated~.
             1. Let _stack_ be a new empty List.
             1. Let _result_ be Completion(InnerModuleLinking(_module_, _stack_, 0)).
             1. If _result_ is an abrupt completion, then
@@ -26109,7 +26357,7 @@
               1. Set _index_ to _index_ + 1.
               1. Append _module_ to _stack_.
               1. For each String _required_ of _module_.[[RequestedModules]], do
-                1. Let _requiredModule_ be ? HostResolveImportedModule(_module_, _required_).
+                1. Let _requiredModule_ be GetImportedModule(_module_, _required_).
                 1. Set _index_ to ? InnerModuleLinking(_requiredModule_, _stack_, _index_).
                 1. If _requiredModule_ is a Cyclic Module Record, then
                   1. Assert: _requiredModule_.[[Status]] is either ~linking~, ~linked~, ~evaluating-async~, or ~evaluated~.
@@ -26202,8 +26450,7 @@
               1. Set _index_ to _index_ + 1.
               1. Append _module_ to _stack_.
               1. For each String _required_ of _module_.[[RequestedModules]], do
-                1. Let _requiredModule_ be ! HostResolveImportedModule(_module_, _required_).
-                1. NOTE: Link must be completed successfully prior to invoking this method, so every requested module is guaranteed to resolve successfully.
+                1. Let _requiredModule_ be GetImportedModule(_module_, _required_).
                 1. Set _index_ to ? InnerModuleEvaluation(_requiredModule_, _stack_, _index_).
                 1. If _requiredModule_ is a Cyclic Module Record, then
                   1. Assert: _requiredModule_.[[Status]] is either ~evaluating~, ~evaluating-async~, or ~evaluated~.
@@ -26380,12 +26627,11 @@
             <img alt="A module graph in which module A depends on module B, and module B depends on module C" width="121" height="211" src="img/module-graph-simple.svg">
           </emu-figure>
 
-          <p>Let's first assume that there are no error conditions. When a host first calls _A_.Link(), this will complete successfully by assumption, and recursively link modules _B_ and _C_ as well, such that _A_.[[Status]] = _B_.[[Status]] = _C_.[[Status]] = ~linked~. This preparatory step can be performed at any time. Later, when the host is ready to incur any possible side effects of the modules, it can call _A_.Evaluate(), which will complete successfully, returning a Promise resolving to *undefined* (again by assumption), recursively having evaluated first _C_ and then _B_. Each module's [[Status]] at this point will be ~evaluated~.</p>
-          <p>Consider then cases involving linking errors. If InnerModuleLinking of _C_ succeeds but, thereafter, fails for _B_, for example because it imports something that _C_ does not provide, then the original _A_.Link() will fail, and both _A_ and _B_'s [[Status]] remain ~unlinked~. _C_'s [[Status]] has become ~linked~, though.</p>
+          <p>Let's first assume that there are no error conditions. When a host first calls _A_.LoadRequestedModules(), this will complete successfully by assumption, and recursively load the dependencies of _B_ and _C_ as well (respectively, _C_ and none), and then set _A_.[[Status]] = _B_.[[Status]] = _C_.[[Status]] = ~unlinked~. Then, when the host calls _A_.Link(), it will complete successfully (again by assumption) such that _A_.[[Status]] = _B_.[[Status]] = _C_.[[Status]] = linked. These preparatory steps can be performed at any time. Later, when the host is ready to incur any possible side effects of the modules, it can call _A_.Evaluate(), which will complete successfully, returning a Promise resolving to *undefined* (again by assumption), recursively having evaluated first _C_ and then _B_. Each module's [[Status]] at this point will be ~evaluated~.</p>
 
-          <p>Finally, consider a case involving evaluation errors. If InnerModuleEvaluation of _C_ succeeds but, thereafter, fails for _B_, for example because _B_ contains code that throws an exception, then the original _A_.Evaluate() will fail, returning a rejected Promise. The resulting exception will be recorded in both _A_ and _B_'s [[EvaluationError]] fields, and their [[Status]] will become ~evaluated~. _C_ will also become ~evaluated~ but, in contrast to _A_ and _B_, will remain without an [[EvaluationError]], as it successfully completed evaluation. Storing the exception ensures that any time a host tries to reuse _A_ or _B_ by calling their Evaluate() method, it will encounter the same exception. (Hosts are not required to reuse Cyclic Module Records; similarly, hosts are not required to expose the exception objects thrown by these methods. However, the specification enables such uses.)</p>
+          <p>Consider then cases involving linking errors, after a successful call to _A_.LoadRequestedModules(). If InnerModuleLinking of _C_ succeeds but, thereafter, fails for _B_, for example because it imports something that _C_ does not provide, then the original _A_.Link() will fail, and both _A_ and _B_'s [[Status]] remain ~unlinked~. _C_'s [[Status]] has become ~linked~, though.</p>
 
-          <p>The difference here between linking and evaluation errors is due to how evaluation must be only performed once, as it can cause side effects; it is thus important to remember whether evaluation has already been performed, even if unsuccessfully. (In the error case, it makes sense to also remember the exception because otherwise subsequent Evaluate() calls would have to synthesize a new one.) Linking, on the other hand, is side-effect-free, and thus even if it fails, it can be retried at a later time with no issues.</p>
+          <p>Finally, consider a case involving evaluation errors after a successful call to Link(). If InnerModuleEvaluation of _C_ succeeds but, thereafter, fails for _B_, for example because _B_ contains code that throws an exception, then the original _A_.Evaluate() will fail, returning a rejected Promise. The resulting exception will be recorded in both _A_ and _B_'s [[EvaluationError]] fields, and their [[Status]] will become ~evaluated~. _C_ will also become ~evaluated~ but, in contrast to _A_ and _B_, will remain without an [[EvaluationError]], as it successfully completed evaluation. Storing the exception ensures that any time a host tries to reuse _A_ or _B_ by calling their Evaluate() method, it will encounter the same exception. (Hosts are not required to reuse Cyclic Module Records; similarly, hosts are not required to expose the exception objects thrown by these methods. However, the specification enables such uses.)</p>
 
           <p>Now consider a different type of error condition:</p>
 
@@ -26393,7 +26639,14 @@
             <img alt="A module graph in which module A depends on a missing (unresolvable) module, represented by ???" width="121" height="121" src="img/module-graph-missing.svg">
           </emu-figure>
 
-          <p>In this scenario, module _A_ declares a dependency on some other module, but no Module Record exists for that module, i.e. HostResolveImportedModule throws an exception when asked for it. This could occur for a variety of reasons, such as the corresponding resource not existing, or the resource existing but ParseModule throwing an exception when trying to parse the resulting source text. Hosts can choose to expose the cause of failure via the exception they throw from HostResolveImportedModule. In any case, this exception causes a linking failure, which as before results in _A_'s [[Status]] remaining ~unlinked~.</p>
+          <p>In this scenario, module _A_ declares a dependency on some other module, but no Module Record exists for that module, i.e. HostLoadImportedModule calls FinishLoadingImportedModule with an exception when asked for it. This could occur for a variety of reasons, such as the corresponding resource not existing, or the resource existing but ParseModule returning some errors when trying to parse the resulting source text. Hosts can choose to expose the cause of failure via the completion they pass to FinishLoadingImportedModule. In any case, this exception causes a loading failure, which results in _A_'s [[Status]] remaining ~new~.</p>
+
+          <p>The difference here between loading, linking and evaluation errors is due to the following characteristic:</p>
+          <ul>
+            <li>Evaluation must be only performed once, as it can cause side effects; it is thus important to remember whether evaluation has already been performed, even if unsuccessfully. (In the error case, it makes sense to also remember the exception because otherwise subsequent Evaluate() calls would have to synthesize a new one.)</li>
+            <li>Linking, on the other hand, is side-effect-free, and thus even if it fails, it can be retried at a later time with no issues.</li>
+            <li>Loading closely interacts with the host, and it may be desiderable for some of them to allow users to retry failed loads (for example, if the failure is caused by temporarily bad network conditions).</li>
+          </ul>
 
           <p>Now, consider a module graph with a cycle:</p>
 
@@ -26401,11 +26654,13 @@
             <img alt="A module graph in which module A depends on module B and C, but module B also depends on module A" width="181" height="121" src="img/module-graph-cycle.svg">
           </emu-figure>
 
-          <p>Here we assume that the entry point is module _A_, so that the host proceeds by calling _A_.Link(), which performs InnerModuleLinking on _A_. This in turn calls InnerModuleLinking on _B_. Because of the cycle, this again triggers InnerModuleLinking on _A_, but at this point it is a no-op since _A_.[[Status]] is already ~linking~. _B_.[[Status]] itself remains ~linking~ when control gets back to _A_ and InnerModuleLinking is triggered on _C_. After this returns with _C_.[[Status]] being ~linked~, both _A_ and _B_ transition from ~linking~ to ~linked~ together; this is by design, since they form a strongly connected component.</p>
+          <p>Here we assume that the entry point is module _A_, so that the host proceeds by calling _A_.LoadRequestedModules(), which performs InnerModuleLoading on _A_. This in turn calls InnerModuleLoading on _B_ and _C_. Because of the cycle, this again triggers InnerModuleLoading on _A_, but at this point it is a no-op since _A_'s dependencies loading has already been triggered during this LoadRequestedModules process. When all the modules in the graph have been successfully loaded, their [[Status]] transitions from ~new~ to ~unlinked~ at the same time.</p>
+
+          <p>Then the host proceeds by calling _A_.Link(), which performs InnerModuleLinking on _A_. This in turn calls InnerModuleLinking on _B_. Because of the cycle, this again triggers InnerModuleLinking on _A_, but at this point it is a no-op since _A_.[[Status]] is already ~linking~. _B_.[[Status]] itself remains ~linking~ when control gets back to _A_ and InnerModuleLinking is triggered on _C_. After this returns with _C_.[[Status]] being ~linked~, both _A_ and _B_ transition from ~linking~ to ~linked~ together; this is by design, since they form a strongly connected component. It's possible to transition the status of modules in the same SCC at the same time because during this phase the module graph is traversed with a depth-first search.</p>
 
           <p>An analogous story occurs for the evaluation phase of a cyclic module graph, in the success case.</p>
 
-          <p>Now consider a case where _A_ has an linking error; for example, it tries to import a binding from _C_ that does not exist. In that case, the above steps still occur, including the early return from the second call to InnerModuleLinking on _A_. However, once we unwind back to the original InnerModuleLinking on _A_, it fails during InitializeEnvironment, namely right after _C_.ResolveExport(). The thrown *SyntaxError* exception propagates up to _A_.Link, which resets all modules that are currently on its _stack_ (these are always exactly the modules that are still ~linking~). Hence both _A_ and _B_ become ~unlinked~. Note that _C_ is left as ~linked~.</p>
+          <p>Now consider a case where _A_ has a linking error; for example, it tries to import a binding from _C_ that does not exist. In that case, the above steps still occur, including the early return from the second call to InnerModuleLinking on _A_. However, once we unwind back to the original InnerModuleLinking on _A_, it fails during InitializeEnvironment, namely right after _C_.ResolveExport(). The thrown *SyntaxError* exception propagates up to _A_.Link, which resets all modules that are currently on its _stack_ (these are always exactly the modules that are still ~linking~). Hence both _A_ and _B_ become ~unlinked~. Note that _C_ is left as ~linked~.</p>
 
           <p>Alternatively, consider a case where _A_ has an evaluation error; for example, its source code throws an exception. In that case, the evaluation-time analog of the above steps still occurs, including the early return from the second call to InnerModuleEvaluation on _A_. However, once we unwind back to the original InnerModuleEvaluation on _A_, it fails by assumption. The exception thrown propagates up to _A_.Evaluate(), which records the error in all modules that are currently on its _stack_ (i.e., the modules that are still ~evaluating~) as well as via [[AsyncParentModules]], which form a chain for modules which contain or depend on top-level `await` through the whole dependency graph through the AsyncModuleExecutionRejected algorithm. Hence both _A_ and _B_ become ~evaluated~ and the exception is recorded in both _A_ and _B_'s [[EvaluationError]] fields, while _C_ is left as ~evaluated~ with no [[EvaluationError]].</p>
 
@@ -26413,7 +26668,7 @@
           <emu-figure id="figure-module-graph-cycle-async" caption="An asynchronous cyclic module graph">
             <img alt="A module graph in which module A depends on module B and C, module B depends on module D, module C depends on module D and E, and module D depends on module A" width="241" height="211" src="img/module-graph-cycle-async.svg">
           </emu-figure>
-          <p>Linking happens as before, and all modules end up with [[Status]] set to ~linked~.</p>
+          <p>Loading and linking happen as before, and all modules end up with [[Status]] set to ~linked~.</p>
 
           <p>Calling _A_.Evaluate() calls InnerModuleEvaluation on _A_, _B_, and _D_, which all transition to ~evaluating~. Then InnerModuleEvaluation is called on _A_ again, which is a no-op because it is already ~evaluating~. At this point, _D_.[[PendingAsyncDependencies]] is 0, so ExecuteAsyncModule(_D_) is called and we call _D_.ExecuteModule with a new PromiseCapability tracking the asynchronous execution of _D_. We unwind back to the InnerModuleEvaluation on _B_, setting _B_.[[PendingAsyncDependencies]] to 1 and _B_.[[AsyncEvaluation]] to *true*. We unwind back to the original InnerModuleEvaluation on _A_, setting _A_.[[PendingAsyncDependencies]] to 1. In the next iteration of the loop over _A_'s dependencies, we call InnerModuleEvaluation on _C_ and thus on _D_ (again a no-op) and _E_. As _E_ has no dependencies and is not part of a cycle, we call ExecuteAsyncModule(_E_) in the same manner as _D_ and _E_ is immediately removed from the stack. We unwind once more to the original InnerModuleEvaluation on _A_, setting _C_.[[AsyncEvaluation]] to *true*. Now we finish the loop over _A_'s dependencies, set _A_.[[AsyncEvaluation]] to *true*, and remove the entire strongly connected component from the stack, transitioning all of the modules to ~evaluating-async~ at once. At this point, the fields of the modules are as given in <emu-xref href="#table-module-graph-cycle-async-fields-1"></emu-xref>.</p>
 
@@ -27297,7 +27552,7 @@
               1. Else,
                 1. Append _ee_ to _indirectExportEntries_.
             1. Let _async_ be _body_ Contains `await`.
-            1. Return Source Text Module Record { [[Realm]]: _realm_, [[Environment]]: ~empty~, [[Namespace]]: ~empty~, [[CycleRoot]]: ~empty~, [[HasTLA]]: _async_, [[AsyncEvaluation]]: *false*, [[TopLevelCapability]]: ~empty~, [[AsyncParentModules]]: « », [[PendingAsyncDependencies]]: ~empty~, [[Status]]: ~unlinked~, [[EvaluationError]]: ~empty~, [[HostDefined]]: _hostDefined_, [[ECMAScriptCode]]: _body_, [[Context]]: ~empty~, [[ImportMeta]]: ~empty~, [[RequestedModules]]: _requestedModules_, [[ImportEntries]]: _importEntries_, [[LocalExportEntries]]: _localExportEntries_, [[IndirectExportEntries]]: _indirectExportEntries_, [[StarExportEntries]]: _starExportEntries_, [[DFSIndex]]: ~empty~, [[DFSAncestorIndex]]: ~empty~ }.
+            1. Return Source Text Module Record { [[Realm]]: _realm_, [[Environment]]: ~empty~, [[Namespace]]: ~empty~, [[CycleRoot]]: ~empty~, [[HasTLA]]: _async_, [[AsyncEvaluation]]: *false*, [[TopLevelCapability]]: ~empty~, [[AsyncParentModules]]: « », [[PendingAsyncDependencies]]: ~empty~, [[Status]]: ~new~, [[EvaluationError]]: ~empty~, [[HostDefined]]: _hostDefined_, [[ECMAScriptCode]]: _body_, [[Context]]: ~empty~, [[ImportMeta]]: ~empty~, [[RequestedModules]]: _requestedModules_, [[LoadedModules]]: « », [[ImportEntries]]: _importEntries_, [[LocalExportEntries]]: _localExportEntries_, [[IndirectExportEntries]]: _indirectExportEntries_, [[StarExportEntries]]: _starExportEntries_, [[DFSIndex]]: ~empty~, [[DFSAncestorIndex]]: ~empty~ }.
           </emu-alg>
           <emu-note>
             <p>An implementation may parse module source text and analyse it for Early Error conditions prior to the evaluation of ParseModule for that module source text. However, the reporting of any errors must be deferred until the point where this specification actually performs ParseModule upon that source text.</p>
@@ -27308,13 +27563,14 @@
           <h1>
             GetExportedNames (
               optional _exportStarSet_: a List of Source Text Module Records,
-            ): either a normal completion containing a List of either Strings or *null*, or a throw completion
+            ): a List of either Strings or *null*
           </h1>
           <dl class="header">
             <dt>for</dt>
             <dd>a Source Text Module Record _module_</dd>
           </dl>
           <emu-alg>
+            1. Assert: _module_.[[Status]] is not ~new~.
             1. If _exportStarSet_ is not present, set _exportStarSet_ to a new empty List.
             1. If _exportStarSet_ contains _module_, then
               1. Assert: We've reached the starting point of an `export *` circularity.
@@ -27328,8 +27584,8 @@
               1. Assert: _module_ imports a specific binding for this export.
               1. Append _e_.[[ExportName]] to _exportedNames_.
             1. For each ExportEntry Record _e_ of _module_.[[StarExportEntries]], do
-              1. Let _requestedModule_ be ? HostResolveImportedModule(_module_, _e_.[[ModuleRequest]]).
-              1. Let _starNames_ be ? _requestedModule_.GetExportedNames(_exportStarSet_).
+              1. Let _requestedModule_ be GetImportedModule(_module_, _e_.[[ModuleRequest]]).
+              1. Let _starNames_ be _requestedModule_.GetExportedNames(_exportStarSet_).
               1. For each element _n_ of _starNames_, do
                 1. If SameValue(_n_, *"default"*) is *false*, then
                   1. If _n_ is not an element of _exportedNames_, then
@@ -27346,7 +27602,7 @@
             ResolveExport (
               _exportName_: a String,
               optional _resolveSet_: a List of Records that have [[Module]] and [[ExportName]] fields,
-            ): either a normal completion containing either a ResolvedBinding Record, *null*, or ~ambiguous~, or a throw completion
+            ): a ResolvedBinding Record, *null*, or ~ambiguous~
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -27360,6 +27616,7 @@
           </dl>
 
           <emu-alg>
+            1. Assert: _module_.[[Status]] is not ~new~.
             1. If _resolveSet_ is not present, set _resolveSet_ to a new empty List.
             1. For each Record { [[Module]], [[ExportName]] } _r_ of _resolveSet_, do
               1. If _module_ and _r_.[[Module]] are the same Module Record and SameValue(_exportName_, _r_.[[ExportName]]) is *true*, then
@@ -27372,21 +27629,21 @@
                 1. Return ResolvedBinding Record { [[Module]]: _module_, [[BindingName]]: _e_.[[LocalName]] }.
             1. For each ExportEntry Record _e_ of _module_.[[IndirectExportEntries]], do
               1. If SameValue(_exportName_, _e_.[[ExportName]]) is *true*, then
-                1. Let _importedModule_ be ? HostResolveImportedModule(_module_, _e_.[[ModuleRequest]]).
+                1. Let _importedModule_ be GetImportedModule(_module_, _e_.[[ModuleRequest]]).
                 1. If _e_.[[ImportName]] is ~all~, then
                   1. Assert: _module_ does not provide the direct binding for this export.
                   1. Return ResolvedBinding Record { [[Module]]: _importedModule_, [[BindingName]]: ~namespace~ }.
                 1. Else,
                   1. Assert: _module_ imports a specific binding for this export.
-                  1. Return ? _importedModule_.ResolveExport(_e_.[[ImportName]], _resolveSet_).
+                  1. Return _importedModule_.ResolveExport(_e_.[[ImportName]], _resolveSet_).
             1. If SameValue(_exportName_, *"default"*) is *true*, then
               1. Assert: A `default` export was not explicitly defined by this module.
               1. Return *null*.
               1. NOTE: A `default` export cannot be provided by an `export * from "mod"` declaration.
             1. Let _starResolution_ be *null*.
             1. For each ExportEntry Record _e_ of _module_.[[StarExportEntries]], do
-              1. Let _importedModule_ be ? HostResolveImportedModule(_module_, _e_.[[ModuleRequest]]).
-              1. Let _resolution_ be ? _importedModule_.ResolveExport(_exportName_, _resolveSet_).
+              1. Let _importedModule_ be GetImportedModule(_module_, _e_.[[ModuleRequest]]).
+              1. Let _resolution_ be _importedModule_.ResolveExport(_exportName_, _resolveSet_).
               1. If _resolution_ is ~ambiguous~, return ~ambiguous~.
               1. If _resolution_ is not *null*, then
                 1. Assert: _resolution_ is a ResolvedBinding Record.
@@ -27409,7 +27666,7 @@
 
           <emu-alg>
             1. For each ExportEntry Record _e_ of _module_.[[IndirectExportEntries]], do
-              1. Let _resolution_ be ? _module_.ResolveExport(_e_.[[ExportName]]).
+              1. Let _resolution_ be _module_.ResolveExport(_e_.[[ExportName]]).
               1. If _resolution_ is *null* or ~ambiguous~, throw a *SyntaxError* exception.
               1. Assert: _resolution_ is a ResolvedBinding Record.
             1. Assert: All named exports from _module_ are resolvable.
@@ -27418,17 +27675,16 @@
             1. Let _env_ be NewModuleEnvironment(_realm_.[[GlobalEnv]]).
             1. Set _module_.[[Environment]] to _env_.
             1. For each ImportEntry Record _in_ of _module_.[[ImportEntries]], do
-              1. Let _importedModule_ be ! HostResolveImportedModule(_module_, _in_.[[ModuleRequest]]).
-              1. NOTE: The above call cannot fail because imported module requests are a subset of _module_.[[RequestedModules]], and these have been resolved earlier in this algorithm.
+              1. Let _importedModule_ be GetImportedModule(_module_, _in_.[[ModuleRequest]]).
               1. If _in_.[[ImportName]] is ~namespace-object~, then
-                1. Let _namespace_ be ? GetModuleNamespace(_importedModule_).
+                1. Let _namespace_ be GetModuleNamespace(_importedModule_).
                 1. Perform ! _env_.CreateImmutableBinding(_in_.[[LocalName]], *true*).
                 1. Perform ! _env_.InitializeBinding(_in_.[[LocalName]], _namespace_).
               1. Else,
-                1. Let _resolution_ be ? _importedModule_.ResolveExport(_in_.[[ImportName]]).
+                1. Let _resolution_ be _importedModule_.ResolveExport(_in_.[[ImportName]]).
                 1. If _resolution_ is *null* or ~ambiguous~, throw a *SyntaxError* exception.
                 1. If _resolution_.[[BindingName]] is ~namespace~, then
-                  1. Let _namespace_ be ? GetModuleNamespace(_resolution_.[[Module]]).
+                  1. Let _namespace_ be GetModuleNamespace(_resolution_.[[Module]]).
                   1. Perform ! _env_.CreateImmutableBinding(_in_.[[LocalName]], *true*).
                   1. Perform ! _env_.InitializeBinding(_in_.[[LocalName]], _namespace_).
                 1. Else,
@@ -27504,122 +27760,85 @@
         </emu-clause>
       </emu-clause>
 
-      <emu-clause id="sec-hostresolveimportedmodule" type="host-defined abstract operation">
+      <emu-clause id="sec-GetImportedModule" type="abstract operation">
         <h1>
-          HostResolveImportedModule (
-            _referencingScriptOrModule_: a Script Record, a Module Record, or *null*,
+          GetImportedModule (
+            _referrer_: a Cyclic Module Record,
             _specifier_: a String,
-          ): either a normal completion containing a Module Record or a throw completion
+          ): a Module Record
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It provides the concrete Module Record subclass instance that corresponds to _specifier_ occurring within the context of the script or module represented by _referencingScriptOrModule_. _referencingScriptOrModule_ may be *null* if the resolution is being performed in the context of an <emu-xref href="#sec-import-calls">`import()`</emu-xref> expression and there is no active script or module at that time.</dd>
+          <dd></dd>
         </dl>
 
-        <emu-note>
-          <p>An example of when _referencingScriptOrModule_ can be *null* is in a web browser host. There, if a user clicks on a control given by</p>
+        <emu-alg>
+          1. Assert: Exactly one element of _referrer_.[[LoadedModules]] is a Record whose [[Specifier]] is _specifier_, since LoadRequestedModules has completed successfully on _referrer_ prior to invoking this abstract operation.
+          1. Let _record_ be the Record in _referrer_.[[LoadedModules]] whose [[Specifier]] is _specifier_.
+          1. Return _record_.[[Module]].
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-HostLoadImportedModule" type="host-defined abstract operation" oldids="sec-hostresolveimportedmodule,sec-hostimportmoduledynamically">
+        <h1>
+          HostLoadImportedModule (
+            _referrer_: a Script Record, a Cyclic Module Record, or a Realm Record,
+            _specifier_: a String,
+            _hostDefined_: anything,
+            _payload_: a GraphLoadingState Record or a PromiseCapability Record,
+          ): ~unused~
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd></dd>
+        </dl>
+
+        <emu-note id="note-HostLoadImportedModule-referrer-Realm-Record">
+          <p>An example of when _referrer_ can be a Realm Record is in a web browser host. There, if a user clicks on a control given by</p>
 
           <pre><code class="html">&lt;button type="button" onclick="import('./foo.mjs')"&gt;Click me&lt;/button&gt;</code></pre>
 
           <p>there will be no active script or module at the time the <emu-xref href="#sec-import-calls">`import()`</emu-xref> expression runs. More generally, this can happen in any situation where the host pushes execution contexts with *null* ScriptOrModule components onto the execution context stack.</p>
         </emu-note>
 
-        <p>An implementation of HostResolveImportedModule must conform to the following requirements:</p>
+        <p>An implementation of HostLoadImportedModule must conform to the following requirements:</p>
         <ul>
           <li>
-            If the returned Completion Record is a normal completion, it must be a normal completion containing an instance of a concrete subclass of Module Record.
+            The host environment must perform FinishLoadingImportedModule(_referrer_, _specifier_, _payload_, _result_), where _result_ is either a normal completion containing the loaded Module Record or a throw completion, either synchronously or asynchronously.
           </li>
           <li>
-            If a Module Record corresponding to the pair _referencingScriptOrModule_, _specifier_ does not exist or cannot be created, an exception must be thrown.
+            If this operation is called multiple times with the same (_referrer_, _specifier_) pair and it performs FinishLoadingImportedModule(_referrer_, _specifier_, _payload_, _result_) where _result_ is a normal completion, then it must perform FinishLoadingImportedModule(_referrer_, _specifier_, _payload_, _result_) with the same _result_ each time.
           </li>
           <li>
-            Each time this operation is called, if it completes normally and the (_referencingScriptOrModule_, _specifier_, current Realm Record) triple is the same, it must return the same Module Record instance.
+            The operation must treat _payload_ as an opaque value to be passed through to FinishLoadingImportedModule.
           </li>
         </ul>
-        <p>Multiple different _referencingScriptOrModule_, _specifier_ pairs may map to the same Module Record instance. The actual mapping semantic is host-defined but typically a normalization process is applied to _specifier_ as part of the mapping process. A typical normalization process would include actions such as alphabetic case folding and expansion of relative and abbreviated path specifiers.</p>
+
+        <p>The actual process performed is host-defined, but typically consists of performing whatever I/O operations are necessary to load the appropriate Module Record. Multiple different (_referrer_, _specifier_) pairs may map to the same Module Record instance. The actual mapping semantics is host-defined but typically a normalization process is applied to _specifier_ as part of the mapping process. A typical normalization process would include actions such as expansion of relative and abbreviated path specifiers.</p>
       </emu-clause>
 
-      <emu-clause id="sec-hostimportmoduledynamically" type="host-defined abstract operation">
+      <emu-clause id="sec-FinishLoadingImportedModule" type="abstract operation" oldids="sec-finishdynamicimport">
         <h1>
-          HostImportModuleDynamically (
-            _referencingScriptOrModule_: a Script Record, a Module Record, or *null*,
+          FinishLoadingImportedModule (
+            _referrer_: a Script Record, a Cyclic Module Record, or a Realm Record,
             _specifier_: a String,
-            _promiseCapability_: a PromiseCapability Record,
+            _payload_: a GraphLoadingState Record or a PromiseCapability Record,
+            _result_: either a normal completion containing a Module Record or a throw completion,
           ): ~unused~
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It performs any necessary setup work in order to make available the module corresponding to _specifier_ occurring within the context of the script or module represented by _referencingScriptOrModule_. _referencingScriptOrModule_ may be *null* if there is no active script or module when the <emu-xref href="#sec-import-calls">`import()`</emu-xref> expression occurs. It then performs FinishDynamicImport to finish the dynamic import process.</dd>
-        </dl>
-        <p>An implementation of HostImportModuleDynamically must conform to the following requirements:</p>
-
-        <ul>
-          <li>
-            It must return ~unused~. Success or failure must instead be signaled as discussed below.
-          </li>
-          <li>
-            The host environment must conform to one of the two following sets of requirements:
-            <dl>
-              <dt>Success path</dt>
-
-              <dd>
-                <ul>
-                  <li>At some future time, the host environment must perform FinishDynamicImport(_referencingScriptOrModule_, _specifier_, _promiseCapability_, _promise_), where _promise_ is a Promise resolved with *undefined*.</li>
-
-                  <li>Any subsequent call to HostResolveImportedModule after FinishDynamicImport has completed, given the arguments _referencingScriptOrModule_ and _specifier_, must return a normal completion containing a module which has already been evaluated, i.e. whose Evaluate concrete method has already been called and returned a normal completion.</li>
-                </ul>
-              </dd>
-
-              <dt>Failure path</dt>
-
-              <dd>
-                <ul>
-                  <li>At some future time, the host environment must perform FinishDynamicImport(_referencingScriptOrModule_, _specifier_, _promiseCapability_, _promise_), where _promise_ is a Promise rejected with an error representing the cause of failure.</li>
-                </ul>
-              </dd>
-            </dl>
-          </li>
-          <li>
-            If the host environment takes the success path once for a given _referencingScriptOrModule_, _specifier_ pair, it must always do so for subsequent calls.
-          </li>
-          <li>
-            The operation must not call _promiseCapability_.[[Resolve]] or _promiseCapability_.[[Reject]], but instead must treat _promiseCapability_ as an opaque identifying value to be passed through to FinishDynamicImport.
-          </li>
-        </ul>
-
-        <p>The actual process performed is host-defined, but typically consists of performing whatever I/O operations are necessary to allow HostResolveImportedModule to synchronously retrieve the appropriate Module Record, and then calling its Evaluate concrete method. This might require performing similar normalization as HostResolveImportedModule does.</p>
-      </emu-clause>
-
-      <emu-clause id="sec-finishdynamicimport" type="abstract operation">
-        <h1>
-          FinishDynamicImport (
-            _referencingScriptOrModule_: a Script Record, a Module Record, or *null*,
-            _specifier_: a String,
-            _promiseCapability_: a PromiseCapability Record,
-            _innerPromise_: a Promise,
-          ): ~unused~
-        </h1>
-        <dl class="header">
-          <dt>description</dt>
-          <dd>FinishDynamicImport completes the process of a dynamic import originally started by an <emu-xref href="#sec-import-calls">`import()`</emu-xref> call, resolving or rejecting the promise returned by that call as appropriate according to _innerPromise_'s resolution. It is performed by host environments as part of HostImportModuleDynamically.</dd>
+          <dd></dd>
         </dl>
         <emu-alg>
-          1. Let _fulfilledClosure_ be a new Abstract Closure with parameters (_result_) that captures _referencingScriptOrModule_, _specifier_, and _promiseCapability_ and performs the following steps when called:
-            1. Assert: _result_ is *undefined*.
-            1. Let _moduleRecord_ be ! HostResolveImportedModule(_referencingScriptOrModule_, _specifier_).
-            1. Assert: Evaluate has already been invoked on _moduleRecord_ and successfully completed.
-            1. Let _namespace_ be Completion(GetModuleNamespace(_moduleRecord_)).
-            1. If _namespace_ is an abrupt completion, then
-              1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, « _namespace_.[[Value]] »).
-            1. Else,
-              1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, « _namespace_.[[Value]] »).
-            1. Return ~unused~.
-          1. Let _onFulfilled_ be CreateBuiltinFunction(_fulfilledClosure_, 0, *""*, « »).
-          1. Let _rejectedClosure_ be a new Abstract Closure with parameters (_error_) that captures _promiseCapability_ and performs the following steps when called:
-            1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, « _error_ »).
-            1. Return ~unused~.
-          1. Let _onRejected_ be CreateBuiltinFunction(_rejectedClosure_, 0, *""*, « »).
-          1. Perform PerformPromiseThen(_innerPromise_, _onFulfilled_, _onRejected_).
+          1. If _result_ is a normal completion, then
+            1. If _referrer_.[[LoadedModules]] contains a Record whose [[Specifier]] is _specifier_, then
+              1. Assert: That Record's [[Module]] is _result_.[[Value]].
+            1. Else, append the Record { [[Specifier]]: _specifier_, [[Module]]: _result_.[[Value]] } to _referrer_.[[LoadedModules]].
+          1. If _payload_ is a GraphLoadingState Record, then
+            1. Perform ContinueModuleLoading(_payload_, _result_).
+          1. Else,
+            1. Perform ContinueDynamicImport(_payload_, _result_).
           1. Return ~unused~.
         </emu-alg>
       </emu-clause>
@@ -27628,7 +27847,7 @@
         <h1>
           GetModuleNamespace (
             _module_: an instance of a concrete subclass of Module Record,
-          ): either a normal completion containing either a Module Namespace Object or ~empty~, or a throw completion
+          ): a Module Namespace Object or ~empty~
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -27636,19 +27855,19 @@
         </dl>
 
         <emu-alg>
-          1. Assert: If _module_ is a Cyclic Module Record, then _module_.[[Status]] is not ~unlinked~.
+          1. Assert: If _module_ is a Cyclic Module Record, then _module_.[[Status]] is not ~new~ or ~unlinked~.
           1. Let _namespace_ be _module_.[[Namespace]].
           1. If _namespace_ is ~empty~, then
-            1. Let _exportedNames_ be ? _module_.GetExportedNames().
+            1. Let _exportedNames_ be _module_.GetExportedNames().
             1. Let _unambiguousNames_ be a new empty List.
             1. For each element _name_ of _exportedNames_, do
-              1. Let _resolution_ be ? _module_.ResolveExport(_name_).
+              1. Let _resolution_ be _module_.ResolveExport(_name_).
               1. If _resolution_ is a ResolvedBinding Record, append _name_ to _unambiguousNames_.
             1. Set _namespace_ to ModuleNamespaceCreate(_module_, _unambiguousNames_).
           1. Return _namespace_.
         </emu-alg>
         <emu-note>
-          <p>The only way GetModuleNamespace can throw is via one of the triggered HostResolveImportedModule calls. Unresolvable names are simply excluded from the namespace at this point. They will lead to a real linking error later unless they are all ambiguous star exports that are not explicitly requested anywhere.</p>
+          <p>GetModuleNamespace never throws. Instead, unresolvable names are simply excluded from the namespace at this point. They will lead to a real linking error later unless they are all ambiguous star exports that are not explicitly requested anywhere.</p>
         </emu-note>
       </emu-clause>
 
@@ -48232,10 +48451,9 @@ THH:mm:ss.sss
     <p><b>HostFinalizeImportMeta(...)</b></p>
     <p><b>HostGetImportMetaProperties(...)</b></p>
     <p><b>HostHasSourceTextAvailable(...)</b></p>
-    <p><b>HostImportModuleDynamically(...)</b></p>
+    <p><b>HostLoadImportedModule(...)</b></p>
     <p><b>HostMakeJobCallback(...)</b></p>
     <p><b>HostPromiseRejectionTracker(...)</b></p>
-    <p><b>HostResolveImportedModule(...)</b></p>
     <p><b>InitializeHostDefinedRealm(...)</b></p>
   </emu-annex>
 


### PR DESCRIPTION
This PR also removes the HostResolveImportedModule and HostImportModuleDynamically hooks.

A few comments/questions:
1. ContinueDynamicImport is kinda messy, with all the closures and PerformPromiseThen. Is it ok to extend AsyncBlockStart like in https://tc39.es/proposal-array-from-async/#sec-asyncblockstart so that I can use the Await macro?
1. ResolveExport is described as returning *null* or something, but it can also return a throw completion (if it's called on a module that re-exports from a dependency that hasn't been already loaded - **NOTE:** this can only happen if a host calls ResolveExport() even if LoadRequestedModules() doesn't succeed, and they don't have any good reason to do so). This was the behavior even before this PR.
   - Is it ok?
   - Should we make it return null?
   - Should we require that it's called only after having loaded the dependencies?
1. I named the new Module Records method LoadRequestedModules() to match the name of the [[RequestedModules]] slot, but maybe LoadImportedModules() or LoadDependencies() are better?
1. I find the _hostDefined_ parameter of LoadRequestedModules() to be incredibly ugly, but it's needed by HTML to pass some context only to modules imported in "the current loading process" and not in "future loading processes" (the `.destination` flag it sets on the `Request` object it creates to fetch modules). It's possible that one day HTML will align requests of static and dynamic imports, but today is not that day yet.
1. I tracked the loading state across the ecma262-host-ecma262 round trip using a `ModuleLoadState` record, which is overloaded for two usages that are distinguished using an [[Action]] enum field. Is it ok, or should I split it into two different record types (`GraphLoadingState` and `DynamicImportState`)? (related: https://github.com/tc39/ecma262/pull/2905#discussion_r988214326)

The HTML PR is https://github.com/whatwg/html/pull/8253. Today's consensus was based on the fact that this refactor is purely editorial for the ECMA-262+(insert known host here) pair, so I would like to get a full review on the HTML side to check if we need any tweaks before moving on with this PR. **EDIT:** Got a :+1: from the HTML side.