### PR TITLE
Editorial: use consistent wording in [[NoTear]] explanation for read/write events

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -46026,7 +46026,7 @@ THH:mm:ss.sss
         <tr>
           <td>[[NoTear]]</td>
           <td>a Boolean</td>
-          <td>Whether this event is allowed to read from multiple write events on equal range as this event.</td>
+          <td>Whether this event is allowed to read from multiple write events with equal range as this event.</td>
         </tr>
         <tr>
           <td>[[Block]]</td>


### PR DESCRIPTION
This makes the phrasing in ReadSharedMemory Event match the phrasing in WriteSharedMemory Event, and in my opinion reads better.