### PR TITLE
Editorial: replace any occurrences of "nonempty" with "non-empty"

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -766,7 +766,7 @@
           `9`
       </emu-grammar>
       <p>If the phrase &ldquo;[empty]&rdquo; appears as the right-hand side of a production, it indicates that the production's right-hand side contains no terminals or nonterminals.</p>
-      <p>If the phrase &ldquo;[lookahead = _seq_]&rdquo; appears in the right-hand side of a production, it indicates that the production may only be used if the token sequence _seq_ is a prefix of the immediately following input token sequence. Similarly, &ldquo;[lookahead &isin; _set_]&rdquo;, where _set_ is a finite nonempty set of token sequences, indicates that the production may only be used if some element of _set_ is a prefix of the immediately following token sequence. For convenience, the set can also be written as a nonterminal, in which case it represents the set of all token sequences to which that nonterminal could expand. It is considered an editorial error if the nonterminal could expand to infinitely many distinct token sequences.</p>
+      <p>If the phrase &ldquo;[lookahead = _seq_]&rdquo; appears in the right-hand side of a production, it indicates that the production may only be used if the token sequence _seq_ is a prefix of the immediately following input token sequence. Similarly, &ldquo;[lookahead &isin; _set_]&rdquo;, where _set_ is a finite non-empty set of token sequences, indicates that the production may only be used if some element of _set_ is a prefix of the immediately following token sequence. For convenience, the set can also be written as a nonterminal, in which case it represents the set of all token sequences to which that nonterminal could expand. It is considered an editorial error if the nonterminal could expand to infinitely many distinct token sequences.</p>
       <p>These conditions may be negated. &ldquo;[lookahead &ne; _seq_]&rdquo; indicates that the containing production may only be used if _seq_ is <em>not</em> a prefix of the immediately following input token sequence, and &ldquo;[lookahead &notin; _set_]&rdquo; indicates that the production may only be used if <em>no</em> element of _set_ is a prefix of the immediately following token sequence.</p>
       <p>As an example, given the definitions:</p>
       <emu-grammar type="definition" example>
@@ -45296,7 +45296,7 @@ THH:mm:ss.sss
           <tr>
             <td>[[AsyncGeneratorQueue]]</td>
             <td>a List of AsyncGeneratorRequest Records</td>
-            <td>Records which represent requests to resume the async generator. Except during state transitions, it is nonempty if and only if [[AsyncGeneratorState]] is either ~executing~ or ~awaiting-return~.</td>
+            <td>Records which represent requests to resume the async generator. Except during state transitions, it is non-empty if and only if [[AsyncGeneratorState]] is either ~executing~ or ~awaiting-return~.</td>
           </tr>
           <tr>
             <td>[[GeneratorBrand]]</td>
@@ -46621,7 +46621,7 @@ THH:mm:ss.sss
           <p>(For example, a transformation may not introduce certain observable writes, such as by using read-modify-write operations on a larger location to write a smaller datum, writing a value to memory that the program could not have written, or writing a just-read value back to the location it was read from, if that location could have been overwritten by another agent after the read.)</p>
         </li>
         <li>
-          <p><em>Possible read values must be nonempty</em>: Program transformations cannot cause the possible read values of a shared memory read to become empty.</p>
+          <p><em>Possible read values must be non-empty</em>: Program transformations cannot cause the possible read values of a shared memory read to become empty.</p>
           <p>(Counterintuitively, this rule in effect restricts transformations on writes, because writes have force in memory model insofar as to be read by read events. For example, writes may be moved and coalesced and sometimes reordered between two ~SeqCst~ operations, but the transformation may not remove every write that updates a location; some write must be preserved.)</p>
         </li>
       </ul>


### PR DESCRIPTION
Fixes #2907. @bakkot Maybe a lint rule is in order?