### PR TITLE
Editorial: refactor remainder AOs

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1985,7 +1985,9 @@
             1. If _d_ is *+0*<sub>𝔽</sub> or _d_ is *-0*<sub>𝔽</sub>, return *NaN*.
             1. If _n_ is *+0*<sub>𝔽</sub> or _n_ is *-0*<sub>𝔽</sub>, return _n_.
             1. Assert: _n_ and _d_ are finite and non-zero.
-            1. Let _r_ be ℝ(_n_) - (ℝ(_d_) &times; _q_) where _q_ is an integer that is negative if and only if _n_ and _d_ have opposite sign, and whose magnitude is as large as possible without exceeding the magnitude of ℝ(_n_) / ℝ(_d_).
+            1. Let _quotient_ be ℝ(_n_) / ℝ(_d_).
+            1. Let _q_ be the mathematical value whose sign is the sign of _quotient_ and whose magnitude is floor(abs(_quotient_)).
+            1. Let _r_ be ℝ(_n_) - (ℝ(_d_) &times; _q_).
             1. If _r_ is 0 and _n_ &lt; *-0*<sub>𝔽</sub>, return *-0*<sub>𝔽</sub>.
             1. Return 𝔽(_r_).
           </emu-alg>
@@ -2409,8 +2411,9 @@
           <emu-alg>
             1. If _d_ is *0*<sub>ℤ</sub>, throw a *RangeError* exception.
             1. If _n_ is *0*<sub>ℤ</sub>, return *0*<sub>ℤ</sub>.
-            1. Let _r_ be the BigInt defined by the mathematical relation _r_ = _n_ - (_d_ &times; _q_) where _q_ is a BigInt that is negative only if _n_/_d_ is negative and positive only if _n_/_d_ is positive, and whose magnitude is as large as possible without exceeding the magnitude of the true mathematical quotient of _n_ and _d_.
-            1. Return _r_.
+            1. Let _quotient_ be ℝ(_n_) / ℝ(_d_).
+            1. Let _q_ be the BigInt whose sign is the sign of _quotient_ and whose magnitude is floor(abs(_quotient_)).
+            1. Return _n_ - (_d_ &times; _q_).
           </emu-alg>
           <emu-note>The sign of the result equals the sign of the dividend.</emu-note>
         </emu-clause>


### PR DESCRIPTION
Extracted from #2901. Makes the wording consistent and clearly separates the aliases being declared from the ones being referenced.