### PR TITLE
Editorial: replace steps embedded in lookup tables with more typical algorithms

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -4847,7 +4847,7 @@
       </emu-clause>
     </emu-clause>
 
-    <emu-clause id="sec-toboolean" type="abstract operation">
+    <emu-clause id="sec-toboolean" oldids="table-toboolean-conversions" type="abstract operation">
       <h1>
         ToBoolean (
           _argument_: an ECMAScript language value,
@@ -4855,87 +4855,14 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It converts _argument_ to a value of type Boolean according to <emu-xref href="#table-toboolean-conversions"></emu-xref>:</dd>
+        <dd>It converts _argument_ to a value of type Boolean.</dd>
       </dl>
-      <emu-table id="table-toboolean-conversions" caption="ToBoolean Conversions" oldids="table-10">
-        <table>
-          <tr>
-            <th>
-              Argument Type
-            </th>
-            <th>
-              Result
-            </th>
-          </tr>
-          <tr>
-            <td>
-              Undefined
-            </td>
-            <td>
-              Return *false*.
-            </td>
-          </tr>
-          <tr>
-            <td>
-              Null
-            </td>
-            <td>
-              Return *false*.
-            </td>
-          </tr>
-          <tr>
-            <td>
-              Boolean
-            </td>
-            <td>
-              Return _argument_.
-            </td>
-          </tr>
-          <tr>
-            <td>
-              Number
-            </td>
-            <td>
-              If _argument_ is *+0*<sub>𝔽</sub>, *-0*<sub>𝔽</sub>, or *NaN*, return *false*; otherwise return *true*.
-            </td>
-          </tr>
-          <tr>
-            <td>
-              String
-            </td>
-            <td>
-              If _argument_ is the empty String (its length is 0), return *false*; otherwise return *true*.
-            </td>
-          </tr>
-          <tr>
-            <td>
-              Symbol
-            </td>
-            <td>
-              Return *true*.
-            </td>
-          </tr>
-          <tr>
-            <td>
-              BigInt
-            </td>
-            <td>
-              If _argument_ is *0*<sub>ℤ</sub>, return *false*; otherwise return *true*.
-            </td>
-          </tr>
-          <tr>
-            <td>
-              Object
-            </td>
-            <td>
-              Return *true*.
-              <emu-note>
-                <p>An alternate algorithm related to the [[IsHTMLDDA]] internal slot is mandated in section <emu-xref href="#sec-IsHTMLDDA-internal-slot-to-boolean"></emu-xref>.</p>
-              </emu-note>
-            </td>
-          </tr>
-        </table>
-      </emu-table>
+      <emu-alg>
+        1. If _argument_ is a Boolean, return _argument_.
+        1. If _argument_ is any of *undefined*, *null*, *+0*<sub>𝔽</sub>, *-0*<sub>𝔽</sub>, *NaN*, *0*<sub>ℤ</sub>, or the empty String, return *false*.
+        1. [id="step-to-boolean-web-compat-insertion-point"] NOTE: This step is replaced in section <emu-xref href="#sec-IsHTMLDDA-internal-slot-to-boolean"></emu-xref>.
+        1. Return *true*.
+      </emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-tonumeric" type="abstract operation">
@@ -4955,7 +4882,7 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-tonumber" type="abstract operation">
+    <emu-clause id="sec-tonumber" oldids="table-tonumber-conversions" type="abstract operation">
       <h1>
         ToNumber (
           _argument_: an ECMAScript language value,
@@ -4963,88 +4890,20 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It converts _argument_ to a value of type Number according to <emu-xref href="#table-tonumber-conversions"></emu-xref>:</dd>
+        <dd>It converts _argument_ to a value of type Number.</dd>
       </dl>
-      <emu-table id="table-tonumber-conversions" caption="ToNumber Conversions" oldids="table-11">
-        <table>
-          <tr>
-            <th>
-              Argument Type
-            </th>
-            <th>
-              Result
-            </th>
-          </tr>
-          <tr>
-            <td>
-              Undefined
-            </td>
-            <td>
-              Return *NaN*.
-            </td>
-          </tr>
-          <tr>
-            <td>
-              Null
-            </td>
-            <td>
-              Return *+0*<sub>𝔽</sub>.
-            </td>
-          </tr>
-          <tr>
-            <td>
-              Boolean
-            </td>
-            <td>
-              If _argument_ is *true*, return *1*<sub>𝔽</sub>. If _argument_ is *false*, return *+0*<sub>𝔽</sub>.
-            </td>
-          </tr>
-          <tr>
-            <td>
-              Number
-            </td>
-            <td>
-              Return _argument_ (no conversion).
-            </td>
-          </tr>
-          <tr>
-            <td>
-              String
-            </td>
-            <td>
-              Return ! StringToNumber(_argument_).
-            </td>
-          </tr>
-          <tr>
-            <td>
-              Symbol
-            </td>
-            <td>
-              Throw a *TypeError* exception.
-            </td>
-          </tr>
-          <tr>
-            <td>
-              BigInt
-            </td>
-            <td>
-              Throw a *TypeError* exception.
-            </td>
-          </tr>
-          <tr>
-            <td>
-              Object
-            </td>
-            <td>
-              <p>Apply the following steps:</p>
-              <emu-alg>
-                1. Let _primValue_ be ? ToPrimitive(_argument_, ~number~).
-                1. Return ? ToNumber(_primValue_).
-              </emu-alg>
-            </td>
-          </tr>
-        </table>
-      </emu-table>
+      <emu-alg>
+        1. If _argument_ is a Number, return _argument_.
+        1. If _argument_ is either a Symbol or a BigInt, throw a *TypeError* exception.
+        1. If _argument_ is *undefined*, return *NaN*.
+        1. If _argument_ is either *null* or *false*, return *+0*<sub>𝔽</sub>.
+        1. If _argument_ is *true*, return *1*<sub>𝔽</sub>.
+        1. If _argument_ is a String, return StringToNumber(_argument_).
+        1. Assert: _argument_ is an Object.
+        1. Let _primValue_ be ? ToPrimitive(_argument_, ~number~).
+        1. Assert: _primValue_ is not an Object.
+        1. Return ? ToNumber(_primValue_).
+      </emu-alg>
 
       <emu-clause id="sec-tonumber-applied-to-the-string-type">
         <h1>ToNumber Applied to the String Type</h1>
@@ -5571,7 +5430,7 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-tostring" type="abstract operation">
+    <emu-clause id="sec-tostring" oldids="table-tostring-conversions" type="abstract operation">
       <h1>
         ToString (
           _argument_: an ECMAScript language value,
@@ -5579,89 +5438,22 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It converts _argument_ to a value of type String according to <emu-xref href="#table-tostring-conversions"></emu-xref>:</dd>
+        <dd>It converts _argument_ to a value of type String.</dd>
       </dl>
-      <emu-table id="table-tostring-conversions" caption="ToString Conversions" oldids="table-12">
-        <table>
-          <tr>
-            <th>
-              Argument Type
-            </th>
-            <th>
-              Result
-            </th>
-          </tr>
-          <tr>
-            <td>
-              Undefined
-            </td>
-            <td>
-              Return *"undefined"*.
-            </td>
-          </tr>
-          <tr>
-            <td>
-              Null
-            </td>
-            <td>
-              Return *"null"*.
-            </td>
-          </tr>
-          <tr>
-            <td>
-              Boolean
-            </td>
-            <td>
-              <p>If _argument_ is *true*, return *"true"*.</p>
-              <p>If _argument_ is *false*, return *"false"*.</p>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              Number
-            </td>
-            <td>
-              Return Number::toString(_argument_, 10).
-            </td>
-          </tr>
-          <tr>
-            <td>
-              String
-            </td>
-            <td>
-              Return _argument_.
-            </td>
-          </tr>
-          <tr>
-            <td>
-              Symbol
-            </td>
-            <td>
-              Throw a *TypeError* exception.
-            </td>
-          </tr>
-          <tr>
-            <td>
-              BigInt
-            </td>
-            <td>
-              Return BigInt::toString(_argument_, 10).
-            </td>
-          </tr>
-          <tr>
-            <td>
-              Object
-            </td>
-            <td>
-              <p>Apply the following steps:</p>
-              <emu-alg>
-                1. Let _primValue_ be ? ToPrimitive(_argument_, ~string~).
-                1. Return ? ToString(_primValue_).
-              </emu-alg>
-            </td>
-          </tr>
-        </table>
-      </emu-table>
+      <emu-alg>
+        1. If _argument_ is a String, return _argument_.
+        1. If _argument_ is a Symbol, throw a *TypeError* exception.
+        1. If _argument_ is *undefined*, return *"undefined"*.
+        1. If _argument_ is *null*, return *"null"*.
+        1. If _argument_ is *true*, return *"true"*.
+        1. If _argument_ is *false*, return *"false"*.
+        1. If _argument_ is a Number, return Number::toString(_argument_, 10).
+        1. If _argument_ is a BigInt, return BigInt::toString(_argument_, 10).
+        1. Assert: _argument_ is an Object.
+        1. Let _primValue_ be ? ToPrimitive(_argument_, ~string~).
+        1. Assert: _primValue_ is not an Object.
+        1. Return ? ToString(_primValue_).
+      </emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-toobject" type="abstract operation">
@@ -19782,7 +19574,7 @@
     <emu-clause id="sec-typeof-operator">
       <h1>The `typeof` Operator</h1>
 
-      <emu-clause id="sec-typeof-operator-runtime-semantics-evaluation" type="sdo">
+      <emu-clause id="sec-typeof-operator-runtime-semantics-evaluation" oldids="table-typeof-operator-results" type="sdo">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>UnaryExpression : `typeof` UnaryExpression</emu-grammar>
         <emu-alg>
@@ -19790,96 +19582,18 @@
           1. If _val_ is a Reference Record, then
             1. If IsUnresolvableReference(_val_) is *true*, return *"undefined"*.
           1. Set _val_ to ? GetValue(_val_).
+          1. If _val_ is *undefined*, return *"undefined"*.
+          1. If _val_ is *null*, return *"object"*.
+          1. If _val_ is a String, return *"string"*.
+          1. If _val_ is a Symbol, return *"symbol"*.
+          1. If _val_ is a Boolean, return *"boolean"*.
+          1. If _val_ is a Number, return *"number"*.
+          1. If _val_ is a BigInt, return *"bigint"*.
+          1. Assert: _val_ is an Object.
           1. [id="step-typeof-web-compat-insertion-point"] NOTE: This step is replaced in section <emu-xref href="#sec-IsHTMLDDA-internal-slot-typeof"></emu-xref>.
-          1. Return a String according to <emu-xref href="#table-typeof-operator-results"></emu-xref>.
+          1. If _val_ has a [[Call]] internal slot, return *"function"*.
+          1. Return *"object"*.
         </emu-alg>
-        <emu-table id="table-typeof-operator-results" caption="typeof Operator Results" oldids="table-35">
-          <table>
-            <tr>
-              <th>
-                Type of _val_
-              </th>
-              <th>
-                Result
-              </th>
-            </tr>
-            <tr>
-              <td>
-                Undefined
-              </td>
-              <td>
-                *"undefined"*
-              </td>
-            </tr>
-            <tr>
-              <td>
-                Null
-              </td>
-              <td>
-                *"object"*
-              </td>
-            </tr>
-            <tr>
-              <td>
-                Boolean
-              </td>
-              <td>
-                *"boolean"*
-              </td>
-            </tr>
-            <tr>
-              <td>
-                Number
-              </td>
-              <td>
-                *"number"*
-              </td>
-            </tr>
-            <tr>
-              <td>
-                String
-              </td>
-              <td>
-                *"string"*
-              </td>
-            </tr>
-            <tr>
-              <td>
-                Symbol
-              </td>
-              <td>
-                *"symbol"*
-              </td>
-            </tr>
-            <tr>
-              <td>
-                BigInt
-              </td>
-              <td>
-                *"bigint"*
-              </td>
-            </tr>
-            <tr>
-              <td>
-                Object (does not implement [[Call]])
-              </td>
-              <td>
-                *"object"*
-              </td>
-            </tr>
-            <tr>
-              <td>
-                Object (implements [[Call]])
-              </td>
-              <td>
-                *"function"*
-              </td>
-            </tr>
-          </table>
-        </emu-table>
-        <emu-note>
-          <p>An additional entry related to [[IsHTMLDDA]] Internal Slot can be found in <emu-xref href="#sec-IsHTMLDDA-internal-slot-typeof"></emu-xref>.</p>
-        </emu-note>
       </emu-clause>
     </emu-clause>
 
@@ -48438,16 +48152,15 @@ THH:mm:ss.sss
 
       <emu-annex id="sec-IsHTMLDDA-internal-slot-to-boolean">
         <h1>Changes to ToBoolean</h1>
-        <p>The result column in <emu-xref href="#table-toboolean-conversions"></emu-xref> for an argument type of Object is replaced with the following algorithm:</p>
-        <emu-alg>
-          1. If _argument_ has an [[IsHTMLDDA]] internal slot, return *false*.
-          1. Return *true*.
+        <p>The following step replaces step <emu-xref href="#step-to-boolean-web-compat-insertion-point"></emu-xref> of ToBoolean:</p>
+        <emu-alg replaces-step="step-to-boolean-web-compat-insertion-point">
+          1. If _argument_ is an Object and _argument_ has an [[IsHTMLDDA]] internal slot, return *false*.
         </emu-alg>
       </emu-annex>
 
       <emu-annex id="sec-IsHTMLDDA-internal-slot-aec">
         <h1>Changes to IsLooselyEqual</h1>
-        <p>During IsLooselyEqual the following steps are performed in place of step <emu-xref href="#step-abstract-equality-comparison-web-compat-insertion-point"></emu-xref>:</p>
+        <p>The following steps replace step <emu-xref href="#step-abstract-equality-comparison-web-compat-insertion-point"></emu-xref> of IsLooselyEqual:</p>
         <emu-alg replaces-step="step-abstract-equality-comparison-web-compat-insertion-point">
           1. Perform the following steps:
             1. If _x_ is an Object, _x_ has an [[IsHTMLDDA]] internal slot, and _y_ is either *null* or *undefined*, return *true*.
@@ -48459,7 +48172,7 @@ THH:mm:ss.sss
         <h1>Changes to the `typeof` Operator</h1>
         <p>The following step replaces step <emu-xref href="#step-typeof-web-compat-insertion-point"></emu-xref> of <emu-xref href="#sec-typeof-operator-runtime-semantics-evaluation">the evaluation semantics for `typeof`</emu-xref>:</p>
         <emu-alg replaces-step="step-typeof-web-compat-insertion-point">
-          1. If _val_ is an Object and _val_ has an [[IsHTMLDDA]] internal slot, return *"undefined"*.
+          1. If _val_ has an [[IsHTMLDDA]] internal slot, return *"undefined"*.
         </emu-alg>
       </emu-annex>
     </emu-annex>


### PR DESCRIPTION
This will help us catch editorial errors (it already caught 1) and IMO reads better by allowing for other groupings (such as by output in `ToBoolean`).

I'd recommend reviewing before/after rendering instead of reading the changeset.

There's probably more opportunities to replace tables, but this is a good start.