### PR TITLE
Editorial: Define alias before reference

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -33708,9 +33708,9 @@ THH:mm:ss.sss
           1. Assert: If _position_ is *undefined*, then _numPos_ is *NaN*.
           1. If _numPos_ is *NaN*, let _pos_ be +&infin;; otherwise, let _pos_ be ! ToIntegerOrInfinity(_numPos_).
           1. Let _len_ be the length of _S_.
+          1. Let _searchLen_ be the length of _searchStr_.
           1. Let _start_ be the result of clamping _pos_ between 0 and _len_ - _searchLen_.
           1. If _searchStr_ is the empty String, return 𝔽(_start_).
-          1. Let _searchLen_ be the length of _searchStr_.
           1. For each integer _i_ such that 0 &le; _i_ &le; _start_, in descending order, do
             1. Let _candidate_ be the substring of _S_ from _i_ to _i_ + _searchLen_.
             1. If _candidate_ is the same sequence of code units as _searchStr_, return 𝔽(_i_).


### PR DESCRIPTION
String.prototype.lastIndexOf must define _searchLen_ before using it.

(fixup for PR #2848)