### PR TITLE
Editorial: Make better use of clamping

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -5586,19 +5586,15 @@
         ToClampedIndex (
           _value_: an ECMAScript language value,
           _length_: a non-negative integer,
-          optional _lowerBound_: an integer,
-          optional _upperBound_: an integer,
         ): either a normal completion containing an integer or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It converts _value_ to an integer (interpreting negative values relative to _length_) and clamps the result to the inclusive interval from _lowerBound_ to _upperBound_ (respectively defaulting to 0 and _length_).</dd>
+        <dd>It converts _value_ to an integer (interpreting negative values relative to _length_) and clamps the result to the inclusive interval from 0 to _length_.</dd>
       </dl>
       <emu-alg>
-        1. If _lowerBound_ is not present, set _lowerBound_ to 0.
-        1. If _upperBound_ is not present, set _upperBound_ to _length_.
-        1. Assert: _lowerBound_ ≤ _upperBound_.
-        1. Return the result of clamping ? ToAbsoluteIndex(_value_, _length_) between _lowerBound_ and _upperBound_.
+        1. Let _index_ be ? ToAbsoluteIndex(_value_, _length_).
+        1. Return the result of clamping _index_ between 0 and _length_.
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -37872,7 +37868,8 @@ THH:mm:ss.sss
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
           1. If _len_ is 0, return *-1*<sub>𝔽</sub>.
-          1. If _fromIndex_ is not present, let _k_ be _len_ - 1; else let _k_ be ? ToClampedIndex(_fromIndex_, _len_, -1, _len_ - 1).
+          1. If _fromIndex_ is not present, let _k_ be _len_ - 1.
+          1. Else, let _k_ be min(? ToAbsoluteIndex(_fromIndex_, _len_), _len_ - 1).
           1. Repeat, while _k_ ≥ 0,
             1. Let _kPresent_ be ? HasProperty(_O_, ! ToString(𝔽(_k_))).
             1. If _kPresent_ is *true*, then
@@ -39281,7 +39278,8 @@ THH:mm:ss.sss
           1. Perform ? ValidateTypedArray(_O_).
           1. Let _len_ be _O_.[[ArrayLength]].
           1. If _len_ is 0, return *-1*<sub>𝔽</sub>.
-          1. If _fromIndex_ is not present, let _k_ be _len_ - 1; else let _k_ be ? ToClampedIndex(_fromIndex_, _len_, -1, _len_ - 1).
+          1. If _fromIndex_ is not present, let _k_ be _len_ - 1.
+          1. Else, let _k_ be min(? ToAbsoluteIndex(_fromIndex_, _len_), _len_ - 1).
           1. Repeat, while _k_ ≥ 0,
             1. Let _kPresent_ be ! HasProperty(_O_, ! ToString(𝔽(_k_))).
             1. If _kPresent_ is *true*, then

--- a/spec.html
+++ b/spec.html
@@ -30014,11 +30014,12 @@
           1. If _targetHasLength_ is *true*, then
             1. Let _targetLen_ be ? Get(_Target_, *"length"*).
             1. If _targetLen_ is a Number, then
-              1. Set _L_ to ! ToIntegerOrInfinity(_targetLen_).
-              1. If _L_ is -∞, set _L_ to 0.
-              1. Else if _L_ is not +∞, then
+              1. Let _targetLenAsInt_ be ! ToIntegerOrInfinity(_targetLen_).
+              1. If _targetLenAsInt_ is +∞, set _L_ to +∞.
+              1. Else if _targetLenAsInt_ is -∞, set _L_ to 0.
+              1. Else,
                 1. Let _argCount_ be the number of elements in _args_.
-                1. Set _L_ to max(_L_ - _argCount_, 0).
+                1. Set _L_ to max(_targetLenAsInt_ - _argCount_, 0).
           1. Perform SetFunctionLength(_F_, _L_).
           1. Let _targetName_ be ? Get(_Target_, *"name"*).
           1. If _targetName_ is not a String, set _targetName_ to the empty String.

--- a/spec.html
+++ b/spec.html
@@ -5562,6 +5562,29 @@
           1. Return _integer_.
       </emu-alg>
     </emu-clause>
+
+    <emu-clause id="sec-toclampedindex" type="abstract operation">
+      <h1>
+        ToClampedIndex (
+          _value_: an ECMAScript language value,
+          _length_: a non-negative integer,
+          optional _lowerBound_: an integer,
+          optional _upperBound_: an integer,
+        ): either a normal completion containing an integer or a throw completion
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It converts _value_ to an integer (interpreting negative values relative to _length_) and clamps the result to the inclusive interval from _lowerBound_ to _upperBound_ (respectively defaulting to 0 and _length_).</dd>
+      </dl>
+      <emu-alg>
+        1. If _lowerBound_ is not present, set _lowerBound_ to 0.
+        1. If _upperBound_ is not present, set _upperBound_ to _length_.
+        1. Assert: _lowerBound_ ≤ _upperBound_.
+        1. Let _integer_ be ? ToIntegerOrInfinity(_value_).
+        1. If _integer_ is finite and _integer_ &lt; 0, set _integer_ to _length_ + _integer_.
+        1. Return the result of clamping _integer_ between _lowerBound_ and _upperBound_.
+      </emu-alg>
+    </emu-clause>
   </emu-clause>
 
   <emu-clause id="sec-testing-and-comparison-operations">
@@ -33737,11 +33760,7 @@ THH:mm:ss.sss
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
           1. Let _len_ be the length of _S_.
-          1. Let _relativeIndex_ be ? ToIntegerOrInfinity(_index_).
-          1. If _relativeIndex_ ≥ 0, then
-            1. Let _k_ be _relativeIndex_.
-          1. Else,
-            1. Let _k_ be _len_ + _relativeIndex_.
+          1. Let _k_ be ? ToClampedIndex(_index_, _len_, -1).
           1. If _k_ &lt; 0 or _k_ ≥ _len_, return *undefined*.
           1. Return the substring of _S_ from _k_ to _k_ + 1.
         </emu-alg>
@@ -34304,14 +34323,8 @@ THH:mm:ss.sss
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
           1. Let _len_ be the length of _S_.
-          1. Let _intStart_ be ? ToIntegerOrInfinity(_start_).
-          1. If _intStart_ = -∞, let _from_ be 0.
-          1. Else if _intStart_ &lt; 0, let _from_ be max(_len_ + _intStart_, 0).
-          1. Else, let _from_ be min(_intStart_, _len_).
-          1. If _end_ is *undefined*, let _intEnd_ be _len_; else let _intEnd_ be ? ToIntegerOrInfinity(_end_).
-          1. If _intEnd_ = -∞, let _to_ be 0.
-          1. Else if _intEnd_ &lt; 0, let _to_ be max(_len_ + _intEnd_, 0).
-          1. Else, let _to_ be min(_intEnd_, _len_).
+          1. Let _from_ be ? ToClampedIndex(_start_, _len_).
+          1. If _end_ is *undefined*, let _to_ be _len_; else let _to_ be ? ToClampedIndex(_end_, _len_).
           1. If _from_ ≥ _to_, return the empty String.
           1. Return the substring of _S_ from _from_ to _to_.
         </emu-alg>
@@ -37311,11 +37324,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
-          1. Let _relativeIndex_ be ? ToIntegerOrInfinity(_index_).
-          1. If _relativeIndex_ ≥ 0, then
-            1. Let _k_ be _relativeIndex_.
-          1. Else,
-            1. Let _k_ be _len_ + _relativeIndex_.
+          1. Let _k_ be ? ToClampedIndex(_index_, _len_, -1).
           1. If _k_ &lt; 0 or _k_ ≥ _len_, return *undefined*.
           1. Return ? Get(_O_, ! ToString(𝔽(_k_))).
         </emu-alg>
@@ -37394,18 +37403,9 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
-          1. Let _relativeTarget_ be ? ToIntegerOrInfinity(_target_).
-          1. If _relativeTarget_ = -∞, let _to_ be 0.
-          1. Else if _relativeTarget_ &lt; 0, let _to_ be max(_len_ + _relativeTarget_, 0).
-          1. Else, let _to_ be min(_relativeTarget_, _len_).
-          1. Let _relativeStart_ be ? ToIntegerOrInfinity(_start_).
-          1. If _relativeStart_ = -∞, let _from_ be 0.
-          1. Else if _relativeStart_ &lt; 0, let _from_ be max(_len_ + _relativeStart_, 0).
-          1. Else, let _from_ be min(_relativeStart_, _len_).
-          1. If _end_ is *undefined*, let _relativeEnd_ be _len_; else let _relativeEnd_ be ? ToIntegerOrInfinity(_end_).
-          1. If _relativeEnd_ = -∞, let _final_ be 0.
-          1. Else if _relativeEnd_ &lt; 0, let _final_ be max(_len_ + _relativeEnd_, 0).
-          1. Else, let _final_ be min(_relativeEnd_, _len_).
+          1. Let _to_ be ? ToClampedIndex(_target_, _len_).
+          1. Let _from_ be ? ToClampedIndex(_start_, _len_).
+          1. If _end_ is *undefined*, let _final_ be _len_; else let _final_ be ? ToClampedIndex(_end_, _len_).
           1. Let _count_ be min(_final_ - _from_, _len_ - _to_).
           1. If _from_ &lt; _to_ and _to_ &lt; _from_ + _count_, then
             1. Let _direction_ be -1.
@@ -37485,14 +37485,8 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
-          1. Let _relativeStart_ be ? ToIntegerOrInfinity(_start_).
-          1. If _relativeStart_ = -∞, let _k_ be 0.
-          1. Else if _relativeStart_ &lt; 0, let _k_ be max(_len_ + _relativeStart_, 0).
-          1. Else, let _k_ be min(_relativeStart_, _len_).
-          1. If _end_ is *undefined*, let _relativeEnd_ be _len_; else let _relativeEnd_ be ? ToIntegerOrInfinity(_end_).
-          1. If _relativeEnd_ = -∞, let _final_ be 0.
-          1. Else if _relativeEnd_ &lt; 0, let _final_ be max(_len_ + _relativeEnd_, 0).
-          1. Else, let _final_ be min(_relativeEnd_, _len_).
+          1. Let _k_ be ? ToClampedIndex(_start_, _len_).
+          1. If _end_ is *undefined*, let _final_ be _len_; else let _final_ be ? ToClampedIndex(_end_, _len_).
           1. Repeat, while _k_ &lt; _final_,
             1. Let _Pk_ be ! ToString(𝔽(_k_)).
             1. Perform ? Set(_O_, _Pk_, _value_, *true*).
@@ -37860,13 +37854,8 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
-          1. If _len_ = 0, return *-1*<sub>𝔽</sub>.
-          1. If _fromIndex_ is present, let _n_ be ? ToIntegerOrInfinity(_fromIndex_); else let _n_ be _len_ - 1.
-          1. If _n_ = -∞, return *-1*<sub>𝔽</sub>.
-          1. If _n_ ≥ 0, then
-            1. Let _k_ be min(_n_, _len_ - 1).
-          1. Else,
-            1. Let _k_ be _len_ + _n_.
+          1. If _len_ is 0, return *-1*<sub>𝔽</sub>.
+          1. If _fromIndex_ is not present, let _k_ be _len_ - 1; else let _k_ be ? ToClampedIndex(_fromIndex_, _len_, -1, _len_ - 1).
           1. Repeat, while _k_ ≥ 0,
             1. Let _kPresent_ be ? HasProperty(_O_, ! ToString(𝔽(_k_))).
             1. If _kPresent_ is *true*, then
@@ -38122,14 +38111,8 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
-          1. Let _relativeStart_ be ? ToIntegerOrInfinity(_start_).
-          1. If _relativeStart_ = -∞, let _k_ be 0.
-          1. Else if _relativeStart_ &lt; 0, let _k_ be max(_len_ + _relativeStart_, 0).
-          1. Else, let _k_ be min(_relativeStart_, _len_).
-          1. If _end_ is *undefined*, let _relativeEnd_ be _len_; else let _relativeEnd_ be ? ToIntegerOrInfinity(_end_).
-          1. If _relativeEnd_ = -∞, let _final_ be 0.
-          1. Else if _relativeEnd_ &lt; 0, let _final_ be max(_len_ + _relativeEnd_, 0).
-          1. Else, let _final_ be min(_relativeEnd_, _len_).
+          1. Let _k_ be ? ToClampedIndex(_start_, _len_).
+          1. If _end_ is *undefined*, let _final_ be _len_; else let _final_ be ? ToClampedIndex(_end_, _len_).
           1. Let _count_ be max(_final_ - _k_, 0).
           1. Let _A_ be ? ArraySpeciesCreate(_O_, _count_).
           1. Let _n_ be 0.
@@ -38298,10 +38281,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
-          1. Let _relativeStart_ be ? ToIntegerOrInfinity(_start_).
-          1. If _relativeStart_ = -∞, let _actualStart_ be 0.
-          1. Else if _relativeStart_ &lt; 0, let _actualStart_ be max(_len_ + _relativeStart_, 0).
-          1. Else, let _actualStart_ be min(_relativeStart_, _len_).
+          1. Let _actualStart_ be ? ToClampedIndex(_start_, _len_).
           1. Let _itemCount_ be the number of elements in _items_.
           1. If _start_ is not present, then
             1. Let _actualDeleteCount_ be 0.
@@ -38912,11 +38892,7 @@ THH:mm:ss.sss
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
           1. Let _len_ be _O_.[[ArrayLength]].
-          1. Let _relativeIndex_ be ? ToIntegerOrInfinity(_index_).
-          1. If _relativeIndex_ ≥ 0, then
-            1. Let _k_ be _relativeIndex_.
-          1. Else,
-            1. Let _k_ be _len_ + _relativeIndex_.
+          1. Let _k_ be ? ToClampedIndex(_index_, _len_, -1).
           1. If _k_ &lt; 0 or _k_ ≥ _len_, return *undefined*.
           1. Return ! Get(_O_, ! ToString(𝔽(_k_))).
         </emu-alg>
@@ -38975,18 +38951,9 @@ THH:mm:ss.sss
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
           1. Let _len_ be _O_.[[ArrayLength]].
-          1. Let _relativeTarget_ be ? ToIntegerOrInfinity(_target_).
-          1. If _relativeTarget_ = -∞, let _to_ be 0.
-          1. Else if _relativeTarget_ &lt; 0, let _to_ be max(_len_ + _relativeTarget_, 0).
-          1. Else, let _to_ be min(_relativeTarget_, _len_).
-          1. Let _relativeStart_ be ? ToIntegerOrInfinity(_start_).
-          1. If _relativeStart_ = -∞, let _from_ be 0.
-          1. Else if _relativeStart_ &lt; 0, let _from_ be max(_len_ + _relativeStart_, 0).
-          1. Else, let _from_ be min(_relativeStart_, _len_).
-          1. If _end_ is *undefined*, let _relativeEnd_ be _len_; else let _relativeEnd_ be ? ToIntegerOrInfinity(_end_).
-          1. If _relativeEnd_ = -∞, let _final_ be 0.
-          1. Else if _relativeEnd_ &lt; 0, let _final_ be max(_len_ + _relativeEnd_, 0).
-          1. Else, let _final_ be min(_relativeEnd_, _len_).
+          1. Let _to_ be ? ToClampedIndex(_target_, _len_).
+          1. Let _from_ be ? ToClampedIndex(_start_, _len_).
+          1. If _end_ is *undefined*, let _final_ be _len_; else let _final_ ? ToClampedIndex(_end_, _len_).
           1. Let _count_ be min(_final_ - _from_, _len_ - _to_).
           1. If _count_ > 0, then
             1. NOTE: The copying must be performed in a manner that preserves the bit-level encoding of the source data.
@@ -39054,14 +39021,8 @@ THH:mm:ss.sss
           1. Let _len_ be _O_.[[ArrayLength]].
           1. If _O_.[[ContentType]] is ~BigInt~, set _value_ to ? ToBigInt(_value_).
           1. Otherwise, set _value_ to ? ToNumber(_value_).
-          1. Let _relativeStart_ be ? ToIntegerOrInfinity(_start_).
-          1. If _relativeStart_ = -∞, let _k_ be 0.
-          1. Else if _relativeStart_ &lt; 0, let _k_ be max(_len_ + _relativeStart_, 0).
-          1. Else, let _k_ be min(_relativeStart_, _len_).
-          1. If _end_ is *undefined*, let _relativeEnd_ be _len_; else let _relativeEnd_ be ? ToIntegerOrInfinity(_end_).
-          1. If _relativeEnd_ = -∞, let _final_ be 0.
-          1. Else if _relativeEnd_ &lt; 0, let _final_ be max(_len_ + _relativeEnd_, 0).
-          1. Else, let _final_ be min(_relativeEnd_, _len_).
+          1. Let _k_ be ? ToClampedIndex(_start_, _len_).
+          1. If _end_ is *undefined*, let _final_ be _len_; else let _final_ be ? ToClampedIndex(_end_, _len_).
           1. If IsDetachedBuffer(_O_.[[ViewedArrayBuffer]]) is *true*, throw a *TypeError* exception.
           1. Repeat, while _k_ &lt; _final_,
             1. Let _Pk_ be ! ToString(𝔽(_k_)).
@@ -39302,13 +39263,8 @@ THH:mm:ss.sss
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
           1. Let _len_ be _O_.[[ArrayLength]].
-          1. If _len_ = 0, return *-1*<sub>𝔽</sub>.
-          1. If _fromIndex_ is present, let _n_ be ? ToIntegerOrInfinity(_fromIndex_); else let _n_ be _len_ - 1.
-          1. If _n_ = -∞, return *-1*<sub>𝔽</sub>.
-          1. If _n_ ≥ 0, then
-            1. Let _k_ be min(_n_, _len_ - 1).
-          1. Else,
-            1. Let _k_ be _len_ + _n_.
+          1. If _len_ is 0, return *-1*<sub>𝔽</sub>.
+          1. If _fromIndex_ is not present, let _k_ be _len_ - 1; else let _k_ be ? ToClampedIndex(_fromIndex_, _len_, -1, _len_ - 1).
           1. Repeat, while _k_ ≥ 0,
             1. Let _kPresent_ be ! HasProperty(_O_, ! ToString(𝔽(_k_))).
             1. If _kPresent_ is *true*, then
@@ -39548,14 +39504,8 @@ THH:mm:ss.sss
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
           1. Let _len_ be _O_.[[ArrayLength]].
-          1. Let _relativeStart_ be ? ToIntegerOrInfinity(_start_).
-          1. If _relativeStart_ = -∞, let _k_ be 0.
-          1. Else if _relativeStart_ &lt; 0, let _k_ be max(_len_ + _relativeStart_, 0).
-          1. Else, let _k_ be min(_relativeStart_, _len_).
-          1. If _end_ is *undefined*, let _relativeEnd_ be _len_; else let _relativeEnd_ be ? ToIntegerOrInfinity(_end_).
-          1. If _relativeEnd_ = -∞, let _final_ be 0.
-          1. Else if _relativeEnd_ &lt; 0, let _final_ be max(_len_ + _relativeEnd_, 0).
-          1. Else, let _final_ be min(_relativeEnd_, _len_).
+          1. Let _k_ be ? ToClampedIndex(_start_, _len_).
+          1. If _end_ is *undefined*, let _final_ be _len_; else let _final_ be ? ToClampedIndex(_end_, _len_).
           1. Let _count_ be max(_final_ - _k_, 0).
           1. Let _A_ be ? TypedArraySpeciesCreate(_O_, « 𝔽(_count_) »).
           1. If _count_ > 0, then
@@ -39652,14 +39602,8 @@ THH:mm:ss.sss
           1. Assert: _O_ has a [[ViewedArrayBuffer]] internal slot.
           1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
           1. Let _srcLength_ be _O_.[[ArrayLength]].
-          1. Let _relativeBegin_ be ? ToIntegerOrInfinity(_begin_).
-          1. If _relativeBegin_ = -∞, let _beginIndex_ be 0.
-          1. Else if _relativeBegin_ &lt; 0, let _beginIndex_ be max(_srcLength_ + _relativeBegin_, 0).
-          1. Else, let _beginIndex_ be min(_relativeBegin_, _srcLength_).
-          1. If _end_ is *undefined*, let _relativeEnd_ be _srcLength_; else let _relativeEnd_ be ? ToIntegerOrInfinity(_end_).
-          1. If _relativeEnd_ = -∞, let _endIndex_ be 0.
-          1. Else if _relativeEnd_ &lt; 0, let _endIndex_ be max(_srcLength_ + _relativeEnd_, 0).
-          1. Else, let _endIndex_ be min(_relativeEnd_, _srcLength_).
+          1. Let _beginIndex_ be ? ToClampedIndex(_begin_, _srcLength_).
+          1. If _end_ is *undefined*, let _endIndex_ be _srcLength_; else let _endIndex_ be ? ToClampedIndex(_end_, _srcLength_).
           1. Let _newLength_ be max(_endIndex_ - _beginIndex_, 0).
           1. Let _elementSize_ be TypedArrayElementSize(_O_).
           1. Let _srcByteOffset_ be _O_.[[ByteOffset]].
@@ -41422,14 +41366,8 @@ THH:mm:ss.sss
           1. If IsSharedArrayBuffer(_O_) is *true*, throw a *TypeError* exception.
           1. If IsDetachedBuffer(_O_) is *true*, throw a *TypeError* exception.
           1. Let _len_ be _O_.[[ArrayBufferByteLength]].
-          1. Let _relativeStart_ be ? ToIntegerOrInfinity(_start_).
-          1. If _relativeStart_ = -∞, let _first_ be 0.
-          1. Else if _relativeStart_ &lt; 0, let _first_ be max(_len_ + _relativeStart_, 0).
-          1. Else, let _first_ be min(_relativeStart_, _len_).
-          1. If _end_ is *undefined*, let _relativeEnd_ be _len_; else let _relativeEnd_ be ? ToIntegerOrInfinity(_end_).
-          1. If _relativeEnd_ = -∞, let _final_ be 0.
-          1. Else if _relativeEnd_ &lt; 0, let _final_ be max(_len_ + _relativeEnd_, 0).
-          1. Else, let _final_ be min(_relativeEnd_, _len_).
+          1. Let _first_ be ? ToClampedIndex(_start_, _len_).
+          1. If _end_ is *undefined*, let _final_ be _len_; else let _final_ be ? ToClampedIndex(_end_, _len_).
           1. Let _newLen_ be max(_final_ - _first_, 0).
           1. Let _ctor_ be ? SpeciesConstructor(_O_, %ArrayBuffer%).
           1. Let _new_ be ? Construct(_ctor_, « 𝔽(_newLen_) »).
@@ -41595,14 +41533,8 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_O_, [[ArrayBufferData]]).
           1. If IsSharedArrayBuffer(_O_) is *false*, throw a *TypeError* exception.
           1. Let _len_ be _O_.[[ArrayBufferByteLength]].
-          1. Let _relativeStart_ be ? ToIntegerOrInfinity(_start_).
-          1. If _relativeStart_ = -∞, let _first_ be 0.
-          1. Else if _relativeStart_ &lt; 0, let _first_ be max(_len_ + _relativeStart_, 0).
-          1. Else, let _first_ be min(_relativeStart_, _len_).
-          1. If _end_ is *undefined*, let _relativeEnd_ be _len_; else let _relativeEnd_ be ? ToIntegerOrInfinity(_end_).
-          1. If _relativeEnd_ = -∞, let _final_ be 0.
-          1. Else if _relativeEnd_ &lt; 0, let _final_ be max(_len_ + _relativeEnd_, 0).
-          1. Else, let _final_ be min(_relativeEnd_, _len_).
+          1. Let _first_ be ? ToClampedIndex(_start_, _len_).
+          1. If _end_ is *undefined*, let _final_ be _len_; else let _final_ be ? ToClampedIndex(_end_, _len_).
           1. Let _newLen_ be max(_final_ - _first_, 0).
           1. Let _ctor_ be ? SpeciesConstructor(_O_, %SharedArrayBuffer%).
           1. Let _new_ be ? Construct(_ctor_, « 𝔽(_newLen_) »).
@@ -47781,10 +47713,7 @@ THH:mm:ss.sss
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
           1. Let _size_ be the length of _S_.
-          1. Let _intStart_ be ? ToIntegerOrInfinity(_start_).
-          1. If _intStart_ = -∞, set _intStart_ to 0.
-          1. Else if _intStart_ &lt; 0, set _intStart_ to max(_size_ + _intStart_, 0).
-          1. Else, set _intStart_ to min(_intStart_, _size_).
+          1. Let _intStart_ be ? ToClampedIndex(_start_, _size_).
           1. If _length_ is *undefined*, let _intLength_ be _size_.
           1. Else, let _intLength_ be the result of clamping ? ToIntegerOrInfinity(_length_) between 0 and _size_.
           1. Let _intEnd_ be min(_intStart_ + _intLength_, _size_).

--- a/spec.html
+++ b/spec.html
@@ -5517,8 +5517,8 @@
       </dl>
       <emu-alg>
         1. Let _len_ be ? ToIntegerOrInfinity(_argument_).
-        1. If _len_ ≤ 0, return *+0*<sub>𝔽</sub>.
-        1. Return 𝔽(min(_len_, 2<sup>53</sup> - 1)).
+        1. Let _actualLen_ be the result of clamping _len_ between 0 and 2<sup>53</sup> - 1.
+        1. Return 𝔽(_len_).
       </emu-alg>
     </emu-clause>
 
@@ -29991,13 +29991,11 @@
           1. If _targetHasLength_ is *true*, then
             1. Let _targetLen_ be ? Get(_Target_, *"length"*).
             1. If _targetLen_ is a Number, then
-              1. If _targetLen_ is *+∞*<sub>𝔽</sub>, set _L_ to +∞.
-              1. Else if _targetLen_ is *-∞*<sub>𝔽</sub>, set _L_ to 0.
-              1. Else,
-                1. Let _targetLenAsInt_ be ! ToIntegerOrInfinity(_targetLen_).
-                1. Assert: _targetLenAsInt_ is finite.
+              1. Set _L_ to ! ToIntegerOrInfinity(_targetLen_).
+              1. If _L_ is -∞, set _L_ to 0.
+              1. Else if _L_ is not +∞, then
                 1. Let _argCount_ be the number of elements in _args_.
-                1. Set _L_ to max(_targetLenAsInt_ - _argCount_, 0).
+                1. Set _L_ to max(_L_ - _argCount_, 0).
           1. Perform SetFunctionLength(_F_, _L_).
           1. Let _targetName_ be ? Get(_Target_, *"name"*).
           1. If _targetName_ is not a String, set _targetName_ to the empty String.
@@ -33844,8 +33842,8 @@ THH:mm:ss.sss
           1. If _isRegExp_ is *true*, throw a *TypeError* exception.
           1. Let _searchStr_ be ? ToString(_searchString_).
           1. Let _len_ be the length of _S_.
-          1. If _endPosition_ is *undefined*, let _pos_ be _len_; else let _pos_ be ? ToIntegerOrInfinity(_endPosition_).
-          1. Let _end_ be the result of clamping _pos_ between 0 and _len_.
+          1. If _endPosition_ is *undefined*, let _end_ be _len_.
+          1. Else, let _end_ be the result of clamping ? ToIntegerOrInfinity(_endPosition_) between 0 and _len_.
           1. Let _searchLength_ be the length of _searchStr_.
           1. If _searchLength_ = 0, return *true*.
           1. Let _start_ be _end_ - _searchLength_.
@@ -33874,10 +33872,9 @@ THH:mm:ss.sss
           1. Let _isRegExp_ be ? IsRegExp(_searchString_).
           1. If _isRegExp_ is *true*, throw a *TypeError* exception.
           1. Let _searchStr_ be ? ToString(_searchString_).
-          1. Let _pos_ be ? ToIntegerOrInfinity(_position_).
-          1. Assert: If _position_ is *undefined*, then _pos_ is 0.
           1. Let _len_ be the length of _S_.
-          1. Let _start_ be the result of clamping _pos_ between 0 and _len_.
+          1. Let _start_ be the result of clamping ? ToIntegerOrInfinity(_position_) between 0 and _len_.
+          1. Assert: If _position_ is *undefined*, then _start_ is 0.
           1. Let _index_ be StringIndexOf(_S_, _searchStr_, _start_).
           1. If _index_ ≠ -1, return *true*.
           1. Return *false*.
@@ -33903,10 +33900,9 @@ THH:mm:ss.sss
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
           1. Let _searchStr_ be ? ToString(_searchString_).
-          1. Let _pos_ be ? ToIntegerOrInfinity(_position_).
-          1. Assert: If _position_ is *undefined*, then _pos_ is 0.
           1. Let _len_ be the length of _S_.
-          1. Let _start_ be the result of clamping _pos_ between 0 and _len_.
+          1. Let _start_ be the result of clamping ? ToIntegerOrInfinity(_position_) between 0 and _len_.
+          1. Assert: If _position_ is *undefined*, then _start_ is 0.
           1. Return 𝔽(StringIndexOf(_S_, _searchStr_, _start_)).
         </emu-alg>
         <emu-note>
@@ -33923,15 +33919,15 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
+          1. Let _len_ be the length of _S_.
           1. Let _searchStr_ be ? ToString(_searchString_).
+          1. Let _searchLen_ be the length of _searchStr_.
           1. Let _numPos_ be ? ToNumber(_position_).
           1. Assert: If _position_ is *undefined*, then _numPos_ is *NaN*.
-          1. If _numPos_ is *NaN*, let _pos_ be +∞; otherwise, let _pos_ be ! ToIntegerOrInfinity(_numPos_).
-          1. Let _len_ be the length of _S_.
-          1. Let _searchLen_ be the length of _searchStr_.
-          1. Let _start_ be the result of clamping _pos_ between 0 and _len_ - _searchLen_.
+          1. If _numPos_ is *NaN*, let _start_ be _len_.
+          1. Else, let _start_ be the result of clamping ! ToIntegerOrInfinity(_numPos_) between 0 and _len_.
           1. If _searchStr_ is the empty String, return 𝔽(_start_).
-          1. For each integer _i_ such that 0 ≤ _i_ ≤ _start_, in descending order, do
+          1. For each integer _i_ such that 0 ≤ _i_ ≤ min(_start_, _len_ - _searchLen_), in descending order, do
             1. Let _candidate_ be the substring of _S_ from _i_ to _i_ + _searchLen_.
             1. If _candidate_ is _searchStr_, return 𝔽(_i_).
           1. Return *-1*<sub>𝔽</sub>.
@@ -34380,8 +34376,8 @@ THH:mm:ss.sss
           1. If _isRegExp_ is *true*, throw a *TypeError* exception.
           1. Let _searchStr_ be ? ToString(_searchString_).
           1. Let _len_ be the length of _S_.
-          1. If _position_ is *undefined*, let _pos_ be 0; else let _pos_ be ? ToIntegerOrInfinity(_position_).
-          1. Let _start_ be the result of clamping _pos_ between 0 and _len_.
+          1. Let _start_ be the result of clamping ? ToIntegerOrInfinity(_position_) between 0 and _len_.
+          1. Assert: If _position_ is *undefined*, then _start_ is 0.
           1. Let _searchLength_ be the length of _searchStr_.
           1. If _searchLength_ = 0, return *true*.
           1. Let _end_ be _start_ + _searchLength_.
@@ -34411,10 +34407,10 @@ THH:mm:ss.sss
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
           1. Let _len_ be the length of _S_.
-          1. Let _intStart_ be ? ToIntegerOrInfinity(_start_).
-          1. If _end_ is *undefined*, let _intEnd_ be _len_; else let _intEnd_ be ? ToIntegerOrInfinity(_end_).
-          1. Let _finalStart_ be the result of clamping _intStart_ between 0 and _len_.
-          1. Let _finalEnd_ be the result of clamping _intEnd_ between 0 and _len_.
+          1. Let _finalStart_ be the result of clamping ? ToIntegerOrInfinity(_start_) between 0 and _len_.
+          1. Assert: If _start_ is *undefined*, then _finalStart_ is 0.
+          1. If _end_ is *undefined*, let _finalEnd_ be _len_.
+          1. Else, let _finalEnd_ be the result of clamping ? ToIntegerOrInfinity(_end_) between 0 and _len_.
           1. Let _from_ be min(_finalStart_, _finalEnd_).
           1. Let _to_ be max(_finalStart_, _finalEnd_).
           1. Return the substring of _S_ from _from_ to _to_.
@@ -47789,8 +47785,8 @@ THH:mm:ss.sss
           1. If _intStart_ = -∞, set _intStart_ to 0.
           1. Else if _intStart_ &lt; 0, set _intStart_ to max(_size_ + _intStart_, 0).
           1. Else, set _intStart_ to min(_intStart_, _size_).
-          1. If _length_ is *undefined*, let _intLength_ be _size_; otherwise let _intLength_ be ? ToIntegerOrInfinity(_length_).
-          1. Set _intLength_ to the result of clamping _intLength_ between 0 and _size_.
+          1. If _length_ is *undefined*, let _intLength_ be _size_.
+          1. Else, let _intLength_ be the result of clamping ? ToIntegerOrInfinity(_length_) between 0 and _size_.
           1. Let _intEnd_ be min(_intStart_ + _intLength_, _size_).
           1. Return the substring of _S_ from _intStart_ to _intEnd_.
         </emu-alg>

--- a/spec.html
+++ b/spec.html
@@ -5563,6 +5563,24 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-toabsoluteindex" type="abstract operation">
+      <h1>
+        ToAbsoluteIndex (
+          _value_: an ECMAScript language value,
+          _length_: a non-negative integer,
+        ): either a normal completion containing either an integer, +&infin;, or -&infin;, or a throw completion
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It converts _value_ to an integer, interpreting negative values relative to _length_.</dd>
+      </dl>
+      <emu-alg>
+        1. Let _integer_ be ? ToIntegerOrInfinity(_value_).
+        1. If _integer_ is finite and _integer_ &lt; 0, set _integer_ to _length_ + _integer_.
+        1. Return _integer_.
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-toclampedindex" type="abstract operation">
       <h1>
         ToClampedIndex (
@@ -5580,9 +5598,7 @@
         1. If _lowerBound_ is not present, set _lowerBound_ to 0.
         1. If _upperBound_ is not present, set _upperBound_ to _length_.
         1. Assert: _lowerBound_ ≤ _upperBound_.
-        1. Let _integer_ be ? ToIntegerOrInfinity(_value_).
-        1. If _integer_ is finite and _integer_ &lt; 0, set _integer_ to _length_ + _integer_.
-        1. Return the result of clamping _integer_ between _lowerBound_ and _upperBound_.
+        1. Return the result of clamping ? ToAbsoluteIndex(_value_, _length_) between _lowerBound_ and _upperBound_.
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -33761,7 +33777,7 @@ THH:mm:ss.sss
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
           1. Let _len_ be the length of _S_.
-          1. Let _k_ be ? ToClampedIndex(_index_, _len_, -1).
+          1. Let _k_ be ? ToAbsoluteIndex(_index_, _len_).
           1. If _k_ &lt; 0 or _k_ ≥ _len_, return *undefined*.
           1. Return the substring of _S_ from _k_ to _k_ + 1.
         </emu-alg>
@@ -37325,7 +37341,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
-          1. Let _k_ be ? ToClampedIndex(_index_, _len_, -1).
+          1. Let _k_ be ? ToAbsoluteIndex(_index_, _len_).
           1. If _k_ &lt; 0 or _k_ ≥ _len_, return *undefined*.
           1. Return ? Get(_O_, ! ToString(𝔽(_k_))).
         </emu-alg>
@@ -38893,7 +38909,7 @@ THH:mm:ss.sss
           1. Let _O_ be the *this* value.
           1. Perform ? ValidateTypedArray(_O_).
           1. Let _len_ be _O_.[[ArrayLength]].
-          1. Let _k_ be ? ToClampedIndex(_index_, _len_, -1).
+          1. Let _k_ be ? ToAbsoluteIndex(_index_, _len_).
           1. If _k_ &lt; 0 or _k_ ≥ _len_, return *undefined*.
           1. Return ! Get(_O_, ! ToString(𝔽(_k_))).
         </emu-alg>

--- a/spec.html
+++ b/spec.html
@@ -5517,8 +5517,8 @@
       </dl>
       <emu-alg>
         1. Let _len_ be ? ToIntegerOrInfinity(_argument_).
-        1. Let _actualLen_ be the result of clamping _len_ between 0 and 2<sup>53</sup> - 1.
-        1. Return 𝔽(_len_).
+        1. Let _clampedLen_ be the result of clamping _len_ between 0 and 2<sup>53</sup> - 1.
+        1. Return 𝔽(_clampedLen_).
       </emu-alg>
     </emu-clause>
 
@@ -38953,7 +38953,7 @@ THH:mm:ss.sss
           1. Let _len_ be _O_.[[ArrayLength]].
           1. Let _to_ be ? ToClampedIndex(_target_, _len_).
           1. Let _from_ be ? ToClampedIndex(_start_, _len_).
-          1. If _end_ is *undefined*, let _final_ be _len_; else let _final_ ? ToClampedIndex(_end_, _len_).
+          1. If _end_ is *undefined*, let _final_ be _len_; else let _final_ be ? ToClampedIndex(_end_, _len_).
           1. Let _count_ be min(_final_ - _from_, _len_ - _to_).
           1. If _count_ > 0, then
             1. NOTE: The copying must be performed in a manner that preserves the bit-level encoding of the source data.

--- a/spec.html
+++ b/spec.html
@@ -5725,8 +5725,8 @@
       </dl>
       <emu-alg>
         1. Let _length_ be ? ToIntegerOrInfinity(_arg_).
-        1. Let _actualLen_ be the result of clamping _length_ between 0 and 2<sup>53</sup> - 1.
-        1. Return 𝔽(_actualLen_).
+        1. Let _clampedLen_ be the result of clamping _length_ between 0 and 2<sup>53</sup> - 1.
+        1. Return 𝔽(_clampedLen_).
       </emu-alg>
     </emu-clause>
 
@@ -5763,6 +5763,29 @@
         1. Let _int_ be ? ToIntegerOrInfinity(_arg_).
         1. If _int_ is not in the inclusive interval from 0 to 2<sup>53</sup> - 1, throw a *RangeError* exception.
         1. Return _int_.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-toclampedindex" type="abstract operation">
+      <h1>
+        ToClampedIndex (
+          _value_: an ECMAScript language value,
+          _length_: a non-negative integer,
+          optional _lowerBound_: an integer,
+          optional _upperBound_: an integer,
+        ): either a normal completion containing an integer or a throw completion
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It converts _value_ to an integer (interpreting negative values relative to _length_) and clamps the result to the inclusive interval from _lowerBound_ to _upperBound_ (respectively defaulting to 0 and _length_).</dd>
+      </dl>
+      <emu-alg>
+        1. If _lowerBound_ is not present, set _lowerBound_ to 0.
+        1. If _upperBound_ is not present, set _upperBound_ to _length_.
+        1. Assert: _lowerBound_ ≤ _upperBound_.
+        1. Let _integer_ be ? ToIntegerOrInfinity(_value_).
+        1. If _integer_ is finite and _integer_ &lt; 0, set _integer_ to _length_ + _integer_.
+        1. Return the result of clamping _integer_ between _lowerBound_ and _upperBound_.
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -36179,11 +36202,7 @@ THH:mm:ss.sss
           1. Perform ? RequireObjectCoercible(_thisValue_).
           1. Let _string_ be ? ToString(_thisValue_).
           1. Let _length_ be the length of _string_.
-          1. Let _relativeIndex_ be ? ToIntegerOrInfinity(_index_).
-          1. If _relativeIndex_ ≥ 0, then
-            1. Let _k_ be _relativeIndex_.
-          1. Else,
-            1. Let _k_ be _length_ + _relativeIndex_.
+          1. Let _k_ be ? ToClampedIndex(_index_, _length_, -1).
           1. If _k_ &lt; 0 or _k_ ≥ _length_, return *undefined*.
           1. Return the substring of _string_ from _k_ to _k_ + 1.
         </emu-alg>
@@ -36796,14 +36815,8 @@ THH:mm:ss.sss
           1. Perform ? RequireObjectCoercible(_thisValue_).
           1. Let _string_ be ? ToString(_thisValue_).
           1. Let _length_ be the length of _string_.
-          1. Let _intStart_ be ? ToIntegerOrInfinity(_start_).
-          1. If _intStart_ = -∞, let _from_ be 0.
-          1. Else if _intStart_ &lt; 0, let _from_ be max(_length_ + _intStart_, 0).
-          1. Else, let _from_ be min(_intStart_, _length_).
-          1. If _end_ is *undefined*, let _intEnd_ be _length_; else let _intEnd_ be ? ToIntegerOrInfinity(_end_).
-          1. If _intEnd_ = -∞, let _to_ be 0.
-          1. Else if _intEnd_ &lt; 0, let _to_ be max(_length_ + _intEnd_, 0).
-          1. Else, let _to_ be min(_intEnd_, _length_).
+          1. Let _from_ be ? ToClampedIndex(_start_, _length_).
+          1. If _end_ is *undefined*, let _to_ be _length_; else let _to_ be ? ToClampedIndex(_end_, _length_).
           1. If _from_ ≥ _to_, return the empty String.
           1. Return the substring of _string_ from _from_ to _to_.
         </emu-alg>
@@ -40707,11 +40720,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _obj_ be ? ToObject(*this* value).
           1. Let _length_ be ? LengthOfArrayLike(_obj_).
-          1. Let _relativeIndex_ be ? ToIntegerOrInfinity(_index_).
-          1. If _relativeIndex_ ≥ 0, then
-            1. Let _k_ be _relativeIndex_.
-          1. Else,
-            1. Let _k_ be _length_ + _relativeIndex_.
+          1. Let _k_ be ? ToClampedIndex(_index_, _length_, -1).
           1. If _k_ &lt; 0 or _k_ ≥ _length_, return *undefined*.
           1. Return ? Get(_obj_, ! ToString(𝔽(_k_))).
         </emu-alg>
@@ -40790,18 +40799,9 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _obj_ be ? ToObject(*this* value).
           1. Let _length_ be ? LengthOfArrayLike(_obj_).
-          1. Let _relativeTarget_ be ? ToIntegerOrInfinity(_target_).
-          1. If _relativeTarget_ = -∞, let _to_ be 0.
-          1. Else if _relativeTarget_ &lt; 0, let _to_ be max(_length_ + _relativeTarget_, 0).
-          1. Else, let _to_ be min(_relativeTarget_, _length_).
-          1. Let _relativeStart_ be ? ToIntegerOrInfinity(_start_).
-          1. If _relativeStart_ = -∞, let _from_ be 0.
-          1. Else if _relativeStart_ &lt; 0, let _from_ be max(_length_ + _relativeStart_, 0).
-          1. Else, let _from_ be min(_relativeStart_, _length_).
-          1. If _end_ is *undefined*, let _relativeEnd_ be _length_; else let _relativeEnd_ be ? ToIntegerOrInfinity(_end_).
-          1. If _relativeEnd_ = -∞, let _final_ be 0.
-          1. Else if _relativeEnd_ &lt; 0, let _final_ be max(_length_ + _relativeEnd_, 0).
-          1. Else, let _final_ be min(_relativeEnd_, _length_).
+          1. Let _to_ be ? ToClampedIndex(_target_, _length_).
+          1. Let _from_ be ? ToClampedIndex(_start_, _length_).
+          1. If _end_ is *undefined*, let _final_ be _length_; else let _final_ be ? ToClampedIndex(_end_, _length_).
           1. Let _count_ be min(_final_ - _from_, _length_ - _to_).
           1. If _from_ &lt; _to_ and _to_ &lt; _from_ + _count_, then
             1. Let _direction_ be -1.
@@ -40881,14 +40881,8 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _obj_ be ? ToObject(*this* value).
           1. Let _length_ be ? LengthOfArrayLike(_obj_).
-          1. Let _relativeStart_ be ? ToIntegerOrInfinity(_start_).
-          1. If _relativeStart_ = -∞, let _k_ be 0.
-          1. Else if _relativeStart_ &lt; 0, let _k_ be max(_length_ + _relativeStart_, 0).
-          1. Else, let _k_ be min(_relativeStart_, _length_).
-          1. If _end_ is *undefined*, let _relativeEnd_ be _length_; else let _relativeEnd_ be ? ToIntegerOrInfinity(_end_).
-          1. If _relativeEnd_ = -∞, let _final_ be 0.
-          1. Else if _relativeEnd_ &lt; 0, let _final_ be max(_length_ + _relativeEnd_, 0).
-          1. Else, let _final_ be min(_relativeEnd_, _length_).
+          1. Let _k_ be ? ToClampedIndex(_start_, _length_).
+          1. If _end_ is *undefined*, let _final_ be _length_; else let _final_ be ? ToClampedIndex(_end_, _length_).
           1. Repeat, while _k_ &lt; _final_,
             1. Let _propertyKey_ be ! ToString(𝔽(_k_)).
             1. Perform ? Set(_obj_, _propertyKey_, _value_, *true*).
@@ -41153,15 +41147,7 @@ THH:mm:ss.sss
           1. Let _obj_ be ? ToObject(*this* value).
           1. Let _length_ be ? LengthOfArrayLike(_obj_).
           1. If _length_ = 0, return *false*.
-          1. Let _startIndex_ be ? ToIntegerOrInfinity(_fromIndex_).
-          1. Assert: If _fromIndex_ is *undefined*, then _startIndex_ is 0.
-          1. If _startIndex_ = +∞, return *false*.
-          1. If _startIndex_ = -∞, set _startIndex_ to 0.
-          1. If _startIndex_ ≥ 0, then
-            1. Let _k_ be _startIndex_.
-          1. Else,
-            1. Let _k_ be _length_ + _startIndex_.
-            1. If _k_ &lt; 0, set _k_ to 0.
+          1. Let _k_ be ? ToClampedIndex(_fromIndex_, _length_).
           1. Repeat, while _k_ &lt; _length_,
             1. Let _elementK_ be ? Get(_obj_, ! ToString(𝔽(_k_))).
             1. If SameValueZero(_searchElement_, _elementK_) is *true*, return *true*.
@@ -41187,15 +41173,7 @@ THH:mm:ss.sss
           1. Let _obj_ be ? ToObject(*this* value).
           1. Let _length_ be ? LengthOfArrayLike(_obj_).
           1. If _length_ = 0, return *-1*<sub>𝔽</sub>.
-          1. Let _startIndex_ be ? ToIntegerOrInfinity(_fromIndex_).
-          1. Assert: If _fromIndex_ is *undefined*, then _startIndex_ is 0.
-          1. If _startIndex_ = +∞, return *-1*<sub>𝔽</sub>.
-          1. If _startIndex_ = -∞, set _startIndex_ to 0.
-          1. If _startIndex_ ≥ 0, then
-            1. Let _k_ be _startIndex_.
-          1. Else,
-            1. Let _k_ be _length_ + _startIndex_.
-            1. If _k_ &lt; 0, set _k_ to 0.
+          1. Let _k_ be ? ToClampedIndex(_fromIndex_, _length_).
           1. Repeat, while _k_ &lt; _length_,
             1. Let _propertyKey_ be ! ToString(𝔽(_k_)).
             1. Let _kPresent_ be ? HasProperty(_obj_, _propertyKey_).
@@ -41255,12 +41233,7 @@ THH:mm:ss.sss
           1. Let _obj_ be ? ToObject(*this* value).
           1. Let _length_ be ? LengthOfArrayLike(_obj_).
           1. If _length_ = 0, return *-1*<sub>𝔽</sub>.
-          1. If _fromIndex_ is present, let _startIndex_ be ? ToIntegerOrInfinity(_fromIndex_); else let _startIndex_ be _length_ - 1.
-          1. If _startIndex_ = -∞, return *-1*<sub>𝔽</sub>.
-          1. If _startIndex_ ≥ 0, then
-            1. Let _k_ be min(_startIndex_, _length_ - 1).
-          1. Else,
-            1. Let _k_ be _length_ + _startIndex_.
+          1. If _fromIndex_ is not present, let _k_ be _length_ - 1; else let _k_ be ? ToClampedIndex(_fromIndex_, _length_, -1, _length_ - 1).
           1. Repeat, while _k_ ≥ 0,
             1. Let _propertyKey_ be ! ToString(𝔽(_k_)).
             1. Let _kPresent_ be ? HasProperty(_obj_, _propertyKey_).
@@ -41516,14 +41489,8 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _obj_ be ? ToObject(*this* value).
           1. Let _length_ be ? LengthOfArrayLike(_obj_).
-          1. Let _relativeStart_ be ? ToIntegerOrInfinity(_start_).
-          1. If _relativeStart_ = -∞, let _k_ be 0.
-          1. Else if _relativeStart_ &lt; 0, let _k_ be max(_length_ + _relativeStart_, 0).
-          1. Else, let _k_ be min(_relativeStart_, _length_).
-          1. If _end_ is *undefined*, let _relativeEnd_ be _length_; else let _relativeEnd_ be ? ToIntegerOrInfinity(_end_).
-          1. If _relativeEnd_ = -∞, let _final_ be 0.
-          1. Else if _relativeEnd_ &lt; 0, let _final_ be max(_length_ + _relativeEnd_, 0).
-          1. Else, let _final_ be min(_relativeEnd_, _length_).
+          1. Let _k_ be ? ToClampedIndex(_start_, _length_).
+          1. If _end_ is *undefined*, let _final_ be _length_; else let _final_ be ? ToClampedIndex(_end_, _length_).
           1. Let _count_ be max(_final_ - _k_, 0).
           1. Let _array_ be ? ArraySpeciesCreate(_obj_, _count_).
           1. Let _resultIndex_ be 0.
@@ -41717,10 +41684,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _obj_ be ? ToObject(*this* value).
           1. Let _length_ be ? LengthOfArrayLike(_obj_).
-          1. Let _relativeStart_ be ? ToIntegerOrInfinity(_start_).
-          1. If _relativeStart_ = -∞, let _actualStart_ be 0.
-          1. Else if _relativeStart_ &lt; 0, let _actualStart_ be max(_length_ + _relativeStart_, 0).
-          1. Else, let _actualStart_ be min(_relativeStart_, _length_).
+          1. Let _actualStart_ be ? ToClampedIndex(_start_, _length_).
           1. Let _itemCount_ be the number of elements in _items_.
           1. If _start_ is not present, then
             1. Let _actualDeleteCount_ be 0.
@@ -41854,19 +41818,17 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _obj_ be ? ToObject(*this* value).
           1. Let _length_ be ? LengthOfArrayLike(_obj_).
-          1. Let _relativeStart_ be ? ToIntegerOrInfinity(_start_).
-          1. If _relativeStart_ = -∞, let _actualStart_ be 0.
-          1. Else if _relativeStart_ &lt; 0, let _actualStart_ be max(_length_ + _relativeStart_, 0).
-          1. Else, let _actualStart_ be min(_relativeStart_, _length_).
+          1. Let _actualStart_ be ? ToClampedIndex(_start_, _length_).
           1. Let _insertCount_ be the number of elements in _items_.
+          1. Let _maxSkipCount_ be _length_ - _actualStart_.
           1. If _start_ is not present, then
             1. Let _actualSkipCount_ be 0.
           1. Else if _skipCount_ is not present, then
-            1. Let _actualSkipCount_ be _length_ - _actualStart_.
+            1. Let _actualSkipCount_ be _maxSkipCount_.
           1. Else,
-            1. Let _sc_ be ? ToIntegerOrInfinity(_skipCount_).
-            1. Let _actualSkipCount_ be the result of clamping _sc_ between 0 and _length_ - _actualStart_.
+            1. Let _actualSkipCount_ be the result of clamping ? ToIntegerOrInfinity(_skipCount_) between 0 and _maxSkipCount_.
           1. Let _newLength_ be _length_ + _insertCount_ - _actualSkipCount_.
+          1. Assert: _newLength_ ≥ 0.
           1. If _newLength_ > 2<sup>53</sup> - 1, throw a *TypeError* exception.
           1. Let _newArray_ be ? ArrayCreate(_newLength_).
           1. Let _writeIndex_ be 0.
@@ -42524,11 +42486,7 @@ THH:mm:ss.sss
           1. Let _obj_ be the *this* value.
           1. Let _taRecord_ be ? ValidateTypedArray(_obj_, ~seq-cst~).
           1. Let _length_ be TypedArrayLength(_taRecord_).
-          1. Let _relativeIndex_ be ? ToIntegerOrInfinity(_index_).
-          1. If _relativeIndex_ ≥ 0, then
-            1. Let _k_ be _relativeIndex_.
-          1. Else,
-            1. Let _k_ be _length_ + _relativeIndex_.
+          1. Let _k_ be ? ToClampedIndex(_index_, _length_, -1).
           1. If _k_ &lt; 0 or _k_ ≥ _length_, return *undefined*.
           1. Return ! Get(_obj_, ! ToString(𝔽(_k_))).
         </emu-alg>
@@ -42587,18 +42545,9 @@ THH:mm:ss.sss
           1. Let _obj_ be the *this* value.
           1. Let _taRecord_ be ? ValidateTypedArray(_obj_, ~seq-cst~).
           1. Let _length_ be TypedArrayLength(_taRecord_).
-          1. Let _relativeTarget_ be ? ToIntegerOrInfinity(_target_).
-          1. If _relativeTarget_ = -∞, let _targetIndex_ be 0.
-          1. Else if _relativeTarget_ &lt; 0, let _targetIndex_ be max(_length_ + _relativeTarget_, 0).
-          1. Else, let _targetIndex_ be min(_relativeTarget_, _length_).
-          1. Let _relativeStart_ be ? ToIntegerOrInfinity(_start_).
-          1. If _relativeStart_ = -∞, let _startIndex_ be 0.
-          1. Else if _relativeStart_ &lt; 0, let _startIndex_ be max(_length_ + _relativeStart_, 0).
-          1. Else, let _startIndex_ be min(_relativeStart_, _length_).
-          1. If _end_ is *undefined*, let _relativeEnd_ be _length_; else let _relativeEnd_ be ? ToIntegerOrInfinity(_end_).
-          1. If _relativeEnd_ = -∞, let _endIndex_ be 0.
-          1. Else if _relativeEnd_ &lt; 0, let _endIndex_ be max(_length_ + _relativeEnd_, 0).
-          1. Else, let _endIndex_ be min(_relativeEnd_, _length_).
+          1. Let _targetIndex_ be ? ToClampedIndex(_target_, _length_).
+          1. Let _startIndex_ be ? ToClampedIndex(_start_, _length_).
+          1. If _end_ is *undefined*, let _endIndex_ be _length_; else let _endIndex_ be ? ToClampedIndex(_end_, _length_).
           1. Let _count_ be min(_endIndex_ - _startIndex_, _length_ - _targetIndex_).
           1. If _count_ > 0, then
             1. NOTE: The copying must be performed in a manner that preserves the bit-level encoding of the source data.
@@ -42670,14 +42619,8 @@ THH:mm:ss.sss
           1. Let _length_ be TypedArrayLength(_taRecord_).
           1. If _obj_.[[ContentType]] is ~bigint~, set _value_ to ? ToBigInt(_value_).
           1. Else, set _value_ to ? ToNumber(_value_).
-          1. Let _relativeStart_ be ? ToIntegerOrInfinity(_start_).
-          1. If _relativeStart_ = -∞, let _startIndex_ be 0.
-          1. Else if _relativeStart_ &lt; 0, let _startIndex_ be max(_length_ + _relativeStart_, 0).
-          1. Else, let _startIndex_ be min(_relativeStart_, _length_).
-          1. If _end_ is *undefined*, let _relativeEnd_ be _length_; else let _relativeEnd_ be ? ToIntegerOrInfinity(_end_).
-          1. If _relativeEnd_ = -∞, let _endIndex_ be 0.
-          1. Else if _relativeEnd_ &lt; 0, let _endIndex_ be max(_length_ + _relativeEnd_, 0).
-          1. Else, let _endIndex_ be min(_relativeEnd_, _length_).
+          1. Let _startIndex_ be ? ToClampedIndex(_start_, _length_).
+          1. If _end_ is *undefined*, let _endIndex_ be _length_; else let _endIndex_ be ? ToClampedIndex(_end_, _length_).
           1. Set _taRecord_ to MakeTypedArrayWithBufferWitnessRecord(_obj_, ~seq-cst~).
           1. If IsTypedArrayOutOfBounds(_taRecord_) is *true*, throw a *TypeError* exception.
           1. Set _length_ to TypedArrayLength(_taRecord_).
@@ -42806,15 +42749,7 @@ THH:mm:ss.sss
           1. Let _taRecord_ be ? ValidateTypedArray(_obj_, ~seq-cst~).
           1. Let _length_ be TypedArrayLength(_taRecord_).
           1. If _length_ = 0, return *false*.
-          1. Let _n_ be ? ToIntegerOrInfinity(_fromIndex_).
-          1. Assert: If _fromIndex_ is *undefined*, then _n_ is 0.
-          1. If _n_ = +∞, return *false*.
-          1. If _n_ = -∞, set _n_ to 0.
-          1. If _n_ ≥ 0, then
-            1. Let _k_ be _n_.
-          1. Else,
-            1. Let _k_ be _length_ + _n_.
-            1. If _k_ &lt; 0, set _k_ to 0.
+          1. Let _k_ be ? ToClampedIndex(_fromIndex_, _length_).
           1. Repeat, while _k_ &lt; _length_,
             1. Let _elementK_ be ! Get(_obj_, ! ToString(𝔽(_k_))).
             1. If SameValueZero(_searchElement_, _elementK_) is *true*, return *true*.
@@ -42833,15 +42768,7 @@ THH:mm:ss.sss
           1. Let _taRecord_ be ? ValidateTypedArray(_obj_, ~seq-cst~).
           1. Let _length_ be TypedArrayLength(_taRecord_).
           1. If _length_ = 0, return *-1*<sub>𝔽</sub>.
-          1. Let _n_ be ? ToIntegerOrInfinity(_fromIndex_).
-          1. Assert: If _fromIndex_ is *undefined*, then _n_ is 0.
-          1. If _n_ = +∞, return *-1*<sub>𝔽</sub>.
-          1. If _n_ = -∞, set _n_ to 0.
-          1. If _n_ ≥ 0, then
-            1. Let _k_ be _n_.
-          1. Else,
-            1. Let _k_ be _length_ + _n_.
-            1. If _k_ &lt; 0, set _k_ to 0.
+          1. Let _k_ be ? ToClampedIndex(_fromIndex_, _length_).
           1. Repeat, while _k_ &lt; _length_,
             1. Let _propertyKey_ be ! ToString(𝔽(_k_)).
             1. Let _kPresent_ be ! HasProperty(_obj_, _propertyKey_).
@@ -42897,12 +42824,7 @@ THH:mm:ss.sss
           1. Let _taRecord_ be ? ValidateTypedArray(_obj_, ~seq-cst~).
           1. Let _length_ be TypedArrayLength(_taRecord_).
           1. If _length_ = 0, return *-1*<sub>𝔽</sub>.
-          1. If _fromIndex_ is present, let _n_ be ? ToIntegerOrInfinity(_fromIndex_); else let _n_ be _length_ - 1.
-          1. If _n_ = -∞, return *-1*<sub>𝔽</sub>.
-          1. If _n_ ≥ 0, then
-            1. Let _k_ be min(_n_, _length_ - 1).
-          1. Else,
-            1. Let _k_ be _length_ + _n_.
+          1. If _fromIndex_ is not present, let _k_ be _length_ - 1; else let _k_ be ? ToClampedIndex(_fromIndex_, _length_, -1, _length_ - 1).
           1. Repeat, while _k_ ≥ 0,
             1. Let _propertyKey_ be ! ToString(𝔽(_k_)).
             1. Let _kPresent_ be ! HasProperty(_obj_, _propertyKey_).
@@ -43146,14 +43068,8 @@ THH:mm:ss.sss
           1. Let _obj_ be the *this* value.
           1. Let _taRecord_ be ? ValidateTypedArray(_obj_, ~seq-cst~).
           1. Let _sourceArrayLength_ be TypedArrayLength(_taRecord_).
-          1. Let _relativeStart_ be ? ToIntegerOrInfinity(_start_).
-          1. If _relativeStart_ = -∞, let _startIndex_ be 0.
-          1. Else if _relativeStart_ &lt; 0, let _startIndex_ be max(_sourceArrayLength_ + _relativeStart_, 0).
-          1. Else, let _startIndex_ be min(_relativeStart_, _sourceArrayLength_).
-          1. If _end_ is *undefined*, let _relativeEnd_ be _sourceArrayLength_; else let _relativeEnd_ be ? ToIntegerOrInfinity(_end_).
-          1. If _relativeEnd_ = -∞, let _endIndex_ be 0.
-          1. Else if _relativeEnd_ &lt; 0, let _endIndex_ be max(_sourceArrayLength_ + _relativeEnd_, 0).
-          1. Else, let _endIndex_ be min(_relativeEnd_, _sourceArrayLength_).
+          1. Let _startIndex_ be ? ToClampedIndex(_start_, _sourceArrayLength_).
+          1. If _end_ is *undefined*, let _endIndex_ be _sourceArrayLength_; else let _endIndex_ be ? ToClampedIndex(_end_, _sourceArrayLength_).
           1. Let _countBytes_ be max(_endIndex_ - _startIndex_, 0).
           1. Let _resultArray_ be ? TypedArraySpeciesCreate(_obj_, « 𝔽(_countBytes_) »).
           1. If _countBytes_ > 0, then
@@ -43251,20 +43167,14 @@ THH:mm:ss.sss
             1. Let _sourceLength_ be 0.
           1. Else,
             1. Let _sourceLength_ be TypedArrayLength(_sourceRecord_).
-          1. Let _relativeStart_ be ? ToIntegerOrInfinity(_start_).
-          1. If _relativeStart_ = -∞, let _startIndex_ be 0.
-          1. Else if _relativeStart_ &lt; 0, let _startIndex_ be max(_sourceLength_ + _relativeStart_, 0).
-          1. Else, let _startIndex_ be min(_relativeStart_, _sourceLength_).
+          1. Let _startIndex_ be ? ToClampedIndex(_start_, _sourceLength_).
           1. Let _elementSize_ be TypedArrayElementSize(_obj_).
           1. Let _sourceByteOffset_ be _obj_.[[ByteOffset]].
           1. Let _beginByteOffset_ be _sourceByteOffset_ + (_startIndex_ × _elementSize_).
           1. If _obj_.[[ArrayLength]] is ~auto~ and _end_ is *undefined*, then
             1. Let _argList_ be « _buffer_, 𝔽(_beginByteOffset_) ».
           1. Else,
-            1. If _end_ is *undefined*, let _relativeEnd_ be _sourceLength_; else let _relativeEnd_ be ? ToIntegerOrInfinity(_end_).
-            1. If _relativeEnd_ = -∞, let _endIndex_ be 0.
-            1. Else if _relativeEnd_ &lt; 0, let _endIndex_ be max(_sourceLength_ + _relativeEnd_, 0).
-            1. Else, let _endIndex_ be min(_relativeEnd_, _sourceLength_).
+            1. If _end_ is *undefined*, let _endIndex_ be _sourceLength_; else let _endIndex_ be ? ToClampedIndex(_end_, _sourceLength_).
             1. Let _newLength_ be max(_endIndex_ - _startIndex_, 0).
             1. Let _argList_ be « _buffer_, 𝔽(_beginByteOffset_), 𝔽(_newLength_) ».
           1. Return ? TypedArraySpeciesCreate(_obj_, _argList_).
@@ -46188,14 +46098,8 @@ THH:mm:ss.sss
           1. If IsSharedArrayBuffer(_obj_) is *true*, throw a *TypeError* exception.
           1. If IsDetachedBuffer(_obj_) is *true*, throw a *TypeError* exception.
           1. Let _length_ be _obj_.[[ArrayBufferByteLength]].
-          1. Let _relativeStart_ be ? ToIntegerOrInfinity(_start_).
-          1. If _relativeStart_ = -∞, let _first_ be 0.
-          1. Else if _relativeStart_ &lt; 0, let _first_ be max(_length_ + _relativeStart_, 0).
-          1. Else, let _first_ be min(_relativeStart_, _length_).
-          1. If _end_ is *undefined*, let _relativeEnd_ be _length_; else let _relativeEnd_ be ? ToIntegerOrInfinity(_end_).
-          1. If _relativeEnd_ = -∞, let _final_ be 0.
-          1. Else if _relativeEnd_ &lt; 0, let _final_ be max(_length_ + _relativeEnd_, 0).
-          1. Else, let _final_ be min(_relativeEnd_, _length_).
+          1. Let _first_ be ? ToClampedIndex(_start_, _length_).
+          1. If _end_ is *undefined*, let _final_ be _length_; else let _final_ be ? ToClampedIndex(_end_, _length_).
           1. Let _newLength_ be max(_final_ - _first_, 0).
           1. Let _ctor_ be ? SpeciesConstructor(_obj_, %ArrayBuffer%).
           1. Let _new_ be ? Construct(_ctor_, « 𝔽(_newLength_) »).
@@ -46521,14 +46425,8 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_obj_, [[ArrayBufferData]]).
           1. If IsSharedArrayBuffer(_obj_) is *false*, throw a *TypeError* exception.
           1. Let _length_ be ArrayBufferByteLength(_obj_, ~seq-cst~).
-          1. Let _relativeStart_ be ? ToIntegerOrInfinity(_start_).
-          1. If _relativeStart_ = -∞, let _first_ be 0.
-          1. Else if _relativeStart_ &lt; 0, let _first_ be max(_length_ + _relativeStart_, 0).
-          1. Else, let _first_ be min(_relativeStart_, _length_).
-          1. If _end_ is *undefined*, let _relativeEnd_ be _length_; else let _relativeEnd_ be ? ToIntegerOrInfinity(_end_).
-          1. If _relativeEnd_ = -∞, let _final_ be 0.
-          1. Else if _relativeEnd_ &lt; 0, let _final_ be max(_length_ + _relativeEnd_, 0).
-          1. Else, let _final_ be min(_relativeEnd_, _length_).
+          1. Let _first_ be ? ToClampedIndex(_start_, _length_).
+          1. If _end_ is *undefined*, let _final_ be _length_; else let _final_ be ? ToClampedIndex(_end_, _length_).
           1. Let _newLength_ be max(_final_ - _first_, 0).
           1. Let _ctor_ be ? SpeciesConstructor(_obj_, %SharedArrayBuffer%).
           1. Let _new_ be ? Construct(_ctor_, « 𝔽(_newLength_) »).
@@ -54504,10 +54402,7 @@ THH:mm:ss.sss
           1. Perform ? RequireObjectCoercible(_obj_).
           1. Let _string_ be ? ToString(_obj_).
           1. Let _size_ be the length of _string_.
-          1. Let _intStart_ be ? ToIntegerOrInfinity(_start_).
-          1. If _intStart_ = -∞, set _intStart_ to 0.
-          1. Else if _intStart_ &lt; 0, set _intStart_ to max(_size_ + _intStart_, 0).
-          1. Else, set _intStart_ to min(_intStart_, _size_).
+          1. Let _intStart_ be ? ToClampedIndex(_start_, _size_).
           1. If _length_ is *undefined*, let _intLength_ be _size_; else let _intLength_ be the result of clamping ? ToIntegerOrInfinity(_length_) between 0 and _size_.
           1. Let _intEnd_ be min(_intStart_ + _intLength_, _size_).
           1. Return the substring of _string_ from _intStart_ to _intEnd_.

--- a/spec.html
+++ b/spec.html
@@ -43182,12 +43182,10 @@ THH:mm:ss.sss
           1. Let _sourceByteOffset_ be _obj_.[[ByteOffset]].
           1. Let _beginByteOffset_ be _sourceByteOffset_ + (_startIndex_ × _elementSize_).
           1. If _obj_.[[ArrayLength]] is ~auto~ and _end_ is *undefined*, then
-            1. Let _argList_ be « _buffer_, 𝔽(_beginByteOffset_) ».
-          1. Else,
-            1. If _end_ is *undefined*, let _endIndex_ be _sourceLength_; else let _endIndex_ be ? ToClampedIndex(_end_, _sourceLength_).
-            1. Let _newLength_ be max(_endIndex_ - _startIndex_, 0).
-            1. Let _argList_ be « _buffer_, 𝔽(_beginByteOffset_), 𝔽(_newLength_) ».
-          1. Return ? TypedArraySpeciesCreate(_obj_, _argList_).
+            1. Return ? TypedArraySpeciesCreate(_obj_, « _buffer_, 𝔽(_beginByteOffset_) »).
+          1. If _end_ is *undefined*, let _endIndex_ be _sourceLength_; else let _endIndex_ be ? ToClampedIndex(_end_, _sourceLength_).
+          1. Let _newLength_ be max(_endIndex_ - _startIndex_, 0).
+          1. Return ? TypedArraySpeciesCreate(_obj_, « _buffer_, 𝔽(_beginByteOffset_), 𝔽(_newLength_) »).
         </emu-alg>
         <p>This method is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
       </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -5725,8 +5725,8 @@
       </dl>
       <emu-alg>
         1. Let _length_ be ? ToIntegerOrInfinity(_arg_).
-        1. If _length_ ≤ 0, return *+0*<sub>𝔽</sub>.
-        1. Return 𝔽(min(_length_, 2<sup>53</sup> - 1)).
+        1. Let _actualLen_ be the result of clamping _length_ between 0 and 2<sup>53</sup> - 1.
+        1. Return 𝔽(_actualLen_).
       </emu-alg>
     </emu-clause>
 
@@ -31884,13 +31884,12 @@
           1. If _targetHasLength_ is *true*, then
             1. Let _targetLength_ be ? Get(_target_, *"length"*).
             1. If _targetLength_ is a Number, then
-              1. If _targetLength_ is *+∞*<sub>𝔽</sub>, then
+              1. Let _targetLengthAsInt_ be ! ToIntegerOrInfinity(_targetLength_).
+              1. If _targetLengthAsInt_ = +∞, then
                 1. Set _length_ to +∞.
-              1. Else if _targetLength_ is *-∞*<sub>𝔽</sub>, then
+              1. Else if _targetLengthAsInt_ = -∞, then
                 1. Set _length_ to 0.
               1. Else,
-                1. Let _targetLengthAsInt_ be ! ToIntegerOrInfinity(_targetLength_).
-                1. Assert: _targetLengthAsInt_ is finite.
                 1. Let _argCount_ be the number of elements in _args_.
                 1. Set _length_ to max(_targetLengthAsInt_ - _argCount_, 0).
           1. Perform SetFunctionLength(_boundFunc_, _length_).
@@ -36290,8 +36289,7 @@ THH:mm:ss.sss
           1. If _isRegexp_ is *true*, throw a *TypeError* exception.
           1. Set _searchString_ to ? ToString(_searchString_).
           1. Let _length_ be the length of _string_.
-          1. If _endPosition_ is *undefined*, let _position_ be _length_; else let _position_ be ? ToIntegerOrInfinity(_endPosition_).
-          1. Let _end_ be the result of clamping _position_ between 0 and _length_.
+          1. If _endPosition_ is *undefined*, let _end_ be _length_; else let _end_ be the result of clamping ? ToIntegerOrInfinity(_endPosition_) between 0 and _length_.
           1. Let _searchLength_ be the length of _searchString_.
           1. If _searchLength_ = 0, return *true*.
           1. Let _start_ be _end_ - _searchLength_.
@@ -36318,10 +36316,9 @@ THH:mm:ss.sss
           1. Let _isRegexp_ be ? IsRegExp(_searchString_).
           1. If _isRegexp_ is *true*, throw a *TypeError* exception.
           1. Set _searchString_ to ? ToString(_searchString_).
-          1. Let _positionInt_ be ? ToIntegerOrInfinity(_position_).
-          1. Assert: If _position_ is *undefined*, then _positionInt_ is 0.
           1. Let _length_ be the length of _string_.
-          1. Let _start_ be the result of clamping _positionInt_ between 0 and _length_.
+          1. Let _start_ be the result of clamping ? ToIntegerOrInfinity(_position_) between 0 and _length_.
+          1. Assert: If _position_ is *undefined*, then _start_ is 0.
           1. Let _index_ be StringIndexOf(_string_, _searchString_, _start_).
           1. If _index_ is ~not-found~, return *false*.
           1. Return *true*.
@@ -36348,10 +36345,9 @@ THH:mm:ss.sss
           1. Perform ? RequireObjectCoercible(_thisValue_).
           1. Let _string_ be ? ToString(_thisValue_).
           1. Set _searchString_ to ? ToString(_searchString_).
-          1. Let _positionInt_ be ? ToIntegerOrInfinity(_position_).
-          1. Assert: If _position_ is *undefined*, then _positionInt_ is 0.
           1. Let _length_ be the length of _string_.
-          1. Let _start_ be the result of clamping _positionInt_ between 0 and _length_.
+          1. Let _start_ be the result of clamping ? ToIntegerOrInfinity(_position_) between 0 and _length_.
+          1. Assert: If _position_ is *undefined*, then _start_ is 0.
           1. Let _result_ be StringIndexOf(_string_, _searchString_, _start_).
           1. If _result_ is ~not-found~, return *-1*<sub>𝔽</sub>.
           1. Return 𝔽(_result_).
@@ -36384,12 +36380,12 @@ THH:mm:ss.sss
           1. Let _string_ be ? ToString(_thisValue_).
           1. Set _searchString_ to ? ToString(_searchString_).
           1. Let _numberPosition_ be ? ToNumber(_position_).
-          1. Assert: If _position_ is *undefined*, then _numberPosition_ is *NaN*.
-          1. If _numberPosition_ is *NaN*, set _position_ to +∞; else set _position_ to ! ToIntegerOrInfinity(_numberPosition_).
           1. Let _length_ be the length of _string_.
           1. Let _searchLength_ be the length of _searchString_.
-          1. If _length_ &lt; _searchLength_, return *-1*<sub>𝔽</sub>.
-          1. Let _start_ be the result of clamping _position_ between 0 and _length_ - _searchLength_.
+          1. Let _maxStart_ be _length_ - _searchLength_.
+          1. If _maxStart_ &lt; 0, return *-1*<sub>𝔽</sub>.
+          1. If _numberPosition_ is *NaN*, let _start_ be _maxStart_; else let _start_ be the result of clamping ! ToIntegerOrInfinity(_numberPosition_) between 0 and _maxStart_.
+          1. Assert: If _position_ is *undefined*, then _start_ is _maxStart_.
           1. Let _result_ be StringLastIndexOf(_string_, _searchString_, _start_).
           1. If _result_ is ~not-found~, return *-1*<sub>𝔽</sub>.
           1. Return 𝔽(_result_).
@@ -36876,8 +36872,8 @@ THH:mm:ss.sss
           1. If _isRegexp_ is *true*, throw a *TypeError* exception.
           1. Set _searchString_ to ? ToString(_searchString_).
           1. Let _length_ be the length of _string_.
-          1. If _position_ is *undefined*, set _position_ to 0; else set _position_ to ? ToIntegerOrInfinity(_position_).
-          1. Let _start_ be the result of clamping _position_ between 0 and _length_.
+          1. Let _start_ be the result of clamping ? ToIntegerOrInfinity(_position_) between 0 and _length_.
+          1. Assert: If _position_ is *undefined*, then _start_ is 0.
           1. Let _searchLength_ be the length of _searchString_.
           1. If _searchLength_ = 0, return *true*.
           1. Let _end_ be _start_ + _searchLength_.
@@ -36905,10 +36901,9 @@ THH:mm:ss.sss
           1. Perform ? RequireObjectCoercible(_thisValue_).
           1. Let _string_ be ? ToString(_thisValue_).
           1. Let _length_ be the length of _string_.
-          1. Let _intStart_ be ? ToIntegerOrInfinity(_start_).
-          1. If _end_ is *undefined*, let _intEnd_ be _length_; else let _intEnd_ be ? ToIntegerOrInfinity(_end_).
-          1. Let _finalStart_ be the result of clamping _intStart_ between 0 and _length_.
-          1. Let _finalEnd_ be the result of clamping _intEnd_ between 0 and _length_.
+          1. Let _finalStart_ be the result of clamping ? ToIntegerOrInfinity(_start_) between 0 and _length_.
+          1. Assert: If _start_ is *undefined*, then _finalStart_ is 0.
+          1. If _end_ is *undefined*, let _finalEnd_ be _length_; else let _finalEnd_ be the result of clamping ? ToIntegerOrInfinity(_end_) between 0 and _length_.
           1. Let _from_ be min(_finalStart_, _finalEnd_).
           1. Let _to_ be max(_finalStart_, _finalEnd_).
           1. Return the substring of _string_ from _from_ to _to_.
@@ -54513,8 +54508,7 @@ THH:mm:ss.sss
           1. If _intStart_ = -∞, set _intStart_ to 0.
           1. Else if _intStart_ &lt; 0, set _intStart_ to max(_size_ + _intStart_, 0).
           1. Else, set _intStart_ to min(_intStart_, _size_).
-          1. If _length_ is *undefined*, let _intLength_ be _size_; else let _intLength_ be ? ToIntegerOrInfinity(_length_).
-          1. Set _intLength_ to the result of clamping _intLength_ between 0 and _size_.
+          1. If _length_ is *undefined*, let _intLength_ be _size_; else let _intLength_ be the result of clamping ? ToIntegerOrInfinity(_length_) between 0 and _size_.
           1. Let _intEnd_ be min(_intStart_ + _intLength_, _size_).
           1. Return the substring of _string_ from _intStart_ to _intEnd_.
         </emu-alg>

--- a/spec.html
+++ b/spec.html
@@ -5766,26 +5766,38 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-toabsoluteindex" type="abstract operation">
+      <h1>
+        ToAbsoluteIndex (
+          _value_: an ECMAScript language value,
+          _length_: a non-negative integer,
+        ): either a normal completion containing either an integer, +&infin;, or -&infin;, or a throw completion
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It converts _value_ to an integer, +∞, or -∞, interpreting negative values relative to _length_.</dd>
+      </dl>
+      <emu-alg>
+        1. Let _int_ be ? ToIntegerOrInfinity(_value_).
+        1. If _int_ is finite and _int_ &lt; 0, set _int_ to _length_ + _int_.
+        1. Return _int_.
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-toclampedindex" type="abstract operation">
       <h1>
         ToClampedIndex (
           _value_: an ECMAScript language value,
           _length_: a non-negative integer,
-          optional _lowerBound_: an integer,
-          optional _upperBound_: an integer,
-        ): either a normal completion containing an integer or a throw completion
+        ): either a normal completion containing a non-negative integer or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It converts _value_ to an integer (interpreting negative values relative to _length_) and clamps the result to the inclusive interval from _lowerBound_ to _upperBound_ (respectively defaulting to 0 and _length_).</dd>
+        <dd>It converts _value_ to an integer (interpreting negative values relative to _length_) and clamps the result to the inclusive interval from 0 to _length_.</dd>
       </dl>
       <emu-alg>
-        1. If _lowerBound_ is not present, set _lowerBound_ to 0.
-        1. If _upperBound_ is not present, set _upperBound_ to _length_.
-        1. Assert: _lowerBound_ ≤ _upperBound_.
-        1. Let _integer_ be ? ToIntegerOrInfinity(_value_).
-        1. If _integer_ is finite and _integer_ &lt; 0, set _integer_ to _length_ + _integer_.
-        1. Return the result of clamping _integer_ between _lowerBound_ and _upperBound_.
+        1. Let _index_ be ? ToAbsoluteIndex(_value_, _length_).
+        1. Return the result of clamping _index_ between 0 and _length_.
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -36202,7 +36214,7 @@ THH:mm:ss.sss
           1. Perform ? RequireObjectCoercible(_thisValue_).
           1. Let _string_ be ? ToString(_thisValue_).
           1. Let _length_ be the length of _string_.
-          1. Let _k_ be ? ToClampedIndex(_index_, _length_, -1).
+          1. Let _k_ be ? ToAbsoluteIndex(_index_, _length_).
           1. If _k_ &lt; 0 or _k_ ≥ _length_, return *undefined*.
           1. Return the substring of _string_ from _k_ to _k_ + 1.
         </emu-alg>
@@ -40720,7 +40732,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _obj_ be ? ToObject(*this* value).
           1. Let _length_ be ? LengthOfArrayLike(_obj_).
-          1. Let _k_ be ? ToClampedIndex(_index_, _length_, -1).
+          1. Let _k_ be ? ToAbsoluteIndex(_index_, _length_).
           1. If _k_ &lt; 0 or _k_ ≥ _length_, return *undefined*.
           1. Return ? Get(_obj_, ! ToString(𝔽(_k_))).
         </emu-alg>
@@ -41233,7 +41245,7 @@ THH:mm:ss.sss
           1. Let _obj_ be ? ToObject(*this* value).
           1. Let _length_ be ? LengthOfArrayLike(_obj_).
           1. If _length_ = 0, return *-1*<sub>𝔽</sub>.
-          1. If _fromIndex_ is not present, let _k_ be _length_ - 1; else let _k_ be ? ToClampedIndex(_fromIndex_, _length_, -1, _length_ - 1).
+          1. If _fromIndex_ is not present, let _k_ be _length_ - 1; else let _k_ be min(? ToAbsoluteIndex(_fromIndex_, _length_), _length_ - 1).
           1. Repeat, while _k_ ≥ 0,
             1. Let _propertyKey_ be ! ToString(𝔽(_k_)).
             1. Let _kPresent_ be ? HasProperty(_obj_, _propertyKey_).
@@ -41917,10 +41929,8 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _obj_ be ? ToObject(*this* value).
           1. Let _length_ be ? LengthOfArrayLike(_obj_).
-          1. Let _relativeIndex_ be ? ToIntegerOrInfinity(_index_).
-          1. If _relativeIndex_ ≥ 0, let _actualIndex_ be _relativeIndex_.
-          1. Else, let _actualIndex_ be _length_ + _relativeIndex_.
-          1. If _actualIndex_ ≥ _length_ or _actualIndex_ &lt; 0, throw a *RangeError* exception.
+          1. Let _actualIndex_ be ? ToAbsoluteIndex(_index_, _length_).
+          1. If _actualIndex_ &lt; 0 or _actualIndex_ ≥ _length_, throw a *RangeError* exception.
           1. Let _array_ be ? ArrayCreate(_length_).
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _length_,
@@ -42486,7 +42496,7 @@ THH:mm:ss.sss
           1. Let _obj_ be the *this* value.
           1. Let _taRecord_ be ? ValidateTypedArray(_obj_, ~seq-cst~).
           1. Let _length_ be TypedArrayLength(_taRecord_).
-          1. Let _k_ be ? ToClampedIndex(_index_, _length_, -1).
+          1. Let _k_ be ? ToAbsoluteIndex(_index_, _length_).
           1. If _k_ &lt; 0 or _k_ ≥ _length_, return *undefined*.
           1. Return ! Get(_obj_, ! ToString(𝔽(_k_))).
         </emu-alg>
@@ -42824,7 +42834,7 @@ THH:mm:ss.sss
           1. Let _taRecord_ be ? ValidateTypedArray(_obj_, ~seq-cst~).
           1. Let _length_ be TypedArrayLength(_taRecord_).
           1. If _length_ = 0, return *-1*<sub>𝔽</sub>.
-          1. If _fromIndex_ is not present, let _k_ be _length_ - 1; else let _k_ be ? ToClampedIndex(_fromIndex_, _length_, -1, _length_ - 1).
+          1. If _fromIndex_ is not present, let _k_ be _length_ - 1; else let _k_ be min(? ToAbsoluteIndex(_fromIndex_, _length_), _length_ - 1).
           1. Repeat, while _k_ ≥ 0,
             1. Let _propertyKey_ be ! ToString(𝔽(_k_)).
             1. Let _kPresent_ be ! HasProperty(_obj_, _propertyKey_).
@@ -43253,9 +43263,7 @@ THH:mm:ss.sss
           1. Let _obj_ be the *this* value.
           1. Let _taRecord_ be ? ValidateTypedArray(_obj_, ~seq-cst~).
           1. Let _length_ be TypedArrayLength(_taRecord_).
-          1. Let _relativeIndex_ be ? ToIntegerOrInfinity(_index_).
-          1. If _relativeIndex_ ≥ 0, let _actualIndex_ be _relativeIndex_.
-          1. Else, let _actualIndex_ be _length_ + _relativeIndex_.
+          1. Let _actualIndex_ be ? ToAbsoluteIndex(_index_, _length_).
           1. If _obj_.[[ContentType]] is ~bigint~, let _numericValue_ be ? ToBigInt(_value_).
           1. Else, let _numericValue_ be ? ToNumber(_value_).
           1. If IsValidIntegerIndex(_obj_, 𝔽(_actualIndex_)) is *false*, throw a *RangeError* exception.

--- a/spec.html
+++ b/spec.html
@@ -41702,6 +41702,7 @@ THH:mm:ss.sss
             1. Let _actualDeleteCount_ be 0.
           1. Else if _deleteCount_ is not present, then
             1. Let _actualDeleteCount_ be _length_ - _actualStart_.
+            1. Assert: _actualDeleteCount_ ≥ 0.
           1. Else,
             1. Let _dc_ be ? ToIntegerOrInfinity(_deleteCount_).
             1. Let _actualDeleteCount_ be the result of clamping _dc_ between 0 and _length_ - _actualStart_.
@@ -42579,6 +42580,7 @@ THH:mm:ss.sss
             1. Else,
               1. Let _direction_ be 1.
             1. Repeat, while _countBytes_ > 0,
+              1. Assert: _fromByteIndex_ ≥ 0 and _toByteIndex_ ≥ 0.
               1. Let _value_ be GetValueFromBuffer(_buffer_, _fromByteIndex_, ~uint8~, *true*, ~unordered~).
               1. Perform SetValueInBuffer(_buffer_, _toByteIndex_, ~uint8~, _value_, *true*, ~unordered~).
               1. Set _fromByteIndex_ to _fromByteIndex_ + _direction_.
@@ -46119,8 +46121,9 @@ THH:mm:ss.sss
           1. Let _fromBuf_ be _obj_.[[ArrayBufferData]].
           1. Let _toBuf_ be _new_.[[ArrayBufferData]].
           1. Let _currentLength_ be _obj_.[[ArrayBufferByteLength]].
-          1. If _first_ &lt; _currentLength_, then
-            1. Let _count_ be min(_newLength_, _currentLength_ - _first_).
+          1. Let _maxCount_ be _currentLength_ - _first_.
+          1. If _maxCount_ > 0, then
+            1. Let _count_ be min(_newLength_, _maxCount_).
             1. Perform CopyDataBlockBytes(_toBuf_, 0, _fromBuf_, _first_, _count_).
           1. Return _new_.
         </emu-alg>


### PR DESCRIPTION
* Reduce single-use aliases.
* Introduce `ToClampedIndex` for relative-to-start-or-end index values.