### PR TITLE
Editorial: Add a missing check in String.prototype.substring

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -34197,6 +34197,7 @@ THH:mm:ss.sss
           1. Let _finalEnd_ be the result of clamping _intEnd_ between 0 and _len_.
           1. Let _from_ be min(_finalStart_, _finalEnd_).
           1. Let _to_ be max(_finalStart_, _finalEnd_).
+          1. If _from_ = _to_, return the empty String.
           1. Return the substring of _S_ from _from_ to _to_.
         </emu-alg>
         <emu-note>


### PR DESCRIPTION
Not necessary, but (IMO) helpful.