### PR TITLE
Fixed bugs in return type of CatchClauseEvaluation algorithm

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -22912,7 +22912,7 @@
       <h1>
         Runtime Semantics: CatchClauseEvaluation (
           _thrownValue_: an ECMAScript language value,
-        ): either a normal completion containing an ECMAScript language value or an abrupt completion
+        ): either a normal completion containing either an ECMAScript language value or ~empty~, or an abrupt completion
       </h1>
       <dl class="header">
       </dl>


### PR DESCRIPTION
We found the return type bug in the syntax-directed operation: [14.15.2 Runtime semantics: CatchClauseEvaluation](https://tc39.es/ecma262/#sec-runtime-semantics-catchclauseevaluation) via [ESMeta](https://github.com/es-meta/esmeta) type analyzer.

Currently, the type of `CatchClauseEvaluation` is defined as follows:
```
       Runtime Semantics: CatchClauseEvaluation (
         _thrownValue_: an ECMAScript language value,
       ): either a normal completion containing an ECMAScript language value or an abrupt completion
```

However, I think its return type should contain `a normal completion containing ~empty~`.

In step 7 for ``Catch : `catch` `(` CatchParameter `)` Block`` case, the variable `B` stores the result of `Evaluation of |Block|`. According to [14.2.2 Runtime Semantics: Evaluation](https://tc39.es/ecma262/#sec-block-runtime-semantics-evaluation), the variable `B` might be a normal completion containing `~empty~`. Then, step 9 returns the value stored in the variable `B`.

Similarly, in step 1 for ``Catch : `catch` Block`` case, it directly returns the result of `Evaluation of |Block|`.

Therefore, I suggest extending its return type as follows:
```diff
         Runtime Semantics: CatchClauseEvaluation (
           _thrownValue_: an ECMAScript language value,
-        ): either a normal completion containing an ECMAScript language value or an abrupt completion
+        ): either a normal completion containing either an ECMAScript language value or ~empty~, or an abrupt completion
```