### PR TITLE
Fixed bugs in parameter type of AddEntriesFromIterable algorithm

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -24772,7 +24772,7 @@
       <h1>
         Runtime Semantics: EvaluateClassStaticBlockBody (
           _functionObject_: a function object,
-        ): either a normal completion containing an ECMAScript language value or an abrupt completion
+        ): either a normal completion containing an either ECMAScript language value or ~empty~, or an abrupt completion
       </h1>
       <dl class="header">
       </dl>

--- a/spec.html
+++ b/spec.html
@@ -39948,7 +39948,7 @@ THH:mm:ss.sss
           AddEntriesFromIterable (
             _target_: an Object,
             _iterable_: an ECMAScript language value, but not *undefined* or *null*,
-            _adder_: a function object,
+            _adder_: an ECMAScript language value,
           ): either a normal completion containing an ECMAScript language value or a throw completion
         </h1>
         <dl class="header">

--- a/spec.html
+++ b/spec.html
@@ -24772,7 +24772,7 @@
       <h1>
         Runtime Semantics: EvaluateClassStaticBlockBody (
           _functionObject_: a function object,
-        ): either a normal completion containing an either ECMAScript language value or ~empty~, or an abrupt completion
+        ): either a normal completion containing either an ECMAScript language value or ~empty~, or an abrupt completion
       </h1>
       <dl class="header">
       </dl>


### PR DESCRIPTION
We found a bug in parameter types of the abstract algorithm [24.1.1.2 AddEntriesFromIterable](24.1.1.2 AddEntriesFromIterable) via [ESMeta](https://github.com/es-meta/esmeta) type analyzer.

Currently, the type of `AddEntriesFromIterable` AO is defined as follows:
```
AddEntriesFromIterable (
  _target_: an Object,
  _iterable_: an ECMAScript language value, but not *undefined* or *null*,
  _adder_: a function object,
): either a normal completion containing an ECMAScript language value or a throw completion
```
However, I think the parameter `adder` could have any ECMAScript value.
The `AddEntriesFromIterable` is referred in three different algorithms:
- [Step 6 in 20.1.2.7 Object.fromEntries](https://tc39.es/ecma262/#_ref_8810)
- [Step 6 in Step 24.1.1.1 Map](https://tc39.es/ecma262/#_ref_12341)
- [Step 6 in 24.3.1.1 WeakMap](https://tc39.es/ecma262/#_ref_12522)

In `Object.fromEntries`, the argument of `adder` is always created by invoking [10.3.3 CreateBuiltinFunction](https://tc39.es/ecma262/#sec-createbuiltinfunction). Thus, it is always a function object in this case.

However, in the other two invocations in `Map` and `WeakMap`, the argument of `adder` is created by invoking the following step:
```
5. Let _adder_ be ? Get(_map_, *"set"*).
```
Thus, we can insert any ECMAScript values by modifying the value of `Map.prototype.set` or `WeakMap.prototype.set` as follows:
```js
Object.defineProperty(
  Map.prototype,
  "set",
  {
    get: () => {
      console.log(42);
      return 42 /* any value */;
    }
  }
);
new Map([1, 2]);
// 42
// Uncaught:
// TypeError: '42' returned for property 'set' of object '#<Map>' is not a function at new Map (<anonymous>)
```

Therefore, I suggest extending the type of the parameter `adder` as follows:

```diff
           AddEntriesFromIterable (
             _target_: an Object,
             _iterable_: an ECMAScript language value, but not *undefined* or *null*,
-            _adder_: a function object,
+            _adder_: an ECMAScript language value,
           ): either a normal completion containing an ECMAScript language value or a throw completion
```