### PR TITLE
Fixed bugs in return type of EvaluateClassStaticBlockBody algorithm

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -24772,7 +24772,7 @@
       <h1>
         Runtime Semantics: EvaluateClassStaticBlockBody (
           _functionObject_: a function object,
-        ): either a normal completion containing an ECMAScript language value or an abrupt completion
+        ): either a normal completion containing an either ECMAScript language value or ~empty~, or an abrupt completion
       </h1>
       <dl class="header">
       </dl>

--- a/spec.html
+++ b/spec.html
@@ -24772,7 +24772,7 @@
       <h1>
         Runtime Semantics: EvaluateClassStaticBlockBody (
           _functionObject_: a function object,
-        ): either a normal completion containing an either ECMAScript language value or ~empty~, or an abrupt completion
+        ): either a normal completion containing either an ECMAScript language value or ~empty~, or an abrupt completion
       </h1>
       <dl class="header">
       </dl>


### PR DESCRIPTION
We found the return type bug in the syntax-directed operation: [15.7.12 Runtime Semantics: EvaluateClassStaticBlockBody](https://tc39.es/ecma262/#sec-runtime-semantics-evaluateclassstaticblockbody) via [ESMeta](https://github.com/es-meta/esmeta) type analyzer.

Currently, the type of `CatchClauseEvaluation` is defined as follows:
```
Runtime Semantics: EvaluateClassStaticBlockBody (
  _functionObject_: a function object,
): either a normal completion containing an ECMAScript language value or an abrupt completion
```

However, I think its return type should contain `a normal completion containing ~empty~`.

In step 2 for, it returns the result of `Evaluation of |ClassStaticBlockStatementList|`. Because of the implicit definition of operations for chain productions (`ClassStaticBlockStatementList` -> `StatementList` -> `StatementListItem` -> `Statement` -> `BlockStatement` -> `Block`), the `Evaluation of |Block|` might be invoked, and it returns a normal completion containing `~empty~`. Thus, `CatchClauseEvaluation` algorithm could return `a normal completion containing ~empty~`.

Therefore, I suggest extending its return type as follows:
```diff
         Runtime Semantics: EvaluateClassStaticBlockBody (
           _functionObject_: a function object,
-        ): either a normal completion containing an ECMAScript language value or an abrupt completion
+        ): either a normal completion containing either an ECMAScript language value or ~empty~, or an abrupt completion
```