### PR TITLE
Editorial: move adder callability check out of `AddEntriesFromIterable`

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -40219,6 +40219,7 @@ THH:mm:ss.sss
           1. Set _map_.[[MapData]] to a new empty List.
           1. If _iterable_ is either *undefined* or *null*, return _map_.
           1. Let _adder_ be ? Get(_map_, *"set"*).
+          1. If IsCallable(_adder_) is *false*, throw a *TypeError* exception.
           1. Return ? AddEntriesFromIterable(_map_, _iterable_, _adder_).
         </emu-alg>
         <emu-note>
@@ -40239,7 +40240,6 @@ THH:mm:ss.sss
           <dd>_adder_ will be invoked, with _target_ as the receiver.</dd>
         </dl>
         <emu-alg>
-          1. If IsCallable(_adder_) is *false*, throw a *TypeError* exception.
           1. Let _iteratorRecord_ be ? GetIterator(_iterable_).
           1. Repeat,
             1. Let _next_ be ? IteratorStep(_iteratorRecord_).
@@ -40858,6 +40858,7 @@ THH:mm:ss.sss
           1. Set _map_.[[WeakMapData]] to a new empty List.
           1. If _iterable_ is either *undefined* or *null*, return _map_.
           1. Let _adder_ be ? Get(_map_, *"set"*).
+          1. If IsCallable(_adder_) is *false*, throw a *TypeError* exception.
           1. Return ? AddEntriesFromIterable(_map_, _iterable_, _adder_).
         </emu-alg>
         <emu-note>


### PR DESCRIPTION
We found a bug in parameter types of the abstract algorithm [24.1.1.2 AddEntriesFromIterable](24.1.1.2 AddEntriesFromIterable) via [ESMeta](https://github.com/es-meta/esmeta) type analyzer.

Currently, the type of `AddEntriesFromIterable` AO is defined as follows:
```
AddEntriesFromIterable (
  _target_: an Object,
  _iterable_: an ECMAScript language value, but not *undefined* or *null*,
  _adder_: a function object,
): either a normal completion containing an ECMAScript language value or a throw completion
```
However, I think the parameter `adder` could have any ECMAScript value.
The `AddEntriesFromIterable` is referred in three different algorithms:
- [Step 6 in 20.1.2.7 Object.fromEntries](https://tc39.es/ecma262/#_ref_8810)
- [Step 6 in Step 24.1.1.1 Map](https://tc39.es/ecma262/#_ref_12341)
- [Step 6 in 24.3.1.1 WeakMap](https://tc39.es/ecma262/#_ref_12522)

In `Object.fromEntries`, the argument of `adder` is always created by invoking [10.3.3 CreateBuiltinFunction](https://tc39.es/ecma262/#sec-createbuiltinfunction). Thus, it is always a function object in this case.

However, in the other two invocations in `Map` and `WeakMap`, the argument of `adder` is created by invoking the following step:
```
5. Let _adder_ be ? Get(_map_, *"set"*).
```
Thus, we can insert any ECMAScript values by modifying the value of `Map.prototype.set` or `WeakMap.prototype.set` as follows:
```js
Object.defineProperty(
  Map.prototype,
  "set",
  {
    get: () => {
      console.log(42);
      return 42 /* any value */;
    }
  }
);
new Map([1, 2]);
// 42
// Uncaught:
// TypeError: '42' returned for property 'set' of object '#<Map>' is not a function at new Map (<anonymous>)
```

Therefore, I suggest extending the type of the parameter `adder` as follows:

```diff
           AddEntriesFromIterable (
             _target_: an Object,
             _iterable_: an ECMAScript language value, but not *undefined* or *null*,
-            _adder_: a function object,
+            _adder_: an ECMAScript language value,
           ): either a normal completion containing an ECMAScript language value or a throw completion
```