### PR TITLE
Editorial: Fix return type of ChainEvaluation algorithm

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -19393,7 +19393,7 @@
           Runtime Semantics: ChainEvaluation (
             _baseValue_: an ECMAScript language value,
             _baseReference_: an ECMAScript language value or a Reference Record,
-          ): either a normal completion containing an ECMAScript language value or an abrupt completion
+          ): either a normal completion containing either an ECMAScript language value or a Reference Record, or an abrupt completion
         </h1>
         <dl class="header">
         </dl>


### PR DESCRIPTION
We found the return type bug in the syntax-directed operation: [13.3.9.2 Runtime Semantics: ChainEvaluation](https://tc39.es/ecma262/#sec-optional-chaining-chain-evaluation) via [ESMeta](https://github.com/es-meta/esmeta) type analyzer.

Currently, the type of `ChainEvaluation` is defined as follows:
```
Runtime Semantics: ChainEvaluation (
  _baseValue_: an ECMAScript language value,
  _baseReference_: an ECMAScript language value or a Reference Record,
): either a normal completion containing an ECMAScript language value or an abrupt completion
completion
```

However, I think its return type should contain `a normal completion containing a Reference Record`.

For the following cases, it invokes [13.3.6.2 EvaluateCall](https://tc39.es/ecma262/#sec-evaluatecall) and returns its result. So, it really returns a completion record of an ECMAScript language value.
- ``OptionalChain : `?.` Arguments``
- ``OptionalChain : OptionalChain Arguments``

However, in the following other cases, it invokes [13.3.3 EvaluatePropertyAccessWithExpressionKey](https://tc39.es/ecma262/#sec-evaluate-property-access-with-expression-key), [13.3.4 EvaluatePropertyAccessWithIdentifierKey](https://tc39.es/ecma262/#sec-evaluate-property-access-with-identifier-key), or [6.2.5.9 MakePrivateReference](https://tc39.es/ecma262/#sec-makeprivatereference) and returns its result. All these algorithms return `a normal completion record containing a Reference Record`.

Therefore, I suggest extending its return type as follows:
```diff
           Runtime Semantics: ChainEvaluation (
             _baseValue_: an ECMAScript language value,
             _baseReference_: an ECMAScript language value or a Reference Record,
-          ): either a normal completion containing an ECMAScript language value or an abrupt completion
+          ): either a normal completion containing either an ECMAScript language value or a Reference Record, or an abrupt completion
```