### PR TITLE
Editorial: Document use of <ABBREV> grammar covering multiple code points

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -585,7 +585,7 @@
         <p>In contrast, in the syntactic grammar, a contiguous run of fixed-width code points is a single terminal symbol.</p>
         <p>Terminal symbols come in two other forms:</p>
         <ul>
-          <li>In the lexical and RegExp grammars, Unicode code points without a conventional printed representation are instead shown in the form "&lt;ABBREV&gt;" where "ABBREV" is a mnemonic for the code point. These forms are defined in <emu-xref href="#sec-unicode-format-control-characters" title></emu-xref> and <emu-xref href="#sec-white-space" title></emu-xref>.</li>
+          <li>In the lexical and RegExp grammars, Unicode code points without a conventional printed representation are instead shown in the form "&lt;ABBREV&gt;" where "ABBREV" is a mnemonic for the code point or set of code points. These forms are defined in <emu-xref href="#sec-unicode-format-control-characters" title></emu-xref>, <emu-xref href="#sec-white-space" title></emu-xref>, and <emu-xref href="#sec-line-terminators" title></emu-xref>.</li>
           <li>In the syntactic grammar, certain terminal symbols (e.g. |IdentifierName| and |RegularExpressionLiteral|) are shown in italics, as they refer to the nonterminals of the same name in the lexical grammar.</li>
         </ul>
       </emu-clause>
@@ -16223,7 +16223,7 @@
       <table>
         <tr>
           <th>
-            Code Point
+            Code Points
           </th>
           <th>
             Name
@@ -16278,10 +16278,9 @@
         </tr>
         <tr>
           <td>
-            Category &ldquo;Zs&rdquo;
+            any code point in general category &ldquo;Space_Separator&rdquo;
           </td>
           <td>
-            Any Unicode &ldquo;Space_Separator&rdquo; code point
           </td>
           <td>
             &lt;USP&gt;
@@ -16293,7 +16292,7 @@
       <p>U+0020 (SPACE) and U+00A0 (NO-BREAK SPACE) code points are part of &lt;USP&gt;.</p>
     </emu-note>
     <emu-note>
-      <p>Other than for the code points listed in <emu-xref href="#table-white-space-code-points"></emu-xref>, ECMAScript |WhiteSpace| intentionally excludes all code points that have the Unicode &ldquo;White_Space&rdquo; property but which are not classified in category &ldquo;Space_Separator&rdquo; (&ldquo;Zs&rdquo;).</p>
+      <p>Other than for the code points listed in <emu-xref href="#table-white-space-code-points"></emu-xref>, ECMAScript |WhiteSpace| intentionally excludes all code points that have the Unicode &ldquo;White_Space&rdquo; property but which are not classified in general category &ldquo;Space_Separator&rdquo; (&ldquo;Zs&rdquo;).</p>
     </emu-note>
     <h2>Syntax</h2>
     <emu-grammar type="definition">


### PR DESCRIPTION
Fixes #2927