### PR TITLE
Editorial: EvaluateClassStaticBlockBody cannot throw during function instantiation

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -24816,7 +24816,7 @@
         1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
         1. Let _sourceText_ be the empty sequence of Unicode code points.
         1. Let _formalParameters_ be an instance of the production <emu-grammar>FormalParameters : [empty]</emu-grammar>.
-        1. Let _bodyFunction_ be OrdinaryFunctionCreate(%Function.prototype%, _sourceText_, _formalParameters_, |ClassStaticBlockBody|, ~non-lexical-this~, _lex_, _privateEnv_).
+        1. [id="step-synthetic-class-static-block-fn"] Let _bodyFunction_ be OrdinaryFunctionCreate(%Function.prototype%, _sourceText_, _formalParameters_, |ClassStaticBlockBody|, ~non-lexical-this~, _lex_, _privateEnv_).
         1. Perform MakeMethod(_bodyFunction_, _homeObject_).
         1. Return the ClassStaticBlockDefinition Record { [[BodyFunction]]: _bodyFunction_ }.
       </emu-alg>
@@ -24833,7 +24833,8 @@
       </dl>
       <emu-grammar>ClassStaticBlockBody : ClassStaticBlockStatementList</emu-grammar>
       <emu-alg>
-        1. Perform ? FunctionDeclarationInstantiation(_functionObject_, « »).
+        1. Assert: _functionObject_ is a synthetic function created by ClassStaticBlockDefinitionEvaluation step <emu-xref href="#step-synthetic-class-static-block-fn"></emu-xref>.
+        1. Perform ! FunctionDeclarationInstantiation(_functionObject_, « »).
         1. Return ? Evaluation of |ClassStaticBlockStatementList|.
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
This changes a `?` to a `!` in [EvaluateClassStaticBlockBody](https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-runtime-semantics-evaluateclassstaticblockbody).

[FunctionDeclarationInstantiation](https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-functiondeclarationinstantiation) only throws if there is a parameter expression (computed member in destructuring, or default value) which throws. In this case the "function object" being evaluated is a synthetic value created by [ClassStaticBlockDefinitionEvaluation](https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-runtime-semantics-classstaticblockdefinitionevaluation) which is used to explain how static blocks work (threaded through from [ClassDefinitionEvaluation](https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-runtime-semantics-classdefinitionevaluation) step 31.b.ii). This synthetic value does not have any parameters, so FunctionDeclarationInstantiation on it cannot throw.
