### PR TITLE
Editorial: Fix ClassElementEvaluation's return type

### DIFF
--- a/esmeta-ignore.json
+++ b/esmeta-ignore.json
@@ -3,8 +3,6 @@
   "AsyncGeneratorBody[0,0].EvaluateAsyncGeneratorBody",
   "BoundFunctionCreate",
   "Catch[1,0].CatchClauseEvaluation",
-  "ClassElement[0,0].ClassElementEvaluation",
-  "ClassElement[1,0].ClassElementEvaluation",
   "ClassStaticBlockBody[0,0].EvaluateClassStaticBlockBody",
   "CreateArrayIterator",
   "CreateBuiltinFunction",

--- a/spec.html
+++ b/spec.html
@@ -24501,7 +24501,7 @@
       <h1>
         Runtime Semantics: ClassElementEvaluation (
           _object_: an Object,
-        ): either a normal completion containing either a ClassFieldDefinition Record, a ClassStaticBlockDefinition Record, a Private Name, or ~unused~, or an abrupt completion
+        ): either a normal completion containing either a ClassFieldDefinition Record, a ClassStaticBlockDefinition Record, a PrivateElement, or ~unused~, or an abrupt completion
       </h1>
       <dl class="header">
       </dl>


### PR DESCRIPTION
Specifically, replace "Private Name" with "PrivateElement".

ClassElementEvaluation's second definition is relevant: it returns the result of calling MethodDefinitionEvaluation, which can return a PrivateElement, not a Private Name.
