### PR TITLE
Editorial: Consistify re "elements in/of"

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -4502,7 +4502,7 @@
         <emu-alg>
           1. Let _db_ be a new Shared Data Block value consisting of _size_ bytes. If it is impossible to create such a Shared Data Block, throw a *RangeError* exception.
           1. Let _execution_ be the [[CandidateExecution]] field of the surrounding agent's Agent Record.
-          1. Let _eventList_ be the [[EventList]] field of the element in _execution_.[[EventsRecords]] whose [[AgentSignifier]] is AgentSignifier().
+          1. Let _eventList_ be the [[EventList]] field of the element of _execution_.[[EventsRecords]] whose [[AgentSignifier]] is AgentSignifier().
           1. Let _zero_ be « 0 ».
           1. For each index _i_ of _db_, do
             1. Append WriteSharedMemory { [[Order]]: ~Init~, [[NoTear]]: *true*, [[Block]]: _db_, [[ByteIndex]]: _i_, [[ElementSize]]: 1, [[Payload]]: _zero_ } to _eventList_.
@@ -4531,7 +4531,7 @@
           1. Repeat, while _count_ > 0,
             1. If _fromBlock_ is a Shared Data Block, then
               1. Let _execution_ be the [[CandidateExecution]] field of the surrounding agent's Agent Record.
-              1. Let _eventList_ be the [[EventList]] field of the element in _execution_.[[EventsRecords]] whose [[AgentSignifier]] is AgentSignifier().
+              1. Let _eventList_ be the [[EventList]] field of the element of _execution_.[[EventsRecords]] whose [[AgentSignifier]] is AgentSignifier().
               1. Let _bytes_ be a List whose sole element is a nondeterministically chosen byte value.
               1. NOTE: In implementations, _bytes_ is the result of a non-atomic read instruction on the underlying hardware. The nondeterminism is a semantic prescription of the memory model to describe observable behaviour of hardware with weak consistency.
               1. Let _readEvent_ be ReadSharedMemory { [[Order]]: ~Unordered~, [[NoTear]]: *true*, [[Block]]: _fromBlock_, [[ByteIndex]]: _fromIndex_, [[ElementSize]]: 1 }.
@@ -26387,7 +26387,7 @@
               1. If _module_.[[DFSAncestorIndex]] = _module_.[[DFSIndex]], then
                 1. Let _done_ be *false*.
                 1. Repeat, while _done_ is *false*,
-                  1. Let _requiredModule_ be the last element in _stack_.
+                  1. Let _requiredModule_ be the last element of _stack_.
                   1. Remove the last element of _stack_.
                   1. Assert: _requiredModule_ is a Cyclic Module Record.
                   1. Set _requiredModule_.[[Status]] to ~linked~.
@@ -26492,7 +26492,7 @@
               1. If _module_.[[DFSAncestorIndex]] = _module_.[[DFSIndex]], then
                 1. Let _done_ be *false*.
                 1. Repeat, while _done_ is *false*,
-                  1. Let _requiredModule_ be the last element in _stack_.
+                  1. Let _requiredModule_ be the last element of _stack_.
                   1. Remove the last element of _stack_.
                   1. Assert: _requiredModule_ is a Cyclic Module Record.
                   1. If _requiredModule_.[[AsyncEvaluation]] is *false*, set _requiredModule_.[[Status]] to ~evaluated~.
@@ -34349,7 +34349,7 @@ THH:mm:ss.sss
           1. Repeat, while _j_ is not -1,
             1. Let _T_ be the substring of _S_ from _i_ to _j_.
             1. Append _T_ to _substrings_.
-            1. If the number of elements of _substrings_ is _lim_, return CreateArrayFromList(_substrings_).
+            1. If the number of elements in _substrings_ is _lim_, return CreateArrayFromList(_substrings_).
             1. Set _i_ to _j_ + _separatorLength_.
             1. Set _j_ to StringIndexOf(_S_, _R_, _i_).
           1. Let _T_ be the substring of _S_ from _i_.
@@ -36432,7 +36432,7 @@ THH:mm:ss.sss
           1. If _unicode_ is *true*, append the code unit 0x0075 (LATIN SMALL LETTER U) to _codeUnits_.
           1. Let _sticky_ be ToBoolean(? Get(_R_, *"sticky"*)).
           1. If _sticky_ is *true*, append the code unit 0x0079 (LATIN SMALL LETTER Y) to _codeUnits_.
-          1. Return the String value whose code units are the elements in the List _codeUnits_. If _codeUnits_ has no elements, the empty String is returned.
+          1. Return the String value whose code units are the elements of the List _codeUnits_. If _codeUnits_ has no elements, the empty String is returned.
         </emu-alg>
 
         <emu-clause id="sec-regexphasflag" type="abstract operation">
@@ -40250,7 +40250,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_M_, [[MapData]]).
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
           1. Let _entries_ be the List that is _M_.[[MapData]].
-          1. Let _numEntries_ be the number of elements of _entries_.
+          1. Let _numEntries_ be the number of elements in _entries_.
           1. Let _index_ be 0.
           1. Repeat, while _index_ &lt; _numEntries_,
             1. Let _e_ be the Record { [[Key]], [[Value]] } that is the value of _entries_[_index_].
@@ -40258,7 +40258,7 @@ THH:mm:ss.sss
             1. If _e_.[[Key]] is not ~empty~, then
               1. Perform ? Call(_callbackfn_, _thisArg_, « _e_.[[Value]], _e_.[[Key]], _M_ »).
               1. NOTE: The number of elements in _entries_ may have increased during execution of _callbackfn_.
-              1. Set _numEntries_ to the number of elements of _entries_.
+              1. Set _numEntries_ to the number of elements in _entries_.
           1. Return *undefined*.
         </emu-alg>
         <emu-note>
@@ -40382,7 +40382,7 @@ THH:mm:ss.sss
           1. Let _closure_ be a new Abstract Closure with no parameters that captures _map_ and _kind_ and performs the following steps when called:
             1. Let _entries_ be the List that is _map_.[[MapData]].
             1. Let _index_ be 0.
-            1. Let _numEntries_ be the number of elements of _entries_.
+            1. Let _numEntries_ be the number of elements in _entries_.
             1. Repeat, while _index_ &lt; _numEntries_,
               1. Let _e_ be the Record { [[Key]], [[Value]] } that is the value of _entries_[_index_].
               1. Set _index_ to _index_ + 1.
@@ -40394,7 +40394,7 @@ THH:mm:ss.sss
                   1. Let _result_ be CreateArrayFromList(« _e_.[[Key]], _e_.[[Value]] »).
                 1. Perform ? GeneratorYield(CreateIterResultObject(_result_, *false*)).
                 1. NOTE: The number of elements in _entries_ may have increased while execution of this abstract operation was paused by Yield.
-                1. Set _numEntries_ to the number of elements of _entries_.
+                1. Set _numEntries_ to the number of elements in _entries_.
             1. Return *undefined*.
           1. Return CreateIteratorFromClosure(_closure_, *"%MapIteratorPrototype%"*, %MapIteratorPrototype%).
         </emu-alg>
@@ -40575,7 +40575,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_S_, [[SetData]]).
           1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
           1. Let _entries_ be the List that is _S_.[[SetData]].
-          1. Let _numEntries_ be the number of elements of _entries_.
+          1. Let _numEntries_ be the number of elements in _entries_.
           1. Let _index_ be 0.
           1. Repeat, while _index_ &lt; _numEntries_,
             1. Let _e_ be _entries_[_index_].
@@ -40583,7 +40583,7 @@ THH:mm:ss.sss
             1. If _e_ is not ~empty~, then
               1. Perform ? Call(_callbackfn_, _thisArg_, « _e_, _e_, _S_ »).
               1. NOTE: The number of elements in _entries_ may have increased during execution of _callbackfn_.
-              1. Set _numEntries_ to the number of elements of _entries_.
+              1. Set _numEntries_ to the number of elements in _entries_.
           1. Return *undefined*.
         </emu-alg>
         <emu-note>
@@ -40677,7 +40677,7 @@ THH:mm:ss.sss
           1. Let _closure_ be a new Abstract Closure with no parameters that captures _set_ and _kind_ and performs the following steps when called:
             1. Let _index_ be 0.
             1. Let _entries_ be the List that is _set_.[[SetData]].
-            1. Let _numEntries_ be the number of elements of _entries_.
+            1. Let _numEntries_ be the number of elements in _entries_.
             1. Repeat, while _index_ &lt; _numEntries_,
               1. Let _e_ be _entries_[_index_].
               1. Set _index_ to _index_ + 1.
@@ -40689,7 +40689,7 @@ THH:mm:ss.sss
                   1. Assert: _kind_ is ~value~.
                   1. Perform ? GeneratorYield(CreateIterResultObject(_e_, *false*)).
                 1. NOTE: The number of elements in _entries_ may have increased while execution of this abstract operation was paused by Yield.
-                1. Set _numEntries_ to the number of elements of _entries_.
+                1. Set _numEntries_ to the number of elements in _entries_.
             1. Return *undefined*.
           1. Return CreateIteratorFromClosure(_closure_, *"%SetIteratorPrototype%"*, %SetIteratorPrototype%).
         </emu-alg>
@@ -41222,7 +41222,7 @@ THH:mm:ss.sss
           1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for Element Type _type_.
           1. If IsSharedArrayBuffer(_arrayBuffer_) is *true*, then
             1. Let _execution_ be the [[CandidateExecution]] field of the surrounding agent's Agent Record.
-            1. Let _eventList_ be the [[EventList]] field of the element in _execution_.[[EventsRecords]] whose [[AgentSignifier]] is AgentSignifier().
+            1. Let _eventList_ be the [[EventList]] field of the element of _execution_.[[EventsRecords]] whose [[AgentSignifier]] is AgentSignifier().
             1. If _isTypedArray_ is *true* and IsNoTearConfiguration(_type_, _order_) is *true*, let _noTear_ be *true*; otherwise let _noTear_ be *false*.
             1. Let _rawValue_ be a List of length _elementSize_ whose elements are nondeterministically chosen byte values.
             1. NOTE: In implementations, _rawValue_ is the result of a non-atomic or atomic read instruction on the underlying hardware. The nondeterminism is a semantic prescription of the memory model to describe observable behaviour of hardware with weak consistency.
@@ -41288,7 +41288,7 @@ THH:mm:ss.sss
           1. Let _rawBytes_ be NumericToRawBytes(_type_, _value_, _isLittleEndian_).
           1. If IsSharedArrayBuffer(_arrayBuffer_) is *true*, then
             1. Let _execution_ be the [[CandidateExecution]] field of the surrounding agent's Agent Record.
-            1. Let _eventList_ be the [[EventList]] field of the element in _execution_.[[EventsRecords]] whose [[AgentSignifier]] is AgentSignifier().
+            1. Let _eventList_ be the [[EventList]] field of the element of _execution_.[[EventsRecords]] whose [[AgentSignifier]] is AgentSignifier().
             1. If _isTypedArray_ is *true* and IsNoTearConfiguration(_type_, _order_) is *true*, let _noTear_ be *true*; otherwise let _noTear_ be *false*.
             1. Append WriteSharedMemory { [[Order]]: _order_, [[NoTear]]: _noTear_, [[Block]]: _block_, [[ByteIndex]]: _byteIndex_, [[ElementSize]]: _elementSize_, [[Payload]]: _rawBytes_ } to _eventList_.
           1. Else, store the individual bytes of _rawBytes_ into _block_, starting at _block_[_byteIndex_].
@@ -41319,7 +41319,7 @@ THH:mm:ss.sss
           1. Let _rawBytes_ be NumericToRawBytes(_type_, _value_, _isLittleEndian_).
           1. If IsSharedArrayBuffer(_arrayBuffer_) is *true*, then
             1. Let _execution_ be the [[CandidateExecution]] field of the surrounding agent's Agent Record.
-            1. Let _eventList_ be the [[EventList]] field of the element in _execution_.[[EventsRecords]] whose [[AgentSignifier]] is AgentSignifier().
+            1. Let _eventList_ be the [[EventList]] field of the element of _execution_.[[EventsRecords]] whose [[AgentSignifier]] is AgentSignifier().
             1. Let _rawBytesRead_ be a List of length _elementSize_ whose elements are nondeterministically chosen byte values.
             1. NOTE: In implementations, _rawBytesRead_ is the result of a load-link, of a load-exclusive, or of an operand of a read-modify-write instruction on the underlying hardware. The nondeterminism is a semantic prescription of the memory model to describe observable behaviour of hardware with weak consistency.
             1. Let _rmwEvent_ be ReadModifyWriteSharedMemory { [[Order]]: ~SeqCst~, [[NoTear]]: *true*, [[Block]]: _block_, [[ByteIndex]]: _byteIndex_, [[ElementSize]]: _elementSize_, [[Payload]]: _rawBytes_, [[ModifyOp]]: _op_ }.
@@ -42382,7 +42382,7 @@ THH:mm:ss.sss
         1. Let _replacementBytes_ be NumericToRawBytes(_elementType_, _replacement_, _isLittleEndian_).
         1. If IsSharedArrayBuffer(_buffer_) is *true*, then
           1. Let _execution_ be the [[CandidateExecution]] field of the surrounding agent's Agent Record.
-          1. Let _eventList_ be the [[EventList]] field of the element in _execution_.[[EventsRecords]] whose [[AgentSignifier]] is AgentSignifier().
+          1. Let _eventList_ be the [[EventList]] field of the element of _execution_.[[EventsRecords]] whose [[AgentSignifier]] is AgentSignifier().
           1. Let _rawBytesRead_ be a List of length _elementSize_ whose elements are nondeterministically chosen byte values.
           1. NOTE: In implementations, _rawBytesRead_ is the result of a load-link, of a load-exclusive, or of an operand of a read-modify-write instruction on the underlying hardware. The nondeterminism is a semantic prescription of the memory model to describe observable behaviour of hardware with weak consistency.
           1. NOTE: The comparison of the expected value and the read value is performed outside of the read-modify-write modification function to avoid needlessly strong synchronization when the expected value is not equal to the read value.
@@ -46742,8 +46742,8 @@ THH:mm:ss.sss
           1. Let _chosenValueRecord_ be the element of _execution_.[[ChosenValues]] whose [[Event]] field is _R_.
           1. Let _chosenValue_ be _chosenValueRecord_.[[ChosenValue]].
           1. Let _readValue_ be ValueOfReadEvent(_execution_, _R_).
-          1. Let _chosenLen_ be the number of elements of _chosenValue_.
-          1. Let _readLen_ be the number of elements of _readValue_.
+          1. Let _chosenLen_ be the number of elements in _chosenValue_.
+          1. Let _readLen_ be the number of elements in _readValue_.
           1. If _chosenLen_ ≠ _readLen_, then
             1. Return *false*.
           1. If _chosenValue_[_i_] ≠ _readValue_[_i_] for some integer _i_ in the interval from 0 (inclusive) to _chosenLen_ (exclusive), then


### PR DESCRIPTION
The spec is inconsistent on "element[s] in X" vs "element[s] of X".

In pseudocode, I count 37 "in" vs 229 "of".

So in the first commit, I change all the "in" to "of".

----

However, I don't entirely like the result. While:
- "the elements of X"
- "each element of X"
- "an element of X"
- "the first/last element of X"

all sound fine to me, "the number of elements of X" sounds odd.

Compare:
- "the number of hours in a day" vs "the number of hours of a day"
- "the number of pups in a litter" vs "the number of pups of a litter"

Also note that the status quo spec has
- ~28 occurrences of "the number of elements in" vs
- ~11 of "the number of elements of".

So in the second commit, I change "of" to "in" just for "the number of elements of X".

(Alternatively, we could avoid this question by instead using the phrase "the length of X". Currently we only use that for Strings.)

----

The net effect of the 2 commits is:
- 11x "the number of elements of X" -> "the number of elements in X"
- 1x "the elements in the List X" -> "the elements of the List X"
- 2x "the last element in X" -> "the last element of X"
- 6x "the element in X" -> "the element of X"

I've left it as two commits in case you want to look at the effect of just the first.

----

Historical note: PR #2152 standardized on "of" for iteration: "For each element _foo_ of X".