### PR TITLE
Editorial: Remove redundant table of assignment operators

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -20505,25 +20505,9 @@
         1. Let _rref_ be ? Evaluation of |AssignmentExpression|.
         1. Let _rval_ be ? GetValue(_rref_).
         1. Let _assignmentOpText_ be the source text matched by |AssignmentOperator|.
-        1. Let _opText_ be the sequence of Unicode code points associated with _assignmentOpText_ in the following table:
-          <figure>
-            <!-- emu-format ignore -->
-            <table class="lightweight-table">
-              <tr><th> _assignmentOpText_ </th><th> _opText_       </th></tr>
-              <tr><td> `**=`              </td><td> `**`           </td></tr>
-              <tr><td> `*=`               </td><td> `*`            </td></tr>
-              <tr><td> `/=`               </td><td> `/`            </td></tr>
-              <tr><td> `%=`               </td><td> `%`            </td></tr>
-              <tr><td> `+=`               </td><td> `+`            </td></tr>
-              <tr><td> `-=`               </td><td> `-`            </td></tr>
-              <tr><td> `&lt;&lt;=`        </td><td> `&lt;&lt;`     </td></tr>
-              <tr><td> `&gt;&gt;=`        </td><td> `&gt;&gt;`     </td></tr>
-              <tr><td> `&gt;&gt;&gt;=`    </td><td> `&gt;&gt;&gt;` </td></tr>
-              <tr><td> `&amp;=`           </td><td> `&amp;`        </td></tr>
-              <tr><td> `^=`               </td><td> `^`            </td></tr>
-              <tr><td> `|=`               </td><td> `|`            </td></tr>
-            </table>
-          </figure>
+        1. Let _len_ be the number of code points in _assignmentOpText_.
+        1. Assert: _len_ &ge; 2 and the last code point of _assignmentOpText_ is `=`.
+        1. Let _opText_ be the sequence of the first _len_ - 1 code points of _assignmentOpText_.
         1. Let _r_ be ? ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
         1. [id="step-assignmentexpression-evaluation-compound-putvalue"] Perform ? PutValue(_lref_, _r_).
         1. Return _r_.


### PR DESCRIPTION
The relevant grammar production is already linked to by |AssignmentOperator|.