### PR TITLE
Editorial: Use consistent algorithm steps to consume the head of a List

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -42020,13 +42020,11 @@ THH:mm:ss.sss
         </dl>
         <emu-alg>
           1. Assert: The surrounding agent is in the critical section for _WL_.
-          1. Let _L_ be a new empty List.
           1. Let _S_ be a reference to the list of waiters in _WL_.
-          1. Repeat, while _c_ > 0 and _S_ is not empty,
-            1. Let _W_ be the first waiter in _S_.
-            1. Append _W_ to _L_.
-            1. Remove _W_ from _S_.
-            1. If _c_ is finite, set _c_ to _c_ - 1.
+          1. Let _len_ be the number of elements in _S_.
+          1. Let _n_ be min(_c_, _len_).
+          1. Let _L_ be a List whose elements are the first _n_ elements of _S_.
+          1. Remove the first _n_ elements of _S_.
           1. Return _L_.
         </emu-alg>
       </emu-clause>
@@ -42356,15 +42354,12 @@ THH:mm:ss.sss
         1. Let _block_ be _buffer_.[[ArrayBufferData]].
         1. If IsSharedArrayBuffer(_buffer_) is *false*, return *+0*<sub>𝔽</sub>.
         1. Let _WL_ be GetWaiterList(_block_, _indexedPosition_).
-        1. Let _n_ be 0.
         1. Perform EnterCriticalSection(_WL_).
         1. Let _S_ be RemoveWaiters(_WL_, _c_).
-        1. Repeat, while _S_ is not empty,
-          1. Let _W_ be the first agent in _S_.
-          1. Remove _W_ from the front of _S_.
+        1. For each element _W_ of _S_, do
           1. Perform NotifyWaiter(_WL_, _W_).
-          1. Set _n_ to _n_ + 1.
         1. Perform LeaveCriticalSection(_WL_).
+        1. Let _n_ be the number of elements in _S_.
         1. Return 𝔽(_n_).
       </emu-alg>
     </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -38657,7 +38657,8 @@ THH:mm:ss.sss
             1. Let _k_ be 0.
             1. Repeat, while _k_ &lt; _len_,
               1. Let _Pk_ be ! ToString(𝔽(_k_)).
-              1. Let _kValue_ be the first element of _values_ and remove that element from _values_.
+              1. Let _kValue_ be the first element of _values_.
+              1. Remove the first element from _values_.
               1. If _mapping_ is *true*, then
                 1. Let _mappedValue_ be ? Call(_mapfn_, _thisArg_, « _kValue_, 𝔽(_k_) »).
               1. Else, let _mappedValue_ be _kValue_.
@@ -39797,7 +39798,8 @@ THH:mm:ss.sss
             1. Let _k_ be 0.
             1. Repeat, while _k_ &lt; _len_,
               1. Let _Pk_ be ! ToString(𝔽(_k_)).
-              1. Let _kValue_ be the first element of _values_ and remove that element from _values_.
+              1. Let _kValue_ be the first element of _values_.
+              1. Remove the first element from _values_.
               1. Perform ? Set(_O_, _Pk_, _kValue_, *true*).
               1. Set _k_ to _k_ + 1.
             1. Assert: _values_ is now an empty List.


### PR DESCRIPTION
cf. [AsyncGeneratorCompleteStep](https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-asyncgeneratorcompletestep) and [%ForInIteratorPrototype%.next](https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#sec-%foriniteratorprototype%.next)
> 1. Let _element_ be the first element of _list_.
> 2. Remove the first element from _list_.