### PR TITLE
Editorial: Generalize the note about when StringIndexOf is guaranteed to return -1

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1167,7 +1167,7 @@
           <p>If _searchValue_ is the empty String and _fromIndex_ is less than or equal to the length of _string_, this algorithm returns _fromIndex_. The empty String is effectively found at every position within a string, including after the last code unit.</p>
         </emu-note>
         <emu-note>
-          <p>This algorithm always returns -1 if _fromIndex_ > the length of _string_.</p>
+          <p>This algorithm always returns -1 if _fromIndex_ + the length of _searchValue_ > the length of _string_.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>


### PR DESCRIPTION
String contents don't matter any time _fromIndex_ + _searchValue_.length > _string_.length, not just when _fromIndex_ exceeds the length on its own.