### PR TITLE
Editorial: Clarify proxy operations with a named helper operation

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -5667,7 +5667,8 @@
         1. If _argument_ is not an Object, return *false*.
         1. If _argument_ is an Array exotic object, return *true*.
         1. If _argument_ is a Proxy exotic object, then
-          1. Let _proxyTarget_ be ? GetNonRevokedProxyTarget(_argument_).
+          1. Perform ? ValidateNonRevokedProxy(_argument_).
+          1. Let _proxyTarget_ be _argument_.[[ProxyTarget]].
           1. Return ? IsArray(_proxyTarget_).
         1. Return *false*.
       </emu-alg>
@@ -6522,7 +6523,8 @@
           1. Let _boundTargetFunction_ be _obj_.[[BoundTargetFunction]].
           1. Return ? GetFunctionRealm(_boundTargetFunction_).
         1. If _obj_ is a Proxy exotic object, then
-          1. Let _proxyTarget_ be ? GetNonRevokedProxyTarget(_obj_).
+          1. Perform ? ValidateNonRevokedProxy(_obj_).
+          1. Let _proxyTarget_ be _obj_.[[ProxyTarget]].
           1. Return ? GetFunctionRealm(_proxyTarget_).
         1. [id="step-getfunctionrealm-default-return"] Return the current Realm Record.
       </emu-alg>
@@ -15033,7 +15035,8 @@
         <dd>a Proxy exotic object _O_</dd>
       </dl>
       <emu-alg>
-        1. Let _target_ be ? GetNonRevokedProxyTarget(_O_).
+        1. Perform ? ValidateNonRevokedProxy(_O_).
+        1. Let _target_ be _O_.[[ProxyTarget]].
         1. Let _handler_ be _O_.[[ProxyHandler]].
         1. Assert: _handler_ is an Object.
         1. Let _trap_ be ? GetMethod(_handler_, *"getPrototypeOf"*).
@@ -15071,7 +15074,8 @@
         <dd>a Proxy exotic object _O_</dd>
       </dl>
       <emu-alg>
-        1. Let _target_ be ? GetNonRevokedProxyTarget(_O_).
+        1. Perform ? ValidateNonRevokedProxy(_O_).
+        1. Let _target_ be _O_.[[ProxyTarget]].
         1. Let _handler_ be _O_.[[ProxyHandler]].
         1. Assert: _handler_ is an Object.
         1. Let _trap_ be ? GetMethod(_handler_, *"setPrototypeOf"*).
@@ -15105,7 +15109,8 @@
         <dd>a Proxy exotic object _O_</dd>
       </dl>
       <emu-alg>
-        1. Let _target_ be ? GetNonRevokedProxyTarget(_O_).
+        1. Perform ? ValidateNonRevokedProxy(_O_).
+        1. Let _target_ be _O_.[[ProxyTarget]].
         1. Let _handler_ be _O_.[[ProxyHandler]].
         1. Assert: _handler_ is an Object.
         1. Let _trap_ be ? GetMethod(_handler_, *"isExtensible"*).
@@ -15136,7 +15141,8 @@
         <dd>a Proxy exotic object _O_</dd>
       </dl>
       <emu-alg>
-        1. Let _target_ be ? GetNonRevokedProxyTarget(_O_).
+        1. Perform ? ValidateNonRevokedProxy(_O_).
+        1. Let _target_ be _O_.[[ProxyTarget]].
         1. Let _handler_ be _O_.[[ProxyHandler]].
         1. Assert: _handler_ is an Object.
         1. Let _trap_ be ? GetMethod(_handler_, *"preventExtensions"*).
@@ -15172,7 +15178,8 @@
         <dd>a Proxy exotic object _O_</dd>
       </dl>
       <emu-alg>
-        1. Let _target_ be ? GetNonRevokedProxyTarget(_O_).
+        1. Perform ? ValidateNonRevokedProxy(_O_).
+        1. Let _target_ be _O_.[[ProxyTarget]].
         1. Let _handler_ be _O_.[[ProxyHandler]].
         1. Assert: _handler_ is an Object.
         1. Let _trap_ be ? GetMethod(_handler_, *"getOwnPropertyDescriptor"*).
@@ -15237,7 +15244,8 @@
         <dd>a Proxy exotic object _O_</dd>
       </dl>
       <emu-alg>
-        1. Let _target_ be ? GetNonRevokedProxyTarget(_O_).
+        1. Perform ? ValidateNonRevokedProxy(_O_).
+        1. Let _target_ be _O_.[[ProxyTarget]].
         1. Let _handler_ be _O_.[[ProxyHandler]].
         1. Assert: _handler_ is an Object.
         1. Let _trap_ be ? GetMethod(_handler_, *"defineProperty"*).
@@ -15294,7 +15302,8 @@
         <dd>a Proxy exotic object _O_</dd>
       </dl>
       <emu-alg>
-        1. Let _target_ be ? GetNonRevokedProxyTarget(_O_).
+        1. Perform ? ValidateNonRevokedProxy(_O_).
+        1. Let _target_ be _O_.[[ProxyTarget]].
         1. Let _handler_ be _O_.[[ProxyHandler]].
         1. Assert: _handler_ is an Object.
         1. Let _trap_ be ? GetMethod(_handler_, *"has"*).
@@ -15337,7 +15346,8 @@
         <dd>a Proxy exotic object _O_</dd>
       </dl>
       <emu-alg>
-        1. Let _target_ be ? GetNonRevokedProxyTarget(_O_).
+        1. Perform ? ValidateNonRevokedProxy(_O_).
+        1. Let _target_ be _O_.[[ProxyTarget]].
         1. Let _handler_ be _O_.[[ProxyHandler]].
         1. Assert: _handler_ is an Object.
         1. Let _trap_ be ? GetMethod(_handler_, *"get"*).
@@ -15378,7 +15388,8 @@
         <dd>a Proxy exotic object _O_</dd>
       </dl>
       <emu-alg>
-        1. Let _target_ be ? GetNonRevokedProxyTarget(_O_).
+        1. Perform ? ValidateNonRevokedProxy(_O_).
+        1. Let _target_ be _O_.[[ProxyTarget]].
         1. Let _handler_ be _O_.[[ProxyHandler]].
         1. Assert: _handler_ is an Object.
         1. Let _trap_ be ? GetMethod(_handler_, *"set"*).
@@ -15421,7 +15432,8 @@
         <dd>a Proxy exotic object _O_</dd>
       </dl>
       <emu-alg>
-        1. Let _target_ be ? GetNonRevokedProxyTarget(_O_).
+        1. Perform ? ValidateNonRevokedProxy(_O_).
+        1. Let _target_ be _O_.[[ProxyTarget]].
         1. Let _handler_ be _O_.[[ProxyHandler]].
         1. Assert: _handler_ is an Object.
         1. Let _trap_ be ? GetMethod(_handler_, *"deleteProperty"*).
@@ -15459,7 +15471,8 @@
         <dd>a Proxy exotic object _O_</dd>
       </dl>
       <emu-alg>
-        1. Let _target_ be ? GetNonRevokedProxyTarget(_O_).
+        1. Perform ? ValidateNonRevokedProxy(_O_).
+        1. Let _target_ be _O_.[[ProxyTarget]].
         1. Let _handler_ be _O_.[[ProxyHandler]].
         1. Assert: _handler_ is an Object.
         1. Let _trap_ be ? GetMethod(_handler_, *"ownKeys"*).
@@ -15527,7 +15540,8 @@
         <dd>a Proxy exotic object _O_</dd>
       </dl>
       <emu-alg>
-        1. Let _target_ be ? GetNonRevokedProxyTarget(_O_).
+        1. Perform ? ValidateNonRevokedProxy(_O_).
+        1. Let _target_ be _O_.[[ProxyTarget]].
         1. Let _handler_ be _O_.[[ProxyHandler]].
         1. Assert: _handler_ is an Object.
         1. Let _trap_ be ? GetMethod(_handler_, *"apply"*).
@@ -15553,7 +15567,8 @@
         <dd>a Proxy exotic object _O_</dd>
       </dl>
       <emu-alg>
-        1. Let _target_ be ? GetNonRevokedProxyTarget(_O_).
+        1. Perform ? ValidateNonRevokedProxy(_O_).
+        1. Let _target_ be _O_.[[ProxyTarget]].
         1. Assert: IsConstructor(_target_) is *true*.
         1. Let _handler_ be _O_.[[ProxyHandler]].
         1. Assert: _handler_ is an Object.
@@ -15578,20 +15593,20 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-getnonrevokedproxytarget" type="abstract operation">
+    <emu-clause id="sec-validatenonrevokedproxy" type="abstract operation">
       <h1>
-        GetNonRevokedProxyTarget (
+        ValidateNonRevokedProxy (
           _proxy_: a Proxy exotic object,
-        ): either a normal completion containing an Object or a throw completion
+        ): either a normal completion containing ~unused~ or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It returns _proxy_.[[ProxyTarget]] unless _proxy_ has been revoked.</dd>
+        <dd>It throws a *TypeError* exception if _proxy_ has been revoked.</dd>
       </dl>
       <emu-alg>
-        1. Let _target_ be _proxy_.[[ProxyTarget]].
-        1. If _target_ is *null*, throw a *TypeError* exception.
-        1. Return _target_.
+        1. If _proxy_.[[ProxyTarget]] is *null*, throw a *TypeError* exception.
+        1. Assert: _proxy_.[[ProxyHandler]] is not *null*.
+        1. Return ~unused~.
       </emu-alg>
     </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -5667,9 +5667,8 @@
         1. If _argument_ is not an Object, return *false*.
         1. If _argument_ is an Array exotic object, return *true*.
         1. If _argument_ is a Proxy exotic object, then
-          1. If _argument_.[[ProxyHandler]] is *null*, throw a *TypeError* exception.
-          1. Let _target_ be _argument_.[[ProxyTarget]].
-          1. Return ? IsArray(_target_).
+          1. Let _proxyTarget_ be ? GetNonRevokedProxyTarget(_argument_).
+          1. Return ? IsArray(_proxyTarget_).
         1. Return *false*.
       </emu-alg>
     </emu-clause>
@@ -6520,11 +6519,10 @@
         1. If _obj_ has a [[Realm]] internal slot, then
           1. Return _obj_.[[Realm]].
         1. If _obj_ is a bound function exotic object, then
-          1. Let _target_ be _obj_.[[BoundTargetFunction]].
-          1. Return ? GetFunctionRealm(_target_).
+          1. Let _boundTargetFunction_ be _obj_.[[BoundTargetFunction]].
+          1. Return ? GetFunctionRealm(_boundTargetFunction_).
         1. If _obj_ is a Proxy exotic object, then
-          1. If _obj_.[[ProxyHandler]] is *null*, throw a *TypeError* exception.
-          1. Let _proxyTarget_ be _obj_.[[ProxyTarget]].
+          1. Let _proxyTarget_ be ? GetNonRevokedProxyTarget(_obj_).
           1. Return ? GetFunctionRealm(_proxyTarget_).
         1. [id="step-getfunctionrealm-default-return"] Return the current Realm Record.
       </emu-alg>
@@ -15035,10 +15033,9 @@
         <dd>a Proxy exotic object _O_</dd>
       </dl>
       <emu-alg>
+        1. Let _target_ be ? GetNonRevokedProxyTarget(_O_).
         1. Let _handler_ be _O_.[[ProxyHandler]].
-        1. If _handler_ is *null*, throw a *TypeError* exception.
         1. Assert: _handler_ is an Object.
-        1. Let _target_ be _O_.[[ProxyTarget]].
         1. Let _trap_ be ? GetMethod(_handler_, *"getPrototypeOf"*).
         1. If _trap_ is *undefined*, then
           1. Return ? <emu-meta effects="user-code">_target_.[[GetPrototypeOf]]</emu-meta>().
@@ -15074,10 +15071,9 @@
         <dd>a Proxy exotic object _O_</dd>
       </dl>
       <emu-alg>
+        1. Let _target_ be ? GetNonRevokedProxyTarget(_O_).
         1. Let _handler_ be _O_.[[ProxyHandler]].
-        1. If _handler_ is *null*, throw a *TypeError* exception.
         1. Assert: _handler_ is an Object.
-        1. Let _target_ be _O_.[[ProxyTarget]].
         1. Let _trap_ be ? GetMethod(_handler_, *"setPrototypeOf"*).
         1. If _trap_ is *undefined*, then
           1. Return ? <emu-meta effects="user-code">_target_.[[SetPrototypeOf]]</emu-meta>(_V_).
@@ -15109,10 +15105,9 @@
         <dd>a Proxy exotic object _O_</dd>
       </dl>
       <emu-alg>
+        1. Let _target_ be ? GetNonRevokedProxyTarget(_O_).
         1. Let _handler_ be _O_.[[ProxyHandler]].
-        1. If _handler_ is *null*, throw a *TypeError* exception.
         1. Assert: _handler_ is an Object.
-        1. Let _target_ be _O_.[[ProxyTarget]].
         1. Let _trap_ be ? GetMethod(_handler_, *"isExtensible"*).
         1. If _trap_ is *undefined*, then
           1. Return ? IsExtensible(_target_).
@@ -15141,10 +15136,9 @@
         <dd>a Proxy exotic object _O_</dd>
       </dl>
       <emu-alg>
+        1. Let _target_ be ? GetNonRevokedProxyTarget(_O_).
         1. Let _handler_ be _O_.[[ProxyHandler]].
-        1. If _handler_ is *null*, throw a *TypeError* exception.
         1. Assert: _handler_ is an Object.
-        1. Let _target_ be _O_.[[ProxyTarget]].
         1. Let _trap_ be ? GetMethod(_handler_, *"preventExtensions"*).
         1. If _trap_ is *undefined*, then
           1. Return ? <emu-meta effects="user-code">_target_.[[PreventExtensions]]()</emu-meta>.
@@ -15178,10 +15172,9 @@
         <dd>a Proxy exotic object _O_</dd>
       </dl>
       <emu-alg>
+        1. Let _target_ be ? GetNonRevokedProxyTarget(_O_).
         1. Let _handler_ be _O_.[[ProxyHandler]].
-        1. If _handler_ is *null*, throw a *TypeError* exception.
         1. Assert: _handler_ is an Object.
-        1. Let _target_ be _O_.[[ProxyTarget]].
         1. Let _trap_ be ? GetMethod(_handler_, *"getOwnPropertyDescriptor"*).
         1. If _trap_ is *undefined*, then
           1. Return ? <emu-meta effects="user-code">_target_.[[GetOwnProperty]]</emu-meta>(_P_).
@@ -15244,10 +15237,9 @@
         <dd>a Proxy exotic object _O_</dd>
       </dl>
       <emu-alg>
+        1. Let _target_ be ? GetNonRevokedProxyTarget(_O_).
         1. Let _handler_ be _O_.[[ProxyHandler]].
-        1. If _handler_ is *null*, throw a *TypeError* exception.
         1. Assert: _handler_ is an Object.
-        1. Let _target_ be _O_.[[ProxyTarget]].
         1. Let _trap_ be ? GetMethod(_handler_, *"defineProperty"*).
         1. If _trap_ is *undefined*, then
           1. Return ? <emu-meta effects="user-code">_target_.[[DefineOwnProperty]]</emu-meta>(_P_, _Desc_).
@@ -15302,10 +15294,9 @@
         <dd>a Proxy exotic object _O_</dd>
       </dl>
       <emu-alg>
+        1. Let _target_ be ? GetNonRevokedProxyTarget(_O_).
         1. Let _handler_ be _O_.[[ProxyHandler]].
-        1. If _handler_ is *null*, throw a *TypeError* exception.
         1. Assert: _handler_ is an Object.
-        1. Let _target_ be _O_.[[ProxyTarget]].
         1. Let _trap_ be ? GetMethod(_handler_, *"has"*).
         1. If _trap_ is *undefined*, then
           1. Return ? <emu-meta effects="user-code">_target_.[[HasProperty]]</emu-meta>(_P_).
@@ -15346,10 +15337,9 @@
         <dd>a Proxy exotic object _O_</dd>
       </dl>
       <emu-alg>
+        1. Let _target_ be ? GetNonRevokedProxyTarget(_O_).
         1. Let _handler_ be _O_.[[ProxyHandler]].
-        1. If _handler_ is *null*, throw a *TypeError* exception.
         1. Assert: _handler_ is an Object.
-        1. Let _target_ be _O_.[[ProxyTarget]].
         1. Let _trap_ be ? GetMethod(_handler_, *"get"*).
         1. If _trap_ is *undefined*, then
           1. Return ? <emu-meta effects="user-code">_target_.[[Get]]</emu-meta>(_P_, _Receiver_).
@@ -15388,10 +15378,9 @@
         <dd>a Proxy exotic object _O_</dd>
       </dl>
       <emu-alg>
+        1. Let _target_ be ? GetNonRevokedProxyTarget(_O_).
         1. Let _handler_ be _O_.[[ProxyHandler]].
-        1. If _handler_ is *null*, throw a *TypeError* exception.
         1. Assert: _handler_ is an Object.
-        1. Let _target_ be _O_.[[ProxyTarget]].
         1. Let _trap_ be ? GetMethod(_handler_, *"set"*).
         1. If _trap_ is *undefined*, then
           1. Return ? <emu-meta effects="user-code">_target_.[[Set]]</emu-meta>(_P_, _V_, _Receiver_).
@@ -15432,10 +15421,9 @@
         <dd>a Proxy exotic object _O_</dd>
       </dl>
       <emu-alg>
+        1. Let _target_ be ? GetNonRevokedProxyTarget(_O_).
         1. Let _handler_ be _O_.[[ProxyHandler]].
-        1. If _handler_ is *null*, throw a *TypeError* exception.
         1. Assert: _handler_ is an Object.
-        1. Let _target_ be _O_.[[ProxyTarget]].
         1. Let _trap_ be ? GetMethod(_handler_, *"deleteProperty"*).
         1. If _trap_ is *undefined*, then
           1. Return ? <emu-meta effects="user-code">_target_.[[Delete]]</emu-meta>(_P_).
@@ -15471,10 +15459,9 @@
         <dd>a Proxy exotic object _O_</dd>
       </dl>
       <emu-alg>
+        1. Let _target_ be ? GetNonRevokedProxyTarget(_O_).
         1. Let _handler_ be _O_.[[ProxyHandler]].
-        1. If _handler_ is *null*, throw a *TypeError* exception.
         1. Assert: _handler_ is an Object.
-        1. Let _target_ be _O_.[[ProxyTarget]].
         1. Let _trap_ be ? GetMethod(_handler_, *"ownKeys"*).
         1. If _trap_ is *undefined*, then
           1. Return ? <emu-meta effects="user-code">_target_.[[OwnPropertyKeys]]()</emu-meta>.
@@ -15540,10 +15527,9 @@
         <dd>a Proxy exotic object _O_</dd>
       </dl>
       <emu-alg>
+        1. Let _target_ be ? GetNonRevokedProxyTarget(_O_).
         1. Let _handler_ be _O_.[[ProxyHandler]].
-        1. If _handler_ is *null*, throw a *TypeError* exception.
         1. Assert: _handler_ is an Object.
-        1. Let _target_ be _O_.[[ProxyTarget]].
         1. Let _trap_ be ? GetMethod(_handler_, *"apply"*).
         1. If _trap_ is *undefined*, then
           1. Return ? Call(_target_, _thisArgument_, _argumentsList_).
@@ -15567,11 +15553,10 @@
         <dd>a Proxy exotic object _O_</dd>
       </dl>
       <emu-alg>
-        1. Let _handler_ be _O_.[[ProxyHandler]].
-        1. If _handler_ is *null*, throw a *TypeError* exception.
-        1. Assert: _handler_ is an Object.
-        1. Let _target_ be _O_.[[ProxyTarget]].
+        1. Let _target_ be ? GetNonRevokedProxyTarget(_O_).
         1. Assert: IsConstructor(_target_) is *true*.
+        1. Let _handler_ be _O_.[[ProxyHandler]].
+        1. Assert: _handler_ is an Object.
         1. Let _trap_ be ? GetMethod(_handler_, *"construct"*).
         1. If _trap_ is *undefined*, then
           1. Return ? Construct(_target_, _argumentsList_, _newTarget_).
@@ -15591,6 +15576,23 @@
           </li>
         </ul>
       </emu-note>
+    </emu-clause>
+
+    <emu-clause id="sec-getnonrevokedproxytarget" type="abstract operation">
+      <h1>
+        GetNonRevokedProxyTarget (
+          _proxy_: a Proxy exotic object,
+        ): either a normal completion containing an Object or a throw completion
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It returns _proxy_.[[ProxyTarget]] unless _proxy_ has been revoked.</dd>
+      </dl>
+      <emu-alg>
+        1. Let _target_ be _proxy_.[[ProxyTarget]].
+        1. If _target_ is *null*, throw a *TypeError* exception.
+        1. Return _target_.
+      </emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-proxycreate" type="abstract operation">


### PR DESCRIPTION
Consolidates the exception throwing associated with trying to interact with a revoked proxy.