### PR TITLE
Editorial: Evaluation is user code by definition

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -7085,6 +7085,8 @@
   <emu-clause id="sec-evaluation" type="sdo">
     <h1>Runtime Semantics: Evaluation ( ): a Completion Record</h1>
     <dl class="header">
+      <dt>effects</dt>
+      <dd>user-code</dd>
     </dl>
     <emu-note>
       The definitions for this operation are distributed over the "ECMAScript Language" sections of this specification. Each definition appears after the defining occurrence of the relevant productions.


### PR DESCRIPTION
Ecmarkup currently special-cases the phrase "the result of evaluating" as invoking user code, but as of https://github.com/tc39/ecma262/pull/2744 we barely use that terminology and instead invoke the Evaluation SDO. But we forgot to mark that SDO as invoking user code, despite that being definitionally what it is.

I recall discussing that we'd need to do this, but either I dreamt that or we forgot. Either way, whoops.