### PR TITLE
Editorial: Convert `Await` from a shorthand to an abstract operation

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -4058,42 +4058,6 @@
       <p>Callable objects that are defined in this specification only return a normal completion or a throw completion. Returning any other kind of Completion Record is considered an editorial error.</p>
       <p>Implementation-defined callable objects must return either a normal completion or a throw completion.</p>
 
-      <emu-clause id="await" oldids="await-fulfilled,await-rejected" type="abstract operation">
-        <h1>
-          Await (
-            _value_: an ECMAScript language value,
-          ): either a normal completion containing either an ECMAScript language value or ~empty~, or a throw completion
-        </h1>
-        <dl class="header">
-        </dl>
-        <emu-alg>
-          1. Let _asyncContext_ be the running execution context.
-          1. Let _promise_ be ? PromiseResolve(%Promise%, _value_).
-          1. Let _fulfilledClosure_ be a new Abstract Closure with parameters (_value_) that captures _asyncContext_ and performs the following steps when called:
-            1. Let _prevContext_ be the running execution context.
-            1. Suspend _prevContext_.
-            1. Push _asyncContext_ onto the execution context stack; _asyncContext_ is now the running execution context.
-            1. <emu-meta effects="user-code">Resume the suspended evaluation of _asyncContext_</emu-meta> using NormalCompletion(_value_) as the result of the operation that suspended it.
-            1. Assert: When we reach this step, _asyncContext_ has already been removed from the execution context stack and _prevContext_ is the currently running execution context.
-            1. Return *undefined*.
-          1. Let _onFulfilled_ be CreateBuiltinFunction(_fulfilledClosure_, 1, *""*, « »).
-          1. Let _rejectedClosure_ be a new Abstract Closure with parameters (_reason_) that captures _asyncContext_ and performs the following steps when called:
-            1. Let _prevContext_ be the running execution context.
-            1. Suspend _prevContext_.
-            1. Push _asyncContext_ onto the execution context stack; _asyncContext_ is now the running execution context.
-            1. <emu-meta effects="user-code">Resume the suspended evaluation of _asyncContext_</emu-meta> using ThrowCompletion(_reason_) as the result of the operation that suspended it.
-            1. Assert: When we reach this step, _asyncContext_ has already been removed from the execution context stack and _prevContext_ is the currently running execution context.
-            1. Return *undefined*.
-          1. Let _onRejected_ be CreateBuiltinFunction(_rejectedClosure_, 1, *""*, « »).
-          1. Perform PerformPromiseThen(_promise_, _onFulfilled_, _onRejected_).
-          1. Remove _asyncContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
-          1. Let _callerContext_ be the running execution context.
-          1. Resume _callerContext_ passing ~empty~. If _asyncContext_ is ever resumed again, let _completion_ be the Completion Record with which it is resumed.
-          1. Assert: If control reaches here, then _asyncContext_ is the running execution context again.
-          1. Return _completion_.
-        </emu-alg>
-      </emu-clause>
-
       <emu-clause id="sec-normalcompletion" type="abstract operation">
         <h1>
           NormalCompletion (
@@ -45787,6 +45751,42 @@ THH:mm:ss.sss
           1. Assert: When we return here, _asyncContext_ has already been removed from the execution context stack and _runningContext_ is the currently running execution context.
           1. Assert: _result_ is a normal completion with a value of ~unused~. The possible sources of this value are Await or, if the async function doesn't await anything, step <emu-xref href="#step-asyncblockstart-return-undefined"></emu-xref> above.
           1. Return ~unused~.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="await" oldids="await-fulfilled,await-rejected" type="abstract operation">
+        <h1>
+          Await (
+            _value_: an ECMAScript language value,
+          ): either a normal completion containing either an ECMAScript language value or ~empty~, or a throw completion
+        </h1>
+        <dl class="header">
+        </dl>
+        <emu-alg>
+          1. Let _asyncContext_ be the running execution context.
+          1. Let _promise_ be ? PromiseResolve(%Promise%, _value_).
+          1. Let _fulfilledClosure_ be a new Abstract Closure with parameters (_value_) that captures _asyncContext_ and performs the following steps when called:
+            1. Let _prevContext_ be the running execution context.
+            1. Suspend _prevContext_.
+            1. Push _asyncContext_ onto the execution context stack; _asyncContext_ is now the running execution context.
+            1. <emu-meta effects="user-code">Resume the suspended evaluation of _asyncContext_</emu-meta> using NormalCompletion(_value_) as the result of the operation that suspended it.
+            1. Assert: When we reach this step, _asyncContext_ has already been removed from the execution context stack and _prevContext_ is the currently running execution context.
+            1. Return *undefined*.
+          1. Let _onFulfilled_ be CreateBuiltinFunction(_fulfilledClosure_, 1, *""*, « »).
+          1. Let _rejectedClosure_ be a new Abstract Closure with parameters (_reason_) that captures _asyncContext_ and performs the following steps when called:
+            1. Let _prevContext_ be the running execution context.
+            1. Suspend _prevContext_.
+            1. Push _asyncContext_ onto the execution context stack; _asyncContext_ is now the running execution context.
+            1. <emu-meta effects="user-code">Resume the suspended evaluation of _asyncContext_</emu-meta> using ThrowCompletion(_reason_) as the result of the operation that suspended it.
+            1. Assert: When we reach this step, _asyncContext_ has already been removed from the execution context stack and _prevContext_ is the currently running execution context.
+            1. Return *undefined*.
+          1. Let _onRejected_ be CreateBuiltinFunction(_rejectedClosure_, 1, *""*, « »).
+          1. Perform PerformPromiseThen(_promise_, _onFulfilled_, _onRejected_).
+          1. Remove _asyncContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
+          1. Let _callerContext_ be the running execution context.
+          1. Resume _callerContext_ passing ~empty~. If _asyncContext_ is ever resumed again, let _completion_ be the Completion Record with which it is resumed.
+          1. Assert: If control reaches here, then _asyncContext_ is the running execution context again.
+          1. Return _completion_.
         </emu-alg>
       </emu-clause>
     </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -4058,18 +4058,15 @@
       <p>Callable objects that are defined in this specification only return a normal completion or a throw completion. Returning any other kind of Completion Record is considered an editorial error.</p>
       <p>Implementation-defined callable objects must return either a normal completion or a throw completion.</p>
 
-      <emu-clause id="await" oldids="await-fulfilled,await-rejected" aoid="Await">
-        <h1>Await</h1>
-
-        <p>Algorithm steps that say</p>
-
-        <emu-alg example>
-          1. Let _completion_ be Await(_value_).
-        </emu-alg>
-
-        <p>mean the same thing as:</p>
-
-        <emu-alg example>
+      <emu-clause id="await" oldids="await-fulfilled,await-rejected" type="abstract operation">
+        <h1>
+          Await (
+            _value_: an ECMAScript language value,
+          ): either a normal completion containing either an ECMAScript language value or ~empty~, or a throw completion
+        </h1>
+        <dl class="header">
+        </dl>
+        <emu-alg>
           1. Let _asyncContext_ be the running execution context.
           1. Let _promise_ be ? PromiseResolve(%Promise%, _value_).
           1. Let _fulfilledClosure_ be a new Abstract Closure with parameters (_value_) that captures _asyncContext_ and performs the following steps when called:
@@ -4093,25 +4090,8 @@
           1. Let _callerContext_ be the running execution context.
           1. Resume _callerContext_ passing ~empty~. If _asyncContext_ is ever resumed again, let _completion_ be the Completion Record with which it is resumed.
           1. Assert: If control reaches here, then _asyncContext_ is the running execution context again.
-          1. NOTE: The following steps of the algorithm that invoked Await will be performed, with _completion_ available.
+          1. Return _completion_.
         </emu-alg>
-
-        <p>where all aliases in the above steps, with the exception of _completion_, are ephemeral and visible only in the steps pertaining to Await.</p>
-
-        <emu-note>
-          <p>Await can be combined with the `?` and `!` prefixes, so that for example</p>
-
-          <emu-alg example>
-            1. Let _result_ be ? Await(_value_).
-          </emu-alg>
-
-          <p>means the same thing as:</p>
-
-          <emu-alg example>
-            1. Let _result_ be Await(_value_).
-            1. ReturnIfAbrupt(_result_).
-          </emu-alg>
-        </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-normalcompletion" type="abstract operation">
@@ -45205,7 +45185,7 @@ THH:mm:ss.sss
         <dl class="header">
         </dl>
         <emu-alg>
-          1. NOTE: _closure_ can contain uses of the Yield shorthand to yield an IteratorResult object.
+          1. NOTE: _closure_ can contain uses of the Yield operation to yield an IteratorResult object.
           1. Let _internalSlotsList_ be « [[GeneratorState]], [[GeneratorContext]], [[GeneratorBrand]] ».
           1. Let _generator_ be OrdinaryObjectCreate(_generatorPrototype_, _internalSlotsList_).
           1. Set _generator_.[[GeneratorBrand]] to _generatorBrand_.
@@ -45638,7 +45618,7 @@ THH:mm:ss.sss
         <dl class="header">
         </dl>
         <emu-alg>
-          1. NOTE: _closure_ can contain uses of the Await shorthand and uses of the Yield shorthand to yield an IteratorResult object.
+          1. NOTE: _closure_ can contain uses of the Await operation and uses of the Yield operation to yield an IteratorResult object.
           1. Let _internalSlotsList_ be « [[AsyncGeneratorState]], [[AsyncGeneratorContext]], [[AsyncGeneratorQueue]], [[GeneratorBrand]] ».
           1. Let _generator_ be OrdinaryObjectCreate(_generatorPrototype_, _internalSlotsList_).
           1. Set _generator_.[[GeneratorBrand]] to _generatorBrand_.


### PR DESCRIPTION
The first commit does the conversion, which is possible now that PR #2665 is merged.

The second commit moves the `Await` section to a more appropriate location. Currently, it's in 6.2.4 "The Completion Record Specification Type", and I move it to the end of "27.6.3 AsyncGenerator Abstract Operations". (There isn't one obviously perfect spot for it, but this is my guess at the best.)