### PR TITLE
Editorial: Various changes around execution contexts

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -50583,13 +50583,13 @@ THH:mm:ss.sss
             1. Set _acGenerator_.[[GeneratorState]] to ~completed~.
             1. NOTE: Once a generator enters the ~completed~ state it never leaves it and its associated execution context is never resumed. Any execution state associated with _acGenerator_ can be discarded at this point.
             1. If _result_ is a normal completion, then
-              1. Let _resultValue_ be *undefined*.
+              1. Let _finalCompletion_ be NormalCompletion(CreateIteratorResultObject(*undefined*, *true*)).
             1. Else if _result_ is a return completion, then
-              1. Let _resultValue_ be _result_.[[Value]].
+              1. Let _finalCompletion_ be NormalCompletion(CreateIteratorResultObject(_result_.[[Value]], *true*)).
             1. Else,
               1. Assert: _result_ is a throw completion.
-              1. Return ? _result_.
-            1. Return NormalCompletion(CreateIteratorResultObject(_resultValue_, *true*)).
+              1. Let _finalCompletion_ be _result_.
+            1. Return _finalCompletion_.
           1. Set the code evaluation state of _genContext_ such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
           1. Set _generator_.[[GeneratorContext]] to _genContext_.
           1. Return ~unused~.

--- a/spec.html
+++ b/spec.html
@@ -48492,7 +48492,7 @@ THH:mm:ss.sss
             1. Assert: _obj_ has a [[GeneratorState]] internal slot.
             1. If _obj_.[[GeneratorState]] is ~suspended-start~, then
               1. Set _obj_.[[GeneratorState]] to ~completed~.
-              1. NOTE: Once a generator enters the completed state it never leaves it and its associated execution context is never resumed. Any execution state associated with _obj_ can be discarded at this point.
+              1. NOTE: Once a generator enters the completed state it never leaves it and there is never again a transfer of control to its associated execution context. Any execution state associated with _obj_ can be discarded at this point.
               1. Perform ? IteratorCloseAll(_obj_.[[UnderlyingIterators]], NormalCompletion(~unused~)).
               1. Return CreateIteratorResultObject(*undefined*, *true*).
             1. Let _completion_ be ReturnCompletion(*undefined*).
@@ -50578,7 +50578,7 @@ THH:mm:ss.sss
             1. Assert: If we return here, the generator either threw an exception or performed either an implicit or explicit return.
             1. Remove _acGenContext_ from the execution context stack.
             1. Set _acGenerator_.[[GeneratorState]] to ~completed~.
-            1. NOTE: Once a generator enters the ~completed~ state it never leaves it and its associated execution context is never resumed. Any execution state associated with _acGenerator_ can be discarded at this point.
+            1. NOTE: Once a generator enters the ~completed~ state it never leaves it and there is never again a transfer of control to its associated execution context. Any execution state associated with _acGenerator_ can be discarded at this point.
             1. If _result_ is a normal completion, then
               1. Let _finalCompletion_ be NormalCompletion(CreateIteratorResultObject(*undefined*, *true*)).
             1. Else if _result_ is a return completion, then
@@ -50650,7 +50650,7 @@ THH:mm:ss.sss
           1. Let _state_ be ? GeneratorValidate(_generator_, _generatorBrand_).
           1. If _state_ is ~suspended-start~, then
             1. Set _generator_.[[GeneratorState]] to ~completed~.
-            1. NOTE: Once a generator enters the ~completed~ state it never leaves it and its associated execution context is never resumed. Any execution state associated with _generator_ can be discarded at this point.
+            1. NOTE: Once a generator enters the ~completed~ state it never leaves it and there is never again a transfer of control to its associated execution context. Any execution state associated with _generator_ can be discarded at this point.
             1. Set _state_ to ~completed~.
           1. If _state_ is ~completed~, then
             1. If _abruptCompletion_ is a return completion, then
@@ -51269,7 +51269,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _runningContext_ be the running execution context.
           1. Let _asyncContext_ be a copy of _runningContext_.
-          1. NOTE: Copying the execution state is required for AsyncBlockStart to resume its execution. It is ill-defined to resume a currently executing context.
+          1. NOTE: Copying is required because AsyncFunctionStart has different roles for _asyncContext_ and _runningContext_ that cannot (easily) be filled by a single execution context.
           1. Perform AsyncBlockStart(_promiseCapability_, _asyncFunctionBody_, _asyncContext_).
           1. Return ~unused~.
         </emu-alg>

--- a/spec.html
+++ b/spec.html
@@ -26197,7 +26197,6 @@
             1. Set _result_ to NormalCompletion(*undefined*).
         1. Suspend _scriptContext_ and remove it from the execution context stack.
         1. Assert: The execution context stack is not empty.
-        1. Resume the context that is now on the top of the execution context stack as the running execution context.
         1. Return ? _result_.
       </emu-alg>
     </emu-clause>
@@ -28688,7 +28687,6 @@
                 1. Push _moduleContext_ onto the execution context stack; _moduleContext_ is now the running execution context.
                 1. Let _result_ be Completion(Evaluation of _module_.[[ECMAScriptCode]]).
                 1. Suspend _moduleContext_ and remove it from the execution context stack.
-                1. Resume the context that is now on the top of the execution context stack as the running execution context.
                 1. If _result_ is an abrupt completion, then
                   1. Return ? _result_.
               1. Else,
@@ -28888,7 +28886,6 @@
               1. Let _steps_ be _module_.[[EvaluationSteps]].
               1. Let _result_ be Completion(_steps_(_module_)).
               1. Suspend _moduleContext_ and remove it from the execution context stack.
-              1. Resume the context that is now on the top of the execution context stack as the running execution context.
               1. Let _pc_ be ! NewPromiseCapability(%Promise%).
               1. IfAbruptRejectPromise(_result_, _pc_).
               1. Perform ! Call(_pc_.[[Resolve]], *undefined*, « *undefined* »).
@@ -29879,7 +29876,6 @@
           1. If _result_ is a normal completion and _result_.[[Value]] is ~empty~, then
             1. Set _result_ to NormalCompletion(*undefined*).
           1. Suspend _evalContext_ and remove it from the execution context stack.
-          1. Resume the context that is now on the top of the execution context stack as the running execution context.
           1. Return ? _result_.
         </emu-alg>
         <emu-note>

--- a/spec.html
+++ b/spec.html
@@ -11762,8 +11762,8 @@
 
   <emu-clause id="sec-execution-contexts">
     <h1>Execution Contexts</h1>
-    <p>An <dfn variants="execution contexts">execution context</dfn> is a specification device that is used to track the runtime evaluation of code by an ECMAScript implementation. At any point in time, there is at most one execution context per agent that is actually executing code. This is known as the agent's <dfn id="running-execution-context" variants="running execution contexts">running execution context</dfn>. All references to the running execution context in this specification denote the running execution context of the surrounding agent.</p>
-    <p>An execution context contains whatever implementation specific state is necessary to track the execution progress of its associated code. Each execution context has at least the state components listed in <emu-xref href="#table-state-components-for-all-execution-contexts"></emu-xref>.</p>
+    <p>An <dfn variants="execution contexts">execution context</dfn> brings together information that is relevant for the runtime evaluation of some unit of code (e.g., a script, a module, or a function object). At any point in time, there is at most one execution context per agent whose associated code is being evaluated. This is known as the agent's <dfn id="running-execution-context">running execution context</dfn>. All references to the running execution context in this specification denote the running execution context of the surrounding agent.</p>
+    <p>Each execution context has at least the state components listed in <emu-xref href="#table-state-components-for-all-execution-contexts"></emu-xref>.</p>
     <emu-table id="table-state-components-for-all-execution-contexts" caption="State Components for All Execution Contexts" oldids="table-22">
       <table>
         <thead>
@@ -11781,7 +11781,7 @@
             code evaluation state
           </td>
           <td>
-            Any state needed to perform, suspend, and resume evaluation of the code associated with this execution context.
+            Determines what happens the next time there is a transfer of control to the execution context.
           </td>
         </tr>
         <tr>
@@ -11789,7 +11789,7 @@
             Function
           </td>
           <td>
-            If this execution context is evaluating the code of a function object, then the value of this component is that function object. If the context is evaluating the code of a |Script| or |Module|, the value is *null*.
+            If this execution context is established for evaluating a call to a function object, then the value of this component is that function object. If the execution context is established for evaluating a |Script| or |Module|, the value is *null*.
           </td>
         </tr>
         <tr>
@@ -11829,7 +11829,7 @@
             LexicalEnvironment
           </td>
           <td>
-            Identifies the Environment Record used to resolve identifier references made by code within this execution context.
+            Identifies the Environment Record used to resolve identifier references made by code associated with this execution context.
           </td>
         </tr>
         <tr>
@@ -11837,7 +11837,7 @@
             VariableEnvironment
           </td>
           <td>
-            Identifies the Environment Record that holds bindings created by |VariableStatement|s within this execution context.
+            Identifies the Environment Record that holds bindings created by |VariableStatement|s in the code associated with this execution context.
           </td>
         </tr>
         <tr>
@@ -11871,7 +11871,7 @@
             Generator
           </td>
           <td>
-            The Generator that this execution context is evaluating.
+            The Generator that is associated with this execution context.
           </td>
         </tr>
       </table>
@@ -11981,7 +11981,7 @@
       <h1>GetGlobalObject ( ): an Object</h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It returns the global object used by the currently running execution context.</dd>
+        <dd>It returns the global object used by the running execution context.</dd>
       </dl>
       <emu-alg>
         1. Let _currentRealm_ be the current Realm Record.
@@ -12386,7 +12386,7 @@
   <emu-clause id="sec-forward-progress">
     <h1>Forward Progress</h1>
     <p>For an agent to <em>make forward progress</em> is for it to perform an evaluation step according to this specification.</p>
-    <p>An agent becomes <em>blocked</em> when its running execution context waits synchronously and indefinitely for an external event. Only agents whose Agent Record's [[CanBlock]] field is *true* can become blocked in this sense. An <em>unblocked</em> agent is one that is not blocked.</p>
+    <p>An agent becomes <em>blocked</em> when it waits synchronously and indefinitely for an external event. Only agents whose Agent Record's [[CanBlock]] field is *true* can become blocked in this sense. An <em>unblocked</em> agent is one that is not blocked.</p>
 
     <p>Implementations must ensure that:</p>
     <ul>
@@ -26005,7 +26005,7 @@
         1. Discard all resources associated with the current execution context.
         1. Return ~unused~.
       </emu-alg>
-      <p>A tail position call must either release any transient internal resources associated with the currently executing function execution context before invoking the target function or reuse those resources in support of the target function.</p>
+      <p>A tail position call must either release any transient internal resources associated with the currently executing function's execution context before invoking the target function or reuse those resources in support of the target function.</p>
       <emu-note>
         <p>For example, a tail position call should only grow an implementation's activation record stack by the amount that the size of the target function's activation record exceeds the size of the calling function's activation record. If the target function's activation record is smaller, then the total size of the stack should decrease.</p>
       </emu-note>
@@ -26967,7 +26967,7 @@
                 ): either a normal completion containing ~unused~ or a throw completion
               </td>
               <td>
-                It evaluates the module's code within its execution context. If this module has *true* in [[HasTLA]], then a PromiseCapability Record is passed as an argument, and the method is expected to resolve or reject the given capability. In this case, the method must not throw an exception, but instead reject the PromiseCapability Record if necessary.
+                It evaluates the module's code using its execution context. If this module has *true* in [[HasTLA]], then a PromiseCapability Record is passed as an argument, and the method is expected to resolve or reject the given capability. In this case, the method must not throw an exception, but instead reject the PromiseCapability Record if necessary.
               </td>
               <td>
                 Within this specification it has definitions in the following types; hosts may provide additional types with their own definitions:
@@ -29766,7 +29766,7 @@
   <h1>The Global Object</h1>
   <p>The <dfn variants="global objects">global object</dfn>:</p>
   <ul>
-    <li>is created before control enters any execution context.</li>
+    <li>is created in InitializeHostDefinedRealm.</li>
     <li>does not have a [[Construct]] internal method; it cannot be used as a constructor with the `new` operator.</li>
     <li>does not have a [[Call]] internal method; it cannot be invoked as a function.</li>
     <li>has a [[Prototype]] internal slot whose value is host-defined.</li>

--- a/spec.html
+++ b/spec.html
@@ -50592,7 +50592,8 @@ THH:mm:ss.sss
             1. Let _callerContext_ be the running execution context.
             1. Transfer control from _acGenContext_ to _callerContext_, passing _finalCompletion_.
             1. NOTE: This step is never reached, because control is never transferred back to _acGenContext_.
-          1. Set the code evaluation state of _genContext_ such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
+          1. Set _genContext_'s code evaluation state to _closure_.
+          1. NOTE: The next time there is a transfer of control to _genContext_, _closure_ will be called with no arguments.
           1. Set _generator_.[[GeneratorContext]] to _genContext_.
           1. Return ~unused~.
         </emu-alg>
@@ -50947,7 +50948,8 @@ THH:mm:ss.sss
             1. Let _callerContext_ be the running execution context.
             1. Transfer control from _acGenContext_ to _callerContext_, passing NormalCompletion(*undefined*).
             1. NOTE: This step is never reached, because control is never transferred back to _acGenContext_.
-          1. Set the code evaluation state of _genContext_ such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
+          1. Set _genContext_'s code evaluation state to _closure_.
+          1. NOTE: The next time there is a transfer of control to _genContext_, _closure_ will be called with no arguments.
           1. Set _generator_.[[AsyncGeneratorContext]] to _genContext_.
           1. Set _generator_.[[AsyncGeneratorQueue]] to a new empty List.
           1. Return ~unused~.
@@ -51307,7 +51309,8 @@ THH:mm:ss.sss
             1. Let _callerContext_ be the running execution context.
             1. [id="step-asyncblockstart-return-undefined"] Transfer control from _acAsyncContext_ to _callerContext_, passing NormalCompletion(~unused~).
             1. NOTE: This step is never reached, because control is never transferred back to _acAsyncContext_.
-          1. Set the code evaluation state of _asyncContext_ such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
+          1. Set _asyncContext_'s code evaluation state to _closure_.
+          1. NOTE: The next time there is a transfer of control to _asyncContext_, _closure_ will be called with no arguments.
           1. Let _result_ be ! RunSuspendedContext(_asyncContext_, NormalCompletion(~unused~)).
           1. Assert: _result_ is ~unused~.
           1. NOTE: The possible sources of _result_ values are Await or, if the async function doesn't await anything, step <emu-xref href="#step-asyncblockstart-return-undefined"></emu-xref> above.

--- a/spec.html
+++ b/spec.html
@@ -11876,6 +11876,15 @@
         </tr>
       </table>
     </emu-table>
+    <p>To express the semantics of generators, this document uses steps of the form “<dfn id="transfer-control" variants="transfers control,transfer of control">Transfer control</dfn> from _aContext_ to _bContext_, passing _completion_”, where _aContext_ and _bContext_ are execution contexts and _completion_ is a Completion Record. This means:</p>
+    <ul>
+      <li>Execution of the current algorithm (the one with the “Transfer control” step) is suspended, and a representation of that suspended execution is saved in the code evaluation state of _aContext_.</li>
+      <li>The code evaluation state of _bContext_ is typically a representation of an execution that was suspended in another “Transfer control” step; that execution is resumed, and _completion_ is provided as “the Completion Record passed when control was transferred back to _bContext_”. Alternatively, _bContext_'s code evaluation state is an Abstract Closure; in that case, the Abstract Closure is called with no arguments, and _completion_ is ignored.</li>
+    </ul>
+    <p>The suspended execution associated with _aContext_ will stay suspended until some step transfers control back to _aContext_, which might never happen.</p>
+    <emu-note>This is analogous to the concept of coroutines in programming languages.</emu-note>
+    <emu-note>In practice, _aContext_ was the running execution context until just before the “Transfer control” step, and _bContext_ is the new running execution context. However, the “Transfer control” step itself doesn't manipulate the execution context stack.</emu-note>
+
     <p>In most situations only the running execution context (the top of the execution context stack) is directly manipulated by algorithms within this specification. Hence when the terms “LexicalEnvironment”, and “VariableEnvironment” are used without qualification they are in reference to those components of the running execution context.</p>
     <p>An execution context is purely a specification mechanism and need not correspond to any particular artefact of an ECMAScript implementation. It is impossible for ECMAScript code to directly access or observe an execution context.</p>
 

--- a/spec.html
+++ b/spec.html
@@ -50589,7 +50589,9 @@ THH:mm:ss.sss
             1. Else,
               1. Assert: _result_ is a throw completion.
               1. Let _finalCompletion_ be _result_.
-            1. Return _finalCompletion_.
+            1. Let _callerContext_ be the running execution context.
+            1. Transfer control from _acGenContext_ to _callerContext_, passing _finalCompletion_.
+            1. NOTE: This step is never reached, because control is never transferred back to _acGenContext_.
           1. Set the code evaluation state of _genContext_ such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
           1. Set _generator_.[[GeneratorContext]] to _genContext_.
           1. Return ~unused~.
@@ -50942,7 +50944,9 @@ THH:mm:ss.sss
             1. If _result_ is a return completion, set _result_ to NormalCompletion(_result_.[[Value]]).
             1. Perform AsyncGeneratorCompleteStep(_acGenerator_, _result_, *true*).
             1. Perform AsyncGeneratorDrainQueue(_acGenerator_).
-            1. Return NormalCompletion(*undefined*).
+            1. Let _callerContext_ be the running execution context.
+            1. Transfer control from _acGenContext_ to _callerContext_, passing NormalCompletion(*undefined*).
+            1. NOTE: This step is never reached, because control is never transferred back to _acGenContext_.
           1. Set the code evaluation state of _genContext_ such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
           1. Set _generator_.[[AsyncGeneratorContext]] to _genContext_.
           1. Set _generator_.[[AsyncGeneratorQueue]] to a new empty List.
@@ -51300,7 +51304,9 @@ THH:mm:ss.sss
             1. Else,
               1. Assert: _result_ is a throw completion.
               1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, « _result_.[[Value]] »).
-            1. [id="step-asyncblockstart-return-undefined"] Return NormalCompletion(~unused~).
+            1. Let _callerContext_ be the running execution context.
+            1. [id="step-asyncblockstart-return-undefined"] Transfer control from _acAsyncContext_ to _callerContext_, passing NormalCompletion(~unused~).
+            1. NOTE: This step is never reached, because control is never transferred back to _acAsyncContext_.
           1. Set the code evaluation state of _asyncContext_ such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
           1. Let _result_ be ! RunSuspendedContext(_asyncContext_, NormalCompletion(~unused~)).
           1. Assert: _result_ is ~unused~.

--- a/spec.html
+++ b/spec.html
@@ -11763,7 +11763,6 @@
   <emu-clause id="sec-execution-contexts">
     <h1>Execution Contexts</h1>
     <p>An <dfn variants="execution contexts">execution context</dfn> is a specification device that is used to track the runtime evaluation of code by an ECMAScript implementation. At any point in time, there is at most one execution context per agent that is actually executing code. This is known as the agent's <dfn id="running-execution-context" variants="running execution contexts">running execution context</dfn>. All references to the running execution context in this specification denote the running execution context of the surrounding agent.</p>
-    <p>The <dfn id="execution-context-stack" variants="execution context stacks">execution context stack</dfn> is used to track execution contexts. The running execution context is always the top element of this stack. A new execution context is created whenever control is transferred from the executable code associated with the currently running execution context to executable code that is not associated with that execution context. The newly created execution context is pushed onto the stack and becomes the running execution context.</p>
     <p>An execution context contains whatever implementation specific state is necessary to track the execution progress of its associated code. Each execution context has at least the state components listed in <emu-xref href="#table-state-components-for-all-execution-contexts"></emu-xref>.</p>
     <emu-table id="table-state-components-for-all-execution-contexts" caption="State Components for All Execution Contexts" oldids="table-22">
       <table>
@@ -11811,7 +11810,6 @@
         </tr>
       </table>
     </emu-table>
-    <p>Evaluation of code by the running execution context may be suspended at various points defined within this specification. Once the running execution context has been suspended a different execution context may become the running execution context and commence evaluating its code. At some later time a suspended execution context may again become the running execution context and continue evaluating its code at the point where it had previously been suspended. Transition of the running execution context status among execution contexts usually occurs in stack-like last-in/first-out manner. However, some ECMAScript features require non-LIFO transitions of the running execution context.</p>
     <p>The value of the Realm component of the running execution context is also called <dfn id="current-realm">the current Realm Record</dfn>. The value of the Function component of the running execution context is also called the <dfn id="active-function-object">active function object</dfn>.</p>
     <p><dfn id="ecmascript-code-execution-context" variants="ECMAScript code execution context">ECMAScript code execution contexts</dfn> have the additional state components listed in <emu-xref href="#table-additional-state-components-for-ecmascript-code-execution-contexts"></emu-xref>.</p>
     <emu-table id="table-additional-state-components-for-ecmascript-code-execution-contexts" caption="Additional State Components for ECMAScript Code Execution Contexts" oldids="table-23">
@@ -11853,7 +11851,7 @@
       </table>
     </emu-table>
     <p>The LexicalEnvironment and VariableEnvironment components of an execution context are always Environment Records.</p>
-    <p>In most situations only the running execution context (the top of the execution context stack) is directly manipulated by algorithms within this specification. Hence when the terms “LexicalEnvironment”, and “VariableEnvironment” are used without qualification they are in reference to those components of the running execution context.</p>
+    <p>In most situations only the running execution context is directly manipulated by algorithms within this specification. Hence when the terms “LexicalEnvironment”, and “VariableEnvironment” are used without qualification they are in reference to those components of the running execution context.</p>
 
     <p>Execution contexts representing the evaluation of Generators have the additional state components listed in <emu-xref href="#table-additional-state-components-for-generator-execution-contexts"></emu-xref>.</p>
     <emu-table id="table-additional-state-components-for-generator-execution-contexts" caption="Additional State Components for Generator Execution Contexts" oldids="table-24">
@@ -11888,6 +11886,13 @@
     <emu-note>In practice, _aContext_ was the running execution context until just before the “Transfer control” step, and _bContext_ is the new running execution context. However, the “Transfer control” step itself doesn't manipulate the execution context stack.</emu-note>
 
     <p>An execution context is purely a specification mechanism and need not correspond to any particular artefact of an ECMAScript implementation. It is impossible for ECMAScript code to directly access or observe an execution context.</p>
+
+    <emu-clause id="sec-execution-context-stack">
+      <h1>Execution Context Stack</h1>
+      <p>An agent's <dfn id="execution-context-stack" variants="execution context stacks">execution context stack</dfn> is used to organize some or all of the agent's execution contexts. The running execution context is always the top element of this stack.</p>
+      <p>Adding and removing always happens at the “top” of the execution context stack. When an execution context is added, it becomes the topmost (i.e., the running execution context), and when it is later removed, the execution context “below” it becomes topmost again.</p>
+      <emu-note>In the absence of generators and async functions, every execution context that is pushed onto the stack is new, and when it's removed from the stack it can be discarded. With generators and async functions, some execution contexts outlive their time on the stack, exist for a while outside the stack, and then later are pushed onto the stack again.</emu-note>
+    </emu-clause>
 
     <emu-clause id="sec-getactivescriptormodule" type="abstract operation">
       <h1>GetActiveScriptOrModule ( ): a Script Record, a Module Record, or *null*</h1>

--- a/spec.html
+++ b/spec.html
@@ -51296,7 +51296,7 @@ THH:mm:ss.sss
               1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, « _result_.[[Value]] »).
             1. [id="step-asyncblockstart-return-undefined"] Return NormalCompletion(~unused~).
           1. Set the code evaluation state of _asyncContext_ such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
-          1. Let _result_ be ! RunSuspendedContext(_asyncContext_, NormalCompletion(~empty~)).
+          1. Let _result_ be ! RunSuspendedContext(_asyncContext_, NormalCompletion(~unused~)).
           1. Assert: _result_ is ~unused~.
           1. NOTE: The possible sources of _result_ values are Await or, if the async function doesn't await anything, step <emu-xref href="#step-asyncblockstart-return-undefined"></emu-xref> above.
           1. Return ~unused~.

--- a/spec.html
+++ b/spec.html
@@ -13355,11 +13355,13 @@
         1. If _func_.[[IsClassConstructor]] is *true*, then
           1. Let _error_ be a newly created *TypeError* object.
           1. NOTE: _error_ is created in _calleeContext_ with _func_'s associated Realm Record.
-          1. Remove _calleeContext_ from the execution context stack and restore _callerContext_ as the running execution context.
+          1. Remove _calleeContext_ from the execution context stack.
+          1. Assert: _callerContext_ is the running execution context again.
           1. Throw _error_.
         1. Perform OrdinaryCallBindThis(_func_, _calleeContext_, _thisArgument_).
         1. Let _result_ be Completion(OrdinaryCallEvaluateBody(_func_, _argumentsList_)).
-        1. [id="step-call-pop-context-stack"] Remove _calleeContext_ from the execution context stack and restore _callerContext_ as the running execution context.
+        1. [id="step-call-pop-context-stack"] Remove _calleeContext_ from the execution context stack.
+        1. Assert: _callerContext_ is the running execution context again.
         1. If _result_ is a return completion, return _result_.[[Value]].
         1. Assert: _result_ is a throw completion.
         1. Return ? _result_.
@@ -13529,11 +13531,13 @@
           1. Perform OrdinaryCallBindThis(_func_, _calleeContext_, _thisArgument_).
           1. Let _initializeResult_ be Completion(InitializeInstanceElements(_thisArgument_, _func_)).
           1. If _initializeResult_ is an abrupt completion, then
-            1. Remove _calleeContext_ from the execution context stack and restore _callerContext_ as the running execution context.
+            1. Remove _calleeContext_ from the execution context stack.
+            1. Assert: _callerContext_ is the running execution context again.
             1. Return ? _initializeResult_.
         1. Let _constructorEnv_ be the LexicalEnvironment of _calleeContext_.
         1. Let _result_ be Completion(OrdinaryCallEvaluateBody(_func_, _argumentsList_)).
-        1. Remove _calleeContext_ from the execution context stack and restore _callerContext_ as the running execution context.
+        1. Remove _calleeContext_ from the execution context stack.
+        1. Assert: _callerContext_ is the running execution context again.
         1. If _result_ is a throw completion, then
           1. Return ? _result_.
         1. Assert: _result_ is a return completion.
@@ -13976,11 +13980,13 @@
             1. NOTE: If _func_ is defined in this document, “the specification of _func_” is the behaviour specified for it via algorithm steps or other means.
             1. Return Completion(_result_).
           1. Perform AsyncFunctionStart(_promiseCapability_, _resultsClosure_).
-          1. Remove _calleeContext_ from the execution context stack and restore _callerContext_ as the running execution context.
+          1. Remove _calleeContext_ from the execution context stack.
+          1. Assert: _callerContext_ is the running execution context again.
           1. Return _promiseCapability_.[[Promise]].
         1. [id="step-call-builtin-function-result"] Let _result_ be the Completion Record that is <emu-meta effects="user-code">the result of evaluating</emu-meta> _func_ in a manner that conforms to the specification of _func_. If _thisArgument_ is ~uninitialized~, the *this* value is uninitialized; else _thisArgument_ provides the *this* value. _argumentsList_ provides the named parameters. _newTarget_ provides the NewTarget value.
         1. NOTE: If _func_ is defined in this document, “the specification of _func_” is the behaviour specified for it via algorithm steps or other means.
-        1. Remove _calleeContext_ from the execution context stack and restore _callerContext_ as the running execution context.
+        1. Remove _calleeContext_ from the execution context stack.
+        1. Assert: _callerContext_ is the running execution context again.
         1. Return ? _result_.
       </emu-alg>
       <emu-note>
@@ -50571,7 +50577,7 @@ THH:mm:ss.sss
               1. Assert: _generatorBody_ is an Abstract Closure with no parameters.
               1. Let _result_ be Completion(_generatorBody_()).
             1. Assert: If we return here, the generator either threw an exception or performed either an implicit or explicit return.
-            1. Remove _acGenContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
+            1. Remove _acGenContext_ from the execution context stack.
             1. Set _acGenerator_.[[GeneratorState]] to ~completed~.
             1. NOTE: Once a generator enters the ~completed~ state it never leaves it and its associated execution context is never resumed. Any execution state associated with _acGenerator_ can be discarded at this point.
             1. If _result_ is a normal completion, then
@@ -50684,7 +50690,7 @@ THH:mm:ss.sss
           1. Let _generator_ be the value of the Generator component of _genContext_.
           1. Assert: GetGeneratorKind() is ~sync~.
           1. Set _generator_.[[GeneratorState]] to ~suspended-yield~.
-          1. Remove _genContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
+          1. Remove _genContext_ from the execution context stack.
           1. Let _callerContext_ be the running execution context.
           1. Resume _callerContext_ passing NormalCompletion(_iteratorResult_). If _genContext_ is ever resumed again, let _resumptionValue_ be the Completion Record with which it is resumed.
           1. Assert: If control reaches here, then _genContext_ is the running execution context again.
@@ -50733,7 +50739,8 @@ THH:mm:ss.sss
           1. If _callerContext_ is not already suspended, suspend _callerContext_.
           1. Push _calleeContext_ onto the execution context stack; _calleeContext_ is now the running execution context.
           1. Perform GeneratorStart(_generator_, _closure_).
-          1. Remove _calleeContext_ from the execution context stack and restore _callerContext_ as the running execution context.
+          1. Remove _calleeContext_ from the execution context stack.
+          1. Assert: _callerContext_ is the running execution context again.
           1. Return _generator_.
         </emu-alg>
       </emu-clause>
@@ -50925,7 +50932,7 @@ THH:mm:ss.sss
               1. Assert: _generatorBody_ is an Abstract Closure with no parameters.
               1. Let _result_ be Completion(_generatorBody_()).
             1. Assert: If we return here, the async generator either threw an exception or performed either an implicit or explicit return.
-            1. Remove _acGenContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
+            1. Remove _acGenContext_ from the execution context stack.
             1. Set _acGenerator_.[[AsyncGeneratorState]] to ~draining-queue~.
             1. If _result_ is a normal completion, set _result_ to NormalCompletion(*undefined*).
             1. If _result_ is a return completion, set _result_ to NormalCompletion(_result_.[[Value]]).
@@ -51067,7 +51074,7 @@ THH:mm:ss.sss
             1. Let _resumptionValue_ be Completion(_toYield_.[[Completion]]).
             1. Return ? AsyncGeneratorUnwrapYieldResumption(_resumptionValue_).
           1. Set _generator_.[[AsyncGeneratorState]] to ~suspended-yield~.
-          1. Remove _genContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
+          1. Remove _genContext_ from the execution context stack.
           1. Let _callerContext_ be the running execution context.
           1. Resume _callerContext_ passing *undefined*. If _genContext_ is ever resumed again, let _resumptionValue_ be the Completion Record with which it is resumed.
           1. Assert: If control reaches here, then _genContext_ is the running execution context again.
@@ -51279,7 +51286,7 @@ THH:mm:ss.sss
               1. Assert: _asyncBody_ is an Abstract Closure with no parameters.
               1. Let _result_ be Completion(_asyncBody_()).
             1. Assert: If we return here, the async function either threw an exception or performed an implicit or explicit return; all awaiting is done.
-            1. Remove _acAsyncContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
+            1. Remove _acAsyncContext_ from the execution context stack.
             1. If _result_ is a normal completion, then
               1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, « *undefined* »).
             1. Else if _result_ is a return completion, then
@@ -51318,7 +51325,7 @@ THH:mm:ss.sss
             1. Return NormalCompletion(*undefined*).
           1. Let _onRejected_ be CreateBuiltinFunction(_rejectedClosure_, 1, *""*, « »).
           1. Perform PerformPromiseThen(_promise_, _onFulfilled_, _onRejected_).
-          1. Remove _asyncContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
+          1. Remove _asyncContext_ from the execution context stack.
           1. Let _callerContext_ be the running execution context.
           1. Resume _callerContext_ passing ~empty~. If _asyncContext_ is ever resumed again, let _completion_ be the Completion Record with which it is resumed.
           1. Assert: If control reaches here, then _asyncContext_ is the running execution context again.

--- a/spec.html
+++ b/spec.html
@@ -11996,7 +11996,6 @@
       </dl>
       <emu-alg>
         1. Let _callerContext_ be the running execution context.
-        1. Suspend _callerContext_.
         1. Push _context_ onto the execution context stack; _context_ is now the running execution context.
         1. Transfer control from _callerContext_ to _context_, passing _completionRecord_.
         1. NOTE: This step is reached only when control is transferred back to _callerContext_, which might not happen.
@@ -13378,7 +13377,7 @@
         1. Return ? _result_.
       </emu-alg>
       <emu-note>
-        <p>When _calleeContext_ is removed from the execution context stack in step <emu-xref href="#step-call-pop-context-stack"></emu-xref> it must not be destroyed if it is suspended and retained for later resumption by an accessible Generator.</p>
+        <p>When _calleeContext_ is removed from the execution context stack in step <emu-xref href="#step-call-pop-context-stack"></emu-xref> it must not be destroyed if it is retained for later resumption by an accessible Generator.</p>
       </emu-note>
 
       <emu-clause id="sec-prepareforordinarycall" type="abstract operation">
@@ -13391,7 +13390,6 @@
         <dl class="header">
         </dl>
         <emu-alg>
-          1. Let _callerContext_ be the running execution context.
           1. Let _calleeContext_ be a new ECMAScript code execution context.
           1. Set the Function of _calleeContext_ to _func_.
           1. Let _calleeRealm_ be _func_.[[Realm]].
@@ -13401,7 +13399,6 @@
           1. Set the LexicalEnvironment of _calleeContext_ to _localEnv_.
           1. Set the VariableEnvironment of _calleeContext_ to _localEnv_.
           1. Set the PrivateEnvironment of _calleeContext_ to _func_.[[PrivateEnvironment]].
-          1. If _callerContext_ is not already suspended, suspend _callerContext_.
           1. Push _calleeContext_ onto the execution context stack; _calleeContext_ is now the running execution context.
           1. NOTE: Any exception objects produced after this point are associated with _calleeRealm_.
           1. Return _calleeContext_.
@@ -13976,7 +13973,6 @@
       </dl>
       <emu-alg>
         1. Let _callerContext_ be the running execution context.
-        1. If _callerContext_ is not already suspended, suspend _callerContext_.
         1. Let _calleeContext_ be a new execution context.
         1. Set the Function of _calleeContext_ to _func_.
         1. Let _calleeRealm_ be _func_.[[Realm]].
@@ -14001,7 +13997,7 @@
         1. Return ? _result_.
       </emu-alg>
       <emu-note>
-        <p>When _calleeContext_ is removed from the execution context stack it must not be destroyed if it has been suspended and retained by an accessible Generator for later resumption.</p>
+        <p>When _calleeContext_ is removed from the execution context stack it must not be destroyed if it has been retained by an accessible Generator for later resumption.</p>
       </emu-note>
     </emu-clause>
 
@@ -26187,7 +26183,6 @@
         1. Set the VariableEnvironment of _scriptContext_ to _globalEnv_.
         1. Set the LexicalEnvironment of _scriptContext_ to _globalEnv_.
         1. Set the PrivateEnvironment of _scriptContext_ to *null*.
-        1. Suspend the running execution context.
         1. Push _scriptContext_ onto the execution context stack; _scriptContext_ is now the running execution context.
         1. Let _script_ be _scriptRecord_.[[ECMAScriptCode]].
         1. Let _result_ be Completion(GlobalDeclarationInstantiation(_script_, _globalEnv_)).
@@ -26195,7 +26190,7 @@
           1. Set _result_ to Completion(Evaluation of _script_).
           1. If _result_ is a normal completion and _result_.[[Value]] is ~empty~, then
             1. Set _result_ to NormalCompletion(*undefined*).
-        1. Suspend _scriptContext_ and remove it from the execution context stack.
+        1. Remove _scriptContext_ from the execution context stack.
         1. Assert: The execution context stack is not empty.
         1. Return ? _result_.
       </emu-alg>
@@ -28683,10 +28678,9 @@
               1. Let _moduleContext_ be _module_.[[Context]].
               1. If _module_.[[HasTLA]] is *false*, then
                 1. Assert: _capability_ is not present.
-                1. Suspend the running execution context.
                 1. Push _moduleContext_ onto the execution context stack; _moduleContext_ is now the running execution context.
                 1. Let _result_ be Completion(Evaluation of _module_.[[ECMAScriptCode]]).
-                1. Suspend _moduleContext_ and remove it from the execution context stack.
+                1. Remove _moduleContext_ from the execution context stack.
                 1. If _result_ is an abrupt completion, then
                   1. Return ? _result_.
               1. Else,
@@ -28881,11 +28875,10 @@
               1. Set the ScriptOrModule of _moduleContext_ to _module_.
               1. Set the VariableEnvironment of _moduleContext_ to _module_.[[Environment]].
               1. Set the LexicalEnvironment of _moduleContext_ to _module_.[[Environment]].
-              1. Suspend the running execution context.
               1. Push _moduleContext_ onto the execution context stack; _moduleContext_ is now the running execution context.
               1. Let _steps_ be _module_.[[EvaluationSteps]].
               1. Let _result_ be Completion(_steps_(_module_)).
-              1. Suspend _moduleContext_ and remove it from the execution context stack.
+              1. Remove _moduleContext_ from the execution context stack.
               1. Let _pc_ be ! NewPromiseCapability(%Promise%).
               1. IfAbruptRejectPromise(_result_, _pc_).
               1. Perform ! Call(_pc_.[[Resolve]], *undefined*, « *undefined* »).
@@ -29861,7 +29854,6 @@
             1. Let _varEnv_ be _evalRealm_.[[GlobalEnv]].
             1. Let _privateEnv_ be *null*.
           1. If _strictEval_ is *true*, set _varEnv_ to _lexEnv_.
-          1. If _runningContext_ is not already suspended, suspend _runningContext_.
           1. Let _evalContext_ be a new ECMAScript code execution context.
           1. Set _evalContext_'s Function to *null*.
           1. Set _evalContext_'s Realm to _evalRealm_.
@@ -29875,7 +29867,7 @@
             1. Set _result_ to Completion(Evaluation of _body_).
           1. If _result_ is a normal completion and _result_.[[Value]] is ~empty~, then
             1. Set _result_ to NormalCompletion(*undefined*).
-          1. Suspend _evalContext_ and remove it from the execution context stack.
+          1. Remove _evalContext_ from the execution context stack.
           1. Return ? _result_.
         </emu-alg>
         <emu-note>
@@ -50748,7 +50740,6 @@ THH:mm:ss.sss
           1. Set the Function of _calleeContext_ to *null*.
           1. Set the Realm of _calleeContext_ to the current Realm Record.
           1. Set the ScriptOrModule of _calleeContext_ to _callerContext_'s ScriptOrModule.
-          1. If _callerContext_ is not already suspended, suspend _callerContext_.
           1. Push _calleeContext_ onto the execution context stack; _calleeContext_ is now the running execution context.
           1. Perform GeneratorStart(_generator_, _closure_).
           1. Remove _calleeContext_ from the execution context stack.

--- a/spec.html
+++ b/spec.html
@@ -11853,6 +11853,8 @@
       </table>
     </emu-table>
     <p>The LexicalEnvironment and VariableEnvironment components of an execution context are always Environment Records.</p>
+    <p>In most situations only the running execution context (the top of the execution context stack) is directly manipulated by algorithms within this specification. Hence when the terms “LexicalEnvironment”, and “VariableEnvironment” are used without qualification they are in reference to those components of the running execution context.</p>
+
     <p>Execution contexts representing the evaluation of Generators have the additional state components listed in <emu-xref href="#table-additional-state-components-for-generator-execution-contexts"></emu-xref>.</p>
     <emu-table id="table-additional-state-components-for-generator-execution-contexts" caption="Additional State Components for Generator Execution Contexts" oldids="table-24">
       <table>
@@ -11885,7 +11887,6 @@
     <emu-note>This is analogous to the concept of coroutines in programming languages.</emu-note>
     <emu-note>In practice, _aContext_ was the running execution context until just before the “Transfer control” step, and _bContext_ is the new running execution context. However, the “Transfer control” step itself doesn't manipulate the execution context stack.</emu-note>
 
-    <p>In most situations only the running execution context (the top of the execution context stack) is directly manipulated by algorithms within this specification. Hence when the terms “LexicalEnvironment”, and “VariableEnvironment” are used without qualification they are in reference to those components of the running execution context.</p>
     <p>An execution context is purely a specification mechanism and need not correspond to any particular artefact of an ECMAScript implementation. It is impossible for ECMAScript code to directly access or observe an execution context.</p>
 
     <emu-clause id="sec-getactivescriptormodule" type="abstract operation">

--- a/spec.html
+++ b/spec.html
@@ -11989,8 +11989,10 @@
         1. Let _callerContext_ be the running execution context.
         1. Suspend _callerContext_.
         1. Push _context_ onto the execution context stack; _context_ is now the running execution context.
-        1. <emu-meta effects="user-code">Resume the suspended evaluation of _context_</emu-meta> using _completionRecord_ as the result of the operation that suspended it. Let _result_ be the Completion Record returned by the resumed computation.
-        1. Assert: When we reach this step, _context_ has already been removed from the execution context stack and _callerContext_ is the running execution context again.
+        1. Transfer control from _callerContext_ to _context_, passing _completionRecord_.
+        1. NOTE: This step is reached only when control is transferred back to _callerContext_, which might not happen.
+        1. Let _result_ be the Completion Record passed when control was transferred back to _callerContext_.
+        1. Assert: _context_ has already been removed from the execution context stack and _callerContext_ is the running execution context again.
         1. Return Completion(_result_).
       </emu-alg>
     </emu-clause>
@@ -50692,8 +50694,10 @@ THH:mm:ss.sss
           1. Set _generator_.[[GeneratorState]] to ~suspended-yield~.
           1. Remove _genContext_ from the execution context stack.
           1. Let _callerContext_ be the running execution context.
-          1. Resume _callerContext_ passing NormalCompletion(_iteratorResult_). If _genContext_ is ever resumed again, let _resumptionValue_ be the Completion Record with which it is resumed.
-          1. Assert: If control reaches here, then _genContext_ is the running execution context again.
+          1. Transfer control from _genContext_ to _callerContext_, passing NormalCompletion(_iteratorResult_).
+          1. NOTE: This step is reached only when control is transferred back to _genContext_, which might not happen.
+          1. Let _resumptionValue_ be the Completion Record passed when control was transferred back to _genContext_.
+          1. Assert: _genContext_ is the running execution context again.
           1. Return _resumptionValue_.
         </emu-alg>
       </emu-clause>
@@ -51076,8 +51080,10 @@ THH:mm:ss.sss
           1. Set _generator_.[[AsyncGeneratorState]] to ~suspended-yield~.
           1. Remove _genContext_ from the execution context stack.
           1. Let _callerContext_ be the running execution context.
-          1. Resume _callerContext_ passing *undefined*. If _genContext_ is ever resumed again, let _resumptionValue_ be the Completion Record with which it is resumed.
-          1. Assert: If control reaches here, then _genContext_ is the running execution context again.
+          1. Transfer control from _genContext_ to _callerContext_, passing NormalCompletion(*undefined*).
+          1. NOTE: This step is reached only when control is transferred back to _genContext_, which might not happen.
+          1. Let _resumptionValue_ be the Completion Record passed when control was transferred back to _genContext_.
+          1. Assert: _genContext_ is the running execution context again.
           1. Return ? AsyncGeneratorUnwrapYieldResumption(_resumptionValue_).
         </emu-alg>
       </emu-clause>
@@ -51327,8 +51333,10 @@ THH:mm:ss.sss
           1. Perform PerformPromiseThen(_promise_, _onFulfilled_, _onRejected_).
           1. Remove _asyncContext_ from the execution context stack.
           1. Let _callerContext_ be the running execution context.
-          1. Resume _callerContext_ passing ~empty~. If _asyncContext_ is ever resumed again, let _completion_ be the Completion Record with which it is resumed.
-          1. Assert: If control reaches here, then _asyncContext_ is the running execution context again.
+          1. Transfer control from _asyncContext_ to _callerContext_, passing NormalCompletion(~empty~).
+          1. NOTE: This step is reached only when control is transferred back to _asyncContext_, which might not happen.
+          1. Let _completion_ be the Completion Record passed when control was transferred back to _asyncContext_.
+          1. Assert: _asyncContext_ is the running execution context again.
           1. Return _completion_.
         </emu-alg>
       </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -12262,6 +12262,8 @@
       </table>
     </emu-table>
     <p>The LexicalEnvironment and VariableEnvironment components of an execution context are always Environment Records.</p>
+    <p>In most situations only the running execution context (the top of the execution context stack) is directly manipulated by algorithms within this specification. Hence when the terms “LexicalEnvironment”, and “VariableEnvironment” are used without qualification they are in reference to those components of the running execution context.</p>
+
     <p>Execution contexts representing the evaluation of Generators have the additional state components listed in <emu-xref href="#table-additional-state-components-for-generator-execution-contexts"></emu-xref>.</p>
     <emu-table id="table-additional-state-components-for-generator-execution-contexts" caption="Additional State Components for Generator Execution Contexts" oldids="table-24">
       <table>
@@ -12294,7 +12296,6 @@
     <emu-note>This is analogous to the concept of coroutines in programming languages.</emu-note>
     <emu-note>In practice, _aContext_ was the running execution context until just before the “Transfer control” step, and _bContext_ is the new running execution context. However, the “Transfer control” step itself doesn't manipulate the execution context stack.</emu-note>
 
-    <p>In most situations only the running execution context (the top of the execution context stack) is directly manipulated by algorithms within this specification. Hence when the terms “LexicalEnvironment”, and “VariableEnvironment” are used without qualification they are in reference to those components of the running execution context.</p>
     <p>An execution context is purely a specification mechanism and need not correspond to any particular artefact of an ECMAScript implementation. It is impossible for ECMAScript code to directly access or observe an execution context.</p>
 
     <emu-clause id="sec-getactivescriptormodule" type="abstract operation">

--- a/spec.html
+++ b/spec.html
@@ -26830,7 +26830,6 @@
             1. Set _result_ to NormalCompletion(*undefined*).
         1. Suspend _scriptContext_ and remove it from the execution context stack.
         1. Assert: The execution context stack is not empty.
-        1. Resume the context that is now on the top of the execution context stack as the running execution context.
         1. Return ? _result_.
       </emu-alg>
     </emu-clause>
@@ -29323,7 +29322,6 @@
                 1. Let _result_ be Completion(Evaluation of _module_.[[ECMAScriptCode]]).
                 1. Set _result_ to Completion(DisposeResources(_env_.[[DisposableResourceStack]], _result_)).
                 1. Suspend _moduleContext_ and remove it from the execution context stack.
-                1. Resume the context that is now on the top of the execution context stack as the running execution context.
                 1. If _result_ is an abrupt completion, then
                   1. Return ? _result_.
               1. Else,
@@ -29523,7 +29521,6 @@
               1. Let _steps_ be _module_.[[EvaluationSteps]].
               1. Let _result_ be Completion(_steps_(_module_)).
               1. Suspend _moduleContext_ and remove it from the execution context stack.
-              1. Resume the context that is now on the top of the execution context stack as the running execution context.
               1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
               1. IfAbruptRejectPromise(_result_, _promiseCapability_).
               1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, « *undefined* »).
@@ -30517,7 +30514,6 @@
           1. If _result_ is a normal completion and _result_.[[Value]] is ~empty~, then
             1. Set _result_ to NormalCompletion(*undefined*).
           1. Suspend _evalContext_ and remove it from the execution context stack.
-          1. Resume the context that is now on the top of the execution context stack as the running execution context.
           1. Return ? _result_.
         </emu-alg>
         <emu-note>

--- a/spec.html
+++ b/spec.html
@@ -12416,7 +12416,7 @@
       </dl>
       <emu-alg>
         1. Let _genContext_ be the running execution context.
-        1. Remove _genContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
+        1. Remove _genContext_ from the execution context stack.
         1. Let _callerContext_ be the running execution context.
         1. Resume _callerContext_, passing NormalCompletion(_value_).
         1. NOTE: The above step transfers control to _callerContext_ and pauses. The only way for it to un-pause and have control proceed to the subsequent steps in this algorithm is for _genContext_ to be resumed again, which might never happen.
@@ -13794,11 +13794,13 @@
         1. If _func_.[[IsClassConstructor]] is *true*, then
           1. Let _error_ be a newly created *TypeError* object.
           1. NOTE: _error_ is created in _calleeContext_ with _func_'s associated Realm Record.
-          1. Remove _calleeContext_ from the execution context stack and restore _callerContext_ as the running execution context.
+          1. Remove _calleeContext_ from the execution context stack.
+          1. Assert: _callerContext_ is the running execution context again.
           1. Throw _error_.
         1. Perform OrdinaryCallBindThis(_func_, _calleeContext_, _thisArg_).
         1. Let _result_ be Completion(OrdinaryCallEvaluateBody(_func_, _argList_)).
-        1. [id="step-call-pop-context-stack"] Remove _calleeContext_ from the execution context stack and restore _callerContext_ as the running execution context.
+        1. [id="step-call-pop-context-stack"] Remove _calleeContext_ from the execution context stack.
+        1. Assert: _callerContext_ is the running execution context again.
         1. If _result_ is a return completion, return _result_.[[Value]].
         1. Assert: _result_ is a throw completion.
         1. Return ? _result_.
@@ -13968,11 +13970,13 @@
           1. Perform OrdinaryCallBindThis(_func_, _calleeContext_, _thisArg_).
           1. Let _initializeResult_ be Completion(InitializeInstanceElements(_thisArg_, _func_)).
           1. If _initializeResult_ is an abrupt completion, then
-            1. Remove _calleeContext_ from the execution context stack and restore _callerContext_ as the running execution context.
+            1. Remove _calleeContext_ from the execution context stack.
+            1. Assert: _callerContext_ is the running execution context again.
             1. Return ? _initializeResult_.
         1. Let _ctorEnv_ be the LexicalEnvironment of _calleeContext_.
         1. Let _result_ be Completion(OrdinaryCallEvaluateBody(_func_, _argList_)).
-        1. Remove _calleeContext_ from the execution context stack and restore _callerContext_ as the running execution context.
+        1. Remove _calleeContext_ from the execution context stack.
+        1. Assert: _callerContext_ is the running execution context again.
         1. If _result_ is a throw completion, then
           1. Return ? _result_.
         1. Assert: _result_ is a return completion.
@@ -14416,11 +14420,13 @@
             1. NOTE: If _func_ is defined in this document, “the specification of _func_” is the behaviour specified for it via algorithm steps or other means.
             1. Return Completion(_result_).
           1. Perform AsyncFunctionStart(_promiseCapability_, _resultsClosure_).
-          1. Remove _calleeContext_ from the execution context stack and restore _callerContext_ as the running execution context.
+          1. Remove _calleeContext_ from the execution context stack.
+          1. Assert: _callerContext_ is the running execution context again.
           1. Return _promiseCapability_.[[Promise]].
         1. [id="step-call-builtin-function-result"] Let _result_ be the Completion Record that is <emu-meta effects="user-code">the result of evaluating</emu-meta> _func_ in a manner that conforms to the specification of _func_. If _thisArg_ is ~uninitialized~, the *this* value is uninitialized; else _thisArg_ provides the *this* value. _argList_ provides the named parameters. _newTarget_ provides the NewTarget value.
         1. NOTE: If _func_ is defined in this document, “the specification of _func_” is the behaviour specified for it via algorithm steps or other means.
-        1. Remove _calleeContext_ from the execution context stack and restore _callerContext_ as the running execution context.
+        1. Remove _calleeContext_ from the execution context stack.
+        1. Assert: _callerContext_ is the running execution context again.
         1. Return ? _result_.
       </emu-alg>
       <emu-note>
@@ -51872,7 +51878,7 @@ THH:mm:ss.sss
               1. Assert: _genBody_ is an Abstract Closure with no parameters.
               1. Let _result_ be Completion(_genBody_()).
             1. Assert: If we return here, the generator either threw an exception or performed either an implicit or explicit return.
-            1. Remove _acGenContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
+            1. Remove _acGenContext_ from the execution context stack.
             1. Set _acGen_.[[GeneratorState]] to ~completed~.
             1. NOTE: Once a generator enters the ~completed~ state it never leaves it and its associated execution context is never resumed. Any execution state associated with _acGen_ can be discarded at this point.
             1. If _result_ is a throw completion, then
@@ -52031,7 +52037,8 @@ THH:mm:ss.sss
           1. If _callerContext_ is not already suspended, suspend _callerContext_.
           1. Push _calleeContext_ onto the execution context stack; _calleeContext_ is now the running execution context.
           1. Perform GeneratorStart(_gen_, _closure_).
-          1. Remove _calleeContext_ from the execution context stack and restore _callerContext_ as the running execution context.
+          1. Remove _calleeContext_ from the execution context stack.
+          1. Assert: _callerContext_ is the running execution context again.
           1. Return _gen_.
         </emu-alg>
       </emu-clause>
@@ -52223,7 +52230,7 @@ THH:mm:ss.sss
               1. Assert: _genBody_ is an Abstract Closure with no parameters.
               1. Let _result_ be Completion(_genBody_()).
             1. Assert: If we return here, the async generator either threw an exception or performed either an implicit or explicit return.
-            1. Remove _acGenContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
+            1. Remove _acGenContext_ from the execution context stack.
             1. Set _acGen_.[[AsyncGeneratorState]] to ~draining-queue~.
             1. If _result_ is a normal completion, set _result_ to NormalCompletion(*undefined*).
             1. If _result_ is a return completion, set _result_ to NormalCompletion(_result_.[[Value]]).
@@ -52576,7 +52583,7 @@ THH:mm:ss.sss
               1. Assert: _asyncBody_ is an Abstract Closure with no parameters.
               1. Let _result_ be Completion(_asyncBody_()).
             1. Assert: If we return here, the async function either threw an exception or performed an implicit or explicit return; all awaiting is done.
-            1. Remove _acAsyncContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
+            1. Remove _acAsyncContext_ from the execution context stack.
             1. If _result_ is a normal completion, then
               1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, « *undefined* »).
             1. Else if _result_ is a return completion, then

--- a/spec.html
+++ b/spec.html
@@ -49126,7 +49126,7 @@ THH:mm:ss.sss
             1. Assert: _obj_ has a [[GeneratorState]] internal slot.
             1. If _obj_.[[GeneratorState]] is ~suspended-start~, then
               1. Set _obj_.[[GeneratorState]] to ~completed~.
-              1. NOTE: Once a generator enters the completed state it never leaves it and its associated execution context is never resumed. Any execution state associated with _obj_ can be discarded at this point.
+              1. NOTE: Once a generator enters the completed state it never leaves it and there is never again a transfer of control to its associated execution context. Any execution state associated with _obj_ can be discarded at this point.
               1. Perform ? IteratorCloseAll(_obj_.[[UnderlyingIterators]], NormalCompletion(~unused~)).
               1. Return CreateIteratorResultObject(*undefined*, *true*).
             1. Let _completion_ be ReturnCompletion(*undefined*).
@@ -51879,7 +51879,7 @@ THH:mm:ss.sss
             1. Assert: If we return here, the generator either threw an exception or performed either an implicit or explicit return.
             1. Remove _acGenContext_ from the execution context stack.
             1. Set _acGen_.[[GeneratorState]] to ~completed~.
-            1. NOTE: Once a generator enters the ~completed~ state it never leaves it and its associated execution context is never resumed. Any execution state associated with _acGen_ can be discarded at this point.
+            1. NOTE: Once a generator enters the ~completed~ state it never leaves it and there is never again a transfer of control to its associated execution context. Any execution state associated with _acGen_ can be discarded at this point.
             1. If _result_ is a throw completion, then
               1. Let _resumption_ be _result_.
             1. Else,
@@ -51952,7 +51952,7 @@ THH:mm:ss.sss
           1. Let _state_ be ? GeneratorValidate(_gen_, _genBrand_).
           1. If _state_ is ~suspended-start~, then
             1. Set _gen_.[[GeneratorState]] to ~completed~.
-            1. NOTE: Once a generator enters the ~completed~ state it never leaves it and its associated execution context is never resumed. Any execution state associated with _gen_ can be discarded at this point.
+            1. NOTE: Once a generator enters the ~completed~ state it never leaves it and there is never again a transfer of control to its associated execution context. Any execution state associated with _gen_ can be discarded at this point.
             1. Set _state_ to ~completed~.
           1. If _state_ is ~completed~, then
             1. If _abruptCompletion_ is a return completion, then
@@ -52558,7 +52558,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _runningContext_ be the running execution context.
           1. Let _asyncContext_ be a copy of _runningContext_.
-          1. NOTE: Copying the execution state is required for AsyncBlockStart to resume its execution. It is ill-defined to resume a currently executing context.
+          1. NOTE: Copying is required because AsyncFunctionStart has different roles for _asyncContext_ and _runningContext_ that cannot (easily) be filled by a single execution context.
           1. Perform AsyncBlockStart(_promiseCapability_, _asyncFuncBody_, _asyncContext_).
           1. Return ~unused~.
         </emu-alg>

--- a/spec.html
+++ b/spec.html
@@ -12171,8 +12171,8 @@
 
   <emu-clause id="sec-execution-contexts">
     <h1>Execution Contexts</h1>
-    <p>An <dfn variants="execution contexts">execution context</dfn> is a specification device that is used to track the runtime evaluation of code by an ECMAScript implementation. At any point in time, there is at most one execution context per agent that is actually executing code. This is known as the agent's <dfn id="running-execution-context" variants="running execution contexts">running execution context</dfn>. All references to the running execution context in this specification denote the running execution context of the surrounding agent.</p>
-    <p>An execution context contains whatever implementation specific state is necessary to track the execution progress of its associated code. Each execution context has at least the state components listed in <emu-xref href="#table-state-components-for-all-execution-contexts"></emu-xref>.</p>
+    <p>An <dfn variants="execution contexts">execution context</dfn> brings together information that is relevant for the runtime evaluation of some unit of code (e.g., a script, a module, or a function object). At any point in time, there is at most one execution context per agent whose associated code is being evaluated. This is known as the agent's <dfn id="running-execution-context">running execution context</dfn>. All references to the running execution context in this specification denote the running execution context of the surrounding agent.</p>
+    <p>Each execution context has at least the state components listed in <emu-xref href="#table-state-components-for-all-execution-contexts"></emu-xref>.</p>
     <emu-table id="table-state-components-for-all-execution-contexts" caption="State Components for All Execution Contexts" oldids="table-22">
       <table>
         <thead>
@@ -12190,7 +12190,7 @@
             code evaluation state
           </td>
           <td>
-            Any state needed to perform, suspend, and resume evaluation of the code associated with this execution context.
+            Determines what happens the next time there is a transfer of control to the execution context.
           </td>
         </tr>
         <tr>
@@ -12198,7 +12198,7 @@
             Function
           </td>
           <td>
-            If this execution context is evaluating the code of a function object, then the value of this component is that function object. If the context is evaluating the code of a |Script| or |Module|, the value is *null*.
+            If this execution context is established for evaluating a call to a function object, then the value of this component is that function object. If the execution context is established for evaluating a |Script| or |Module|, the value is *null*.
           </td>
         </tr>
         <tr>
@@ -12238,7 +12238,7 @@
             LexicalEnvironment
           </td>
           <td>
-            Identifies the Environment Record used to resolve identifier references made by code within this execution context.
+            Identifies the Environment Record used to resolve identifier references made by code associated with this execution context.
           </td>
         </tr>
         <tr>
@@ -12246,7 +12246,7 @@
             VariableEnvironment
           </td>
           <td>
-            Identifies the Environment Record that holds bindings created by |VariableStatement|s within this execution context.
+            Identifies the Environment Record that holds bindings created by |VariableStatement|s in the code associated with this execution context.
           </td>
         </tr>
         <tr>
@@ -12280,7 +12280,7 @@
             Generator
           </td>
           <td>
-            The Generator that this execution context is evaluating.
+            The Generator that is associated with this execution context.
           </td>
         </tr>
       </table>
@@ -12390,7 +12390,7 @@
       <h1>GetGlobalObject ( ): an Object</h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It returns the global object used by the currently running execution context.</dd>
+        <dd>It returns the global object used by the running execution context.</dd>
       </dl>
       <emu-alg>
         1. Let _currentRealm_ be the current Realm Record.
@@ -12824,7 +12824,7 @@
   <emu-clause id="sec-forward-progress">
     <h1>Forward Progress</h1>
     <p>For an agent to <em>make forward progress</em> is for it to perform an evaluation step according to this specification.</p>
-    <p>An agent becomes <em>blocked</em> when its running execution context waits synchronously and indefinitely for an external event. Only agents whose Agent Record's [[CanBlock]] field is *true* can become blocked in this sense. An <em>unblocked</em> agent is one that is not blocked.</p>
+    <p>An agent becomes <em>blocked</em> when it waits synchronously and indefinitely for an external event. Only agents whose Agent Record's [[CanBlock]] field is *true* can become blocked in this sense. An <em>unblocked</em> agent is one that is not blocked.</p>
 
     <p>Implementations must ensure that:</p>
     <ul>
@@ -26635,7 +26635,7 @@
         1. Discard all resources associated with the current execution context.
         1. Return ~unused~.
       </emu-alg>
-      <p>A tail position call must either release any transient internal resources associated with the currently executing function execution context before invoking the target function or reuse those resources in support of the target function.</p>
+      <p>A tail position call must either release any transient internal resources associated with the currently executing function's execution context before invoking the target function or reuse those resources in support of the target function.</p>
       <emu-note>
         <p>For example, a tail position call should only grow an implementation's activation record stack by the amount that the size of the target function's activation record exceeds the size of the calling function's activation record. If the target function's activation record is smaller, then the total size of the stack should decrease.</p>
       </emu-note>
@@ -27600,7 +27600,7 @@
                 ): either a normal completion containing ~unused~ or a throw completion
               </td>
               <td>
-                It evaluates the module's code within its execution context. If this module has *true* in [[HasTLA]], then a PromiseCapability Record is passed as an argument, and the method is expected to resolve or reject the given capability. In this case, the method must not throw an exception, but instead reject the PromiseCapability Record if necessary.
+                It evaluates the module's code using its execution context. If this module has *true* in [[HasTLA]], then a PromiseCapability Record is passed as an argument, and the method is expected to resolve or reject the given capability. In this case, the method must not throw an exception, but instead reject the PromiseCapability Record if necessary.
               </td>
               <td>
                 Within this specification it has definitions in the following types; hosts may provide additional types with their own definitions:
@@ -30401,7 +30401,7 @@
   <h1>The Global Object</h1>
   <p>The <dfn variants="global objects">global object</dfn>:</p>
   <ul>
-    <li>is created before control enters any execution context.</li>
+    <li>is created in InitializeHostDefinedRealm.</li>
     <li>does not have a [[Construct]] internal method; it cannot be used as a constructor with the `new` operator.</li>
     <li>does not have a [[Call]] internal method; it cannot be invoked as a function.</li>
     <li>has a [[Prototype]] internal slot whose value is host-defined.</li>

--- a/spec.html
+++ b/spec.html
@@ -51894,7 +51894,8 @@ THH:mm:ss.sss
             1. Let _callerContext_ be the running execution context.
             1. Transfer control from _acGenContext_ to _callerContext_, passing _resumption_.
             1. Assert: This step is never reached.
-          1. Set the code evaluation state of _genContext_ such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
+          1. Set _genContext_'s code evaluation state to _closure_.
+          1. NOTE: The next time there is a transfer of control to _genContext_, _closure_ will be called with no arguments.
           1. Set _gen_.[[GeneratorContext]] to _genContext_.
           1. Return ~unused~.
         </emu-alg>
@@ -52241,7 +52242,8 @@ THH:mm:ss.sss
             1. Let _callerContext_ be the running execution context.
             1. Transfer control from _acGenContext_ to _callerContext_, passing NormalCompletion(*undefined*).
             1. Assert: This step is never reached.
-          1. Set the code evaluation state of _genContext_ such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
+          1. Set _genContext_'s code evaluation state to _closure_.
+          1. NOTE: The next time there is a transfer of control to _genContext_, _closure_ will be called with no arguments.
           1. Set _gen_.[[AsyncGeneratorContext]] to _genContext_.
           1. Set _gen_.[[AsyncGeneratorQueue]] to a new empty List.
           1. Return ~unused~.
@@ -52596,7 +52598,8 @@ THH:mm:ss.sss
             1. Let _callerContext_ be the running execution context.
             1. [id="step-asyncblockstart-return-undefined"] Transfer control from _acAsyncContext_ to _callerContext_, passing NormalCompletion(~unused~).
             1. Assert: This step is never reached.
-          1. Set the code evaluation state of _asyncContext_ such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
+          1. Set _asyncContext_'s code evaluation state to _closure_.
+          1. NOTE: The next time there is a transfer of control to _asyncContext_, _closure_ will be called with no arguments.
           1. Let _result_ be ! RunSuspendedContext(_asyncContext_, NormalCompletion(~unused~)).
           1. Assert: _result_ is ~unused~.
           1. NOTE: The possible sources of _result_ values are Await or, if the async function doesn't await anything, step <emu-xref href="#step-asyncblockstart-return-undefined"></emu-xref> above.

--- a/spec.html
+++ b/spec.html
@@ -12285,6 +12285,15 @@
         </tr>
       </table>
     </emu-table>
+    <p>To express the semantics of generators, this document uses steps of the form “<dfn id="transfer-control" variants="transfers control,transfer of control">Transfer control</dfn> from _aContext_ to _bContext_, passing _completion_”, where _aContext_ and _bContext_ are execution contexts and _completion_ is a Completion Record. This means:</p>
+    <ul>
+      <li>Execution of the current algorithm (the one with the “Transfer control” step) is suspended, and a representation of that suspended execution is saved in the code evaluation state of _aContext_.</li>
+      <li>The code evaluation state of _bContext_ is typically a representation of an execution that was suspended in another “Transfer control” step; that execution is resumed, and _completion_ is provided as “the Completion Record passed when control was transferred back to _bContext_”. Alternatively, _bContext_'s code evaluation state is an Abstract Closure; in that case, the Abstract Closure is called with no arguments, and _completion_ is ignored.</li>
+    </ul>
+    <p>The suspended execution associated with _aContext_ will stay suspended until some step transfers control back to _aContext_, which might never happen.</p>
+    <emu-note>This is analogous to the concept of coroutines in programming languages.</emu-note>
+    <emu-note>In practice, _aContext_ was the running execution context until just before the “Transfer control” step, and _bContext_ is the new running execution context. However, the “Transfer control” step itself doesn't manipulate the execution context stack.</emu-note>
+
     <p>In most situations only the running execution context (the top of the execution context stack) is directly manipulated by algorithms within this specification. Hence when the terms “LexicalEnvironment”, and “VariableEnvironment” are used without qualification they are in reference to those components of the running execution context.</p>
     <p>An execution context is purely a specification mechanism and need not correspond to any particular artefact of an ECMAScript implementation. It is impossible for ECMAScript code to directly access or observe an execution context.</p>
 

--- a/spec.html
+++ b/spec.html
@@ -52595,7 +52595,7 @@ THH:mm:ss.sss
             1. [id="step-asyncblockstart-return-undefined"] Resume _callerContext_, passing NormalCompletion(~unused~).
             1. Assert: This step is never reached.
           1. Set the code evaluation state of _asyncContext_ such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
-          1. Let _result_ be ! RunSuspendedContext(_asyncContext_, NormalCompletion(~empty~)).
+          1. Let _result_ be ! RunSuspendedContext(_asyncContext_, NormalCompletion(~unused~)).
           1. Assert: _result_ is ~unused~.
           1. NOTE: The possible sources of _result_ values are Await or, if the async function doesn't await anything, step <emu-xref href="#step-asyncblockstart-return-undefined"></emu-xref> above.
           1. Return ~unused~.

--- a/spec.html
+++ b/spec.html
@@ -12398,8 +12398,10 @@
         1. Let _callerContext_ be the running execution context.
         1. Suspend _callerContext_.
         1. Push _context_ onto the execution context stack; _context_ is now the running execution context.
-        1. <emu-meta effects="user-code">Resume the suspended evaluation of _context_</emu-meta> passing _completionRecord_ as the result of the operation that suspended it. Let _result_ be the Completion Record passed by the resumed computation.
-        1. Assert: When we reach this step, _context_ has already been removed from the execution context stack and _callerContext_ is the running execution context again.
+        1. Transfer control from _callerContext_ to _context_, passing _completionRecord_.
+        1. NOTE: This step is reached only when control is transferred back to _callerContext_, which might not happen.
+        1. Let _result_ be the Completion Record passed when control was transferred back to _callerContext_.
+        1. Assert: _context_ has already been removed from the execution context stack and _callerContext_ is the running execution context again.
         1. Return Completion(_result_).
       </emu-alg>
     </emu-clause>
@@ -12418,10 +12420,10 @@
         1. Let _genContext_ be the running execution context.
         1. Remove _genContext_ from the execution context stack.
         1. Let _callerContext_ be the running execution context.
-        1. Resume _callerContext_, passing NormalCompletion(_value_).
-        1. NOTE: The above step transfers control to _callerContext_ and pauses. The only way for it to un-pause and have control proceed to the subsequent steps in this algorithm is for _genContext_ to be resumed again, which might never happen.
-        1. Assert: _genContext_ is the running execution context.
-        1. Let _result_ be the Completion Record with which _genContext_ was just resumed.
+        1. Transfer control from _genContext_ to _callerContext_, passing NormalCompletion(_value_).
+        1. NOTE: This step is reached only when control is transferred back to _genContext_, which might not happen.
+        1. Let _result_ be the Completion Record passed when control was transferred back to _genContext_.
+        1. Assert: _genContext_ is the running execution context again.
         1. Return Completion(_result_).
       </emu-alg>
     </emu-clause>
@@ -51890,7 +51892,7 @@ THH:mm:ss.sss
                 1. Let _resultValue_ be _result_.[[Value]].
               1. Let _resumption_ be NormalCompletion(CreateIteratorResultObject(_resultValue_, *true*)).
             1. Let _callerContext_ be the running execution context.
-            1. Resume _callerContext_, passing _resumption_.
+            1. Transfer control from _acGenContext_ to _callerContext_, passing _resumption_.
             1. Assert: This step is never reached.
           1. Set the code evaluation state of _genContext_ such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
           1. Set _gen_.[[GeneratorContext]] to _genContext_.
@@ -52237,7 +52239,7 @@ THH:mm:ss.sss
             1. Perform AsyncGeneratorCompleteStep(_acGen_, _result_, *true*).
             1. Perform AsyncGeneratorDrainQueue(_acGen_).
             1. Let _callerContext_ be the running execution context.
-            1. Resume _callerContext_, passing NormalCompletion(*undefined*).
+            1. Transfer control from _acGenContext_ to _callerContext_, passing NormalCompletion(*undefined*).
             1. Assert: This step is never reached.
           1. Set the code evaluation state of _genContext_ such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
           1. Set _gen_.[[AsyncGeneratorContext]] to _genContext_.
@@ -52592,7 +52594,7 @@ THH:mm:ss.sss
               1. Assert: _result_ is a throw completion.
               1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, « _result_.[[Value]] »).
             1. Let _callerContext_ be the running execution context.
-            1. [id="step-asyncblockstart-return-undefined"] Resume _callerContext_, passing NormalCompletion(~unused~).
+            1. [id="step-asyncblockstart-return-undefined"] Transfer control from _acAsyncContext_ to _callerContext_, passing NormalCompletion(~unused~).
             1. Assert: This step is never reached.
           1. Set the code evaluation state of _asyncContext_ such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
           1. Let _result_ be ! RunSuspendedContext(_asyncContext_, NormalCompletion(~unused~)).

--- a/spec.html
+++ b/spec.html
@@ -12405,7 +12405,6 @@
       </dl>
       <emu-alg>
         1. Let _callerContext_ be the running execution context.
-        1. Suspend _callerContext_.
         1. Push _context_ onto the execution context stack; _context_ is now the running execution context.
         1. Transfer control from _callerContext_ to _context_, passing _completionRecord_.
         1. NOTE: This step is reached only when control is transferred back to _callerContext_, which might not happen.
@@ -13817,7 +13816,7 @@
         1. Return ? _result_.
       </emu-alg>
       <emu-note>
-        <p>When _calleeContext_ is removed from the execution context stack in step <emu-xref href="#step-call-pop-context-stack"></emu-xref> it must not be destroyed if it is suspended and retained for later resumption by an accessible Generator.</p>
+        <p>When _calleeContext_ is removed from the execution context stack in step <emu-xref href="#step-call-pop-context-stack"></emu-xref> it must not be destroyed if it is retained for later resumption by an accessible Generator.</p>
       </emu-note>
 
       <emu-clause id="sec-prepareforordinarycall" type="abstract operation">
@@ -13830,7 +13829,6 @@
         <dl class="header">
         </dl>
         <emu-alg>
-          1. Let _callerContext_ be the running execution context.
           1. Let _calleeContext_ be a new ECMAScript code execution context.
           1. Set the Function of _calleeContext_ to _func_.
           1. Let _calleeRealm_ be _func_.[[Realm]].
@@ -13840,7 +13838,6 @@
           1. Set the LexicalEnvironment of _calleeContext_ to _localEnv_.
           1. Set the VariableEnvironment of _calleeContext_ to _localEnv_.
           1. Set the PrivateEnvironment of _calleeContext_ to _func_.[[PrivateEnvironment]].
-          1. If _callerContext_ is not already suspended, suspend _callerContext_.
           1. Push _calleeContext_ onto the execution context stack; _calleeContext_ is now the running execution context.
           1. NOTE: Any exception objects produced after this point are associated with _calleeRealm_.
           1. Return _calleeContext_.
@@ -14416,7 +14413,6 @@
       </dl>
       <emu-alg>
         1. Let _callerContext_ be the running execution context.
-        1. If _callerContext_ is not already suspended, suspend _callerContext_.
         1. Let _calleeContext_ be a new execution context.
         1. Set the Function of _calleeContext_ to _func_.
         1. Let _calleeRealm_ be _func_.[[Realm]].
@@ -14441,7 +14437,7 @@
         1. Return ? _result_.
       </emu-alg>
       <emu-note>
-        <p>When _calleeContext_ is removed from the execution context stack it must not be destroyed if it has been suspended and retained by an accessible Generator for later resumption.</p>
+        <p>When _calleeContext_ is removed from the execution context stack it must not be destroyed if it has been retained by an accessible Generator for later resumption.</p>
       </emu-note>
     </emu-clause>
 
@@ -26820,7 +26816,6 @@
         1. Set the VariableEnvironment of _scriptContext_ to _globalEnv_.
         1. Set the LexicalEnvironment of _scriptContext_ to _globalEnv_.
         1. Set the PrivateEnvironment of _scriptContext_ to *null*.
-        1. Suspend the running execution context.
         1. Push _scriptContext_ onto the execution context stack; _scriptContext_ is now the running execution context.
         1. Let _scriptNode_ be _scriptRecord_.[[ECMAScriptCode]].
         1. Let _result_ be Completion(GlobalDeclarationInstantiation(_scriptNode_, _globalEnv_)).
@@ -26828,7 +26823,7 @@
           1. Set _result_ to Completion(Evaluation of _scriptNode_).
           1. If _result_ is a normal completion and _result_.[[Value]] is ~empty~, then
             1. Set _result_ to NormalCompletion(*undefined*).
-        1. Suspend _scriptContext_ and remove it from the execution context stack.
+        1. Remove _scriptContext_ from the execution context stack.
         1. Assert: The execution context stack is not empty.
         1. Return ? _result_.
       </emu-alg>
@@ -29317,11 +29312,10 @@
               1. If _module_.[[HasTLA]] is *false*, then
                 1. Assert: _capability_ is not present.
                 1. Let _env_ be _module_.[[Environment]].
-                1. Suspend the running execution context.
                 1. Push _moduleContext_ onto the execution context stack; _moduleContext_ is now the running execution context.
                 1. Let _result_ be Completion(Evaluation of _module_.[[ECMAScriptCode]]).
                 1. Set _result_ to Completion(DisposeResources(_env_.[[DisposableResourceStack]], _result_)).
-                1. Suspend _moduleContext_ and remove it from the execution context stack.
+                1. Remove _moduleContext_ from the execution context stack.
                 1. If _result_ is an abrupt completion, then
                   1. Return ? _result_.
               1. Else,
@@ -29516,11 +29510,10 @@
               1. Set the ScriptOrModule of _moduleContext_ to _module_.
               1. Set the VariableEnvironment of _moduleContext_ to _module_.[[Environment]].
               1. Set the LexicalEnvironment of _moduleContext_ to _module_.[[Environment]].
-              1. Suspend the running execution context.
               1. Push _moduleContext_ onto the execution context stack; _moduleContext_ is now the running execution context.
               1. Let _steps_ be _module_.[[EvaluationSteps]].
               1. Let _result_ be Completion(_steps_(_module_)).
-              1. Suspend _moduleContext_ and remove it from the execution context stack.
+              1. Remove _moduleContext_ from the execution context stack.
               1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
               1. IfAbruptRejectPromise(_result_, _promiseCapability_).
               1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, « *undefined* »).
@@ -30499,7 +30492,6 @@
             1. Let _variableEnv_ be _evalRealm_.[[GlobalEnv]].
             1. Let _privateEnv_ be *null*.
           1. If _strictEval_ is *true*, set _variableEnv_ to _lexicalEnv_.
-          1. If _runningContext_ is not already suspended, suspend _runningContext_.
           1. Let _evalContext_ be a new ECMAScript code execution context.
           1. Set _evalContext_'s Function to *null*.
           1. Set _evalContext_'s Realm to _evalRealm_.
@@ -30513,7 +30505,7 @@
             1. Set _result_ to Completion(Evaluation of _body_).
           1. If _result_ is a normal completion and _result_.[[Value]] is ~empty~, then
             1. Set _result_ to NormalCompletion(*undefined*).
-          1. Suspend _evalContext_ and remove it from the execution context stack.
+          1. Remove _evalContext_ from the execution context stack.
           1. Return ? _result_.
         </emu-alg>
         <emu-note>
@@ -52042,7 +52034,6 @@ THH:mm:ss.sss
           1. Set the Function of _calleeContext_ to *null*.
           1. Set the Realm of _calleeContext_ to the current Realm Record.
           1. Set the ScriptOrModule of _calleeContext_ to _callerContext_'s ScriptOrModule.
-          1. If _callerContext_ is not already suspended, suspend _callerContext_.
           1. Push _calleeContext_ onto the execution context stack; _calleeContext_ is now the running execution context.
           1. Perform GeneratorStart(_gen_, _closure_).
           1. Remove _calleeContext_ from the execution context stack.

--- a/spec.html
+++ b/spec.html
@@ -12172,7 +12172,6 @@
   <emu-clause id="sec-execution-contexts">
     <h1>Execution Contexts</h1>
     <p>An <dfn variants="execution contexts">execution context</dfn> is a specification device that is used to track the runtime evaluation of code by an ECMAScript implementation. At any point in time, there is at most one execution context per agent that is actually executing code. This is known as the agent's <dfn id="running-execution-context" variants="running execution contexts">running execution context</dfn>. All references to the running execution context in this specification denote the running execution context of the surrounding agent.</p>
-    <p>The <dfn id="execution-context-stack" variants="execution context stacks">execution context stack</dfn> is used to track execution contexts. The running execution context is always the top element of this stack. A new execution context is created whenever control is transferred from the executable code associated with the currently running execution context to executable code that is not associated with that execution context. The newly created execution context is pushed onto the stack and becomes the running execution context.</p>
     <p>An execution context contains whatever implementation specific state is necessary to track the execution progress of its associated code. Each execution context has at least the state components listed in <emu-xref href="#table-state-components-for-all-execution-contexts"></emu-xref>.</p>
     <emu-table id="table-state-components-for-all-execution-contexts" caption="State Components for All Execution Contexts" oldids="table-22">
       <table>
@@ -12220,7 +12219,6 @@
         </tr>
       </table>
     </emu-table>
-    <p>Evaluation of code by the running execution context may be suspended at various points defined within this specification. Once the running execution context has been suspended a different execution context may become the running execution context and commence evaluating its code. At some later time a suspended execution context may again become the running execution context and continue evaluating its code at the point where it had previously been suspended. Transition of the running execution context status among execution contexts usually occurs in stack-like last-in/first-out manner. However, some ECMAScript features require non-LIFO transitions of the running execution context.</p>
     <p>The value of the Realm component of the running execution context is also called <dfn id="current-realm">the current Realm Record</dfn>. The value of the Function component of the running execution context is also called the <dfn id="active-function-object">active function object</dfn>.</p>
     <p><dfn id="ecmascript-code-execution-context" variants="ECMAScript code execution context">ECMAScript code execution contexts</dfn> have the additional state components listed in <emu-xref href="#table-additional-state-components-for-ecmascript-code-execution-contexts"></emu-xref>.</p>
     <emu-table id="table-additional-state-components-for-ecmascript-code-execution-contexts" caption="Additional State Components for ECMAScript Code Execution Contexts" oldids="table-23">
@@ -12262,7 +12260,7 @@
       </table>
     </emu-table>
     <p>The LexicalEnvironment and VariableEnvironment components of an execution context are always Environment Records.</p>
-    <p>In most situations only the running execution context (the top of the execution context stack) is directly manipulated by algorithms within this specification. Hence when the terms “LexicalEnvironment”, and “VariableEnvironment” are used without qualification they are in reference to those components of the running execution context.</p>
+    <p>In most situations only the running execution context is directly manipulated by algorithms within this specification. Hence when the terms “LexicalEnvironment”, and “VariableEnvironment” are used without qualification they are in reference to those components of the running execution context.</p>
 
     <p>Execution contexts representing the evaluation of Generators have the additional state components listed in <emu-xref href="#table-additional-state-components-for-generator-execution-contexts"></emu-xref>.</p>
     <emu-table id="table-additional-state-components-for-generator-execution-contexts" caption="Additional State Components for Generator Execution Contexts" oldids="table-24">
@@ -12297,6 +12295,13 @@
     <emu-note>In practice, _aContext_ was the running execution context until just before the “Transfer control” step, and _bContext_ is the new running execution context. However, the “Transfer control” step itself doesn't manipulate the execution context stack.</emu-note>
 
     <p>An execution context is purely a specification mechanism and need not correspond to any particular artefact of an ECMAScript implementation. It is impossible for ECMAScript code to directly access or observe an execution context.</p>
+
+    <emu-clause id="sec-execution-context-stack">
+      <h1>Execution Context Stack</h1>
+      <p>An agent's <dfn id="execution-context-stack" variants="execution context stacks">execution context stack</dfn> is used to organize some or all of the agent's execution contexts. The running execution context is always the top element of this stack.</p>
+      <p>Adding and removing always happens at the “top” of the execution context stack. When an execution context is added, it becomes the topmost (i.e., the running execution context), and when it is later removed, the execution context “below” it becomes topmost again.</p>
+      <emu-note>In the absence of generators and async functions, every execution context that is pushed onto the stack is new, and when it's removed from the stack it can be discarded. With generators and async functions, some execution contexts outlive their time on the stack, exist for a while outside the stack, and then later are pushed onto the stack again.</emu-note>
+    </emu-clause>
 
     <emu-clause id="sec-getactivescriptormodule" type="abstract operation">
       <h1>GetActiveScriptOrModule ( ): a Script Record, a Module Record, or *null*</h1>

--- a/spec.html
+++ b/spec.html
@@ -12221,8 +12221,8 @@
 
   <emu-clause id="sec-execution-contexts">
     <h1>Execution Contexts</h1>
-    <p>An <dfn variants="execution contexts">execution context</dfn> is a specification device that is used to track the runtime evaluation of code by an ECMAScript implementation. At any point in time, there is at most one execution context per agent that is actually executing code. This is known as the agent's <dfn id="running-execution-context" variants="running execution contexts">running execution context</dfn>. All references to the running execution context in this specification denote the running execution context of the surrounding agent.</p>
-    <p>An execution context contains whatever implementation specific state is necessary to track the execution progress of its associated code. Each execution context has at least the state components listed in <emu-xref href="#table-state-components-for-all-execution-contexts"></emu-xref>.</p>
+    <p>An <dfn variants="execution contexts">execution context</dfn> brings together information that is relevant for the runtime evaluation of some unit of code (e.g., a script, a module, or a function object). At any point in time, there is at most one execution context per agent whose associated code is being evaluated. This is known as the agent's <dfn id="running-execution-context">running execution context</dfn>. All references to the running execution context in this specification denote the running execution context of the surrounding agent.</p>
+    <p>Each execution context has at least the state components listed in <emu-xref href="#table-state-components-for-all-execution-contexts"></emu-xref>.</p>
     <emu-table id="table-state-components-for-all-execution-contexts" caption="State Components for All Execution Contexts" oldids="table-22">
       <table>
         <thead>
@@ -12240,7 +12240,7 @@
             code evaluation state
           </td>
           <td>
-            Any state needed to perform, suspend, and resume evaluation of the code associated with this execution context.
+            Determines what happens the next time there is a transfer of control to the execution context.
           </td>
         </tr>
         <tr>
@@ -12248,7 +12248,7 @@
             Function
           </td>
           <td>
-            If this execution context is evaluating the code of a function object, then the value of this component is that function object. If the context is evaluating the code of a |Script| or |Module|, the value is *null*.
+            If this execution context is established for evaluating a call to a function object, then the value of this component is that function object. If the execution context is established for evaluating a |Script| or |Module|, the value is *null*.
           </td>
         </tr>
         <tr>
@@ -12288,7 +12288,7 @@
             LexicalEnvironment
           </td>
           <td>
-            Identifies the Environment Record used to resolve identifier references made by code within this execution context.
+            Identifies the Environment Record used to resolve identifier references made by code associated with this execution context.
           </td>
         </tr>
         <tr>
@@ -12296,7 +12296,7 @@
             VariableEnvironment
           </td>
           <td>
-            Identifies the Environment Record that holds bindings created by |VariableStatement|s within this execution context.
+            Identifies the Environment Record that holds bindings created by |VariableStatement|s in the code associated with this execution context.
           </td>
         </tr>
         <tr>
@@ -12330,7 +12330,7 @@
             Generator
           </td>
           <td>
-            The Generator that this execution context is evaluating.
+            The Generator that is associated with this execution context.
           </td>
         </tr>
       </table>
@@ -12440,7 +12440,7 @@
       <h1>GetGlobalObject ( ): an Object</h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It returns the global object used by the currently running execution context.</dd>
+        <dd>It returns the global object used by the running execution context.</dd>
       </dl>
       <emu-alg>
         1. Let _currentRealm_ be the current Realm Record.
@@ -12874,7 +12874,7 @@
   <emu-clause id="sec-forward-progress">
     <h1>Forward Progress</h1>
     <p>For an agent to <em>make forward progress</em> is for it to perform an evaluation step according to this specification.</p>
-    <p>An agent becomes <em>blocked</em> when its running execution context waits synchronously and indefinitely for an external event. Only agents whose Agent Record's [[CanBlock]] field is *true* can become blocked in this sense. An <em>unblocked</em> agent is one that is not blocked.</p>
+    <p>An agent becomes <em>blocked</em> when it waits synchronously and indefinitely for an external event. Only agents whose Agent Record's [[CanBlock]] field is *true* can become blocked in this sense. An <em>unblocked</em> agent is one that is not blocked.</p>
 
     <p>Implementations must ensure that:</p>
     <ul>
@@ -26642,7 +26642,7 @@
         1. Discard all resources associated with the current execution context.
         1. Return ~unused~.
       </emu-alg>
-      <p>A tail position call must either release any transient internal resources associated with the currently executing function execution context before invoking the target function or reuse those resources in support of the target function.</p>
+      <p>A tail position call must either release any transient internal resources associated with the currently executing function's execution context before invoking the target function or reuse those resources in support of the target function.</p>
       <emu-note>
         <p>For example, a tail position call should only grow an implementation's activation record stack by the amount that the size of the target function's activation record exceeds the size of the calling function's activation record. If the target function's activation record is smaller, then the total size of the stack should decrease.</p>
       </emu-note>
@@ -27607,7 +27607,7 @@
                 ): either a normal completion containing ~unused~ or a throw completion
               </td>
               <td>
-                It evaluates the module's code within its execution context. If this module has *true* in [[HasTLA]], then a PromiseCapability Record is passed as an argument, and the method is expected to resolve or reject the given capability. In this case, the method must not throw an exception, but instead reject the PromiseCapability Record if necessary.
+                It evaluates the module's code using its execution context. If this module has *true* in [[HasTLA]], then a PromiseCapability Record is passed as an argument, and the method is expected to resolve or reject the given capability. In this case, the method must not throw an exception, but instead reject the PromiseCapability Record if necessary.
               </td>
               <td>
                 Within this specification it has definitions in the following types; hosts may provide additional types with their own definitions:
@@ -30406,7 +30406,7 @@
   <h1>The Global Object</h1>
   <p>The <dfn variants="global objects">global object</dfn>:</p>
   <ul>
-    <li>is created before control enters any execution context.</li>
+    <li>is created in InitializeHostDefinedRealm.</li>
     <li>does not have a [[Construct]] internal method; it cannot be used as a constructor with the `new` operator.</li>
     <li>does not have a [[Call]] internal method; it cannot be invoked as a function.</li>
     <li>has a [[Prototype]] internal slot whose value is host-defined.</li>

--- a/spec.html
+++ b/spec.html
@@ -12222,7 +12222,6 @@
   <emu-clause id="sec-execution-contexts">
     <h1>Execution Contexts</h1>
     <p>An <dfn variants="execution contexts">execution context</dfn> is a specification device that is used to track the runtime evaluation of code by an ECMAScript implementation. At any point in time, there is at most one execution context per agent that is actually executing code. This is known as the agent's <dfn id="running-execution-context" variants="running execution contexts">running execution context</dfn>. All references to the running execution context in this specification denote the running execution context of the surrounding agent.</p>
-    <p>The <dfn id="execution-context-stack" variants="execution context stacks">execution context stack</dfn> is used to track execution contexts. The running execution context is always the top element of this stack. A new execution context is created whenever control is transferred from the executable code associated with the currently running execution context to executable code that is not associated with that execution context. The newly created execution context is pushed onto the stack and becomes the running execution context.</p>
     <p>An execution context contains whatever implementation specific state is necessary to track the execution progress of its associated code. Each execution context has at least the state components listed in <emu-xref href="#table-state-components-for-all-execution-contexts"></emu-xref>.</p>
     <emu-table id="table-state-components-for-all-execution-contexts" caption="State Components for All Execution Contexts" oldids="table-22">
       <table>
@@ -12270,7 +12269,6 @@
         </tr>
       </table>
     </emu-table>
-    <p>Evaluation of code by the running execution context may be suspended at various points defined within this specification. Once the running execution context has been suspended a different execution context may become the running execution context and commence evaluating its code. At some later time a suspended execution context may again become the running execution context and continue evaluating its code at the point where it had previously been suspended. Transition of the running execution context status among execution contexts usually occurs in stack-like last-in/first-out manner. However, some ECMAScript features require non-LIFO transitions of the running execution context.</p>
     <p>The value of the Realm component of the running execution context is also called <dfn id="current-realm">the current Realm Record</dfn>. The value of the Function component of the running execution context is also called the <dfn id="active-function-object">active function object</dfn>.</p>
     <p><dfn id="ecmascript-code-execution-context" variants="ECMAScript code execution context">ECMAScript code execution contexts</dfn> have the additional state components listed in <emu-xref href="#table-additional-state-components-for-ecmascript-code-execution-contexts"></emu-xref>.</p>
     <emu-table id="table-additional-state-components-for-ecmascript-code-execution-contexts" caption="Additional State Components for ECMAScript Code Execution Contexts" oldids="table-23">
@@ -12312,7 +12310,7 @@
       </table>
     </emu-table>
     <p>The LexicalEnvironment and VariableEnvironment components of an execution context are always Environment Records.</p>
-    <p>In most situations only the running execution context (the top of the execution context stack) is directly manipulated by algorithms within this specification. Hence when the terms “LexicalEnvironment”, and “VariableEnvironment” are used without qualification they are in reference to those components of the running execution context.</p>
+    <p>In most situations only the running execution context is directly manipulated by algorithms within this specification. Hence when the terms “LexicalEnvironment”, and “VariableEnvironment” are used without qualification they are in reference to those components of the running execution context.</p>
 
     <p>Execution contexts representing the evaluation of Generators have the additional state components listed in <emu-xref href="#table-additional-state-components-for-generator-execution-contexts"></emu-xref>.</p>
     <emu-table id="table-additional-state-components-for-generator-execution-contexts" caption="Additional State Components for Generator Execution Contexts" oldids="table-24">
@@ -12347,6 +12345,13 @@
     <emu-note>In practice, _aContext_ was the running execution context until just before the “Transfer control” step, and _bContext_ is the new running execution context. However, the “Transfer control” step itself doesn't manipulate the execution context stack.</emu-note>
 
     <p>An execution context is purely a specification mechanism and need not correspond to any particular artefact of an ECMAScript implementation. It is impossible for ECMAScript code to directly access or observe an execution context.</p>
+
+    <emu-clause id="sec-execution-context-stack">
+      <h1>Execution Context Stack</h1>
+      <p>An agent's <dfn id="execution-context-stack" variants="execution context stacks">execution context stack</dfn> is used to organize some or all of the agent's execution contexts. The running execution context is always the top element of this stack.</p>
+      <p>Adding and removing always happens at the “top” of the execution context stack. When an execution context is added, it becomes the topmost (i.e., the running execution context), and when it is later removed, the execution context “below” it becomes topmost again.</p>
+      <emu-note>In the absence of generators and async functions, every execution context that is pushed onto the stack is new, and when it's removed from the stack it can be discarded. With generators and async functions, some execution contexts outlive their time on the stack, exist for a while outside the stack, and then later are pushed onto the stack again.</emu-note>
+    </emu-clause>
 
     <emu-clause id="sec-getactivescriptormodule" type="abstract operation">
       <h1>GetActiveScriptOrModule ( ): a Script Record, a Module Record, or *null*</h1>

--- a/spec.html
+++ b/spec.html
@@ -13872,7 +13872,7 @@
         1. Return _result_.[[Value]].
       </emu-alg>
       <emu-note>
-        <p>When _calleeContext_ is removed from the execution context stack in step <emu-xref href="#step-call-pop-context-stack"></emu-xref> it must not be destroyed if it is retained for later resumption by an accessible Generator.</p>
+        <p>When _calleeContext_ is removed from the execution context stack in step <emu-xref href="#step-call-pop-context-stack"></emu-xref> it must not be destroyed if it is retained for later use by an accessible Generator.</p>
       </emu-note>
 
       <emu-clause id="sec-prepareforordinarycall" type="abstract operation">
@@ -14494,7 +14494,7 @@
         1. Return ? _result_.
       </emu-alg>
       <emu-note>
-        <p>When _calleeContext_ is removed from the execution context stack it must not be destroyed if it has been retained by an accessible Generator for later resumption.</p>
+        <p>When _calleeContext_ is removed from the execution context stack it must not be destroyed if it has been retained by an accessible Generator for later use.</p>
       </emu-note>
     </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -12455,7 +12455,6 @@
       </dl>
       <emu-alg>
         1. Let _callerContext_ be the running execution context.
-        1. Suspend _callerContext_.
         1. Push _context_ onto the execution context stack; _context_ is now the running execution context.
         1. Transfer control from _callerContext_ to _context_, passing _completionRecord_.
         1. NOTE: This step is reached only when control is transferred back to _callerContext_, which might not happen.
@@ -13867,7 +13866,7 @@
         1. Return _result_.[[Value]].
       </emu-alg>
       <emu-note>
-        <p>When _calleeContext_ is removed from the execution context stack in step <emu-xref href="#step-call-pop-context-stack"></emu-xref> it must not be destroyed if it is suspended and retained for later resumption by an accessible Generator.</p>
+        <p>When _calleeContext_ is removed from the execution context stack in step <emu-xref href="#step-call-pop-context-stack"></emu-xref> it must not be destroyed if it is retained for later resumption by an accessible Generator.</p>
       </emu-note>
 
       <emu-clause id="sec-prepareforordinarycall" type="abstract operation">
@@ -13880,7 +13879,6 @@
         <dl class="header">
         </dl>
         <emu-alg>
-          1. Let _callerContext_ be the running execution context.
           1. Let _calleeContext_ be a new ECMAScript code execution context.
           1. Set the Function of _calleeContext_ to _func_.
           1. Let _calleeRealm_ be _func_.[[Realm]].
@@ -13890,7 +13888,6 @@
           1. Set the LexicalEnvironment of _calleeContext_ to _localEnv_.
           1. Set the VariableEnvironment of _calleeContext_ to _localEnv_.
           1. Set the PrivateEnvironment of _calleeContext_ to _func_.[[PrivateEnvironment]].
-          1. If _callerContext_ is not already suspended, suspend _callerContext_.
           1. Push _calleeContext_ onto the execution context stack; _calleeContext_ is now the running execution context.
           1. NOTE: Any exception objects produced after this point are associated with _calleeRealm_.
           1. Return _calleeContext_.
@@ -14467,7 +14464,6 @@
       </dl>
       <emu-alg>
         1. Let _callerContext_ be the running execution context.
-        1. If _callerContext_ is not already suspended, suspend _callerContext_.
         1. Let _calleeContext_ be a new execution context.
         1. Set the Function of _calleeContext_ to _func_.
         1. Let _calleeRealm_ be _func_.[[Realm]].
@@ -14492,7 +14488,7 @@
         1. Return ? _result_.
       </emu-alg>
       <emu-note>
-        <p>When _calleeContext_ is removed from the execution context stack it must not be destroyed if it has been suspended and retained by an accessible Generator for later resumption.</p>
+        <p>When _calleeContext_ is removed from the execution context stack it must not be destroyed if it has been retained by an accessible Generator for later resumption.</p>
       </emu-note>
     </emu-clause>
 
@@ -26827,7 +26823,6 @@
         1. Set the VariableEnvironment of _scriptContext_ to _globalEnv_.
         1. Set the LexicalEnvironment of _scriptContext_ to _globalEnv_.
         1. Set the PrivateEnvironment of _scriptContext_ to *null*.
-        1. Suspend the running execution context.
         1. Push _scriptContext_ onto the execution context stack; _scriptContext_ is now the running execution context.
         1. Let _scriptNode_ be _scriptRecord_.[[ECMAScriptCode]].
         1. Let _result_ be Completion(GlobalDeclarationInstantiation(_scriptNode_, _globalEnv_)).
@@ -26835,7 +26830,7 @@
           1. Set _result_ to Completion(Evaluation of _scriptNode_).
           1. If _result_ is a normal completion and _result_.[[Value]] is ~empty~, then
             1. Set _result_ to NormalCompletion(*undefined*).
-        1. Suspend _scriptContext_ and remove it from the execution context stack.
+        1. Remove _scriptContext_ from the execution context stack.
         1. Assert: The execution context stack is not empty.
         1. Return ? _result_.
       </emu-alg>
@@ -29324,11 +29319,10 @@
               1. If _module_.[[HasTLA]] is *false*, then
                 1. Assert: _capability_ is not present.
                 1. Let _env_ be _module_.[[Environment]].
-                1. Suspend the running execution context.
                 1. Push _moduleContext_ onto the execution context stack; _moduleContext_ is now the running execution context.
                 1. Let _result_ be Completion(Evaluation of _module_.[[ECMAScriptCode]]).
                 1. Set _result_ to Completion(DisposeResources(_env_.[[DisposableResourceStack]], _result_)).
-                1. Suspend _moduleContext_ and remove it from the execution context stack.
+                1. Remove _moduleContext_ from the execution context stack.
                 1. If _result_ is an abrupt completion, then
                   1. Return ? _result_.
               1. Else,
@@ -29523,11 +29517,10 @@
               1. Set the ScriptOrModule of _moduleContext_ to _module_.
               1. Set the VariableEnvironment of _moduleContext_ to _module_.[[Environment]].
               1. Set the LexicalEnvironment of _moduleContext_ to _module_.[[Environment]].
-              1. Suspend the running execution context.
               1. Push _moduleContext_ onto the execution context stack; _moduleContext_ is now the running execution context.
               1. Let _steps_ be _module_.[[EvaluationSteps]].
               1. Let _result_ be Completion(_steps_(_module_)).
-              1. Suspend _moduleContext_ and remove it from the execution context stack.
+              1. Remove _moduleContext_ from the execution context stack.
               1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
               1. IfAbruptRejectPromise(_result_, _promiseCapability_).
               1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, « *undefined* »).
@@ -30504,7 +30497,6 @@
             1. Let _variableEnv_ be _evalRealm_.[[GlobalEnv]].
             1. Let _privateEnv_ be *null*.
           1. If _strictEval_ is *true*, set _variableEnv_ to _lexicalEnv_.
-          1. If _runningContext_ is not already suspended, suspend _runningContext_.
           1. Let _evalContext_ be a new ECMAScript code execution context.
           1. Set _evalContext_'s Function to *null*.
           1. Set _evalContext_'s Realm to _evalRealm_.
@@ -30518,7 +30510,7 @@
             1. Set _result_ to Completion(Evaluation of _body_).
           1. If _result_ is a normal completion and _result_.[[Value]] is ~empty~, then
             1. Set _result_ to NormalCompletion(*undefined*).
-          1. Suspend _evalContext_ and remove it from the execution context stack.
+          1. Remove _evalContext_ from the execution context stack.
           1. Return ? _result_.
         </emu-alg>
         <emu-note>
@@ -52047,7 +52039,6 @@ THH:mm:ss.sss
           1. Set the Function of _calleeContext_ to *null*.
           1. Set the Realm of _calleeContext_ to the current Realm Record.
           1. Set the ScriptOrModule of _calleeContext_ to _callerContext_'s ScriptOrModule.
-          1. If _callerContext_ is not already suspended, suspend _callerContext_.
           1. Push _calleeContext_ onto the execution context stack; _calleeContext_ is now the running execution context.
           1. Perform GeneratorStart(_gen_, _closure_).
           1. Remove _calleeContext_ from the execution context stack.

--- a/spec.html
+++ b/spec.html
@@ -52600,7 +52600,7 @@ THH:mm:ss.sss
             1. [id="step-asyncblockstart-return-undefined"] Resume _callerContext_, passing NormalCompletion(~unused~).
             1. Assert: This step is never reached.
           1. Set the code evaluation state of _asyncContext_ such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
-          1. Let _result_ be ! RunSuspendedContext(_asyncContext_, NormalCompletion(~empty~)).
+          1. Let _result_ be ! RunSuspendedContext(_asyncContext_, NormalCompletion(~unused~)).
           1. Assert: _result_ is ~unused~.
           1. NOTE: The possible sources of _result_ values are Await or, if the async function doesn't await anything, step <emu-xref href="#step-asyncblockstart-return-undefined"></emu-xref> above.
           1. Return ~unused~.

--- a/spec.html
+++ b/spec.html
@@ -49119,7 +49119,7 @@ THH:mm:ss.sss
             1. Assert: _obj_ has a [[GeneratorState]] internal slot.
             1. If _obj_.[[GeneratorState]] is ~suspended-start~, then
               1. Set _obj_.[[GeneratorState]] to ~completed~.
-              1. NOTE: Once a generator enters the completed state it never leaves it and its associated execution context is never resumed. Any execution state associated with _obj_ can be discarded at this point.
+              1. NOTE: Once a generator enters the completed state it never leaves it and there is never again a transfer of control to its associated execution context. Any execution state associated with _obj_ can be discarded at this point.
               1. Perform ? IteratorCloseAll(_obj_.[[UnderlyingIterators]], NormalCompletion(~unused~)).
               1. Return CreateIteratorResultObject(*undefined*, *true*).
             1. Let _completion_ be ReturnCompletion(*undefined*).
@@ -51884,7 +51884,7 @@ THH:mm:ss.sss
             1. Assert: If we return here, the generator either threw an exception or performed either an implicit or explicit return.
             1. Remove _acGenContext_ from the execution context stack.
             1. Set _acGen_.[[GeneratorState]] to ~completed~.
-            1. NOTE: Once a generator enters the ~completed~ state it never leaves it and its associated execution context is never resumed. Any execution state associated with _acGen_ can be discarded at this point.
+            1. NOTE: Once a generator enters the ~completed~ state it never leaves it and there is never again a transfer of control to its associated execution context. Any execution state associated with _acGen_ can be discarded at this point.
             1. If _result_ is a throw completion, then
               1. Let _resumption_ be _result_.
             1. Else,
@@ -51957,7 +51957,7 @@ THH:mm:ss.sss
           1. Let _state_ be ? GeneratorValidate(_gen_, _genBrand_).
           1. If _state_ is ~suspended-start~, then
             1. Set _gen_.[[GeneratorState]] to ~completed~.
-            1. NOTE: Once a generator enters the ~completed~ state it never leaves it and its associated execution context is never resumed. Any execution state associated with _gen_ can be discarded at this point.
+            1. NOTE: Once a generator enters the ~completed~ state it never leaves it and there is never again a transfer of control to its associated execution context. Any execution state associated with _gen_ can be discarded at this point.
             1. Set _state_ to ~completed~.
           1. If _state_ is ~completed~, then
             1. If _abruptCompletion_ is a return completion, then
@@ -52563,7 +52563,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _runningContext_ be the running execution context.
           1. Let _asyncContext_ be a copy of _runningContext_.
-          1. NOTE: Copying the execution state is required for AsyncBlockStart to resume its execution. It is ill-defined to resume a currently executing context.
+          1. NOTE: Copying is required because AsyncFunctionStart has different roles for _asyncContext_ and _runningContext_ that cannot (easily) be filled by a single execution context.
           1. Perform AsyncBlockStart(_promiseCapability_, _asyncFuncBody_, _asyncContext_).
           1. Return ~unused~.
         </emu-alg>

--- a/spec.html
+++ b/spec.html
@@ -51899,7 +51899,8 @@ THH:mm:ss.sss
             1. Let _callerContext_ be the running execution context.
             1. Transfer control from _acGenContext_ to _callerContext_, passing _resumption_.
             1. Assert: This step is never reached.
-          1. Set the code evaluation state of _genContext_ such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
+          1. Set _genContext_'s code evaluation state to _closure_.
+          1. NOTE: The next time there is a transfer of control to _genContext_, _closure_ will be called with no arguments.
           1. Set _gen_.[[GeneratorContext]] to _genContext_.
           1. Return ~unused~.
         </emu-alg>
@@ -52246,7 +52247,8 @@ THH:mm:ss.sss
             1. Let _callerContext_ be the running execution context.
             1. Transfer control from _acGenContext_ to _callerContext_, passing NormalCompletion(*undefined*).
             1. Assert: This step is never reached.
-          1. Set the code evaluation state of _genContext_ such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
+          1. Set _genContext_'s code evaluation state to _closure_.
+          1. NOTE: The next time there is a transfer of control to _genContext_, _closure_ will be called with no arguments.
           1. Set _gen_.[[AsyncGeneratorContext]] to _genContext_.
           1. Set _gen_.[[AsyncGeneratorQueue]] to a new empty List.
           1. Return ~unused~.
@@ -52601,7 +52603,8 @@ THH:mm:ss.sss
             1. Let _callerContext_ be the running execution context.
             1. [id="step-asyncblockstart-return-undefined"] Transfer control from _acAsyncContext_ to _callerContext_, passing NormalCompletion(~unused~).
             1. Assert: This step is never reached.
-          1. Set the code evaluation state of _asyncContext_ such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
+          1. Set _asyncContext_'s code evaluation state to _closure_.
+          1. NOTE: The next time there is a transfer of control to _asyncContext_, _closure_ will be called with no arguments.
           1. Let _result_ be ! RunSuspendedContext(_asyncContext_, NormalCompletion(~unused~)).
           1. Assert: _result_ is ~unused~.
           1. NOTE: The possible sources of _result_ values are Await or, if the async function doesn't await anything, step <emu-xref href="#step-asyncblockstart-return-undefined"></emu-xref> above.

--- a/spec.html
+++ b/spec.html
@@ -12448,8 +12448,10 @@
         1. Let _callerContext_ be the running execution context.
         1. Suspend _callerContext_.
         1. Push _context_ onto the execution context stack; _context_ is now the running execution context.
-        1. <emu-meta effects="user-code">Resume the suspended evaluation of _context_</emu-meta> passing _completionRecord_ as the result of the operation that suspended it. Let _result_ be the Completion Record passed by the resumed computation.
-        1. Assert: When we reach this step, _context_ has already been removed from the execution context stack and _callerContext_ is the running execution context again.
+        1. Transfer control from _callerContext_ to _context_, passing _completionRecord_.
+        1. NOTE: This step is reached only when control is transferred back to _callerContext_, which might not happen.
+        1. Let _result_ be the Completion Record passed when control was transferred back to _callerContext_.
+        1. Assert: _context_ has already been removed from the execution context stack and _callerContext_ is the running execution context again.
         1. Return Completion(_result_).
       </emu-alg>
     </emu-clause>
@@ -12468,10 +12470,10 @@
         1. Let _genContext_ be the running execution context.
         1. Remove _genContext_ from the execution context stack.
         1. Let _callerContext_ be the running execution context.
-        1. Resume _callerContext_, passing NormalCompletion(_value_).
-        1. NOTE: The above step transfers control to _callerContext_ and pauses. The only way for it to un-pause and have control proceed to the subsequent steps in this algorithm is for _genContext_ to be resumed again, which might never happen.
-        1. Assert: _genContext_ is the running execution context.
-        1. Let _result_ be the Completion Record with which _genContext_ was just resumed.
+        1. Transfer control from _genContext_ to _callerContext_, passing NormalCompletion(_value_).
+        1. NOTE: This step is reached only when control is transferred back to _genContext_, which might not happen.
+        1. Let _result_ be the Completion Record passed when control was transferred back to _genContext_.
+        1. Assert: _genContext_ is the running execution context again.
         1. Return Completion(_result_).
       </emu-alg>
     </emu-clause>
@@ -51895,7 +51897,7 @@ THH:mm:ss.sss
                 1. Let _resultValue_ be _result_.[[Value]].
               1. Let _resumption_ be NormalCompletion(CreateIteratorResultObject(_resultValue_, *true*)).
             1. Let _callerContext_ be the running execution context.
-            1. Resume _callerContext_, passing _resumption_.
+            1. Transfer control from _acGenContext_ to _callerContext_, passing _resumption_.
             1. Assert: This step is never reached.
           1. Set the code evaluation state of _genContext_ such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
           1. Set _gen_.[[GeneratorContext]] to _genContext_.
@@ -52242,7 +52244,7 @@ THH:mm:ss.sss
             1. Perform AsyncGeneratorCompleteStep(_acGen_, _result_, *true*).
             1. Perform AsyncGeneratorDrainQueue(_acGen_).
             1. Let _callerContext_ be the running execution context.
-            1. Resume _callerContext_, passing NormalCompletion(*undefined*).
+            1. Transfer control from _acGenContext_ to _callerContext_, passing NormalCompletion(*undefined*).
             1. Assert: This step is never reached.
           1. Set the code evaluation state of _genContext_ such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
           1. Set _gen_.[[AsyncGeneratorContext]] to _genContext_.
@@ -52597,7 +52599,7 @@ THH:mm:ss.sss
               1. Assert: _result_ is a throw completion.
               1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, « _result_.[[Value]] »).
             1. Let _callerContext_ be the running execution context.
-            1. [id="step-asyncblockstart-return-undefined"] Resume _callerContext_, passing NormalCompletion(~unused~).
+            1. [id="step-asyncblockstart-return-undefined"] Transfer control from _acAsyncContext_ to _callerContext_, passing NormalCompletion(~unused~).
             1. Assert: This step is never reached.
           1. Set the code evaluation state of _asyncContext_ such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
           1. Let _result_ be ! RunSuspendedContext(_asyncContext_, NormalCompletion(~unused~)).

--- a/spec.html
+++ b/spec.html
@@ -26837,7 +26837,6 @@
             1. Set _result_ to NormalCompletion(*undefined*).
         1. Suspend _scriptContext_ and remove it from the execution context stack.
         1. Assert: The execution context stack is not empty.
-        1. Resume the context that is now on the top of the execution context stack as the running execution context.
         1. Return ? _result_.
       </emu-alg>
     </emu-clause>
@@ -29330,7 +29329,6 @@
                 1. Let _result_ be Completion(Evaluation of _module_.[[ECMAScriptCode]]).
                 1. Set _result_ to Completion(DisposeResources(_env_.[[DisposableResourceStack]], _result_)).
                 1. Suspend _moduleContext_ and remove it from the execution context stack.
-                1. Resume the context that is now on the top of the execution context stack as the running execution context.
                 1. If _result_ is an abrupt completion, then
                   1. Return ? _result_.
               1. Else,
@@ -29530,7 +29528,6 @@
               1. Let _steps_ be _module_.[[EvaluationSteps]].
               1. Let _result_ be Completion(_steps_(_module_)).
               1. Suspend _moduleContext_ and remove it from the execution context stack.
-              1. Resume the context that is now on the top of the execution context stack as the running execution context.
               1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
               1. IfAbruptRejectPromise(_result_, _promiseCapability_).
               1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, « *undefined* »).
@@ -30522,7 +30519,6 @@
           1. If _result_ is a normal completion and _result_.[[Value]] is ~empty~, then
             1. Set _result_ to NormalCompletion(*undefined*).
           1. Suspend _evalContext_ and remove it from the execution context stack.
-          1. Resume the context that is now on the top of the execution context stack as the running execution context.
           1. Return ? _result_.
         </emu-alg>
         <emu-note>

--- a/spec.html
+++ b/spec.html
@@ -12335,6 +12335,15 @@
         </tr>
       </table>
     </emu-table>
+    <p>To express the semantics of generators, this document uses steps of the form “<dfn id="transfer-control" variants="transfers control,transfer of control">Transfer control</dfn> from _aContext_ to _bContext_, passing _completion_”, where _aContext_ and _bContext_ are execution contexts and _completion_ is a Completion Record. This means:</p>
+    <ul>
+      <li>Execution of the current algorithm (the one with the “Transfer control” step) is suspended, and a representation of that suspended execution is saved in the code evaluation state of _aContext_.</li>
+      <li>The code evaluation state of _bContext_ is typically a representation of an execution that was suspended in another “Transfer control” step; that execution is resumed, and _completion_ is provided as “the Completion Record passed when control was transferred back to _bContext_”. Alternatively, _bContext_'s code evaluation state is an Abstract Closure; in that case, the Abstract Closure is called with no arguments, and _completion_ is ignored.</li>
+    </ul>
+    <p>The suspended execution associated with _aContext_ will stay suspended until some step transfers control back to _aContext_, which might never happen.</p>
+    <emu-note>This is analogous to the concept of coroutines in programming languages.</emu-note>
+    <emu-note>In practice, _aContext_ was the running execution context until just before the “Transfer control” step, and _bContext_ is the new running execution context. However, the “Transfer control” step itself doesn't manipulate the execution context stack.</emu-note>
+
     <p>In most situations only the running execution context (the top of the execution context stack) is directly manipulated by algorithms within this specification. Hence when the terms “LexicalEnvironment”, and “VariableEnvironment” are used without qualification they are in reference to those components of the running execution context.</p>
     <p>An execution context is purely a specification mechanism and need not correspond to any particular artefact of an ECMAScript implementation. It is impossible for ECMAScript code to directly access or observe an execution context.</p>
 

--- a/spec.html
+++ b/spec.html
@@ -12312,6 +12312,8 @@
       </table>
     </emu-table>
     <p>The LexicalEnvironment and VariableEnvironment components of an execution context are always Environment Records.</p>
+    <p>In most situations only the running execution context (the top of the execution context stack) is directly manipulated by algorithms within this specification. Hence when the terms “LexicalEnvironment”, and “VariableEnvironment” are used without qualification they are in reference to those components of the running execution context.</p>
+
     <p>Execution contexts representing the evaluation of Generators have the additional state components listed in <emu-xref href="#table-additional-state-components-for-generator-execution-contexts"></emu-xref>.</p>
     <emu-table id="table-additional-state-components-for-generator-execution-contexts" caption="Additional State Components for Generator Execution Contexts" oldids="table-24">
       <table>
@@ -12344,7 +12346,6 @@
     <emu-note>This is analogous to the concept of coroutines in programming languages.</emu-note>
     <emu-note>In practice, _aContext_ was the running execution context until just before the “Transfer control” step, and _bContext_ is the new running execution context. However, the “Transfer control” step itself doesn't manipulate the execution context stack.</emu-note>
 
-    <p>In most situations only the running execution context (the top of the execution context stack) is directly manipulated by algorithms within this specification. Hence when the terms “LexicalEnvironment”, and “VariableEnvironment” are used without qualification they are in reference to those components of the running execution context.</p>
     <p>An execution context is purely a specification mechanism and need not correspond to any particular artefact of an ECMAScript implementation. It is impossible for ECMAScript code to directly access or observe an execution context.</p>
 
     <emu-clause id="sec-getactivescriptormodule" type="abstract operation">

--- a/spec.html
+++ b/spec.html
@@ -12466,7 +12466,7 @@
       </dl>
       <emu-alg>
         1. Let _genContext_ be the running execution context.
-        1. Remove _genContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
+        1. Remove _genContext_ from the execution context stack.
         1. Let _callerContext_ be the running execution context.
         1. Resume _callerContext_, passing NormalCompletion(_value_).
         1. NOTE: The above step transfers control to _callerContext_ and pauses. The only way for it to un-pause and have control proceed to the subsequent steps in this algorithm is for _genContext_ to be resumed again, which might never happen.
@@ -13844,11 +13844,13 @@
         1. If _func_.[[IsClassConstructor]] is *true*, then
           1. Let _error_ be a newly created *TypeError* object.
           1. NOTE: _error_ is created in _calleeContext_ with _func_'s associated Realm Record.
-          1. Remove _calleeContext_ from the execution context stack and restore _callerContext_ as the running execution context.
+          1. Remove _calleeContext_ from the execution context stack.
+          1. Assert: _callerContext_ is the running execution context again.
           1. Throw _error_.
         1. Perform OrdinaryCallBindThis(_func_, _calleeContext_, _thisArg_).
         1. Let _result_ be Completion(OrdinaryCallEvaluateBody(_func_, _argList_)).
-        1. [id="step-call-pop-context-stack"] Remove _calleeContext_ from the execution context stack and restore _callerContext_ as the running execution context.
+        1. [id="step-call-pop-context-stack"] Remove _calleeContext_ from the execution context stack.
+        1. Assert: _callerContext_ is the running execution context again.
         1. If _result_ is a throw completion, return ? _result_.
         1. Assert: _result_ is a return completion.
         1. Return _result_.[[Value]].
@@ -14018,11 +14020,13 @@
           1. Perform OrdinaryCallBindThis(_func_, _calleeContext_, _thisArg_).
           1. Let _initializeResult_ be Completion(InitializeInstanceElements(_thisArg_, _func_)).
           1. If _initializeResult_ is an abrupt completion, then
-            1. Remove _calleeContext_ from the execution context stack and restore _callerContext_ as the running execution context.
+            1. Remove _calleeContext_ from the execution context stack.
+            1. Assert: _callerContext_ is the running execution context again.
             1. Return ? _initializeResult_.
         1. Let _ctorEnv_ be the LexicalEnvironment of _calleeContext_.
         1. Let _result_ be Completion(OrdinaryCallEvaluateBody(_func_, _argList_)).
-        1. Remove _calleeContext_ from the execution context stack and restore _callerContext_ as the running execution context.
+        1. Remove _calleeContext_ from the execution context stack.
+        1. Assert: _callerContext_ is the running execution context again.
         1. If _result_ is a throw completion, return ? _result_.
         1. Assert: _result_ is a return completion.
         1. If _result_.[[Value]] is an Object, return _result_.[[Value]].
@@ -14467,11 +14471,13 @@
             1. NOTE: If _func_ is defined in this document, “the specification of _func_” is the behaviour specified for it via algorithm steps or other means.
             1. Return Completion(_result_).
           1. Perform AsyncFunctionStart(_promiseCapability_, _resultsClosure_).
-          1. Remove _calleeContext_ from the execution context stack and restore _callerContext_ as the running execution context.
+          1. Remove _calleeContext_ from the execution context stack.
+          1. Assert: _callerContext_ is the running execution context again.
           1. Return _promiseCapability_.[[Promise]].
         1. [id="step-call-builtin-function-result"] Let _result_ be the Completion Record that is <emu-meta effects="user-code">the result of evaluating</emu-meta> _func_ in a manner that conforms to the specification of _func_. If _thisArg_ is ~uninitialized~, the *this* value is uninitialized; else _thisArg_ provides the *this* value. _argList_ provides the named parameters. _newTarget_ provides the NewTarget value.
         1. NOTE: If _func_ is defined in this document, “the specification of _func_” is the behaviour specified for it via algorithm steps or other means.
-        1. Remove _calleeContext_ from the execution context stack and restore _callerContext_ as the running execution context.
+        1. Remove _calleeContext_ from the execution context stack.
+        1. Assert: _callerContext_ is the running execution context again.
         1. Return ? _result_.
       </emu-alg>
       <emu-note>
@@ -51877,7 +51883,7 @@ THH:mm:ss.sss
               1. Assert: _genBody_ is an Abstract Closure with no parameters.
               1. Let _result_ be Completion(_genBody_()).
             1. Assert: If we return here, the generator either threw an exception or performed either an implicit or explicit return.
-            1. Remove _acGenContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
+            1. Remove _acGenContext_ from the execution context stack.
             1. Set _acGen_.[[GeneratorState]] to ~completed~.
             1. NOTE: Once a generator enters the ~completed~ state it never leaves it and its associated execution context is never resumed. Any execution state associated with _acGen_ can be discarded at this point.
             1. If _result_ is a throw completion, then
@@ -52036,7 +52042,8 @@ THH:mm:ss.sss
           1. If _callerContext_ is not already suspended, suspend _callerContext_.
           1. Push _calleeContext_ onto the execution context stack; _calleeContext_ is now the running execution context.
           1. Perform GeneratorStart(_gen_, _closure_).
-          1. Remove _calleeContext_ from the execution context stack and restore _callerContext_ as the running execution context.
+          1. Remove _calleeContext_ from the execution context stack.
+          1. Assert: _callerContext_ is the running execution context again.
           1. Return _gen_.
         </emu-alg>
       </emu-clause>
@@ -52228,7 +52235,7 @@ THH:mm:ss.sss
               1. Assert: _genBody_ is an Abstract Closure with no parameters.
               1. Let _result_ be Completion(_genBody_()).
             1. Assert: If we return here, the async generator either threw an exception or performed either an implicit or explicit return.
-            1. Remove _acGenContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
+            1. Remove _acGenContext_ from the execution context stack.
             1. Set _acGen_.[[AsyncGeneratorState]] to ~draining-queue~.
             1. If _result_ is a normal completion, set _result_ to NormalCompletion(*undefined*).
             1. If _result_ is a return completion, set _result_ to NormalCompletion(_result_.[[Value]]).
@@ -52581,7 +52588,7 @@ THH:mm:ss.sss
               1. Assert: _asyncBody_ is an Abstract Closure with no parameters.
               1. Let _result_ be Completion(_asyncBody_()).
             1. Assert: If we return here, the async function either threw an exception or performed an implicit or explicit return; all awaiting is done.
-            1. Remove _acAsyncContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
+            1. Remove _acAsyncContext_ from the execution context stack.
             1. If _result_ is a normal completion, then
               1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, « *undefined* »).
             1. Else if _result_ is a return completion, then


### PR DESCRIPTION
This PR follows up on some things that came up in the discussion of PR #2665, and then goes farther.

I've organized it into a bunch of fairly focused commits, in case that helps with review. The commits are divided into 5 groups.

----
Preliminaries:

- Editorial: Eliminate "restore <context> as the running execution context"

  Specifically, change:
  > Remove _X_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.

  to just:
  > Remove _X_ from the execution context stack.
  
  and change:
  > Remove _X_ from the execution context stack and restore _Y_ as the running execution context.

  to:
  > Remove _X_ from the execution context stack.
  > Assert: _Y_ is the running execution context again.
  
  The "restore" phrasing suggests that the implementation needs to do something, when in fact the context in question becomes the running execution context automatically, because the running execution context is always the top element of the execution context stack.

- In AsyncBlockStart, change `~empty~` to `~unused~`

  Prior to PR #2664, AsyncBlockStart resumed the suspended evaluation of _asyncContext_ without passing a value. This made sense, because _asyncContext_'s code evaluation state had just been set so that the next resumption would invoke a closure with no arguments, i.e. any value passed to the resumption would be ignored.

  But in PR 2664, I introduced RunSuspendedContext, which requires its callers to supply a value. For the call in AsyncBlockStart, that value didn't matter, and I picked `NormalCompletion(~empty~)`.

  I now think it would be clearer to pick `NormalCompletion(~unused~)`.

----
Transfer control:

- Replace all blocking-Resume steps with "Transfer control"

  Specifically:
  - the "Resume the suspended evaluation" step in RunSuspendedContext
  - the "Resume" step in RunCallerContext
  - the abstract closure's terminal "Resume" step in GeneratorStart, AsyncGeneratorStart, and AsyncBlockStart 

  <!--
  Incorporates fixups for:
    - "The above step completes ..." -> "This step is reached ..."
    - Reword "if/when control is transferred back"
  -->

- Tweak wording re setting `code evaluation state`

  Change:
  > Set the code evaluation state of _context_ such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.

  to:
  > Set _context_'s code evaluation state to _closure_.
  > NOTE: The next time there is a transfer of control to _context_, _closure_ will be called with no arguments.

- Define "Transfer control"

----
Resume+Suspend:

- Eliminate `Resume` steps

  The only remaining `Resume` steps are the 4 non-blocking Resumes in ScriptEvaluation, ExecuteModule, Evaluate, and PerformEval.

  Since there's no definition for "resuming" an execution context, and since it doesn't come up any other time that an EC is removed from the EC stack, I'm concluding that it has no normative effect.

  So remove the remaining `Resume` steps.

- Eliminate `Suspend` steps

  As with `Resume`, there's no definition for "suspending" an execution context.  And if `Resume` has no normative effect, it seems very unlikely that `Suspend` would.

  So drop mentions of suspending an execution context.

  (The "Execution Contexts" section does have a paragraph that talks about suspending execution contexts, but it doesn't really say what the effect of `Suspend` is, it just implies that it's a prerequisite for making a different EC become the running EC.  But that seems like a pointless hoop to jump through.)

- Re-word Note steps that talk about resuming execution contexts

----
Execution Context section:

- Move a paragraph

  Take a paragraph that talks about LexicalEnvironment and VariableEnvironment, and move it to a better spot.

- Make the EC Stack subsection

  Collect stuff about the execution context stack, move it to a new subsection, and then rework it. 

  Note that there a couple of problems in the status quo:
  > A new execution context is created whenever control is transferred from the executable code associated with the currently running execution context to executable code that is not associated with that execution context.

  That became false when generators were added.

  > Transition of the running execution context status among execution contexts usually occurs in stack-like last-in/first-out manner. However, some ECMAScript features require non-LIFO transitions of the running execution context.

  No, it's always stack-like.

----
Cleanup:

- Eliminate certain wording around execution contexts

  Specifically, eliminate wording such as: 
  - an EC tracks the evaluation/execution of code
  - an EC evaluates/executes code
  - an EC can wait for an event
  - code is 'within' an EC
  - code is evaluated within an EC
  - control enters an EC

  Also:
  - Drop "currently" from "the currently running execution context".
  - Drop "running execution contexts" (plural) variant.

