### PR TITLE
Editorial: Correct the 'Value Type' of a few Record fields

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -10421,7 +10421,7 @@
                 [[FunctionObject]]
               </td>
               <td>
-                an Object
+                an ECMAScript function object
               </td>
               <td>
                 The function object whose invocation caused this Environment Record to be created.
@@ -25551,10 +25551,10 @@
               [[ECMAScriptCode]]
             </td>
             <td>
-              a Parse Node
+              a |Script| Parse Node
             </td>
             <td>
-              The result of parsing the source text of this script using |Script| as the goal symbol.
+              The result of parsing the source text of this script.
             </td>
           </tr>
           <tr>
@@ -27076,10 +27076,10 @@
                 [[Context]]
               </td>
               <td>
-                an ECMAScript execution context
+                an ECMAScript code execution context or ~empty~
               </td>
               <td>
-                The execution context associated with this module.
+                The execution context associated with this module. It is ~empty~ until the module's environment has been initialized.
               </td>
             </tr>
             <tr>
@@ -27087,7 +27087,7 @@
                 [[ImportMeta]]
               </td>
               <td>
-                an Object
+                an Object or ~empty~
               </td>
               <td>
                 An object exposed through the `import.meta` meta property. It is ~empty~ until it is accessed by ECMAScript code.


### PR DESCRIPTION
The first two make the declared type narrower, and the rest make it wider (by adding `~empty~` or `*undefined*`).

The changes can be confirmed by looking at the places where the fields are set.