### PR TITLE
Editorial: Rephrase 2 "List of Records" types

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -11463,7 +11463,7 @@
             [[TemplateMap]]
           </td>
           <td>
-            a List of Record { [[Site]]: Parse Node, [[Array]]: Object }
+            a List of Records with fields [[Site]] (a |TemplateLiteral| Parse Node) and [[Array]] (an Array)
           </td>
           <td>
             <p>Template objects are canonicalized separately for each realm using its Realm Record's [[TemplateMap]]. Each [[Site]] value is a Parse Node that is a |TemplateLiteral|. The associated [[Array]] value is the corresponding template object that is passed to a tag function.</p>
@@ -27618,7 +27618,7 @@
           <h1>
             ResolveExport (
               _exportName_: a String,
-              optional _resolveSet_: a List of Records that have [[Module]] and [[ExportName]] fields,
+              optional _resolveSet_: a List of Records with fields [[Module]] (a Module Record) and [[ExportName]] (a String),
             ): a ResolvedBinding Record, *null*, or ~ambiguous~
           </h1>
           <dl class="header">


### PR DESCRIPTION
Some Record values don't have a named schema. The spec has a standard way to refer to these in parameter-types and return-types, e.g.:
`a Record with fields [[CharSet]] (a CharSet) and [[Invert]] (a Boolean)`

However, for a *List* of such values, the spec isn't so consistent. This PR changes 2 "List of Records" types to use the "with fields" phrasing.

---

Also, for [[TemplateMap]], I made the field types more precise.
