### PR TITLE
Normative: Treat the Atomics.wait timeout as an extended mathematical lower bound

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -41981,7 +41981,7 @@ THH:mm:ss.sss
           SuspendAgent (
             _WL_: a WaiterList,
             _W_: an agent signifier,
-            _timeout_: a non-negative integer,
+            _timeout_: a non-negative extended mathematical value,
           ): a Boolean
         </h1>
         <dl class="header">
@@ -41991,7 +41991,7 @@ THH:mm:ss.sss
           1. Assert: _W_ is equivalent to AgentSignifier().
           1. Assert: _W_ is on the list of waiters in _WL_.
           1. Assert: AgentCanSuspend() is *true*.
-          1. Perform LeaveCriticalSection(_WL_) and suspend _W_ for up to _timeout_ milliseconds, performing the combined operation in such a way that a notification that arrives after the critical section is exited but before the suspension takes effect is not lost. _W_ can notify either because the timeout expired or because it was notified explicitly by another agent calling NotifyWaiter with arguments _WL_ and _W_, and not for any other reasons at all.
+          1. Perform LeaveCriticalSection(_WL_) and suspend _W_ until either _W_ is notified by another agent calling NotifyWaiter with arguments _WL_ and _W_ or at least _timeout_ milliseconds have elapsed, performing the combined operation in such a way that a notification arriving after the critical section is exited but before the suspension takes effect is not lost.
           1. Perform EnterCriticalSection(_WL_).
           1. If _W_ was notified explicitly by another agent calling NotifyWaiter with arguments _WL_ and _W_, return *true*.
           1. Return *false*.
@@ -42282,9 +42282,14 @@ THH:mm:ss.sss
         1. Else,
           1. Perform RemoveWaiter(_WL_, _W_).
         1. Perform LeaveCriticalSection(_WL_).
+        1. Let _padding_ be an implementation-defined non-negative mathematical value.
+        1. [id="step-atomics.wait-degrade-resolution"] If _padding_ ≠ 0, wait until a further _padding_ milliseconds have elapsed.
         1. If _notified_ is *true*, return *"ok"*.
         1. Return *"timed-out"*.
       </emu-alg>
+      <emu-note>
+        <p>Step <emu-xref href="#step-atomics.wait-degrade-resolution"></emu-xref> allows implementations to pad timeouts, which they might use to mitigate timing attacks and/or support processor timers with coarse resolution.</p>
+      </emu-note>
     </emu-clause>
 
     <emu-clause id="sec-atomics.notify">


### PR DESCRIPTION
Fixes #2914