### PR TITLE
Editorial: Fixed mutable completion records as immutable

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -23791,8 +23791,10 @@
             1. Assert: _received_.[[Type]] is ~return~.
             1. Let _return_ be ? GetMethod(_iterator_, *"return"*).
             1. If _return_ is *undefined*, then
-              1. If _generatorKind_ is ~async~, set _received_.[[Value]] to ? Await(_received_.[[Value]]).
-              1. Return ? _received_.
+              1. Let _value_ be _received_.[[Value]].
+              1. If _generatorKind_ is ~async~, then
+                1. Set _value_ to ? Await(_value_).
+              1. Return Completion Record { [[Type]]: ~return~, [[Value]]: _value_, [[Target]]: ~empty~ }.
             1. Let _innerReturnResult_ be ? Call(_return_, _iterator_, « _received_.[[Value]] »).
             1. If _generatorKind_ is ~async~, set _innerReturnResult_ to ? Await(_innerReturnResult_).
             1. If _innerReturnResult_ is not an Object, throw a *TypeError* exception.


### PR DESCRIPTION
In my understanding, the common practice for completion records is to use them as immutable records. For example, [6.2.4.3 UpdateEmpty](https://tc39.es/ecma262/#sec-updateempty) does not directly modify the `[[Value]]` field but creates another completion record having the given value in the `[[Value]]` field.

However, step 7.c.iii.2 in the [15.5.5 Runtime Semantics: Evaluation](https://tc39.es/ecma262/#sec-generator-function-definitions-runtime-semantics-evaluation) for ``<emu-grammar>YieldExpression : `yield` `*` AssignmentExpression</emu-grammar>`` breaks this common practice. I think this is the only step that treats completion records as mutable in the spec.

In addition, as mentioned in https://github.com/es-meta/esmeta/issues/65, we found that only three Test262 tests related to this issue:
- [language/expressions/async-generator/yield-star-getiter-async-return-method-is-null.js](https://github.com/tc39/test262/blob/main/test/language/expressions/async-generator/yield-star-getiter-async-return-method-is-null.js)
- [language/statements/async-generator/yield-star-return-then-getter-ticks.js](https://github.com/tc39/test262/blob/main/test/language/statements/async-generator/yield-star-return-then-getter-ticks.js)
- [language/statements/async-generator/yield-star-return-missing-value-is-awaited.js](https://github.com/tc39/test262/blob/main/test/language/statements/async-generator/yield-star-return-missing-value-is-awaited.js)

So, I modified step 7.c.iii.2 in the [15.5.5 Runtime Semantics: Evaluation](https://tc39.es/ecma262/#sec-generator-function-definitions-runtime-semantics-evaluation) to introduce a new completion record instead of updating its `[[Value]]` field.