### PR TITLE
Normative: Allow implementations to pad timeouts in SuspendAgent

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -42214,7 +42214,7 @@ THH:mm:ss.sss
           SuspendAgent (
             _WL_: a WaiterList,
             _W_: an agent signifier,
-            _timeout_: a non-negative integer,
+            _minimumTimeout_: a non-negative extended mathematical value,
           ): a Boolean
         </h1>
         <dl class="header">
@@ -42224,11 +42224,17 @@ THH:mm:ss.sss
           1. Assert: _W_ is equivalent to AgentSignifier().
           1. Assert: _W_ is on the list of waiters in _WL_.
           1. Assert: AgentCanSuspend() is *true*.
-          1. Perform LeaveCriticalSection(_WL_) and suspend _W_ for up to _timeout_ milliseconds, performing the combined operation in such a way that a notification that arrives after the critical section is exited but before the suspension takes effect is not lost. _W_ can notify either because the timeout expired or because it was notified explicitly by another agent calling NotifyWaiter with arguments _WL_ and _W_, and not for any other reasons at all.
+          1. Let _additionalTimeout_ be an implementation-defined non-negative mathematical value.
+          1. Let _timeout_ be _minimumTimeout_ + _additionalTimeout_.
+          1. NOTE: When _minimumTimeout_ is +∞, _timeout_ is also +∞ and the following step can terminate only by another agent calling NotifyWaiter.
+          1. Perform LeaveCriticalSection(_WL_) and suspend _W_ for up to _timeout_ milliseconds, performing the combined operation in such a way that a notification that arrives after the critical section is exited but before the suspension takes effect is not lost. _W_ can wake from suspension either because the timeout expired or because it was notified explicitly by another agent calling NotifyWaiter with arguments _WL_ and _W_, and not for any other reasons at all.
           1. Perform EnterCriticalSection(_WL_).
           1. If _W_ was notified explicitly by another agent calling NotifyWaiter with arguments _WL_ and _W_, return *true*.
           1. Return *false*.
         </emu-alg>
+        <emu-note>
+          <p>_additionalTimeout_ allows implementations to pad timeouts as necessary, such as for reducing power consumption or coarsening timer resolution to mitigate timing attacks. This value may differ from call to call of SuspendAgent.</p>
+        </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-notifywaiter" type="abstract operation">


### PR DESCRIPTION
Closes #2914.
