### PR TITLE
Editorial: Increase consistency and clarity of string operations

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -28953,12 +28953,12 @@
           <dd>It performs URI encoding and escaping, interpreting _string_ as a sequence of UTF-16 encoded code points as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>. If a character is identified as unreserved in RFC 2396 or appears in _extraUnescaped_, it is not escaped.</dd>
         </dl>
         <emu-alg>
-          1. Let _strLen_ be the length of _string_.
+          1. Let _len_ be the length of _string_.
           1. Let _R_ be the empty String.
           1. Let _alwaysUnescaped_ be the string-concatenation of the ASCII word characters and *"-.!~\*'()"*.
           1. Let _unescapedSet_ be the string-concatenation of _alwaysUnescaped_ and _extraUnescaped_.
           1. Let _k_ be 0.
-          1. Repeat, while _k_ &lt; _strLen_,
+          1. Repeat, while _k_ &lt; _len_,
             1. Let _C_ be the code unit at index _k_ within _string_.
             1. If _unescapedSet_ contains _C_, then
               1. Set _k_ to _k_ + 1.
@@ -28990,16 +28990,16 @@
           <dd>It performs URI unescaping and decoding, preserving any escape sequences that correspond to Basic Latin characters in _preserveEscapeSet_.</dd>
         </dl>
         <emu-alg>
-          1. Let _strLen_ be the length of _string_.
+          1. Let _len_ be the length of _string_.
           1. Let _R_ be the empty String.
           1. Let _k_ be 0.
-          1. Repeat, while _k_ &lt; _strLen_,
+          1. Repeat, while _k_ &lt; _len_,
             1. Let _C_ be the code unit at index _k_ within _string_.
             1. If _C_ is not the code unit 0x0025 (PERCENT SIGN), then
               1. Let _S_ be the String value containing only the code unit _C_.
             1. Else,
               1. Let _start_ be _k_.
-              1. If _k_ + 2 ≥ _strLen_, throw a *URIError* exception.
+              1. If _k_ + 2 ≥ _len_, throw a *URIError* exception.
               1. Let _hexDigits_ be the substring of _string_ from _k_ + 1 to _k_ + 3.
               1. Let _parseResult_ be ParseText(StringToCodePoints(_hexDigits_), |HexDigits[~Sep]|).
               1. If _parseResult_ is not a Parse Node, throw a *URIError* exception.
@@ -29014,7 +29014,7 @@
                   1. Let _S_ be the substring of _string_ from _start_ to _k_ + 1.
               1. Else,
                 1. If _n_ = 1 or _n_ > 4, throw a *URIError* exception.
-                1. If _k_ + (3 × (_n_ - 1)) ≥ _strLen_, throw a *URIError* exception.
+                1. If _k_ + (3 × (_n_ - 1)) ≥ _len_, throw a *URIError* exception.
                 1. Let _Octets_ be « _B_ ».
                 1. Let _j_ be 1.
                 1. Repeat, while _j_ &lt; _n_,
@@ -47955,11 +47955,11 @@ THH:mm:ss.sss
         <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Set _string_ to ? ToString(_string_).
-          1. Let _strLen_ be the length of _string_.
+          1. Let _len_ be the length of _string_.
           1. Let _R_ be the empty String.
           1. Let _unescapedSet_ be the string-concatenation of the ASCII word characters and *"@\*+-./"*.
           1. Let _k_ be 0.
-          1. Repeat, while _k_ &lt; _strLen_,
+          1. Repeat, while _k_ &lt; _len_,
             1. Let _C_ be the code unit at index _k_ within _string_.
             1. If _unescapedSet_ contains _C_, then
               1. Let _S_ be _C_.
@@ -47987,18 +47987,18 @@ THH:mm:ss.sss
         <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Set _string_ to ? ToString(_string_).
-          1. Let _strLen_ be the length of _string_.
+          1. Let _len_ be the length of _string_.
           1. Let _R_ be the empty String.
           1. Let _k_ be 0.
-          1. Repeat, while _k_ &lt; _strLen_,
+          1. Repeat, while _k_ &lt; _len_,
             1. Let _C_ be the code unit at index _k_ within _string_.
             1. If _C_ is the code unit 0x0025 (PERCENT SIGN), then
               1. Let _hexDigits_ be the empty String.
               1. Let _optionalAdvance_ be 0.
-              1. If _k_ + 5 &lt; _strLen_ and the code unit at index _k_ + 1 within _string_ is the code unit 0x0075 (LATIN SMALL LETTER U), then
+              1. If _k_ + 5 &lt; _len_ and the code unit at index _k_ + 1 within _string_ is the code unit 0x0075 (LATIN SMALL LETTER U), then
                 1. Set _hexDigits_ to the substring of _string_ from _k_ + 2 to _k_ + 6.
                 1. Set _optionalAdvance_ to 5.
-              1. Else if _k_ + 2 &lt; _strLen_, then
+              1. Else if _k_ + 2 &lt; _len_, then
                 1. Set _hexDigits_ to the substring of _string_ from _k_ + 1 to _k_ + 3.
                 1. Set _optionalAdvance_ to 2.
               1. Let _parseResult_ be ParseText(StringToCodePoints(_hexDigits_), |HexDigits[~Sep]|).

--- a/spec.html
+++ b/spec.html
@@ -48000,7 +48000,7 @@ THH:mm:ss.sss
               1. Let _parseResult_ be ParseText(StringToCodePoints(_hexDigits_), |HexDigits[~Sep]|).
               1. If _parseResult_ is a Parse Node, then
                 1. Let _n_ be the MV of _parseResult_.
-                1. Set _C_ to the code unit whose numeric value is ℝ(_n_).
+                1. Set _C_ to the code unit whose numeric value is _n_.
                 1. Set _k_ to _k_ + _optionalAdvance_.
             1. Set _R_ to the string-concatenation of _R_ and _C_.
             1. Set _k_ to _k_ + 1.

--- a/spec.html
+++ b/spec.html
@@ -15685,9 +15685,9 @@
       </dl>
       <emu-alg>
         1. Assert: 0 ≤ _cp_ ≤ 0x10FFFF.
-        1. If _cp_ ≤ 0xFFFF, return the String value consisting of the code unit whose value is _cp_.
-        1. Let _cu1_ be the code unit whose value is floor((_cp_ - 0x10000) / 0x400) + 0xD800.
-        1. Let _cu2_ be the code unit whose value is ((_cp_ - 0x10000) modulo 0x400) + 0xDC00.
+        1. If _cp_ ≤ 0xFFFF, return the String value consisting of the code unit whose numeric value is _cp_.
+        1. Let _cu1_ be the code unit whose numeric value is floor((_cp_ - 0x10000) / 0x400) + 0xD800.
+        1. Let _cu2_ be the code unit whose numeric value is ((_cp_ - 0x10000) modulo 0x400) + 0xDC00.
         1. Return the string-concatenation of _cu1_ and _cu2_.
       </emu-alg>
     </emu-clause>
@@ -16927,7 +16927,7 @@
             The SV of <emu-grammar>EscapeSequence :: `0`</emu-grammar> is the String value consisting of the code unit 0x0000 (NULL).
           </li>
           <li>
-            The SV of <emu-grammar>CharacterEscapeSequence :: SingleEscapeCharacter</emu-grammar> is the String value consisting of the code unit whose value is determined by the |SingleEscapeCharacter| according to <emu-xref href="#table-string-single-character-escape-sequences"></emu-xref>.
+            The SV of <emu-grammar>CharacterEscapeSequence :: SingleEscapeCharacter</emu-grammar> is the String value consisting of the code unit whose numeric value is determined by the |SingleEscapeCharacter| according to <emu-xref href="#table-string-single-character-escape-sequences"></emu-xref>.
           </li>
         </ul>
         <emu-table id="table-string-single-character-escape-sequences" caption="String Single Character Escape Sequences" oldids="table-34">
@@ -17079,7 +17079,7 @@
             The SV of <emu-grammar>NonEscapeCharacter :: SourceCharacter but not one of EscapeCharacter or LineTerminator</emu-grammar> is the result of performing UTF16EncodeCodePoint on the code point matched by |SourceCharacter|.
           </li>
           <li>
-            The SV of <emu-grammar>EscapeSequence :: LegacyOctalEscapeSequence</emu-grammar> is the String value consisting of the code unit whose value is the MV of |LegacyOctalEscapeSequence|.
+            The SV of <emu-grammar>EscapeSequence :: LegacyOctalEscapeSequence</emu-grammar> is the String value consisting of the code unit whose numeric value is the MV of |LegacyOctalEscapeSequence|.
           </li>
           <li>
             The SV of <emu-grammar>NonOctalDecimalEscapeSequence :: `8`</emu-grammar> is the String value consisting of the code unit 0x0038 (DIGIT EIGHT).
@@ -17088,10 +17088,10 @@
             The SV of <emu-grammar>NonOctalDecimalEscapeSequence :: `9`</emu-grammar> is the String value consisting of the code unit 0x0039 (DIGIT NINE).
           </li>
           <li>
-            The SV of <emu-grammar>HexEscapeSequence :: `x` HexDigit HexDigit</emu-grammar> is the String value consisting of the code unit whose value is the MV of |HexEscapeSequence|.
+            The SV of <emu-grammar>HexEscapeSequence :: `x` HexDigit HexDigit</emu-grammar> is the String value consisting of the code unit whose numeric value is the MV of |HexEscapeSequence|.
           </li>
           <li>
-            The SV of <emu-grammar>Hex4Digits :: HexDigit HexDigit HexDigit HexDigit</emu-grammar> is the String value consisting of the code unit whose value is the MV of |Hex4Digits|.
+            The SV of <emu-grammar>Hex4Digits :: HexDigit HexDigit HexDigit HexDigit</emu-grammar> is the String value consisting of the code unit whose numeric value is the MV of |Hex4Digits|.
           </li>
           <li>
             The SV of <emu-grammar>UnicodeEscapeSequence :: `u{` CodePoint `}`</emu-grammar> is the result of performing UTF16EncodeCodePoint on the MV of |CodePoint|.
@@ -29007,7 +29007,7 @@
               1. Set _k_ to _k_ + 2.
               1. Let _n_ be the number of leading 1 bits in _B_.
               1. If _n_ = 0, then
-                1. Let _C_ be the code unit whose value is _B_.
+                1. Let _C_ be the code unit whose numeric value is _B_.
                 1. If _C_ is not in _preserveEscapeSet_, then
                   1. Let _S_ be the String value containing only the code unit _C_.
                 1. Else,

--- a/spec.html
+++ b/spec.html
@@ -28997,7 +28997,7 @@
             1. Let _C_ be the code unit at index _k_ within _string_.
             1. Let _S_ be _C_.
             1. If _C_ is the code unit 0x0025 (PERCENT SIGN), then
-              1. If _k_ + 2 ≥ _len_, throw a *URIError* exception.
+              1. If _k_ + 3 &gt; _len_, throw a *URIError* exception.
               1. Let _escape_ be the substring of _string_ from _k_ to _k_ + 3.
               1. Let _hexDigits_ be the substring of _string_ from _k_ + 1 to _k_ + 3.
               1. Let _parseResult_ be ParseText(StringToCodePoints(_hexDigits_), |HexDigits[~Sep]|).
@@ -29014,7 +29014,7 @@
                 1. Let _j_ be 1.
                 1. Repeat, while _j_ &lt; _n_,
                   1. Set _k_ to _k_ + 1.
-                  1. If _k_ + 2 ≥ _len_, throw a *URIError* exception.
+                  1. If _k_ + 3 &gt; _len_, throw a *URIError* exception.
                   1. If the code unit at index _k_ within _string_ is not the code unit 0x0025 (PERCENT SIGN), throw a *URIError* exception.
                   1. Let _hexDigits_ be the substring of _string_ from _k_ + 1 to _k_ + 3.
                   1. Let _parseResult_ be ParseText(StringToCodePoints(_hexDigits_), |HexDigits[~Sep]|).
@@ -47994,7 +47994,7 @@ THH:mm:ss.sss
               1. If _k_ + 5 &lt; _len_ and the code unit at index _k_ + 1 within _string_ is the code unit 0x0075 (LATIN SMALL LETTER U), then
                 1. Set _hexDigits_ to the substring of _string_ from _k_ + 2 to _k_ + 6.
                 1. Set _optionalAdvance_ to 5.
-              1. Else if _k_ + 2 &lt; _len_, then
+              1. Else if _k_ + 3 ≤ _len_, then
                 1. Set _hexDigits_ to the substring of _string_ from _k_ + 1 to _k_ + 3.
                 1. Set _optionalAdvance_ to 2.
               1. Let _parseResult_ be ParseText(StringToCodePoints(_hexDigits_), |HexDigits[~Sep]|).

--- a/spec.html
+++ b/spec.html
@@ -28995,11 +28995,10 @@
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_,
             1. Let _C_ be the code unit at index _k_ within _string_.
-            1. If _C_ is not the code unit 0x0025 (PERCENT SIGN), then
-              1. Let _S_ be the String value containing only the code unit _C_.
-            1. Else,
-              1. Let _start_ be _k_.
+            1. Let _S_ be _C_.
+            1. If _C_ is the code unit 0x0025 (PERCENT SIGN), then
               1. If _k_ + 2 ≥ _len_, throw a *URIError* exception.
+              1. Let _escape_ be the substring of _string_ from _k_ to _k_ + 3.
               1. Let _hexDigits_ be the substring of _string_ from _k_ + 1 to _k_ + 3.
               1. Let _parseResult_ be ParseText(StringToCodePoints(_hexDigits_), |HexDigits[~Sep]|).
               1. If _parseResult_ is not a Parse Node, throw a *URIError* exception.
@@ -29007,18 +29006,15 @@
               1. Set _k_ to _k_ + 2.
               1. Let _n_ be the number of leading 1 bits in _B_.
               1. If _n_ = 0, then
-                1. Let _C_ be the code unit whose numeric value is _B_.
-                1. If _C_ is not in _preserveEscapeSet_, then
-                  1. Let _S_ be the String value containing only the code unit _C_.
-                1. Else,
-                  1. Let _S_ be the substring of _string_ from _start_ to _k_ + 1.
+                1. Let _asciiChar_ be the code unit whose numeric value is _B_.
+                1. If _preserveEscapeSet_ contains _asciiChar_, set _S_ to _escape_. Otherwise, set _S_ to _asciiChar_.
               1. Else,
                 1. If _n_ = 1 or _n_ > 4, throw a *URIError* exception.
-                1. If _k_ + (3 × (_n_ - 1)) ≥ _len_, throw a *URIError* exception.
                 1. Let _Octets_ be « _B_ ».
                 1. Let _j_ be 1.
                 1. Repeat, while _j_ &lt; _n_,
                   1. Set _k_ to _k_ + 1.
+                  1. If _k_ + 2 ≥ _len_, throw a *URIError* exception.
                   1. If the code unit at index _k_ within _string_ is not the code unit 0x0025 (PERCENT SIGN), throw a *URIError* exception.
                   1. Let _hexDigits_ be the substring of _string_ from _k_ + 1 to _k_ + 3.
                   1. Let _parseResult_ be ParseText(StringToCodePoints(_hexDigits_), |HexDigits[~Sep]|).
@@ -29030,7 +29026,7 @@
                 1. Assert: The length of _Octets_ is _n_.
                 1. If _Octets_ does not contain a valid UTF-8 encoding of a Unicode code point, throw a *URIError* exception.
                 1. Let _V_ be the code point obtained by applying the UTF-8 transformation to _Octets_, that is, from a List of octets into a 21-bit value.
-                1. Let _S_ be UTF16EncodeCodePoint(_V_).
+                1. Set _S_ to UTF16EncodeCodePoint(_V_).
             1. Set _R_ to the string-concatenation of _R_ and _S_.
             1. Set _k_ to _k_ + 1.
           1. Return _R_.

--- a/spec.html
+++ b/spec.html
@@ -47987,8 +47987,8 @@ THH:mm:ss.sss
           1. Let _R_ be the empty String.
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _length_,
-            1. Let _c_ be the code unit at index _k_ within _string_.
-            1. If _c_ is the code unit 0x0025 (PERCENT SIGN), then
+            1. Let _char_ be the code unit at index _k_ within _string_.
+            1. If _char_ is the code unit 0x0025 (PERCENT SIGN), then
               1. Let _hexDigits_ be the empty String.
               1. Let _optionalAdvance_ be 0.
               1. If _k_ + 5 &lt; _length_ and the code unit at index _k_ + 1 within _string_ is the code unit 0x0075 (LATIN SMALL LETTER U), then
@@ -48000,9 +48000,9 @@ THH:mm:ss.sss
               1. Let _parseResult_ be ParseText(StringToCodePoints(_hexDigits_), |HexDigits[~Sep]|).
               1. If _parseResult_ is a Parse Node, then
                 1. Let _n_ be the MV of _parseResult_.
-                1. Set _c_ to the code unit whose value is ℝ(_n_).
+                1. Set _char_ to the code unit whose numeric value is ℝ(_n_).
                 1. Set _k_ to _k_ + _optionalAdvance_.
-            1. Set _R_ to the string-concatenation of _R_ and _c_.
+            1. Set _R_ to the string-concatenation of _R_ and _char_.
             1. Set _k_ to _k_ + 1.
           1. Return _R_.
         </emu-alg>

--- a/spec.html
+++ b/spec.html
@@ -47986,22 +47986,22 @@ THH:mm:ss.sss
           1. Let _length_ be the length of _string_.
           1. Let _R_ be the empty String.
           1. Let _k_ be 0.
-          1. Repeat, while _k_ ≠ _length_,
+          1. Repeat, while _k_ &lt; _length_,
             1. Let _c_ be the code unit at index _k_ within _string_.
             1. If _c_ is the code unit 0x0025 (PERCENT SIGN), then
-              1. Let _hexEscape_ be the empty String.
-              1. Let _skip_ be 0.
-              1. If _k_ ≤ _length_ - 6 and the code unit at index _k_ + 1 within _string_ is the code unit 0x0075 (LATIN SMALL LETTER U), then
-                1. Set _hexEscape_ to the substring of _string_ from _k_ + 2 to _k_ + 6.
-                1. Set _skip_ to 5.
-              1. Else if _k_ ≤ _length_ - 3, then
-                1. Set _hexEscape_ to the substring of _string_ from _k_ + 1 to _k_ + 3.
-                1. Set _skip_ to 2.
-              1. If _hexEscape_ can be interpreted as an expansion of |HexDigits[~Sep]|, then
-                1. Let _hexIntegerLiteral_ be the string-concatenation of *"0x"* and _hexEscape_.
-                1. Let _n_ be ! ToNumber(_hexIntegerLiteral_).
+              1. Let _hexDigits_ be the empty String.
+              1. Let _optionalAdvance_ be 0.
+              1. If _k_ + 5 &lt; _length_ and the code unit at index _k_ + 1 within _string_ is the code unit 0x0075 (LATIN SMALL LETTER U), then
+                1. Set _hexDigits_ to the substring of _string_ from _k_ + 2 to _k_ + 6.
+                1. Set _optionalAdvance_ to 5.
+              1. Else if _k_ + 2 &lt; _length_, then
+                1. Set _hexDigits_ to the substring of _string_ from _k_ + 1 to _k_ + 3.
+                1. Set _optionalAdvance_ to 2.
+              1. Let _parseResult_ be ParseText(StringToCodePoints(_hexDigits_), |HexDigits[~Sep]|).
+              1. If _parseResult_ is a Parse Node, then
+                1. Let _n_ be the MV of _parseResult_.
                 1. Set _c_ to the code unit whose value is ℝ(_n_).
-                1. Set _k_ to _k_ + _skip_.
+                1. Set _k_ to _k_ + _optionalAdvance_.
             1. Set _R_ to the string-concatenation of _R_ and _c_.
             1. Set _k_ to _k_ + 1.
           1. Return _R_.

--- a/spec.html
+++ b/spec.html
@@ -5787,9 +5787,9 @@
         <dd>It interprets _string_ as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>, and determines whether it is a <a href="http://www.unicode.org/glossary/#well_formed_code_unit_sequence">well formed</a> UTF-16 sequence.</dd>
       </dl>
       <emu-alg>
-        1. Let _strLen_ be the length of _string_.
+        1. Let _len_ be the length of _string_.
         1. Let _k_ be 0.
-        1. Repeat, while _k_ ≠ _strLen_,
+        1. Repeat, while _k_ &lt; _len_,
           1. Let _cp_ be CodePointAt(_string_, _k_).
           1. If _cp_.[[IsUnpairedSurrogate]] is *true*, return *false*.
           1. Set _k_ to _k_ + _cp_.[[CodeUnitCount]].

--- a/spec.html
+++ b/spec.html
@@ -28836,9 +28836,9 @@
       <emu-alg>
         1. Let _inputString_ be ? ToString(_string_).
         1. Let _trimmedString_ be ! TrimString(_inputString_, ~start~).
-        1. If neither _trimmedString_ nor any prefix of _trimmedString_ satisfies the syntax of a |StrDecimalLiteral| (see <emu-xref href="#sec-tonumber-applied-to-the-string-type"></emu-xref>), return *NaN*.
-        1. Let _numberString_ be the longest prefix of _trimmedString_, which might be _trimmedString_ itself, that satisfies the syntax of a |StrDecimalLiteral|.
-        1. Let _parsedNumber_ be ParseText(StringToCodePoints(_numberString_), |StrDecimalLiteral|).
+        1. Let _trimmed_ be StringToCodePoints(_trimmedString_).
+        1. Let _trimmedPrefix_ be the longest prefix of _trimmed_ that satisfies the syntax of a |StrDecimalLiteral|, which might be _trimmed_ itself. If there is no such prefix, return *NaN*.
+        1. Let _parsedNumber_ be ParseText(_trimmedPrefix_, |StrDecimalLiteral|).
         1. Assert: _parsedNumber_ is a Parse Node.
         1. Return StringNumericValue of _parsedNumber_.
       </emu-alg>

--- a/spec.html
+++ b/spec.html
@@ -28958,8 +28958,7 @@
           1. Let _alwaysUnescaped_ be the string-concatenation of the ASCII word characters and *"-.!~\*'()"*.
           1. Let _unescapedSet_ be the string-concatenation of _alwaysUnescaped_ and _extraUnescaped_.
           1. Let _k_ be 0.
-          1. Repeat,
-            1. If _k_ = _strLen_, return _R_.
+          1. Repeat, while _k_ &lt; _strLen_,
             1. Let _C_ be the code unit at index _k_ within _string_.
             1. If _unescapedSet_ contains _C_, then
               1. Set _k_ to _k_ + 1.
@@ -28972,6 +28971,7 @@
               1. For each element _octet_ of _Octets_, do
                 1. Let _hex_ be the String representation of _octet_, formatted as an uppercase hexadecimal number.
                 1. Set _R_ to the string-concatenation of _R_, *"%"*, and ! StringPad(_hex_, *2*<sub>𝔽</sub>, *"0"*, ~start~).
+          1. Return _R_.
         </emu-alg>
         <emu-note>
           <p>Because percent-encoding is used to represent individual octets, a single code point may be expressed as multiple consecutive escape sequences (one for each of its 8-bit UTF-8 code units).</p>
@@ -28993,16 +28993,17 @@
           1. Let _strLen_ be the length of _string_.
           1. Let _R_ be the empty String.
           1. Let _k_ be 0.
-          1. Repeat,
-            1. If _k_ = _strLen_, return _R_.
+          1. Repeat, while _k_ &lt; _strLen_,
             1. Let _C_ be the code unit at index _k_ within _string_.
             1. If _C_ is not the code unit 0x0025 (PERCENT SIGN), then
               1. Let _S_ be the String value containing only the code unit _C_.
             1. Else,
               1. Let _start_ be _k_.
               1. If _k_ + 2 ≥ _strLen_, throw a *URIError* exception.
-              1. If the code units at index (_k_ + 1) and (_k_ + 2) within _string_ do not represent hexadecimal digits, throw a *URIError* exception.
-              1. Let _B_ be the 8-bit value represented by the two hexadecimal digits at index (_k_ + 1) and (_k_ + 2).
+              1. Let _hexDigits_ be the substring of _string_ from _k_ + 1 to _k_ + 3.
+              1. Let _parseResult_ be ParseText(StringToCodePoints(_hexDigits_), |HexDigits[~Sep]|).
+              1. If _parseResult_ is not a Parse Node, throw a *URIError* exception.
+              1. Let _B_ be the unsigned 8-bit value corresponding with the MV of _parseResult_.
               1. Set _k_ to _k_ + 2.
               1. Let _n_ be the number of leading 1 bits in _B_.
               1. If _n_ = 0, then
@@ -29019,10 +29020,12 @@
                 1. Repeat, while _j_ &lt; _n_,
                   1. Set _k_ to _k_ + 1.
                   1. If the code unit at index _k_ within _string_ is not the code unit 0x0025 (PERCENT SIGN), throw a *URIError* exception.
-                  1. If the code units at index (_k_ + 1) and (_k_ + 2) within _string_ do not represent hexadecimal digits, throw a *URIError* exception.
-                  1. Let _B_ be the 8-bit value represented by the two hexadecimal digits at index (_k_ + 1) and (_k_ + 2).
-                  1. Set _k_ to _k_ + 2.
+                  1. Let _hexDigits_ be the substring of _string_ from _k_ + 1 to _k_ + 3.
+                  1. Let _parseResult_ be ParseText(StringToCodePoints(_hexDigits_), |HexDigits[~Sep]|).
+                  1. If _parseResult_ is not a Parse Node, throw a *URIError* exception.
+                  1. Let _B_ be the unsigned 8-bit value corresponding with the MV of _parseResult_.
                   1. Append _B_ to _Octets_.
+                  1. Set _k_ to _k_ + 2.
                   1. Set _j_ to _j_ + 1.
                 1. Assert: The length of _Octets_ is _n_.
                 1. If _Octets_ does not contain a valid UTF-8 encoding of a Unicode code point, throw a *URIError* exception.
@@ -29030,6 +29033,7 @@
                 1. Let _S_ be UTF16EncodeCodePoint(_V_).
             1. Set _R_ to the string-concatenation of _R_ and _S_.
             1. Set _k_ to _k_ + 1.
+          1. Return _R_.
         </emu-alg>
         <emu-note>
           <p>RFC 3629 prohibits the decoding of invalid UTF-8 octet sequences. For example, the invalid sequence 0xC0 0x80 must not decode into the code unit 0x0000. Implementations of the Decode algorithm are required to throw a *URIError* when encountering such invalid sequences.</p>
@@ -47951,16 +47955,16 @@ THH:mm:ss.sss
         <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Set _string_ to ? ToString(_string_).
-          1. Let _length_ be the length of _string_.
+          1. Let _strLen_ be the length of _string_.
           1. Let _R_ be the empty String.
           1. Let _unescapedSet_ be the string-concatenation of the ASCII word characters and *"@\*+-./"*.
           1. Let _k_ be 0.
-          1. Repeat, while _k_ &lt; _length_,
-            1. Let _char_ be the code unit at index _k_ within _string_.
-            1. If _unescapedSet_ contains _char_, then
-              1. Let _S_ be the String value containing the single code unit _char_.
+          1. Repeat, while _k_ &lt; _strLen_,
+            1. Let _C_ be the code unit at index _k_ within _string_.
+            1. If _unescapedSet_ contains _C_, then
+              1. Let _S_ be _C_.
             1. Else,
-              1. Let _n_ be the numeric value of _char_.
+              1. Let _n_ be the numeric value of _C_.
               1. If _n_ &lt; 256, then
                 1. Let _hex_ be the String representation of _n_, formatted as an uppercase hexadecimal number.
                 1. Let _S_ be the string-concatenation of *"%"* and ! StringPad(_hex_, *2*<sub>𝔽</sub>, *"0"*, ~start~).
@@ -47983,26 +47987,26 @@ THH:mm:ss.sss
         <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Set _string_ to ? ToString(_string_).
-          1. Let _length_ be the length of _string_.
+          1. Let _strLen_ be the length of _string_.
           1. Let _R_ be the empty String.
           1. Let _k_ be 0.
-          1. Repeat, while _k_ &lt; _length_,
-            1. Let _char_ be the code unit at index _k_ within _string_.
-            1. If _char_ is the code unit 0x0025 (PERCENT SIGN), then
+          1. Repeat, while _k_ &lt; _strLen_,
+            1. Let _C_ be the code unit at index _k_ within _string_.
+            1. If _C_ is the code unit 0x0025 (PERCENT SIGN), then
               1. Let _hexDigits_ be the empty String.
               1. Let _optionalAdvance_ be 0.
-              1. If _k_ + 5 &lt; _length_ and the code unit at index _k_ + 1 within _string_ is the code unit 0x0075 (LATIN SMALL LETTER U), then
+              1. If _k_ + 5 &lt; _strLen_ and the code unit at index _k_ + 1 within _string_ is the code unit 0x0075 (LATIN SMALL LETTER U), then
                 1. Set _hexDigits_ to the substring of _string_ from _k_ + 2 to _k_ + 6.
                 1. Set _optionalAdvance_ to 5.
-              1. Else if _k_ + 2 &lt; _length_, then
+              1. Else if _k_ + 2 &lt; _strLen_, then
                 1. Set _hexDigits_ to the substring of _string_ from _k_ + 1 to _k_ + 3.
                 1. Set _optionalAdvance_ to 2.
               1. Let _parseResult_ be ParseText(StringToCodePoints(_hexDigits_), |HexDigits[~Sep]|).
               1. If _parseResult_ is a Parse Node, then
                 1. Let _n_ be the MV of _parseResult_.
-                1. Set _char_ to the code unit whose numeric value is ℝ(_n_).
+                1. Set _C_ to the code unit whose numeric value is ℝ(_n_).
                 1. Set _k_ to _k_ + _optionalAdvance_.
-            1. Set _R_ to the string-concatenation of _R_ and _char_.
+            1. Set _R_ to the string-concatenation of _R_ and _C_.
             1. Set _k_ to _k_ + 1.
           1. Return _R_.
         </emu-alg>

--- a/spec.html
+++ b/spec.html
@@ -28997,7 +28997,7 @@
             1. Let _C_ be the code unit at index _k_ within _string_.
             1. Let _S_ be _C_.
             1. If _C_ is the code unit 0x0025 (PERCENT SIGN), then
-              1. If _k_ + 3 &gt; _len_, throw a *URIError* exception.
+              1. If _k_ + 3 > _len_, throw a *URIError* exception.
               1. Let _escape_ be the substring of _string_ from _k_ to _k_ + 3.
               1. Let _B_ be ParseHexOctet(_string_, _k_ + 1).
               1. If _B_ is not an integer, throw a *URIError* exception.
@@ -29012,7 +29012,7 @@
                 1. Let _j_ be 1.
                 1. Repeat, while _j_ &lt; _n_,
                   1. Set _k_ to _k_ + 1.
-                  1. If _k_ + 3 &gt; _len_, throw a *URIError* exception.
+                  1. If _k_ + 3 > _len_, throw a *URIError* exception.
                   1. If the code unit at index _k_ within _string_ is not the code unit 0x0025 (PERCENT SIGN), throw a *URIError* exception.
                   1. Let _continuationByte_ be ParseHexOctet(_string_, _k_ + 1).
                   1. If _continuationByte_ is not an integer, throw a *URIError* exception.
@@ -29045,13 +29045,12 @@
         </dl>
         <emu-alg>
           1. Let _len_ be the length of _string_.
-          1. If _position_ + 2 &gt; _len_, then
-            1. Let _error_ be a newly created *SyntaxError* object.
-            1. Return « _error_ ».
+          1. Assert: _position_ + 2 ≤ _len_.
           1. Let _hexDigits_ be the substring of _string_ from _position_ to _position_ + 2.
           1. Let _parseResult_ be ParseText(StringToCodePoints(_hexDigits_), |HexDigits[~Sep]|).
           1. If _parseResult_ is not a Parse Node, return _parseResult_.
-          1. Let _n_ be the unsigned 8-bit value corresponding with the MV of _parseResult_.
+          1. Let _n_ be the MV of _parseResult_.
+          1. Assert: _n_ is in the inclusive interval from 0 to 255.
           1. Return _n_.
         </emu-alg>
       </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -28999,10 +28999,8 @@
             1. If _C_ is the code unit 0x0025 (PERCENT SIGN), then
               1. If _k_ + 3 &gt; _len_, throw a *URIError* exception.
               1. Let _escape_ be the substring of _string_ from _k_ to _k_ + 3.
-              1. Let _hexDigits_ be the substring of _string_ from _k_ + 1 to _k_ + 3.
-              1. Let _parseResult_ be ParseText(StringToCodePoints(_hexDigits_), |HexDigits[~Sep]|).
-              1. If _parseResult_ is not a Parse Node, throw a *URIError* exception.
-              1. Let _B_ be the unsigned 8-bit value corresponding with the MV of _parseResult_.
+              1. Let _B_ be ParseHexOctet(_string_, _k_ + 1).
+              1. If _B_ is not an integer, throw a *URIError* exception.
               1. Set _k_ to _k_ + 2.
               1. Let _n_ be the number of leading 1 bits in _B_.
               1. If _n_ = 0, then
@@ -29016,11 +29014,9 @@
                   1. Set _k_ to _k_ + 1.
                   1. If _k_ + 3 &gt; _len_, throw a *URIError* exception.
                   1. If the code unit at index _k_ within _string_ is not the code unit 0x0025 (PERCENT SIGN), throw a *URIError* exception.
-                  1. Let _hexDigits_ be the substring of _string_ from _k_ + 1 to _k_ + 3.
-                  1. Let _parseResult_ be ParseText(StringToCodePoints(_hexDigits_), |HexDigits[~Sep]|).
-                  1. If _parseResult_ is not a Parse Node, throw a *URIError* exception.
-                  1. Let _B_ be the unsigned 8-bit value corresponding with the MV of _parseResult_.
-                  1. Append _B_ to _Octets_.
+                  1. Let _continuationByte_ be ParseHexOctet(_string_, _k_ + 1).
+                  1. If _continuationByte_ is not an integer, throw a *URIError* exception.
+                  1. Append _continuationByte_ to _Octets_.
                   1. Set _k_ to _k_ + 2.
                   1. Set _j_ to _j_ + 1.
                 1. Assert: The length of _Octets_ is _n_.
@@ -29034,6 +29030,30 @@
         <emu-note>
           <p>RFC 3629 prohibits the decoding of invalid UTF-8 octet sequences. For example, the invalid sequence 0xC0 0x80 must not decode into the code unit 0x0000. Implementations of the Decode algorithm are required to throw a *URIError* when encountering such invalid sequences.</p>
         </emu-note>
+      </emu-clause>
+
+      <emu-clause id="sec-parsehexoctet" type="abstract operation">
+        <h1>
+          ParseHexOctet (
+            _string_: a String,
+            _position_: a non-negative integer,
+          ): either a non-negative integer or a non-empty List of *SyntaxError* objects
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It parses a sequence of two hexadecimal characters at the specified _position_ in _string_ into an unsigned 8-bit integer.</dd>
+        </dl>
+        <emu-alg>
+          1. Let _len_ be the length of _string_.
+          1. If _position_ + 2 &gt; _len_, then
+            1. Let _error_ be a newly created *SyntaxError* object.
+            1. Return « _error_ ».
+          1. Let _hexDigits_ be the substring of _string_ from _position_ to _position_ + 2.
+          1. Let _parseResult_ be ParseText(StringToCodePoints(_hexDigits_), |HexDigits[~Sep]|).
+          1. If _parseResult_ is not a Parse Node, return _parseResult_.
+          1. Let _n_ be the unsigned 8-bit value corresponding with the MV of _parseResult_.
+          1. Return _n_.
+        </emu-alg>
       </emu-clause>
     </emu-clause>
   </emu-clause>


### PR DESCRIPTION
There was a lot of gratuitous divergence between Encode, Decode, escape, and unescape, and also between those operations and other string operations.

Non-comprehensive improvements:
* Make better use of ParseText to get Parse Nodes or errors rather than testing syntax first.
* Align on `code {unit,point} whose numeric value is…` phrasing rather than `code {unit,point} whose value is…`.
* Increase the majority of `Let _len_ be the length of…` over alternate aliases for `_len_`.
* Increase the majority of `Repeat, while _k_ &lt; _len_` iteration over alternatives like `while _k_ ≠ _len_` or embedded `If _k_ = _len_, return…`.
* Make better use of string-concatenation accepting both strings and code units.