### PR TITLE
Editorial: Highlight diff in B.3.4 compared to the original semantics

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -48246,7 +48246,7 @@ THH:mm:ss.sss
 
     <emu-annex id="sec-variablestatements-in-catch-blocks">
       <h1>VariableStatements in Catch Blocks</h1>
-      <p>The content of subclause <emu-xref href="#sec-try-statement-static-semantics-early-errors"></emu-xref> is replaced with the following:</p>
+      <p>The rules for the following production in <emu-xref href="#sec-try-statement-static-semantics-early-errors"></emu-xref> are modified with the addition of the <ins>highlighted</ins> text:</p>
       <emu-grammar>Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
       <ul>
         <li>
@@ -48256,7 +48256,7 @@ THH:mm:ss.sss
           It is a Syntax Error if any element of the BoundNames of |CatchParameter| also occurs in the LexicallyDeclaredNames of |Block|.
         </li>
         <li>
-          It is a Syntax Error if any element of the BoundNames of |CatchParameter| also occurs in the VarDeclaredNames of |Block| unless |CatchParameter| is <emu-grammar>CatchParameter : BindingIdentifier</emu-grammar>.
+          It is a Syntax Error if any element of the BoundNames of |CatchParameter| also occurs in the VarDeclaredNames of |Block| <ins>unless |CatchParameter| is <emu-grammar>CatchParameter : BindingIdentifier</emu-grammar></ins>.
         </li>
       </ul>
       <emu-note>


### PR DESCRIPTION
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->

This is also done in [B.3.1](https://tc39.es/ecma262/#sec-labelled-function-declarations), [B.3.2.4](https://tc39.es/ecma262/#sec-block-duplicates-allowed-static-semantics) and [B.3.2.5](https://tc39.es/ecma262/#sec-switch-duplicates-allowed-static-semantics), and it makes it easier to understand how Annex B is modifying the original semantics.