### PR TITLE
Editorial: Create PromiseCapability Record with non-transient field values

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -44022,19 +44022,18 @@ THH:mm:ss.sss
         <emu-alg>
           1. If IsConstructor(_C_) is *false*, throw a *TypeError* exception.
           1. NOTE: _C_ is assumed to be a constructor function that supports the parameter conventions of the Promise constructor (see <emu-xref href="#sec-promise-executor"></emu-xref>).
-          1. Let _promiseCapability_ be the PromiseCapability Record { [[Promise]]: *undefined*, [[Resolve]]: *undefined*, [[Reject]]: *undefined* }.
-          1. Let _executorClosure_ be a new Abstract Closure with parameters (_resolve_, _reject_) that captures _promiseCapability_ and performs the following steps when called:
-            1. If _promiseCapability_.[[Resolve]] is not *undefined*, throw a *TypeError* exception.
-            1. If _promiseCapability_.[[Reject]] is not *undefined*, throw a *TypeError* exception.
-            1. Set _promiseCapability_.[[Resolve]] to _resolve_.
-            1. Set _promiseCapability_.[[Reject]] to _reject_.
+          1. Let _resolvingFunctions_ be the Record { [[Resolve]]: *undefined*, [[Reject]]: *undefined* }.
+          1. Let _executorClosure_ be a new Abstract Closure with parameters (_resolve_, _reject_) that captures _resolvingFunctions_ and performs the following steps when called:
+            1. If _resolvingFunctions_.[[Resolve]] is not *undefined*, throw a *TypeError* exception.
+            1. If _resolvingFunctions_.[[Reject]] is not *undefined*, throw a *TypeError* exception.
+            1. Set _resolvingFunctions_.[[Resolve]] to _resolve_.
+            1. Set _resolvingFunctions_.[[Reject]] to _reject_.
             1. Return *undefined*.
           1. Let _executor_ be CreateBuiltinFunction(_executorClosure_, 2, *""*, « »).
           1. Let _promise_ be ? Construct(_C_, « _executor_ »).
-          1. If IsCallable(_promiseCapability_.[[Resolve]]) is *false*, throw a *TypeError* exception.
-          1. If IsCallable(_promiseCapability_.[[Reject]]) is *false*, throw a *TypeError* exception.
-          1. Set _promiseCapability_.[[Promise]] to _promise_.
-          1. Return _promiseCapability_.
+          1. If IsCallable(_resolvingFunctions_.[[Resolve]]) is *false*, throw a *TypeError* exception.
+          1. If IsCallable(_resolvingFunctions_.[[Reject]]) is *false*, throw a *TypeError* exception.
+          1. Return the PromiseCapability Record { [[Promise]]: _promise_, [[Resolve]]: _resolvingFunctions_.[[Resolve]], [[Reject]]: _resolvingFunctions_.[[Reject]] }.
         </emu-alg>
         <emu-note>
           <p>This abstract operation supports Promise subclassing, as it is generic on any constructor that calls a passed executor function argument in the same way as the Promise constructor. It is used to generalize static methods of the Promise constructor to any subclass.</p>


### PR DESCRIPTION
Modify NewPromiseCapability() to wait until the very end to create the PromiseCapability Record, so that its fields have non-transient values.

As suggested in https://github.com/tc39/ecma262/pull/2963#discussion_r1033986008