### PR TITLE
Editorial: Use linkable terms for coercion to BigInt

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -2352,7 +2352,7 @@
           </dl>
           <emu-alg>
             1. If _x_ is *0*<sub>ℤ</sub>, return *0*<sub>ℤ</sub>.
-            1. Return the BigInt value that represents the negation of ℝ(_x_).
+            1. Return -_x_.
           </emu-alg>
         </emu-clause>
 
@@ -2383,7 +2383,7 @@
           <emu-alg>
             1. If _exponent_ &lt; *0*<sub>ℤ</sub>, throw a *RangeError* exception.
             1. If _base_ is *0*<sub>ℤ</sub> and _exponent_ is *0*<sub>ℤ</sub>, return *1*<sub>ℤ</sub>.
-            1. Return the BigInt value that represents ℝ(_base_) raised to the power ℝ(_exponent_).
+            1. Return _base_ raised to the power _exponent_.
           </emu-alg>
         </emu-clause>
 
@@ -2397,7 +2397,7 @@
           <dl class="header">
           </dl>
           <emu-alg>
-            1. Return the BigInt value that represents the product of _x_ and _y_.
+            1. Return _x_ × _y_.
           </emu-alg>
           <emu-note>Even if the result has a much larger bit width than the input, the exact mathematical answer is given.</emu-note>
         </emu-clause>
@@ -2447,7 +2447,7 @@
           <dl class="header">
           </dl>
           <emu-alg>
-            1. Return the BigInt value that represents the sum of _x_ and _y_.
+            1. Return _x_ + _y_.
           </emu-alg>
         </emu-clause>
 
@@ -2461,7 +2461,7 @@
           <dl class="header">
           </dl>
           <emu-alg>
-            1. Return the BigInt value that represents the difference _x_ minus _y_.
+            1. Return _x_ - _y_.
           </emu-alg>
         </emu-clause>
 
@@ -2476,8 +2476,8 @@
           </dl>
           <emu-alg>
             1. If _y_ &lt; *0*<sub>ℤ</sub>, then
-              1. Return the BigInt value that represents ℝ(_x_) / 2<sup>-ℝ(_y_)</sup>, rounding down to the nearest integer, including for negative numbers.
-            1. Return the BigInt value that represents ℝ(_x_) × 2<sup>ℝ(_y_)</sup>.
+              1. Return ℤ(floor(ℝ(_x_) / 2<sup>-ℝ(_y_)</sup>)).
+            1. Return _x_ × *2*<sub>ℤ</sub><sup>_y_</sup>.
           </emu-alg>
           <emu-note>Semantics here should be equivalent to a bitwise shift, treating the BigInt as an infinite length string of binary two's complement digits.</emu-note>
         </emu-clause>
@@ -16836,7 +16836,7 @@
         </emu-alg>
         <emu-grammar>NumericLiteral :: NonDecimalIntegerLiteral BigIntLiteralSuffix</emu-grammar>
         <emu-alg>
-          1. Return the BigInt value that represents the MV of |NonDecimalIntegerLiteral|.
+          1. Return the BigInt value for the MV of |NonDecimalIntegerLiteral|.
         </emu-alg>
         <emu-grammar>DecimalBigIntegerLiteral :: `0` BigIntLiteralSuffix</emu-grammar>
         <emu-alg>
@@ -16844,7 +16844,7 @@
         </emu-alg>
         <emu-grammar>DecimalBigIntegerLiteral :: NonZeroDigit BigIntLiteralSuffix</emu-grammar>
         <emu-alg>
-          1. Return the BigInt value that represents the MV of |NonZeroDigit|.
+          1. Return the BigInt value for the MV of |NonZeroDigit|.
         </emu-alg>
         <emu-grammar>
           DecimalBigIntegerLiteral ::
@@ -31354,7 +31354,7 @@
           </dl>
           <emu-alg>
             1. If IsIntegralNumber(_number_) is *false*, throw a *RangeError* exception.
-            1. Return the BigInt value that represents ℝ(_number_).
+            1. Return ℤ(ℝ(_number_)).
           </emu-alg>
         </emu-clause>
       </emu-clause>
@@ -31385,7 +31385,7 @@
         <emu-alg>
           1. Set _bits_ to ? ToIndex(_bits_).
           1. Set _bigint_ to ? ToBigInt(_bigint_).
-          1. Return the BigInt value that represents ℝ(_bigint_) modulo 2<sup>_bits_</sup>.
+          1. Return ℤ(ℝ(_bigint_) modulo 2<sup>_bits_</sup>).
         </emu-alg>
       </emu-clause>
 


### PR DESCRIPTION
Followup to #2960.

"**BigInt value for**" is a term, but "**BigInt value that represents**" is not (and most uses of the latter can be replaced with "ℤ" anyway). Even the ℝ-coercions are technically unnecessary because of [Mathematical Operations](https://tc39.es/ecma262/multipage/notational-conventions.html#sec-mathematical-operations) ("_When applied to BigInts, [operators such as +, ×, =, and ≥] refer to the usual mathematical operations applied to the mathematical value of the BigInt_"), but I've kept them here to avoid making the BigInt operations trivial (e.g., [BigInt::unaryMinus](https://tc39.es/ecma262/multipage/ecmascript-data-types-and-values.html#sec-numeric-types-bigint-unaryMinus) would be `<emu-alg>1. Return -_x_.</emu-alg>`).