### PR TITLE
Editorial: Clarify Proxy.revocable

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -46709,7 +46709,7 @@ THH:mm:ss.sss
             1. Let _p_ be _F_.[[RevocableProxy]].
             1. If _p_ is *null*, return *undefined*.
             1. Set _F_.[[RevocableProxy]] to *null*.
-            1. Assert: _p_ is a Proxy object.
+            1. Assert: _p_ is a Proxy exotic object.
             1. Set _p_.[[ProxyTarget]] to *null*.
             1. Set _p_.[[ProxyHandler]] to *null*.
             1. Return *undefined*.


### PR DESCRIPTION
It seems that while "Proxy object" and 'Proxy exotic object" refer to the same thing. Considering algorithm steps in [isArray](https://tc39.es/ecma262/#sec-isarray) and [getFunctionRealm](https://tc39.es/ecma262/#sec-getfunctionrealm), it seems more appropriate to use "Proxy exotic object" instead of "Proxy object" for [Proxy.revocable](https://tc39.es/ecma262/#sec-proxy.revocable)

It also gives a nice highlight and link to proxy exotic object definition.