### PR TITLE
Meta: bump ecmarkup to 16.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://tc39.es/ecma262/#sec-copyright-and-software-license",
       "dependencies": {
-        "ecmarkup": "^15.0.4"
+        "ecmarkup": "^16.0.1"
       },
       "devDependencies": {
         "glob": "^7.1.6",
@@ -724,9 +724,9 @@
       }
     },
     "node_modules/ecmarkup": {
-      "version": "15.0.4",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-15.0.4.tgz",
-      "integrity": "sha512-ZNq+8lZCFwX2dgcRS9xwQfVjFwlF83zzoEQk1l9LHiyxBCG9QtMm8ZwJnONsMlehuoFJKq+nC4vStIbELYDDFg==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-16.0.1.tgz",
+      "integrity": "sha512-Vs2kMzfaxUi2GW5VyXQwz7LFk7Y3A1uJvsQpGsgcA1CAr2e1IcpmtRL6SQVjU1hmvUbVRXBlxpIBhJYE4jgiBw==",
       "dependencies": {
         "chalk": "^4.1.2",
         "command-line-args": "^5.2.0",
@@ -2940,9 +2940,9 @@
       }
     },
     "ecmarkup": {
-      "version": "15.0.4",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-15.0.4.tgz",
-      "integrity": "sha512-ZNq+8lZCFwX2dgcRS9xwQfVjFwlF83zzoEQk1l9LHiyxBCG9QtMm8ZwJnONsMlehuoFJKq+nC4vStIbELYDDFg==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-16.0.1.tgz",
+      "integrity": "sha512-Vs2kMzfaxUi2GW5VyXQwz7LFk7Y3A1uJvsQpGsgcA1CAr2e1IcpmtRL6SQVjU1hmvUbVRXBlxpIBhJYE4jgiBw==",
       "requires": {
         "chalk": "^4.1.2",
         "command-line-args": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "license": "SEE LICENSE IN https://tc39.es/ecma262/#sec-copyright-and-software-license",
   "homepage": "https://tc39.es/ecma262/",
   "dependencies": {
-    "ecmarkup": "^15.0.4"
+    "ecmarkup": "^16.0.1"
   },
   "devDependencies": {
     "glob": "^7.1.6",

--- a/spec.html
+++ b/spec.html
@@ -13640,7 +13640,7 @@
         1. Set the ScriptOrModule of _calleeContext_ to *null*.
         1. Perform any necessary implementation-defined initialization of _calleeContext_.
         1. Push _calleeContext_ onto the execution context stack; _calleeContext_ is now the running execution context.
-        1. [id="step-call-builtin-function-result"] Let _result_ be the Completion Record that is the result of evaluating _F_ in a manner that conforms to the specification of _F_. _thisArgument_ is the *this* value, _argumentsList_ provides the named parameters, and the NewTarget value is *undefined*.
+        1. [id="step-call-builtin-function-result"] Let _result_ be the Completion Record that is <emu-meta effects="user-code">the result of evaluating</emu-meta> _F_ in a manner that conforms to the specification of _F_. _thisArgument_ is the *this* value, _argumentsList_ provides the named parameters, and the NewTarget value is *undefined*.
         1. Remove _calleeContext_ from the execution context stack and restore _callerContext_ as the running execution context.
         1. Return ? _result_.
       </emu-alg>
@@ -13664,7 +13664,7 @@
         <dd>The steps performed are the same as [[Call]] (see <emu-xref href="#sec-built-in-function-objects-call-thisargument-argumentslist"></emu-xref>) except that step <emu-xref href="#step-call-builtin-function-result"></emu-xref> is replaced by:</dd>
       </dl>
       <emu-alg replaces-step="step-call-builtin-function-result">
-        1. Let _result_ be the Completion Record that is the result of evaluating _F_ in a manner that conforms to the specification of _F_. The *this* value is uninitialized, _argumentsList_ provides the named parameters, and _newTarget_ provides the NewTarget value.
+        1. Let _result_ be the Completion Record that is <emu-meta effects="user-code">the result of evaluating</emu-meta> _F_ in a manner that conforms to the specification of _F_. The *this* value is uninitialized, _argumentsList_ provides the named parameters, and _newTarget_ provides the NewTarget value.
       </emu-alg>
     </emu-clause>
 


### PR DESCRIPTION
The breaking change in version 16 is the removal of the automatic handing of the phrase "the result of evaluating" as user code. Our use of that phrase was almost entirely removed in https://github.com/tc39/ecma262/pull/2744, so only two sites still require manual marking.

This should also unblock https://github.com/tc39/ecma262/pull/2972 via inclusion of https://github.com/tc39/ecmarkup/pull/514.