### PR TITLE
Editorial: Replace the operator tables with explicit steps

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -20236,25 +20236,9 @@
         1. Let _rref_ be ? Evaluation of |AssignmentExpression|.
         1. Let _rval_ be ? GetValue(_rref_).
         1. Let _assignmentOpText_ be the source text matched by |AssignmentOperator|.
-        1. Let _opText_ be the sequence of Unicode code points associated with _assignmentOpText_ in the following table:
-          <figure>
-            <!-- emu-format ignore -->
-            <table class="lightweight-table">
-              <tr><th> _assignmentOpText_ </th><th> _opText_       </th></tr>
-              <tr><td> `**=`              </td><td> `**`           </td></tr>
-              <tr><td> `*=`               </td><td> `*`            </td></tr>
-              <tr><td> `/=`               </td><td> `/`            </td></tr>
-              <tr><td> `%=`               </td><td> `%`            </td></tr>
-              <tr><td> `+=`               </td><td> `+`            </td></tr>
-              <tr><td> `-=`               </td><td> `-`            </td></tr>
-              <tr><td> `&lt;&lt;=`        </td><td> `&lt;&lt;`     </td></tr>
-              <tr><td> `&gt;&gt;=`        </td><td> `&gt;&gt;`     </td></tr>
-              <tr><td> `&gt;&gt;&gt;=`    </td><td> `&gt;&gt;&gt;` </td></tr>
-              <tr><td> `&amp;=`           </td><td> `&amp;`        </td></tr>
-              <tr><td> `^=`               </td><td> `^`            </td></tr>
-              <tr><td> `|=`               </td><td> `|`            </td></tr>
-            </table>
-          </figure>
+        1. Let _len_ be the number of code points in _assignmentOpText_.
+        1. Assert: _len_ ≥ 2 and the last code point in _assignmentOpText_ is `=`.
+        1. Let _opText_ be the sequence of the first _len_ - 1 code points of _assignmentOpText_.
         1. Let _r_ be ? ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
         1. [id="step-assignmentexpression-evaluation-compound-putvalue"] Perform ? PutValue(_lref_, _r_).
         1. Return _r_.

--- a/spec.html
+++ b/spec.html
@@ -20313,39 +20313,44 @@
         1. Let _lnum_ be ? ToNumeric(_lval_).
         1. Let _rnum_ be ? ToNumeric(_rval_).
         1. If Type(_lnum_) is different from Type(_rnum_), throw a *TypeError* exception.
-        1. If _lnum_ is a BigInt, then
-          1. If _opText_ is `**`, return ? BigInt::exponentiate(_lnum_, _rnum_).
-          1. If _opText_ is `/`, return ? BigInt::divide(_lnum_, _rnum_).
-          1. If _opText_ is `%`, return ? BigInt::remainder(_lnum_, _rnum_).
-          1. If _opText_ is `>>>`, return ? BigInt::unsignedRightShift(_lnum_, _rnum_).
-        1. Let _operation_ be the abstract operation associated with _opText_ and Type(_lnum_) in the following table:
-          <figure>
-            <!-- emu-format ignore -->
-            <table class="lightweight-table">
-              <tr><th> _opText_       </th><th> Type(_lnum_) </th><th> _operation_                </th></tr>
-              <tr><td> `**`           </td><td> Number       </td><td> Number::exponentiate       </td></tr>
-              <tr><td> `*`            </td><td> Number       </td><td> Number::multiply           </td></tr>
-              <tr><td> `*`            </td><td> BigInt       </td><td> BigInt::multiply           </td></tr>
-              <tr><td> `/`            </td><td> Number       </td><td> Number::divide             </td></tr>
-              <tr><td> `%`            </td><td> Number       </td><td> Number::remainder          </td></tr>
-              <tr><td> `+`            </td><td> Number       </td><td> Number::add                </td></tr>
-              <tr><td> `+`            </td><td> BigInt       </td><td> BigInt::add                </td></tr>
-              <tr><td> `-`            </td><td> Number       </td><td> Number::subtract           </td></tr>
-              <tr><td> `-`            </td><td> BigInt       </td><td> BigInt::subtract           </td></tr>
-              <tr><td> `&lt;&lt;`     </td><td> Number       </td><td> Number::leftShift          </td></tr>
-              <tr><td> `&lt;&lt;`     </td><td> BigInt       </td><td> BigInt::leftShift          </td></tr>
-              <tr><td> `&gt;&gt;`     </td><td> Number       </td><td> Number::signedRightShift   </td></tr>
-              <tr><td> `&gt;&gt;`     </td><td> BigInt       </td><td> BigInt::signedRightShift   </td></tr>
-              <tr><td> `&gt;&gt;&gt;` </td><td> Number       </td><td> Number::unsignedRightShift </td></tr>
-              <tr><td> `&amp;`        </td><td> Number       </td><td> Number::bitwiseAND         </td></tr>
-              <tr><td> `&amp;`        </td><td> BigInt       </td><td> BigInt::bitwiseAND         </td></tr>
-              <tr><td> `^`            </td><td> Number       </td><td> Number::bitwiseXOR         </td></tr>
-              <tr><td> `^`            </td><td> BigInt       </td><td> BigInt::bitwiseXOR         </td></tr>
-              <tr><td> `|`            </td><td> Number       </td><td> Number::bitwiseOR          </td></tr>
-              <tr><td> `|`            </td><td> BigInt       </td><td> BigInt::bitwiseOR          </td></tr>
-            </table>
-          </figure>
-        1. Return _operation_(_lnum_, _rnum_).
+        1. NOTE: The following steps can only throw an exception if _lnum_ is a BigInt and _opText_ is `**`, `/`, `%`, or `>>>`.
+        1. If _opText_ is `**`, then
+          1. If _lnum_ is a Number, return Number::exponentiate(_lnum_, _rnum_).
+          1. If _lnum_ is a BigInt, return ? BigInt::exponentiate(_lnum_, _rnum_).
+        1. If _opText_ is `*`, then
+          1. If _lnum_ is a Number, return Number::multiply(_lnum_, _rnum_).
+          1. If _lnum_ is a BigInt, return BigInt::multiply(_lnum_, _rnum_).
+        1. If _opText_ is `/`, then
+          1. If _lnum_ is a Number, return Number::divide(_lnum_, _rnum_).
+          1. If _lnum_ is a BigInt, return ? BigInt::divide(_lnum_, _rnum_).
+        1. If _opText_ is `%`, then
+          1. If _lnum_ is a Number, return Number::remainder(_lnum_, _rnum_).
+          1. If _lnum_ is a BigInt, return ? BigInt::remainder(_lnum_, _rnum_).
+        1. If _opText_ is `+`, then
+          1. If _lnum_ is a Number, return Number::add(_lnum_, _rnum_).
+          1. If _lnum_ is a BigInt, return BigInt::add(_lnum_, _rnum_).
+        1. If _opText_ is `-`, then
+          1. If _lnum_ is a Number, return Number::subtract(_lnum_, _rnum_).
+          1. If _lnum_ is a BigInt, return BigInt::subtract(_lnum_, _rnum_).
+        1. If _opText_ is `<<`, then
+          1. If _lnum_ is a Number, return Number::leftShift(_lnum_, _rnum_).
+          1. If _lnum_ is a BigInt, return BigInt::leftShift(_lnum_, _rnum_).
+        1. If _opText_ is `>>`, then
+          1. If _lnum_ is a Number, return Number::signedRightShift(_lnum_, _rnum_).
+          1. If _lnum_ is a BigInt, return BigInt::signedRightShift(_lnum_, _rnum_).
+        1. If _opText_ is `>>>`, then
+          1. If _lnum_ is a Number, return Number::unsignedRightShift(_lnum_, _rnum_).
+          1. If _lnum_ is a BigInt, return ? BigInt::unsignedRightShift(_lnum_, _rnum_).
+        1. If _opText_ is `&amp;`, then
+          1. If _lnum_ is a Number, return Number::bitwiseAND(_lnum_, _rnum_).
+          1. If _lnum_ is a BigInt, return BigInt::bitwiseAND(_lnum_, _rnum_).
+        1. If _opText_ is `^`, then
+          1. If _lnum_ is a Number, return Number::bitwiseXOR(_lnum_, _rnum_).
+          1. If _lnum_ is a BigInt, return BigInt::bitwiseXOR(_lnum_, _rnum_).
+        1. If _opText_ is `|`, then
+          1. If _lnum_ is a Number, return Number::bitwiseOR(_lnum_, _rnum_).
+          1. If _lnum_ is a BigInt, return BigInt::bitwiseOR(_lnum_, _rnum_).
+        1. Assert: This step is not reached.
       </emu-alg>
       <emu-note>
         <p>No hint is provided in the calls to ToPrimitive in steps <emu-xref href="#step-binary-op-toprimitive-lval"></emu-xref> and <emu-xref href="#step-binary-op-toprimitive-rval"></emu-xref>. All standard objects except Dates handle the absence of a hint as if ~number~ were given; Dates handle the absence of a hint as if ~string~ were given. Exotic objects may handle the absence of a hint in some other manner.</p>

--- a/spec.html
+++ b/spec.html
@@ -20313,7 +20313,7 @@
         1. Let _lnum_ be ? ToNumeric(_lval_).
         1. Let _rnum_ be ? ToNumeric(_rval_).
         1. If Type(_lnum_) is different from Type(_rnum_), throw a *TypeError* exception.
-        1. NOTE: The following steps can only throw an exception if _lnum_ is a BigInt and _opText_ is `**`, `/`, `%`, or `>>>`.
+        1. NOTE: The following steps can only throw an exception if _lnum_ is a BigInt and _opText_ is one of `**`, `/`, `%`, or `>>>`.
         1. If _lnum_ is a Number, then
           1. If _opText_ is `**`, return Number::exponentiate(_lnum_, _rnum_).
           1. If _opText_ is `*`, return Number::multiply(_lnum_, _rnum_).

--- a/spec.html
+++ b/spec.html
@@ -20314,42 +20314,32 @@
         1. Let _rnum_ be ? ToNumeric(_rval_).
         1. If Type(_lnum_) is different from Type(_rnum_), throw a *TypeError* exception.
         1. NOTE: The following steps can only throw an exception if _lnum_ is a BigInt and _opText_ is `**`, `/`, `%`, or `>>>`.
-        1. If _opText_ is `**`, then
-          1. If _lnum_ is a Number, return Number::exponentiate(_lnum_, _rnum_).
-          1. If _lnum_ is a BigInt, return ? BigInt::exponentiate(_lnum_, _rnum_).
-        1. If _opText_ is `*`, then
-          1. If _lnum_ is a Number, return Number::multiply(_lnum_, _rnum_).
-          1. If _lnum_ is a BigInt, return BigInt::multiply(_lnum_, _rnum_).
-        1. If _opText_ is `/`, then
-          1. If _lnum_ is a Number, return Number::divide(_lnum_, _rnum_).
-          1. If _lnum_ is a BigInt, return ? BigInt::divide(_lnum_, _rnum_).
-        1. If _opText_ is `%`, then
-          1. If _lnum_ is a Number, return Number::remainder(_lnum_, _rnum_).
-          1. If _lnum_ is a BigInt, return ? BigInt::remainder(_lnum_, _rnum_).
-        1. If _opText_ is `+`, then
-          1. If _lnum_ is a Number, return Number::add(_lnum_, _rnum_).
-          1. If _lnum_ is a BigInt, return BigInt::add(_lnum_, _rnum_).
-        1. If _opText_ is `-`, then
-          1. If _lnum_ is a Number, return Number::subtract(_lnum_, _rnum_).
-          1. If _lnum_ is a BigInt, return BigInt::subtract(_lnum_, _rnum_).
-        1. If _opText_ is `<<`, then
-          1. If _lnum_ is a Number, return Number::leftShift(_lnum_, _rnum_).
-          1. If _lnum_ is a BigInt, return BigInt::leftShift(_lnum_, _rnum_).
-        1. If _opText_ is `>>`, then
-          1. If _lnum_ is a Number, return Number::signedRightShift(_lnum_, _rnum_).
-          1. If _lnum_ is a BigInt, return BigInt::signedRightShift(_lnum_, _rnum_).
-        1. If _opText_ is `>>>`, then
-          1. If _lnum_ is a Number, return Number::unsignedRightShift(_lnum_, _rnum_).
-          1. If _lnum_ is a BigInt, return ? BigInt::unsignedRightShift(_lnum_, _rnum_).
-        1. If _opText_ is `&amp;`, then
-          1. If _lnum_ is a Number, return Number::bitwiseAND(_lnum_, _rnum_).
-          1. If _lnum_ is a BigInt, return BigInt::bitwiseAND(_lnum_, _rnum_).
-        1. If _opText_ is `^`, then
-          1. If _lnum_ is a Number, return Number::bitwiseXOR(_lnum_, _rnum_).
-          1. If _lnum_ is a BigInt, return BigInt::bitwiseXOR(_lnum_, _rnum_).
-        1. If _opText_ is `|`, then
-          1. If _lnum_ is a Number, return Number::bitwiseOR(_lnum_, _rnum_).
-          1. If _lnum_ is a BigInt, return BigInt::bitwiseOR(_lnum_, _rnum_).
+        1. If _lnum_ is a Number, then
+          1. If _opText_ is `**`, return Number::exponentiate(_lnum_, _rnum_).
+          1. If _opText_ is `*`, return Number::multiply(_lnum_, _rnum_).
+          1. If _opText_ is `/`, return Number::divide(_lnum_, _rnum_).
+          1. If _opText_ is `%`, return Number::remainder(_lnum_, _rnum_).
+          1. If _opText_ is `+`, return Number::add(_lnum_, _rnum_).
+          1. If _opText_ is `-`, return Number::subtract(_lnum_, _rnum_).
+          1. If _opText_ is `<<`, return Number::leftShift(_lnum_, _rnum_).
+          1. If _opText_ is `>>`, return Number::signedRightShift(_lnum_, _rnum_).
+          1. If _opText_ is `>>>`, return Number::unsignedRightShift(_lnum_, _rnum_).
+          1. If _opText_ is `&amp;`, return Number::bitwiseAND(_lnum_, _rnum_).
+          1. If _opText_ is `^`, return Number::bitwiseXOR(_lnum_, _rnum_).
+          1. If _opText_ is `|`, return Number::bitwiseOR(_lnum_, _rnum_).
+        1. If _lnum_ is a BigInt, then
+          1. If _opText_ is `**`, return ? BigInt::exponentiate(_lnum_, _rnum_).
+          1. If _opText_ is `*`, return BigInt::multiply(_lnum_, _rnum_).
+          1. If _opText_ is `/`, return ? BigInt::divide(_lnum_, _rnum_).
+          1. If _opText_ is `%`, return ? BigInt::remainder(_lnum_, _rnum_).
+          1. If _opText_ is `+`, return BigInt::add(_lnum_, _rnum_).
+          1. If _opText_ is `-`, return BigInt::subtract(_lnum_, _rnum_).
+          1. If _opText_ is `<<`, return BigInt::leftShift(_lnum_, _rnum_).
+          1. If _opText_ is `>>`, return BigInt::signedRightShift(_lnum_, _rnum_).
+          1. If _opText_ is `>>>`, return ? BigInt::unsignedRightShift(_lnum_, _rnum_).
+          1. If _opText_ is `&amp;`, return BigInt::bitwiseAND(_lnum_, _rnum_).
+          1. If _opText_ is `^`, return BigInt::bitwiseXOR(_lnum_, _rnum_).
+          1. If _opText_ is `|`, return BigInt::bitwiseOR(_lnum_, _rnum_).
         1. Assert: This step is not reached.
       </emu-alg>
       <emu-note>


### PR DESCRIPTION
The tables in [Assignment Operators Evaluation](https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-assignment-operators-runtime-semantics-evaluation) and [ApplyStringOrNumericBinaryOperator](https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-applystringornumericbinaryoperator) are somewhat redundant with each other, and the latter in particular is more complex than https://github.com/tc39/ecma262/issues/2944#issuecomment-1292722630 suggests to me is desirable (especially considering the resulting `_operation_(_lnum_, _rnum_)` indirection), and incidentally are also the only examples of block-level elements inside an \<emu-alg> step. I think they can be clarified and simplified by replacement with explicit algorithm steps.