### PR TITLE
Meta: Limit IPR check job to the tc39 repository

### DIFF
--- a/.github/workflows/ipr.yml
+++ b/.github/workflows/ipr.yml
@@ -12,6 +12,7 @@ jobs:
   build:
     name: 'check IPR form'
     runs-on: ubuntu-latest
+    if: ${{ secrets.GH_IPR_TOKEN != '' && secrets.GOOGLE_API_KEY != '' }}
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This aligns it with the other privileged jobs.