### PR TITLE
Editorial: Consistently represent expressions that include exponents

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -5371,7 +5371,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It converts _argument_ to one of 2<sup>64</sup> BigInt values in the inclusive interval from ℤ(-2<sup>63</sup>) to ℤ(2<sup>63</sup>-1).</dd>
+        <dd>It converts _argument_ to one of 2<sup>64</sup> BigInt values in the inclusive interval from ℤ(-2<sup>63</sup>) to ℤ(2<sup>63</sup> - 1).</dd>
       </dl>
       <emu-alg>
         1. Let _n_ be ? ToBigInt(_argument_).
@@ -5388,7 +5388,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It converts _argument_ to one of 2<sup>64</sup> BigInt values in the inclusive interval from *0*<sub>ℤ</sub> to ℤ(2<sup>64</sup>-1).</dd>
+        <dd>It converts _argument_ to one of 2<sup>64</sup> BigInt values in the inclusive interval from *0*<sub>ℤ</sub> to ℤ(2<sup>64</sup> - 1).</dd>
       </dl>
       <emu-alg>
         1. Let _n_ be ? ToBigInt(_argument_).
@@ -18052,7 +18052,7 @@
         <emu-alg>
           1. Let _len_ be _nextIndex_ + 1.
           1. Perform ? Set(_array_, *"length"*, 𝔽(_len_), *true*).
-          1. NOTE: The above step throws if _len_ exceeds 2<sup>32</sup>-1.
+          1. NOTE: The above step throws if _len_ exceeds 2<sup>32</sup> - 1.
           1. Return _len_.
         </emu-alg>
         <emu-grammar>Elision : Elision `,`</emu-grammar>

--- a/spec.html
+++ b/spec.html
@@ -28931,7 +28931,7 @@
         1. If _S_ contains a code unit that is not a radix-_R_ digit, let _end_ be the index within _S_ of the first such code unit; otherwise, let _end_ be the length of _S_.
         1. Let _Z_ be the substring of _S_ from 0 to _end_.
         1. If _Z_ is empty, return *NaN*.
-        1. Let _mathInt_ be the integer value that is represented by _Z_ in radix-_R_ notation, using the letters <b>A</b>-<b>Z</b> and <b>a</b>-<b>z</b> for digits with values 10 through 35. (However, if _R_ = 10 and _Z_ contains more than 20 significant digits, every significant digit after the 20th may be replaced by a 0 digit, at the option of the implementation; and if _R_ is not one of 2, 4, 8, 10, 16, or 32, then _mathInt_ may be an implementation-approximated integer representing the integer value denoted by _Z_ in radix-_R_ notation.)
+        1. Let _mathInt_ be the integer value that is represented by _Z_ in radix-_R_ notation, using the letters <b>A</b> through <b>Z</b> and <b>a</b> through <b>z</b> for digits with values 10 through 35. (However, if _R_ = 10 and _Z_ contains more than 20 significant digits, every significant digit after the 20th may be replaced by a 0 digit, at the option of the implementation; and if _R_ is not one of 2, 4, 8, 10, 16, or 32, then _mathInt_ may be an implementation-approximated integer representing the integer value denoted by _Z_ in radix-_R_ notation.)
         1. If _mathInt_ = 0, then
           1. If _sign_ = -1, return *-0*<sub>𝔽</sub>.
           1. Return *+0*<sub>𝔽</sub>.

--- a/spec.html
+++ b/spec.html
@@ -5056,7 +5056,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It converts _argument_ to one of 2<sup>32</sup> integral Number values in the inclusive interval from 𝔽(<emu-eqn>-2<sup>31</sup></emu-eqn>) to 𝔽(<emu-eqn>2<sup>31</sup> - 1</emu-eqn>).</dd>
+        <dd>It converts _argument_ to one of 2<sup>32</sup> integral Number values in the inclusive interval from 𝔽(-2<sup>31</sup>) to 𝔽(2<sup>31</sup> - 1).</dd>
       </dl>
       <emu-alg>
         1. Let _number_ be ? ToNumber(_argument_).
@@ -5089,7 +5089,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It converts _argument_ to one of 2<sup>32</sup> integral Number values in the inclusive interval from *+0*<sub>𝔽</sub> to 𝔽(<emu-eqn>2<sup>32</sup> - 1</emu-eqn>).</dd>
+        <dd>It converts _argument_ to one of 2<sup>32</sup> integral Number values in the inclusive interval from *+0*<sub>𝔽</sub> to 𝔽(2<sup>32</sup> - 1).</dd>
       </dl>
       <emu-alg>
         1. Let _number_ be ? ToNumber(_argument_).
@@ -5125,7 +5125,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It converts _argument_ to one of 2<sup>16</sup> integral Number values in the inclusive interval from 𝔽(<emu-eqn>-2<sup>15</sup></emu-eqn>) to 𝔽(<emu-eqn>2<sup>15</sup> - 1</emu-eqn>).</dd>
+        <dd>It converts _argument_ to one of 2<sup>16</sup> integral Number values in the inclusive interval from 𝔽(-2<sup>15</sup>) to 𝔽(2<sup>15</sup> - 1).</dd>
       </dl>
       <emu-alg>
         1. Let _number_ be ? ToNumber(_argument_).
@@ -5144,7 +5144,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It converts _argument_ to one of 2<sup>16</sup> integral Number values in the inclusive interval from *+0*<sub>𝔽</sub> to 𝔽(<emu-eqn>2<sup>16</sup> - 1</emu-eqn>).</dd>
+        <dd>It converts _argument_ to one of 2<sup>16</sup> integral Number values in the inclusive interval from *+0*<sub>𝔽</sub> to 𝔽(2<sup>16</sup> - 1).</dd>
       </dl>
       <emu-alg>
         1. Let _number_ be ? ToNumber(_argument_).
@@ -13905,7 +13905,7 @@
       <h1>Array Exotic Objects</h1>
       <p>An Array is an exotic object that gives special treatment to array index property keys (see <emu-xref href="#sec-object-type"></emu-xref>). A property whose property name is an array index is also called an <em>element</em>. Every Array has a non-configurable *"length"* property whose value is always a non-negative integral Number whose mathematical value is strictly less than 2<sup>32</sup>. The value of the *"length"* property is numerically greater than the name of every own property whose name is an array index; whenever an own property of an Array is created or changed, other properties are adjusted as necessary to maintain this invariant. Specifically, whenever an own property is added whose name is an array index, the value of the *"length"* property is changed, if necessary, to be one more than the numeric value of that array index; and whenever the value of the *"length"* property is changed, every own property whose name is an array index whose value is not smaller than the new length is deleted. This constraint applies only to own properties of an Array and is unaffected by *"length"* or array index properties that may be inherited from its prototypes.</p>
       <emu-note>
-        <p>A String property name _P_ is an <em>array index</em> if and only if ToString(ToUint32(_P_)) is _P_ and ToUint32(_P_) is not 𝔽(<emu-eqn>2<sup>32</sup> - 1</emu-eqn>).</p>
+        <p>A String property name _P_ is an <em>array index</em> if and only if ToString(ToUint32(_P_)) is _P_ and ToUint32(_P_) is not 𝔽(2<sup>32</sup> - 1).</p>
       </emu-note>
 
       <p>An object is an <dfn id="array-exotic-object" variants="Array exotic objects">Array exotic object</dfn> (or simply, an Array) if its [[DefineOwnProperty]] internal method uses the following implementation, and its other essential internal methods use the definitions found in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>. These methods are installed in ArrayCreate.</p>


### PR DESCRIPTION
This PR addresses two inconsistencies:
* Some expressions of the form "_x_<sup>_y_</sup> - _z_" are missing spaces around the operator.
* Some uses of 𝔽/ℤ/ℝ wrap the argument in `<emu-eqn>` when it includes exponentiation, while others do not. Uses inside of `<emu-alg>` never include the wrapping, while uses outside of it are evenly split (but never wrap any argument _without_ exponentiation, even if it uses other operations such as division with `/`):
  ```sh
  $ grep -v '^ *1[.]' spec.html | grep -o '[𝔽ℤℝ][(][^()]*\([(][^()]*[)][^()]*\)*[)]' | grep '<sup>' | sort | uniq -c
        1 𝔽(2<sup>32</sup> - 1)
        1 𝔽(-(2<sup>53</sup> - 1))
        2 𝔽(2<sup>53</sup> - 1)
        1 ℤ(-2<sup>63</sup>)
        1 ℤ(2<sup>63</sup> - 1)
        1 ℤ(2<sup>64</sup> - 1)
        1 𝔽(<emu-eqn>2<sup>15</sup> - 1</emu-eqn>)
        1 𝔽(<emu-eqn>-2<sup>15</sup></emu-eqn>)
        1 𝔽(<emu-eqn>2<sup>16</sup> - 1</emu-eqn>)
        1 𝔽(<emu-eqn>2<sup>31</sup> - 1</emu-eqn>)
        1 𝔽(<emu-eqn>-2<sup>31</sup></emu-eqn>)
        2 𝔽(<emu-eqn>2<sup>32</sup> - 1</emu-eqn>)
  ```
  Given the apparent lack of problems from the simpler form and the likelihood of forgetting the more complex form in the absence of lint warnings, I've opted for exclusive use of the former.