### PR TITLE
Editorial: add emu-not-ref for "date-time values"

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -32419,7 +32419,7 @@ THH:mm:ss.sss
           <h1>Expanded Years</h1>
           <p>Covering the full time value range of approximately 273,790 years forward or backward from 1 January 1970 (<emu-xref href="#sec-time-values-and-time-range"></emu-xref>) requires representing years before 0 or after 9999. ISO 8601 permits expansion of the year representation, but only by mutual agreement of the partners in information interchange. In the simplified ECMAScript format, such an expanded year representation shall have 6 digits and is always prefixed with a + or - sign. The year 0 is considered positive and must be prefixed with a + sign. The representation of the year 0 as -000000 is invalid. Strings matching the <emu-xref href="#sec-date-time-string-format">Date Time String Format</emu-xref> with expanded years representing instants in time outside the range of a time value are treated as unrecognizable by <emu-xref href="#sec-date.parse">`Date.parse`</emu-xref> and cause that function to return *NaN* without falling back to implementation-specific behaviour or heuristics.</p>
           <emu-note>
-            <p>Examples of date-time values with expanded years:</p>
+            <p>Examples of date-<emu-not-ref>time values</emu-not-ref> with expanded years:</p>
             <figure>
               <table class="lightweight-table">
                 <tr>


### PR DESCRIPTION
Found this while investigating a different issue here: https://github.com/tc39/ecmarkup/issues/518#issuecomment-1430542065