### PR TITLE
Editorial: Ensure Abstract Closures don't re-use outer aliases

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -43698,8 +43698,8 @@ THH:mm:ss.sss
           1. IfAbruptRejectPromise(_value_, _promiseCapability_).
           1. Let _valueWrapper_ be Completion(PromiseResolve(%Promise%, _value_)).
           1. IfAbruptRejectPromise(_valueWrapper_, _promiseCapability_).
-          1. Let _unwrap_ be a new Abstract Closure with parameters (_value_) that captures _done_ and performs the following steps when called:
-            1. Return CreateIterResultObject(_value_, _done_).
+          1. Let _unwrap_ be a new Abstract Closure with parameters (_v_) that captures _done_ and performs the following steps when called:
+            1. Return CreateIterResultObject(_v_, _done_).
           1. Let _onFulfilled_ be CreateBuiltinFunction(_unwrap_, 1, *""*, « »).
           1. NOTE: _onFulfilled_ is used when processing the *"value"* property of an IteratorResult object in order to wait for its value if it is a promise and re-package the result in a new "unwrapped" IteratorResult object.
           1. Perform PerformPromiseThen(_valueWrapper_, _onFulfilled_, *undefined*, _promiseCapability_).
@@ -44666,19 +44666,19 @@ THH:mm:ss.sss
           1. Else,
             1. Let _thenFinallyClosure_ be a new Abstract Closure with parameters (_value_) that captures _onFinally_ and _C_ and performs the following steps when called:
               1. Let _result_ be ? Call(_onFinally_, *undefined*).
-              1. Let _promise_ be ? PromiseResolve(_C_, _result_).
+              1. Let _p_ be ? PromiseResolve(_C_, _result_).
               1. Let _returnValue_ be a new Abstract Closure with no parameters that captures _value_ and performs the following steps when called:
                 1. Return _value_.
               1. Let _valueThunk_ be CreateBuiltinFunction(_returnValue_, 0, *""*, « »).
-              1. Return ? Invoke(_promise_, *"then"*, « _valueThunk_ »).
+              1. Return ? Invoke(_p_, *"then"*, « _valueThunk_ »).
             1. Let _thenFinally_ be CreateBuiltinFunction(_thenFinallyClosure_, 1, *""*, « »).
             1. Let _catchFinallyClosure_ be a new Abstract Closure with parameters (_reason_) that captures _onFinally_ and _C_ and performs the following steps when called:
               1. Let _result_ be ? Call(_onFinally_, *undefined*).
-              1. Let _promise_ be ? PromiseResolve(_C_, _result_).
+              1. Let _p_ be ? PromiseResolve(_C_, _result_).
               1. Let _throwReason_ be a new Abstract Closure with no parameters that captures _reason_ and performs the following steps when called:
                 1. Return ThrowCompletion(_reason_).
               1. Let _thrower_ be CreateBuiltinFunction(_throwReason_, 0, *""*, « »).
-              1. Return ? Invoke(_promise_, *"then"*, « _thrower_ »).
+              1. Return ? Invoke(_p_, *"then"*, « _thrower_ »).
             1. Let _catchFinally_ be CreateBuiltinFunction(_catchFinallyClosure_, 1, *""*, « »).
           1. Return ? Invoke(_promise_, *"then"*, « _thenFinally_, _catchFinally_ »).
         </emu-alg>
@@ -45169,17 +45169,17 @@ THH:mm:ss.sss
           1. Let _genContext_ be the running execution context.
           1. Set the Generator component of _genContext_ to _generator_.
           1. Let _closure_ be a new Abstract Closure with no parameters that captures _generatorBody_ and performs the following steps when called:
-            1. Let _genContext_ be the running execution context.
-            1. Let _generator_ be the Generator component of _genContext_.
+            1. Let _acGenContext_ be the running execution context.
+            1. Let _acGenerator_ be the Generator component of _acGenContext_.
             1. If _generatorBody_ is a Parse Node, then
               1. Let _result_ be Completion(Evaluation of _generatorBody_).
             1. Else,
               1. Assert: _generatorBody_ is an Abstract Closure with no parameters.
               1. Let _result_ be _generatorBody_().
             1. Assert: If we return here, the generator either threw an exception or performed either an implicit or explicit return.
-            1. Remove _genContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
-            1. Set _generator_.[[GeneratorState]] to ~completed~.
-            1. Once a generator enters the ~completed~ state it never leaves it and its associated execution context is never resumed. Any execution state associated with _generator_ can be discarded at this point.
+            1. Remove _acGenContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
+            1. Set _acGenerator_.[[GeneratorState]] to ~completed~.
+            1. Once a generator enters the ~completed~ state it never leaves it and its associated execution context is never resumed. Any execution state associated with _acGenerator_ can be discarded at this point.
             1. If _result_.[[Type]] is ~normal~, let _resultValue_ be *undefined*.
             1. Else if _result_.[[Type]] is ~return~, let _resultValue_ be _result_.[[Value]].
             1. Else,
@@ -45524,20 +45524,20 @@ THH:mm:ss.sss
           1. Let _genContext_ be the running execution context.
           1. Set the Generator component of _genContext_ to _generator_.
           1. Let _closure_ be a new Abstract Closure with no parameters that captures _generatorBody_ and performs the following steps when called:
-            1. Let _genContext_ be the running execution context.
-            1. Let _generator_ be the Generator component of _genContext_.
+            1. Let _acGenContext_ be the running execution context.
+            1. Let _acGenerator_ be the Generator component of _acGenContext_.
             1. If _generatorBody_ is a Parse Node, then
               1. Let _result_ be Completion(Evaluation of _generatorBody_).
             1. Else,
               1. Assert: _generatorBody_ is an Abstract Closure with no parameters.
               1. Let _result_ be Completion(_generatorBody_()).
             1. Assert: If we return here, the async generator either threw an exception or performed either an implicit or explicit return.
-            1. Remove _genContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
-            1. Set _generator_.[[AsyncGeneratorState]] to ~completed~.
+            1. Remove _acGenContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
+            1. Set _acGenerator_.[[AsyncGeneratorState]] to ~completed~.
             1. If _result_.[[Type]] is ~normal~, set _result_ to NormalCompletion(*undefined*).
             1. If _result_.[[Type]] is ~return~, set _result_ to NormalCompletion(_result_.[[Value]]).
-            1. Perform AsyncGeneratorCompleteStep(_generator_, _result_, *true*).
-            1. Perform AsyncGeneratorDrainQueue(_generator_).
+            1. Perform AsyncGeneratorCompleteStep(_acGenerator_, _result_, *true*).
+            1. Perform AsyncGeneratorDrainQueue(_acGenerator_).
             1. Return *undefined*.
           1. Set the code evaluation state of _genContext_ such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
           1. Set _generator_.[[AsyncGeneratorContext]] to _genContext_.
@@ -45918,10 +45918,10 @@ THH:mm:ss.sss
           1. Assert: _promiseCapability_ is a PromiseCapability Record.
           1. Let _runningContext_ be the running execution context.
           1. Let _closure_ be a new Abstract Closure with no parameters that captures _promiseCapability_ and _asyncBody_ and performs the following steps when called:
-            1. Let _asyncContext_ be the running execution context.
+            1. Let _acAsyncContext_ be the running execution context.
             1. Let _result_ be Completion(Evaluation of _asyncBody_).
             1. Assert: If we return here, the async function either threw an exception or performed an implicit or explicit return; all awaiting is done.
-            1. Remove _asyncContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
+            1. Remove _acAsyncContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
             1. If _result_.[[Type]] is ~normal~, then
               1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, « *undefined* »).
             1. Else if _result_.[[Type]] is ~return~, then
@@ -45950,11 +45950,11 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _asyncContext_ be the running execution context.
           1. Let _promise_ be ? PromiseResolve(%Promise%, _value_).
-          1. Let _fulfilledClosure_ be a new Abstract Closure with parameters (_value_) that captures _asyncContext_ and performs the following steps when called:
+          1. Let _fulfilledClosure_ be a new Abstract Closure with parameters (_v_) that captures _asyncContext_ and performs the following steps when called:
             1. Let _prevContext_ be the running execution context.
             1. Suspend _prevContext_.
             1. Push _asyncContext_ onto the execution context stack; _asyncContext_ is now the running execution context.
-            1. <emu-meta effects="user-code">Resume the suspended evaluation of _asyncContext_</emu-meta> using NormalCompletion(_value_) as the result of the operation that suspended it.
+            1. <emu-meta effects="user-code">Resume the suspended evaluation of _asyncContext_</emu-meta> using NormalCompletion(_v_) as the result of the operation that suspended it.
             1. Assert: When we reach this step, _asyncContext_ has already been removed from the execution context stack and _prevContext_ is the currently running execution context.
             1. Return *undefined*.
           1. Let _onFulfilled_ be CreateBuiltinFunction(_fulfilledClosure_, 1, *""*, « »).
@@ -46174,7 +46174,7 @@ THH:mm:ss.sss
         <p>This function creates a revocable Proxy object.</p>
         <p>It performs the following steps when called:</p>
         <emu-alg>
-          1. Let _p_ be ? ProxyCreate(_target_, _handler_).
+          1. Let _proxy_ be ? ProxyCreate(_target_, _handler_).
           1. Let _revokerClosure_ be a new Abstract Closure with no parameters that captures nothing and performs the following steps when called:
             1. Let _F_ be the active function object.
             1. Let _p_ be _F_.[[RevocableProxy]].
@@ -46185,9 +46185,9 @@ THH:mm:ss.sss
             1. Set _p_.[[ProxyHandler]] to *null*.
             1. Return *undefined*.
           1. Let _revoker_ be CreateBuiltinFunction(_revokerClosure_, 0, *""*, « [[RevocableProxy]] »).
-          1. Set _revoker_.[[RevocableProxy]] to _p_.
+          1. Set _revoker_.[[RevocableProxy]] to _proxy_.
           1. Let _result_ be OrdinaryObjectCreate(%Object.prototype%).
-          1. Perform ! CreateDataPropertyOrThrow(_result_, *"proxy"*, _p_).
+          1. Perform ! CreateDataPropertyOrThrow(_result_, *"proxy"*, _proxy_).
           1. Perform ! CreateDataPropertyOrThrow(_result_, *"revoke"*, _revoker_).
           1. Return _result_.
         </emu-alg>


### PR DESCRIPTION
Resolves issue #3010.

----

Usually, I rename the inner alias, but in one case, I rename the outer...

- In `AsyncFromSyncIteratorContinuation` and `Await`: change the AC's `_value_` to `_val_`.
- In `Promise.prototype.finally`: change both ACs' `_promise_` to `_prom_`.
- In `GeneratorStart` and `AsyncGeneratorStart`: change the AC's `_genContext_` and `_generator_` by prepending 'ac'.
- In `AsyncBlockStart`: change the AC's `_asyncContext_` likewise.
- In `Proxy.revocable`: change the *outer* `_p_` to `_proxy_`.

----

Possible wording for editorial convention:
> Every Abstract Closure (AC) is defined within an 'outer' algorithm. Inside the AC, the only outer aliases that are visible are the ones explicitly captured in the AC's header. Any other outer aliases cannot be referenced within the AC. Since these aliases are inaccessible, it might seem that their names could be re-used within the AC (e.g., for a parameter or let-alias), but they should not be re-used, for the sake of clarity.

or:
> The body of an Abstract Closure (AC) must not reference aliases of the outer algorithm, other than those explicitly captured in the AC's header. Moreover, for clarity, the AC should not re-use the names of outer aliases for its own purposes (even though those aliases are inacessible).