### PR TITLE
Meta: bump ecmarkup to 16.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://tc39.es/ecma262/#sec-copyright-and-software-license",
       "dependencies": {
-        "ecmarkup": "^16.0.1"
+        "ecmarkup": "^16.1.1"
       },
       "devDependencies": {
         "glob": "^7.1.6",
@@ -716,23 +716,23 @@
       }
     },
     "node_modules/ecmarkdown": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/ecmarkdown/-/ecmarkdown-7.2.0.tgz",
-      "integrity": "sha512-p0C4SJCvnvtm0y9gPhXBb5DlNbHsNS44ihVKBw3MXviZG2QQpZNH4z/3PbkpgECOjKOeZI+m84ISHVV9WLECFQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/ecmarkdown/-/ecmarkdown-8.0.0.tgz",
+      "integrity": "sha512-6NqsQWozoUxbd/xWF8XBbGn8zl/PkAjeh4nEnXBzFAEOxP0N0tJYvenmlfycsnR35gne2FgrrvTYmEgtXDO3lw==",
       "dependencies": {
         "escape-html": "^1.0.1"
       }
     },
     "node_modules/ecmarkup": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-16.0.1.tgz",
-      "integrity": "sha512-Vs2kMzfaxUi2GW5VyXQwz7LFk7Y3A1uJvsQpGsgcA1CAr2e1IcpmtRL6SQVjU1hmvUbVRXBlxpIBhJYE4jgiBw==",
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-16.1.1.tgz",
+      "integrity": "sha512-t+AYUKhN6tizXYtDAxM1RFN8rfKWs78uA6+Cdr+5oF00BOekW+JQLmXXoXgoy4ct19HJzXMvCd0XThkBm4MXhQ==",
       "dependencies": {
         "chalk": "^4.1.2",
         "command-line-args": "^5.2.0",
         "command-line-usage": "^6.1.1",
         "dedent-js": "^1.0.1",
-        "ecmarkdown": "^7.2.0",
+        "ecmarkdown": "^8.0.0",
         "eslint-formatter-codeframe": "^7.32.1",
         "fast-glob": "^3.2.7",
         "grammarkdown": "^3.2.0",
@@ -2932,23 +2932,23 @@
       }
     },
     "ecmarkdown": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/ecmarkdown/-/ecmarkdown-7.2.0.tgz",
-      "integrity": "sha512-p0C4SJCvnvtm0y9gPhXBb5DlNbHsNS44ihVKBw3MXviZG2QQpZNH4z/3PbkpgECOjKOeZI+m84ISHVV9WLECFQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/ecmarkdown/-/ecmarkdown-8.0.0.tgz",
+      "integrity": "sha512-6NqsQWozoUxbd/xWF8XBbGn8zl/PkAjeh4nEnXBzFAEOxP0N0tJYvenmlfycsnR35gne2FgrrvTYmEgtXDO3lw==",
       "requires": {
         "escape-html": "^1.0.1"
       }
     },
     "ecmarkup": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-16.0.1.tgz",
-      "integrity": "sha512-Vs2kMzfaxUi2GW5VyXQwz7LFk7Y3A1uJvsQpGsgcA1CAr2e1IcpmtRL6SQVjU1hmvUbVRXBlxpIBhJYE4jgiBw==",
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-16.1.1.tgz",
+      "integrity": "sha512-t+AYUKhN6tizXYtDAxM1RFN8rfKWs78uA6+Cdr+5oF00BOekW+JQLmXXoXgoy4ct19HJzXMvCd0XThkBm4MXhQ==",
       "requires": {
         "chalk": "^4.1.2",
         "command-line-args": "^5.2.0",
         "command-line-usage": "^6.1.1",
         "dedent-js": "^1.0.1",
-        "ecmarkdown": "^7.2.0",
+        "ecmarkdown": "^8.0.0",
         "eslint-formatter-codeframe": "^7.32.1",
         "fast-glob": "^3.2.7",
         "grammarkdown": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "license": "SEE LICENSE IN https://tc39.es/ecma262/#sec-copyright-and-software-license",
   "homepage": "https://tc39.es/ecma262/",
   "dependencies": {
-    "ecmarkup": "^16.0.1"
+    "ecmarkup": "^16.1.1"
   },
   "devDependencies": {
     "glob": "^7.1.6",


### PR DESCRIPTION
The notable change here is that you can now click on `[[FieldNames]]` to highlight other uses of that name within the same algorithm, like you could already do for variable names. Thanks to @gibson042 for [the PR](https://github.com/tc39/ecmarkdown/pull/96).

This is mainly expected to be useful for specs like 402 and Temporal, which make heavier use of objects with many internal slots than 262 does. But we might as well have it here as well.

~~(Edit: sigh, I see I need to do a patch release first...)~~ Done.

<img width="911" alt="Screenshot 2023-02-16 at 9 07 49 AM" src="https://user-images.githubusercontent.com/1653598/219437877-fa35b4a8-39f2-4177-a606-db39a9e7504f.png">
