### PR TITLE
Editorial: Replace biblio term "safe" with the more specific "safe integer"

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -31015,7 +31015,7 @@
       <emu-clause id="sec-number.issafeinteger">
         <h1>Number.isSafeInteger ( _number_ )</h1>
         <emu-note>
-          <p>An integer _n_ is considered "<dfn id="safe-integer">safe</dfn>" if and only if the Number value for _n_ is not the Number value for any other integer.</p>
+          <p>An integer _n_ is a "<dfn id="safe-integer">safe integer</dfn>" if and only if the Number value for _n_ is not the Number value for any other integer.</p>
         </emu-note>
         <p>This function performs the following steps when called:</p>
         <emu-alg>


### PR DESCRIPTION
This preserves the existing "safe-integer" id, but fixes autolinking issues necessitating things like https://github.com/tc39/proposal-temporal/pull/2502 .