### PR TITLE
Editorial: Clarify GetIterator

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -6797,31 +6797,43 @@
       </emu-table>
     </emu-clause>
 
+    <emu-clause id="sec-getiteratorfrommethod" type="abstract operation">
+      <h1>
+        GetIteratorFromMethod (
+          _obj_: an ECMAScript language value,
+          _method_: a function object,
+        ): either a normal completion containing an Iterator Record or a throw completion
+      </h1>
+      <dl class="header">
+      </dl>
+      <emu-alg>
+        1. Let _iterator_ be ? Call(_method_, _obj_).
+        1. If _iterator_ is not an Object, throw a *TypeError* exception.
+        1. Let _nextMethod_ be ? GetV(_iterator_, *"next"*).
+        1. Let _iteratorRecord_ be the Iterator Record { [[Iterator]]: _iterator_, [[NextMethod]]: _nextMethod_, [[Done]]: *false* }.
+        1. Return _iteratorRecord_.
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-getiterator" type="abstract operation">
       <h1>
         GetIterator (
           _obj_: an ECMAScript language value,
           optional _hint_: ~sync~ or ~async~,
-          optional _method_: a function object,
         ): either a normal completion containing an Iterator Record or a throw completion
       </h1>
       <dl class="header">
       </dl>
       <emu-alg>
         1. If _hint_ is not present, set _hint_ to ~sync~.
-        1. If _method_ is not present, then
-          1. If _hint_ is ~async~, then
-            1. Set _method_ to ? GetMethod(_obj_, @@asyncIterator).
-            1. If _method_ is *undefined*, then
-              1. Let _syncMethod_ be ? GetMethod(_obj_, @@iterator).
-              1. Let _syncIteratorRecord_ be ? GetIterator(_obj_, ~sync~, _syncMethod_).
-              1. Return CreateAsyncFromSyncIterator(_syncIteratorRecord_).
-          1. Otherwise, set _method_ to ? GetMethod(_obj_, @@iterator).
-        1. Let _iterator_ be ? Call(_method_, _obj_).
-        1. If _iterator_ is not an Object, throw a *TypeError* exception.
-        1. Let _nextMethod_ be ? GetV(_iterator_, *"next"*).
-        1. Let _iteratorRecord_ be the Iterator Record { [[Iterator]]: _iterator_, [[NextMethod]]: _nextMethod_, [[Done]]: *false* }.
-        1. Return _iteratorRecord_.
+        1. If _hint_ is ~async~, then
+          1. Let _method_ be ? GetMethod(_obj_, @@asyncIterator).
+          1. If _method_ is *undefined*, then
+            1. Let _syncMethod_ be ? GetMethod(_obj_, @@iterator).
+            1. Let _syncIteratorRecord_ be ? GetIteratorFromMethod(_obj_, _syncMethod_).
+            1. Return CreateAsyncFromSyncIterator(_syncIteratorRecord_).
+        1. Otherwise, let _method_ be ? GetMethod(_obj_, @@iterator).
+        1. Return ? GetIteratorFromMethod(_obj_, _method_).
       </emu-alg>
     </emu-clause>
 
@@ -7008,7 +7020,7 @@
       </dl>
       <emu-alg>
         1. If _method_ is present, then
-          1. Let _iteratorRecord_ be ? GetIterator(_items_, ~sync~, _method_).
+          1. Let _iteratorRecord_ be ? GetIteratorFromMethod(_items_, _method_).
         1. Else,
           1. Let _iteratorRecord_ be ? GetIterator(_items_, ~sync~).
         1. Let _values_ be a new empty List.
@@ -37258,7 +37270,7 @@ THH:mm:ss.sss
               1. Let _A_ be ? Construct(_C_).
             1. Else,
               1. Let _A_ be ! ArrayCreate(0).
-            1. Let _iteratorRecord_ be ? GetIterator(_items_, ~sync~, _usingIterator_).
+            1. Let _iteratorRecord_ be ? GetIteratorFromMethod(_items_, _usingIterator_).
             1. Let _k_ be 0.
             1. Repeat,
               1. If _k_ ≥ 2<sup>53</sup> - 1, then

--- a/spec.html
+++ b/spec.html
@@ -7008,20 +7008,15 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-iterabletolist" type="abstract operation">
+    <emu-clause id="sec-iteratortolist" oldids="sec-iterabletolist" type="abstract operation">
       <h1>
-        IterableToList (
-          _items_: an ECMAScript language value,
-          optional _method_: a function object,
+        IteratorToList (
+          _iteratorRecord_: an Iterator Record,
         ): either a normal completion containing a List of ECMAScript language values or a throw completion
       </h1>
       <dl class="header">
       </dl>
       <emu-alg>
-        1. If _method_ is present, then
-          1. Let _iteratorRecord_ be ? GetIteratorFromMethod(_items_, _method_).
-        1. Else,
-          1. Let _iteratorRecord_ be ? GetIterator(_items_, ~sync~).
         1. Let _values_ be a new empty List.
         1. Let _next_ be *true*.
         1. Repeat, while _next_ is not *false*,
@@ -30789,7 +30784,7 @@
               1. Let _msg_ be ? ToString(_message_).
               1. Perform CreateNonEnumerableDataPropertyOrThrow(_O_, *"message"*, _msg_).
             1. Perform ? InstallErrorCause(_O_, _options_).
-            1. Let _errorsList_ be ? IterableToList(_errors_).
+            1. Let _errorsList_ be ? IteratorToList(? GetIterator(_errors_, ~sync~)).
             1. Perform ! DefinePropertyOrThrow(_O_, *"errors"*, PropertyDescriptor { [[Configurable]]: *true*, [[Enumerable]]: *false*, [[Writable]]: *true*, [[Value]]: CreateArrayFromList(_errorsList_) }).
             1. Return _O_.
           </emu-alg>
@@ -39022,7 +39017,7 @@ THH:mm:ss.sss
             1. Let _mapping_ be *true*.
           1. Let _usingIterator_ be ? GetMethod(_source_, @@iterator).
           1. If _usingIterator_ is not *undefined*, then
-            1. Let _values_ be ? IterableToList(_source_, _usingIterator_).
+            1. Let _values_ be ? IteratorToList(? GetIteratorFromMethod(_source_, _usingIterator_)).
             1. Let _len_ be the number of elements in _values_.
             1. Let _targetObj_ be ? TypedArrayCreate(_C_, « 𝔽(_len_) »).
             1. Let _k_ be 0.
@@ -40113,7 +40108,7 @@ THH:mm:ss.sss
                 1. Assert: _firstArgument_ is an Object and _firstArgument_ does not have either a [[TypedArrayName]] or an [[ArrayBufferData]] internal slot.
                 1. Let _usingIterator_ be ? GetMethod(_firstArgument_, @@iterator).
                 1. If _usingIterator_ is not *undefined*, then
-                  1. Let _values_ be ? IterableToList(_firstArgument_, _usingIterator_).
+                  1. Let _values_ be ? IteratorToList(? GetIteratorFromMethod(_firstArgument_, _usingIterator_)).
                   1. Perform ? InitializeTypedArrayFromList(_O_, _values_).
                 1. Else,
                   1. NOTE: _firstArgument_ is not an Iterable so assume it is already an array-like object.

--- a/spec.html
+++ b/spec.html
@@ -6829,9 +6829,11 @@
           1. Let _method_ be ? GetMethod(_obj_, @@asyncIterator).
           1. If _method_ is *undefined*, then
             1. Let _syncMethod_ be ? GetMethod(_obj_, @@iterator).
+            1. If _syncMethod_ is *undefined*, throw a *TypeError* exception.
             1. Let _syncIteratorRecord_ be ? GetIteratorFromMethod(_obj_, _syncMethod_).
             1. Return CreateAsyncFromSyncIterator(_syncIteratorRecord_).
         1. Otherwise, let _method_ be ? GetMethod(_obj_, @@iterator).
+        1. If _method_ is *undefined*, throw a *TypeError* exception.
         1. Return ? GetIteratorFromMethod(_obj_, _method_).
       </emu-alg>
     </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -6819,14 +6819,13 @@
       <h1>
         GetIterator (
           _obj_: an ECMAScript language value,
-          optional _hint_: ~sync~ or ~async~,
+          _kind_: ~sync~ or ~async~,
         ): either a normal completion containing an Iterator Record or a throw completion
       </h1>
       <dl class="header">
       </dl>
       <emu-alg>
-        1. If _hint_ is not present, set _hint_ to ~sync~.
-        1. If _hint_ is ~async~, then
+        1. If _kind_ is ~async~, then
           1. Let _method_ be ? GetMethod(_obj_, @@asyncIterator).
           1. If _method_ is *undefined*, then
             1. Let _syncMethod_ be ? GetMethod(_obj_, @@iterator).
@@ -9363,7 +9362,7 @@
       </emu-alg>
       <emu-grammar>BindingPattern : ArrayBindingPattern</emu-grammar>
       <emu-alg>
-        1. Let _iteratorRecord_ be ? GetIterator(_value_).
+        1. Let _iteratorRecord_ be ? GetIterator(_value_, ~sync~).
         1. Let _result_ be Completion(IteratorBindingInitialization of |ArrayBindingPattern| with arguments _iteratorRecord_ and _environment_).
         1. If _iteratorRecord_.[[Done]] is *false*, return ? IteratorClose(_iteratorRecord_, _result_).
         1. Return ? _result_.
@@ -18058,7 +18057,7 @@
         <emu-alg>
           1. Let _spreadRef_ be ? Evaluation of |AssignmentExpression|.
           1. Let _spreadObj_ be ? GetValue(_spreadRef_).
-          1. Let _iteratorRecord_ be ? GetIterator(_spreadObj_).
+          1. Let _iteratorRecord_ be ? GetIterator(_spreadObj_, ~sync~).
           1. Repeat,
             1. Let _next_ be ? IteratorStep(_iteratorRecord_).
             1. If _next_ is *false*, return _nextIndex_.
@@ -19099,7 +19098,7 @@
           1. Let _list_ be a new empty List.
           1. Let _spreadRef_ be ? Evaluation of |AssignmentExpression|.
           1. Let _spreadObj_ be ? GetValue(_spreadRef_).
-          1. Let _iteratorRecord_ be ? GetIterator(_spreadObj_).
+          1. Let _iteratorRecord_ be ? GetIterator(_spreadObj_, ~sync~).
           1. Repeat,
             1. Let _next_ be ? IteratorStep(_iteratorRecord_).
             1. If _next_ is *false*, return _list_.
@@ -19117,7 +19116,7 @@
         <emu-alg>
           1. Let _precedingArgs_ be ? ArgumentListEvaluation of |ArgumentList|.
           1. Let _spreadRef_ be ? Evaluation of |AssignmentExpression|.
-          1. Let _iteratorRecord_ be ? GetIterator(? GetValue(_spreadRef_)).
+          1. Let _iteratorRecord_ be ? GetIterator(? GetValue(_spreadRef_), ~sync~).
           1. Repeat,
             1. Let _next_ be ? IteratorStep(_iteratorRecord_).
             1. If _next_ is *false*, return _precedingArgs_.
@@ -20541,19 +20540,19 @@
         </emu-alg>
         <emu-grammar>ArrayAssignmentPattern : `[` `]`</emu-grammar>
         <emu-alg>
-          1. Let _iteratorRecord_ be ? GetIterator(_value_).
+          1. Let _iteratorRecord_ be ? GetIterator(_value_, ~sync~).
           1. Return ? IteratorClose(_iteratorRecord_, NormalCompletion(~unused~)).
         </emu-alg>
         <emu-grammar>ArrayAssignmentPattern : `[` Elision `]`</emu-grammar>
         <emu-alg>
-          1. Let _iteratorRecord_ be ? GetIterator(_value_).
+          1. Let _iteratorRecord_ be ? GetIterator(_value_, ~sync~).
           1. Let _result_ be Completion(IteratorDestructuringAssignmentEvaluation of |Elision| with argument _iteratorRecord_).
           1. If _iteratorRecord_.[[Done]] is *false*, return ? IteratorClose(_iteratorRecord_, _result_).
           1. Return _result_.
         </emu-alg>
         <emu-grammar>ArrayAssignmentPattern : `[` Elision? AssignmentRestElement `]`</emu-grammar>
         <emu-alg>
-          1. Let _iteratorRecord_ be ? GetIterator(_value_).
+          1. Let _iteratorRecord_ be ? GetIterator(_value_, ~sync~).
           1. If |Elision| is present, then
             1. Let _status_ be Completion(IteratorDestructuringAssignmentEvaluation of |Elision| with argument _iteratorRecord_).
             1. If _status_ is an abrupt completion, then
@@ -20565,14 +20564,14 @@
         </emu-alg>
         <emu-grammar>ArrayAssignmentPattern : `[` AssignmentElementList `]`</emu-grammar>
         <emu-alg>
-          1. Let _iteratorRecord_ be ? GetIterator(_value_).
+          1. Let _iteratorRecord_ be ? GetIterator(_value_, ~sync~).
           1. Let _result_ be Completion(IteratorDestructuringAssignmentEvaluation of |AssignmentElementList| with argument _iteratorRecord_).
           1. If _iteratorRecord_.[[Done]] is *false*, return ? IteratorClose(_iteratorRecord_, _result_).
           1. Return _result_.
         </emu-alg>
         <emu-grammar>ArrayAssignmentPattern : `[` AssignmentElementList `,` Elision? AssignmentRestElement? `]`</emu-grammar>
         <emu-alg>
-          1. Let _iteratorRecord_ be ? GetIterator(_value_).
+          1. Let _iteratorRecord_ be ? GetIterator(_value_, ~sync~).
           1. Let _status_ be Completion(IteratorDestructuringAssignmentEvaluation of |AssignmentElementList| with argument _iteratorRecord_).
           1. If _status_ is an abrupt completion, then
             1. If _iteratorRecord_.[[Done]] is *false*, return ? IteratorClose(_iteratorRecord_, _status_).
@@ -21903,9 +21902,9 @@
             1. Return the Iterator Record { [[Iterator]]: _iterator_, [[NextMethod]]: _nextMethod_, [[Done]]: *false* }.
           1. Else,
             1. Assert: _iterationKind_ is either ~iterate~ or ~async-iterate~.
-            1. If _iterationKind_ is ~async-iterate~, let _iteratorHint_ be ~async~.
-            1. Else, let _iteratorHint_ be ~sync~.
-            1. Return ? GetIterator(_exprValue_, _iteratorHint_).
+            1. If _iterationKind_ is ~async-iterate~, let _iteratorKind_ be ~async~.
+            1. Else, let _iteratorKind_ be ~sync~.
+            1. Return ? GetIterator(_exprValue_, _iteratorKind_).
         </emu-alg>
       </emu-clause>
 
@@ -40402,7 +40401,7 @@ THH:mm:ss.sss
           <dd>_adder_ will be invoked, with _target_ as the receiver.</dd>
         </dl>
         <emu-alg>
-          1. Let _iteratorRecord_ be ? GetIterator(_iterable_).
+          1. Let _iteratorRecord_ be ? GetIterator(_iterable_, ~sync~).
           1. Repeat,
             1. Let _next_ be ? IteratorStep(_iteratorRecord_).
             1. If _next_ is *false*, return _target_.
@@ -40714,7 +40713,7 @@ THH:mm:ss.sss
           1. If _iterable_ is either *undefined* or *null*, return _set_.
           1. Let _adder_ be ? Get(_set_, *"add"*).
           1. If IsCallable(_adder_) is *false*, throw a *TypeError* exception.
-          1. Let _iteratorRecord_ be ? GetIterator(_iterable_).
+          1. Let _iteratorRecord_ be ? GetIterator(_iterable_, ~sync~).
           1. Repeat,
             1. Let _next_ be ? IteratorStep(_iteratorRecord_).
             1. If _next_ is *false*, return _set_.
@@ -41153,7 +41152,7 @@ THH:mm:ss.sss
           1. If _iterable_ is either *undefined* or *null*, return _set_.
           1. Let _adder_ be ? Get(_set_, *"add"*).
           1. If IsCallable(_adder_) is *false*, throw a *TypeError* exception.
-          1. Let _iteratorRecord_ be ? GetIterator(_iterable_).
+          1. Let _iteratorRecord_ be ? GetIterator(_iterable_, ~sync~).
           1. Repeat,
             1. Let _next_ be ? IteratorStep(_iteratorRecord_).
             1. If _next_ is *false*, return _set_.
@@ -44505,7 +44504,7 @@ THH:mm:ss.sss
           1. Let _promiseCapability_ be ? NewPromiseCapability(_C_).
           1. Let _promiseResolve_ be Completion(GetPromiseResolve(_C_)).
           1. IfAbruptRejectPromise(_promiseResolve_, _promiseCapability_).
-          1. Let _iteratorRecord_ be Completion(GetIterator(_iterable_)).
+          1. Let _iteratorRecord_ be Completion(GetIterator(_iterable_, ~sync~)).
           1. IfAbruptRejectPromise(_iteratorRecord_, _promiseCapability_).
           1. Let _result_ be Completion(PerformPromiseAll(_iteratorRecord_, _C_, _promiseCapability_, _promiseResolve_)).
           1. If _result_ is an abrupt completion, then
@@ -44608,7 +44607,7 @@ THH:mm:ss.sss
           1. Let _promiseCapability_ be ? NewPromiseCapability(_C_).
           1. Let _promiseResolve_ be Completion(GetPromiseResolve(_C_)).
           1. IfAbruptRejectPromise(_promiseResolve_, _promiseCapability_).
-          1. Let _iteratorRecord_ be Completion(GetIterator(_iterable_)).
+          1. Let _iteratorRecord_ be Completion(GetIterator(_iterable_, ~sync~)).
           1. IfAbruptRejectPromise(_iteratorRecord_, _promiseCapability_).
           1. Let _result_ be Completion(PerformPromiseAllSettled(_iteratorRecord_, _C_, _promiseCapability_, _promiseResolve_)).
           1. If _result_ is an abrupt completion, then
@@ -44735,7 +44734,7 @@ THH:mm:ss.sss
           1. Let _promiseCapability_ be ? NewPromiseCapability(_C_).
           1. Let _promiseResolve_ be Completion(GetPromiseResolve(_C_)).
           1. IfAbruptRejectPromise(_promiseResolve_, _promiseCapability_).
-          1. Let _iteratorRecord_ be Completion(GetIterator(_iterable_)).
+          1. Let _iteratorRecord_ be Completion(GetIterator(_iterable_, ~sync~)).
           1. IfAbruptRejectPromise(_iteratorRecord_, _promiseCapability_).
           1. Let _result_ be Completion(PerformPromiseAny(_iteratorRecord_, _C_, _promiseCapability_, _promiseResolve_)).
           1. If _result_ is an abrupt completion, then
@@ -44831,7 +44830,7 @@ THH:mm:ss.sss
           1. Let _promiseCapability_ be ? NewPromiseCapability(_C_).
           1. Let _promiseResolve_ be Completion(GetPromiseResolve(_C_)).
           1. IfAbruptRejectPromise(_promiseResolve_, _promiseCapability_).
-          1. Let _iteratorRecord_ be Completion(GetIterator(_iterable_)).
+          1. Let _iteratorRecord_ be Completion(GetIterator(_iterable_, ~sync~)).
           1. IfAbruptRejectPromise(_iteratorRecord_, _promiseCapability_).
           1. Let _result_ be Completion(PerformPromiseRace(_iteratorRecord_, _C_, _promiseCapability_, _promiseResolve_)).
           1. If _result_ is an abrupt completion, then


### PR DESCRIPTION
I find GetIterator's optional parameters confusing because the hint is ignored when the method is passed. There's also a recursive call that serves no real purpose.

This PR gets rid of the optional parameters and does some refactoring.