### PR TITLE
Normative: Avoid initializing fields twice for instances of base classes without explicit constructors

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -24657,10 +24657,10 @@
               1. Let _func_ be ! _F_.[[GetPrototypeOf]]().
               1. If IsConstructor(_func_) is *false*, throw a *TypeError* exception.
               1. Let _result_ be ? Construct(_func_, _args_, NewTarget).
+              1. Perform ? InitializeInstanceElements(_result_, _F_).
             1. Else,
               1. NOTE: This branch behaves similarly to `constructor() {}`.
               1. Let _result_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Object.prototype%"*).
-            1. Perform ? InitializeInstanceElements(_result_, _F_).
             1. Return _result_.
           1. Let _F_ be CreateBuiltinFunction(_defaultConstructor_, 0, _className_, « [[ConstructorKind]], [[SourceText]] », the current Realm Record, _constructorParent_).
         1. Else,


### PR DESCRIPTION
Closes #3020 
Since both [[Construct]] and the constructor function that the class is (as described in Runtime Semantics: ClassDefinitionEvaluation) initialize the instance fields for base classes with implicit constructor method, and since [[Construct]] does not initialize them for instances of derived classes, but instead super calls do, the step that initializes them in the implicit constructor should only be present for derived classes. This PR fixes this, as discussed in the issue refferenced.