### PR TITLE
Editorial: fix the Unary - Operator's description

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -19633,7 +19633,7 @@
     <emu-clause id="sec-unary-minus-operator">
       <h1>Unary `-` Operator</h1>
       <emu-note>
-        <p>The unary `-` operator converts its operand to Number type and then negates it. Negating *+0*<sub>𝔽</sub> produces *-0*<sub>𝔽</sub>, and negating *-0*<sub>𝔽</sub> produces *+0*<sub>𝔽</sub>.</p>
+        <p>The unary `-` operator converts its operand to a numeric value and then negates it. Negating *+0*<sub>𝔽</sub> produces *-0*<sub>𝔽</sub>, and negating *-0*<sub>𝔽</sub> produces *+0*<sub>𝔽</sub>.</p>
       </emu-note>
 
       <emu-clause id="sec-unary-minus-operator-runtime-semantics-evaluation" type="sdo">


### PR DESCRIPTION
#3024 
change:
    The unary `-` operator converts its operand to Number type and then negates it.
to:
    The unary `-` operator converts its operand to a numeric value and then negates it. 