### PR TITLE
Editorial: Remove incorrect equivalence claim for RegExp constructor

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -36389,7 +36389,7 @@ THH:mm:ss.sss
       <ul>
         <li>is <dfn>%RegExp%</dfn>.</li>
         <li>is the initial value of the *"RegExp"* property of the global object.</li>
-        <li>creates and initializes a new RegExp object when called as a function rather than as a constructor. Thus the function call `RegExp(…)` is equivalent to the object creation expression `new RegExp(…)` with the same arguments.</li>
+        <li>when called as a function, returns either a new RegExp object, or the argument itself if the only argument is a RegExp object.</li>
         <li>may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified RegExp behaviour must include a `super` call to the RegExp constructor to create and initialize subclass instances with the necessary internal slots.</li>
       </ul>
 


### PR DESCRIPTION
`RegExp(…)` is not equivalent to `new RegExp(…)`, because when the argument is an existing `RegExp` object, the former passes through the same object and the latter creates a new one (with e.g. `lastIndex` reset).

Fixes #3028.