### PR TITLE
Editorial: Fix `[[DFSIndex]]` in cyclic module record async evaluation example

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -26972,7 +26972,7 @@
               </tr>
               <tr>
                 <th>_C_</th>
-                <td>2</td>
+                <td>3</td>
                 <td>0</td>
                 <td>~evaluating-async~</td>
                 <td>*true*</td>
@@ -26981,7 +26981,7 @@
               </tr>
               <tr>
                 <th>_D_</th>
-                <td>3</td>
+                <td>2</td>
                 <td>0</td>
                 <td>~evaluating-async~</td>
                 <td>*true*</td>
@@ -27017,7 +27017,7 @@
               </thead>
               <tr>
                 <th>_C_</th>
-                <td>2</td>
+                <td>3</td>
                 <td>0</td>
                 <td>~evaluating-async~</td>
                 <td>*true*</td>
@@ -27062,7 +27062,7 @@
               </tr>
               <tr>
                 <th>_C_</th>
-                <td>2</td>
+                <td>3</td>
                 <td>0</td>
                 <td>~evaluating-async~</td>
                 <td>*true*</td>
@@ -27071,7 +27071,7 @@
               </tr>
               <tr>
                 <th>_D_</th>
-                <td>3</td>
+                <td>2</td>
                 <td>0</td>
                 <td>~evaluated~</td>
                 <td>*true*</td>
@@ -27107,7 +27107,7 @@
               </tr>
               <tr>
                 <th>_C_</th>
-                <td>2</td>
+                <td>3</td>
                 <td>0</td>
                 <td>~evaluated~</td>
                 <td>*true*</td>
@@ -27208,8 +27208,8 @@
               </tr>
               <tr>
                 <th>_C_</th>
-                <td>2</td>
-                <td>1</td>
+                <td>3</td>
+                <td>0</td>
                 <td>~evaluated~</td>
                 <td>*true*</td>
                 <td>« _A_ »</td>


### PR DESCRIPTION
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->

As the textual description of the example suggests, _D_ is visited before _C_ and thus its `[[DFSIndex]]` is lower.

You can test the indexes for various graphs at https://nicolo-ribaudo.github.io/es-module-evaluation/#s=IEEKQiBDCiBEIEUK&c=QSAtPiBCCkEgLT4gQwpCIC0%2BIEQKQyAtPiBECkQgLT4gQQpDIC0%2BIEUK&a=RSBEIEMgQiBB&f=