### PR TITLE
replace an unnecessary GetV with a Get

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -6822,7 +6822,7 @@
       <emu-alg>
         1. Let _iterator_ be ? Call(_method_, _obj_).
         1. If _iterator_ is not an Object, throw a *TypeError* exception.
-        1. Let _nextMethod_ be ? GetV(_iterator_, *"next"*).
+        1. Let _nextMethod_ be ? Get(_iterator_, *"next"*).
         1. Let _iteratorRecord_ be the Iterator Record { [[Iterator]]: _iterator_, [[NextMethod]]: _nextMethod_, [[Done]]: *false* }.
         1. Return _iteratorRecord_.
       </emu-alg>


### PR DESCRIPTION
`GetV` just does a `ToObject`, but we already know `iterator` is an Object due to the check in the previous step.