### PR TITLE
Editorial: Fix notes about explicit setting of "length" in certain Array methods

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -37435,7 +37435,7 @@ THH:mm:ss.sss
         </emu-alg>
         <p>The *"length"* property of this method is *1*<sub>𝔽</sub>.</p>
         <emu-note>
-          <p>The explicit setting of the *"length"* property in step <emu-xref href="#step-array-proto-concat-set-length"></emu-xref> is necessary to ensure that its value is correct in situations where the trailing elements of the result Array are not present.</p>
+          <p>The explicit setting of the *"length"* property in step <emu-xref href="#step-array-proto-concat-set-length"></emu-xref> is intended to ensure the length is correct when the final non-empty element of _items_ has trailing holes or when _A_ is not a built-in Array.</p>
         </emu-note>
         <emu-note>
           <p>This method is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
@@ -38222,7 +38222,7 @@ THH:mm:ss.sss
           1. Return _A_.
         </emu-alg>
         <emu-note>
-          <p>The explicit setting of the *"length"* property of the result Array in step <emu-xref href="#step-array-proto-slice-set-length"></emu-xref> was necessary in previous editions of ECMAScript to ensure that its length was correct in situations where the trailing elements of the result Array were not present. Setting *"length"* became unnecessary starting in ES2015 when the result Array was initialized to its proper length rather than an empty Array but is carried forward to preserve backward compatibility.</p>
+          <p>The explicit setting of the *"length"* property in step <emu-xref href="#step-array-proto-slice-set-length"></emu-xref> is intended to ensure the length is correct even when _A_ is not a built-in Array.</p>
         </emu-note>
         <emu-note>
           <p>This method is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
@@ -38418,7 +38418,7 @@ THH:mm:ss.sss
               1. Let _fromValue_ be ? Get(_O_, _from_).
               1. Perform ? CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_k_)), _fromValue_).
             1. Set _k_ to _k_ + 1.
-          1. Perform ? Set(_A_, *"length"*, 𝔽(_actualDeleteCount_), *true*).
+          1. [id="step-array-proto-splice-set-length"] Perform ? Set(_A_, *"length"*, 𝔽(_actualDeleteCount_), *true*).
           1. If _itemCount_ &lt; _actualDeleteCount_, then
             1. Set _k_ to _actualStart_.
             1. Repeat, while _k_ &lt; (_len_ - _actualDeleteCount_),
@@ -38449,11 +38449,11 @@ THH:mm:ss.sss
           1. For each element _E_ of _items_, do
             1. Perform ? Set(_O_, ! ToString(𝔽(_k_)), _E_, *true*).
             1. Set _k_ to _k_ + 1.
-          1. [id="step-array-proto-splice-set-length"] Perform ? Set(_O_, *"length"*, 𝔽(_len_ - _actualDeleteCount_ + _itemCount_), *true*).
+          1. [id="step-array-proto-splice-set-length-2"] Perform ? Set(_O_, *"length"*, 𝔽(_len_ - _actualDeleteCount_ + _itemCount_), *true*).
           1. Return _A_.
         </emu-alg>
         <emu-note>
-          <p>The explicit setting of the *"length"* property of the result Array in step <emu-xref href="#step-array-proto-splice-set-length"></emu-xref> was necessary in previous editions of ECMAScript to ensure that its length was correct in situations where the trailing elements of the result Array were not present. Setting *"length"* became unnecessary starting in ES2015 when the result Array was initialized to its proper length rather than an empty Array but is carried forward to preserve backward compatibility.</p>
+          <p>The explicit setting of the *"length"* property in steps <emu-xref href="#step-array-proto-splice-set-length"></emu-xref> and <emu-xref href="#step-array-proto-splice-set-length-2"></emu-xref> is intended to ensure the lengths are correct even when the objects are not built-in Arrays.</p>
         </emu-note>
         <emu-note>
           <p>This method is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>


### PR DESCRIPTION
Fixes #3036. Closes #1277.

There's other places where such a note could be warranted (e.g. in `push`) but I'm not adding new notes in this PR.