### PR TITLE
Editorial: Avoid preceding a multi-step Else with a collapsed single-step If

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -6514,10 +6514,12 @@
           1. If _key_ is a String, then
             1. Let _desc_ be ? <emu-meta effects="user-code">_O_.[[GetOwnProperty]]</emu-meta>(_key_).
             1. If _desc_ is not *undefined* and _desc_.[[Enumerable]] is *true*, then
-              1. If _kind_ is ~key~, append _key_ to _results_.
+              1. If _kind_ is ~key~, then
+                1. Append _key_ to _results_.
               1. Else,
                 1. Let _value_ be ? Get(_O_, _key_).
-                1. If _kind_ is ~value~, append _value_ to _results_.
+                1. If _kind_ is ~value~, then
+                  1. Append _value_ to _results_.
                 1. Else,
                   1. Assert: _kind_ is ~key+value~.
                   1. Let _entry_ be CreateArrayFromList(« _key_, _value_ »).
@@ -9479,7 +9481,8 @@
           1. Let _next_ be Completion(IteratorStep(_iteratorRecord_)).
           1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
           1. ReturnIfAbrupt(_next_).
-          1. If _next_ is *false*, set _iteratorRecord_.[[Done]] to *true*.
+          1. If _next_ is *false*, then
+            1. Set _iteratorRecord_.[[Done]] to *true*.
           1. Else,
             1. Set _v_ to Completion(IteratorValue(_next_)).
             1. If _v_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
@@ -9500,7 +9503,8 @@
           1. Let _next_ be Completion(IteratorStep(_iteratorRecord_)).
           1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
           1. ReturnIfAbrupt(_next_).
-          1. If _next_ is *false*, set _iteratorRecord_.[[Done]] to *true*.
+          1. If _next_ is *false*, then
+            1. Set _iteratorRecord_.[[Done]] to *true*.
           1. Else,
             1. Set _v_ to Completion(IteratorValue(_next_)).
             1. If _v_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
@@ -9569,7 +9573,8 @@
         1. Let _next_ be Completion(IteratorStep(_iteratorRecord_)).
         1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
         1. ReturnIfAbrupt(_next_).
-        1. If _next_ is *false*, set _iteratorRecord_.[[Done]] to *true*.
+        1. If _next_ is *false*, then
+          1. Set _iteratorRecord_.[[Done]] to *true*.
         1. Else,
           1. Set _v_ to Completion(IteratorValue(_next_)).
           1. If _v_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
@@ -9590,7 +9595,8 @@
         1. Let _next_ be Completion(IteratorStep(_iteratorRecord_)).
         1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
         1. ReturnIfAbrupt(_next_).
-        1. If _next_ is *false*, set _iteratorRecord_.[[Done]] to *true*.
+        1. If _next_ is *false*, then
+          1. Set _iteratorRecord_.[[Done]] to *true*.
         1. Else,
           1. Set _v_ to Completion(IteratorValue(_next_)).
           1. If _v_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
@@ -13172,7 +13178,8 @@
           1. If _thisMode_ is ~lexical~, return ~unused~.
           1. Let _calleeRealm_ be _F_.[[Realm]].
           1. Let _localEnv_ be the LexicalEnvironment of _calleeContext_.
-          1. If _thisMode_ is ~strict~, let _thisValue_ be _thisArgument_.
+          1. If _thisMode_ is ~strict~, then
+            1. Let _thisValue_ be _thisArgument_.
           1. Else,
             1. If _thisArgument_ is either *undefined* or *null*, then
               1. Let _globalEnv_ be _calleeRealm_.[[GlobalEnv]].
@@ -13617,7 +13624,8 @@
             1. If _instantiatedVarNames_ does not contain _n_, then
               1. Append _n_ to _instantiatedVarNames_.
               1. Perform ! _varEnv_.CreateMutableBinding(_n_, *false*).
-              1. If _parameterBindings_ does not contain _n_, or if _functionNames_ contains _n_, let _initialValue_ be *undefined*.
+              1. If _parameterBindings_ does not contain _n_, or if _functionNames_ contains _n_, then
+                1. Let _initialValue_ be *undefined*.
               1. Else,
                 1. Let _initialValue_ be ! _env_.GetBindingValue(_n_, *false*).
               1. Perform ! _varEnv_.InitializeBinding(_n_, _initialValue_).
@@ -13995,7 +14003,8 @@
           1. If _newLen_ ≥ _oldLen_, then
             1. Return ! OrdinaryDefineOwnProperty(_A_, *"length"*, _newLenDesc_).
           1. If _oldLenDesc_.[[Writable]] is *false*, return *false*.
-          1. If _newLenDesc_ does not have a [[Writable]] field or _newLenDesc_.[[Writable]] is *true*, let _newWritable_ be *true*.
+          1. If _newLenDesc_ does not have a [[Writable]] field or _newLenDesc_.[[Writable]] is *true*, then
+            1. Let _newWritable_ be *true*.
           1. Else,
             1. NOTE: Setting the [[Writable]] attribute to *false* is deferred in case any elements cannot be deleted.
             1. Let _newWritable_ be *false*.
@@ -18936,7 +18945,8 @@
           <emu-alg>
             1. Let _ref_ be ? Evaluation of _constructExpr_.
             1. Let _constructor_ be ? GetValue(_ref_).
-            1. If _arguments_ is ~empty~, let _argList_ be a new empty List.
+            1. If _arguments_ is ~empty~, then
+              1. Let _argList_ be a new empty List.
             1. Else,
               1. Let _argList_ be ? ArgumentListEvaluation of _arguments_.
             1. If IsConstructor(_constructor_) is *false*, throw a *TypeError* exception.
@@ -20709,7 +20719,8 @@
             1. Let _next_ be Completion(IteratorStep(_iteratorRecord_)).
             1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
             1. ReturnIfAbrupt(_next_).
-            1. If _next_ is *false*, set _iteratorRecord_.[[Done]] to *true*.
+            1. If _next_ is *false*, then
+              1. Set _iteratorRecord_.[[Done]] to *true*.
             1. Else,
               1. Let _value_ be Completion(IteratorValue(_next_)).
               1. If _value_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
@@ -20740,7 +20751,8 @@
             1. Let _next_ be Completion(IteratorStep(_iteratorRecord_)).
             1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
             1. ReturnIfAbrupt(_next_).
-            1. If _next_ is *false*, set _iteratorRecord_.[[Done]] to *true*.
+            1. If _next_ is *false*, then
+              1. Set _iteratorRecord_.[[Done]] to *true*.
             1. Else,
               1. Let _nextValue_ be Completion(IteratorValue(_next_)).
               1. If _nextValue_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
@@ -27705,7 +27717,8 @@
               1. If _resolution_ is ~ambiguous~, return ~ambiguous~.
               1. If _resolution_ is not *null*, then
                 1. Assert: _resolution_ is a ResolvedBinding Record.
-                1. If _starResolution_ is *null*, set _starResolution_ to _resolution_.
+                1. If _starResolution_ is *null*, then
+                  1. Set _starResolution_ to _resolution_.
                 1. Else,
                   1. Assert: There is more than one `*` import that includes the requested name.
                   1. If _resolution_.[[Module]] and _starResolution_.[[Module]] are not the same Module Record, return ~ambiguous~.
@@ -31095,7 +31108,8 @@
             1. Let _c_ be *"+"*.
             1. Let _d_ be *"0"*.
           1. Else,
-            1. If _e_ > 0, let _c_ be *"+"*.
+            1. If _e_ > 0, then
+              1. Let _c_ be *"+"*.
             1. Else,
               1. Assert: _e_ &lt; 0.
               1. Let _c_ be *"-"*.
@@ -32732,7 +32746,8 @@ THH:mm:ss.sss
             1. If _numberOfArgs_ > 4, let _min_ be ? ToNumber(_values_[4]); else let _min_ be *+0*<sub>𝔽</sub>.
             1. If _numberOfArgs_ > 5, let _s_ be ? ToNumber(_values_[5]); else let _s_ be *+0*<sub>𝔽</sub>.
             1. If _numberOfArgs_ > 6, let _milli_ be ? ToNumber(_values_[6]); else let _milli_ be *+0*<sub>𝔽</sub>.
-            1. If _y_ is *NaN*, let _yr_ be *NaN*.
+            1. If _y_ is *NaN*, then
+              1. Let _yr_ be *NaN*.
             1. Else,
               1. Let _yi_ be ! ToIntegerOrInfinity(_y_).
               1. If 0 ≤ _yi_ ≤ 99, let _yr_ be *1900*<sub>𝔽</sub> + 𝔽(_yi_); otherwise, let _yr_ be _y_.
@@ -32793,7 +32808,8 @@ THH:mm:ss.sss
           1. If _minutes_ is present, let _min_ be ? ToNumber(_minutes_); else let _min_ be *+0*<sub>𝔽</sub>.
           1. If _seconds_ is present, let _s_ be ? ToNumber(_seconds_); else let _s_ be *+0*<sub>𝔽</sub>.
           1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_); else let _milli_ be *+0*<sub>𝔽</sub>.
-          1. If _y_ is *NaN*, let _yr_ be *NaN*.
+          1. If _y_ is *NaN*, then
+            1. Let _yr_ be *NaN*.
           1. Else,
             1. Let _yi_ be ! ToIntegerOrInfinity(_y_).
             1. If 0 ≤ _yi_ ≤ 99, let _yr_ be *1900*<sub>𝔽</sub> + 𝔽(_yi_); otherwise, let _yr_ be _y_.
@@ -33703,7 +33719,8 @@ THH:mm:ss.sss
         <h1>String ( _value_ )</h1>
         <p>This function performs the following steps when called:</p>
         <emu-alg>
-          1. If _value_ is not present, let _s_ be the empty String.
+          1. If _value_ is not present, then
+            1. Let _s_ be the empty String.
           1. Else,
             1. If NewTarget is *undefined* and _value_ is a Symbol, return SymbolDescriptiveString(_value_).
             1. Let _s_ be ? ToString(_value_).
@@ -36653,10 +36670,12 @@ THH:mm:ss.sss
           1. Let _done_ be *false*.
           1. Repeat, while _done_ is *false*,
             1. Let _result_ be ? RegExpExec(_rx_, _S_).
-            1. If _result_ is *null*, set _done_ to *true*.
+            1. If _result_ is *null*, then
+              1. Set _done_ to *true*.
             1. Else,
               1. Append _result_ to _results_.
-              1. If _global_ is *false*, set _done_ to *true*.
+              1. If _global_ is *false*, then
+                1. Set _done_ to *true*.
               1. Else,
                 1. Let _matchStr_ be ? ToString(? Get(_result_, *"0"*)).
                 1. If _matchStr_ is the empty String, then
@@ -36796,11 +36815,13 @@ THH:mm:ss.sss
           1. Repeat, while _q_ &lt; _size_,
             1. Perform ? Set(_splitter_, *"lastIndex"*, 𝔽(_q_), *true*).
             1. Let _z_ be ? RegExpExec(_splitter_, _S_).
-            1. If _z_ is *null*, set _q_ to AdvanceStringIndex(_S_, _q_, _unicodeMatching_).
+            1. If _z_ is *null*, then
+              1. Set _q_ to AdvanceStringIndex(_S_, _q_, _unicodeMatching_).
             1. Else,
               1. Let _e_ be ℝ(? ToLength(? Get(_splitter_, *"lastIndex"*))).
               1. Set _e_ to min(_e_, _size_).
-              1. If _e_ = _p_, set _q_ to AdvanceStringIndex(_S_, _q_, _unicodeMatching_).
+              1. If _e_ = _p_, then
+                1. Set _q_ to AdvanceStringIndex(_S_, _q_, _unicodeMatching_).
               1. Else,
                 1. Let _T_ be the substring of _S_ from _p_ to _q_.
                 1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_lengthA_)), _T_).
@@ -37269,7 +37290,8 @@ THH:mm:ss.sss
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _C_ be the *this* value.
-          1. If _mapfn_ is *undefined*, let _mapping_ be *false*.
+          1. If _mapfn_ is *undefined*, then
+            1. Let _mapping_ be *false*.
           1. Else,
             1. If IsCallable(_mapfn_) is *false*, throw a *TypeError* exception.
             1. Let _mapping_ be *true*.
@@ -38728,11 +38750,13 @@ THH:mm:ss.sss
               1. Else,
                 1. Let _len_ be ? LengthOfArrayLike(_array_).
               1. If _index_ ≥ _len_, return NormalCompletion(*undefined*).
-              1. If _kind_ is ~key~, perform ? GeneratorYield(CreateIterResultObject(𝔽(_index_), *false*)).
+              1. If _kind_ is ~key~, then
+                1. Perform ? GeneratorYield(CreateIterResultObject(𝔽(_index_), *false*)).
               1. Else,
                 1. Let _elementKey_ be ! ToString(𝔽(_index_)).
                 1. Let _elementValue_ be ? Get(_array_, _elementKey_).
-                1. If _kind_ is ~value~, perform ? GeneratorYield(CreateIterResultObject(_elementValue_, *false*)).
+                1. If _kind_ is ~value~, then
+                  1. Perform ? GeneratorYield(CreateIterResultObject(_elementValue_, *false*)).
                 1. Else,
                   1. Assert: _kind_ is ~key+value~.
                   1. Let _result_ be CreateArrayFromList(« 𝔽(_index_), _elementValue_ »).
@@ -39026,7 +39050,8 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _C_ be the *this* value.
           1. If IsConstructor(_C_) is *false*, throw a *TypeError* exception.
-          1. If _mapfn_ is *undefined*, let _mapping_ be *false*.
+          1. If _mapfn_ is *undefined*, then
+            1. Let _mapping_ be *false*.
           1. Else,
             1. If IsCallable(_mapfn_) is *false*, throw a *TypeError* exception.
             1. Let _mapping_ be *true*.
@@ -42790,7 +42815,8 @@ THH:mm:ss.sss
       <emu-alg>
         1. Let _buffer_ be ? ValidateIntegerTypedArray(_typedArray_, *true*).
         1. Let _indexedPosition_ be ? ValidateAtomicAccess(_typedArray_, _index_).
-        1. If _count_ is *undefined*, let _c_ be +∞.
+        1. If _count_ is *undefined*, then
+          1. Let _c_ be +∞.
         1. Else,
           1. Let _intCount_ be ? ToIntegerOrInfinity(_count_).
           1. Let _c_ be max(_intCount_, 0).
@@ -44409,7 +44435,8 @@ THH:mm:ss.sss
             1. Let _type_ be _reaction_.[[Type]].
             1. Let _handler_ be _reaction_.[[Handler]].
             1. If _handler_ is ~empty~, then
-              1. If _type_ is ~Fulfill~, let _handlerResult_ be NormalCompletion(_argument_).
+              1. If _type_ is ~Fulfill~, then
+                1. Let _handlerResult_ be NormalCompletion(_argument_).
               1. Else,
                 1. Assert: _type_ is ~Reject~.
                 1. Let _handlerResult_ be ThrowCompletion(_argument_).


### PR DESCRIPTION
We have a few cases of algorithms with steps like
```
1. …
1. If <condition>, <simple consequent>.
1. Else,
  1. <alternative step 1>.
  1. …
1. …
```
This makes it unnecessarily difficult to track expected behavior, especially when skimming, and I think the spec should have a convention (ultimately codified as a lint rule) to avoid mixing collapsed an non-collapsed steps at the same level of an If–Else construct.

The first commit of this PR replaces violations of that convention, and ~~later commits (removable upon request)~~ PRs #3044, #3045, and #3046 apply simplifications in the neighborhood of its changes.