### PR TITLE
Editorial: Simplify CreateArrayIterator

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -38827,17 +38827,18 @@ THH:mm:ss.sss
               1. Else,
                 1. Let _len_ be ? LengthOfArrayLike(_array_).
               1. If _index_ ≥ _len_, return NormalCompletion(*undefined*).
+              1. Let _indexNumber_ be 𝔽(_index_).
               1. If _kind_ is ~key~, then
-                1. Perform ? GeneratorYield(CreateIterResultObject(𝔽(_index_), *false*)).
+                1. Let _result_ be _indexNumber_.
               1. Else,
-                1. Let _elementKey_ be ! ToString(𝔽(_index_)).
+                1. Let _elementKey_ be ! ToString(_indexNumber_).
                 1. Let _elementValue_ be ? Get(_array_, _elementKey_).
                 1. If _kind_ is ~value~, then
-                  1. Perform ? GeneratorYield(CreateIterResultObject(_elementValue_, *false*)).
+                  1. Let _result_ be _elementValue_.
                 1. Else,
                   1. Assert: _kind_ is ~key+value~.
-                  1. Let _result_ be CreateArrayFromList(« 𝔽(_index_), _elementValue_ »).
-                  1. Perform ? GeneratorYield(CreateIterResultObject(_result_, *false*)).
+                  1. Let _result_ be CreateArrayFromList(« _indexNumber_, _elementValue_ »).
+              1. Perform ? GeneratorYield(CreateIterResultObject(_result_, *false*)).
               1. Set _index_ to _index_ + 1.
           1. Return CreateIteratorFromClosure(_closure_, *"%ArrayIteratorPrototype%"*, %ArrayIteratorPrototype%).
         </emu-alg>


### PR DESCRIPTION
Extends #3043 to simplify CreateArrayIterator by combining GeneratorYield steps and adding an alias to avoid repeating `𝔽(_index_)`.