### PR TITLE
Editorial: Simplify Date(…) and Date.UTC(…)

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -32403,6 +32403,7 @@
           </dd>
         </dl>
         <emu-alg>
+          1. If _t_ is not finite, return *NaN*.
           1. Let _systemTimeZoneIdentifier_ be SystemTimeZoneIdentifier().
           1. If IsTimeZoneOffsetString(_systemTimeZoneIdentifier_) is *true*, then
             1. Let _offsetNs_ be ParseTimeZoneOffsetString(_systemTimeZoneIdentifier_).
@@ -32523,6 +32524,24 @@
           1. Let _tv_ be _day_ × msPerDay + _time_.
           1. If _tv_ is not finite, return *NaN*.
           1. Return _tv_.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-makefullyear" type="abstract operation">
+        <h1>
+          MakeFullYear (
+            _year_: a Number,
+          ): an integral Number or *NaN*
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It returns the full year associated with the integer part of _year_, interpreting any value in the inclusive interval from 0 to 99 as a count of years since the start of 1900. For alignment with the proleptic Gregorian calendar, "full year" is defined as the signed count of complete years since the start of year 0 (1 B.C.).</dd>
+        </dl>
+        <emu-alg>
+          1. If _year_ is *NaN*, return *NaN*.
+          1. Let _truncated_ be ! ToIntegerOrInfinity(_year_).
+          1. If _truncated_ is in the inclusive interval from 0 to 99, return *1900*<sub>𝔽</sub> + 𝔽(_truncated_).
+          1. Return 𝔽(_truncated_).
         </emu-alg>
       </emu-clause>
 
@@ -32904,11 +32923,7 @@ THH:mm:ss.sss
             1. If _numberOfArgs_ > 4, let _min_ be ? ToNumber(_values_[4]); else let _min_ be *+0*<sub>𝔽</sub>.
             1. If _numberOfArgs_ > 5, let _s_ be ? ToNumber(_values_[5]); else let _s_ be *+0*<sub>𝔽</sub>.
             1. If _numberOfArgs_ > 6, let _milli_ be ? ToNumber(_values_[6]); else let _milli_ be *+0*<sub>𝔽</sub>.
-            1. If _y_ is *NaN*, then
-              1. Let _yr_ be *NaN*.
-            1. Else,
-              1. Let _yi_ be ! ToIntegerOrInfinity(_y_).
-              1. If 0 ≤ _yi_ ≤ 99, let _yr_ be *1900*<sub>𝔽</sub> + 𝔽(_yi_); otherwise, let _yr_ be _y_.
+            1. Let _yr_ be MakeFullYear(_y_).
             1. Let _finalDate_ be MakeDate(MakeDay(_yr_, _m_, _dt_), MakeTime(_h_, _min_, _s_, _milli_)).
             1. Let _dv_ be TimeClip(UTC(_finalDate_)).
           1. Let _O_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Date.prototype%"*, « [[DateValue]] »).
@@ -32966,11 +32981,7 @@ THH:mm:ss.sss
           1. If _minutes_ is present, let _min_ be ? ToNumber(_minutes_); else let _min_ be *+0*<sub>𝔽</sub>.
           1. If _seconds_ is present, let _s_ be ? ToNumber(_seconds_); else let _s_ be *+0*<sub>𝔽</sub>.
           1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_); else let _milli_ be *+0*<sub>𝔽</sub>.
-          1. If _y_ is *NaN*, then
-            1. Let _yr_ be *NaN*.
-          1. Else,
-            1. Let _yi_ be ! ToIntegerOrInfinity(_y_).
-            1. If 0 ≤ _yi_ ≤ 99, let _yr_ be *1900*<sub>𝔽</sub> + 𝔽(_yi_); otherwise, let _yr_ be _y_.
+          1. Let _yr_ be MakeFullYear(_y_).
           1. Return TimeClip(MakeDate(MakeDay(_yr_, _m_, _dt_), MakeTime(_h_, _min_, _s_, _milli_))).
         </emu-alg>
         <p>The *"length"* property of this function is *7*<sub>𝔽</sub>.</p>
@@ -48711,16 +48722,12 @@ THH:mm:ss.sss
           1. Let _t_ be ? thisTimeValue(*this* value).
           1. Let _y_ be ? ToNumber(_year_).
           1. If _t_ is *NaN*, set _t_ to *+0*<sub>𝔽</sub>; otherwise, set _t_ to LocalTime(_t_).
-          1. If _y_ is *NaN*, then
-            1. Set the [[DateValue]] internal slot of this Date object to *NaN*.
-            1. Return *NaN*.
-          1. Let _yi_ be ! ToIntegerOrInfinity(_y_).
-          1. If 0 ≤ _yi_ ≤ 99, let _yyyy_ be *1900*<sub>𝔽</sub> + 𝔽(_yi_).
-          1. Else, let _yyyy_ be _y_.
+          1. Let _yyyy_ be MakeFullYear(_y_).
           1. Let _d_ be MakeDay(_yyyy_, MonthFromTime(_t_), DateFromTime(_t_)).
-          1. Let _date_ be UTC(MakeDate(_d_, TimeWithinDay(_t_))).
-          1. Set the [[DateValue]] internal slot of this Date object to TimeClip(_date_).
-          1. Return the value of the [[DateValue]] internal slot of this Date object.
+          1. Let _date_ be MakeDate(_d_, TimeWithinDay(_t_)).
+          1. Let _u_ be TimeClip(UTC(_date_)).
+          1. Set the [[DateValue]] internal slot of this Date object to _u_.
+          1. Return _u_.
         </emu-alg>
       </emu-annex>
 


### PR DESCRIPTION
Extends #3043 to simplify `Date(…)` and `Date.UTC(…)` by combining common steps for handling years between 0 and 99 into a new MakeFullYear operation.