### PR TITLE
Editorial: String.prototype.normalize references the Unicode Standard instead of Annex 15

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -34157,7 +34157,7 @@ THH:mm:ss.sss
           1. If _form_ is *undefined*, let _f_ be *"NFC"*.
           1. Else, let _f_ be ? ToString(_form_).
           1. If _f_ is not one of *"NFC"*, *"NFD"*, *"NFKC"*, or *"NFKD"*, throw a *RangeError* exception.
-          1. Let _ns_ be the String value that is the result of normalizing _S_ into the normalization form named by _f_ as specified in <a href="https://unicode.org/reports/tr15/">https://unicode.org/reports/tr15/</a>.
+          1. Let _ns_ be the String value that is the result of normalizing _S_ into the normalization form named by _f_ as specified in <a href="https://www.unicode.org/versions/latest/ch03.pdf">the latest Unicode Standard, Normalization Forms</a>.
           1. Return _ns_.
         </emu-alg>
         <emu-note>


### PR DESCRIPTION
Changed the reference [String.prototype.normalize](https://tc39.es/ecma262/#sec-string.prototype.normalize) is using as per https://github.com/tc39/ecma262/issues/912

Please let me know if any further changes are needed, thanks!

![image](https://user-images.githubusercontent.com/13694167/235085150-21e59e96-1417-4886-b7ff-7a295e6a9ffe.png)
