### PR TITLE
Normative: Disallow ArrayBuffers bigger than 2**53

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -4507,6 +4507,7 @@
         <dl class="header">
         </dl>
         <emu-alg>
+          1. If _size_ > 2<sup>53</sup> - 1, throw a *RangeError* exception.
           1. Let _db_ be a new Data Block value consisting of _size_ bytes. If it is impossible to create such a Data Block, throw a *RangeError* exception.
           1. Set all of the bytes of _db_ to 0.
           1. Return _db_.


### PR DESCRIPTION
Added an additional step to check if `size` is bigger than `2**53` as per https://github.com/tc39/ecma262/issues/1032

I could create a `test262` PR once the edit is approved.
Please let me know if any further changes are needed, thanks!