### PR TITLE
Editorial: add mention that RegExp is constructible

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -37165,7 +37165,8 @@ THH:mm:ss.sss
       <ul>
         <li>is <dfn>%RegExp%</dfn>.</li>
         <li>is the initial value of the *"RegExp"* property of the global object.</li>
-        <li>when called as a function, returns either a new RegExp object, or the argument itself if the only argument is a RegExp object.</li>
+        <li>creates and initializes a new RegExp object when called as a constructor.</li>
+        <li>when called as a function rather than as a constructor, returns either a new RegExp object, or the argument itself if the only argument is a RegExp object.</li>
         <li>may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified RegExp behaviour must include a `super` call to the RegExp constructor to create and initialize subclass instances with the necessary internal slots.</li>
       </ul>
 


### PR DESCRIPTION
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->

After https://github.com/tc39/ecma262/pull/3029, there's no mention that `RegExp` is constructible any more. This PR aligns the text with the other similar methods.

Note that ideally it should put "when called as a function rather than as a constructor" at the end of the sentence, but that makes the structure too awkward, so I have to do it this way.
