### PR TITLE
Normative: Add Import Attributes

### DIFF
--- a/esmeta-ignore.json
+++ b/esmeta-ignore.json
@@ -4,9 +4,14 @@
   "ClassStaticBlockBody[0,0].EvaluateClassStaticBlockBody",
   "CompareTypedArrayElements",
   "DoWait",
+  "EvaluateImportCall",
+  "FinishLoadingImportedModule",
   "FunctionBody[0,0].EvaluateFunctionBody",
   "GetViewByteLength",
   "INTRINSICS.Atomics.notify",
   "Record[SourceTextModuleRecord].ExecuteModule",
+  "Record[SourceTextModuleRecord].GetExportedNames",
+  "Record[SourceTextModuleRecord].InitializeEnvironment",
+  "Record[SourceTextModuleRecord].ResolveExport",
   "TypedArrayLength"
 ]

--- a/spec.html
+++ b/spec.html
@@ -7506,11 +7506,11 @@
         1. Let _head_ be the |AsyncArrowHead| that is covered by |CoverCallExpressionAndAsyncArrowHead|.
         1. Return the BoundNames of _head_.
       </emu-alg>
-      <emu-grammar>ImportDeclaration : `import` ImportClause FromClause `;`</emu-grammar>
+      <emu-grammar>ImportDeclaration : `import` ImportClause FromClause WithClause? `;`</emu-grammar>
       <emu-alg>
         1. Return the BoundNames of |ImportClause|.
       </emu-alg>
-      <emu-grammar>ImportDeclaration : `import` ModuleSpecifier `;`</emu-grammar>
+      <emu-grammar>ImportDeclaration : `import` ModuleSpecifier WithClause? `;`</emu-grammar>
       <emu-alg>
         1. Return a new empty List.
       </emu-alg>
@@ -7542,7 +7542,7 @@
       </emu-alg>
       <emu-grammar>
         ExportDeclaration :
-          `export` ExportFromClause FromClause `;`
+          `export` ExportFromClause FromClause WithClause? `;`
           `export` NamedExports `;`
       </emu-grammar>
       <emu-alg>
@@ -7900,7 +7900,7 @@
       </emu-alg>
       <emu-grammar>
         ExportDeclaration :
-          `export` ExportFromClause FromClause `;`
+          `export` ExportFromClause FromClause WithClause? `;`
           `export` NamedExports `;`
           `export` VariableStatement
       </emu-grammar>
@@ -10003,11 +10003,19 @@
       <emu-alg>
         1. Return the PropName of |PropertyName|.
       </emu-alg>
-      <emu-grammar>LiteralPropertyName : IdentifierName</emu-grammar>
+      <emu-grammar>
+        LiteralPropertyName : IdentifierName
+
+        AttributeKey : IdentifierName
+      </emu-grammar>
       <emu-alg>
         1. Return the StringValue of |IdentifierName|.
       </emu-alg>
-      <emu-grammar>LiteralPropertyName : StringLiteral</emu-grammar>
+      <emu-grammar>
+        LiteralPropertyName : StringLiteral
+
+        AttributeKey : StringLiteral
+      </emu-grammar>
       <emu-alg>
         1. Return the SV of |StringLiteral|.
       </emu-alg>
@@ -11659,10 +11667,10 @@
             [[LoadedModules]]
           </td>
           <td>
-            a List of Records with fields [[Specifier]] (a String) and [[Module]] (a Module Record)
+            a List of LoadedModuleRequest Records
           </td>
           <td>
-            <p>A map from the specifier strings imported by this realm to the resolved Module Record. The list does not contain two different Records with the same [[Specifier]].</p>
+            <p>A map from the specifier strings imported by this realm to the resolved Module Record. The list does not contain two different Records _r1_ and _r2_ such that ModuleRequestsEqual(_r1_, _r2_) is *true*.</p>
             <emu-note>
               As mentioned in HostLoadImportedModule (<emu-xref href="#note-HostLoadImportedModule-referrer-Realm-Record"></emu-xref>), [[LoadedModules]] in Realm Records is only used when running an `import()` expression in a context where there is no active script or module.
             </emu-note>
@@ -19070,7 +19078,8 @@
         `super` Arguments[?Yield, ?Await]
 
       ImportCall[Yield, Await] :
-        `import` `(` AssignmentExpression[+In, ?Yield, ?Await] `)`
+        `import` `(` AssignmentExpression[+In, ?Yield, ?Await] `,`? `)`
+        `import` `(` AssignmentExpression[+In, ?Yield, ?Await] `,` AssignmentExpression[+In, ?Yield, ?Await] `,`? `)`
 
       Arguments[Yield, Await] :
         `(` `)`
@@ -19631,58 +19640,108 @@
       <emu-clause id="sec-import-call-runtime-semantics-evaluation" type="sdo">
         <h1>Runtime Semantics: Evaluation</h1>
 
-        <emu-grammar>ImportCall : `import` `(` AssignmentExpression `)`</emu-grammar>
+        <emu-grammar>ImportCall : `import` `(` AssignmentExpression `,`? `)`</emu-grammar>
+        <emu-alg>
+          1. Return ? EvaluateImportCall(|AssignmentExpression|).
+        </emu-alg>
+
+        <emu-grammar>ImportCall : `import` `(` AssignmentExpression `,` AssignmentExpression `,`? `)`</emu-grammar>
+        <emu-alg>
+          1. Return ? EvaluateImportCall(the first |AssignmentExpression|, the second |AssignmentExpression|).
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-evaluate-import-call" type="abstract operation">
+        <h1>
+          EvaluateImportCall (
+            _specifierExpression_: a Parse Node,
+            optional _optionsExpression_: a Parse Node,
+          ): either a normal completion containing a Promise or an abrupt completion
+        </h1>
+        <dl class="header">
+        </dl>
         <emu-alg>
           1. Let _referrer_ be GetActiveScriptOrModule().
           1. If _referrer_ is *null*, set _referrer_ to the current Realm Record.
-          1. Let _argRef_ be ? Evaluation of |AssignmentExpression|.
-          1. Let _specifier_ be ? GetValue(_argRef_).
+          1. Let _specifierRef_ be ? Evaluation of _specifierExpression_.
+          1. Let _specifier_ be ? GetValue(_specifierRef_).
+          1. If _optionsExpression_ is present, then
+            1. Let _optionsRef_ be ? Evaluation of _optionsExpression_.
+            1. Let _options_ be ? GetValue(_optionsRef_).
+          1. Else,
+            1. Let _options_ be *undefined*.
           1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
           1. Let _specifierString_ be Completion(ToString(_specifier_)).
           1. IfAbruptRejectPromise(_specifierString_, _promiseCapability_).
-          1. Perform HostLoadImportedModule(_referrer_, _specifierString_, ~empty~, _promiseCapability_).
+          1. Let _attributes_ be a new empty List.
+          1. If _options_ is not *undefined*, then
+            1. If _options_ is not an Object, then
+              1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, « a newly created *TypeError* object »).
+              1. Return _promiseCapability_.[[Promise]].
+            1. Let _attributesObj_ be Completion(Get(_options_, *"with"*)).
+            1. IfAbruptRejectPromise(_attributesObj_, _promiseCapability_).
+            1. If _attributesObj_ is not *undefined*, then
+              1. If _attributesObj_ is not an Object, then
+                1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, « a newly created *TypeError* object »).
+                1. Return _promiseCapability_.[[Promise]].
+              1. Let _entries_ be Completion(EnumerableOwnProperties(_attributesObj_, ~key+value~)).
+              1. IfAbruptRejectPromise(_entries_, _promiseCapability_).
+              1. For each element _entry_ of _entries_, do
+                1. Let _key_ be ! Get(_entry_, *"0"*).
+                1. Let _value_ be ! Get(_entry_, *"1"*).
+                1. If _key_ is a String, then
+                  1. If _value_ is not a String, then
+                    1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, « a newly created *TypeError* object »).
+                    1. Return _promiseCapability_.[[Promise]].
+                  1. Append the ImportAttribute Record { [[Key]]: _key_, [[Value]]: _value_ } to _attributes_.
+            1. If AllImportAttributesSupported(_attributes_) is *false*, then
+              1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, « a newly created *TypeError* object »).
+              1. Return _promiseCapability_.[[Promise]].
+            1. Sort _attributes_ according to the lexicographic order of their [[Key]] field, treating the value of each such field as a sequence of UTF-16 code unit values. NOTE: This sorting is observable only in that hosts are prohibited from changing behaviour based on the order in which attributes are enumerated.
+          1. Let _moduleRequest_ be a new ModuleRequest Record { [[Specifier]]: _specifierString_, [[Attributes]]: _attributes_ }.
+          1. Perform HostLoadImportedModule(_referrer_, _moduleRequest_, ~empty~, _promiseCapability_).
           1. Return _promiseCapability_.[[Promise]].
         </emu-alg>
+      </emu-clause>
 
-        <emu-clause id="sec-ContinueDynamicImport" type="abstract operation">
-          <h1>
-            ContinueDynamicImport (
-              _promiseCapability_: a PromiseCapability Record,
-              _moduleCompletion_: either a normal completion containing a Module Record or a throw completion,
-            ): ~unused~
-          </h1>
-          <dl class="header">
-            <dt>description</dt>
-            <dd>It completes the process of a dynamic import originally started by an <emu-xref href="#sec-import-calls">`import()`</emu-xref> call, resolving or rejecting the promise returned by that call as appropriate.</dd>
-          </dl>
-          <emu-alg>
-            1. If _moduleCompletion_ is an abrupt completion, then
-              1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, « _moduleCompletion_.[[Value]] »).
-              1. Return ~unused~.
-            1. Let _module_ be _moduleCompletion_.[[Value]].
-            1. Let _loadPromise_ be _module_.LoadRequestedModules().
-            1. Let _rejectedClosure_ be a new Abstract Closure with parameters (_reason_) that captures _promiseCapability_ and performs the following steps when called:
-              1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, « _reason_ »).
-              1. Return ~unused~.
-            1. Let _onRejected_ be CreateBuiltinFunction(_rejectedClosure_, 1, *""*, « »).
-            1. Let _linkAndEvaluateClosure_ be a new Abstract Closure with no parameters that captures _module_, _promiseCapability_, and _onRejected_ and performs the following steps when called:
-              1. Let _link_ be Completion(_module_.Link()).
-              1. If _link_ is an abrupt completion, then
-                1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, « _link_.[[Value]] »).
-                1. Return ~unused~.
-              1. Let _evaluatePromise_ be _module_.Evaluate().
-              1. Let _fulfilledClosure_ be a new Abstract Closure with no parameters that captures _module_ and _promiseCapability_ and performs the following steps when called:
-                1. Let _namespace_ be GetModuleNamespace(_module_).
-                1. Perform ! <emu-meta effects="user-code">Call</emu-meta>(_promiseCapability_.[[Resolve]], *undefined*, « _namespace_ »).
-                1. Return ~unused~.
-              1. Let _onFulfilled_ be CreateBuiltinFunction(_fulfilledClosure_, 0, *""*, « »).
-              1. Perform PerformPromiseThen(_evaluatePromise_, _onFulfilled_, _onRejected_).
-              1. Return ~unused~.
-            1. Let _linkAndEvaluate_ be CreateBuiltinFunction(_linkAndEvaluateClosure_, 0, *""*, « »).
-            1. Perform PerformPromiseThen(_loadPromise_, _linkAndEvaluate_, _onRejected_).
+      <emu-clause id="sec-ContinueDynamicImport" type="abstract operation">
+        <h1>
+          ContinueDynamicImport (
+            _promiseCapability_: a PromiseCapability Record,
+            _moduleCompletion_: either a normal completion containing a Module Record or a throw completion,
+          ): ~unused~
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It completes the process of a dynamic import originally started by an <emu-xref href="#sec-import-calls">`import()`</emu-xref> call, resolving or rejecting the promise returned by that call as appropriate.</dd>
+        </dl>
+        <emu-alg>
+          1. If _moduleCompletion_ is an abrupt completion, then
+            1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, « _moduleCompletion_.[[Value]] »).
             1. Return ~unused~.
-          </emu-alg>
-        </emu-clause>
+          1. Let _module_ be _moduleCompletion_.[[Value]].
+          1. Let _loadPromise_ be _module_.LoadRequestedModules().
+          1. Let _rejectedClosure_ be a new Abstract Closure with parameters (_reason_) that captures _promiseCapability_ and performs the following steps when called:
+            1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, « _reason_ »).
+            1. Return ~unused~.
+          1. Let _onRejected_ be CreateBuiltinFunction(_rejectedClosure_, 1, *""*, « »).
+          1. Let _linkAndEvaluateClosure_ be a new Abstract Closure with no parameters that captures _module_, _promiseCapability_, and _onRejected_ and performs the following steps when called:
+            1. Let _link_ be Completion(_module_.Link()).
+            1. If _link_ is an abrupt completion, then
+              1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, « _link_.[[Value]] »).
+              1. Return ~unused~.
+            1. Let _evaluatePromise_ be _module_.Evaluate().
+            1. Let _fulfilledClosure_ be a new Abstract Closure with no parameters that captures _module_ and _promiseCapability_ and performs the following steps when called:
+              1. Let _namespace_ be GetModuleNamespace(_module_).
+              1. Perform ! <emu-meta effects="user-code">Call</emu-meta>(_promiseCapability_.[[Resolve]], *undefined*, « _namespace_ »).
+              1. Return ~unused~.
+            1. Let _onFulfilled_ be CreateBuiltinFunction(_fulfilledClosure_, 0, *""*, « »).
+            1. Perform PerformPromiseThen(_evaluatePromise_, _onFulfilled_, _onRejected_).
+            1. Return ~unused~.
+          1. Let _linkAndEvaluate_ be CreateBuiltinFunction(_linkAndEvaluateClosure_, 0, *""*, « »).
+          1. Perform PerformPromiseThen(_loadPromise_, _linkAndEvaluate_, _onRejected_).
+          1. Return ~unused~.
+        </emu-alg>
       </emu-clause>
     </emu-clause>
 
@@ -25959,10 +26018,10 @@
               [[LoadedModules]]
             </td>
             <td>
-              a List of Records with fields [[Specifier]] (a String) and [[Module]] (a Module Record)
+              a List of LoadedModuleRequest Records
             </td>
             <td>
-              A map from the specifier strings imported by this script to the resolved Module Record. The list does not contain two different Records with the same [[Specifier]].
+              A map from the specifier strings imported by this script to the resolved Module Record. The list does not contain two different Records _r1_ and _r2_ such that ModuleRequestsEqual(_r1_, _r2_) is *true*.
             </td>
           </tr>
           <tr>
@@ -26203,8 +26262,165 @@
         </emu-alg>
       </emu-clause>
 
+      <emu-clause id="sec-modulerequest-record">
+        <h1>ModuleRequest Records</h1>
+
+        <p>A <dfn id="modulerequest-record" variants="ModuleRequest Records">ModuleRequest Record</dfn> represents the request to import a module with given import attributes. It consists of the following fields:</p>
+        <emu-table id="table-modulerequest-fields" caption="ModuleRequest Record Fields">
+          <table>
+            <tr>
+              <th>
+                Field Name
+              </th>
+              <th>
+                Value Type
+              </th>
+              <th>
+                Meaning
+              </th>
+            </tr>
+            <tr>
+              <td>
+                [[Specifier]]
+              </td>
+              <td>
+                a String
+              </td>
+              <td>
+                The module specifier
+              </td>
+            </tr>
+            <tr>
+              <td>
+                [[Attributes]]
+              </td>
+              <td>
+                a List of ImportAttribute Records
+              </td>
+              <td>
+                The import attributes
+              </td>
+            </tr>
+          </table>
+        </emu-table>
+
+        <p>A <dfn id="loadedmodulerequest-record" variants="LoadedModuleRequest Records">LoadedModuleRequest Record</dfn> represents the request to import a module together with the resulting Module Record. It consists of the same fields defined in table <emu-xref href="#table-modulerequest-fields"></emu-xref>, with the addition of [[Module]]:</p>
+        <emu-table id="table-loadedmodulerequest-fields" caption="LoadedModuleRequest Record Fields">
+          <table>
+            <tr>
+              <th>
+                Field Name
+              </th>
+              <th>
+                Value Type
+              </th>
+              <th>
+                Meaning
+              </th>
+            </tr>
+            <tr>
+              <td>
+                [[Specifier]]
+              </td>
+              <td>
+                a String
+              </td>
+              <td>
+                The module specifier
+              </td>
+            </tr>
+            <tr>
+              <td>
+                [[Attributes]]
+              </td>
+              <td>
+                a List of ImportAttribute Records
+              </td>
+              <td>
+                The import attributes
+              </td>
+            </tr>
+            <tr>
+              <td>
+                [[Module]]
+              </td>
+              <td>
+                a Module Record
+              </td>
+              <td>
+                The loaded module corresponding to this module request
+              </td>
+            </tr>
+          </table>
+        </emu-table>
+
+        <p>An <dfn id="importattribute-record" variants="ImportAttribute Records">ImportAttribute Record</dfn> consists of the following fields:</p>
+        <emu-table id="table-importattribute-fields" caption="ImportAttribute Record Fields">
+          <table>
+            <tr>
+              <th>
+                Field Name
+              </th>
+              <th>
+                Value Type
+              </th>
+              <th>
+                Meaning
+              </th>
+            </tr>
+            <tr>
+              <td>
+                [[Key]]
+              </td>
+              <td>
+                a String
+              </td>
+              <td>
+                The attribute key
+              </td>
+            </tr>
+            <tr>
+              <td>
+                [[Value]]
+              </td>
+              <td>
+                a String
+              </td>
+              <td>
+                The attribute value
+              </td>
+            </tr>
+          </table>
+        </emu-table>
+
+        <emu-clause id="sec-ModuleRequestsEqual" type="abstract operation">
+          <h1>
+            ModuleRequestsEqual (
+              _left_: a ModuleRequest Record or a LoadedModuleRequest Record,
+              _right_: a ModuleRequest Record or a LoadedModuleRequest Record,
+            ): a Boolean
+          </h1>
+          <dl class="header">
+            <dt>description</dt>
+            <dd></dd>
+          </dl>
+
+          <emu-alg>
+            1. If _left_.[[Specifier]] is not _right_.[[Specifier]], return *false*.
+            1. Let _leftAttrs_ be _left_.[[Attributes]].
+            1. Let _rightAttrs_ be _right_.[[Attributes]].
+            1. Let _leftAttrsCount_ be the number of elements in _leftAttrs_.
+            1. Let _rightAttrsCount_ be the number of elements in _rightAttrs_.
+            1. If _leftAttrsCount_ ≠ _rightAttrsCount_, return *false*.
+            1. For each ImportAttribute Record _l_ of _leftAttrs_, do
+              1. If _rightAttrs_ does not contain an ImportAttribute Record _r_ such that _l_.[[Key]] is _r_.[[Key]] and _l_.[[Value]] is _r_.[[Value]], return *false*.
+            1. Return *true*.
+          </emu-alg>
+        </emu-clause>
+      </emu-clause>
+
       <emu-clause id="sec-static-semantics-modulerequests" oldids="sec-module-semantics-static-semantics-modulerequests,sec-imports-static-semantics-modulerequests,sec-exports-static-semantics-modulerequests" type="sdo">
-        <h1>Static Semantics: ModuleRequests ( ): a List of Strings</h1>
+        <h1>Static Semantics: ModuleRequests ( ): a List of ModuleRequest Records</h1>
         <dl class="header">
         </dl>
         <emu-grammar>Module : [empty]</emu-grammar>
@@ -26217,12 +26433,12 @@
         </emu-alg>
         <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
         <emu-alg>
-          1. Let _moduleNames_ be the ModuleRequests of |ModuleItemList|.
-          1. Let _additionalNames_ be the ModuleRequests of |ModuleItem|.
-          1. For each String _name_ of _additionalNames_, do
-            1. If _moduleNames_ does not contain _name_, then
-              1. Append _name_ to _moduleNames_.
-          1. Return _moduleNames_.
+          1. Let _requests_ be the ModuleRequests of |ModuleItemList|.
+          1. Let _additionalRequests_ be the ModuleRequests of |ModuleItem|.
+          1. For each ModuleRequest Record _mr_ of _additionalRequests_, do
+            1. If _requests_ does not contain a ModuleRequest Record _mr2_ such that ModuleRequestsEqual(_mr_, _mr2_) is *true*, then
+              1. Append _mr_ to _requests_.
+          1. Return _requests_.
         </emu-alg>
         <emu-grammar>ModuleItem : StatementListItem</emu-grammar>
         <emu-alg>
@@ -26230,17 +26446,40 @@
         </emu-alg>
         <emu-grammar>ImportDeclaration : `import` ImportClause FromClause `;`</emu-grammar>
         <emu-alg>
-          1. Return the ModuleRequests of |FromClause|.
+          1. Let _specifier_ be the SV of |FromClause|.
+          1. Return a List whose sole element is the ModuleRequest Record { [[Specifier]]: _specifier_, [[Attributes]]: « » }.
         </emu-alg>
-        <emu-grammar>ModuleSpecifier : StringLiteral</emu-grammar>
+        <emu-grammar>ImportDeclaration : `import` ImportClause FromClause WithClause `;`</emu-grammar>
         <emu-alg>
-          1. Return a List whose sole element is the SV of |StringLiteral|.
+          1. Let _specifier_ be the SV of |FromClause|.
+          1. Let _attributes_ be WithClauseToAttributes of |WithClause|.
+          1. Return a List whose sole element is the ModuleRequest Record { [[Specifier]]: _specifier_, [[Attributes]]: _attributes_ }.
+        </emu-alg>
+        <emu-grammar>ImportDeclaration : `import` ModuleSpecifier `;`</emu-grammar>
+        <emu-alg>
+          1. Let _specifier_ be the SV of |ModuleSpecifier|.
+          1. Return a List whose sole element is the ModuleRequest Record { [[Specifier]]: _specifier_, [[Attributes]]: « » }.
+        </emu-alg>
+        <emu-grammar>ImportDeclaration : `import` ModuleSpecifier WithClause `;`</emu-grammar>
+        <emu-alg>
+          1. Let _specifier_ be the SV of |ModuleSpecifier|.
+          1. Let _attributes_ be WithClauseToAttributes of |WithClause|.
+          1. Return a List whose sole element is the ModuleRequest Record { [[Specifier]]: _specifier_, [[Attributes]]: _attributes_ }.
         </emu-alg>
         <emu-grammar>
           ExportDeclaration : `export` ExportFromClause FromClause `;`
         </emu-grammar>
         <emu-alg>
-          1. Return the ModuleRequests of |FromClause|.
+          1. Let _specifier_ be the SV of |FromClause|.
+          1. Return a List whose sole element is the ModuleRequest Record { [[Specifier]]: _specifier_, [[Attributes]]: « » }.
+        </emu-alg>
+        <emu-grammar>
+          ExportDeclaration : `export` ExportFromClause FromClause WithClause `;`
+        </emu-grammar>
+        <emu-alg>
+          1. Let _specifier_ be the SV of |FromClause|.
+          1. Let _attributes_ be WithClauseToAttributes of |WithClause|.
+          1. Return a List whose sole element is the ModuleRequest Record { [[Specifier]]: _specifier_, [[Attributes]]: _attributes_ }.
         </emu-alg>
         <emu-grammar>
           ExportDeclaration :
@@ -26451,10 +26690,10 @@
                 [[RequestedModules]]
               </td>
               <td>
-                a List of Strings
+                a List of ModuleRequest Records
               </td>
               <td>
-                A List of all the |ModuleSpecifier| strings used by the module represented by this record to request the importation of a module. The List is in source text occurrence order.
+                A List of the ModuleRequest Records associated with the imports in this module. The List is in source text occurrence order of the imports.
               </td>
             </tr>
             <tr>
@@ -26462,10 +26701,10 @@
                 [[LoadedModules]]
               </td>
               <td>
-                a List of Records with fields [[Specifier]] (a String) and [[Module]] (a Module Record)
+                a List of LoadedModuleRequest Records
               </td>
               <td>
-                A map from the specifier strings used by the module represented by this record to request the importation of a module to the resolved Module Record. The list does not contain two different Records with the same [[Specifier]].
+                A map from the specifier strings used by the module represented by this record to request the importation of a module with the relative import attributes to the resolved Module Record. The list does not contain two different Records _r1_ and _r2_ such that ModuleRequestsEqual(_r1_, _r2_) is *true*.
               </td>
             </tr>
             <tr>
@@ -26687,12 +26926,14 @@
                 1. Append _module_ to _state_.[[Visited]].
                 1. Let _requestedModulesCount_ be the number of elements in _module_.[[RequestedModules]].
                 1. Set _state_.[[PendingModulesCount]] to _state_.[[PendingModulesCount]] + _requestedModulesCount_.
-                1. For each String _required_ of _module_.[[RequestedModules]], do
-                  1. If _module_.[[LoadedModules]] contains a Record whose [[Specifier]] is _required_, then
-                    1. Let _record_ be that Record.
+                1. For each ModuleRequest Record _request_ of _module_.[[RequestedModules]], do
+                  1. If AllImportAttributesSupported(_request_.[[Attributes]]) is *false*, then
+                    1. Let _error_ be ThrowCompletion(a newly created *SyntaxError* object).
+                    1. Perform ContinueModuleLoading(_state_, _error_).
+                  1. Else if _module_.[[LoadedModules]] contains a LoadedModuleRequest Record _record_ such that ModuleRequestsEqual(_record_, _request_) is *true*, then
                     1. Perform InnerModuleLoading(_state_, _record_.[[Module]]).
                   1. Else,
-                    1. Perform HostLoadImportedModule(_module_, _required_, _state_.[[HostDefined]], _state_).
+                    1. Perform HostLoadImportedModule(_module_, _request_, _state_.[[HostDefined]], _state_).
                     1. NOTE: HostLoadImportedModule will call FinishLoadingImportedModule, which re-enters the graph loading process through ContinueModuleLoading.
                   1. If _state_.[[IsLoading]] is *false*, return ~unused~.
               1. Assert: _state_.[[PendingModulesCount]] ≥ 1.
@@ -26780,8 +27021,8 @@
               1. Set _module_.[[DFSAncestorIndex]] to _index_.
               1. Set _index_ to _index_ + 1.
               1. Append _module_ to _stack_.
-              1. For each String _required_ of _module_.[[RequestedModules]], do
-                1. Let _requiredModule_ be GetImportedModule(_module_, _required_).
+              1. For each ModuleRequest Record _request_ of _module_.[[RequestedModules]], do
+                1. Let _requiredModule_ be GetImportedModule(_module_, _request_).
                 1. Set _index_ to ? InnerModuleLinking(_requiredModule_, _stack_, _index_).
                 1. If _requiredModule_ is a Cyclic Module Record, then
                   1. Assert: _requiredModule_.[[Status]] is one of ~linking~, ~linked~, ~evaluating-async~, or ~evaluated~.
@@ -26873,8 +27114,8 @@
               1. Set _module_.[[PendingAsyncDependencies]] to 0.
               1. Set _index_ to _index_ + 1.
               1. Append _module_ to _stack_.
-              1. For each String _required_ of _module_.[[RequestedModules]], do
-                1. Let _requiredModule_ be GetImportedModule(_module_, _required_).
+              1. For each ModuleRequest Record _request_ of _module_.[[RequestedModules]], do
+                1. Let _requiredModule_ be GetImportedModule(_module_, _request_).
                 1. Set _index_ to ? InnerModuleEvaluation(_requiredModule_, _stack_, _index_).
                 1. If _requiredModule_ is a Cyclic Module Record, then
                   1. Assert: _requiredModule_.[[Status]] is one of ~evaluating~, ~evaluating-async~, or ~evaluated~.
@@ -27653,10 +27894,10 @@
                 [[ModuleRequest]]
               </td>
               <td>
-                a String
+                a ModuleRequest Record
               </td>
               <td>
-                String value of the |ModuleSpecifier| of the |ImportDeclaration|.
+                ModuleRequest Record representing the |ModuleSpecifier| and import attributes of the |ImportDeclaration|.
               </td>
             </tr>
             <tr>
@@ -27802,10 +28043,10 @@
                 [[ModuleRequest]]
               </td>
               <td>
-                a String or *null*
+                a ModuleRequest Record or *null*
               </td>
               <td>
-                The String value of the |ModuleSpecifier| of the |ExportDeclaration|. *null* if the |ExportDeclaration| does not have a |ModuleSpecifier|.
+                The ModuleRequest Record representing the |ModuleSpecifier| and import attributes of the |ExportDeclaration|. *null* if the |ExportDeclaration| does not have a |ModuleSpecifier|.
               </td>
             </tr>
             <tr>
@@ -28290,7 +28531,7 @@
         <h1>
           GetImportedModule (
             _referrer_: a Cyclic Module Record,
-            _specifier_: a String,
+            _request_: a ModuleRequest Record,
           ): a Module Record
         </h1>
         <dl class="header">
@@ -28299,8 +28540,9 @@
         </dl>
 
         <emu-alg>
-          1. Assert: Exactly one element of _referrer_.[[LoadedModules]] is a Record whose [[Specifier]] is _specifier_, since LoadRequestedModules has completed successfully on _referrer_ prior to invoking this abstract operation.
-          1. Let _record_ be the Record in _referrer_.[[LoadedModules]] whose [[Specifier]] is _specifier_.
+          1. [declared="r"] Let _records_ be a List consisting of each LoadedModuleRequest Record _r_ of _referrer_.[[LoadedModules]] such that ModuleRequestsEqual(_r_, _request_) is *true*.
+          1. Assert: _records_ has exactly one element, since LoadRequestedModules has completed successfully on _referrer_ prior to invoking this abstract operation.
+          1. Let _record_ be the sole element of _records_.
           1. Return _record_.[[Module]].
         </emu-alg>
       </emu-clause>
@@ -28309,7 +28551,7 @@
         <h1>
           HostLoadImportedModule (
             _referrer_: a Script Record, a Cyclic Module Record, or a Realm Record,
-            _specifier_: a String,
+            _moduleRequest_: a ModuleRequest Record,
             _hostDefined_: anything,
             _payload_: a GraphLoadingState Record or a PromiseCapability Record,
           ): ~unused~
@@ -28330,24 +28572,29 @@
         <p>An implementation of HostLoadImportedModule must conform to the following requirements:</p>
         <ul>
           <li>
-            The host environment must perform FinishLoadingImportedModule(_referrer_, _specifier_, _payload_, _result_), where _result_ is either a normal completion containing the loaded Module Record or a throw completion, either synchronously or asynchronously.
+            The host environment must perform FinishLoadingImportedModule(_referrer_, _moduleRequest_, _payload_, _result_), where _result_ is either a normal completion containing the loaded Module Record or a throw completion, either synchronously or asynchronously.
           </li>
           <li>
-            If this operation is called multiple times with the same (_referrer_, _specifier_) pair and it performs FinishLoadingImportedModule(_referrer_, _specifier_, _payload_, _result_) where _result_ is a normal completion, then it must perform FinishLoadingImportedModule(_referrer_, _specifier_, _payload_, _result_) with the same _result_ each time.
+            <p>If this operation is called multiple times with two (_referrer_, _moduleRequest_) pairs such that:</p>
+            <ul>
+              <li>the first _referrer_ is the same as the second _referrer_;</li>
+              <li>ModuleRequestsEqual(the first _moduleRequest_, the second _moduleRequest_) is *true*;</li>
+            </ul>
+            <p>and it performs FinishLoadingImportedModule(_referrer_, _moduleRequest_, _payload_, _result_) where _result_ is a normal completion, then it must perform FinishLoadingImportedModule(_referrer_, _moduleRequest_, _payload_, _result_) with the same _result_ each time.</p>
           </li>
           <li>
             The operation must treat _payload_ as an opaque value to be passed through to FinishLoadingImportedModule.
           </li>
         </ul>
 
-        <p>The actual process performed is host-defined, but typically consists of performing whatever I/O operations are necessary to load the appropriate Module Record. Multiple different (_referrer_, _specifier_) pairs may map to the same Module Record instance. The actual mapping semantics is host-defined but typically a normalization process is applied to _specifier_ as part of the mapping process. A typical normalization process would include actions such as expansion of relative and abbreviated path specifiers.</p>
+        <p>The actual process performed is host-defined, but typically consists of performing whatever I/O operations are necessary to load the appropriate Module Record. Multiple different (_referrer_, _moduleRequest_.[[Specifier]], _moduleRequest_.[[Attributes]]) triples may map to the same Module Record instance. The actual mapping semantics is host-defined but typically a normalization process is applied to _specifier_ as part of the mapping process. A typical normalization process would include actions such as expansion of relative and abbreviated path specifiers.</p>
       </emu-clause>
 
       <emu-clause id="sec-FinishLoadingImportedModule" type="abstract operation" oldids="sec-finishdynamicimport">
         <h1>
           FinishLoadingImportedModule (
             _referrer_: a Script Record, a Cyclic Module Record, or a Realm Record,
-            _specifier_: a String,
+            _moduleRequest_: a ModuleRequest Record,
             _payload_: a GraphLoadingState Record or a PromiseCapability Record,
             _result_: either a normal completion containing a Module Record or a throw completion,
           ): ~unused~
@@ -28358,16 +28605,54 @@
         </dl>
         <emu-alg>
           1. If _result_ is a normal completion, then
-            1. If _referrer_.[[LoadedModules]] contains a Record whose [[Specifier]] is _specifier_, then
-              1. Assert: That Record's [[Module]] is _result_.[[Value]].
+            1. If _referrer_.[[LoadedModules]] contains a LoadedModuleRequest Record _record_ such that ModuleRequestsEqual(_record_, _moduleRequest_) is *true*, then
+              1. Assert: _record_.[[Module]] and _result_.[[Value]] are the same Module Record.
             1. Else,
-              1. Append the Record { [[Specifier]]: _specifier_, [[Module]]: _result_.[[Value]] } to _referrer_.[[LoadedModules]].
+              1. Append the LoadedModuleRequest Record { [[Specifier]]: _moduleRequest_.[[Specifier]], [[Attributes]]: _moduleRequest_.[[Attributes]], [[Module]]: _result_.[[Value]] } to _referrer_.[[LoadedModules]].
           1. If _payload_ is a GraphLoadingState Record, then
             1. Perform ContinueModuleLoading(_payload_, _result_).
           1. Else,
             1. Perform ContinueDynamicImport(_payload_, _result_).
           1. Return ~unused~.
         </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-AllImportAttributesSupported" type="abstract operation">
+        <h1>
+          AllImportAttributesSupported (
+            _attributes_: a List of ImportAttribute Records,
+          ): a Boolean
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd></dd>
+        </dl>
+        <emu-alg>
+          1. Let _supported_ be HostGetSupportedImportAttributes().
+          1. For each ImportAttribute Record _attribute_ of _attributes_, do
+            1. If _supported_ does not contain _attribute_.[[Key]], return *false*.
+          1. Return *true*.
+        </emu-alg>
+
+        <emu-clause id="sec-hostgetsupportedimportattributes" type="host-defined abstract operation">
+          <h1>HostGetSupportedImportAttributes ( ): a List of Strings</h1>
+          <dl class="header">
+            <dt>description</dt>
+            <dd>It allows host environments to specify which import attributes they support. Only attributes with supported keys will be provided to the host.</dd>
+          </dl>
+
+          <p>An implementation of HostGetSupportedImportAttributes must conform to the following requrements:</p>
+
+          <ul>
+            <li>It must return a List of Strings, each indicating a supported attribute.</li>
+
+            <li>Each time this operation is called, it must return the same List with the same contents in the same order.</li>
+          </ul>
+
+          <p>The default implementation of HostGetSupportedImportAttributes is to return a new empty List.</p>
+
+          <emu-note>The purpose of requiring the host to specify its supported import attributes, rather than passing all attributes to the host and letting it then choose which ones it wants to handle, is to ensure that unsupported attributes are handled in a consistent way across different hosts.</emu-note>
+        </emu-clause>
       </emu-clause>
 
       <emu-clause id="sec-getmodulenamespace" type="abstract operation">
@@ -28432,8 +28717,8 @@
       <h2>Syntax</h2>
       <emu-grammar type="definition">
         ImportDeclaration :
-          `import` ImportClause FromClause `;`
-          `import` ModuleSpecifier `;`
+          `import` ImportClause FromClause WithClause? `;`
+          `import` ModuleSpecifier WithClause? `;`
 
         ImportClause :
           ImportedDefaultBinding
@@ -28469,6 +28754,18 @@
 
         ImportedBinding :
           BindingIdentifier[~Yield, +Await]
+
+        WithClause :
+          `with` `{` `}`
+          `with` `{` WithEntries `,`? `}`
+
+        WithEntries :
+          AttributeKey `:` StringLiteral
+          AttributeKey `:` StringLiteral `,` WithEntries
+
+        AttributeKey :
+          IdentifierName
+          StringLiteral
       </emu-grammar>
 
       <emu-clause id="sec-imports-static-semantics-early-errors">
@@ -28477,6 +28774,13 @@
         <ul>
           <li>
             It is a Syntax Error if the BoundNames of |ImportDeclaration| contains any duplicate entries.
+          </li>
+        </ul>
+
+        <emu-grammar>WithClause : `with` `{` WithEntries `,`? `}`</emu-grammar>
+        <ul>
+          <li>
+            It is a Syntax Error if WithClauseToAttributes of |WithClause| has two different entries _a_ and _b_ such that _a_.[[Key]] is _b_.[[Key]].
           </li>
         </ul>
       </emu-clause>
@@ -28503,12 +28807,12 @@
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
-        <emu-grammar>ImportDeclaration : `import` ImportClause FromClause `;`</emu-grammar>
+        <emu-grammar>ImportDeclaration : `import` ImportClause FromClause WithClause? `;`</emu-grammar>
         <emu-alg>
-          1. Let _module_ be the sole element of the ModuleRequests of |FromClause|.
+          1. Let _module_ be the sole element of the ModuleRequests of |ImportDeclaration|.
           1. Return the ImportEntriesForModule of |ImportClause| with argument _module_.
         </emu-alg>
-        <emu-grammar>ImportDeclaration : `import` ModuleSpecifier `;`</emu-grammar>
+        <emu-grammar>ImportDeclaration : `import` ModuleSpecifier WithClause? `;`</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
@@ -28517,7 +28821,7 @@
       <emu-clause id="sec-static-semantics-importentriesformodule" type="sdo">
         <h1>
           Static Semantics: ImportEntriesForModule (
-            _module_: a String,
+            _module_: a ModuleRequest Record,
           ): a List of ImportEntry Records
         </h1>
         <dl class="header">
@@ -28570,6 +28874,43 @@
           1. Return « _entry_ ».
         </emu-alg>
       </emu-clause>
+
+      <emu-clause id="sec-withclausetoattributes" type="sdo">
+        <h1>Static Semantics: WithClauseToAttributes ( ): a List of ImportAttribute Records</h1>
+        <dl class="header">
+        </dl>
+
+        <emu-grammar>
+          WithClause : `with` `{` `}`
+        </emu-grammar>
+        <emu-alg>
+          1. Return a new empty List.
+        </emu-alg>
+
+        <emu-grammar>
+          WithClause : `with` `{` WithEntries `,`? `}`
+        </emu-grammar>
+        <emu-alg>
+          1. Let _attributes_ be WithClauseToAttributes of |WithEntries|.
+          1. Sort _attributes_ according to the lexicographic order of their [[Key]] field, treating the value of each such field as a sequence of UTF-16 code unit values. NOTE: This sorting is observable only in that hosts are prohibited from changing behaviour based on the order in which attributes are enumerated.
+          1. Return _attributes_.
+        </emu-alg>
+
+        <emu-grammar>WithEntries : AttributeKey `:` StringLiteral</emu-grammar>
+        <emu-alg>
+          1. Let _key_ be the PropName of |AttributeKey|.
+          1. Let _entry_ be the ImportAttribute Record { [[Key]]: _key_, [[Value]]: the SV of |StringLiteral| }.
+          1. Return « _entry_ ».
+        </emu-alg>
+
+        <emu-grammar>WithEntries : AttributeKey `:` StringLiteral `,` WithEntries</emu-grammar>
+        <emu-alg>
+          1. Let _key_ be the PropName of |AttributeKey|.
+          1. Let _entry_ be the ImportAttribute Record { [[Key]]: _key_, [[Value]]: the SV of |StringLiteral| }.
+          1. Let _rest_ be WithClauseToAttributes of |WithEntries|.
+          1. Return the list-concatenation of « _entry_ » and _rest_.
+        </emu-alg>
+      </emu-clause>
     </emu-clause>
 
     <emu-clause id="sec-exports">
@@ -28577,7 +28918,7 @@
       <h2>Syntax</h2>
       <emu-grammar type="definition">
         ExportDeclaration :
-          `export` ExportFromClause FromClause `;`
+          `export` ExportFromClause FromClause WithClause? `;`
           `export` NamedExports `;`
           `export` VariableStatement[~Yield, +Await]
           `export` Declaration[~Yield, +Await]
@@ -28641,10 +28982,7 @@
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
-        <emu-grammar>
-          ExportDeclaration :
-            `export` ExportFromClause FromClause `;`
-        </emu-grammar>
+        <emu-grammar>ExportDeclaration : `export` ExportFromClause FromClause WithClause? `;`</emu-grammar>
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
@@ -28714,7 +29052,7 @@
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
-        <emu-grammar>ExportDeclaration : `export` ExportFromClause FromClause `;`</emu-grammar>
+        <emu-grammar>ExportDeclaration : `export` ExportFromClause FromClause WithClause? `;`</emu-grammar>
         <emu-alg>
           1. Return the ExportedNames of |ExportFromClause|.
         </emu-alg>
@@ -28789,9 +29127,9 @@
         <emu-alg>
           1. Return a new empty List.
         </emu-alg>
-        <emu-grammar>ExportDeclaration : `export` ExportFromClause FromClause `;`</emu-grammar>
+        <emu-grammar>ExportDeclaration : `export` ExportFromClause FromClause WithClause? `;`</emu-grammar>
         <emu-alg>
-          1. Let _module_ be the sole element of the ModuleRequests of |FromClause|.
+          1. Let _module_ be the sole element of the ModuleRequests of |ExportDeclaration|.
           1. Return the ExportEntriesForModule of |ExportFromClause| with argument _module_.
         </emu-alg>
         <emu-grammar>ExportDeclaration : `export` NamedExports `;`</emu-grammar>
@@ -28839,7 +29177,7 @@
       <emu-clause id="sec-static-semantics-exportentriesformodule" type="sdo">
         <h1>
           Static Semantics: ExportEntriesForModule (
-            _module_: a String or *null*,
+            _module_: a ModuleRequest Record or *null*,
           ): a List of ExportEntry Records
         </h1>
         <dl class="header">
@@ -28922,7 +29260,7 @@
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>
           ExportDeclaration :
-            `export` ExportFromClause FromClause `;`
+            `export` ExportFromClause FromClause WithClause? `;`
             `export` NamedExports `;`
         </emu-grammar>
         <emu-alg>
@@ -50787,6 +51125,9 @@ THH:mm:ss.sss
     <emu-prodref name="ImportSpecifier"></emu-prodref>
     <emu-prodref name="ModuleSpecifier"></emu-prodref>
     <emu-prodref name="ImportedBinding"></emu-prodref>
+    <emu-prodref name="WithClause"></emu-prodref>
+    <emu-prodref name="WithEntries"></emu-prodref>
+    <emu-prodref name="AttributeKey"></emu-prodref>
     <emu-prodref name="ExportDeclaration"></emu-prodref>
     <emu-prodref name="ExportFromClause"></emu-prodref>
     <emu-prodref name="NamedExports"></emu-prodref>
@@ -52046,6 +52387,7 @@ THH:mm:ss.sss
     <p><b>HostGrowSharedArrayBuffer(...)</b></p>
     <p><b>HostHasSourceTextAvailable(...)</b></p>
     <p><b>HostLoadImportedModule(...)</b></p>
+    <p><b>HostGetSupportedImportAttributes(...)</b></p>
     <p><b>HostMakeJobCallback(...)</b></p>
     <p><b>HostPromiseRejectionTracker(...)</b></p>
     <p><b>HostResizeArrayBuffer(...)</b></p>


### PR DESCRIPTION
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->

This proposal (https://tc39.es/proposal-import-attributes/, https://github.com/tc39/proposal-import-attributes) reached stage 3 during the March 2023 meeting, conditional on [stage 3 reviews](https://github.com/tc39/proposal-import-attributes/issues/137). I'm opening this PR before "real" stage 3 to help editors reviewing the full spec changes.

The proposal has already been integrated in HTML: https://html.spec.whatwg.org/#hostloadimportedmodule

**PREVIEW**: https://ci.tc39.es/preview/tc39/ecma262/pull/3057
**DIFF**: https://arai-a.github.io/ecma262-compare/?pr=3057 (note: the diff doesn't mark _deprecated_ sections)