### PR TITLE
Editorial: Define each `thisFooValue` AO in its own section

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -30314,15 +30314,6 @@
         <li>is itself a Boolean object; it has a [[BooleanData]] internal slot with the value *false*.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
       </ul>
-      <p>The abstract operation <dfn id="thisbooleanvalue" aoid="thisBooleanValue" oldids="sec-thisbooleanvalue">thisBooleanValue</dfn> takes argument _value_. It performs the following steps when called:</p>
-      <emu-alg>
-        1. If _value_ is a Boolean, return _value_.
-        1. If _value_ is an Object and _value_ has a [[BooleanData]] internal slot, then
-          1. Let _b_ be _value_.[[BooleanData]].
-          1. Assert: _b_ is a Boolean.
-          1. Return _b_.
-        1. Throw a *TypeError* exception.
-      </emu-alg>
 
       <emu-clause id="sec-boolean.prototype.constructor">
         <h1>Boolean.prototype.constructor</h1>
@@ -30344,6 +30335,24 @@
         <emu-alg>
           1. Return ? thisBooleanValue(*this* value).
         </emu-alg>
+
+        <emu-clause id="sec-thisbooleanvalue" type="abstract operation">
+          <h1>
+            thisBooleanValue (
+              _value_: an ECMAScript language value,
+            ): either a normal completion containing a Boolean or a throw completion
+          </h1>
+          <dl class="header">
+          </dl>
+          <emu-alg>
+            1. If _value_ is a Boolean, return _value_.
+            1. If _value_ is an Object and _value_ has a [[BooleanData]] internal slot, then
+              1. Let _b_ be _value_.[[BooleanData]].
+              1. Assert: _b_ is a Boolean.
+              1. Return _b_.
+            1. Throw a *TypeError* exception.
+          </emu-alg>
+        </emu-clause>
       </emu-clause>
     </emu-clause>
 
@@ -30543,15 +30552,6 @@
         <li>is not a Symbol instance and does not have a [[SymbolData]] internal slot.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
       </ul>
-      <p>The abstract operation <dfn id="thissymbolvalue" aoid="thisSymbolValue" oldids="sec-thissymbolvalue">thisSymbolValue</dfn> takes argument _value_. It performs the following steps when called:</p>
-      <emu-alg>
-        1. If _value_ is a Symbol, return _value_.
-        1. If _value_ is an Object and _value_ has a [[SymbolData]] internal slot, then
-          1. Let _s_ be _value_.[[SymbolData]].
-          1. Assert: _s_ is a Symbol.
-          1. Return _s_.
-        1. Throw a *TypeError* exception.
-      </emu-alg>
 
       <emu-clause id="sec-symbol.prototype.constructor">
         <h1>Symbol.prototype.constructor</h1>
@@ -30599,6 +30599,24 @@
         <emu-alg>
           1. Return ? thisSymbolValue(*this* value).
         </emu-alg>
+
+        <emu-clause id="sec-thissymbolvalue" type="abstract operation">
+          <h1>
+            thisSymbolValue (
+              _value_: an ECMAScript language value,
+            ): either a normal completion containing a Symbol or a throw completion
+          </h1>
+          <dl class="header">
+          </dl>
+          <emu-alg>
+            1. If _value_ is a Symbol, return _value_.
+            1. If _value_ is an Object and _value_ has a [[SymbolData]] internal slot, then
+              1. Let _s_ be _value_.[[SymbolData]].
+              1. Assert: _s_ is a Symbol.
+              1. Return _s_.
+            1. Throw a *TypeError* exception.
+          </emu-alg>
+        </emu-clause>
       </emu-clause>
 
       <emu-clause id="sec-symbol.prototype-@@toprimitive">
@@ -31130,15 +31148,6 @@
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
       </ul>
       <p>Unless explicitly stated otherwise, the methods of the Number prototype object defined below are not generic and the *this* value passed to them must be either a Number value or an object that has a [[NumberData]] internal slot that has been initialized to a Number value.</p>
-      <p>The abstract operation <dfn id="thisnumbervalue" aoid="thisNumberValue" oldids="sec-thisnumbervalue">thisNumberValue</dfn> takes argument _value_. It performs the following steps when called:</p>
-      <emu-alg>
-        1. If _value_ is a Number, return _value_.
-        1. If _value_ is an Object and _value_ has a [[NumberData]] internal slot, then
-          1. Let _n_ be _value_.[[NumberData]].
-          1. Assert: _n_ is a Number.
-          1. Return _n_.
-        1. Throw a *TypeError* exception.
-      </emu-alg>
       <p>The phrase “this Number value” within the specification of a method refers to the result returned by calling the abstract operation thisNumberValue with the *this* value of the method invocation passed as the argument.</p>
 
       <emu-clause id="sec-number.prototype.constructor">
@@ -31312,6 +31321,24 @@
         <emu-alg>
           1. Return ? thisNumberValue(*this* value).
         </emu-alg>
+
+        <emu-clause id="sec-thisnumbervalue" type="abstract operation">
+          <h1>
+            thisNumberValue (
+              _value_: an ECMAScript language value,
+            ): either a normal completion containing a Number or a throw completion
+          </h1>
+          <dl class="header">
+          </dl>
+          <emu-alg>
+            1. If _value_ is a Number, return _value_.
+            1. If _value_ is an Object and _value_ has a [[NumberData]] internal slot, then
+              1. Let _n_ be _value_.[[NumberData]].
+              1. Assert: _n_ is a Number.
+              1. Return _n_.
+            1. Throw a *TypeError* exception.
+          </emu-alg>
+        </emu-clause>
       </emu-clause>
     </emu-clause>
 
@@ -31405,14 +31432,6 @@
         <li>is not a BigInt object; it does not have a [[BigIntData]] internal slot.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
       </ul>
-      <p>The abstract operation <dfn id="thisbigintvalue" aoid="thisBigIntValue" oldids="sec-thisbigintvalue">thisBigIntValue</dfn> takes argument _value_. It performs the following steps when called:</p>
-      <emu-alg>
-        1. If _value_ is a BigInt, return _value_.
-        1. If _value_ is an Object and _value_ has a [[BigIntData]] internal slot, then
-          1. Assert: _value_.[[BigIntData]] is a BigInt.
-          1. Return _value_.[[BigIntData]].
-        1. Throw a *TypeError* exception.
-      </emu-alg>
       <p>The phrase “this BigInt value” within the specification of a method refers to the result returned by calling the abstract operation thisBigIntValue with the *this* value of the method invocation passed as the argument.</p>
 
       <emu-clause id="sec-bigint.prototype.constructor">
@@ -31448,6 +31467,23 @@
         <emu-alg>
           1. Return ? thisBigIntValue(*this* value).
         </emu-alg>
+
+        <emu-clause id="sec-thisbigintvalue" type="abstract operation">
+          <h1>
+            thisBigIntValue (
+              _value_: an ECMAScript language value,
+            ): either a normal completion containing a BigInt or a throw completion
+          </h1>
+          <dl class="header">
+          </dl>
+          <emu-alg>
+            1. If _value_ is a BigInt, return _value_.
+            1. If _value_ is an Object and _value_ has a [[BigIntData]] internal slot, then
+              1. Assert: _value_.[[BigIntData]] is a BigInt.
+              1. Return _value_.[[BigIntData]].
+            1. Throw a *TypeError* exception.
+          </emu-alg>
+        </emu-clause>
       </emu-clause>
 
       <emu-clause id="sec-bigint.prototype-@@tostringtag">
@@ -34235,15 +34271,6 @@ THH:mm:ss.sss
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
       </ul>
       <p>Unless explicitly stated otherwise, the methods of the String prototype object defined below are not generic and the *this* value passed to them must be either a String value or an object that has a [[StringData]] internal slot that has been initialized to a String value.</p>
-      <p>The abstract operation <dfn id="thisstringvalue" aoid="thisStringValue" oldids="sec-thisstringvalue">thisStringValue</dfn> takes argument _value_. It performs the following steps when called:</p>
-      <emu-alg>
-        1. If _value_ is a String, return _value_.
-        1. If _value_ is an Object and _value_ has a [[StringData]] internal slot, then
-          1. Let _s_ be _value_.[[StringData]].
-          1. Assert: _s_ is a String.
-          1. Return _s_.
-        1. Throw a *TypeError* exception.
-      </emu-alg>
 
       <emu-clause id="sec-string.prototype.at">
         <h1>String.prototype.at ( _index_ )</h1>
@@ -35119,6 +35146,24 @@ THH:mm:ss.sss
         <emu-alg>
           1. Return ? thisStringValue(*this* value).
         </emu-alg>
+
+        <emu-clause id="sec-thisstringvalue" type="abstract operation">
+          <h1>
+            thisStringValue (
+              _value_: an ECMAScript language value,
+            ): either a normal completion containing a String or a throw completion
+          </h1>
+          <dl class="header">
+          </dl>
+          <emu-alg>
+            1. If _value_ is a String, return _value_.
+            1. If _value_ is an Object and _value_ has a [[StringData]] internal slot, then
+              1. Let _s_ be _value_.[[StringData]].
+              1. Assert: _s_ is a String.
+              1. Return _s_.
+            1. Throw a *TypeError* exception.
+          </emu-alg>
+        </emu-clause>
       </emu-clause>
 
       <emu-clause id="sec-string.prototype-@@iterator" oldids="sec-createstringiterator,sec-properties-of-string-iterator-instances,table-46,table-internal-slots-of-string-iterator-instances">

--- a/spec.html
+++ b/spec.html
@@ -30324,7 +30324,7 @@
         <h1>Boolean.prototype.toString ( )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _b_ be ? thisBooleanValue(*this* value).
+          1. Let _b_ be ? ThisBooleanValue(*this* value).
           1. If _b_ is *true*, return *"true"*; else return *"false"*.
         </emu-alg>
       </emu-clause>
@@ -30333,12 +30333,12 @@
         <h1>Boolean.prototype.valueOf ( )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Return ? thisBooleanValue(*this* value).
+          1. Return ? ThisBooleanValue(*this* value).
         </emu-alg>
 
         <emu-clause id="sec-thisbooleanvalue" type="abstract operation">
           <h1>
-            thisBooleanValue (
+            ThisBooleanValue (
               _value_: an ECMAScript language value,
             ): either a normal completion containing a Boolean or a throw completion
           </h1>
@@ -30563,7 +30563,7 @@
         <p>`Symbol.prototype.description` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _s_ be the *this* value.
-          1. Let _sym_ be ? thisSymbolValue(_s_).
+          1. Let _sym_ be ? ThisSymbolValue(_s_).
           1. Return _sym_.[[Description]].
         </emu-alg>
       </emu-clause>
@@ -30572,7 +30572,7 @@
         <h1>Symbol.prototype.toString ( )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _sym_ be ? thisSymbolValue(*this* value).
+          1. Let _sym_ be ? ThisSymbolValue(*this* value).
           1. Return SymbolDescriptiveString(_sym_).
         </emu-alg>
 
@@ -30597,12 +30597,12 @@
         <h1>Symbol.prototype.valueOf ( )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Return ? thisSymbolValue(*this* value).
+          1. Return ? ThisSymbolValue(*this* value).
         </emu-alg>
 
         <emu-clause id="sec-thissymbolvalue" type="abstract operation">
           <h1>
-            thisSymbolValue (
+            ThisSymbolValue (
               _value_: an ECMAScript language value,
             ): either a normal completion containing a Symbol or a throw completion
           </h1>
@@ -30624,7 +30624,7 @@
         <p>This method is called by ECMAScript language operators to convert a Symbol object to a primitive value.</p>
         <p>It performs the following steps when called:</p>
         <emu-alg>
-          1. Return ? thisSymbolValue(*this* value).
+          1. Return ? ThisSymbolValue(*this* value).
         </emu-alg>
         <emu-note>
           <p>The argument is ignored.</p>
@@ -31148,7 +31148,7 @@
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
       </ul>
       <p>Unless explicitly stated otherwise, the methods of the Number prototype object defined below are not generic and the *this* value passed to them must be either a Number value or an object that has a [[NumberData]] internal slot that has been initialized to a Number value.</p>
-      <p>The phrase “this Number value” within the specification of a method refers to the result returned by calling the abstract operation thisNumberValue with the *this* value of the method invocation passed as the argument.</p>
+      <p>The phrase “this Number value” within the specification of a method refers to the result returned by calling the abstract operation ThisNumberValue with the *this* value of the method invocation passed as the argument.</p>
 
       <emu-clause id="sec-number.prototype.constructor">
         <h1>Number.prototype.constructor</h1>
@@ -31160,7 +31160,7 @@
         <p>This method returns a String containing this Number value represented in decimal exponential notation with one digit before the significand's decimal point and _fractionDigits_ digits after the significand's decimal point. If _fractionDigits_ is *undefined*, it includes as many significand digits as necessary to uniquely specify the Number (just like in ToString except that in this case the Number is always output in exponential notation).</p>
         <p>It performs the following steps when called:</p>
         <emu-alg>
-          1. Let _x_ be ? thisNumberValue(*this* value).
+          1. Let _x_ be ? ThisNumberValue(*this* value).
           1. Let _f_ be ? ToIntegerOrInfinity(_fractionDigits_).
           1. Assert: If _fractionDigits_ is *undefined*, then _f_ is 0.
           1. If _x_ is not finite, return Number::toString(_x_, 10).
@@ -31212,7 +31212,7 @@
         </emu-note>
         <p>It performs the following steps when called:</p>
         <emu-alg>
-          1. Let _x_ be ? thisNumberValue(*this* value).
+          1. Let _x_ be ? ThisNumberValue(*this* value).
           1. Let _f_ be ? ToIntegerOrInfinity(_fractionDigits_).
           1. Assert: If _fractionDigits_ is *undefined*, then _f_ is 0.
           1. If _f_ is not finite, throw a *RangeError* exception.
@@ -31260,7 +31260,7 @@
         <p>This method returns a String containing this Number value represented either in decimal exponential notation with one digit before the significand's decimal point and <emu-eqn>_precision_ - 1</emu-eqn> digits after the significand's decimal point or in decimal fixed notation with _precision_ significant digits. If _precision_ is *undefined*, it calls ToString instead.</p>
         <p>It performs the following steps when called:</p>
         <emu-alg>
-          1. Let _x_ be ? thisNumberValue(*this* value).
+          1. Let _x_ be ? ThisNumberValue(*this* value).
           1. If _precision_ is *undefined*, return ! ToString(_x_).
           1. Let _p_ be ? ToIntegerOrInfinity(_precision_).
           1. If _x_ is not finite, return Number::toString(_x_, 10).
@@ -31306,7 +31306,7 @@
         </emu-note>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _x_ be ? thisNumberValue(*this* value).
+          1. Let _x_ be ? ThisNumberValue(*this* value).
           1. If _radix_ is *undefined*, let _radixMV_ be 10.
           1. Else, let _radixMV_ be ? ToIntegerOrInfinity(_radix_).
           1. If _radixMV_ is not in the inclusive interval from 2 to 36, throw a *RangeError* exception.
@@ -31319,12 +31319,12 @@
       <emu-clause id="sec-number.prototype.valueof">
         <h1>Number.prototype.valueOf ( )</h1>
         <emu-alg>
-          1. Return ? thisNumberValue(*this* value).
+          1. Return ? ThisNumberValue(*this* value).
         </emu-alg>
 
         <emu-clause id="sec-thisnumbervalue" type="abstract operation">
           <h1>
-            thisNumberValue (
+            ThisNumberValue (
               _value_: an ECMAScript language value,
             ): either a normal completion containing a Number or a throw completion
           </h1>
@@ -31432,7 +31432,7 @@
         <li>is not a BigInt object; it does not have a [[BigIntData]] internal slot.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
       </ul>
-      <p>The phrase “this BigInt value” within the specification of a method refers to the result returned by calling the abstract operation thisBigIntValue with the *this* value of the method invocation passed as the argument.</p>
+      <p>The phrase “this BigInt value” within the specification of a method refers to the result returned by calling the abstract operation ThisBigIntValue with the *this* value of the method invocation passed as the argument.</p>
 
       <emu-clause id="sec-bigint.prototype.constructor">
         <h1>BigInt.prototype.constructor</h1>
@@ -31453,7 +31453,7 @@
         </emu-note>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _x_ be ? thisBigIntValue(*this* value).
+          1. Let _x_ be ? ThisBigIntValue(*this* value).
           1. If _radix_ is *undefined*, let _radixMV_ be 10.
           1. Else, let _radixMV_ be ? ToIntegerOrInfinity(_radix_).
           1. If _radixMV_ is not in the inclusive interval from 2 to 36, throw a *RangeError* exception.
@@ -31465,12 +31465,12 @@
       <emu-clause id="sec-bigint.prototype.valueof">
         <h1>BigInt.prototype.valueOf ( )</h1>
         <emu-alg>
-          1. Return ? thisBigIntValue(*this* value).
+          1. Return ? ThisBigIntValue(*this* value).
         </emu-alg>
 
         <emu-clause id="sec-thisbigintvalue" type="abstract operation">
           <h1>
-            thisBigIntValue (
+            ThisBigIntValue (
               _value_: an ECMAScript language value,
             ): either a normal completion containing a BigInt or a throw completion
           </h1>
@@ -35038,7 +35038,7 @@ THH:mm:ss.sss
         <h1>String.prototype.toString ( )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Return ? thisStringValue(*this* value).
+          1. Return ? ThisStringValue(*this* value).
         </emu-alg>
         <emu-note>
           <p>For a String object, this method happens to return the same thing as the `valueOf` method.</p>
@@ -35144,12 +35144,12 @@ THH:mm:ss.sss
         <h1>String.prototype.valueOf ( )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Return ? thisStringValue(*this* value).
+          1. Return ? ThisStringValue(*this* value).
         </emu-alg>
 
         <emu-clause id="sec-thisstringvalue" type="abstract operation">
           <h1>
-            thisStringValue (
+            ThisStringValue (
               _value_: an ECMAScript language value,
             ): either a normal completion containing a String or a throw completion
           </h1>


### PR DESCRIPTION
Specifically:
- thisBooleanValue
- thisSymbolValue
- thisNumberValue
- thisBigIntValue
- ~thisTimeValue~
- thisStringValue

Since ES6, each of these operations has been defined in the corresponding "Properties of the Foo Prototype Object" section, rather than in a section dedicated to the operation, with a structured header, as is now the norm. 

Past efforts in this direction have encountered the problem of placement. E.g., in the status quo, `thisBooleanValue` is defined within [20.3.3 Properties of the Boolean Prototype Object](https://tc39.es/ecma262/#sec-properties-of-the-boolean-prototype-object), so if you were to simply create a subsection for `thisBooleanValue` right there, context would suggest that `thisBooleanValue` is a *property* of the Boolean Prototype Object.

This PR solves that problem by placing each new section within the section for the corresponding `valueOf` method, which in each case is basically just a call to the `thisFooValue` operation.

For Symbol ~and Date~, there's an "Abstract Operations" section where the `thisFooValue` operation could go instead if you wanted. I like the consistency of it always being under the corresponding `valueOf`.