### PR TITLE
Normative: make non-USV import strings a syntax error

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -25913,6 +25913,9 @@
         <emu-alg>
           1. Return a List whose sole element is the SV of |StringLiteral|.
         </emu-alg>
+        <ul>
+          <li>It is a Syntax Error if IsStringWellFormedUnicode(the SV of |StringLiteral|) is *false*.</li>
+        </ul>
         <emu-grammar>
           ExportDeclaration : `export` ExportFromClause FromClause `;`
         </emu-grammar>


### PR DESCRIPTION
Just like export name strings must be valid well-formed unicode strings, this adds a SyntaxError for `import` specifier strings which are invalid unicode.

While this is a normative change, it is hard to imagine it being a breaking one. At the very least, opening for discussion - having module specifiers / module IDs as valid unicode seems a desirable property.
