### PR TITLE
Editorial: take ToString and ToLength out of StringPad and make it infallible

### DIFF
--- a/esmeta-ignore.json
+++ b/esmeta-ignore.json
@@ -51,5 +51,6 @@
   "Statement[0,0].LabelledEvaluation",
   "Statement[1,0].LabelledEvaluation",
   "Statement[2,0].LabelledEvaluation",
-  "StringCreate"
+  "StringCreate",
+  "StringPad"
 ]

--- a/spec.html
+++ b/spec.html
@@ -29073,7 +29073,7 @@
               1. Let _Octets_ be the List of octets resulting by applying the UTF-8 transformation to _cp_.[[CodePoint]].
               1. For each element _octet_ of _Octets_, do
                 1. Let _hex_ be the String representation of _octet_, formatted as an uppercase hexadecimal number.
-                1. Set _R_ to the string-concatenation of _R_, *"%"*, and ! StringPad(_hex_, *2*<sub>𝔽</sub>, *"0"*, ~start~).
+                1. Set _R_ to the string-concatenation of _R_, *"%"*, and StringPad(_hex_, 2, *"0"*, ~start~).
           1. Return _R_.
         </emu-alg>
         <emu-note>
@@ -34326,7 +34326,7 @@ THH:mm:ss.sss
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
-          1. Return ? StringPad(_O_, _maxLength_, _fillString_, ~end~).
+          1. Return ? StringPaddingBuiltinsImpl(_O_, _maxLength_, _fillString_, ~end~).
         </emu-alg>
       </emu-clause>
 
@@ -34335,12 +34335,12 @@ THH:mm:ss.sss
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
-          1. Return ? StringPad(_O_, _maxLength_, _fillString_, ~start~).
+          1. Return ? StringPaddingBuiltinsImpl(_O_, _maxLength_, _fillString_, ~start~).
         </emu-alg>
 
-        <emu-clause id="sec-stringpad" type="abstract operation">
+        <emu-clause id="sec-stringpaddingbuiltinsimpl" type="abstract operation">
           <h1>
-            StringPad (
+            StringPaddingBuiltinsImpl (
               _O_: an ECMAScript language value,
               _maxLength_: an ECMAScript language value,
               _fillString_: an ECMAScript language value,
@@ -34354,11 +34354,29 @@ THH:mm:ss.sss
             1. Let _intMaxLength_ be ℝ(? ToLength(_maxLength_)).
             1. Let _stringLength_ be the length of _S_.
             1. If _intMaxLength_ ≤ _stringLength_, return _S_.
-            1. If _fillString_ is *undefined*, let _filler_ be the String value consisting solely of the code unit 0x0020 (SPACE).
-            1. Else, let _filler_ be ? ToString(_fillString_).
-            1. If _filler_ is the empty String, return _S_.
-            1. Let _fillLen_ be _intMaxLength_ - _stringLength_.
-            1. Let _truncatedStringFiller_ be the String value consisting of repeated concatenations of _filler_ truncated to length _fillLen_.
+            1. If _fillString_ is *undefined*, set _fillString_ to the String value consisting solely of the code unit 0x0020 (SPACE).
+            1. Else, set _fillString_ to ? ToString(_fillString_).
+            1. Return StringPad(_S_, _intMaxLength_, _fillString_, _placement_).
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-stringpad" type="abstract operation">
+          <h1>
+            StringPad (
+              _S_: a String,
+              _maxLength_: a non-negative integer,
+              _fillString_: a String,
+              _placement_: ~start~ or ~end~,
+            ): a String
+          </h1>
+          <dl class="header">
+          </dl>
+          <emu-alg>
+            1. Let _stringLength_ be the length of _S_.
+            1. If _maxLength_ ≤ _stringLength_, return _S_.
+            1. If _fillString_ is the empty String, return _S_.
+            1. Let _fillLen_ be _maxLength_ - _stringLength_.
+            1. Let _truncatedStringFiller_ be the String value consisting of repeated concatenations of _fillString_ truncated to length _fillLen_.
             1. If _placement_ is ~start~, return the string-concatenation of _truncatedStringFiller_ and _S_.
             1. Else, return the string-concatenation of _S_ and _truncatedStringFiller_.
           </emu-alg>
@@ -34381,7 +34399,7 @@ THH:mm:ss.sss
           </dl>
           <emu-alg>
             1. Let _S_ be the String representation of _n_, formatted as a decimal number.
-            1. Return ! StringPad(_S_, 𝔽(_minLength_), *"0"*, ~start~).
+            1. Return StringPad(_S_, _minLength_, *"0"*, ~start~).
           </emu-alg>
         </emu-clause>
       </emu-clause>
@@ -44220,7 +44238,7 @@ THH:mm:ss.sss
           1. Let _n_ be the numeric value of _C_.
           1. Assert: _n_ ≤ 0xFFFF.
           1. Let _hex_ be the String representation of _n_, formatted as a lowercase hexadecimal number.
-          1. Return the string-concatenation of the code unit 0x005C (REVERSE SOLIDUS), *"u"*, and ! StringPad(_hex_, *4*<sub>𝔽</sub>, *"0"*, ~start~).
+          1. Return the string-concatenation of the code unit 0x005C (REVERSE SOLIDUS), *"u"*, and StringPad(_hex_, 4, *"0"*, ~start~).
         </emu-alg>
       </emu-clause>
 
@@ -49034,10 +49052,10 @@ THH:mm:ss.sss
               1. Let _n_ be the numeric value of _C_.
               1. If _n_ &lt; 256, then
                 1. Let _hex_ be the String representation of _n_, formatted as an uppercase hexadecimal number.
-                1. Let _S_ be the string-concatenation of *"%"* and ! StringPad(_hex_, *2*<sub>𝔽</sub>, *"0"*, ~start~).
+                1. Let _S_ be the string-concatenation of *"%"* and StringPad(_hex_, 2, *"0"*, ~start~).
               1. Else,
                 1. Let _hex_ be the String representation of _n_, formatted as an uppercase hexadecimal number.
-                1. Let _S_ be the string-concatenation of *"%u"* and ! StringPad(_hex_, *4*<sub>𝔽</sub>, *"0"*, ~start~).
+                1. Let _S_ be the string-concatenation of *"%u"* and StringPad(_hex_, 4, *"0"*, ~start~).
             1. Set _R_ to the string-concatenation of _R_ and _S_.
             1. Set _k_ to _k_ + 1.
           1. Return _R_.


### PR DESCRIPTION
Changed argument types and removed `ToString` and `ToLength` calls from `StringPad` as per https://github.com/tc39/ecma262/issues/2634

For `maxLength`, I went with `a non-negative integer` instead of `a Number`.
I'm not sure if the new steps for `String.prototype.padStart` and `String.prototype.padEnd` are needed or not.

Please let me know if any further changes are needed, thanks!