### PR TITLE
Meta: upgrade ESMeta to v0.3.0

### DIFF
--- a/.github/workflows/esmeta-typecheck.yml
+++ b/.github/workflows/esmeta-typecheck.yml
@@ -24,7 +24,7 @@ jobs:
           cd "${ESMETA_HOME}"
           git init
           git remote add origin https://github.com/es-meta/esmeta.git
-          git fetch --depth 1 origin 688f6241f1a82259504775bcec790bde467b2be9 ;# v0.1.0
+          git fetch --depth 1 origin f6c24d62ef5a59b16a1f4d8e023eb44da99283fb ;# v0.3.0
           git checkout FETCH_HEAD
       - name: build esmeta
         run: |

--- a/esmeta-ignore.json
+++ b/esmeta-ignore.json
@@ -32,7 +32,6 @@
   "GetPromiseResolve",
   "GetPrototypeFromConstructor",
   "GetThisValue",
-  "HostEnqueuePromiseJob",
   "INTRINSICS.DefaultTimeZone",
   "InnerModuleEvaluation",
   "IntegerIndexedObjectCreate",


### PR DESCRIPTION
I updated the version of [ESMeta](https://github.com/es-meta/esmeta) to [`v0.3.0`](https://github.com/es-meta/esmeta/releases/tag/v0.3.0).

Now, ESMeta supports that not only nonterminals but also any symbols can be optional (https://github.com/es-meta/esmeta/issues/144) by (https://github.com/es-meta/esmeta/commit/503b2fae9ceb0bbc58162a85d89cad831f29e97c).

And we fixed several minor issues. Thus, we can remove one unnecessary ignore case in the `esmeta-ignore.json`:
```diff
   "GetThisValue",
-  "HostEnqueuePromiseJob",
   "INTRINSICS.DefaultTimeZone",
```