### PR TITLE
Meta: Upgrade ESMeta to v0.3.1

### DIFF
--- a/.github/workflows/esmeta-typecheck.yml
+++ b/.github/workflows/esmeta-typecheck.yml
@@ -24,7 +24,7 @@ jobs:
           cd "${ESMETA_HOME}"
           git init
           git remote add origin https://github.com/es-meta/esmeta.git
-          git fetch --depth 1 origin f6c24d62ef5a59b16a1f4d8e023eb44da99283fb ;# v0.3.0
+          git fetch --depth 1 origin 604160b059a026a28654d192e4fe0fb461527623 ;# v0.3.1
           git checkout FETCH_HEAD
       - name: build esmeta
         run: |


### PR DESCRIPTION
I updated the version of [ESMeta](https://github.com/es-meta/esmeta) to [`v0.3.1`](https://github.com/es-meta/esmeta/releases/tag/v0.3.1).

We fixed the bug in the grammar parser related to https://github.com/es-meta/esmeta/issues/145 and https://github.com/tc39/ecma262/pull/2418#discussion_r1173563802.