### PR TITLE
Editorial: Simplify ToIndex

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -5579,17 +5579,12 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It converts _value_ to a non-negative integer if the corresponding decimal representation, as a String, is an integer index.</dd>
+        <dd>It converts _value_ to an integer and returns that integer if it is non-negative and corresponds with an integer index. Otherwise, it throws an exception.</dd>
       </dl>
       <emu-alg>
-        1. If _value_ is *undefined*, then
-          1. Return 0.
-        1. Else,
-          1. Let _integer_ be ? ToIntegerOrInfinity(_value_).
-          1. Let _clamped_ be ! ToLength(𝔽(_integer_)).
-          1. If SameValue(𝔽(_integer_), _clamped_) is *false*, throw a *RangeError* exception.
-          1. Assert: 0 ≤ _integer_ ≤ 2<sup>53</sup> - 1.
-          1. Return _integer_.
+        1. Let _integer_ be ? ToIntegerOrInfinity(_value_).
+        1. If _integer_ is not in the inclusive interval from 0 to 2<sup>53</sup> - 1, throw a *RangeError* exception.
+        1. Return _integer_.
       </emu-alg>
     </emu-clause>
   </emu-clause>


### PR DESCRIPTION
* `ToIntegerOrInfinity(*undefined*)` already returns 0, so no special case is necessary.
* ToLength is superfluous vs. just checking directly against the valid range.