### PR TITLE
Editorial: Simplify object snapshotting

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -6598,6 +6598,28 @@
       </emu-note>
     </emu-clause>
 
+    <emu-clause id="sec-snapshotownproperties" type="abstract operation">
+      <h1>
+        SnapshotOwnProperties (
+          _source_: an ECMAScript language value,
+          _proto_: an Object or *null*,
+          optional _excludedKeys_: a List of property keys,
+        ): either a normal completion containing an Object, or a throw completion
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>
+          It enumerates the own properties of _source_ and copies them into data properties on a new object with the specified prototype, subject to the specified exclusions.
+        </dd>
+      </dl>
+      <emu-alg>
+        1. Let _copy_ be OrdinaryObjectCreate(_proto_).
+        1. If _excludedKeys_ is not present, set _excludedKeys_ to « ».
+        1. Perform ? CopyDataProperties(_copy_, ? ToObject(_source_), _excludedKeys_).
+        1. Return _copy_.
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-privateelementfind" type="abstract operation">
       <h1>
         PrivateElementFind (
@@ -20693,8 +20715,7 @@
         <emu-grammar>AssignmentRestProperty : `...` DestructuringAssignmentTarget</emu-grammar>
         <emu-alg>
           1. Let _lref_ be ? Evaluation of |DestructuringAssignmentTarget|.
-          1. Let _restObj_ be OrdinaryObjectCreate(%Object.prototype%).
-          1. Perform ? CopyDataProperties(_restObj_, _value_, _excludedNames_).
+          1. Let _restObj_ be ? SnapshotOwnProperties(_value_, %Object.prototype%, _excludedNames_).
           1. Return ? PutValue(_lref_, _restObj_).
         </emu-alg>
       </emu-clause>
@@ -21271,8 +21292,7 @@
         <emu-grammar>BindingRestProperty : `...` BindingIdentifier</emu-grammar>
         <emu-alg>
           1. Let _lhs_ be ? ResolveBinding(StringValue of |BindingIdentifier|, _environment_).
-          1. Let _restObj_ be OrdinaryObjectCreate(%Object.prototype%).
-          1. Perform ? CopyDataProperties(_restObj_, _value_, _excludedNames_).
+          1. Let _restObj_ be ? SnapshotOwnProperties(_value_, %Object.prototype%, _excludedNames_).
           1. If _environment_ is *undefined*, return ? PutValue(_lhs_, _restObj_).
           1. Return ? InitializeReferencedBinding(_lhs_, _restObj_).
         </emu-alg>


### PR DESCRIPTION
Introduces SnapshotOwnProperties to precede CopyDataProperties with creating the target object and follow it with returning that object, collapsing some algorithm subsequences. This was recently added to the Temporal proposal, and is being suggested here to reduce the scope of differences as suggested in https://github.com/tc39/proposal-temporal/pull/2586#pullrequestreview-1449761560 (albeit without the _excludedValues_ parameter because the ECMA-262 CopyDataProperties does not yet support it).