### PR TITLE
Editorial: Cleanup ToUint8Clamp

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -5216,23 +5216,20 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It converts _argument_ to one of 2<sup>8</sup> integral Number values in the inclusive interval from *+0*<sub>𝔽</sub> to *255*<sub>𝔽</sub>.</dd>
+        <dd>It clamps and rounds _argument_ to one of 2<sup>8</sup> integral Number values in the inclusive interval from *+0*<sub>𝔽</sub> to *255*<sub>𝔽</sub>.</dd>
       </dl>
       <emu-alg>
         1. Let _number_ be ? ToNumber(_argument_).
-        1. If _number_ is *+∞*<sub>𝔽</sub>, return *255*<sub>𝔽</sub>.
-        1. If _number_ is *-∞*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
         1. If _number_ is *NaN*, return *+0*<sub>𝔽</sub>.
-        1. If ℝ(_number_) ≤ 0, return *+0*<sub>𝔽</sub>.
-        1. If ℝ(_number_) ≥ 255, return *255*<sub>𝔽</sub>.
-        1. Let _f_ be floor(ℝ(_number_)).
-        1. If _f_ + 0.5 &lt; ℝ(_number_), return 𝔽(_f_ + 1).
-        1. If ℝ(_number_) &lt; _f_ + 0.5, return 𝔽(_f_).
-        1. If _f_ is odd, return 𝔽(_f_ + 1).
-        1. Return 𝔽(_f_).
+        1. Let _mv_ be the extended mathematical value of _number_.
+        1. Let _clamped_ be the result of clamping _mv_ between 0 and 255.
+        1. Let _f_ be floor(_clamped_).
+        1. If _clamped_ &lt; _f_ + 0.5, return 𝔽(_f_).
+        1. If _clamped_ > _f_ + 0.5, return 𝔽(_f_ + 1).
+        1. If _f_ is even, return 𝔽(_f_). Otherwise, return 𝔽(_f_ + 1).
       </emu-alg>
       <emu-note>
-        <p>Unlike the other ECMAScript integer conversion abstract operation, ToUint8Clamp rounds rather than truncates non-integral values and does not convert *+∞*<sub>𝔽</sub> to *+0*<sub>𝔽</sub>. ToUint8Clamp does “round half to even” tie-breaking. This differs from `Math.round` which does “round half up” tie-breaking.</p>
+        <p>Unlike most other ECMAScript integer conversion operations, ToUint8Clamp rounds rather than truncates non-integral values. It also uses “round half to even” tie-breaking, which differs from the “round half up” tie-breaking of <emu-xref href="#sec-math.round">`Math.round`</emu-xref>.</p>
       </emu-note>
     </emu-clause>
 
@@ -5543,7 +5540,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It clamps _argument_ to an integral Number suitable for use as the length of an array-like object.</dd>
+        <dd>It clamps and truncates _argument_ to an integral Number suitable for use as the length of an array-like object.</dd>
       </dl>
       <emu-alg>
         1. Let _len_ be ? ToIntegerOrInfinity(_argument_).


### PR DESCRIPTION
I noticed that ToUint8Clamp inappropriately uses [ℝ](https://tc39.es/ecma262/multipage/notational-conventions.html#%E2%84%9D) with an input that might be infinite. This PR fixes that by replacing it with [the extended mathematical value of](https://tc39.es/ecma262/multipage/notational-conventions.html#extended-mathematical-value-of), and also performs some related cleanup of text and refactoring of algorithm steps.