### PR TITLE
Markup: Update bold tags to use strong tag to prevent deprecation

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -48260,7 +48260,7 @@ THH:mm:ss.sss
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
-          1. Return ? CreateHTML(_S_, *"b"*, *""*, *""*).
+          1. Return ? CreateHTML(_S_, *"strong"*, *""*, *""*).
         </emu-alg>
       </emu-annex>
 


### PR DESCRIPTION
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->

This change updates the existing `string.prototype.bold()` method to use the HTML5 `<strong>` tag to bold text rather than the deprecated `<b>` HTML tag. This could prevent the `bold()` method from being removed from ecma standard as it is helpful when attempting to bolden a string programmatically.

Thank you.
