### PR TITLE
Editorial: fix capitalization of "Object type"

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -2689,7 +2689,7 @@
 
     <emu-clause id="sec-object-type">
       <h1>The Object Type</h1>
-      <p>Each instance of the <dfn variants="is an Object,is not an Object">Object Type</dfn>, also referred to simply as “an Object”, represents a collection of properties. Each property is either a data property, or an accessor property:</p>
+      <p>Each instance of the <dfn variants="is an Object,is not an Object">Object type</dfn>, also referred to simply as “an Object”, represents a collection of properties. Each property is either a data property, or an accessor property:</p>
       <ul>
         <li>
           A <dfn variants="data properties">data property</dfn> associates a key value with an ECMAScript language value and a set of Boolean attributes.


### PR DESCRIPTION
https://github.com/tc39/ecma262/pull/3077 moved the definition of "Object type" out of header text, but kept the capitalization of "Type" in the non-header text, which is inconsistent with other sections.