### PR TITLE
Normative: Limit time zone offset precision to minutes

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -32221,7 +32221,7 @@
         <h1>DefaultTimeZone ( ): a String</h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It returns a String value representing the host environment's current time zone, which is either a String representing a UTC offset for which IsTimeZoneOffsetString returns *true* and ParseTimeZoneOffsetString returns an integer evenly divisible by 6 × 10<sup>10</sup> (i.e., an offset in which all units smaller than minutes are 0), or a String identifier accepted by GetNamedTimeZoneEpochNanoseconds and GetNamedTimeZoneOffsetNanoseconds.</dd>
+          <dd>It returns a String _id_ representing the host environment's current time zone as either an offset time zone or as an available named time zone identifier. In the former case, IsTimeZoneOffsetString(_id_) returns *true* and ParseTimeZoneOffsetString(_id_) returns an integer evenly divisible by 6 × 10<sup>10</sup> (i.e., any second and fractional second units in _id_ are 0). In the latter case, the result from AvailableNamedTimeZoneIdentifiers() contains a Time Zone Identifier Record _r_ such that _r_.[[Identifier]] is _id_, and _id_ is valid as the first argument to GetNamedTimeZoneEpochNanoseconds and GetNamedTimeZoneOffsetNanoseconds.</dd>
         </dl>
 
         <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the DefaultTimeZone abstract operation as specified in the ECMA-402 specification.</p>

--- a/spec.html
+++ b/spec.html
@@ -32221,7 +32221,7 @@
         <h1>DefaultTimeZone ( ): a String</h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It returns a String value representing the host environment's current time zone, which is either a String representing a UTC offset for which IsTimeZoneOffsetString returns *true*, or a String identifier accepted by GetNamedTimeZoneEpochNanoseconds and GetNamedTimeZoneOffsetNanoseconds.</dd>
+          <dd>It returns a String value representing the host environment's current time zone, which is either a String representing a UTC offset for which IsTimeZoneOffsetString returns *true* and ParseTimeZoneOffsetString returns an integer evenly divisible by 6 × 10<sup>10</sup> (i.e., an offset in which all units smaller than minutes are 0), or a String identifier accepted by GetNamedTimeZoneEpochNanoseconds and GetNamedTimeZoneOffsetNanoseconds.</dd>
         </dl>
 
         <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the DefaultTimeZone abstract operation as specified in the ECMA-402 specification.</p>


### PR DESCRIPTION
This aligns with [RFC 9557](https://www.rfc-editor.org/rfc/rfc9557#section-4), which allows expression of UTC offsets per [RFC 3339](https://www.rfc-editor.org/rfc/rfc3339#section-5.6) `time-numoffset`:
> ```
> time-zone         = "[" critical-flag
>                         time-zone-name / time-numoffset "]"
> …
> suffix            = [time-zone] *suffix-tag
> 
> date-time-ext     = date-time suffix
> ```
> ```
> time-minute     = 2DIGIT  ; 00-59
> …
> time-numoffset  = ("+" / "-") time-hour ":" time-minute
> ```

Prompted by discussion in TG2 about https://github.com/tc39/ecma402/pull/788 .
