### PR TITLE
Editorial: e, used as the base of the natural logarithm, is not an alias

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -31450,7 +31450,7 @@
 
       <emu-clause id="sec-math.e">
         <h1>Math.E</h1>
-        <p>The Number value for _e_, the base of the natural logarithms, which is approximately 2.7182818284590452354.</p>
+        <p>The Number value for <i>e</i>, the base of the natural logarithms, which is approximately 2.7182818284590452354.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
 
@@ -31468,7 +31468,7 @@
 
       <emu-clause id="sec-math.log10e">
         <h1>Math.LOG10E</h1>
-        <p>The Number value for the base-10 logarithm of _e_, the base of the natural logarithms; this value is approximately 0.4342944819032518.</p>
+        <p>The Number value for the base-10 logarithm of <i>e</i>, the base of the natural logarithms; this value is approximately 0.4342944819032518.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
         <emu-note>
           <p>The value of `Math.LOG10E` is approximately the reciprocal of the value of `Math.LN10`.</p>
@@ -31477,7 +31477,7 @@
 
       <emu-clause id="sec-math.log2e">
         <h1>Math.LOG2E</h1>
-        <p>The Number value for the base-2 logarithm of _e_, the base of the natural logarithms; this value is approximately 1.4426950408889634.</p>
+        <p>The Number value for the base-2 logarithm of <i>e</i>, the base of the natural logarithms; this value is approximately 1.4426950408889634.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
         <emu-note>
           <p>The value of `Math.LOG2E` is approximately the reciprocal of the value of `Math.LN2`.</p>


### PR DESCRIPTION
I used `<em>`, but I'm open to other ideas for how to stylise it. Either way, it shouldn't be an unbound alias reference.

before:

![image](https://github.com/tc39/ecma262/assets/218840/246b2d63-cd88-4dad-9d38-1cdc342c26ad)

after:

![image](https://github.com/tc39/ecma262/assets/218840/73795811-aff2-4cc0-ab42-5ca68fcb7203)

