### PR TITLE
Editorial: use standard arithmetic operators in MakeTime

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -32478,9 +32478,11 @@
           1. Let _m_ be 𝔽(! ToIntegerOrInfinity(_min_)).
           1. Let _s_ be 𝔽(! ToIntegerOrInfinity(_sec_)).
           1. Let _milli_ be 𝔽(! ToIntegerOrInfinity(_ms_)).
-          1. Let _t_ be ((_h_ `*` msPerHour `+` _m_ `*` msPerMinute) `+` _s_ `*` msPerSecond) `+` _milli_, performing the arithmetic according to IEEE 754-2019 rules (that is, as if using the ECMAScript operators `*` and `+`).
-          1. Return _t_.
+          1. Return ((_h_ × msPerHour + _m_ × msPerMinute) + _s_ × msPerSecond) + _milli_.
         </emu-alg>
+        <emu-note>
+          <p>The arithmetic in MakeTime is floating-point arithmetic, which is not associative, so the operations must be performed in the correct order.</p>
+        </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-makeday" type="abstract operation">


### PR DESCRIPTION
Fixes #3089.

From [5.2.5](https://tc39.es/ecma262/#sec-mathematical-operations):

> Numeric operators such as +, ×, =, and ≥ refer to those operations as determined by the type of the operands. [&hellip;] When applied to Numbers, the operators refer to the relevant operations within [IEEE 754-2019](https://tc39.es/ecma262/#sec-bibliography).