### PR TITLE
Editorial: Replace the single-row time zone code points table

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -32747,7 +32747,7 @@ THH:mm:ss.sss
 
           TemporalSign :::
             ASCIISign
-            &lt;U+2212 (MINUS SIGN)&gt;
+            &lt;U+2212 MINUS SIGN&gt;
 
           ASCIISign ::: one of
             `+` `-`

--- a/spec.html
+++ b/spec.html
@@ -32736,35 +32736,7 @@ THH:mm:ss.sss
         <p>
           ECMAScript defines a string interchange format for UTC offsets, derived from ISO 8601.
           The format is described by the following grammar.
-          The usage of Unicode code points in this grammar is listed in <emu-xref href="#table-time-zone-offset-string-code-points"></emu-xref>.
         </p>
-
-        <emu-table id="table-time-zone-offset-string-code-points" caption="Time Zone Offset String Code Points">
-          <table>
-            <tr>
-              <th>
-                Code Point
-              </th>
-              <th>
-                Unicode Name
-              </th>
-              <th>
-                Abbreviation
-              </th>
-            </tr>
-            <tr>
-              <td>
-                `U+2212`
-              </td>
-              <td>
-                MINUS SIGN
-              </td>
-              <td>
-                &lt;MINUS>
-              </td>
-            </tr>
-          </table>
-        </emu-table>
 
         <h2>Syntax</h2>
         <emu-grammar type="definition">
@@ -32775,7 +32747,7 @@ THH:mm:ss.sss
 
           TemporalSign :::
             ASCIISign
-            &lt;MINUS&gt;
+            &lt;U+2212 (MINUS SIGN)&gt;
 
           ASCIISign ::: one of
             `+` `-`


### PR DESCRIPTION
The single-row [Time Zone Offset String Code Points table](https://tc39.es/ecma262/multipage/numbers-and-dates.html#table-time-zone-offset-string-code-points) takes up a large amount of visual space for little practical benefit. This PR replaces it with direct use of `<U+2212 MINUS SIGN>` in the only grammar production that references the abbreviation defined by the table.