### PR TITLE
Editorial: Generalize ParseText to support String input

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -4995,8 +4995,7 @@
           <dl class="header">
           </dl>
           <emu-alg>
-            1. Let _text_ be StringToCodePoints(_str_).
-            1. Let _literal_ be ParseText(_text_, |StringNumericLiteral|).
+            1. Let _literal_ be ParseText(_str_, |StringNumericLiteral|).
             1. If _literal_ is a List of errors, return *NaN*.
             1. Return StringNumericValue of _literal_.
           </emu-alg>
@@ -5379,8 +5378,7 @@
       <dl class="header">
       </dl>
       <emu-alg>
-        1. Let _text_ be StringToCodePoints(_str_).
-        1. Let _literal_ be ParseText(_text_, |StringIntegerLiteral|).
+        1. Let _literal_ be ParseText(_str_, |StringIntegerLiteral|).
         1. If _literal_ is a List of errors, return *undefined*.
         1. Let _mv_ be the MV of _literal_.
         1. Assert: _mv_ is an integer.
@@ -16124,13 +16122,14 @@
     <emu-clause id="sec-parsetext" type="abstract operation">
       <h1>
         Static Semantics: ParseText (
-          _sourceText_: a sequence of Unicode code points,
+          _sourceText_: a String or a sequence of Unicode code points,
           _goalSymbol_: a nonterminal in one of the ECMAScript grammars,
         ): a Parse Node or a non-empty List of *SyntaxError* objects
       </h1>
       <dl class="header">
       </dl>
       <emu-alg>
+        1. If _sourceText_ is a String, set _sourceText_ to StringToCodePoints(_sourceText_).
         1. Attempt to parse _sourceText_ using _goalSymbol_ as the goal symbol, and analyse the parse result for any early error conditions. Parsing and early error detection may be interleaved in an implementation-defined manner.
         1. If the parse succeeded and no early errors were found, return the Parse Node (an instance of _goalSymbol_) at the root of the parse tree resulting from the parse.
         1. Otherwise, return a List of one or more *SyntaxError* objects representing the parsing errors and/or early errors. If more than one parsing error or early error is present, the number and ordering of error objects in the list is implementation-defined, but at least one must be present.
@@ -28899,7 +28898,7 @@
               1. Let _classFieldInitializerName_ be _F_.[[ClassFieldInitializerName]].
               1. If _classFieldInitializerName_ is not ~empty~, set _inClassFieldInitializer_ to *true*.
           1. Perform the following substeps in an implementation-defined order, possibly interleaving parsing and error detection:
-            1. Let _script_ be ParseText(StringToCodePoints(_x_), |Script|).
+            1. Let _script_ be ParseText(_x_, |Script|).
             1. If _script_ is a List of errors, throw a *SyntaxError* exception.
             1. If _script_ Contains |ScriptBody| is *false*, return *undefined*.
             1. Let _body_ be the |ScriptBody| of _script_.
@@ -29314,7 +29313,7 @@
           1. Let _len_ be the length of _string_.
           1. Assert: _position_ + 2 ≤ _len_.
           1. Let _hexDigits_ be the substring of _string_ from _position_ to _position_ + 2.
-          1. Let _parseResult_ be ParseText(StringToCodePoints(_hexDigits_), |HexDigits[~Sep]|).
+          1. Let _parseResult_ be ParseText(_hexDigits_, |HexDigits[~Sep]|).
           1. If _parseResult_ is not a Parse Node, return _parseResult_.
           1. Let _n_ be the MV of _parseResult_.
           1. Assert: _n_ is in the inclusive interval from 0 to 255.
@@ -30208,9 +30207,9 @@
             1. Let _bodyParseString_ be the string-concatenation of 0x000A (LINE FEED), _bodyString_, and 0x000A (LINE FEED).
             1. Let _sourceString_ be the string-concatenation of _prefix_, *" anonymous("*, _P_, 0x000A (LINE FEED), *") {"*, _bodyParseString_, and *"}"*.
             1. Let _sourceText_ be StringToCodePoints(_sourceString_).
-            1. Let _parameters_ be ParseText(StringToCodePoints(_P_), _parameterSym_).
+            1. Let _parameters_ be ParseText(_P_, _parameterSym_).
             1. If _parameters_ is a List of errors, throw a *SyntaxError* exception.
-            1. Let _body_ be ParseText(StringToCodePoints(_bodyParseString_), _bodySym_).
+            1. Let _body_ be ParseText(_bodyParseString_, _bodySym_).
             1. If _body_ is a List of errors, throw a *SyntaxError* exception.
             1. NOTE: The parameters and body are parsed separately to ensure that each is valid alone. For example, `new Function("/*", "*/ ) {")` does not evaluate to a function.
             1. NOTE: If this step is reached, _sourceText_ must have the syntax of _exprSym_ (although the reverse implication does not hold). The purpose of the next two steps is to enforce any Early Error rules which apply to _exprSym_ directly.
@@ -33230,7 +33229,7 @@ THH:mm:ss.sss
             <dd>The return value indicates whether _offsetString_ conforms to the grammar given by |UTCOffset|.</dd>
           </dl>
           <emu-alg>
-            1. Let _parseResult_ be ParseText(StringToCodePoints(_offsetString_), |UTCOffset|).
+            1. Let _parseResult_ be ParseText(_offsetString_, |UTCOffset|).
             1. If _parseResult_ is a List of errors, return *false*.
             1. Return *true*.
           </emu-alg>
@@ -33247,7 +33246,7 @@ THH:mm:ss.sss
             <dd>The return value is the UTC offset, as a number of nanoseconds, that corresponds to the String _offsetString_.</dd>
           </dl>
           <emu-alg>
-            1. Let _parseResult_ be ParseText(StringToCodePoints(_offsetString_), |UTCOffset|).
+            1. Let _parseResult_ be ParseText(_offsetString_, |UTCOffset|).
             1. Assert: _parseResult_ is not a List of errors.
             1. Assert: _parseResult_ contains a |TemporalSign| Parse Node.
             1. Let _parsedSign_ be the source text matched by the |TemporalSign| Parse Node contained within _parseResult_.
@@ -44944,7 +44943,7 @@ THH:mm:ss.sss
         1. Let _jsonString_ be ? ToString(_text_).
         1. [id="step-json-parse-validate"] Parse StringToCodePoints(_jsonString_) as a JSON text as specified in ECMA-404. Throw a *SyntaxError* exception if it is not a valid JSON text as defined in that specification.
         1. Let _scriptString_ be the string-concatenation of *"("*, _jsonString_, and *");"*.
-        1. [id="step-json-parse-parse"] Let _script_ be ParseText(StringToCodePoints(_scriptString_), |Script|).
+        1. [id="step-json-parse-parse"] Let _script_ be ParseText(_scriptString_, |Script|).
         1. NOTE: The early error rules defined in <emu-xref href="#sec-object-initializer-static-semantics-early-errors"></emu-xref> have special handling for the above invocation of ParseText.
         1. Assert: _script_ is a Parse Node.
         1. [id="step-json-parse-eval"] Let _completion_ be Completion(<emu-meta suppress-effects="user-code">Evaluation of _script_</emu-meta>).
@@ -50143,7 +50142,7 @@ THH:mm:ss.sss
               1. Else if _k_ + 3 ≤ _len_, then
                 1. Set _hexDigits_ to the substring of _string_ from _k_ + 1 to _k_ + 3.
                 1. Set _optionalAdvance_ to 2.
-              1. Let _parseResult_ be ParseText(StringToCodePoints(_hexDigits_), |HexDigits[~Sep]|).
+              1. Let _parseResult_ be ParseText(_hexDigits_, |HexDigits[~Sep]|).
               1. If _parseResult_ is a Parse Node, then
                 1. Let _n_ be the MV of _parseResult_.
                 1. Set _C_ to the code unit whose numeric value is _n_.


### PR DESCRIPTION
`ParseText(StringToCodePoints(_str_), |Nonterminal|)`, often introducing a new alias just for the output of StringToCodePoints, is a common pattern necessitated by ParseText expecting its first argument to be a sequence of code points in operations that have a String. I think it makes sense to simplify those call sites by allowing ParseText to directly accept the String and perform conversion itself.