### PR TITLE
Meta: Upgrade ESMeta to v0.3.2

### DIFF
--- a/.github/workflows/esmeta-typecheck.yml
+++ b/.github/workflows/esmeta-typecheck.yml
@@ -24,7 +24,7 @@ jobs:
           cd "${ESMETA_HOME}"
           git init
           git remote add origin https://github.com/es-meta/esmeta.git
-          git fetch --depth 1 origin 604160b059a026a28654d192e4fe0fb461527623 ;# v0.3.1
+          git fetch --depth 1 origin af37f8a694d749bb9a624de71407eed2fa71b1dc ;# v0.3.2
           git checkout FETCH_HEAD
       - name: build esmeta
         run: |


### PR DESCRIPTION
I updated the version of [ESMeta](https://github.com/es-meta/esmeta) to [v0.3.2](https://github.com/es-meta/esmeta/releases/tag/v0.3.2).

We fixed the bug in the grammar parser related to https://github.com/tc39/ecma262/pull/3098 (https://github.com/es-meta/esmeta/issues/147 and https://github.com/rbuckton/grammarkdown/issues/91).