### PR TITLE
Editorial: Remove unnecessary `If` in SystemTimeZoneIdentifier

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -32343,7 +32343,6 @@
         <emu-alg>
           1. If the implementation only supports the UTC time zone, return *"UTC"*.
           1. Let _systemTimeZoneString_ be the String representing the host environment's current time zone, either a primary time zone identifier or an offset time zone identifier.
-          1. If IsTimeZoneOffsetString(_systemTimeZoneString_) is *true*, return _systemTimeZoneString_.
           1. Return _systemTimeZoneString_.
         </emu-alg>
 


### PR DESCRIPTION
Originally the [SystemTimeZoneIdentifier](https://tc39.es/ecma262/#sec-systemtimezoneidentifier) AO contained an assert that applied to named time zones but not offset time zones. Based on editors' feedback in #3035, this assertion was removed and replaced with different text, making the remaining If statement unnecessary. But I didn't notice this until after #3035 was merged.

This commit removes the now-unnecessary `If` statement.