### PR TITLE
Editorial: rename `~Uint8C~` type to `~Uint8Clamped~`

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -39633,7 +39633,7 @@ THH:mm:ss.sss
             <dfn>%Uint8ClampedArray%</dfn>
           </td>
           <td>
-            ~Uint8C~
+            ~Uint8Clamped~
           </td>
           <td>
             1
@@ -42185,7 +42185,7 @@ THH:mm:ss.sss
           <dd>It verifies if the argument _type_ is an unsigned TypedArray element type.</dd>
         </dl>
         <emu-alg>
-          1. If _type_ is one of ~Uint8~, ~Uint8C~, ~Uint16~, ~Uint32~, or ~BigUint64~, return *true*.
+          1. If _type_ is one of ~Uint8~, ~Uint8Clamped~, ~Uint16~, ~Uint32~, or ~BigUint64~, return *true*.
           1. Return *false*.
         </emu-alg>
       </emu-clause>
@@ -42198,7 +42198,7 @@ THH:mm:ss.sss
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It verifies if the argument _type_ is an Integer TypedArray element type not including ~Uint8C~.</dd>
+          <dd>It verifies if the argument _type_ is an Integer TypedArray element type not including ~Uint8Clamped~.</dd>
         </dl>
         <emu-alg>
           1. If _type_ is one of ~Int8~, ~Uint8~, ~Int16~, ~Uint16~, ~Int32~, or ~Uint32~, return *true*.


### PR DESCRIPTION
This means that types match the constructors. This both reads more cleanly, and also supports https://github.com/ljharb/proposal-dataview-get-set-uint8c.