### PR TITLE
Editorial: Add <dfn> variants for "offset time zone identifier(s)"

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -32188,7 +32188,7 @@
 
         <p>
           Time zones in ECMAScript are represented by <dfn variants="time zone identifier">time zone identifiers</dfn>, which are Strings composed entirely of code units in the inclusive interval from 0x0000 to 0x007F.
-          Time zones supported by an ECMAScript implementation may be <dfn variants="available named time zone">available named time zones</dfn>, represented by the [[Identifier]] field of the Time Zone Identifier Records returned by AvailableNamedTimeZoneIdentifiers, or <dfn variants="offset time zone">offset time zones</dfn>, represented by Strings for which IsTimeZoneOffsetString returns *true*.
+          Time zones supported by an ECMAScript implementation may be <dfn variants="available named time zone">available named time zones</dfn>, represented by the [[Identifier]] field of the Time Zone Identifier Records returned by AvailableNamedTimeZoneIdentifiers, or <dfn variants="offset time zone,offset time zone identifier,offset time zone identifiers">offset time zones</dfn>, represented by Strings for which IsTimeZoneOffsetString returns *true*.
         </p>
         <p>
           A <dfn variants="primary time zone identifiers">primary time zone identifier</dfn> is the preferred identifier for an available named time zone.


### PR DESCRIPTION
Adds `<dfn>` variants for "offset time zone identifier" and "offset time zone identifiers" for clearer hyperlinking in 262, 402, and Temporal specs. This is especially helpful when "available named time zone identifier" and "offset time zone identifier" are included in the same sentence, so that "identifier" is hyperlinked in both cases. 

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
