### PR TITLE
Meta: bump ecmarkup to 17.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://tc39.es/ecma262/#sec-copyright-and-software-license",
       "dependencies": {
-        "ecmarkup": "^17.0.0"
+        "ecmarkup": "^17.0.2"
       },
       "devDependencies": {
         "glob": "^7.1.6",
@@ -724,9 +724,9 @@
       }
     },
     "node_modules/ecmarkup": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-17.0.0.tgz",
-      "integrity": "sha512-eQr9Vn9IPIH3rrbYEGPqfAwDJ9pg1zrOSZXc8HQwVMQ9d5tb+BsoPeKw5W1SinL09yZalcbLyqnX7rC393VRdA==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-17.0.2.tgz",
+      "integrity": "sha512-+vvA1tI9sISgCKtnfwdC6dcuLGX4DGHPVy9zPh3XJLHeRxxy8euG1vklMM7gsEb6/J4H0ks2yup5Y/ekU51k6g==",
       "dependencies": {
         "chalk": "^4.1.2",
         "command-line-args": "^5.2.0",
@@ -2940,9 +2940,9 @@
       }
     },
     "ecmarkup": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-17.0.0.tgz",
-      "integrity": "sha512-eQr9Vn9IPIH3rrbYEGPqfAwDJ9pg1zrOSZXc8HQwVMQ9d5tb+BsoPeKw5W1SinL09yZalcbLyqnX7rC393VRdA==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-17.0.2.tgz",
+      "integrity": "sha512-+vvA1tI9sISgCKtnfwdC6dcuLGX4DGHPVy9zPh3XJLHeRxxy8euG1vklMM7gsEb6/J4H0ks2yup5Y/ekU51k6g==",
       "requires": {
         "chalk": "^4.1.2",
         "command-line-args": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "license": "SEE LICENSE IN https://tc39.es/ecma262/#sec-copyright-and-software-license",
   "homepage": "https://tc39.es/ecma262/",
   "dependencies": {
-    "ecmarkup": "^17.0.0"
+    "ecmarkup": "^17.0.2"
   },
   "devDependencies": {
     "glob": "^7.1.6",

--- a/spec.html
+++ b/spec.html
@@ -36482,7 +36482,7 @@ THH:mm:ss.sss
             1. If _rer_.[[UnicodeSets]] is *true*, then
               1. Assert: _invert_ is *false*.
               1. Assert: Every element of _A_ consists of a single character.
-            1. Return a new Matcher with parameters (_x_, _c_) that captures _rer_, _invert_, and _direction_ and performs the following steps when called:
+            1. Return a new Matcher with parameters (_x_, _c_) that captures _rer_, _A_, _invert_, and _direction_ and performs the following steps when called:
               1. Assert: _x_ is a MatchState.
               1. Assert: _c_ is a MatcherContinuation.
               1. Let _Input_ be _x_'s _input_.


### PR DESCRIPTION
Should unblock https://github.com/tc39/ecma262/pull/3102 via inclusion of https://github.com/tc39/ecmarkup/pull/538.

Includes a commit cherry-picked from https://github.com/tc39/ecma262/pull/3102 (which should be included as a separate commit, marked editorial) so that it can pass CI.