### PR TITLE
Editorial: Fix return-type of TemplateString[s]

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -18525,7 +18525,7 @@
         <h1>
           Static Semantics: TemplateStrings (
             _raw_: a Boolean,
-          ): a List of Strings
+          ): a List of either Strings or *undefined*
         </h1>
         <dl class="header">
         </dl>
@@ -18566,7 +18566,7 @@
           Static Semantics: TemplateString (
             _templateToken_: a |NoSubstitutionTemplate| Parse Node, a |TemplateHead| Parse Node, a |TemplateMiddle| Parse Node, or a |TemplateTail| Parse Node,
             _raw_: a Boolean,
-          ): a String
+          ): a String or *undefined*
         </h1>
         <dl class="header">
         </dl>
@@ -18577,6 +18577,9 @@
             1. Let _string_ be the TV of _templateToken_.
           1. Return _string_.
         </emu-alg>
+        <emu-note>
+          <p>This operation returns *undefined* if _raw_ is *false* and _templateToken_ contains a |NotEscapeSequence|. In all other cases, it returns a String.</p>
+        </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-gettemplateobject" type="abstract operation">
@@ -18594,6 +18597,7 @@
             1. If _e_.[[Site]] is the same Parse Node as _templateLiteral_, then
               1. Return _e_.[[Array]].
           1. Let _rawStrings_ be TemplateStrings of _templateLiteral_ with argument *true*.
+          1. Assert: _rawStrings_ is a List of Strings.
           1. Let _cookedStrings_ be TemplateStrings of _templateLiteral_ with argument *false*.
           1. Let _count_ be the number of elements in the List _cookedStrings_.
           1. Assert: _count_ ≤ 2<sup>32</sup> - 1.


### PR DESCRIPTION
In a tagged TemplateLiteral, NotEscapeSequence is allowed.
The TV of `TemplateCharacter :: \ NotEscapeSequence` is `*undefined*`.
This will then propagate up to TemplateString and TemplateStrings (when `_raw_` is `*false*`).

This PR fixes the return-type of TemplateString[s] accordingly.