### PR TITLE
Editorial: Clarify RegExp grammar parameter N → NamedCaptureGroups

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -35256,31 +35256,31 @@ THH:mm:ss.sss
       <p>The RegExp constructor applies the following grammar to the input pattern String. An error occurs if the grammar cannot interpret the String as an expansion of |Pattern|.</p>
       <h2>Syntax</h2>
       <emu-grammar type="definition">
-        Pattern[UnicodeMode, UnicodeSetsMode, N] ::
-          Disjunction[?UnicodeMode, ?UnicodeSetsMode, ?N]
+        Pattern[UnicodeMode, UnicodeSetsMode, NamedCaptureGroups] ::
+          Disjunction[?UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups]
 
-        Disjunction[UnicodeMode, UnicodeSetsMode, N] ::
-          Alternative[?UnicodeMode, ?UnicodeSetsMode, ?N]
-          Alternative[?UnicodeMode, ?UnicodeSetsMode, ?N] `|` Disjunction[?UnicodeMode, ?UnicodeSetsMode, ?N]
+        Disjunction[UnicodeMode, UnicodeSetsMode, NamedCaptureGroups] ::
+          Alternative[?UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups]
+          Alternative[?UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups] `|` Disjunction[?UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups]
 
-        Alternative[UnicodeMode, UnicodeSetsMode, N] ::
+        Alternative[UnicodeMode, UnicodeSetsMode, NamedCaptureGroups] ::
           [empty]
-          Alternative[?UnicodeMode, ?UnicodeSetsMode, ?N] Term[?UnicodeMode, ?UnicodeSetsMode, ?N]
+          Alternative[?UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups] Term[?UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups]
 
-        Term[UnicodeMode, UnicodeSetsMode, N] ::
-          Assertion[?UnicodeMode, ?UnicodeSetsMode, ?N]
-          Atom[?UnicodeMode, ?UnicodeSetsMode, ?N]
-          Atom[?UnicodeMode, ?UnicodeSetsMode, ?N] Quantifier
+        Term[UnicodeMode, UnicodeSetsMode, NamedCaptureGroups] ::
+          Assertion[?UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups]
+          Atom[?UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups]
+          Atom[?UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups] Quantifier
 
-        Assertion[UnicodeMode, UnicodeSetsMode, N] ::
+        Assertion[UnicodeMode, UnicodeSetsMode, NamedCaptureGroups] ::
           `^`
           `$`
           `\b`
           `\B`
-          `(?=` Disjunction[?UnicodeMode, ?UnicodeSetsMode, ?N] `)`
-          `(?!` Disjunction[?UnicodeMode, ?UnicodeSetsMode, ?N] `)`
-          `(?&lt;=` Disjunction[?UnicodeMode, ?UnicodeSetsMode, ?N] `)`
-          `(?&lt;!` Disjunction[?UnicodeMode, ?UnicodeSetsMode, ?N] `)`
+          `(?=` Disjunction[?UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups] `)`
+          `(?!` Disjunction[?UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups] `)`
+          `(?&lt;=` Disjunction[?UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups] `)`
+          `(?&lt;!` Disjunction[?UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups] `)`
 
         Quantifier ::
           QuantifierPrefix
@@ -35294,13 +35294,13 @@ THH:mm:ss.sss
           `{` DecimalDigits[~Sep] `,}`
           `{` DecimalDigits[~Sep] `,` DecimalDigits[~Sep] `}`
 
-        Atom[UnicodeMode, UnicodeSetsMode, N] ::
+        Atom[UnicodeMode, UnicodeSetsMode, NamedCaptureGroups] ::
           PatternCharacter
           `.`
-          `\` AtomEscape[?UnicodeMode, ?N]
+          `\` AtomEscape[?UnicodeMode, ?NamedCaptureGroups]
           CharacterClass[?UnicodeMode, ?UnicodeSetsMode]
-          `(` GroupSpecifier[?UnicodeMode]? Disjunction[?UnicodeMode, ?UnicodeSetsMode, ?N] `)`
-          `(?:` Disjunction[?UnicodeMode, ?UnicodeSetsMode, ?N] `)`
+          `(` GroupSpecifier[?UnicodeMode]? Disjunction[?UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups] `)`
+          `(?:` Disjunction[?UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups] `)`
 
         SyntaxCharacter :: one of
           `^` `$` `\` `.` `*` `+` `?` `(` `)` `[` `]` `{` `}` `|`
@@ -35308,11 +35308,11 @@ THH:mm:ss.sss
         PatternCharacter ::
           SourceCharacter but not SyntaxCharacter
 
-        AtomEscape[UnicodeMode, N] ::
+        AtomEscape[UnicodeMode, NamedCaptureGroups] ::
           DecimalEscape
           CharacterClassEscape[?UnicodeMode]
           CharacterEscape[?UnicodeMode]
-          [+N] `k` GroupName[?UnicodeMode]
+          [+NamedCaptureGroups] `k` GroupName[?UnicodeMode]
 
         CharacterEscape[UnicodeMode] ::
           ControlEscape
@@ -37455,11 +37455,11 @@ THH:mm:ss.sss
           1. If _v_ is *true* and _u_ is *true*, then
             1. Let _parseResult_ be a List containing one or more *SyntaxError* objects.
           1. Else if _v_ is *true*, then
-            1. Let _parseResult_ be ParseText(_patternText_, |Pattern[+UnicodeMode, +UnicodeSetsMode, +N]|).
+            1. Let _parseResult_ be ParseText(_patternText_, |Pattern[+UnicodeMode, +UnicodeSetsMode, +NamedCaptureGroups]|).
           1. Else if _u_ is *true*, then
-            1. Let _parseResult_ be ParseText(_patternText_, |Pattern[+UnicodeMode, ~UnicodeSetsMode, +N]|).
+            1. Let _parseResult_ be ParseText(_patternText_, |Pattern[+UnicodeMode, ~UnicodeSetsMode, +NamedCaptureGroups]|).
           1. Else,
-            1. Let _parseResult_ be ParseText(_patternText_, |Pattern[~UnicodeMode, ~UnicodeSetsMode, +N]|).
+            1. Let _parseResult_ be ParseText(_patternText_, |Pattern[~UnicodeMode, ~UnicodeSetsMode, +NamedCaptureGroups]|).
           1. Return _parseResult_.
         </emu-alg>
       </emu-clause>
@@ -49020,37 +49020,37 @@ THH:mm:ss.sss
       <p>This alternative pattern grammar and semantics only changes the syntax and semantics of BMP patterns. The following grammar extensions include productions parameterized with the [UnicodeMode] parameter. However, none of these extensions change the syntax of Unicode patterns recognized when parsing with the [UnicodeMode] parameter present on the goal symbol.</p>
       <h2>Syntax</h2>
       <emu-grammar type="definition">
-        Term[UnicodeMode, UnicodeSetsMode, N] ::
-          [+UnicodeMode] Assertion[+UnicodeMode, ?UnicodeSetsMode, ?N]
-          [+UnicodeMode] Atom[+UnicodeMode, ?UnicodeSetsMode, ?N] Quantifier
-          [+UnicodeMode] Atom[+UnicodeMode, ?UnicodeSetsMode, ?N]
-          [~UnicodeMode] QuantifiableAssertion[?N] Quantifier
-          [~UnicodeMode] Assertion[~UnicodeMode, ~UnicodeSetsMode, ?N]
-          [~UnicodeMode] ExtendedAtom[?N] Quantifier
-          [~UnicodeMode] ExtendedAtom[?N]
+        Term[UnicodeMode, UnicodeSetsMode, NamedCaptureGroups] ::
+          [+UnicodeMode] Assertion[+UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups]
+          [+UnicodeMode] Atom[+UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups] Quantifier
+          [+UnicodeMode] Atom[+UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups]
+          [~UnicodeMode] QuantifiableAssertion[?NamedCaptureGroups] Quantifier
+          [~UnicodeMode] Assertion[~UnicodeMode, ~UnicodeSetsMode, ?NamedCaptureGroups]
+          [~UnicodeMode] ExtendedAtom[?NamedCaptureGroups] Quantifier
+          [~UnicodeMode] ExtendedAtom[?NamedCaptureGroups]
 
-        Assertion[UnicodeMode, UnicodeSetsMode, N] ::
+        Assertion[UnicodeMode, UnicodeSetsMode, NamedCaptureGroups] ::
           `^`
           `$`
           `\b`
           `\B`
-          [+UnicodeMode] `(?=` Disjunction[+UnicodeMode, ?UnicodeSetsMode, ?N] `)`
-          [+UnicodeMode] `(?!` Disjunction[+UnicodeMode, ?UnicodeSetsMode, ?N] `)`
-          [~UnicodeMode] QuantifiableAssertion[?N]
-          `(?&lt;=` Disjunction[?UnicodeMode, ?UnicodeSetsMode, ?N] `)`
-          `(?&lt;!` Disjunction[?UnicodeMode, ?UnicodeSetsMode, ?N] `)`
+          [+UnicodeMode] `(?=` Disjunction[+UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups] `)`
+          [+UnicodeMode] `(?!` Disjunction[+UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups] `)`
+          [~UnicodeMode] QuantifiableAssertion[?NamedCaptureGroups]
+          `(?&lt;=` Disjunction[?UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups] `)`
+          `(?&lt;!` Disjunction[?UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups] `)`
 
-        QuantifiableAssertion[N] ::
-          `(?=` Disjunction[~UnicodeMode, ~UnicodeSetsMode, ?N] `)`
-          `(?!` Disjunction[~UnicodeMode, ~UnicodeSetsMode, ?N] `)`
+        QuantifiableAssertion[NamedCaptureGroups] ::
+          `(?=` Disjunction[~UnicodeMode, ~UnicodeSetsMode, ?NamedCaptureGroups] `)`
+          `(?!` Disjunction[~UnicodeMode, ~UnicodeSetsMode, ?NamedCaptureGroups] `)`
 
-        ExtendedAtom[N] ::
+        ExtendedAtom[NamedCaptureGroups] ::
           `.`
-          `\` AtomEscape[~UnicodeMode, ?N]
+          `\` AtomEscape[~UnicodeMode, ?NamedCaptureGroups]
           `\` [lookahead == `c`]
           CharacterClass[~UnicodeMode, ~UnicodeSetsMode]
-          `(` GroupSpecifier[~UnicodeMode]? Disjunction[~UnicodeMode, ~UnicodeSetsMode, ?N] `)`
-          `(?:` Disjunction[~UnicodeMode, ~UnicodeSetsMode, ?N] `)`
+          `(` GroupSpecifier[~UnicodeMode]? Disjunction[~UnicodeMode, ~UnicodeSetsMode, ?NamedCaptureGroups] `)`
+          `(?:` Disjunction[~UnicodeMode, ~UnicodeSetsMode, ?NamedCaptureGroups] `)`
           InvalidBracedQuantifier
           ExtendedPatternCharacter
 
@@ -49062,42 +49062,42 @@ THH:mm:ss.sss
         ExtendedPatternCharacter ::
           SourceCharacter but not one of `^` `$` `\` `.` `*` `+` `?` `(` `)` `[` `|`
 
-        AtomEscape[UnicodeMode, N] ::
+        AtomEscape[UnicodeMode, NamedCaptureGroups] ::
           [+UnicodeMode] DecimalEscape
           [~UnicodeMode] DecimalEscape [> but only if the CapturingGroupNumber of |DecimalEscape| is &le; CountLeftCapturingParensWithin(the |Pattern| containing |DecimalEscape|)]
           CharacterClassEscape[?UnicodeMode]
-          CharacterEscape[?UnicodeMode, ?N]
-          [+N] `k` GroupName[?UnicodeMode]
+          CharacterEscape[?UnicodeMode, ?NamedCaptureGroups]
+          [+NamedCaptureGroups] `k` GroupName[?UnicodeMode]
 
-        CharacterEscape[UnicodeMode, N] ::
+        CharacterEscape[UnicodeMode, NamedCaptureGroups] ::
           ControlEscape
           `c` AsciiLetter
           `0` [lookahead &notin; DecimalDigit]
           HexEscapeSequence
           RegExpUnicodeEscapeSequence[?UnicodeMode]
           [~UnicodeMode] LegacyOctalEscapeSequence
-          IdentityEscape[?UnicodeMode, ?N]
+          IdentityEscape[?UnicodeMode, ?NamedCaptureGroups]
 
-        IdentityEscape[UnicodeMode, N] ::
+        IdentityEscape[UnicodeMode, NamedCaptureGroups] ::
           [+UnicodeMode] SyntaxCharacter
           [+UnicodeMode] `/`
-          [~UnicodeMode] SourceCharacterIdentityEscape[?N]
+          [~UnicodeMode] SourceCharacterIdentityEscape[?NamedCaptureGroups]
 
-        SourceCharacterIdentityEscape[N] ::
-          [~N] SourceCharacter but not `c`
-          [+N] SourceCharacter but not one of `c` or `k`
+        SourceCharacterIdentityEscape[NamedCaptureGroups] ::
+          [~NamedCaptureGroups] SourceCharacter but not `c`
+          [+NamedCaptureGroups] SourceCharacter but not one of `c` or `k`
 
-        ClassAtomNoDash[UnicodeMode, N] ::
+        ClassAtomNoDash[UnicodeMode, NamedCaptureGroups] ::
           SourceCharacter but not one of `\` or `]` or `-`
-          `\` ClassEscape[?UnicodeMode, ?N]
+          `\` ClassEscape[?UnicodeMode, ?NamedCaptureGroups]
           `\` [lookahead == `c`]
 
-        ClassEscape[UnicodeMode, N] ::
+        ClassEscape[UnicodeMode, NamedCaptureGroups] ::
           `b`
           [+UnicodeMode] `-`
           [~UnicodeMode] `c` ClassControlLetter
           CharacterClassEscape[?UnicodeMode]
-          CharacterEscape[?UnicodeMode, ?N]
+          CharacterEscape[?UnicodeMode, ?NamedCaptureGroups]
 
         ClassControlLetter ::
           DecimalDigit
@@ -49268,13 +49268,13 @@ THH:mm:ss.sss
           1. If _v_ is *true* and _u_ is *true*, then
             1. Let _parseResult_ be a List containing one or more *SyntaxError* objects.
           1. Else if _v_ is *true*, then
-            1. Let _parseResult_ be ParseText(_patternText_, |Pattern[+UnicodeMode, +UnicodeSetsMode, +N]|).
+            1. Let _parseResult_ be ParseText(_patternText_, |Pattern[+UnicodeMode, +UnicodeSetsMode, +NamedCaptureGroups]|).
           1. Else if _u_ is *true*, then
-            1. Let _parseResult_ be ParseText(_patternText_, |Pattern[+UnicodeMode, ~UnicodeSetsMode, +N]|).
+            1. Let _parseResult_ be ParseText(_patternText_, |Pattern[+UnicodeMode, ~UnicodeSetsMode, +NamedCaptureGroups]|).
           1. Else,
-            1. Let _parseResult_ be ParseText(_patternText_, |Pattern[~UnicodeMode, ~UnicodeSetsMode, ~N]|).
+            1. Let _parseResult_ be ParseText(_patternText_, |Pattern[~UnicodeMode, ~UnicodeSetsMode, ~NamedCaptureGroups]|).
             1. If _parseResult_ is a Parse Node and _parseResult_ contains a |GroupName|, then
-              1. Set _parseResult_ to ParseText(_patternText_, |Pattern[~UnicodeMode, ~UnicodeSetsMode, +N]|).
+              1. Set _parseResult_ to ParseText(_patternText_, |Pattern[~UnicodeMode, ~UnicodeSetsMode, +NamedCaptureGroups]|).
           1. Return _parseResult_.
         </emu-alg>
       </emu-annex>


### PR DESCRIPTION
This makes the parameter more easily searchable while clarifying its meaning.

Issue: #2411
