### PR TITLE
Editorial: Eliminate some Date cruft

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -33669,7 +33669,13 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype.toisostring">
         <h1>Date.prototype.toISOString ( )</h1>
-        <p>If this time value is not a finite Number or if it corresponds with a year that cannot be represented in the <emu-xref href="#sec-date-time-string-format">Date Time String Format</emu-xref>, this method throws a *RangeError* exception. Otherwise, it returns a String representation of this time value in that format on the UTC time scale, including all format elements and the UTC offset representation *"Z"*.</p>
+        <p>This method performs the following steps when called:</p>
+        <emu-alg>
+          1. Let _tv_ be this time value.
+          1. If _tv_ is not finite, throw a *RangeError* exception.
+          1. If _tv_ corresponds with a year that cannot be represented in the <emu-xref href="#sec-date-time-string-format">Date Time String Format</emu-xref>, throw a *RangeError* exception.
+          1. Return a String representation of _tv_ in the <emu-xref href="#sec-date-time-string-format">Date Time String Format</emu-xref> on the UTC time scale, including all format elements and the UTC offset representation *"Z"*.
+        </emu-alg>
       </emu-clause>
 
       <emu-clause id="sec-date.prototype.tojson">

--- a/spec.html
+++ b/spec.html
@@ -33056,7 +33056,7 @@ THH:mm:ss.sss
       </emu-clause>
     </emu-clause>
 
-    <emu-clause id="sec-date-constructor">
+    <emu-clause id="sec-date-constructor" oldids="this-time-value,sec-thistimevalue,thistimevalue,this-Date-object">
       <h1>The Date Constructor</h1>
       <p>The Date constructor:</p>
       <ul>
@@ -33081,7 +33081,7 @@ THH:mm:ss.sss
           1. Else if _numberOfArgs_ = 1, then
             1. Let _value_ be _values_[0].
             1. If _value_ is an Object and _value_ has a [[DateValue]] internal slot, then
-              1. Let _tv_ be ! thisTimeValue(_value_).
+              1. Let _tv_ be _value_.[[DateValue]].
             1. Else,
               1. Let _v_ be ? ToPrimitive(_value_).
               1. If _v_ is a String, then
@@ -33178,13 +33178,6 @@ THH:mm:ss.sss
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
       </ul>
       <p>Unless explicitly defined otherwise, the methods of the Date prototype object defined below are not generic and the *this* value passed to them must be an object that has a [[DateValue]] internal slot that has been initialized to a time value.</p>
-      <p>The abstract operation <dfn id="thistimevalue" aoid="thisTimeValue" oldids="sec-thistimevalue,this-time-value">thisTimeValue</dfn> takes argument _value_. It performs the following steps when called:</p>
-      <emu-alg>
-        1. If _value_ is an Object and _value_ has a [[DateValue]] internal slot, then
-          1. Return _value_.[[DateValue]].
-        1. Throw a *TypeError* exception.
-      </emu-alg>
-      <p>In following descriptions of functions that are properties of the Date prototype object, the phrase “<dfn id="this-Date-object">this Date object</dfn>” refers to the object that is the *this* value for the invocation of the function. If the Type of the *this* value is not Object, a *TypeError* exception is thrown.</p>
 
       <emu-clause id="sec-date.prototype.constructor">
         <h1>Date.prototype.constructor</h1>
@@ -33195,7 +33188,9 @@ THH:mm:ss.sss
         <h1>Date.prototype.getDate ( )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _t_ be ? thisTimeValue(*this* value).
+          1. Let _dateObject_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
+          1. Let _t_ be _dateObject_.[[DateValue]].
           1. If _t_ is *NaN*, return *NaN*.
           1. Return DateFromTime(LocalTime(_t_)).
         </emu-alg>
@@ -33205,7 +33200,9 @@ THH:mm:ss.sss
         <h1>Date.prototype.getDay ( )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _t_ be ? thisTimeValue(*this* value).
+          1. Let _dateObject_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
+          1. Let _t_ be _dateObject_.[[DateValue]].
           1. If _t_ is *NaN*, return *NaN*.
           1. Return WeekDay(LocalTime(_t_)).
         </emu-alg>
@@ -33215,7 +33212,9 @@ THH:mm:ss.sss
         <h1>Date.prototype.getFullYear ( )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _t_ be ? thisTimeValue(*this* value).
+          1. Let _dateObject_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
+          1. Let _t_ be _dateObject_.[[DateValue]].
           1. If _t_ is *NaN*, return *NaN*.
           1. Return YearFromTime(LocalTime(_t_)).
         </emu-alg>
@@ -33225,7 +33224,9 @@ THH:mm:ss.sss
         <h1>Date.prototype.getHours ( )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _t_ be ? thisTimeValue(*this* value).
+          1. Let _dateObject_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
+          1. Let _t_ be _dateObject_.[[DateValue]].
           1. If _t_ is *NaN*, return *NaN*.
           1. Return HourFromTime(LocalTime(_t_)).
         </emu-alg>
@@ -33235,7 +33236,9 @@ THH:mm:ss.sss
         <h1>Date.prototype.getMilliseconds ( )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _t_ be ? thisTimeValue(*this* value).
+          1. Let _dateObject_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
+          1. Let _t_ be _dateObject_.[[DateValue]].
           1. If _t_ is *NaN*, return *NaN*.
           1. Return msFromTime(LocalTime(_t_)).
         </emu-alg>
@@ -33245,7 +33248,9 @@ THH:mm:ss.sss
         <h1>Date.prototype.getMinutes ( )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _t_ be ? thisTimeValue(*this* value).
+          1. Let _dateObject_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
+          1. Let _t_ be _dateObject_.[[DateValue]].
           1. If _t_ is *NaN*, return *NaN*.
           1. Return MinFromTime(LocalTime(_t_)).
         </emu-alg>
@@ -33255,7 +33260,9 @@ THH:mm:ss.sss
         <h1>Date.prototype.getMonth ( )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _t_ be ? thisTimeValue(*this* value).
+          1. Let _dateObject_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
+          1. Let _t_ be _dateObject_.[[DateValue]].
           1. If _t_ is *NaN*, return *NaN*.
           1. Return MonthFromTime(LocalTime(_t_)).
         </emu-alg>
@@ -33265,7 +33272,9 @@ THH:mm:ss.sss
         <h1>Date.prototype.getSeconds ( )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _t_ be ? thisTimeValue(*this* value).
+          1. Let _dateObject_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
+          1. Let _t_ be _dateObject_.[[DateValue]].
           1. If _t_ is *NaN*, return *NaN*.
           1. Return SecFromTime(LocalTime(_t_)).
         </emu-alg>
@@ -33275,7 +33284,9 @@ THH:mm:ss.sss
         <h1>Date.prototype.getTime ( )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Return ? thisTimeValue(*this* value).
+          1. Let _dateObject_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
+          1. Return _dateObject_.[[DateValue]].
         </emu-alg>
       </emu-clause>
 
@@ -33283,7 +33294,9 @@ THH:mm:ss.sss
         <h1>Date.prototype.getTimezoneOffset ( )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _t_ be ? thisTimeValue(*this* value).
+          1. Let _dateObject_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
+          1. Let _t_ be _dateObject_.[[DateValue]].
           1. If _t_ is *NaN*, return *NaN*.
           1. Return (_t_ - LocalTime(_t_)) / msPerMinute.
         </emu-alg>
@@ -33293,7 +33306,9 @@ THH:mm:ss.sss
         <h1>Date.prototype.getUTCDate ( )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _t_ be ? thisTimeValue(*this* value).
+          1. Let _dateObject_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
+          1. Let _t_ be _dateObject_.[[DateValue]].
           1. If _t_ is *NaN*, return *NaN*.
           1. Return DateFromTime(_t_).
         </emu-alg>
@@ -33303,7 +33318,9 @@ THH:mm:ss.sss
         <h1>Date.prototype.getUTCDay ( )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _t_ be ? thisTimeValue(*this* value).
+          1. Let _dateObject_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
+          1. Let _t_ be _dateObject_.[[DateValue]].
           1. If _t_ is *NaN*, return *NaN*.
           1. Return WeekDay(_t_).
         </emu-alg>
@@ -33313,7 +33330,9 @@ THH:mm:ss.sss
         <h1>Date.prototype.getUTCFullYear ( )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _t_ be ? thisTimeValue(*this* value).
+          1. Let _dateObject_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
+          1. Let _t_ be _dateObject_.[[DateValue]].
           1. If _t_ is *NaN*, return *NaN*.
           1. Return YearFromTime(_t_).
         </emu-alg>
@@ -33323,7 +33342,9 @@ THH:mm:ss.sss
         <h1>Date.prototype.getUTCHours ( )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _t_ be ? thisTimeValue(*this* value).
+          1. Let _dateObject_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
+          1. Let _t_ be _dateObject_.[[DateValue]].
           1. If _t_ is *NaN*, return *NaN*.
           1. Return HourFromTime(_t_).
         </emu-alg>
@@ -33333,7 +33354,9 @@ THH:mm:ss.sss
         <h1>Date.prototype.getUTCMilliseconds ( )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _t_ be ? thisTimeValue(*this* value).
+          1. Let _dateObject_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
+          1. Let _t_ be _dateObject_.[[DateValue]].
           1. If _t_ is *NaN*, return *NaN*.
           1. Return msFromTime(_t_).
         </emu-alg>
@@ -33343,7 +33366,9 @@ THH:mm:ss.sss
         <h1>Date.prototype.getUTCMinutes ( )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _t_ be ? thisTimeValue(*this* value).
+          1. Let _dateObject_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
+          1. Let _t_ be _dateObject_.[[DateValue]].
           1. If _t_ is *NaN*, return *NaN*.
           1. Return MinFromTime(_t_).
         </emu-alg>
@@ -33353,7 +33378,9 @@ THH:mm:ss.sss
         <h1>Date.prototype.getUTCMonth ( )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _t_ be ? thisTimeValue(*this* value).
+          1. Let _dateObject_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
+          1. Let _t_ be _dateObject_.[[DateValue]].
           1. If _t_ is *NaN*, return *NaN*.
           1. Return MonthFromTime(_t_).
         </emu-alg>
@@ -33363,7 +33390,9 @@ THH:mm:ss.sss
         <h1>Date.prototype.getUTCSeconds ( )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _t_ be ? thisTimeValue(*this* value).
+          1. Let _dateObject_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
+          1. Let _t_ be _dateObject_.[[DateValue]].
           1. If _t_ is *NaN*, return *NaN*.
           1. Return SecFromTime(_t_).
         </emu-alg>
@@ -33373,13 +33402,15 @@ THH:mm:ss.sss
         <h1>Date.prototype.setDate ( _date_ )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _t_ be ? thisTimeValue(*this* value).
+          1. Let _dateObject_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
+          1. Let _t_ be _dateObject_.[[DateValue]].
           1. Let _dt_ be ? ToNumber(_date_).
           1. If _t_ is *NaN*, return *NaN*.
           1. Set _t_ to LocalTime(_t_).
           1. Let _newDate_ be MakeDate(MakeDay(YearFromTime(_t_), MonthFromTime(_t_), _dt_), TimeWithinDay(_t_)).
           1. Let _u_ be TimeClip(UTC(_newDate_)).
-          1. Set the [[DateValue]] internal slot of this Date object to _u_.
+          1. Set _dateObject_.[[DateValue]] to _u_.
           1. Return _u_.
         </emu-alg>
       </emu-clause>
@@ -33388,14 +33419,16 @@ THH:mm:ss.sss
         <h1>Date.prototype.setFullYear ( _year_ [ , _month_ [ , _date_ ] ] )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _t_ be ? thisTimeValue(*this* value).
+          1. Let _dateObject_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
+          1. Let _t_ be _dateObject_.[[DateValue]].
           1. Let _y_ be ? ToNumber(_year_).
           1. If _t_ is *NaN*, set _t_ to *+0*<sub>𝔽</sub>; otherwise, set _t_ to LocalTime(_t_).
           1. If _month_ is not present, let _m_ be MonthFromTime(_t_); otherwise, let _m_ be ? ToNumber(_month_).
           1. If _date_ is not present, let _dt_ be DateFromTime(_t_); otherwise, let _dt_ be ? ToNumber(_date_).
           1. Let _newDate_ be MakeDate(MakeDay(_y_, _m_, _dt_), TimeWithinDay(_t_)).
           1. Let _u_ be TimeClip(UTC(_newDate_)).
-          1. Set the [[DateValue]] internal slot of this Date object to _u_.
+          1. Set _dateObject_.[[DateValue]] to _u_.
           1. Return _u_.
         </emu-alg>
         <p>The *"length"* property of this method is *3*<sub>𝔽</sub>.</p>
@@ -33408,7 +33441,9 @@ THH:mm:ss.sss
         <h1>Date.prototype.setHours ( _hour_ [ , _min_ [ , _sec_ [ , _ms_ ] ] ] )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _t_ be ? thisTimeValue(*this* value).
+          1. Let _dateObject_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
+          1. Let _t_ be _dateObject_.[[DateValue]].
           1. Let _h_ be ? ToNumber(_hour_).
           1. If _min_ is present, let _m_ be ? ToNumber(_min_).
           1. If _sec_ is present, let _s_ be ? ToNumber(_sec_).
@@ -33420,7 +33455,7 @@ THH:mm:ss.sss
           1. If _ms_ is not present, let _milli_ be msFromTime(_t_).
           1. Let _date_ be MakeDate(Day(_t_), MakeTime(_h_, _m_, _s_, _milli_)).
           1. Let _u_ be TimeClip(UTC(_date_)).
-          1. Set the [[DateValue]] internal slot of this Date object to _u_.
+          1. Set _dateObject_.[[DateValue]] to _u_.
           1. Return _u_.
         </emu-alg>
         <p>The *"length"* property of this method is *4*<sub>𝔽</sub>.</p>
@@ -33433,13 +33468,15 @@ THH:mm:ss.sss
         <h1>Date.prototype.setMilliseconds ( _ms_ )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _t_ be ? thisTimeValue(*this* value).
+          1. Let _dateObject_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
+          1. Let _t_ be _dateObject_.[[DateValue]].
           1. Set _ms_ to ? ToNumber(_ms_).
           1. If _t_ is *NaN*, return *NaN*.
           1. Set _t_ to LocalTime(_t_).
           1. Let _time_ be MakeTime(HourFromTime(_t_), MinFromTime(_t_), SecFromTime(_t_), _ms_).
           1. Let _u_ be TimeClip(UTC(MakeDate(Day(_t_), _time_))).
-          1. Set the [[DateValue]] internal slot of this Date object to _u_.
+          1. Set _dateObject_.[[DateValue]] to _u_.
           1. Return _u_.
         </emu-alg>
       </emu-clause>
@@ -33448,7 +33485,9 @@ THH:mm:ss.sss
         <h1>Date.prototype.setMinutes ( _min_ [ , _sec_ [ , _ms_ ] ] )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _t_ be ? thisTimeValue(*this* value).
+          1. Let _dateObject_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
+          1. Let _t_ be _dateObject_.[[DateValue]].
           1. Let _m_ be ? ToNumber(_min_).
           1. If _sec_ is present, let _s_ be ? ToNumber(_sec_).
           1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_).
@@ -33458,7 +33497,7 @@ THH:mm:ss.sss
           1. If _ms_ is not present, let _milli_ be msFromTime(_t_).
           1. Let _date_ be MakeDate(Day(_t_), MakeTime(HourFromTime(_t_), _m_, _s_, _milli_)).
           1. Let _u_ be TimeClip(UTC(_date_)).
-          1. Set the [[DateValue]] internal slot of this Date object to _u_.
+          1. Set _dateObject_.[[DateValue]] to _u_.
           1. Return _u_.
         </emu-alg>
         <p>The *"length"* property of this method is *3*<sub>𝔽</sub>.</p>
@@ -33471,7 +33510,9 @@ THH:mm:ss.sss
         <h1>Date.prototype.setMonth ( _month_ [ , _date_ ] )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _t_ be ? thisTimeValue(*this* value).
+          1. Let _dateObject_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
+          1. Let _t_ be _dateObject_.[[DateValue]].
           1. Let _m_ be ? ToNumber(_month_).
           1. If _date_ is present, let _dt_ be ? ToNumber(_date_).
           1. If _t_ is *NaN*, return *NaN*.
@@ -33479,7 +33520,7 @@ THH:mm:ss.sss
           1. If _date_ is not present, let _dt_ be DateFromTime(_t_).
           1. Let _newDate_ be MakeDate(MakeDay(YearFromTime(_t_), _m_, _dt_), TimeWithinDay(_t_)).
           1. Let _u_ be TimeClip(UTC(_newDate_)).
-          1. Set the [[DateValue]] internal slot of this Date object to _u_.
+          1. Set _dateObject_.[[DateValue]] to _u_.
           1. Return _u_.
         </emu-alg>
         <p>The *"length"* property of this method is *2*<sub>𝔽</sub>.</p>
@@ -33492,7 +33533,9 @@ THH:mm:ss.sss
         <h1>Date.prototype.setSeconds ( _sec_ [ , _ms_ ] )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _t_ be ? thisTimeValue(*this* value).
+          1. Let _dateObject_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
+          1. Let _t_ be _dateObject_.[[DateValue]].
           1. Let _s_ be ? ToNumber(_sec_).
           1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_).
           1. If _t_ is *NaN*, return *NaN*.
@@ -33500,7 +33543,7 @@ THH:mm:ss.sss
           1. If _ms_ is not present, let _milli_ be msFromTime(_t_).
           1. Let _date_ be MakeDate(Day(_t_), MakeTime(HourFromTime(_t_), MinFromTime(_t_), _s_, _milli_)).
           1. Let _u_ be TimeClip(UTC(_date_)).
-          1. Set the [[DateValue]] internal slot of this Date object to _u_.
+          1. Set _dateObject_.[[DateValue]] to _u_.
           1. Return _u_.
         </emu-alg>
         <p>The *"length"* property of this method is *2*<sub>𝔽</sub>.</p>
@@ -33513,10 +33556,11 @@ THH:mm:ss.sss
         <h1>Date.prototype.setTime ( _time_ )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Perform ? thisTimeValue(*this* value).
+          1. Let _dateObject_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
           1. Let _t_ be ? ToNumber(_time_).
           1. Let _v_ be TimeClip(_t_).
-          1. Set the [[DateValue]] internal slot of this Date object to _v_.
+          1. Set _dateObject_.[[DateValue]] to _v_.
           1. Return _v_.
         </emu-alg>
       </emu-clause>
@@ -33525,12 +33569,14 @@ THH:mm:ss.sss
         <h1>Date.prototype.setUTCDate ( _date_ )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _t_ be ? thisTimeValue(*this* value).
+          1. Let _dateObject_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
+          1. Let _t_ be _dateObject_.[[DateValue]].
           1. Let _dt_ be ? ToNumber(_date_).
           1. If _t_ is *NaN*, return *NaN*.
           1. Let _newDate_ be MakeDate(MakeDay(YearFromTime(_t_), MonthFromTime(_t_), _dt_), TimeWithinDay(_t_)).
           1. Let _v_ be TimeClip(_newDate_).
-          1. Set the [[DateValue]] internal slot of this Date object to _v_.
+          1. Set _dateObject_.[[DateValue]] to _v_.
           1. Return _v_.
         </emu-alg>
       </emu-clause>
@@ -33539,14 +33585,16 @@ THH:mm:ss.sss
         <h1>Date.prototype.setUTCFullYear ( _year_ [ , _month_ [ , _date_ ] ] )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _t_ be ? thisTimeValue(*this* value).
+          1. Let _dateObject_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
+          1. Let _t_ be _dateObject_.[[DateValue]].
           1. If _t_ is *NaN*, set _t_ to *+0*<sub>𝔽</sub>.
           1. Let _y_ be ? ToNumber(_year_).
           1. If _month_ is not present, let _m_ be MonthFromTime(_t_); otherwise, let _m_ be ? ToNumber(_month_).
           1. If _date_ is not present, let _dt_ be DateFromTime(_t_); otherwise, let _dt_ be ? ToNumber(_date_).
           1. Let _newDate_ be MakeDate(MakeDay(_y_, _m_, _dt_), TimeWithinDay(_t_)).
           1. Let _v_ be TimeClip(_newDate_).
-          1. Set the [[DateValue]] internal slot of this Date object to _v_.
+          1. Set _dateObject_.[[DateValue]] to _v_.
           1. Return _v_.
         </emu-alg>
         <p>The *"length"* property of this method is *3*<sub>𝔽</sub>.</p>
@@ -33559,7 +33607,9 @@ THH:mm:ss.sss
         <h1>Date.prototype.setUTCHours ( _hour_ [ , _min_ [ , _sec_ [ , _ms_ ] ] ] )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _t_ be ? thisTimeValue(*this* value).
+          1. Let _dateObject_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
+          1. Let _t_ be _dateObject_.[[DateValue]].
           1. Let _h_ be ? ToNumber(_hour_).
           1. If _min_ is present, let _m_ be ? ToNumber(_min_).
           1. If _sec_ is present, let _s_ be ? ToNumber(_sec_).
@@ -33570,7 +33620,7 @@ THH:mm:ss.sss
           1. If _ms_ is not present, let _milli_ be msFromTime(_t_).
           1. Let _date_ be MakeDate(Day(_t_), MakeTime(_h_, _m_, _s_, _milli_)).
           1. Let _v_ be TimeClip(_date_).
-          1. Set the [[DateValue]] internal slot of this Date object to _v_.
+          1. Set _dateObject_.[[DateValue]] to _v_.
           1. Return _v_.
         </emu-alg>
         <p>The *"length"* property of this method is *4*<sub>𝔽</sub>.</p>
@@ -33583,12 +33633,14 @@ THH:mm:ss.sss
         <h1>Date.prototype.setUTCMilliseconds ( _ms_ )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _t_ be ? thisTimeValue(*this* value).
+          1. Let _dateObject_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
+          1. Let _t_ be _dateObject_.[[DateValue]].
           1. Set _ms_ to ? ToNumber(_ms_).
           1. If _t_ is *NaN*, return *NaN*.
           1. Let _time_ be MakeTime(HourFromTime(_t_), MinFromTime(_t_), SecFromTime(_t_), _ms_).
           1. Let _v_ be TimeClip(MakeDate(Day(_t_), _time_)).
-          1. Set the [[DateValue]] internal slot of this Date object to _v_.
+          1. Set _dateObject_.[[DateValue]] to _v_.
           1. Return _v_.
         </emu-alg>
       </emu-clause>
@@ -33597,7 +33649,9 @@ THH:mm:ss.sss
         <h1>Date.prototype.setUTCMinutes ( _min_ [ , _sec_ [ , _ms_ ] ] )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _t_ be ? thisTimeValue(*this* value).
+          1. Let _dateObject_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
+          1. Let _t_ be _dateObject_.[[DateValue]].
           1. Let _m_ be ? ToNumber(_min_).
           1. If _sec_ is present, let _s_ be ? ToNumber(_sec_).
           1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_).
@@ -33606,7 +33660,7 @@ THH:mm:ss.sss
           1. If _ms_ is not present, let _milli_ be msFromTime(_t_).
           1. Let _date_ be MakeDate(Day(_t_), MakeTime(HourFromTime(_t_), _m_, _s_, _milli_)).
           1. Let _v_ be TimeClip(_date_).
-          1. Set the [[DateValue]] internal slot of this Date object to _v_.
+          1. Set _dateObject_.[[DateValue]] to _v_.
           1. Return _v_.
         </emu-alg>
         <p>The *"length"* property of this method is *3*<sub>𝔽</sub>.</p>
@@ -33619,14 +33673,16 @@ THH:mm:ss.sss
         <h1>Date.prototype.setUTCMonth ( _month_ [ , _date_ ] )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _t_ be ? thisTimeValue(*this* value).
+          1. Let _dateObject_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
+          1. Let _t_ be _dateObject_.[[DateValue]].
           1. Let _m_ be ? ToNumber(_month_).
           1. If _date_ is present, let _dt_ be ? ToNumber(_date_).
           1. If _t_ is *NaN*, return *NaN*.
           1. If _date_ is not present, let _dt_ be DateFromTime(_t_).
           1. Let _newDate_ be MakeDate(MakeDay(YearFromTime(_t_), _m_, _dt_), TimeWithinDay(_t_)).
           1. Let _v_ be TimeClip(_newDate_).
-          1. Set the [[DateValue]] internal slot of this Date object to _v_.
+          1. Set _dateObject_.[[DateValue]] to _v_.
           1. Return _v_.
         </emu-alg>
         <p>The *"length"* property of this method is *2*<sub>𝔽</sub>.</p>
@@ -33639,14 +33695,16 @@ THH:mm:ss.sss
         <h1>Date.prototype.setUTCSeconds ( _sec_ [ , _ms_ ] )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _t_ be ? thisTimeValue(*this* value).
+          1. Let _dateObject_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
+          1. Let _t_ be _dateObject_.[[DateValue]].
           1. Let _s_ be ? ToNumber(_sec_).
           1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_).
           1. If _t_ is *NaN*, return *NaN*.
           1. If _ms_ is not present, let _milli_ be msFromTime(_t_).
           1. Let _date_ be MakeDate(Day(_t_), MakeTime(HourFromTime(_t_), MinFromTime(_t_), _s_, _milli_)).
           1. Let _v_ be TimeClip(_date_).
-          1. Set the [[DateValue]] internal slot of this Date object to _v_.
+          1. Set _dateObject_.[[DateValue]] to _v_.
           1. Return _v_.
         </emu-alg>
         <p>The *"length"* property of this method is *2*<sub>𝔽</sub>.</p>
@@ -33659,8 +33717,9 @@ THH:mm:ss.sss
         <h1>Date.prototype.toDateString ( )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _O_ be this Date object.
-          1. Let _tv_ be ? thisTimeValue(_O_).
+          1. Let _dateObject_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
+          1. Let _tv_ be _dateObject_.[[DateValue]].
           1. If _tv_ is *NaN*, return *"Invalid Date"*.
           1. Let _t_ be LocalTime(_tv_).
           1. Return DateString(_t_).
@@ -33671,7 +33730,9 @@ THH:mm:ss.sss
         <h1>Date.prototype.toISOString ( )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _tv_ be ? thisTimeValue(*this* value).
+          1. Let _dateObject_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
+          1. Let _tv_ be _dateObject_.[[DateValue]].
           1. If _tv_ is not finite, throw a *RangeError* exception.
           1. If _tv_ corresponds with a year that cannot be represented in the <emu-xref href="#sec-date-time-string-format">Date Time String Format</emu-xref>, throw a *RangeError* exception.
           1. Return a String representation of _tv_ in the <emu-xref href="#sec-date-time-string-format">Date Time String Format</emu-xref> on the UTC time scale, including all format elements and the UTC offset representation *"Z"*.
@@ -33721,7 +33782,9 @@ THH:mm:ss.sss
         <h1>Date.prototype.toString ( )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _tv_ be ? thisTimeValue(*this* value).
+          1. Let _dateObject_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
+          1. Let _tv_ be _dateObject_.[[DateValue]].
           1. Return ToDateString(_tv_).
         </emu-alg>
         <emu-note>
@@ -33990,8 +34053,9 @@ THH:mm:ss.sss
         <h1>Date.prototype.toTimeString ( )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _O_ be this Date object.
-          1. Let _tv_ be ? thisTimeValue(_O_).
+          1. Let _dateObject_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
+          1. Let _tv_ be _dateObject_.[[DateValue]].
           1. If _tv_ is *NaN*, return *"Invalid Date"*.
           1. Let _t_ be LocalTime(_tv_).
           1. Return the string-concatenation of TimeString(_t_) and TimeZoneString(_tv_).
@@ -34003,8 +34067,9 @@ THH:mm:ss.sss
         <p>This method returns a String value representing the instant in time corresponding to the *this* value. The format of the String is based upon "HTTP-date" from RFC 7231, generalized to support the full range of times supported by ECMAScript Dates.</p>
         <p>It performs the following steps when called:</p>
         <emu-alg>
-          1. Let _O_ be this Date object.
-          1. Let _tv_ be ? thisTimeValue(_O_).
+          1. Let _dateObject_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
+          1. Let _tv_ be _dateObject_.[[DateValue]].
           1. If _tv_ is *NaN*, return *"Invalid Date"*.
           1. Let _weekday_ be the Name of the entry in <emu-xref href="#sec-todatestring-day-names"></emu-xref> with the Number WeekDay(_tv_).
           1. Let _month_ be the Name of the entry in <emu-xref href="#sec-todatestring-month-names"></emu-xref> with the Number MonthFromTime(_tv_).
@@ -34020,7 +34085,9 @@ THH:mm:ss.sss
         <h1>Date.prototype.valueOf ( )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Return ? thisTimeValue(*this* value).
+          1. Let _dateObject_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
+          1. Return _dateObject_.[[DateValue]].
         </emu-alg>
       </emu-clause>
 
@@ -49469,7 +49536,9 @@ THH:mm:ss.sss
         </emu-note>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _t_ be ? thisTimeValue(*this* value).
+          1. Let _dateObject_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
+          1. Let _t_ be _dateObject_.[[DateValue]].
           1. If _t_ is *NaN*, return *NaN*.
           1. Return YearFromTime(LocalTime(_t_)) - *1900*<sub>𝔽</sub>.
         </emu-alg>
@@ -49482,14 +49551,16 @@ THH:mm:ss.sss
         </emu-note>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _t_ be ? thisTimeValue(*this* value).
+          1. Let _dateObject_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
+          1. Let _t_ be _dateObject_.[[DateValue]].
           1. Let _y_ be ? ToNumber(_year_).
           1. If _t_ is *NaN*, set _t_ to *+0*<sub>𝔽</sub>; otherwise, set _t_ to LocalTime(_t_).
           1. Let _yyyy_ be MakeFullYear(_y_).
           1. Let _d_ be MakeDay(_yyyy_, MonthFromTime(_t_), DateFromTime(_t_)).
           1. Let _date_ be MakeDate(_d_, TimeWithinDay(_t_)).
           1. Let _u_ be TimeClip(UTC(_date_)).
-          1. Set the [[DateValue]] internal slot of this Date object to _u_.
+          1. Set _dateObject_.[[DateValue]] to _u_.
           1. Return _u_.
         </emu-alg>
       </emu-annex>

--- a/spec.html
+++ b/spec.html
@@ -33178,13 +33178,13 @@ THH:mm:ss.sss
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
       </ul>
       <p>Unless explicitly defined otherwise, the methods of the Date prototype object defined below are not generic and the *this* value passed to them must be an object that has a [[DateValue]] internal slot that has been initialized to a time value.</p>
-      <p>The abstract operation <dfn id="thistimevalue" aoid="thisTimeValue" oldids="sec-thistimevalue">thisTimeValue</dfn> takes argument _value_. It performs the following steps when called:</p>
+      <p>The abstract operation <dfn id="thistimevalue" aoid="thisTimeValue" oldids="sec-thistimevalue,this-time-value">thisTimeValue</dfn> takes argument _value_. It performs the following steps when called:</p>
       <emu-alg>
         1. If _value_ is an Object and _value_ has a [[DateValue]] internal slot, then
           1. Return _value_.[[DateValue]].
         1. Throw a *TypeError* exception.
       </emu-alg>
-      <p>In following descriptions of functions that are properties of the Date prototype object, the phrase “<dfn id="this-Date-object">this Date object</dfn>” refers to the object that is the *this* value for the invocation of the function. If the Type of the *this* value is not Object, a *TypeError* exception is thrown. The phrase “<dfn id="this-time-value">this time value</dfn>” within the specification of a method refers to the result returned by calling the abstract operation thisTimeValue with the *this* value of the method invocation passed as the argument.</p>
+      <p>In following descriptions of functions that are properties of the Date prototype object, the phrase “<dfn id="this-Date-object">this Date object</dfn>” refers to the object that is the *this* value for the invocation of the function. If the Type of the *this* value is not Object, a *TypeError* exception is thrown.</p>
 
       <emu-clause id="sec-date.prototype.constructor">
         <h1>Date.prototype.constructor</h1>
@@ -33671,7 +33671,7 @@ THH:mm:ss.sss
         <h1>Date.prototype.toISOString ( )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _tv_ be this time value.
+          1. Let _tv_ be ? thisTimeValue(*this* value).
           1. If _tv_ is not finite, throw a *RangeError* exception.
           1. If _tv_ corresponds with a year that cannot be represented in the <emu-xref href="#sec-date-time-string-format">Date Time String Format</emu-xref>, throw a *RangeError* exception.
           1. Return a String representation of _tv_ in the <emu-xref href="#sec-date-time-string-format">Date Time String Format</emu-xref> on the UTC time scale, including all format elements and the UTC offset representation *"Z"*.
@@ -34000,7 +34000,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype.toutcstring">
         <h1>Date.prototype.toUTCString ( )</h1>
-        <p>This method returns a String value representing the instance in time corresponding to this time value. The format of the String is based upon "HTTP-date" from RFC 7231, generalized to support the full range of times supported by ECMAScript Dates.</p>
+        <p>This method returns a String value representing the instant in time corresponding to the *this* value. The format of the String is based upon "HTTP-date" from RFC 7231, generalized to support the full range of times supported by ECMAScript Dates.</p>
         <p>It performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be this Date object.
@@ -50012,7 +50012,7 @@ THH:mm:ss.sss
   <p><emu-xref href="#sec-timeclip"></emu-xref>: Previous editions permitted the TimeClip abstract operation to return either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub> as the representation of a 0 time value. ECMAScript 2015 specifies that *+0*<sub>𝔽</sub> always returned. This means that for ECMAScript 2015 the time value of a Date is never observably *-0*<sub>𝔽</sub> and methods that return time values never return *-0*<sub>𝔽</sub>.</p>
   <p><emu-xref href="#sec-date-time-string-format"></emu-xref>: If a UTC offset representation is not present, the local time zone is used. Edition 5.1 incorrectly stated that a missing time zone should be interpreted as *"z"*.</p>
   <p><emu-xref href="#sec-date.prototype.toisostring"></emu-xref>: If the year cannot be represented using the Date Time String Format specified in <emu-xref href="#sec-date-time-string-format"></emu-xref> a RangeError exception is thrown. Previous editions did not specify the behaviour for that case.</p>
-  <p><emu-xref href="#sec-date.prototype.tostring"></emu-xref>: Previous editions did not specify the value returned by `Date.prototype.toString` when this time value is *NaN*. ECMAScript 2015 specifies the result to be the String value *"Invalid Date"*.</p>
+  <p><emu-xref href="#sec-date.prototype.tostring"></emu-xref>: Previous editions did not specify the value returned by `Date.prototype.toString` when the time value is *NaN*. ECMAScript 2015 specifies the result to be the String value *"Invalid Date"*.</p>
   <p><emu-xref href="#sec-regexp-pattern-flags"></emu-xref>, <emu-xref href="#sec-escaperegexppattern"></emu-xref>: Any LineTerminator code points in the value of the *"source"* property of a RegExp instance must be expressed using an escape sequence. Edition 5.1 only required the escaping of `/`.</p>
   <p><emu-xref href="#sec-regexp.prototype-@@match"></emu-xref>, <emu-xref href="#sec-regexp.prototype-@@replace"></emu-xref>: In previous editions, the specifications for `String.prototype.match` and `String.prototype.replace` was incorrect for cases where the pattern argument was a RegExp value whose `global` flag is set. The previous specifications stated that for each attempt to match the pattern, if `lastIndex` did not change, it should be incremented by 1. The correct behaviour is that `lastIndex` should be incremented by 1 only if the pattern matched the empty String.</p>
   <p><emu-xref href="#sec-array.prototype.sort"></emu-xref>: Previous editions did not specify how a *NaN* value returned by a _comparefn_ was interpreted by `Array.prototype.sort`. ECMAScript 2015 specifies that such as value is treated as if *+0*<sub>𝔽</sub> was returned from the _comparefn_. ECMAScript 2015 also specifies that ToNumber is applied to the result returned by a _comparefn_. In previous editions, the effect of a _comparefn_ result that is not a Number value was implementation-defined. In practice, implementations call ToNumber.</p>


### PR DESCRIPTION
Resolves #3118.

Eliminates:
- `this time value` term
- `thisTimeValue` operation
- `this Date object` term

and introduces `ThisDateObject` operation.

This PR is structured as a series of small refactorings (with explanatory commit messages), in case that helps review. I intend to squash it somewhat before merging.

This should probably land before #3063, to avoid churn on `thisTimeValue`.