### PR TITLE
Editorial: Change default values of PropertyAttributes and globalThis

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -2746,7 +2746,7 @@
                 a Boolean
               </td>
               <td>
-                *false*
+                *true*
               </td>
               <td>
                 If *false*, attempts by ECMAScript code to change the property's [[Value]] attribute using [[Set]] will not succeed.
@@ -2797,7 +2797,7 @@
                 a Boolean
               </td>
               <td>
-                *false*
+                *true*
               </td>
               <td>
                 If *true*, the property will be enumerated by a for-in enumeration (see <emu-xref href="#sec-for-in-and-for-of-statements"></emu-xref>). Otherwise, the property is said to be non-enumerable.
@@ -2814,7 +2814,7 @@
                 a Boolean
               </td>
               <td>
-                *false*
+                *true*
               </td>
               <td>
                 If *false*, attempts to delete the property, change it from a data property to an accessor property or from an accessor property to a data property, or make any changes to its attributes (other than replacing an existing [[Value]] or setting [[Writable]] to *false*) will fail.
@@ -28683,7 +28683,7 @@
     <emu-clause id="sec-globalthis">
       <h1>globalThis</h1>
       <p>The initial value of the *"globalThis"* property of the global object in a Realm Record _realm_ is _realm_.[[GlobalEnv]].[[GlobalThisValue]].</p>
-      <p>This property has the attributes { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+      <p>This property has the attributes { [[Writable]]: *true*, [[Enumerable]]: *true*, [[Configurable]]: *true* }.</p>
     </emu-clause>
 
     <emu-clause id="sec-value-properties-of-the-global-object-infinity">


### PR DESCRIPTION
Object property's value can be changed, enumerable and deleted by default, the globalThis properties can be accessed by Object.keys and for-in loop by default too