### PR TITLE
Editorial: Correct desiderable to desirable

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -26788,7 +26788,7 @@
           <ul>
             <li>Evaluation must be only performed once, as it can cause side effects; it is thus important to remember whether evaluation has already been performed, even if unsuccessfully. (In the error case, it makes sense to also remember the exception because otherwise subsequent Evaluate() calls would have to synthesize a new one.)</li>
             <li>Linking, on the other hand, is side-effect-free, and thus even if it fails, it can be retried at a later time with no issues.</li>
-            <li>Loading closely interacts with the host, and it may be desiderable for some of them to allow users to retry failed loads (for example, if the failure is caused by temporarily bad network conditions).</li>
+            <li>Loading closely interacts with the host, and it may be desirable for some of them to allow users to retry failed loads (for example, if the failure is caused by temporarily bad network conditions).</li>
           </ul>
 
           <p>Now, consider a module graph with a cycle:</p>


### PR DESCRIPTION
In the section [Example Cyclic Module Record Graphs](https://tc39.es/ecma262/#sec-example-cyclic-module-record-graphs), the word "desiderable" is used.

>Loading closely interacts with the [host](https://tc39.es/ecma262/#host), and it may be **desiderable** for some of them to allow users to retry failed loads (for example, if the failure is caused by temporarily bad network conditions).

Apparently this is actually [an obsolete word](https://en.wiktionary.org/wiki/desiderable), but I've never heard it used in English. I think it's probably an artifact of using the term desideratum.

There's no other use of this word in the spec. There's 1 instance of "desirable", 2 of "undesirable", and 2 of "desired". This patch updates "desiderable" to "desirable" for consistency with the rest of the spec.