### PR TITLE
Editorial: Correct ExportEntry.[[LocalName]] description

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -27454,7 +27454,7 @@
                 a String or *null*
               </td>
               <td>
-                The name that is used to locally access the exported value from within the importing module. *null* if the exported value is not locally accessible from within the module.
+                The name that is used to locally access the exported value from within the exporting module. *null* if the exported value is not locally accessible from within the module.
               </td>
             </tr>
           </table>


### PR DESCRIPTION
`ExportEntry.[[LocalName]]` calls itself the name used in the _importing_ module. I think this is meant to say exporting.

https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#table-exportentry-records

>The name that is used to locally access the exported value from within the **importing** module. null if the exported value is not locally accessible from within the module.

Some export declarations relay imports (which would make this the importing module), but not all. It's always the exporting module for every export.

I think this probably snuck in by analogy with the `ImportEntry.[[LocalName]]` description.

https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#table-importentry-record-fields

>The name that is used to locally access the imported value from within the **importing** module.

This patch changes "importing" to "exporting" in `ExportEntry.[[LocalName]]`.