### PR TITLE
Editorial: Correct GetExportedNames return type

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -27706,7 +27706,7 @@
           <h1>
             GetExportedNames (
               optional _exportStarSet_: a List of Source Text Module Records,
-            ): a List of either Strings or *null*
+            ): a List of Strings
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -27722,9 +27722,11 @@
             1. Let _exportedNames_ be a new empty List.
             1. For each ExportEntry Record _e_ of _module_.[[LocalExportEntries]], do
               1. Assert: _module_ provides the direct binding for this export.
+              1. Assert: _e_.[[ExportName]] is not *null*.
               1. Append _e_.[[ExportName]] to _exportedNames_.
             1. For each ExportEntry Record _e_ of _module_.[[IndirectExportEntries]], do
               1. Assert: _module_ imports a specific binding for this export.
+              1. Assert: _e_.[[ExportName]] is not *null*.
               1. Append _e_.[[ExportName]] to _exportedNames_.
             1. For each ExportEntry Record _e_ of _module_.[[StarExportEntries]], do
               1. Let _requestedModule_ be GetImportedModule(_module_, _e_.[[ModuleRequest]]).


### PR DESCRIPTION
The [`GetExportedNames`](https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-getexportednames) method of Source Text Module Record claims it returns a List of either Strings or `null`. I find no way for it to ever include `null` in the result. Module Record apparently can be subclassed, and I'm unsure how to check all possible subclasses. I'm giving the argument here and hopefully someone familiar with modules can evaluate.

Called this Editorial because it changes no behavior, it just corrects the description of the actual behavior. But maybe it needs to be Normative because it does change a signature.

---

There's only a single use of `GetExportedNames` in the spec, which assumes a String-only result. [`GetModuleNamespace`](https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-getmodulenamespace) calls it an iterates the result, passing each name to [`ResolveExport`](https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-resolveexport). That method accepts only a String for the name.

>The ResolveExport concrete method of a [Source Text Module Record](https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sourctextmodule-record) module takes argument exportName (a String) ..

`GetExportedNames` produces a list of names from `ExportEntry.[[ExportName]]`. The only situation that puts `null` in `[[ExportName]]` is a star export.

```js
export * from './source.mjs'
```

All star exports end up in [`Module.[[StarExportEntries]]`](https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#table-additional-fields-of-source-text-module-records).

>A [List](https://tc39.es/ecma262/multipage/ecmascript-data-types-and-values.html#sec-list-and-record-specification-type) of ExportEntry records derived from the code of this module that correspond to export * declarations that occur within the module

The branch of `GetExportedNames` that handles star exports (line 8 of the algorithm) never reads the export name. It pulls the referenced module and iterates its exported names recursively.

---

I tried to look through history to figure out when the return type was established, but it's difficult to find when a change to a single section happened. Possibly the method return type was just transferred over from the [`ExportEntry.[[ExportName]]`](https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#table-exportentry-records) type, which does allow both (to handle the star export case).

>a String or **null**

This patch changes the `GetExportedEntries` return type from "List of either Strings or null" to "List of Strings", to accurately describe what it returns.