### PR TITLE
Editorial: Correct usage of 'Let'/'Set' in algorithms

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -23928,7 +23928,7 @@
             1. Assert: _received_.[[Type]] is ~return~.
             1. Let _return_ be ? GetMethod(_iterator_, *"return"*).
             1. If _return_ is *undefined*, then
-              1. Let _value_ be _received_.[[Value]].
+              1. Set _value_ to _received_.[[Value]].
               1. If _generatorKind_ is ~async~, then
                 1. Set _value_ to ? Await(_value_).
               1. Return Completion Record { [[Type]]: ~return~, [[Value]]: _value_, [[Target]]: ~empty~ }.
@@ -23937,7 +23937,7 @@
             1. If _innerReturnResult_ is not an Object, throw a *TypeError* exception.
             1. Let _done_ be ? IteratorComplete(_innerReturnResult_).
             1. If _done_ is *true*, then
-              1. Let _value_ be ? IteratorValue(_innerReturnResult_).
+              1. Set _value_ to ? IteratorValue(_innerReturnResult_).
               1. Return Completion Record { [[Type]]: ~return~, [[Value]]: _value_, [[Target]]: ~empty~ }.
             1. If _generatorKind_ is ~async~, set _received_ to Completion(AsyncGeneratorYield(? IteratorValue(_innerReturnResult_))).
             1. Else, set _received_ to Completion(GeneratorYield(_innerReturnResult_)).
@@ -25327,11 +25327,11 @@
       <emu-grammar>CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
       <emu-alg>
         1. Let _has_ be *false*.
-        1. If the first |CaseClauses| is present, let _has_ be HasCallInTailPosition of the first |CaseClauses| with argument _call_.
+        1. If the first |CaseClauses| is present, set _has_ to HasCallInTailPosition of the first |CaseClauses| with argument _call_.
         1. If _has_ is *true*, return *true*.
-        1. Let _has_ be HasCallInTailPosition of |DefaultClause| with argument _call_.
+        1. Set _has_ to HasCallInTailPosition of |DefaultClause| with argument _call_.
         1. If _has_ is *true*, return *true*.
-        1. If the second |CaseClauses| is present, let _has_ be HasCallInTailPosition of the second |CaseClauses| with argument _call_.
+        1. If the second |CaseClauses| is present, set _has_ to HasCallInTailPosition of the second |CaseClauses| with argument _call_.
         1. Return _has_.
       </emu-alg>
       <emu-grammar>CaseClauses : CaseClauses CaseClause</emu-grammar>


### PR DESCRIPTION
There are some algorithms where same variable is defined twice:

- [15.10.2 Static Semantics: HasCallInTailPosition](https://tc39.es/ecma262/#sec-static-semantics-hascallintailposition)
- [15.5.5 Runtime Semantics: Evaluation](https://tc39.es/ecma262/#sec-generator-function-definitions-runtime-semantics-evaluation)

Both algorithms define a (target) variable at the beginning, thus the declarations afterward are redeclaration which should be fixed. 

Please note that this is a continuation of PR #2365.

<details>
    <summary>HasCallInTailPosition, CaseBlock</summary>

```html
1. Let _has_ be *false*.
2. If the first |CaseClauses| is present, let _has_ be HasCallInTailPosition of the first |CaseClauses| with argument _call_.
3. If _has_ is *true*, return *true*.
4. Let _has_ be HasCallInTailPosition of |DefaultClause| with argument _call_.
5. If _has_ is *true*, return *true*.
6. If the second |CaseClauses| is present, let _has_ be HasCallInTailPosition of the second |CaseClauses| with argument _call_.
7. Return _has_.
```

The variable _has_ is defined in step 1. However, in steps 2, 4, and 6, there may be duplication since let is used to modify the value instead of set.

</details>

<details>
    <summary>Evaluation, YieldExpression</summary>

```html
1. Let _generatorKind_ be GetGeneratorKind().
2. Let _exprRef_ be ? Evaluation of |AssignmentExpression|.
3. Let _value_ be ? GetValue(_exprRef_).
...
7. Repeat,
  a. If _received_.[[Type]] is ~normal~, then
    ...
  b. Else if _received_.[[Type]] is ~throw~, then
    ...
  c. Else,
    i. Assert: _received_.[[Type]] is ~return~. 
    ii. Let _return_ be ? GetMethod(_iterator_, *"return"*).
    iii. If _return_ is *undefined*, then
      1. Let _value_ be _received_.[[Value]].
      2. If _generatorKind_ is ~async~, then
        a. Set _value_ to ? Await(_value_).
      3. Return Completion Record { [[Type]]: ~return~, [[Value]]: _value_, [[Target]]: ~empty~ }.
    ...
    viii. If _done_ is *true*, then
      1. Let _value_ be ? IteratorValue(_innerReturnResult_).
      2. Return Completion Record { [[Type]]: ~return~, [[Value]]: _value_, [[Target]]: ~empty~ }.
    ix. If _generatorKind_ is ~async~, set _received_ to Completion(AsyncGeneratorYield(? IteratorValue(_innerReturnResult_))).
    x. Else, set _received_ to Completion(GeneratorYield(_innerReturnResult_)).
```

The variable _value_ is defined in step 3. However, in step 7.c.iii.1, _value_ may be redefined since the spec uses Let to change the value, rather than Set. This potential redefinition may also occur in step 7.c.viii.1.

</details>