### PR TITLE
Editorial: Change alreadyCalled from Record to Boolean

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -45868,7 +45868,7 @@ THH:mm:ss.sss
               1. Let _stepsFulfilled_ be the algorithm steps defined in <emu-xref href="#sec-promise.allsettled-resolve-element-functions" title></emu-xref>.
               1. Let _lengthFulfilled_ be the number of non-optional parameters of the function definition in <emu-xref href="#sec-promise.allsettled-resolve-element-functions" title></emu-xref>.
               1. Let _onFulfilled_ be CreateBuiltinFunction(_stepsFulfilled_, _lengthFulfilled_, *""*, « [[AlreadyCalled]], [[Index]], [[Values]], [[Capability]], [[RemainingElements]] »).
-              1. Let _alreadyCalled_ be the Record { [[Value]]: *false* }.
+              1. Let _alreadyCalled_ be *false*.
               1. Set _onFulfilled_.[[AlreadyCalled]] to _alreadyCalled_.
               1. Set _onFulfilled_.[[Index]] to _index_.
               1. Set _onFulfilled_.[[Values]] to _values_.
@@ -45895,8 +45895,8 @@ THH:mm:ss.sss
           <emu-alg>
             1. Let _F_ be the active function object.
             1. Let _alreadyCalled_ be _F_.[[AlreadyCalled]].
-            1. If _alreadyCalled_.[[Value]] is *true*, return *undefined*.
-            1. Set _alreadyCalled_.[[Value]] to *true*.
+            1. If _alreadyCalled_ is *true*, return *undefined*.
+            1. Set _alreadyCalled_ to *true*.
             1. Let _index_ be _F_.[[Index]].
             1. Let _values_ be _F_.[[Values]].
             1. Let _promiseCapability_ be _F_.[[Capability]].
@@ -45921,8 +45921,8 @@ THH:mm:ss.sss
           <emu-alg>
             1. Let _F_ be the active function object.
             1. Let _alreadyCalled_ be _F_.[[AlreadyCalled]].
-            1. If _alreadyCalled_.[[Value]] is *true*, return *undefined*.
-            1. Set _alreadyCalled_.[[Value]] to *true*.
+            1. If _alreadyCalled_ is *true*, return *undefined*.
+            1. Set _alreadyCalled_ to *true*.
             1. Let _index_ be _F_.[[Index]].
             1. Let _values_ be _F_.[[Values]].
             1. Let _promiseCapability_ be _F_.[[Capability]].


### PR DESCRIPTION
PR #2219 included changes to make `[[AlreadyCalled]]` fields in `Promise.all` and `Promise.any` from Record to boolean. It seems that the changes were not reflected in AOs in sec-promise.allsettled. This Commit fixes this.