### PR TITLE
Meta: remove unnecessary escape

### DIFF
--- a/scripts/check-commit.js
+++ b/scripts/check-commit.js
@@ -8,7 +8,7 @@ const oldestAncestor = String(exec(`bash -c 'diff -u <(git rev-list --first-pare
 
 console.log(`Oldest ancestor SHA: ${oldestAncestor}`);
 
-const messages = oldestAncestor && String(exec(`git log --format=%s ${oldestAncestor}..HEAD | sed '/^[[:space:]]*\$/d'`)).trim().split('\n').reverse();
+const messages = oldestAncestor && String(exec(`git log --format=%s ${oldestAncestor}..HEAD | sed '/^[[:space:]]*$/d'`)).trim().split('\n').reverse();
 
 const errors = [];
 


### PR DESCRIPTION
The escape here has no effect so remove it.

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
