### PR TITLE
Editorial: use "ECMAScript function object" for parameter types

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -13201,7 +13201,7 @@
       <emu-clause id="sec-prepareforordinarycall" type="abstract operation">
         <h1>
           PrepareForOrdinaryCall (
-            _F_: a function object,
+            _F_: an ECMAScript function object,
             _newTarget_: an Object or *undefined*,
           ): an execution context
         </h1>

--- a/spec.html
+++ b/spec.html
@@ -11307,7 +11307,7 @@
       <emu-clause id="sec-newfunctionenvironment" type="abstract operation">
         <h1>
           NewFunctionEnvironment (
-            _F_: an ECMAScript function,
+            _F_: an ECMAScript function object,
             _newTarget_: an Object or *undefined*,
           ): a Function Environment Record
         </h1>


### PR DESCRIPTION
This PR contains two suggested changes to the type signatures of two abstract operations, for different reasons elaborated in the each commit messages.

49fffca0dc0c0f45b45a03f6605fd72630e1c1eb is mainly for style consistency, as it's the only place where just "ECMAScript function" is used in type signatures. I also spotted other places in the spec where "ECMAScript function" is used instead of more prevalent "ECMAScript function object", if those need to be changed, I will change them also.

7d22df7d14340694e120aaa777f86b1336995f0d is for field access `_F_.[[PrivateEnvironment]]` in step 10 of PrepareForOrdinaryCall. The internal slot is guaranteed to exist for an ECMAScript function object but not for other built-in function ojects. Narrowing down the type parameter into ECMAScript function object solves the problem.