### PR TITLE
Editorial: InitializeHostDefinedRealm-related refactorings

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -11596,18 +11596,35 @@
       </table>
     </emu-table>
 
-    <emu-clause id="sec-createrealm" type="abstract operation">
-      <h1>CreateRealm ( ): a Realm Record</h1>
+    <emu-clause id="sec-initializehostdefinedrealm" type="abstract operation" oldids="sec-createrealm,sec-setrealmglobalobject">
+      <h1>InitializeHostDefinedRealm ( ): either a normal completion containing ~unused~ or a throw completion</h1>
       <dl class="header">
       </dl>
       <emu-alg>
-        1. Let _realmRec_ be a new Realm Record.
-        1. Perform CreateIntrinsics(_realmRec_).
-        1. Set _realmRec_.[[AgentSignifier]] to AgentSignifier().
-        1. Set _realmRec_.[[GlobalObject]] to *undefined*.
-        1. Set _realmRec_.[[GlobalEnv]] to *undefined*.
-        1. Set _realmRec_.[[TemplateMap]] to a new empty List.
-        1. Return _realmRec_.
+        1. Let _realm_ be a new Realm Record.
+        1. Perform CreateIntrinsics(_realm_).
+        1. Set _realm_.[[AgentSignifier]] to AgentSignifier().
+        1. Set _realm_.[[GlobalObject]] to *undefined*.
+        1. Set _realm_.[[GlobalEnv]] to *undefined*.
+        1. Set _realm_.[[TemplateMap]] to a new empty List.
+        1. Let _newContext_ be a new execution context.
+        1. Set the Function of _newContext_ to *null*.
+        1. Set the Realm of _newContext_ to _realm_.
+        1. Set the ScriptOrModule of _newContext_ to *null*.
+        1. Push _newContext_ onto the execution context stack; _newContext_ is now the running execution context.
+        1. If the host requires use of an exotic object to serve as _realm_'s global object, then
+          1. Let _global_ be such an object created in a host-defined manner.
+        1. Else,
+          1. Let _global_ be OrdinaryObjectCreate(_realm_.[[Intrinsics]].[[%Object.prototype%]]).
+        1. If the host requires that the `this` binding in _realm_'s global scope return an object other than the global object, then
+          1. Let _thisValue_ be such an object created in a host-defined manner.
+        1. Else,
+          1. Let _thisValue_ be _global_.
+        1. Set _realm_.[[GlobalObject]] to _global_.
+        1. Set _realm_.[[GlobalEnv]] to NewGlobalEnvironment(_global_, _thisValue_).
+        1. Let _globalObj_ be ? SetDefaultGlobalBindings(_realm_).
+        1. Create any host-defined global object properties on _globalObj_.
+        1. Return ~unused~.
       </emu-alg>
     </emu-clause>
 
@@ -11623,29 +11640,6 @@
         1. Set _realmRec_.[[Intrinsics]] to a new Record.
         1. [declared="steps,name,length,slots,prototype"] Set fields of _realmRec_.[[Intrinsics]] with the values listed in <emu-xref href="#table-well-known-intrinsic-objects"></emu-xref>. The field names are the names listed in column one of the table. The value of each field is a new object value fully and recursively populated with property values as defined by the specification of each object in clauses <emu-xref href="#sec-global-object"></emu-xref> through <emu-xref href="#sec-reflection"></emu-xref>. All object property values are newly created object values. All values that are built-in function objects are created by performing CreateBuiltinFunction(_steps_, _length_, _name_, _slots_, _realmRec_, _prototype_) where _steps_ is the definition of that function provided by this specification, _name_ is the initial value of the function's *"name"* property, _length_ is the initial value of the function's *"length"* property, _slots_ is a list of the names, if any, of the function's specified internal slots, and _prototype_ is the specified value of the function's [[Prototype]] internal slot. The creation of the intrinsics and their properties must be ordered to avoid any dependencies upon objects that have not yet been created.
         1. Perform AddRestrictedFunctionProperties(_realmRec_.[[Intrinsics]].[[%Function.prototype%]], _realmRec_).
-        1. Return ~unused~.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-setrealmglobalobject" type="abstract operation">
-      <h1>
-        SetRealmGlobalObject (
-          _realmRec_: a Realm Record,
-          _globalObj_: an Object or *undefined*,
-          _thisValue_: an Object or *undefined*,
-        ): ~unused~
-      </h1>
-      <dl class="header">
-      </dl>
-      <emu-alg>
-        1. If _globalObj_ is *undefined*, then
-          1. Let _intrinsics_ be _realmRec_.[[Intrinsics]].
-          1. Set _globalObj_ to OrdinaryObjectCreate(_intrinsics_.[[%Object.prototype%]]).
-        1. Assert: _globalObj_ is an Object.
-        1. If _thisValue_ is *undefined*, set _thisValue_ to _globalObj_.
-        1. Set _realmRec_.[[GlobalObject]] to _globalObj_.
-        1. Let _newGlobalEnv_ be NewGlobalEnvironment(_globalObj_, _thisValue_).
-        1. Set _realmRec_.[[GlobalEnv]] to _newGlobalEnv_.
         1. Return ~unused~.
       </emu-alg>
     </emu-clause>
@@ -12063,27 +12057,6 @@
       </dl>
       <p>An implementation of HostEnqueueTimeoutJob must conform to the requirements in <emu-xref href="#sec-jobs"></emu-xref>.</p>
     </emu-clause>
-  </emu-clause>
-
-  <emu-clause id="sec-initializehostdefinedrealm" type="abstract operation">
-    <h1>InitializeHostDefinedRealm ( ): either a normal completion containing ~unused~ or a throw completion</h1>
-    <dl class="header">
-    </dl>
-
-    <emu-alg>
-      1. Let _realm_ be CreateRealm().
-      1. Let _newContext_ be a new execution context.
-      1. Set the Function of _newContext_ to *null*.
-      1. Set the Realm of _newContext_ to _realm_.
-      1. Set the ScriptOrModule of _newContext_ to *null*.
-      1. Push _newContext_ onto the execution context stack; _newContext_ is now the running execution context.
-      1. If the host requires use of an exotic object to serve as _realm_'s global object, let _global_ be such an object created in a host-defined manner. Otherwise, let _global_ be *undefined*, indicating that an ordinary object should be created as the global object.
-      1. If the host requires that the `this` binding in _realm_'s global scope return an object other than the global object, let _thisValue_ be such an object created in a host-defined manner. Otherwise, let _thisValue_ be *undefined*, indicating that _realm_'s global `this` binding should be the global object.
-      1. Perform SetRealmGlobalObject(_realm_, _global_, _thisValue_).
-      1. Let _globalObj_ be ? SetDefaultGlobalBindings(_realm_).
-      1. Create any host-defined global object properties on _globalObj_.
-      1. Return ~unused~.
-    </emu-alg>
   </emu-clause>
 
   <emu-clause id="sec-agents">

--- a/spec.html
+++ b/spec.html
@@ -11622,8 +11622,8 @@
           1. Let _thisValue_ be _global_.
         1. Set _realm_.[[GlobalObject]] to _global_.
         1. Set _realm_.[[GlobalEnv]] to NewGlobalEnvironment(_global_, _thisValue_).
-        1. Let _globalObj_ be ? SetDefaultGlobalBindings(_realm_).
-        1. Create any host-defined global object properties on _globalObj_.
+        1. Perform ? SetDefaultGlobalBindings(_realm_).
+        1. Create any host-defined global object properties on _global_.
         1. Return ~unused~.
       </emu-alg>
     </emu-clause>
@@ -11648,7 +11648,7 @@
       <h1>
         SetDefaultGlobalBindings (
           _realmRec_: a Realm Record,
-        ): either a normal completion containing an Object or a throw completion
+        ): either a normal completion containing ~unused~ or a throw completion
       </h1>
       <dl class="header">
       </dl>
@@ -11658,7 +11658,7 @@
           1. Let _name_ be the String value of the property name.
           1. Let _desc_ be the fully populated data Property Descriptor for the property, containing the specified attributes for the property. For properties listed in <emu-xref href="#sec-function-properties-of-the-global-object"></emu-xref>, <emu-xref href="#sec-constructor-properties-of-the-global-object"></emu-xref>, or <emu-xref href="#sec-other-properties-of-the-global-object"></emu-xref> the value of the [[Value]] attribute is the corresponding intrinsic object from _realmRec_.
           1. Perform ? DefinePropertyOrThrow(_global_, _name_, _desc_).
-        1. Return _global_.
+        1. Return ~unused~.
       </emu-alg>
     </emu-clause>
   </emu-clause>


### PR DESCRIPTION
In [9.6 InitializeHostDefinedRealm](https://tc39.es/ecma262/#sec-initializehostdefinedrealm), there are two `If`-steps that allow the host to customize the global object and global `*this*` binding. If the host just wants the default (of either), that's handled by passing `*undefined*` to (the relevant parameter of) `SetRealmGlobalObject`, which takes care of setting the realm's `[[GlobalObject]]` and `[[GlobalEnv]]` appropriately.

This division of labor always struck me as a bit odd. E.g., why set `_global_` to `*undefined*` and then have prose to explain the significance of doing so? Why not just set `_global_` appropriately right there? That was the impetus for this PR. (My guess was that `SetRealmGlobalObject` was used by the HTML spec, but it isn't, and as far as I can tell it never was. Perhaps that was briefly someone's plan.) 


This PR is split into 6 commits for ease of review. If approved, I'll do some squashing.

- I start by moving `InitializeHostDefinedRealm` to a better location.

  It's odd for `InitializeHostDefinedRealm` (clearly a realm-centric operation) to be out on its own in 9.6, when there's a "Realms" section at 9.3.
  
  (When Realms were introduced in ES6, the relative location of InitializeHostDefinedRealm was somewhat different and made more sense, but things have changed since then.)

- Line-break the two "If the host requires" steps for readability.

- Inline `SetRealmGlobalObject` into `InitializeHostDefinedRealm`.

  (Originally, I only hoisted out the `SetRealmGlobalObject` steps that assigned 'meanings' to the `*undefined*` parameters, but that left so little in `SetRealmGlobalObject` that I didn't see any reason for it to continue to exist.)

- Reorganize/simplify the result of the previous commit.

- Tweak the return of `SetDefaultGlobalBindings`.

    In `SetDefaultGlobalBindings`, `_global_` is an alias for `_realmRec_.[[GlobalObject]]`. In `InitializeHostDefinedRealm`, this is `_realm_.[[GlobalObject]]`, which is just `_global_`. But `SetDefaultGlobalBindings` returns that object, which `InitializeHostDefinedRealm` then assigns to `_globalObj_`, meaning that we now have two aliases for the same object, which is unnecessarily confusing.

    So this commit tweaks `SetDefaultGlobalBindings` to return `~unused~`, and tweaks `InitializeHostDefinedRealm` to refer to `_global_` rather than introducing `_globalObj_`.

- Inline `CreateRealm` into `InitializeHostDefinedRealm`.

    This wasn't part of my original plan, but I like it because it surfaces both the early and later settings of `_realm_.[[GlobalObject]]` and `_realm_.[[GlobalEnv]]`. This makes it really obvious that the early settings are transient. (See https://github.com/tc39/ecma262/pull/2380#issuecomment-1661366783)

Checking the downstream specs, nobody references `SetRealmGlobalObject`, `CreateRealm`, or `SetDefaultGlobalBindings`.