### PR TITLE
Meta: bump ecmarkup to 17.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://tc39.es/ecma262/#sec-copyright-and-software-license",
       "dependencies": {
-        "ecmarkup": "^17.0.2"
+        "ecmarkup": "^17.1.1"
       },
       "devDependencies": {
         "glob": "^7.1.6",
@@ -724,9 +724,9 @@
       }
     },
     "node_modules/ecmarkup": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-17.0.2.tgz",
-      "integrity": "sha512-+vvA1tI9sISgCKtnfwdC6dcuLGX4DGHPVy9zPh3XJLHeRxxy8euG1vklMM7gsEb6/J4H0ks2yup5Y/ekU51k6g==",
+      "version": "17.1.1",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-17.1.1.tgz",
+      "integrity": "sha512-nA6a3jZ43tD+Kj8cWdQGQSzCe7iUdiBIdgsImizU8ez7hPri4YNC1vG3Ze6jEhHIrQccOHsrG3FApJKgSRy/cg==",
       "dependencies": {
         "chalk": "^4.1.2",
         "command-line-args": "^5.2.0",
@@ -2940,9 +2940,9 @@
       }
     },
     "ecmarkup": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-17.0.2.tgz",
-      "integrity": "sha512-+vvA1tI9sISgCKtnfwdC6dcuLGX4DGHPVy9zPh3XJLHeRxxy8euG1vklMM7gsEb6/J4H0ks2yup5Y/ekU51k6g==",
+      "version": "17.1.1",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-17.1.1.tgz",
+      "integrity": "sha512-nA6a3jZ43tD+Kj8cWdQGQSzCe7iUdiBIdgsImizU8ez7hPri4YNC1vG3Ze6jEhHIrQccOHsrG3FApJKgSRy/cg==",
       "requires": {
         "chalk": "^4.1.2",
         "command-line-args": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "license": "SEE LICENSE IN https://tc39.es/ecma262/#sec-copyright-and-software-license",
   "homepage": "https://tc39.es/ecma262/",
   "dependencies": {
-    "ecmarkup": "^17.0.2"
+    "ecmarkup": "^17.1.1"
   },
   "devDependencies": {
     "glob": "^7.1.6",

--- a/spec.html
+++ b/spec.html
@@ -22523,9 +22523,9 @@
               1. If _R_.[[Value]] is not ~empty~, set _V_ to _R_.[[Value]].
               1. If _R_ is an abrupt completion, return ? UpdateEmpty(_R_, _V_).
         1. If _foundInB_ is *true*, return _V_.
-        1. Let _R_ be Completion(Evaluation of |DefaultClause|).
-        1. If _R_.[[Value]] is not ~empty~, set _V_ to _R_.[[Value]].
-        1. If _R_ is an abrupt completion, return ? UpdateEmpty(_R_, _V_).
+        1. Let _defaultR_ be Completion(Evaluation of |DefaultClause|).
+        1. If _defaultR_.[[Value]] is not ~empty~, set _V_ to _defaultR_.[[Value]].
+        1. If _defaultR_ is an abrupt completion, return ? UpdateEmpty(_defaultR_, _V_).
         1. NOTE: The following is another complete iteration of the second |CaseClauses|.
         1. For each |CaseClause| _C_ of _B_, do
           1. Let _R_ be Completion(Evaluation of |CaseClause| _C_).
@@ -31190,7 +31190,8 @@
             1. If _fractionDigits_ is not *undefined*, then
               1. Let _e_ and _n_ be integers such that 10<sup>_f_</sup> ≤ _n_ &lt; 10<sup>_f_ + 1</sup> and for which _n_ × 10<sup>_e_ - _f_</sup> - _x_ is as close to zero as possible. If there are two such sets of _e_ and _n_, pick the _e_ and _n_ for which _n_ × 10<sup>_e_ - _f_</sup> is larger.
             1. Else,
-              1. [id="step-number-proto-toexponential-intermediate-values"] Let _e_, _n_, and _f_ be integers such that _f_ ≥ 0, 10<sup>_f_</sup> ≤ _n_ &lt; 10<sup>_f_ + 1</sup>, 𝔽(_n_ × 10<sup>_e_ - _f_</sup>) is 𝔽(_x_), and _f_ is as small as possible. Note that the decimal representation of _n_ has _f_ + 1 digits, _n_ is not divisible by 10, and the least significant digit of _n_ is not necessarily uniquely determined by these criteria.
+              1. [id="step-number-proto-toexponential-intermediate-values"] Let _e_, _n_, and _ff_ be integers such that _ff_ ≥ 0, 10<sup>_ff_</sup> ≤ _n_ &lt; 10<sup>_ff_ + 1</sup>, 𝔽(_n_ × 10<sup>_e_ - _ff_</sup>) is 𝔽(_x_), and _ff_ is as small as possible. Note that the decimal representation of _n_ has _ff_ + 1 digits, _n_ is not divisible by 10, and the least significant digit of _n_ is not necessarily uniquely determined by these criteria.
+              1. Set _f_ to _ff_.
             1. Let _m_ be the String value consisting of the digits of the decimal representation of _n_ (in order, with no leading zeroes).
           1. If _f_ ≠ 0, then
             1. Let _a_ be the first code unit of _m_.


### PR DESCRIPTION
Adds [a new lint rule for redeclarations](https://github.com/tc39/ecmarkup/pull/541). ~~There are 7 such redeclarations right now, which will need to be fixed before landing; I'll add a commit fixing the remaining ones after https://github.com/tc39/ecma262/pull/3131 lands (which fixes most of them).~~

Also fixes the last two remaining redeclaration issues. Feel free to suggest better names for these aliases.