### PR TITLE
Editorial: Reinstate 5 ids

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -30349,7 +30349,7 @@
           1. Return ? ThisBooleanValue(*this* value).
         </emu-alg>
 
-        <emu-clause id="sec-thisbooleanvalue" type="abstract operation">
+        <emu-clause id="sec-thisbooleanvalue" type="abstract operation" oldids="thisbooleanvalue">
           <h1>
             ThisBooleanValue (
               _value_: an ECMAScript language value,
@@ -30613,7 +30613,7 @@
           1. Return ? ThisSymbolValue(*this* value).
         </emu-alg>
 
-        <emu-clause id="sec-thissymbolvalue" type="abstract operation">
+        <emu-clause id="sec-thissymbolvalue" type="abstract operation" oldids="thissymbolvalue">
           <h1>
             ThisSymbolValue (
               _value_: an ECMAScript language value,
@@ -31335,7 +31335,7 @@
           1. Return ? ThisNumberValue(*this* value).
         </emu-alg>
 
-        <emu-clause id="sec-thisnumbervalue" type="abstract operation">
+        <emu-clause id="sec-thisnumbervalue" type="abstract operation" oldids="thisnumbervalue">
           <h1>
             ThisNumberValue (
               _value_: an ECMAScript language value,
@@ -31481,7 +31481,7 @@
           1. Return ? ThisBigIntValue(*this* value).
         </emu-alg>
 
-        <emu-clause id="sec-thisbigintvalue" type="abstract operation">
+        <emu-clause id="sec-thisbigintvalue" type="abstract operation" oldids="thisbigintvalue">
           <h1>
             ThisBigIntValue (
               _value_: an ECMAScript language value,
@@ -35165,7 +35165,7 @@ THH:mm:ss.sss
           1. Return ? ThisStringValue(*this* value).
         </emu-alg>
 
-        <emu-clause id="sec-thisstringvalue" type="abstract operation">
+        <emu-clause id="sec-thisstringvalue" type="abstract operation" oldids="thisstringvalue">
           <h1>
             ThisStringValue (
               _value_: an ECMAScript language value,


### PR DESCRIPTION
In PR #3063, I inadvertently un-defined 5 ids:
- thisbooleanvalue
- thissymbolvalue
- thisnumbervalue
- thisbigintvalue
- thisstringvalue

This PR reinstates them as oldids.