### PR TITLE
Editorial: "a function object" -> "an ECMAScript function object"

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -4705,7 +4705,7 @@
               [[Initializer]]
             </td>
             <td>
-              a function object or ~empty~
+              an ECMAScript function object or ~empty~
             </td>
             <td>
               The initializer of the field, if any.
@@ -4742,7 +4742,7 @@
               [[BodyFunction]]
             </td>
             <td>
-              a function object
+              an ECMAScript function object
             </td>
             <td>
               The function object to be called during static initialization of a class.
@@ -9314,7 +9314,7 @@
         Runtime Semantics: InstantiateFunctionObject (
           _env_: an Environment Record,
           _privateEnv_: a PrivateEnvironment Record or *null*,
-        ): a function object
+        ): an ECMAScript function object
       </h1>
       <dl class="header">
       </dl>
@@ -13228,7 +13228,7 @@
       <emu-clause id="sec-ordinarycallbindthis" type="abstract operation">
         <h1>
           OrdinaryCallBindThis (
-            _F_: a function object,
+            _F_: an ECMAScript function object,
             _calleeContext_: an execution context,
             _thisArgument_: an ECMAScript language value,
           ): ~unused~
@@ -13260,7 +13260,7 @@
       <emu-clause id="sec-runtime-semantics-evaluatebody" type="sdo">
         <h1>
           Runtime Semantics: EvaluateBody (
-            _functionObject_: a function object,
+            _functionObject_: an ECMAScript function object,
             _argumentsList_: a List of ECMAScript language values,
           ): either a normal completion containing an ECMAScript language value or an abrupt completion
         </h1>
@@ -13325,7 +13325,7 @@
       <emu-clause id="sec-ordinarycallevaluatebody" type="abstract operation">
         <h1>
           OrdinaryCallEvaluateBody (
-            _F_: a function object,
+            _F_: an ECMAScript function object,
             _argumentsList_: a List of ECMAScript language values,
           ): either a normal completion containing an ECMAScript language value or an abrupt completion
         </h1>
@@ -13386,7 +13386,7 @@
           _thisMode_: ~lexical-this~ or ~non-lexical-this~,
           _env_: an Environment Record,
           _privateEnv_: a PrivateEnvironment Record or *null*,
-        ): a function object
+        ): an ECMAScript function object
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -13585,7 +13585,7 @@
     <emu-clause id="sec-functiondeclarationinstantiation" type="abstract operation">
       <h1>
         FunctionDeclarationInstantiation (
-          _func_: a function object,
+          _func_: an ECMAScript function object,
           _argumentsList_: a List of ECMAScript language values,
         ): either a normal completion containing ~unused~ or an abrupt completion
       </h1>
@@ -23251,7 +23251,7 @@
     <emu-clause id="sec-runtime-semantics-evaluatefunctionbody" oldids="sec-function-definitions-runtime-semantics-evaluatebody" type="sdo">
       <h1>
         Runtime Semantics: EvaluateFunctionBody (
-          _functionObject_: a function object,
+          _functionObject_: an ECMAScript function object,
           _argumentsList_: a List of ECMAScript language values,
         ): either a normal completion containing an ECMAScript language value or an abrupt completion
       </h1>
@@ -23269,7 +23269,7 @@
         Runtime Semantics: InstantiateOrdinaryFunctionObject (
           _env_: an Environment Record,
           _privateEnv_: a PrivateEnvironment Record or *null*,
-        ): a function object
+        ): an ECMAScript function object
       </h1>
       <dl class="header">
       </dl>
@@ -23299,7 +23299,7 @@
       <h1>
         Runtime Semantics: InstantiateOrdinaryFunctionExpression (
           optional _name_: a property key or a Private Name,
-        ): a function object
+        ): an ECMAScript function object
       </h1>
       <dl class="header">
       </dl>
@@ -23434,7 +23434,7 @@
     <emu-clause id="sec-runtime-semantics-evaluateconcisebody" oldids="sec-arrow-function-definitions-runtime-semantics-evaluatebody" type="sdo">
       <h1>
         Runtime Semantics: EvaluateConciseBody (
-          _functionObject_: a function object,
+          _functionObject_: an ECMAScript function object,
           _argumentsList_: a List of ECMAScript language values,
         ): either a normal completion containing an ECMAScript language value or an abrupt completion
       </h1>
@@ -23451,7 +23451,7 @@
       <h1>
         Runtime Semantics: InstantiateArrowFunctionExpression (
           optional _name_: a property key or a Private Name,
-        ): a function object
+        ): an ECMAScript function object
       </h1>
       <dl class="header">
       </dl>
@@ -23589,7 +23589,7 @@
         Runtime Semantics: DefineMethod (
           _object_: an Object,
           optional _functionPrototype_: an Object,
-        ): either a normal completion containing a Record with fields [[Key]] (a property key) and [[Closure]] (a function object) or an abrupt completion
+        ): either a normal completion containing a Record with fields [[Key]] (a property key) and [[Closure]] (an ECMAScript function object) or an abrupt completion
       </h1>
       <dl class="header">
       </dl>
@@ -23792,7 +23792,7 @@
     <emu-clause id="sec-runtime-semantics-evaluategeneratorbody" oldids="sec-generator-function-definitions-runtime-semantics-evaluatebody" type="sdo">
       <h1>
         Runtime Semantics: EvaluateGeneratorBody (
-          _functionObject_: a function object,
+          _functionObject_: an ECMAScript function object,
           _argumentsList_: a List of ECMAScript language values,
         ): a throw completion or a return completion
       </h1>
@@ -23813,7 +23813,7 @@
         Runtime Semantics: InstantiateGeneratorFunctionObject (
           _env_: an Environment Record,
           _privateEnv_: a PrivateEnvironment Record or *null*,
-        ): a function object
+        ): an ECMAScript function object
       </h1>
       <dl class="header">
       </dl>
@@ -23845,7 +23845,7 @@
       <h1>
         Runtime Semantics: InstantiateGeneratorFunctionExpression (
           optional _name_: a property key or a Private Name,
-        ): a function object
+        ): an ECMAScript function object
       </h1>
       <dl class="header">
       </dl>
@@ -24017,7 +24017,7 @@
     <emu-clause id="sec-runtime-semantics-evaluateasyncgeneratorbody" oldids="sec-asyncgenerator-definitions-evaluatebody" type="sdo">
       <h1>
         Runtime Semantics: EvaluateAsyncGeneratorBody (
-          _functionObject_: a function object,
+          _functionObject_: an ECMAScript function object,
           _argumentsList_: a List of ECMAScript language values,
         ): a throw completion or a return completion
       </h1>
@@ -24040,7 +24040,7 @@
         Runtime Semantics: InstantiateAsyncGeneratorFunctionObject (
           _env_: an Environment Record,
           _privateEnv_: a PrivateEnvironment Record or *null*,
-        ): a function object
+        ): an ECMAScript function object
       </h1>
       <dl class="header">
       </dl>
@@ -24076,7 +24076,7 @@
       <h1>
         Runtime Semantics: InstantiateAsyncGeneratorFunctionExpression (
           optional _name_: a property key or a Private Name,
-        ): a function object
+        ): an ECMAScript function object
       </h1>
       <dl class="header">
       </dl>
@@ -24639,7 +24639,7 @@
     <emu-clause id="sec-runtime-semantics-evaluateclassstaticblockbody" type="sdo">
       <h1>
         Runtime Semantics: EvaluateClassStaticBlockBody (
-          _functionObject_: a function object,
+          _functionObject_: an ECMAScript function object,
         ): either a normal completion containing an ECMAScript language value or an abrupt completion
       </h1>
       <dl class="header">
@@ -24961,7 +24961,7 @@
         Runtime Semantics: InstantiateAsyncFunctionObject (
           _env_: an Environment Record,
           _privateEnv_: a PrivateEnvironment Record or *null*,
-        ): a function object
+        ): an ECMAScript function object
       </h1>
       <dl class="header">
       </dl>
@@ -24990,7 +24990,7 @@
       <h1>
         Runtime Semantics: InstantiateAsyncFunctionExpression (
           optional _name_: a property key or a Private Name,
-        ): a function object
+        ): an ECMAScript function object
       </h1>
       <dl class="header">
       </dl>
@@ -25030,7 +25030,7 @@
     <emu-clause id="sec-runtime-semantics-evaluateasyncfunctionbody" oldids="sec-async-function-definitions-EvaluateBody" type="sdo">
       <h1>
         Runtime Semantics: EvaluateAsyncFunctionBody (
-          _functionObject_: a function object,
+          _functionObject_: an ECMAScript function object,
           _argumentsList_: a List of ECMAScript language values,
         ): a return completion
       </h1>
@@ -25137,7 +25137,7 @@
     <emu-clause id="sec-runtime-semantics-evaluateasyncconcisebody" oldids="sec-async-arrow-function-definitions-EvaluateBody" type="sdo">
       <h1>
         Runtime Semantics: EvaluateAsyncConciseBody (
-          _functionObject_: a function object,
+          _functionObject_: an ECMAScript function object,
           _argumentsList_: a List of ECMAScript language values,
         ): a return completion
       </h1>
@@ -25161,7 +25161,7 @@
       <h1>
         Runtime Semantics: InstantiateAsyncArrowFunctionExpression (
           optional _name_: a property key or a Private Name,
-        ): a function object
+        ): an ECMAScript function object
       </h1>
       <dl class="header">
       </dl>
@@ -29993,7 +29993,7 @@
               _kind_: ~normal~, ~generator~, ~async~, or ~asyncGenerator~,
               _parameterArgs_: a List of ECMAScript language values,
               _bodyArg_: an ECMAScript language value,
-            ): either a normal completion containing a function object or a throw completion
+            ): either a normal completion containing an ECMAScript function object or a throw completion
           </h1>
           <dl class="header">
             <dt>description</dt>


### PR DESCRIPTION
This PR narrows "a function object" to "an ECMAScript function object" where appropriate.

(This is an expansion of https://github.com/tc39/ecma262/pull/3138#issuecomment-1662353988.)

I've split it into 2 commits to make it a bit easier to follow the propagation of narrowing, but they can probably be squashed for merging.

---
commit 1: Creating an ECMAScript function object

OrdinaryFunctionCreate returns an ECMAScript function object (EFO).

(1)
So, every operation that returns the result of OrdinaryFunctionCreate (i.e., every operation that creates a function for a FunctionBody or similar) also returns an EFO:

- InstantiateOrdinaryFunctionObject
- InstantiateOrdinaryFunctionExpression
- InstantiateArrowFunctionExpression
- DefineMethod
- InstantiateGeneratorFunctionObject
- InstantiateGeneratorFunctionExpression
- InstantiateAsyncGeneratorFunctionObject
- InstantiateAsyncGeneratorFunctionExpression
- InstantiateAsyncFunctionObject
- InstantiateAsyncFunctionExpression
- InstantiateAsyncArrowFunctionExpression
- CreateDynamicFunction

and, going one further level up,
- InstantiateFunctionObject

(2)
A Record field that only ever holds the result of OrdinaryFunctionCreate holds an EFO:
- ClassFieldDefinition Record's [[Initializer]] field
- ClassStaticBlockDefinition Record's [[BodyFunction]] field

---
commit 2: Calling an ECMAScript function object

By definition, 10.2.1 [[Call]] and 10.2.2 [[Construct]] only operate on EFOs.

From this, we know the following are only invoked on EFOs:
- PrepareForOrdinaryCall
- OrdinaryCallBindThis
- OrdinaryCallEvaluateBody

And, from the last,
- EvaluateBody

And from that,
- EvaluateFunctionBody
- EvaluateConciseBody
- EvaluateGeneratorBody
- EvaluateAsyncGeneratorBody
- EvaluateAsyncFunctionBody
- EvaluateAsyncConciseBody
- EvaluateClassStaticBlockBody

And from those,
- FunctionDeclarationInstantiation

---
Downstream specs: The only downstream reference to any of these things is HTML's use of `OrdinaryFunctionCreate`, and it doesn't care that we're narrowing the declared return type.