### PR TITLE
Editorial: move built-in constructor into its own Terms & Definitions section

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -328,7 +328,7 @@
       <h1>built-in object</h1>
       <p>object specified and supplied by an ECMAScript implementation</p>
       <emu-note>
-        <p>Standard built-in objects are defined in this specification. An ECMAScript implementation may specify and supply additional kinds of built-in objects. A <em>built-in constructor</em> is a built-in object that is also a constructor.</p>
+        <p>Standard built-in objects are defined in this specification. An ECMAScript implementation may specify and supply additional kinds of built-in objects.</p>
       </emu-note>
     </emu-clause>
 
@@ -468,6 +468,14 @@
       <p>built-in object that is a function</p>
       <emu-note>
         <p>Examples of built-in functions include `parseInt` and `Math.exp`. A host or implementation may provide additional built-in functions that are not described in this specification.</p>
+      </emu-note>
+    </emu-clause>
+
+    <emu-clause id="sec-built-in-constructor">
+      <h1>built-in constructor</h1>
+      <p>built-in function that is a constructor</p>
+      <emu-note>
+        <p>Examples of built-in constructors include `Object` and `Function`. A host or implementation may provide additional built-in constructors that are not described in this specification.</p>
       </emu-note>
     </emu-clause>
 


### PR DESCRIPTION
It was weird that there was what appeared to be a `<dfn>` for "built-in constructor" in a note of the "built-in object" section when both "built-in function" and "built-in method" had their own sections.

Alternatively, for anything with its own actual `<dfn>`, I would prefer we don't have a T&D section. But we can follow up with that later.