### PR TITLE
Editorial: widen parameter type of IsAnonymousFunctionDefinition

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -8990,7 +8990,7 @@
     <emu-clause id="sec-isanonymousfunctiondefinition" type="abstract operation">
       <h1>
         Static Semantics: IsAnonymousFunctionDefinition (
-          _expr_: an |AssignmentExpression| Parse Node or an |Initializer| Parse Node,
+          _expr_: an |AssignmentExpression| Parse Node, an |Initializer| Parse Node, or an |Expression| Parse Node,
         ): a Boolean
       </h1>
       <dl class="header">


### PR DESCRIPTION
Among the 16 call sites of IsAnonymousFunctionDefinition, one of them in NamedEvaluation of ParenthesizedExpression : `(` Expression `)` passes |Expression| Parse Node

https://github.com/tc39/ecma262/blob/0802e7da54fc870af4e6c37b048428611c449f61/spec.html#L9060

 which was not covered in the previous type annotation. This commit fixes this issue.

I checked and confirmed that downstream dependies are not effected.