### PR TITLE
Editorial: avoid duplicate variable identifiers

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -22528,9 +22528,9 @@
         1. If _R_ is an abrupt completion, return ? UpdateEmpty(_R_, _V_).
         1. NOTE: The following is another complete iteration of the second |CaseClauses|.
         1. For each |CaseClause| _C_ of _B_, do
-          1. Let _R_ be Completion(Evaluation of |CaseClause| _C_).
-          1. If _R_.[[Value]] is not ~empty~, set _V_ to _R_.[[Value]].
-          1. If _R_ is an abrupt completion, return ? UpdateEmpty(_R_, _V_).
+          1. Let _R2_ be Completion(Evaluation of |CaseClause| _C_).
+          1. If _R2_.[[Value]] is not ~empty~, set _V_ to _R2_.[[Value]].
+          1. If _R2_ is an abrupt completion, return ? UpdateEmpty(_R2_, _V_).
         1. Return _V_.
       </emu-alg>
     </emu-clause>
@@ -31190,11 +31190,11 @@
             1. If _fractionDigits_ is not *undefined*, then
               1. Let _e_ and _n_ be integers such that 10<sup>_f_</sup> ≤ _n_ &lt; 10<sup>_f_ + 1</sup> and for which _n_ × 10<sup>_e_ - _f_</sup> - _x_ is as close to zero as possible. If there are two such sets of _e_ and _n_, pick the _e_ and _n_ for which _n_ × 10<sup>_e_ - _f_</sup> is larger.
             1. Else,
-              1. [id="step-number-proto-toexponential-intermediate-values"] Let _e_, _n_, and _f_ be integers such that _f_ ≥ 0, 10<sup>_f_</sup> ≤ _n_ &lt; 10<sup>_f_ + 1</sup>, 𝔽(_n_ × 10<sup>_e_ - _f_</sup>) is 𝔽(_x_), and _f_ is as small as possible. Note that the decimal representation of _n_ has _f_ + 1 digits, _n_ is not divisible by 10, and the least significant digit of _n_ is not necessarily uniquely determined by these criteria.
+              1. [id="step-number-proto-toexponential-intermediate-values"] Let _e_, _n_, and _g_ be integers such that _f_ ≥ 0, 10<sup>_f_</sup> ≤ _n_ &lt; 10<sup>_f_ + 1</sup>, 𝔽(_n_ × 10<sup>_e_ - _f_</sup>) is 𝔽(_x_), and _f_ is as small as possible. Note that the decimal representation of _n_ has _f_ + 1 digits, _n_ is not divisible by 10, and the least significant digit of _n_ is not necessarily uniquely determined by these criteria.
             1. Let _m_ be the String value consisting of the digits of the decimal representation of _n_ (in order, with no leading zeroes).
-          1. If _f_ ≠ 0, then
+          1. If _g_ ≠ 0, then
             1. Let _a_ be the first code unit of _m_.
-            1. Let _b_ be the other _f_ code units of _m_.
+            1. Let _b_ be the other _g_ code units of _m_.
             1. Set _m_ to the string-concatenation of _a_, *"."*, and _b_.
           1. If _e_ = 0, then
             1. Let _c_ be *"+"*.


### PR DESCRIPTION
Even though variables with the same identifier are valid in separate scopes since the outer declaration is shadowed, we should avoid this as it could be confusing to the readers.

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
