### PR TITLE
Editorial: fix mailto emails

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -73,9 +73,9 @@
     <li>
       Editors:
       <ul>
-        <li><a href="mailto:syg at google dot com">Shu-yu Guo</a> (<a href="https://twitter.com/_shu">@_shu</a>)</li>
-        <li><a href="mailto:ecma262-editor-list at michael dot ficarra dot me">Michael Ficarra</a> (<a href="https://twitter.com/smooshMap">@smooshMap</a>)</li>
-        <li><a href="mailto:bakkot at gmail dot com">Kevin Gibbons</a> (<a href="https://twitter.com/bakkoting">@bakkoting</a>)</li>
+        <li><a href="mailto:syg@google.com">Shu-yu Guo</a> (<a href="https://twitter.com/_shu">@_shu</a>)</li>
+        <li><a href="mailto:ecma262-editor-list@michael.ficarra.me">Michael Ficarra</a> (<a href="https://twitter.com/smooshMap">@smooshMap</a>)</li>
+        <li><a href="mailto:bakkot@gmail.com">Kevin Gibbons</a> (<a href="https://twitter.com/bakkoting">@bakkoting</a>)</li>
       </ul>
     </li>
     <li>


### PR DESCRIPTION
Prior to these changes, the `mailto:` links would not reference anybody to mail to.

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
