### PR TITLE
Editorial: widen parameter type of IsCompatiblePropertyDescriptor

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -12614,7 +12614,7 @@
           IsCompatiblePropertyDescriptor (
             _Extensible_: a Boolean,
             _Desc_: a Property Descriptor,
-            _Current_: a Property Descriptor,
+            _Current_: a Property Descriptor or *undefined*,
           ): a Boolean
         </h1>
         <dl class="header">


### PR DESCRIPTION
Among three call sites of IsCompatiblePropertyDescriptor, one in [[GetOwnProperty]] internal method of a Proxy exotic object(step 14 with respect to [es2023](https://tc39.es/ecma262/2023/#sec-proxy-object-internal-methods-and-internal-slots-getownproperty-p)) it is possible that argument `targetDesc` is *undefined*. For example, in the below javascript code,

```javascript
const monster1 = {
    eyeCount: 4,
};
const handler1 = {
    getOwnPropertyDescriptor(target, prop) {
        return { enumerable: true, configurable: true, value: "I'm a descriptor!" }
    },
};

const proxy1 = new Proxy(monster1, handler1);
proxy1.hasOwnProperty("noseCount"); // true
```

`targetDesc` is *undefined* as `monster1` does not have `noseCount` property.