### PR TITLE
Markup: add alt text to Ecma logo

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -58,7 +58,7 @@
   location: https://tc39.es/ecma262/
   markEffects: true
 </pre>
-<p><img src="img/ecma-logo.svg" id="ecma-logo"></p>
+<p><img src="img/ecma-logo.svg" id="ecma-logo" alt="Ecma International logo"></p>
 <div id="metadata-block">
   <h1>About this Specification</h1>
   <p>The document at <a href="https://tc39.es/ecma262/">https://tc39.es/ecma262/</a> is the most accurate and up-to-date ECMAScript specification. It contains the content of the most recent yearly snapshot plus any <a href="https://github.com/tc39/proposals/blob/HEAD/finished-proposals.md">finished proposals</a> (those that have reached Stage&nbsp;4 in the <a href="https://tc39.es/process-document/">proposal process</a> and thus are implemented in several implementations and will be in the next practical revision) since that snapshot was taken.</p>


### PR DESCRIPTION
This is the only `<img>` element without an alt text in the entire specification, so add an alt text.

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
