### PR TITLE
Normative: Update GetSubstitution to match reality

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -34929,11 +34929,16 @@ THH:mm:ss.sss
                 1. NOTE: _tailPos_ can exceed _stringLength_ only if this abstract operation was invoked by a call to the intrinsic @@replace method of %RegExp.prototype% on an object whose *"exec"* property is not the intrinsic %RegExp.prototype.exec%.
               1. Else if _templateRemainder_ starts with *"$"* followed by 1 or more decimal digits, then
                 1. If _templateRemainder_ starts with *"$"* followed by 2 or more decimal digits, let _digitCount_ be 2. Otherwise, let _digitCount_ be 1.
-                1. Let _ref_ be the substring of _templateRemainder_ from 0 to 1 + _digitCount_.
                 1. Let _digits_ be the substring of _templateRemainder_ from 1 to 1 + _digitCount_.
                 1. Let _index_ be ℝ(StringToNumber(_digits_)).
                 1. Assert: 0 ≤ _index_ ≤ 99.
                 1. Let _captureLen_ be the number of elements in _captures_.
+                1. If _index_ > _captureLen_ and _digitCount_ = 2, then
+                  1. NOTE: When a two-digit replacement pattern specifies an index exceeding the count of capturing groups, it is treated as a one-digit replacement pattern followed by a literal digit.
+                  1. Set _digitCount_ to 1.
+                  1. Set _digits_ to the substring of _digits_ from 0 to 1.
+                  1. Set _index_ to ℝ(StringToNumber(_digits_)).
+                1. Let _ref_ be the substring of _templateRemainder_ from 0 to 1 + _digitCount_.
                 1. If 1 ≤ _index_ ≤ _captureLen_, then
                   1. Let _capture_ be _captures_[_index_ - 1].
                   1. If _capture_ is *undefined*, then


### PR DESCRIPTION
$nn patterns fall back to $n when there aren't at least nn captures

Fixes gh-1426

test262 PR: https://github.com/tc39/test262/pull/3931