### PR TITLE
Editorial: use proper comparison operation in LabelledEvaluation of LabelledStatement

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -22668,7 +22668,7 @@
         1. Let _label_ be the StringValue of |LabelIdentifier|.
         1. Let _newLabelSet_ be the list-concatenation of _labelSet_ and « _label_ ».
         1. Let _stmtResult_ be Completion(LabelledEvaluation of |LabelledItem| with argument _newLabelSet_).
-        1. If _stmtResult_.[[Type]] is ~break~ and SameValue(_stmtResult_.[[Target]], _label_) is *true*, then
+        1. If _stmtResult_.[[Type]] is ~break~ and _stmtResult_.[[Target]] is _label_, then
           1. Set _stmtResult_ to NormalCompletion(_stmtResult_.[[Value]]).
         1. Return ? _stmtResult_.
       </emu-alg>


### PR DESCRIPTION
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->

This PR adds missing `~empty~` guard in LabelledEvaluation for LabelledStatement.

Currently, [LabelledEvaluation for LabelledStatement](https://tc39.es/ecma262/#sec-runtime-semantics-labelledevaluation) is defined as follows:
```
1. Let label be the StringValue of LabelIdentifier.
2. Let newLabelSet be the list-concatenation of labelSet and « label ».
3. Let stmtResult be Completion(LabelledEvaluation of LabelledItem with argument newLabelSet).
4. If stmtResult.[[Type]] is break and SameValue(stmtResult.[[Target]], label) is true, then
	a. Set stmtResult to NormalCompletion(stmtResult.[[Value]]).
5. Return ? stmtResult.
```
According to the definition, `SameValue`, used in step 4, requires two arguments which are both `ECMAScript langauge value`. In step 3, `stmtResult.[[Target]]` can be `~empty~` if there is no `LabelIdentifier` in [BreakStatement](https://tc39.es/ecma262/2022/#sec-break-statement-runtime-semantics-evaluation). Consequently, providing `stmtResult.[[Target]]` as the argument for `SameValue` should not be allowed.

Following ECMAScript snippet can occur this case:
```javascript
switch (1) {
  case 1:
    foo: { break; } // stmtResult.[[Type]] is break and stmtResult.[[Target]] is ~empty~
}
```

So fix this by adding more condition in step 4 for guard.