### PR TITLE
Editorial: Make parameter of EvaluatePropertyAccessWithExpressionKey more precise

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -19134,7 +19134,7 @@
       <h1>
         EvaluatePropertyAccessWithExpressionKey (
           _baseValue_: an ECMAScript language value,
-          _expression_: a Parse Node,
+          _expression_: an |Expression| Parse Node,
           _strict_: a Boolean,
         ): either a normal completion containing a Reference Record or an abrupt completion
       </h1>


### PR DESCRIPTION
This is more precise specification with EvaluatePropertyAccessWithExpressionKey' usage and also in line with parameter specification of EvaluatePropertyAccessWithIdentifierKey.