### PR TITLE
Editorial: Narrow return type of GetExportedNames and more assertions

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -27895,6 +27895,7 @@
               1. Assert: _e_.[[ExportName]] is not *null*.
               1. Append _e_.[[ExportName]] to _exportedNames_.
             1. For each ExportEntry Record _e_ of _module_.[[StarExportEntries]], do
+              1. Assert: _e_.[[ModuleRequest]] is not *null*.
               1. Let _requestedModule_ be GetImportedModule(_module_, _e_.[[ModuleRequest]]).
               1. Let _starNames_ be _requestedModule_.GetExportedNames(_exportStarSet_).
               1. For each element _n_ of _starNames_, do
@@ -27940,6 +27941,7 @@
                 1. Return ResolvedBinding Record { [[Module]]: _module_, [[BindingName]]: _e_.[[LocalName]] }.
             1. For each ExportEntry Record _e_ of _module_.[[IndirectExportEntries]], do
               1. If SameValue(_exportName_, _e_.[[ExportName]]) is *true*, then
+                1. Assert: _e_.[[ModuleRequest]] is not *null*.
                 1. Let _importedModule_ be GetImportedModule(_module_, _e_.[[ModuleRequest]]).
                 1. If _e_.[[ImportName]] is ~all~, then
                   1. Assert: _module_ does not provide the direct binding for this export.
@@ -27953,6 +27955,7 @@
               1. NOTE: A `default` export cannot be provided by an `export * from "mod"` declaration.
             1. Let _starResolution_ be *null*.
             1. For each ExportEntry Record _e_ of _module_.[[StarExportEntries]], do
+              1. Assert: _e_.[[ModuleRequest]] is not *null*.
               1. Let _importedModule_ be GetImportedModule(_module_, _e_.[[ModuleRequest]]).
               1. Let _resolution_ be _importedModule_.ResolveExport(_exportName_, _resolveSet_).
               1. If _resolution_ is ~ambiguous~, return ~ambiguous~.
@@ -27978,6 +27981,7 @@
 
           <emu-alg>
             1. For each ExportEntry Record _e_ of _module_.[[IndirectExportEntries]], do
+              1. Assert: _e_.[[ExportName]] is not *null*.
               1. Let _resolution_ be _module_.ResolveExport(_e_.[[ExportName]]).
               1. If _resolution_ is either *null* or ~ambiguous~, throw a *SyntaxError* exception.
               1. Assert: _resolution_ is a ResolvedBinding Record.

--- a/spec.html
+++ b/spec.html
@@ -27872,7 +27872,7 @@
           <h1>
             GetExportedNames (
               optional _exportStarSet_: a List of Source Text Module Records,
-            ): a List of either Strings or *null*
+            ): a List of Strings
           </h1>
           <dl class="header">
             <dt>for</dt>
@@ -27888,9 +27888,11 @@
             1. Let _exportedNames_ be a new empty List.
             1. For each ExportEntry Record _e_ of _module_.[[LocalExportEntries]], do
               1. Assert: _module_ provides the direct binding for this export.
+              1. Assert: _e_.[[ExportName]] is not *null*.
               1. Append _e_.[[ExportName]] to _exportedNames_.
             1. For each ExportEntry Record _e_ of _module_.[[IndirectExportEntries]], do
               1. Assert: _module_ imports a specific binding for this export.
+              1. Assert: _e_.[[ExportName]] is not *null*.
               1. Append _e_.[[ExportName]] to _exportedNames_.
             1. For each ExportEntry Record _e_ of _module_.[[StarExportEntries]], do
               1. Let _requestedModule_ be GetImportedModule(_module_, _e_.[[ModuleRequest]]).


### PR DESCRIPTION
The first commit is an exact copy of https://github.com/tc39/ecma262/pull/3127.

The second commit adds more assertions with respect to Abstract Operations in module section, this was done primarily to make clear non-null values are passed into `ResolveExport` and `GetImportedModule`