### PR TITLE
Editorial: fix invalid assertion in Number::lessThan

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -2135,7 +2135,7 @@
             1. If _y_ is *+∞*<sub>𝔽</sub>, return *true*.
             1. If _y_ is *-∞*<sub>𝔽</sub>, return *false*.
             1. If _x_ is *-∞*<sub>𝔽</sub>, return *true*.
-            1. Assert: _x_ and _y_ are finite and non-zero.
+            1. Assert: _x_ and _y_ are finite.
             1. If ℝ(_x_) &lt; ℝ(_y_), return *true*. Otherwise, return *false*.
           </emu-alg>
         </emu-clause>


### PR DESCRIPTION
This fixes https://github.com/tc39/ecma262/issues/3108

## Problem

`Number::lessThan` incorrectly asserts that both numbers must be non-zero before being compared for inequality.

Due to this assertion, expressions such as `0 < 1` or `-5 < 0` would fail.

## Solution

I've removed the mention of `non-zero` from the assertion.

I hope this edit helps! 😄 



<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
