### PR TITLE
Editorial: fix algorithm of Math.atan2

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -31937,7 +31937,13 @@
             1. If _nx_ is *-∞*<sub>𝔽</sub>, return an implementation-approximated Number value representing -π.
             1. If _nx_ is either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, return an implementation-approximated Number value representing -π / 2.
           1. Assert: _nx_ is finite and is neither *+0*<sub>𝔽</sub> nor *-0*<sub>𝔽</sub>.
-          1. Return an implementation-approximated Number value representing the result of the inverse tangent of the quotient ℝ(_ny_) / ℝ(_nx_).
+          1. Let _r_ be the inverse tangent of abs(ℝ(_ny_) / ℝ(_nx_)).
+          1. If _nx_ &lt; *-0*<sub>𝔽</sub>, then
+            1. If _ny_ > *+0*<sub>𝔽</sub>, set _r_ to π - _r_.
+            1. Else, set _r_ to -π + _r_.
+          1. Else,
+            1. If _ny_ &lt; *-0*<sub>𝔽</sub>, set _r_ to -_r_.
+          1. Return an implementation-approximated Number value representing _r_.
         </emu-alg>
       </emu-clause>
 


### PR DESCRIPTION
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->

Fix https://github.com/tc39/ecma262/issues/2897.

I have no idea if this meets the conventions, but I hope the idea is at least correct. Below is the output of `Math.atan2` in Node:

<img width="541" alt="image" src="https://github.com/tc39/ecma262/assets/55398995/74e95f25-0438-4acf-a66b-5e2d6339aca1">
