### PR TITLE
Editorial: remove unused isLittleEndian parameter of GetModifySetValueInBuffer

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -42674,7 +42674,6 @@ THH:mm:ss.sss
             _type_: a TypedArray element type,
             _value_: a Number or a BigInt,
             _op_: a read-modify-write modification function,
-            optional _isLittleEndian_: a Boolean,
           ): a Number or a BigInt
         </h1>
         <dl class="header">
@@ -42685,7 +42684,7 @@ THH:mm:ss.sss
           1. Assert: _value_ is a BigInt if IsBigIntElementType(_type_) is *true*; otherwise, _value_ is a Number.
           1. Let _block_ be _arrayBuffer_.[[ArrayBufferData]].
           1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for Element Type _type_.
-          1. If _isLittleEndian_ is not present, set _isLittleEndian_ to the value of the [[LittleEndian]] field of the surrounding agent's Agent Record.
+          1. Let _isLittleEndian_ be the value of the [[LittleEndian]] field of the surrounding agent's Agent Record.
           1. Let _rawBytes_ be NumericToRawBytes(_type_, _value_, _isLittleEndian_).
           1. If IsSharedArrayBuffer(_arrayBuffer_) is *true*, then
             1. Let _execution_ be the [[CandidateExecution]] field of the surrounding agent's Agent Record.


### PR DESCRIPTION
The only call site of `GetModifySetValueInBuffer` does not pass a value for the `isLittleEndian` parameter.