### PR TITLE
Editorial: remove unhelpful and potentially misleading checks in Number::lessThan

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -2121,8 +2121,6 @@
             1. If _x_ is *NaN*, return *undefined*.
             1. If _y_ is *NaN*, return *undefined*.
             1. If _x_ is _y_, return *false*.
-            1. If _x_ is *+0*<sub>𝔽</sub> and _y_ is *-0*<sub>𝔽</sub>, return *false*.
-            1. If _x_ is *-0*<sub>𝔽</sub> and _y_ is *+0*<sub>𝔽</sub>, return *false*.
             1. If _x_ is *+∞*<sub>𝔽</sub>, return *false*.
             1. If _y_ is *+∞*<sub>𝔽</sub>, return *true*.
             1. If _y_ is *-∞*<sub>𝔽</sub>, return *false*.


### PR DESCRIPTION
As discussed in editor call. Noticed during review of #3169. These checks for zero don't provide anything in terms of readability. The other unnecessary checks of this form in Number::sameValue are helpful for comparison to Number::sameValueZero, and should remain.

Aside: I would maybe also add an emu-note to this AO that says something like "*+∞*<sub>𝔽</sub> is not strictly less than any Number; no Number is strictly less than *-∞*<sub>𝔽</sub>" since inferring this from the sequence of steps handling infinities is harder than reading such a declaration.