### PR TITLE
Meta: bump ecmarkup to v18.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://tc39.es/ecma262/#sec-copyright-and-software-license",
       "dependencies": {
-        "ecmarkup": "^17.1.1"
+        "ecmarkup": "^18.0.0"
       },
       "devDependencies": {
         "glob": "^7.1.6",
@@ -724,9 +724,9 @@
       }
     },
     "node_modules/ecmarkup": {
-      "version": "17.1.1",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-17.1.1.tgz",
-      "integrity": "sha512-nA6a3jZ43tD+Kj8cWdQGQSzCe7iUdiBIdgsImizU8ez7hPri4YNC1vG3Ze6jEhHIrQccOHsrG3FApJKgSRy/cg==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-18.0.0.tgz",
+      "integrity": "sha512-VSItKQ+39dv1FeR1YbGGlJ/rx17wsPSkS7morrOCwLGHh+7ehy89hao+rQ0/ptiBAN3nbytXzwUBUTC3XNmxaA==",
       "dependencies": {
         "chalk": "^4.1.2",
         "command-line-args": "^5.2.0",
@@ -2940,9 +2940,9 @@
       }
     },
     "ecmarkup": {
-      "version": "17.1.1",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-17.1.1.tgz",
-      "integrity": "sha512-nA6a3jZ43tD+Kj8cWdQGQSzCe7iUdiBIdgsImizU8ez7hPri4YNC1vG3Ze6jEhHIrQccOHsrG3FApJKgSRy/cg==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-18.0.0.tgz",
+      "integrity": "sha512-VSItKQ+39dv1FeR1YbGGlJ/rx17wsPSkS7morrOCwLGHh+7ehy89hao+rQ0/ptiBAN3nbytXzwUBUTC3XNmxaA==",
       "requires": {
         "chalk": "^4.1.2",
         "command-line-args": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -5,15 +5,11 @@
   "description": "The ECMAScript specification",
   "scripts": {
     "ipr-check": "node scripts/check-form tc39/ecma262 HEAD --all",
-    "prebuild-spec": "git remote rm travis-origin 2>/dev/null ; git remote add travis-origin \"git@github.com:${TRAVIS_REPO_SLUG:-tc39/ecma262}.git\" && git fetch --quiet travis-origin",
-    "build-spec": "YEAR=2023 && git checkout --quiet \"es${YEAR}\" && mkdir -p \"out/${YEAR}\" && cp -R img \"out/${YEAR}\" && ecmarkup --verbose spec.html \"out/${YEAR}/index.html\" --css \"out/${YEAR}/ecmarkup.css\" --js \"out/${YEAR}/ecmarkup.js\" && git checkout --quiet travis-origin/test-travis",
-    "postbuild-spec": "git remote rm travis-origin",
     "build-head": "npm run build-only -- --lint-spec --strict",
     "prebuild-only": "npm run clean && mkdir out && cp -R img out",
     "build-only": "ecmarkup --verbose spec.html --multipage out",
     "build": "npm run build-head",
     "build-for-pdf": "npm run build-head -- --old-toc",
-    "build-travis": "npm run build-head && npm run build-spec",
     "prebuild-snapshot": "npm run clean",
     "build-snapshot": "npm run build-head && node scripts/insert_snapshot_warning.js",
     "clean": "rm -rf out",
@@ -27,7 +23,7 @@
   "license": "SEE LICENSE IN https://tc39.es/ecma262/#sec-copyright-and-software-license",
   "homepage": "https://tc39.es/ecma262/",
   "dependencies": {
-    "ecmarkup": "^17.1.1"
+    "ecmarkup": "^18.0.0"
   },
   "devDependencies": {
     "glob": "^7.1.6",


### PR DESCRIPTION
This introduces a new, hopefully more legible font.

Also drops some old unused scripts from `package.json`, since they'd be broken by this update and it's not worth fixing them given that they're unused.