### PR TITLE
Editorial: Unconditionally use LookaheadAssertion in Assertion

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -49014,7 +49014,7 @@ THH:mm:ss.sss
           [+UnicodeMode] Assertion[+UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups]
           [+UnicodeMode] Atom[+UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups] Quantifier
           [+UnicodeMode] Atom[+UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups]
-          [~UnicodeMode] QuantifiableAssertion[~UnicodeMode, ~UnicodeSetsMode, ?NamedCaptureGroups] Quantifier
+          [~UnicodeMode] LookaheadAssertion[~UnicodeMode, ~UnicodeSetsMode, ?NamedCaptureGroups] Quantifier
           [~UnicodeMode] Assertion[~UnicodeMode, ~UnicodeSetsMode, ?NamedCaptureGroups]
           [~UnicodeMode] ExtendedAtom[?NamedCaptureGroups] Quantifier
           [~UnicodeMode] ExtendedAtom[?NamedCaptureGroups]
@@ -49024,11 +49024,11 @@ THH:mm:ss.sss
           `$`
           `\b`
           `\B`
-          QuantifiableAssertion[?UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups]
+          LookaheadAssertion[?UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups]
           `(?&lt;=` Disjunction[?UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups] `)`
           `(?&lt;!` Disjunction[?UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups] `)`
 
-        QuantifiableAssertion[UnicodeMode, UnicodeSetsMode, NamedCaptureGroups] ::
+        LookaheadAssertion[UnicodeMode, UnicodeSetsMode, NamedCaptureGroups] ::
           `(?=` Disjunction[?UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups] `)`
           `(?!` Disjunction[?UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups] `)`
 
@@ -49166,14 +49166,14 @@ THH:mm:ss.sss
         <h1>Runtime Semantics: CompileSubpattern</h1>
         <p>The semantics of CompileSubpattern is extended as follows:</p>
 
-        <p>The rule for <emu-grammar>Term :: QuantifiableAssertion Quantifier</emu-grammar> is the same as for <emu-grammar>Term :: Atom Quantifier</emu-grammar> but with |QuantifiableAssertion| substituted for |Atom|.</p>
+        <p>The rule for <emu-grammar>Term :: LookaheadAssertion Quantifier</emu-grammar> is the same as for <emu-grammar>Term :: Atom Quantifier</emu-grammar> but with |LookaheadAssertion| substituted for |Atom|.</p>
         <p>The rule for <emu-grammar>Term :: ExtendedAtom Quantifier</emu-grammar> is the same as for <emu-grammar>Term :: Atom Quantifier</emu-grammar> but with |ExtendedAtom| substituted for |Atom|.</p>
         <p>The rule for <emu-grammar>Term :: ExtendedAtom</emu-grammar> is the same as for <emu-grammar>Term :: Atom</emu-grammar> but with |ExtendedAtom| substituted for |Atom|.</p>
       </emu-annex>
 
       <emu-annex id="sec-compileassertion-annexb">
         <h1>Runtime Semantics: CompileAssertion</h1>
-        <p>CompileAssertion rules for the <emu-grammar>Assertion :: `(?=` Disjunction `)`</emu-grammar> and <emu-grammar>Assertion :: `(?!` Disjunction `)`</emu-grammar> productions are also used for the |QuantifiableAssertion| productions, but with |QuantifiableAssertion| substituted for |Assertion|.</p>
+        <p>CompileAssertion rules for the <emu-grammar>Assertion :: `(?=` Disjunction `)`</emu-grammar> and <emu-grammar>Assertion :: `(?!` Disjunction `)`</emu-grammar> productions are also used for the |LookaheadAssertion| productions, but with |LookaheadAssertion| substituted for |Assertion|.</p>
       </emu-annex>
 
       <emu-annex id="sec-compileatom-annexb">

--- a/spec.html
+++ b/spec.html
@@ -49014,7 +49014,7 @@ THH:mm:ss.sss
           [+UnicodeMode] Assertion[+UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups]
           [+UnicodeMode] Atom[+UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups] Quantifier
           [+UnicodeMode] Atom[+UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups]
-          [~UnicodeMode] QuantifiableAssertion[?NamedCaptureGroups] Quantifier
+          [~UnicodeMode] QuantifiableAssertion[~UnicodeMode, ~UnicodeSetsMode, ?NamedCaptureGroups] Quantifier
           [~UnicodeMode] Assertion[~UnicodeMode, ~UnicodeSetsMode, ?NamedCaptureGroups]
           [~UnicodeMode] ExtendedAtom[?NamedCaptureGroups] Quantifier
           [~UnicodeMode] ExtendedAtom[?NamedCaptureGroups]
@@ -49024,15 +49024,13 @@ THH:mm:ss.sss
           `$`
           `\b`
           `\B`
-          [+UnicodeMode] `(?=` Disjunction[+UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups] `)`
-          [+UnicodeMode] `(?!` Disjunction[+UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups] `)`
-          [~UnicodeMode] QuantifiableAssertion[?NamedCaptureGroups]
+          QuantifiableAssertion[?UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups]
           `(?&lt;=` Disjunction[?UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups] `)`
           `(?&lt;!` Disjunction[?UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups] `)`
 
-        QuantifiableAssertion[NamedCaptureGroups] ::
-          `(?=` Disjunction[~UnicodeMode, ~UnicodeSetsMode, ?NamedCaptureGroups] `)`
-          `(?!` Disjunction[~UnicodeMode, ~UnicodeSetsMode, ?NamedCaptureGroups] `)`
+        QuantifiableAssertion[UnicodeMode, UnicodeSetsMode, NamedCaptureGroups] ::
+          `(?=` Disjunction[?UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups] `)`
+          `(?!` Disjunction[?UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups] `)`
 
         ExtendedAtom[NamedCaptureGroups] ::
           `.`

--- a/spec.html
+++ b/spec.html
@@ -54047,7 +54047,7 @@ THH:mm:ss.sss
           [+UnicodeMode] Assertion[+UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups]
           [+UnicodeMode] Atom[+UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups] Quantifier
           [+UnicodeMode] Atom[+UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups]
-          [~UnicodeMode] QuantifiableAssertion[~UnicodeMode, ~UnicodeSetsMode, ?NamedCaptureGroups] Quantifier
+          [~UnicodeMode] LookaheadAssertion[~UnicodeMode, ~UnicodeSetsMode, ?NamedCaptureGroups] Quantifier
           [~UnicodeMode] Assertion[~UnicodeMode, ~UnicodeSetsMode, ?NamedCaptureGroups]
           [~UnicodeMode] ExtendedAtom[?NamedCaptureGroups] Quantifier
           [~UnicodeMode] ExtendedAtom[?NamedCaptureGroups]
@@ -54057,11 +54057,11 @@ THH:mm:ss.sss
           `$`
           `\b`
           `\B`
-          QuantifiableAssertion[?UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups]
+          LookaheadAssertion[?UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups]
           `(?&lt;=` Disjunction[?UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups] `)`
           `(?&lt;!` Disjunction[?UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups] `)`
 
-        QuantifiableAssertion[UnicodeMode, UnicodeSetsMode, NamedCaptureGroups] ::
+        LookaheadAssertion[UnicodeMode, UnicodeSetsMode, NamedCaptureGroups] ::
           `(?=` Disjunction[?UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups] `)`
           `(?!` Disjunction[?UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups] `)`
 
@@ -54200,14 +54200,14 @@ THH:mm:ss.sss
         <h1>Runtime Semantics: CompileSubpattern</h1>
         <p>The semantics of CompileSubpattern is extended as follows:</p>
 
-        <p>The rule for <emu-grammar>Term :: QuantifiableAssertion Quantifier</emu-grammar> is the same as for <emu-grammar>Term :: Atom Quantifier</emu-grammar> but with |QuantifiableAssertion| substituted for |Atom|.</p>
+        <p>The rule for <emu-grammar>Term :: LookaheadAssertion Quantifier</emu-grammar> is the same as for <emu-grammar>Term :: Atom Quantifier</emu-grammar> but with |LookaheadAssertion| substituted for |Atom|.</p>
         <p>The rule for <emu-grammar>Term :: ExtendedAtom Quantifier</emu-grammar> is the same as for <emu-grammar>Term :: Atom Quantifier</emu-grammar> but with |ExtendedAtom| substituted for |Atom|.</p>
         <p>The rule for <emu-grammar>Term :: ExtendedAtom</emu-grammar> is the same as for <emu-grammar>Term :: Atom</emu-grammar> but with |ExtendedAtom| substituted for |Atom|.</p>
       </emu-annex>
 
       <emu-annex id="sec-compileassertion-annexb">
         <h1>Runtime Semantics: CompileAssertion</h1>
-        <p>CompileAssertion rules for the <emu-grammar>Assertion :: `(?=` Disjunction `)`</emu-grammar> and <emu-grammar>Assertion :: `(?!` Disjunction `)`</emu-grammar> productions are also used for the |QuantifiableAssertion| productions, but with |QuantifiableAssertion| substituted for |Assertion|.</p>
+        <p>CompileAssertion rules for the <emu-grammar>Assertion :: `(?=` Disjunction `)`</emu-grammar> and <emu-grammar>Assertion :: `(?!` Disjunction `)`</emu-grammar> productions are also used for the |LookaheadAssertion| productions, but with |LookaheadAssertion| substituted for |Assertion|.</p>
       </emu-annex>
 
       <emu-annex id="sec-compileatom-annexb">

--- a/spec.html
+++ b/spec.html
@@ -54047,7 +54047,7 @@ THH:mm:ss.sss
           [+UnicodeMode] Assertion[+UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups]
           [+UnicodeMode] Atom[+UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups] Quantifier
           [+UnicodeMode] Atom[+UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups]
-          [~UnicodeMode] QuantifiableAssertion[?NamedCaptureGroups] Quantifier
+          [~UnicodeMode] QuantifiableAssertion[~UnicodeMode, ~UnicodeSetsMode, ?NamedCaptureGroups] Quantifier
           [~UnicodeMode] Assertion[~UnicodeMode, ~UnicodeSetsMode, ?NamedCaptureGroups]
           [~UnicodeMode] ExtendedAtom[?NamedCaptureGroups] Quantifier
           [~UnicodeMode] ExtendedAtom[?NamedCaptureGroups]
@@ -54057,15 +54057,13 @@ THH:mm:ss.sss
           `$`
           `\b`
           `\B`
-          [+UnicodeMode] `(?=` Disjunction[+UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups] `)`
-          [+UnicodeMode] `(?!` Disjunction[+UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups] `)`
-          [~UnicodeMode] QuantifiableAssertion[?NamedCaptureGroups]
+          QuantifiableAssertion[?UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups]
           `(?&lt;=` Disjunction[?UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups] `)`
           `(?&lt;!` Disjunction[?UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups] `)`
 
-        QuantifiableAssertion[NamedCaptureGroups] ::
-          `(?=` Disjunction[~UnicodeMode, ~UnicodeSetsMode, ?NamedCaptureGroups] `)`
-          `(?!` Disjunction[~UnicodeMode, ~UnicodeSetsMode, ?NamedCaptureGroups] `)`
+        QuantifiableAssertion[UnicodeMode, UnicodeSetsMode, NamedCaptureGroups] ::
+          `(?=` Disjunction[?UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups] `)`
+          `(?!` Disjunction[?UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups] `)`
 
         ExtendedAtom[NamedCaptureGroups] ::
           `.`


### PR DESCRIPTION
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->

This PR tries to simplify the Annex B RegExp `Assertion` production, by removing the branching on the `UnicodeMode` parameter. The two branches were effectively the same, just with the `UnicodeMode` parameter hard-coded to either enabled or disabled depending on whether it was enabled or disabled.

Additionally, it renames `QuantifiableAssertion` to `LookaheadAssertion` since now it's also used in contexts where it cannot be followed by a quantifier (i.e. when `UnicodeMode` is enabled).

Note that `[~UnicodeMode, +UnicodeSetsMode]` can never happen, because of https://tc39.es/ecma262/#sec-parsepattern (and https://tc39.es/ecma262/#sec-parsepattern-annexb).