### PR TITLE
Editorial: More tweaks to low-level Date AOs

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -33397,14 +33397,14 @@
         <h1>
           TimeWithinDay (
             _t_: a finite time value,
-          ): an integral Number in the interval from *+0*<sub>𝔽</sub> (inclusive) to 𝔽(msPerDay) (exclusive)
+          ): an integer in the interval from 0 (inclusive) to msPerDay (exclusive)
         </h1>
         <dl class="header">
           <dt>description</dt>
           <dd>It returns the number of milliseconds since the start of the day in which _t_ falls.</dd>
         </dl>
         <emu-alg>
-          1. Return 𝔽(ℝ(_t_) modulo msPerDay).
+          1. Return ℝ(_t_) modulo msPerDay.
         </emu-alg>
       </emu-clause>
 
@@ -34651,7 +34651,7 @@ THH:mm:ss.sss
           1. Let _dt_ be ? ToNumber(_date_).
           1. If _t_ is *NaN*, return *NaN*.
           1. Set _t_ to LocalTime(_t_).
-          1. Let _newDate_ be MakeDate(MakeDay(YearFromTime(_t_), MonthFromTime(_t_), _dt_), TimeWithinDay(_t_)).
+          1. Let _newDate_ be MakeDate(MakeDay(YearFromTime(_t_), MonthFromTime(_t_), _dt_), 𝔽(TimeWithinDay(_t_))).
           1. Let _u_ be TimeClip(UTC(_newDate_)).
           1. Set _dateObject_.[[DateValue]] to _u_.
           1. Return _u_.
@@ -34669,7 +34669,7 @@ THH:mm:ss.sss
           1. If _t_ is *NaN*, set _t_ to *+0*<sub>𝔽</sub>; else set _t_ to LocalTime(_t_).
           1. If _month_ is present, let _m_ be ? ToNumber(_month_); else let _m_ be MonthFromTime(_t_).
           1. If _date_ is present, let _dt_ be ? ToNumber(_date_); else let _dt_ be DateFromTime(_t_).
-          1. Let _newDate_ be MakeDate(MakeDay(_y_, _m_, _dt_), TimeWithinDay(_t_)).
+          1. Let _newDate_ be MakeDate(MakeDay(_y_, _m_, _dt_), 𝔽(TimeWithinDay(_t_))).
           1. Let _u_ be TimeClip(UTC(_newDate_)).
           1. Set _dateObject_.[[DateValue]] to _u_.
           1. Return _u_.
@@ -34761,7 +34761,7 @@ THH:mm:ss.sss
           1. If _t_ is *NaN*, return *NaN*.
           1. Set _t_ to LocalTime(_t_).
           1. If _date_ is not present, let _dt_ be DateFromTime(_t_).
-          1. Let _newDate_ be MakeDate(MakeDay(YearFromTime(_t_), _m_, _dt_), TimeWithinDay(_t_)).
+          1. Let _newDate_ be MakeDate(MakeDay(YearFromTime(_t_), _m_, _dt_), 𝔽(TimeWithinDay(_t_))).
           1. Let _u_ be TimeClip(UTC(_newDate_)).
           1. Set _dateObject_.[[DateValue]] to _u_.
           1. Return _u_.
@@ -34817,7 +34817,7 @@ THH:mm:ss.sss
           1. Let _t_ be _dateObject_.[[DateValue]].
           1. Let _dt_ be ? ToNumber(_date_).
           1. If _t_ is *NaN*, return *NaN*.
-          1. Let _newDate_ be MakeDate(MakeDay(YearFromTime(_t_), MonthFromTime(_t_), _dt_), TimeWithinDay(_t_)).
+          1. Let _newDate_ be MakeDate(MakeDay(YearFromTime(_t_), MonthFromTime(_t_), _dt_), 𝔽(TimeWithinDay(_t_))).
           1. Let _v_ be TimeClip(_newDate_).
           1. Set _dateObject_.[[DateValue]] to _v_.
           1. Return _v_.
@@ -34835,7 +34835,7 @@ THH:mm:ss.sss
           1. Let _y_ be ? ToNumber(_year_).
           1. If _month_ is present, let _m_ be ? ToNumber(_month_); else let _m_ be MonthFromTime(_t_).
           1. If _date_ is present, let _dt_ be ? ToNumber(_date_); else let _dt_ be DateFromTime(_t_).
-          1. Let _newDate_ be MakeDate(MakeDay(_y_, _m_, _dt_), TimeWithinDay(_t_)).
+          1. Let _newDate_ be MakeDate(MakeDay(_y_, _m_, _dt_), 𝔽(TimeWithinDay(_t_))).
           1. Let _v_ be TimeClip(_newDate_).
           1. Set _dateObject_.[[DateValue]] to _v_.
           1. Return _v_.
@@ -34923,7 +34923,7 @@ THH:mm:ss.sss
           1. If _date_ is present, let _dt_ be ? ToNumber(_date_).
           1. If _t_ is *NaN*, return *NaN*.
           1. If _date_ is not present, let _dt_ be DateFromTime(_t_).
-          1. Let _newDate_ be MakeDate(MakeDay(YearFromTime(_t_), _m_, _dt_), TimeWithinDay(_t_)).
+          1. Let _newDate_ be MakeDate(MakeDay(YearFromTime(_t_), _m_, _dt_), 𝔽(TimeWithinDay(_t_))).
           1. Let _v_ be TimeClip(_newDate_).
           1. Set _dateObject_.[[DateValue]] to _v_.
           1. Return _v_.
@@ -53351,7 +53351,7 @@ THH:mm:ss.sss
           1. If _time_ is *NaN*, set _time_ to *+0*<sub>𝔽</sub>; else set _time_ to LocalTime(_time_).
           1. Let _fullYear_ be MakeFullYear(_year_).
           1. Let _day_ be MakeDay(_fullYear_, MonthFromTime(_time_), DateFromTime(_time_)).
-          1. Let _date_ be MakeDate(_day_, TimeWithinDay(_time_)).
+          1. Let _date_ be MakeDate(_day_, 𝔽(TimeWithinDay(_time_))).
           1. Let _utcTimestamp_ be TimeClip(UTC(_date_)).
           1. Set _dateObject_.[[DateValue]] to _utcTimestamp_.
           1. Return _utcTimestamp_.

--- a/spec.html
+++ b/spec.html
@@ -33613,14 +33613,14 @@
         <h1>
           MillisecFromTime (
             _t_: a finite time value,
-          ): an integral Number in the inclusive interval from *+0*<sub>𝔽</sub> to *999*<sub>𝔽</sub>
+          ): an integer in the inclusive interval from 0 to 999
         </h1>
         <dl class="header">
           <dt>description</dt>
           <dd>It returns the millisecond of the second in which _t_ falls.</dd>
         </dl>
         <emu-alg>
-          1. Return 𝔽(ℝ(_t_) modulo msPerSecond).
+          1. Return ℝ(_t_) modulo msPerSecond.
         </emu-alg>
       </emu-clause>
 
@@ -33873,13 +33873,13 @@
           1. If IsTimeZoneOffsetString(_systemTimeZoneIdentifier_) is *true*, then
             1. Let _offsetNs_ be ParseTimeZoneOffsetString(_systemTimeZoneIdentifier_).
           1. Else,
-            1. Let _possibleInstants_ be GetNamedTimeZoneEpochNanoseconds(_systemTimeZoneIdentifier_, YearFromTime(_t_), MonthFromTime(_t_) + 1, DateFromTime(_t_), HourFromTime(_t_), MinFromTime(_t_), SecFromTime(_t_), ℝ(MillisecFromTime(_t_)), 0, 0).
+            1. Let _possibleInstants_ be GetNamedTimeZoneEpochNanoseconds(_systemTimeZoneIdentifier_, YearFromTime(_t_), MonthFromTime(_t_) + 1, DateFromTime(_t_), HourFromTime(_t_), MinFromTime(_t_), SecFromTime(_t_), MillisecFromTime(_t_), 0, 0).
             1. NOTE: The following steps ensure that when _t_ represents local time repeating multiple times at a negative time zone transition (e.g. when the daylight saving time ends or the time zone offset is decreased due to a time zone rule change) or skipped local time at a positive time zone transition (e.g. when the daylight saving time starts or the time zone offset is increased due to a time zone rule change), _t_ is interpreted using the time zone offset before the transition.
             1. If _possibleInstants_ is not empty, then
               1. Let _disambiguatedInstant_ be _possibleInstants_[0].
             1. Else,
               1. NOTE: _t_ represents a local time skipped at a positive time zone transition (e.g. due to daylight saving time starting or a time zone rule change increasing the UTC offset).
-              1. [declared="tBefore"] Let _possibleInstantsBefore_ be GetNamedTimeZoneEpochNanoseconds(_systemTimeZoneIdentifier_, YearFromTime(_tBefore_), MonthFromTime(_tBefore_) + 1, DateFromTime(_tBefore_), HourFromTime(_tBefore_), MinFromTime(_tBefore_), SecFromTime(_tBefore_), ℝ(MillisecFromTime(_tBefore_)), 0, 0), where _tBefore_ is the largest integral Number &lt; _t_ for which _possibleInstantsBefore_ is not empty (i.e., _tBefore_ represents the last local time before the transition).
+              1. [declared="tBefore"] Let _possibleInstantsBefore_ be GetNamedTimeZoneEpochNanoseconds(_systemTimeZoneIdentifier_, YearFromTime(_tBefore_), MonthFromTime(_tBefore_) + 1, DateFromTime(_tBefore_), HourFromTime(_tBefore_), MinFromTime(_tBefore_), SecFromTime(_tBefore_), MillisecFromTime(_tBefore_), 0, 0), where _tBefore_ is the largest integral Number &lt; _t_ for which _possibleInstantsBefore_ is not empty (i.e., _tBefore_ represents the last local time before the transition).
               1. Let _disambiguatedInstant_ be the last element of _possibleInstantsBefore_.
             1. Let _offsetNs_ be GetNamedTimeZoneOffsetNanoseconds(_systemTimeZoneIdentifier_, _disambiguatedInstant_).
           1. Let _offsetMs_ be truncate(_offsetNs_ / 10<sup>6</sup>).
@@ -34482,7 +34482,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
           1. Let _t_ be _dateObject_.[[DateValue]].
           1. If _t_ is *NaN*, return *NaN*.
-          1. Return MillisecFromTime(LocalTime(_t_)).
+          1. Return 𝔽(MillisecFromTime(LocalTime(_t_))).
         </emu-alg>
       </emu-clause>
 
@@ -34600,7 +34600,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
           1. Let _t_ be _dateObject_.[[DateValue]].
           1. If _t_ is *NaN*, return *NaN*.
-          1. Return MillisecFromTime(_t_).
+          1. Return 𝔽(MillisecFromTime(_t_)).
         </emu-alg>
       </emu-clause>
 
@@ -34694,7 +34694,7 @@ THH:mm:ss.sss
           1. Set _t_ to LocalTime(_t_).
           1. If _min_ is not present, let _m_ be 𝔽(MinFromTime(_t_)).
           1. If _sec_ is not present, let _s_ be 𝔽(SecFromTime(_t_)).
-          1. If _ms_ is not present, let _milli_ be MillisecFromTime(_t_).
+          1. If _ms_ is not present, let _milli_ be 𝔽(MillisecFromTime(_t_)).
           1. Let _date_ be MakeDate(𝔽(Day(_t_)), MakeTime(_h_, _m_, _s_, _milli_)).
           1. Let _u_ be TimeClip(UTC(_date_)).
           1. Set _dateObject_.[[DateValue]] to _u_.
@@ -34736,7 +34736,7 @@ THH:mm:ss.sss
           1. If _t_ is *NaN*, return *NaN*.
           1. Set _t_ to LocalTime(_t_).
           1. If _sec_ is not present, let _s_ be 𝔽(SecFromTime(_t_)).
-          1. If _ms_ is not present, let _milli_ be MillisecFromTime(_t_).
+          1. If _ms_ is not present, let _milli_ be 𝔽(MillisecFromTime(_t_)).
           1. Let _date_ be MakeDate(𝔽(Day(_t_)), MakeTime(𝔽(HourFromTime(_t_)), _m_, _s_, _milli_)).
           1. Let _u_ be TimeClip(UTC(_date_)).
           1. Set _dateObject_.[[DateValue]] to _u_.
@@ -34782,7 +34782,7 @@ THH:mm:ss.sss
           1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_).
           1. If _t_ is *NaN*, return *NaN*.
           1. Set _t_ to LocalTime(_t_).
-          1. If _ms_ is not present, let _milli_ be MillisecFromTime(_t_).
+          1. If _ms_ is not present, let _milli_ be 𝔽(MillisecFromTime(_t_)).
           1. Let _date_ be MakeDate(𝔽(Day(_t_)), MakeTime(𝔽(HourFromTime(_t_)), 𝔽(MinFromTime(_t_)), _s_, _milli_)).
           1. Let _u_ be TimeClip(UTC(_date_)).
           1. Set _dateObject_.[[DateValue]] to _u_.
@@ -34859,7 +34859,7 @@ THH:mm:ss.sss
           1. If _t_ is *NaN*, return *NaN*.
           1. If _min_ is not present, let _m_ be 𝔽(MinFromTime(_t_)).
           1. If _sec_ is not present, let _s_ be 𝔽(SecFromTime(_t_)).
-          1. If _ms_ is not present, let _milli_ be MillisecFromTime(_t_).
+          1. If _ms_ is not present, let _milli_ be 𝔽(MillisecFromTime(_t_)).
           1. Let _date_ be MakeDate(𝔽(Day(_t_)), MakeTime(_h_, _m_, _s_, _milli_)).
           1. Let _v_ be TimeClip(_date_).
           1. Set _dateObject_.[[DateValue]] to _v_.
@@ -34899,7 +34899,7 @@ THH:mm:ss.sss
           1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_).
           1. If _t_ is *NaN*, return *NaN*.
           1. If _sec_ is not present, let _s_ be 𝔽(SecFromTime(_t_)).
-          1. If _ms_ is not present, let _milli_ be MillisecFromTime(_t_).
+          1. If _ms_ is not present, let _milli_ be 𝔽(MillisecFromTime(_t_)).
           1. Let _date_ be MakeDate(𝔽(Day(_t_)), MakeTime(𝔽(HourFromTime(_t_)), _m_, _s_, _milli_)).
           1. Let _v_ be TimeClip(_date_).
           1. Set _dateObject_.[[DateValue]] to _v_.
@@ -34943,7 +34943,7 @@ THH:mm:ss.sss
           1. Let _s_ be ? ToNumber(_sec_).
           1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_).
           1. If _t_ is *NaN*, return *NaN*.
-          1. If _ms_ is not present, let _milli_ be MillisecFromTime(_t_).
+          1. If _ms_ is not present, let _milli_ be 𝔽(MillisecFromTime(_t_)).
           1. Let _date_ be MakeDate(𝔽(Day(_t_)), MakeTime(𝔽(HourFromTime(_t_)), 𝔽(MinFromTime(_t_)), _s_, _milli_)).
           1. Let _v_ be TimeClip(_date_).
           1. Set _dateObject_.[[DateValue]] to _v_.

--- a/spec.html
+++ b/spec.html
@@ -33598,14 +33598,14 @@
         <h1>
           SecFromTime (
             _t_: a finite time value,
-          ): an integral Number in the inclusive interval from *+0*<sub>𝔽</sub> to *59*<sub>𝔽</sub>
+          ): an integer in the inclusive interval from 0 to 59
         </h1>
         <dl class="header">
           <dt>description</dt>
           <dd>It returns the second of the minute in which _t_ falls.</dd>
         </dl>
         <emu-alg>
-          1. Return 𝔽(floor(ℝ(_t_) / msPerSecond) modulo SecondsPerMinute).
+          1. Return floor(ℝ(_t_) / msPerSecond) modulo SecondsPerMinute.
         </emu-alg>
       </emu-clause>
 
@@ -33873,13 +33873,13 @@
           1. If IsTimeZoneOffsetString(_systemTimeZoneIdentifier_) is *true*, then
             1. Let _offsetNs_ be ParseTimeZoneOffsetString(_systemTimeZoneIdentifier_).
           1. Else,
-            1. Let _possibleInstants_ be GetNamedTimeZoneEpochNanoseconds(_systemTimeZoneIdentifier_, YearFromTime(_t_), MonthFromTime(_t_) + 1, DateFromTime(_t_), HourFromTime(_t_), MinFromTime(_t_), ℝ(SecFromTime(_t_)), ℝ(MillisecFromTime(_t_)), 0, 0).
+            1. Let _possibleInstants_ be GetNamedTimeZoneEpochNanoseconds(_systemTimeZoneIdentifier_, YearFromTime(_t_), MonthFromTime(_t_) + 1, DateFromTime(_t_), HourFromTime(_t_), MinFromTime(_t_), SecFromTime(_t_), ℝ(MillisecFromTime(_t_)), 0, 0).
             1. NOTE: The following steps ensure that when _t_ represents local time repeating multiple times at a negative time zone transition (e.g. when the daylight saving time ends or the time zone offset is decreased due to a time zone rule change) or skipped local time at a positive time zone transition (e.g. when the daylight saving time starts or the time zone offset is increased due to a time zone rule change), _t_ is interpreted using the time zone offset before the transition.
             1. If _possibleInstants_ is not empty, then
               1. Let _disambiguatedInstant_ be _possibleInstants_[0].
             1. Else,
               1. NOTE: _t_ represents a local time skipped at a positive time zone transition (e.g. due to daylight saving time starting or a time zone rule change increasing the UTC offset).
-              1. [declared="tBefore"] Let _possibleInstantsBefore_ be GetNamedTimeZoneEpochNanoseconds(_systemTimeZoneIdentifier_, YearFromTime(_tBefore_), MonthFromTime(_tBefore_) + 1, DateFromTime(_tBefore_), HourFromTime(_tBefore_), MinFromTime(_tBefore_), ℝ(SecFromTime(_tBefore_)), ℝ(MillisecFromTime(_tBefore_)), 0, 0), where _tBefore_ is the largest integral Number &lt; _t_ for which _possibleInstantsBefore_ is not empty (i.e., _tBefore_ represents the last local time before the transition).
+              1. [declared="tBefore"] Let _possibleInstantsBefore_ be GetNamedTimeZoneEpochNanoseconds(_systemTimeZoneIdentifier_, YearFromTime(_tBefore_), MonthFromTime(_tBefore_) + 1, DateFromTime(_tBefore_), HourFromTime(_tBefore_), MinFromTime(_tBefore_), SecFromTime(_tBefore_), ℝ(MillisecFromTime(_tBefore_)), 0, 0), where _tBefore_ is the largest integral Number &lt; _t_ for which _possibleInstantsBefore_ is not empty (i.e., _tBefore_ represents the last local time before the transition).
               1. Let _disambiguatedInstant_ be the last element of _possibleInstantsBefore_.
             1. Let _offsetNs_ be GetNamedTimeZoneOffsetNanoseconds(_systemTimeZoneIdentifier_, _disambiguatedInstant_).
           1. Let _offsetMs_ be truncate(_offsetNs_ / 10<sup>6</sup>).
@@ -34518,7 +34518,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
           1. Let _t_ be _dateObject_.[[DateValue]].
           1. If _t_ is *NaN*, return *NaN*.
-          1. Return SecFromTime(LocalTime(_t_)).
+          1. Return 𝔽(SecFromTime(LocalTime(_t_))).
         </emu-alg>
       </emu-clause>
 
@@ -34636,7 +34636,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
           1. Let _t_ be _dateObject_.[[DateValue]].
           1. If _t_ is *NaN*, return *NaN*.
-          1. Return SecFromTime(_t_).
+          1. Return 𝔽(SecFromTime(_t_)).
         </emu-alg>
       </emu-clause>
 
@@ -34693,7 +34693,7 @@ THH:mm:ss.sss
           1. If _t_ is *NaN*, return *NaN*.
           1. Set _t_ to LocalTime(_t_).
           1. If _min_ is not present, let _m_ be 𝔽(MinFromTime(_t_)).
-          1. If _sec_ is not present, let _s_ be SecFromTime(_t_).
+          1. If _sec_ is not present, let _s_ be 𝔽(SecFromTime(_t_)).
           1. If _ms_ is not present, let _milli_ be MillisecFromTime(_t_).
           1. Let _date_ be MakeDate(𝔽(Day(_t_)), MakeTime(_h_, _m_, _s_, _milli_)).
           1. Let _u_ be TimeClip(UTC(_date_)).
@@ -34716,7 +34716,7 @@ THH:mm:ss.sss
           1. Set _ms_ to ? ToNumber(_ms_).
           1. If _t_ is *NaN*, return *NaN*.
           1. Set _t_ to LocalTime(_t_).
-          1. Let _time_ be MakeTime(𝔽(HourFromTime(_t_)), 𝔽(MinFromTime(_t_)), SecFromTime(_t_), _ms_).
+          1. Let _time_ be MakeTime(𝔽(HourFromTime(_t_)), 𝔽(MinFromTime(_t_)), 𝔽(SecFromTime(_t_)), _ms_).
           1. Let _u_ be TimeClip(UTC(MakeDate(𝔽(Day(_t_)), _time_))).
           1. Set _dateObject_.[[DateValue]] to _u_.
           1. Return _u_.
@@ -34735,7 +34735,7 @@ THH:mm:ss.sss
           1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_).
           1. If _t_ is *NaN*, return *NaN*.
           1. Set _t_ to LocalTime(_t_).
-          1. If _sec_ is not present, let _s_ be SecFromTime(_t_).
+          1. If _sec_ is not present, let _s_ be 𝔽(SecFromTime(_t_)).
           1. If _ms_ is not present, let _milli_ be MillisecFromTime(_t_).
           1. Let _date_ be MakeDate(𝔽(Day(_t_)), MakeTime(𝔽(HourFromTime(_t_)), _m_, _s_, _milli_)).
           1. Let _u_ be TimeClip(UTC(_date_)).
@@ -34858,7 +34858,7 @@ THH:mm:ss.sss
           1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_).
           1. If _t_ is *NaN*, return *NaN*.
           1. If _min_ is not present, let _m_ be 𝔽(MinFromTime(_t_)).
-          1. If _sec_ is not present, let _s_ be SecFromTime(_t_).
+          1. If _sec_ is not present, let _s_ be 𝔽(SecFromTime(_t_)).
           1. If _ms_ is not present, let _milli_ be MillisecFromTime(_t_).
           1. Let _date_ be MakeDate(𝔽(Day(_t_)), MakeTime(_h_, _m_, _s_, _milli_)).
           1. Let _v_ be TimeClip(_date_).
@@ -34880,7 +34880,7 @@ THH:mm:ss.sss
           1. Let _t_ be _dateObject_.[[DateValue]].
           1. Set _ms_ to ? ToNumber(_ms_).
           1. If _t_ is *NaN*, return *NaN*.
-          1. Let _time_ be MakeTime(𝔽(HourFromTime(_t_)), 𝔽(MinFromTime(_t_)), SecFromTime(_t_), _ms_).
+          1. Let _time_ be MakeTime(𝔽(HourFromTime(_t_)), 𝔽(MinFromTime(_t_)), 𝔽(SecFromTime(_t_)), _ms_).
           1. Let _v_ be TimeClip(MakeDate(𝔽(Day(_t_)), _time_)).
           1. Set _dateObject_.[[DateValue]] to _v_.
           1. Return _v_.
@@ -34898,7 +34898,7 @@ THH:mm:ss.sss
           1. If _sec_ is present, let _s_ be ? ToNumber(_sec_).
           1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_).
           1. If _t_ is *NaN*, return *NaN*.
-          1. If _sec_ is not present, let _s_ be SecFromTime(_t_).
+          1. If _sec_ is not present, let _s_ be 𝔽(SecFromTime(_t_)).
           1. If _ms_ is not present, let _milli_ be MillisecFromTime(_t_).
           1. Let _date_ be MakeDate(𝔽(Day(_t_)), MakeTime(𝔽(HourFromTime(_t_)), _m_, _s_, _milli_)).
           1. Let _v_ be TimeClip(_date_).
@@ -35048,7 +35048,7 @@ THH:mm:ss.sss
           <emu-alg>
             1. Let _hour_ be ToZeroPaddedDecimalString(HourFromTime(_tv_), 2).
             1. Let _minute_ be ToZeroPaddedDecimalString(MinFromTime(_tv_), 2).
-            1. Let _second_ be ToZeroPaddedDecimalString(ℝ(SecFromTime(_tv_)), 2).
+            1. Let _second_ be ToZeroPaddedDecimalString(SecFromTime(_tv_), 2).
             1. Return the string-concatenation of _hour_, *":"*, _minute_, *":"*, _second_, the code unit 0x0020 (SPACE), and *"GMT"*.
           </emu-alg>
         </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -33475,18 +33475,18 @@
         <h1>
           InLeapYear (
             _t_: a finite time value,
-          ): *+0*<sub>𝔽</sub> or *1*<sub>𝔽</sub>
+          ): 0 or 1
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It returns *1*<sub>𝔽</sub> if _t_ is within a leap year and *+0*<sub>𝔽</sub> otherwise.</dd>
+          <dd>It returns 1 if _t_ is within a leap year and 0 otherwise.</dd>
         </dl>
         <emu-alg>
           1. Let _y_ be YearFromTime(_t_).
-          1. If (_y_ modulo 400) = 0, return *1*<sub>𝔽</sub>.
-          1. If (_y_ modulo 100) = 0, return *+0*<sub>𝔽</sub>.
-          1. If (_y_ modulo 4) = 0, return *1*<sub>𝔽</sub>.
-          1. Return *+0*<sub>𝔽</sub>.
+          1. If (_y_ modulo 400) = 0, return 1.
+          1. If (_y_ modulo 100) = 0, return 0.
+          1. If (_y_ modulo 4) = 0, return 1.
+          1. Return 0.
         </emu-alg>
       </emu-clause>
 
@@ -33501,7 +33501,7 @@
           <dd>It returns a Number identifying the month in which _t_ falls. A month value of *+0*<sub>𝔽</sub> specifies January; *1*<sub>𝔽</sub> specifies February; *2*<sub>𝔽</sub> specifies March; *3*<sub>𝔽</sub> specifies April; *4*<sub>𝔽</sub> specifies May; *5*<sub>𝔽</sub> specifies June; *6*<sub>𝔽</sub> specifies July; *7*<sub>𝔽</sub> specifies August; *8*<sub>𝔽</sub> specifies September; *9*<sub>𝔽</sub> specifies October; *10*<sub>𝔽</sub> specifies November; and *11*<sub>𝔽</sub> specifies December. Note that <emu-eqn>MonthFromTime(*+0*<sub>𝔽</sub>) = *+0*<sub>𝔽</sub></emu-eqn>, corresponding to Thursday, 1 January 1970.</dd>
         </dl>
         <emu-alg>
-          1. Let _inLeapYear_ be InLeapYear(_t_).
+          1. Let _inLeapYear_ be 𝔽(InLeapYear(_t_)).
           1. Let _dayWithinYear_ be 𝔽(DayWithinYear(_t_)).
           1. If _dayWithinYear_ &lt; *31*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
           1. If _dayWithinYear_ &lt; *59*<sub>𝔽</sub> + _inLeapYear_, return *1*<sub>𝔽</sub>.
@@ -33530,7 +33530,7 @@
           <dd>It returns the day of the month in which _t_ falls.</dd>
         </dl>
         <emu-alg>
-          1. Let _inLeapYear_ be InLeapYear(_t_).
+          1. Let _inLeapYear_ be 𝔽(InLeapYear(_t_)).
           1. Let _dayWithinYear_ be 𝔽(DayWithinYear(_t_)).
           1. Let _month_ be MonthFromTime(_t_).
           1. If _month_ is *+0*<sub>𝔽</sub>, return _dayWithinYear_ + *1*<sub>𝔽</sub>.

--- a/spec.html
+++ b/spec.html
@@ -33498,7 +33498,7 @@
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It returns a Number identifying the month in which _t_ falls. A month value of 0 specifies January; 1 specifies February; 2 specifies March; 3 specifies April; 4 specifies May; 5 specifies June; 6 specifies July; 7 specifies August; 8 specifies September; 9 specifies October; 10 specifies November; and 11 specifies December. Note that <emu-eqn>MonthFromTime(*+0*<sub>𝔽</sub>) = 0</emu-eqn>, corresponding to Thursday, 1 January 1970.</dd>
+          <dd>It returns an integer identifying the month in which _t_ falls. A month value of 0 specifies January; 1 specifies February; 2 specifies March; 3 specifies April; 4 specifies May; 5 specifies June; 6 specifies July; 7 specifies August; 8 specifies September; 9 specifies October; 10 specifies November; and 11 specifies December. Note that <emu-eqn>MonthFromTime(*+0*<sub>𝔽</sub>) = 0</emu-eqn>, corresponding to Thursday, 1 January 1970.</dd>
         </dl>
         <emu-alg>
           1. Let _inLeapYear_ be InLeapYear(_t_).
@@ -33557,7 +33557,7 @@
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It returns a Number identifying the day of the week in which _t_ falls. A weekday value of 0 specifies Sunday; 1 specifies Monday; 2 specifies Tuesday; 3 specifies Wednesday; 4 specifies Thursday; 5 specifies Friday; and 6 specifies Saturday. Note that <emu-eqn>WeekDay(*+0*<sub>𝔽</sub>) = 4</emu-eqn>, corresponding to Thursday, 1 January 1970.</dd>
+          <dd>It returns an integer identifying the day of the week in which _t_ falls. A weekday value of 0 specifies Sunday; 1 specifies Monday; 2 specifies Tuesday; 3 specifies Wednesday; 4 specifies Thursday; 5 specifies Friday; and 6 specifies Saturday. Note that <emu-eqn>WeekDay(*+0*<sub>𝔽</sub>) = 4</emu-eqn>, corresponding to Thursday, 1 January 1970.</dd>
         </dl>
         <emu-alg>
           1. Return (Day(_t_) + 4) modulo 7.

--- a/spec.html
+++ b/spec.html
@@ -35062,7 +35062,7 @@ THH:mm:ss.sss
           <dl class="header">
           </dl>
           <emu-alg>
-            1. Let _weekday_ be the Name of the entry in <emu-xref href="#sec-todatestring-day-names"></emu-xref> with the Number 𝔽(WeekDay(_tv_)).
+            1. Let _weekday_ be the Name of the entry in <emu-xref href="#sec-todatestring-day-names"></emu-xref> whose WeekDay Index = WeekDay(_tv_).
             1. Let _month_ be the Name of the entry in <emu-xref href="#sec-todatestring-month-names"></emu-xref> with the Number 𝔽(MonthFromTime(_tv_)).
             1. Let _day_ be ToZeroPaddedDecimalString(DateFromTime(_tv_), 2).
             1. Let _yv_ be 𝔽(YearFromTime(_tv_)).
@@ -35075,7 +35075,7 @@ THH:mm:ss.sss
               <thead>
                 <tr>
                   <th>
-                    Number
+                    WeekDay Index
                   </th>
                   <th>
                     Name
@@ -35084,7 +35084,7 @@ THH:mm:ss.sss
               </thead>
               <tr>
                 <td>
-                  *+0*<sub>𝔽</sub>
+                  0
                 </td>
                 <td>
                   *"Sun"*
@@ -35092,7 +35092,7 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  *1*<sub>𝔽</sub>
+                  1
                 </td>
                 <td>
                   *"Mon"*
@@ -35100,7 +35100,7 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  *2*<sub>𝔽</sub>
+                  2
                 </td>
                 <td>
                   *"Tue"*
@@ -35108,7 +35108,7 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  *3*<sub>𝔽</sub>
+                  3
                 </td>
                 <td>
                   *"Wed"*
@@ -35116,7 +35116,7 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  *4*<sub>𝔽</sub>
+                  4
                 </td>
                 <td>
                   *"Thu"*
@@ -35124,7 +35124,7 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  *5*<sub>𝔽</sub>
+                  5
                 </td>
                 <td>
                   *"Fri"*
@@ -35132,7 +35132,7 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  *6*<sub>𝔽</sub>
+                  6
                 </td>
                 <td>
                   *"Sat"*
@@ -35318,7 +35318,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
           1. Let _tv_ be _dateObject_.[[DateValue]].
           1. If _tv_ is *NaN*, return *"Invalid Date"*.
-          1. Let _weekday_ be the Name of the entry in <emu-xref href="#sec-todatestring-day-names"></emu-xref> with the Number 𝔽(WeekDay(_tv_)).
+          1. Let _weekday_ be the Name of the entry in <emu-xref href="#sec-todatestring-day-names"></emu-xref> whose WeekDay Index = WeekDay(_tv_).
           1. Let _month_ be the Name of the entry in <emu-xref href="#sec-todatestring-month-names"></emu-xref> with the Number 𝔽(MonthFromTime(_tv_)).
           1. Let _day_ be ToZeroPaddedDecimalString(DateFromTime(_tv_), 2).
           1. Let _yv_ be 𝔽(YearFromTime(_tv_)).

--- a/spec.html
+++ b/spec.html
@@ -33568,14 +33568,14 @@
         <h1>
           HourFromTime (
             _t_: a finite time value,
-          ): an integral Number in the inclusive interval from *+0*<sub>𝔽</sub> to *23*<sub>𝔽</sub>
+          ): an integer in the inclusive interval from 0 to 23
         </h1>
         <dl class="header">
           <dt>description</dt>
           <dd>It returns the hour of the day in which _t_ falls.</dd>
         </dl>
         <emu-alg>
-          1. Return 𝔽(floor(ℝ(_t_) / msPerHour) modulo HoursPerDay).
+          1. Return floor(ℝ(_t_) / msPerHour) modulo HoursPerDay.
         </emu-alg>
       </emu-clause>
 
@@ -33873,13 +33873,13 @@
           1. If IsTimeZoneOffsetString(_systemTimeZoneIdentifier_) is *true*, then
             1. Let _offsetNs_ be ParseTimeZoneOffsetString(_systemTimeZoneIdentifier_).
           1. Else,
-            1. Let _possibleInstants_ be GetNamedTimeZoneEpochNanoseconds(_systemTimeZoneIdentifier_, YearFromTime(_t_), MonthFromTime(_t_) + 1, DateFromTime(_t_), ℝ(HourFromTime(_t_)), ℝ(MinFromTime(_t_)), ℝ(SecFromTime(_t_)), ℝ(MillisecFromTime(_t_)), 0, 0).
+            1. Let _possibleInstants_ be GetNamedTimeZoneEpochNanoseconds(_systemTimeZoneIdentifier_, YearFromTime(_t_), MonthFromTime(_t_) + 1, DateFromTime(_t_), HourFromTime(_t_), ℝ(MinFromTime(_t_)), ℝ(SecFromTime(_t_)), ℝ(MillisecFromTime(_t_)), 0, 0).
             1. NOTE: The following steps ensure that when _t_ represents local time repeating multiple times at a negative time zone transition (e.g. when the daylight saving time ends or the time zone offset is decreased due to a time zone rule change) or skipped local time at a positive time zone transition (e.g. when the daylight saving time starts or the time zone offset is increased due to a time zone rule change), _t_ is interpreted using the time zone offset before the transition.
             1. If _possibleInstants_ is not empty, then
               1. Let _disambiguatedInstant_ be _possibleInstants_[0].
             1. Else,
               1. NOTE: _t_ represents a local time skipped at a positive time zone transition (e.g. due to daylight saving time starting or a time zone rule change increasing the UTC offset).
-              1. [declared="tBefore"] Let _possibleInstantsBefore_ be GetNamedTimeZoneEpochNanoseconds(_systemTimeZoneIdentifier_, YearFromTime(_tBefore_), MonthFromTime(_tBefore_) + 1, DateFromTime(_tBefore_), ℝ(HourFromTime(_tBefore_)), ℝ(MinFromTime(_tBefore_)), ℝ(SecFromTime(_tBefore_)), ℝ(MillisecFromTime(_tBefore_)), 0, 0), where _tBefore_ is the largest integral Number &lt; _t_ for which _possibleInstantsBefore_ is not empty (i.e., _tBefore_ represents the last local time before the transition).
+              1. [declared="tBefore"] Let _possibleInstantsBefore_ be GetNamedTimeZoneEpochNanoseconds(_systemTimeZoneIdentifier_, YearFromTime(_tBefore_), MonthFromTime(_tBefore_) + 1, DateFromTime(_tBefore_), HourFromTime(_tBefore_), ℝ(MinFromTime(_tBefore_)), ℝ(SecFromTime(_tBefore_)), ℝ(MillisecFromTime(_tBefore_)), 0, 0), where _tBefore_ is the largest integral Number &lt; _t_ for which _possibleInstantsBefore_ is not empty (i.e., _tBefore_ represents the last local time before the transition).
               1. Let _disambiguatedInstant_ be the last element of _possibleInstantsBefore_.
             1. Let _offsetNs_ be GetNamedTimeZoneOffsetNanoseconds(_systemTimeZoneIdentifier_, _disambiguatedInstant_).
           1. Let _offsetMs_ be truncate(_offsetNs_ / 10<sup>6</sup>).
@@ -34470,7 +34470,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
           1. Let _t_ be _dateObject_.[[DateValue]].
           1. If _t_ is *NaN*, return *NaN*.
-          1. Return HourFromTime(LocalTime(_t_)).
+          1. Return 𝔽(HourFromTime(LocalTime(_t_))).
         </emu-alg>
       </emu-clause>
 
@@ -34588,7 +34588,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
           1. Let _t_ be _dateObject_.[[DateValue]].
           1. If _t_ is *NaN*, return *NaN*.
-          1. Return HourFromTime(_t_).
+          1. Return 𝔽(HourFromTime(_t_)).
         </emu-alg>
       </emu-clause>
 
@@ -34716,7 +34716,7 @@ THH:mm:ss.sss
           1. Set _ms_ to ? ToNumber(_ms_).
           1. If _t_ is *NaN*, return *NaN*.
           1. Set _t_ to LocalTime(_t_).
-          1. Let _time_ be MakeTime(HourFromTime(_t_), MinFromTime(_t_), SecFromTime(_t_), _ms_).
+          1. Let _time_ be MakeTime(𝔽(HourFromTime(_t_)), MinFromTime(_t_), SecFromTime(_t_), _ms_).
           1. Let _u_ be TimeClip(UTC(MakeDate(𝔽(Day(_t_)), _time_))).
           1. Set _dateObject_.[[DateValue]] to _u_.
           1. Return _u_.
@@ -34737,7 +34737,7 @@ THH:mm:ss.sss
           1. Set _t_ to LocalTime(_t_).
           1. If _sec_ is not present, let _s_ be SecFromTime(_t_).
           1. If _ms_ is not present, let _milli_ be MillisecFromTime(_t_).
-          1. Let _date_ be MakeDate(𝔽(Day(_t_)), MakeTime(HourFromTime(_t_), _m_, _s_, _milli_)).
+          1. Let _date_ be MakeDate(𝔽(Day(_t_)), MakeTime(𝔽(HourFromTime(_t_)), _m_, _s_, _milli_)).
           1. Let _u_ be TimeClip(UTC(_date_)).
           1. Set _dateObject_.[[DateValue]] to _u_.
           1. Return _u_.
@@ -34783,7 +34783,7 @@ THH:mm:ss.sss
           1. If _t_ is *NaN*, return *NaN*.
           1. Set _t_ to LocalTime(_t_).
           1. If _ms_ is not present, let _milli_ be MillisecFromTime(_t_).
-          1. Let _date_ be MakeDate(𝔽(Day(_t_)), MakeTime(HourFromTime(_t_), MinFromTime(_t_), _s_, _milli_)).
+          1. Let _date_ be MakeDate(𝔽(Day(_t_)), MakeTime(𝔽(HourFromTime(_t_)), MinFromTime(_t_), _s_, _milli_)).
           1. Let _u_ be TimeClip(UTC(_date_)).
           1. Set _dateObject_.[[DateValue]] to _u_.
           1. Return _u_.
@@ -34880,7 +34880,7 @@ THH:mm:ss.sss
           1. Let _t_ be _dateObject_.[[DateValue]].
           1. Set _ms_ to ? ToNumber(_ms_).
           1. If _t_ is *NaN*, return *NaN*.
-          1. Let _time_ be MakeTime(HourFromTime(_t_), MinFromTime(_t_), SecFromTime(_t_), _ms_).
+          1. Let _time_ be MakeTime(𝔽(HourFromTime(_t_)), MinFromTime(_t_), SecFromTime(_t_), _ms_).
           1. Let _v_ be TimeClip(MakeDate(𝔽(Day(_t_)), _time_)).
           1. Set _dateObject_.[[DateValue]] to _v_.
           1. Return _v_.
@@ -34900,7 +34900,7 @@ THH:mm:ss.sss
           1. If _t_ is *NaN*, return *NaN*.
           1. If _sec_ is not present, let _s_ be SecFromTime(_t_).
           1. If _ms_ is not present, let _milli_ be MillisecFromTime(_t_).
-          1. Let _date_ be MakeDate(𝔽(Day(_t_)), MakeTime(HourFromTime(_t_), _m_, _s_, _milli_)).
+          1. Let _date_ be MakeDate(𝔽(Day(_t_)), MakeTime(𝔽(HourFromTime(_t_)), _m_, _s_, _milli_)).
           1. Let _v_ be TimeClip(_date_).
           1. Set _dateObject_.[[DateValue]] to _v_.
           1. Return _v_.
@@ -34944,7 +34944,7 @@ THH:mm:ss.sss
           1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_).
           1. If _t_ is *NaN*, return *NaN*.
           1. If _ms_ is not present, let _milli_ be MillisecFromTime(_t_).
-          1. Let _date_ be MakeDate(𝔽(Day(_t_)), MakeTime(HourFromTime(_t_), MinFromTime(_t_), _s_, _milli_)).
+          1. Let _date_ be MakeDate(𝔽(Day(_t_)), MakeTime(𝔽(HourFromTime(_t_)), MinFromTime(_t_), _s_, _milli_)).
           1. Let _v_ be TimeClip(_date_).
           1. Set _dateObject_.[[DateValue]] to _v_.
           1. Return _v_.
@@ -35046,7 +35046,7 @@ THH:mm:ss.sss
           <dl class="header">
           </dl>
           <emu-alg>
-            1. Let _hour_ be ToZeroPaddedDecimalString(ℝ(HourFromTime(_tv_)), 2).
+            1. Let _hour_ be ToZeroPaddedDecimalString(HourFromTime(_tv_), 2).
             1. Let _minute_ be ToZeroPaddedDecimalString(ℝ(MinFromTime(_tv_)), 2).
             1. Let _second_ be ToZeroPaddedDecimalString(ℝ(SecFromTime(_tv_)), 2).
             1. Return the string-concatenation of _hour_, *":"*, _minute_, *":"*, _second_, the code unit 0x0020 (SPACE), and *"GMT"*.
@@ -35274,7 +35274,7 @@ THH:mm:ss.sss
               1. Let _offsetSign_ be *"-"*.
               1. Let _absOffset_ be -_offset_.
             1. Let _offsetMin_ be ToZeroPaddedDecimalString(ℝ(MinFromTime(_absOffset_)), 2).
-            1. Let _offsetHour_ be ToZeroPaddedDecimalString(ℝ(HourFromTime(_absOffset_)), 2).
+            1. Let _offsetHour_ be ToZeroPaddedDecimalString(HourFromTime(_absOffset_), 2).
             1. Let _tzName_ be an implementation-defined string that is either the empty String or the string-concatenation of the code unit 0x0020 (SPACE), the code unit 0x0028 (LEFT PARENTHESIS), an implementation-defined timezone name, and the code unit 0x0029 (RIGHT PARENTHESIS).
             1. Return the string-concatenation of _offsetSign_, _offsetHour_, _offsetMin_, and _tzName_.
           </emu-alg>

--- a/spec.html
+++ b/spec.html
@@ -33553,14 +33553,14 @@
         <h1>
           WeekDay (
             _t_: a finite time value,
-          ): an integral Number in the inclusive interval from *+0*<sub>𝔽</sub> to *6*<sub>𝔽</sub>
+          ): an integer in the inclusive interval from 0 to 6
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It returns a Number identifying the day of the week in which _t_ falls. A weekday value of *+0*<sub>𝔽</sub> specifies Sunday; *1*<sub>𝔽</sub> specifies Monday; *2*<sub>𝔽</sub> specifies Tuesday; *3*<sub>𝔽</sub> specifies Wednesday; *4*<sub>𝔽</sub> specifies Thursday; *5*<sub>𝔽</sub> specifies Friday; and *6*<sub>𝔽</sub> specifies Saturday. Note that <emu-eqn>WeekDay(*+0*<sub>𝔽</sub>) = *4*<sub>𝔽</sub></emu-eqn>, corresponding to Thursday, 1 January 1970.</dd>
+          <dd>It returns a Number identifying the day of the week in which _t_ falls. A weekday value of 0 specifies Sunday; 1 specifies Monday; 2 specifies Tuesday; 3 specifies Wednesday; 4 specifies Thursday; 5 specifies Friday; and 6 specifies Saturday. Note that <emu-eqn>WeekDay(*+0*<sub>𝔽</sub>) = 4</emu-eqn>, corresponding to Thursday, 1 January 1970.</dd>
         </dl>
         <emu-alg>
-          1. Return 𝔽((Day(_t_) + 4) modulo 7).
+          1. Return (Day(_t_) + 4) modulo 7.
         </emu-alg>
       </emu-clause>
 
@@ -34446,7 +34446,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
           1. Let _t_ be _dateObject_.[[DateValue]].
           1. If _t_ is *NaN*, return *NaN*.
-          1. Return WeekDay(LocalTime(_t_)).
+          1. Return 𝔽(WeekDay(LocalTime(_t_))).
         </emu-alg>
       </emu-clause>
 
@@ -34564,7 +34564,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
           1. Let _t_ be _dateObject_.[[DateValue]].
           1. If _t_ is *NaN*, return *NaN*.
-          1. Return WeekDay(_t_).
+          1. Return 𝔽(WeekDay(_t_)).
         </emu-alg>
       </emu-clause>
 
@@ -35062,7 +35062,7 @@ THH:mm:ss.sss
           <dl class="header">
           </dl>
           <emu-alg>
-            1. Let _weekday_ be the Name of the entry in <emu-xref href="#sec-todatestring-day-names"></emu-xref> with the Number WeekDay(_tv_).
+            1. Let _weekday_ be the Name of the entry in <emu-xref href="#sec-todatestring-day-names"></emu-xref> with the Number 𝔽(WeekDay(_tv_)).
             1. Let _month_ be the Name of the entry in <emu-xref href="#sec-todatestring-month-names"></emu-xref> with the Number 𝔽(MonthFromTime(_tv_)).
             1. Let _day_ be ToZeroPaddedDecimalString(DateFromTime(_tv_), 2).
             1. Let _yv_ be 𝔽(YearFromTime(_tv_)).
@@ -35318,7 +35318,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
           1. Let _tv_ be _dateObject_.[[DateValue]].
           1. If _tv_ is *NaN*, return *"Invalid Date"*.
-          1. Let _weekday_ be the Name of the entry in <emu-xref href="#sec-todatestring-day-names"></emu-xref> with the Number WeekDay(_tv_).
+          1. Let _weekday_ be the Name of the entry in <emu-xref href="#sec-todatestring-day-names"></emu-xref> with the Number 𝔽(WeekDay(_tv_)).
           1. Let _month_ be the Name of the entry in <emu-xref href="#sec-todatestring-month-names"></emu-xref> with the Number 𝔽(MonthFromTime(_tv_)).
           1. Let _day_ be ToZeroPaddedDecimalString(DateFromTime(_tv_), 2).
           1. Let _yv_ be 𝔽(YearFromTime(_tv_)).

--- a/spec.html
+++ b/spec.html
@@ -33411,21 +33411,20 @@
       <emu-clause id="sec-dayfromyear" type="abstract operation" oldids="eqn-DaysFromYear,sec-year-number">
         <h1>
           DayFromYear (
-            _y_: an integral Number,
-          ): an integral Number
+            _y_: an integer,
+          ): an integer
         </h1>
         <dl class="header">
           <dt>description</dt>
           <dd>It returns the day number of the first day of year _y_.</dd>
         </dl>
         <emu-alg>
-          1. Let _ry_ be ℝ(_y_).
           1. [declared="numYears1,numYears4,numYears100,numYears400"] NOTE: In the following steps, _numYears1_, _numYears4_, _numYears100_, and _numYears400_ represent the number of years divisible by 1, 4, 100, and 400, respectively, that occur between the epoch and the start of year _y_. The number is negative if _y_ is before the epoch.
-          1. Let _numYears1_ be (_ry_ - 1970).
-          1. Let _numYears4_ be floor((_ry_ - 1969) / 4).
-          1. Let _numYears100_ be floor((_ry_ - 1901) / 100).
-          1. Let _numYears400_ be floor((_ry_ - 1601) / 400).
-          1. Return 𝔽(365 × _numYears1_ + _numYears4_ - _numYears100_ + _numYears400_).
+          1. Let _numYears1_ be (_y_ - 1970).
+          1. Let _numYears4_ be floor((_y_ - 1969) / 4).
+          1. Let _numYears100_ be floor((_y_ - 1901) / 100).
+          1. Let _numYears400_ be floor((_y_ - 1601) / 400).
+          1. Return 365 × _numYears1_ + _numYears4_ - _numYears100_ + _numYears400_.
         </emu-alg>
       </emu-clause>
 
@@ -33440,7 +33439,7 @@
           <dd>It returns the time value of the start of year _y_.</dd>
         </dl>
         <emu-alg>
-          1. Return 𝔽(msPerDay) × DayFromYear(_y_).
+          1. Return 𝔽(msPerDay × DayFromYear(ℝ(_y_))).
         </emu-alg>
       </emu-clause>
 
@@ -33468,7 +33467,7 @@
         <dl class="header">
         </dl>
         <emu-alg>
-          1. Return 𝔽(Day(_t_)) - DayFromYear(YearFromTime(_t_)).
+          1. Return 𝔽(Day(_t_)) - 𝔽(DayFromYear(ℝ(YearFromTime(_t_)))).
         </emu-alg>
       </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -33462,12 +33462,12 @@
         <h1>
           DayWithinYear (
             _t_: a finite time value,
-          ): an integral Number in the inclusive interval from *+0*<sub>𝔽</sub> to *365*<sub>𝔽</sub>
+          ): an integer in the inclusive interval from 0 to 365
         </h1>
         <dl class="header">
         </dl>
         <emu-alg>
-          1. Return 𝔽(Day(_t_)) - 𝔽(DayFromYear(YearFromTime(_t_))).
+          1. Return Day(_t_) - DayFromYear(YearFromTime(_t_)).
         </emu-alg>
       </emu-clause>
 
@@ -33502,7 +33502,7 @@
         </dl>
         <emu-alg>
           1. Let _inLeapYear_ be InLeapYear(_t_).
-          1. Let _dayWithinYear_ be DayWithinYear(_t_).
+          1. Let _dayWithinYear_ be 𝔽(DayWithinYear(_t_)).
           1. If _dayWithinYear_ &lt; *31*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
           1. If _dayWithinYear_ &lt; *59*<sub>𝔽</sub> + _inLeapYear_, return *1*<sub>𝔽</sub>.
           1. If _dayWithinYear_ &lt; *90*<sub>𝔽</sub> + _inLeapYear_, return *2*<sub>𝔽</sub>.
@@ -33531,7 +33531,7 @@
         </dl>
         <emu-alg>
           1. Let _inLeapYear_ be InLeapYear(_t_).
-          1. Let _dayWithinYear_ be DayWithinYear(_t_).
+          1. Let _dayWithinYear_ be 𝔽(DayWithinYear(_t_)).
           1. Let _month_ be MonthFromTime(_t_).
           1. If _month_ is *+0*<sub>𝔽</sub>, return _dayWithinYear_ + *1*<sub>𝔽</sub>.
           1. If _month_ is *1*<sub>𝔽</sub>, return _dayWithinYear_ - *30*<sub>𝔽</sub>.

--- a/spec.html
+++ b/spec.html
@@ -33382,14 +33382,14 @@
         <h1>
           Day (
             _t_: a finite time value,
-          ): an integral Number
+          ): an integer
         </h1>
         <dl class="header">
           <dt>description</dt>
           <dd>It returns the day number of the day in which _t_ falls.</dd>
         </dl>
         <emu-alg>
-          1. Return 𝔽(floor(ℝ(_t_) / msPerDay)).
+          1. Return floor(ℝ(_t_) / msPerDay).
         </emu-alg>
       </emu-clause>
 
@@ -33468,7 +33468,7 @@
         <dl class="header">
         </dl>
         <emu-alg>
-          1. Return Day(_t_) - DayFromYear(YearFromTime(_t_)).
+          1. Return 𝔽(Day(_t_)) - DayFromYear(YearFromTime(_t_)).
         </emu-alg>
       </emu-clause>
 
@@ -33561,7 +33561,7 @@
           <dd>It returns a Number identifying the day of the week in which _t_ falls. A weekday value of *+0*<sub>𝔽</sub> specifies Sunday; *1*<sub>𝔽</sub> specifies Monday; *2*<sub>𝔽</sub> specifies Tuesday; *3*<sub>𝔽</sub> specifies Wednesday; *4*<sub>𝔽</sub> specifies Thursday; *5*<sub>𝔽</sub> specifies Friday; and *6*<sub>𝔽</sub> specifies Saturday. Note that <emu-eqn>WeekDay(*+0*<sub>𝔽</sub>) = *4*<sub>𝔽</sub></emu-eqn>, corresponding to Thursday, 1 January 1970.</dd>
         </dl>
         <emu-alg>
-          1. Return 𝔽(ℝ(Day(_t_) + *4*<sub>𝔽</sub>) modulo 7).
+          1. Return 𝔽((Day(_t_) + 4) modulo 7).
         </emu-alg>
       </emu-clause>
 
@@ -33956,7 +33956,7 @@
           1. If _ym_ is not finite, return *NaN*.
           1. Let _mn_ be 𝔽(ℝ(_m_) modulo 12).
           1. Find a finite time value _t_ such that YearFromTime(_t_) is _ym_, MonthFromTime(_t_) is _mn_, and DateFromTime(_t_) is *1*<sub>𝔽</sub>; but if this is not possible (because some argument is out of range), return *NaN*.
-          1. Return Day(_t_) + _dt_ - *1*<sub>𝔽</sub>.
+          1. Return 𝔽(Day(_t_)) + _dt_ - *1*<sub>𝔽</sub>.
         </emu-alg>
       </emu-clause>
 
@@ -34696,7 +34696,7 @@ THH:mm:ss.sss
           1. If _min_ is not present, let _m_ be MinFromTime(_t_).
           1. If _sec_ is not present, let _s_ be SecFromTime(_t_).
           1. If _ms_ is not present, let _milli_ be MillisecFromTime(_t_).
-          1. Let _date_ be MakeDate(Day(_t_), MakeTime(_h_, _m_, _s_, _milli_)).
+          1. Let _date_ be MakeDate(𝔽(Day(_t_)), MakeTime(_h_, _m_, _s_, _milli_)).
           1. Let _u_ be TimeClip(UTC(_date_)).
           1. Set _dateObject_.[[DateValue]] to _u_.
           1. Return _u_.
@@ -34718,7 +34718,7 @@ THH:mm:ss.sss
           1. If _t_ is *NaN*, return *NaN*.
           1. Set _t_ to LocalTime(_t_).
           1. Let _time_ be MakeTime(HourFromTime(_t_), MinFromTime(_t_), SecFromTime(_t_), _ms_).
-          1. Let _u_ be TimeClip(UTC(MakeDate(Day(_t_), _time_))).
+          1. Let _u_ be TimeClip(UTC(MakeDate(𝔽(Day(_t_)), _time_))).
           1. Set _dateObject_.[[DateValue]] to _u_.
           1. Return _u_.
         </emu-alg>
@@ -34738,7 +34738,7 @@ THH:mm:ss.sss
           1. Set _t_ to LocalTime(_t_).
           1. If _sec_ is not present, let _s_ be SecFromTime(_t_).
           1. If _ms_ is not present, let _milli_ be MillisecFromTime(_t_).
-          1. Let _date_ be MakeDate(Day(_t_), MakeTime(HourFromTime(_t_), _m_, _s_, _milli_)).
+          1. Let _date_ be MakeDate(𝔽(Day(_t_)), MakeTime(HourFromTime(_t_), _m_, _s_, _milli_)).
           1. Let _u_ be TimeClip(UTC(_date_)).
           1. Set _dateObject_.[[DateValue]] to _u_.
           1. Return _u_.
@@ -34784,7 +34784,7 @@ THH:mm:ss.sss
           1. If _t_ is *NaN*, return *NaN*.
           1. Set _t_ to LocalTime(_t_).
           1. If _ms_ is not present, let _milli_ be MillisecFromTime(_t_).
-          1. Let _date_ be MakeDate(Day(_t_), MakeTime(HourFromTime(_t_), MinFromTime(_t_), _s_, _milli_)).
+          1. Let _date_ be MakeDate(𝔽(Day(_t_)), MakeTime(HourFromTime(_t_), MinFromTime(_t_), _s_, _milli_)).
           1. Let _u_ be TimeClip(UTC(_date_)).
           1. Set _dateObject_.[[DateValue]] to _u_.
           1. Return _u_.
@@ -34861,7 +34861,7 @@ THH:mm:ss.sss
           1. If _min_ is not present, let _m_ be MinFromTime(_t_).
           1. If _sec_ is not present, let _s_ be SecFromTime(_t_).
           1. If _ms_ is not present, let _milli_ be MillisecFromTime(_t_).
-          1. Let _date_ be MakeDate(Day(_t_), MakeTime(_h_, _m_, _s_, _milli_)).
+          1. Let _date_ be MakeDate(𝔽(Day(_t_)), MakeTime(_h_, _m_, _s_, _milli_)).
           1. Let _v_ be TimeClip(_date_).
           1. Set _dateObject_.[[DateValue]] to _v_.
           1. Return _v_.
@@ -34882,7 +34882,7 @@ THH:mm:ss.sss
           1. Set _ms_ to ? ToNumber(_ms_).
           1. If _t_ is *NaN*, return *NaN*.
           1. Let _time_ be MakeTime(HourFromTime(_t_), MinFromTime(_t_), SecFromTime(_t_), _ms_).
-          1. Let _v_ be TimeClip(MakeDate(Day(_t_), _time_)).
+          1. Let _v_ be TimeClip(MakeDate(𝔽(Day(_t_)), _time_)).
           1. Set _dateObject_.[[DateValue]] to _v_.
           1. Return _v_.
         </emu-alg>
@@ -34901,7 +34901,7 @@ THH:mm:ss.sss
           1. If _t_ is *NaN*, return *NaN*.
           1. If _sec_ is not present, let _s_ be SecFromTime(_t_).
           1. If _ms_ is not present, let _milli_ be MillisecFromTime(_t_).
-          1. Let _date_ be MakeDate(Day(_t_), MakeTime(HourFromTime(_t_), _m_, _s_, _milli_)).
+          1. Let _date_ be MakeDate(𝔽(Day(_t_)), MakeTime(HourFromTime(_t_), _m_, _s_, _milli_)).
           1. Let _v_ be TimeClip(_date_).
           1. Set _dateObject_.[[DateValue]] to _v_.
           1. Return _v_.
@@ -34945,7 +34945,7 @@ THH:mm:ss.sss
           1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_).
           1. If _t_ is *NaN*, return *NaN*.
           1. If _ms_ is not present, let _milli_ be MillisecFromTime(_t_).
-          1. Let _date_ be MakeDate(Day(_t_), MakeTime(HourFromTime(_t_), MinFromTime(_t_), _s_, _milli_)).
+          1. Let _date_ be MakeDate(𝔽(Day(_t_)), MakeTime(HourFromTime(_t_), MinFromTime(_t_), _s_, _milli_)).
           1. Let _v_ be TimeClip(_date_).
           1. Set _dateObject_.[[DateValue]] to _v_.
           1. Return _v_.

--- a/spec.html
+++ b/spec.html
@@ -33610,9 +33610,9 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-msfromtime" type="abstract operation" oldids="eqn-msFromTime">
+      <emu-clause id="sec-millisecfromtime" type="abstract operation" oldids="sec-msfromtime,eqn-msFromTime">
         <h1>
-          msFromTime (
+          MillisecFromTime (
             _t_: a finite time value,
           ): an integral Number in the inclusive interval from *+0*<sub>𝔽</sub> to *999*<sub>𝔽</sub>
         </h1>
@@ -33874,13 +33874,13 @@
           1. If IsTimeZoneOffsetString(_systemTimeZoneIdentifier_) is *true*, then
             1. Let _offsetNs_ be ParseTimeZoneOffsetString(_systemTimeZoneIdentifier_).
           1. Else,
-            1. Let _possibleInstants_ be GetNamedTimeZoneEpochNanoseconds(_systemTimeZoneIdentifier_, ℝ(YearFromTime(_t_)), ℝ(MonthFromTime(_t_)) + 1, ℝ(DateFromTime(_t_)), ℝ(HourFromTime(_t_)), ℝ(MinFromTime(_t_)), ℝ(SecFromTime(_t_)), ℝ(msFromTime(_t_)), 0, 0).
+            1. Let _possibleInstants_ be GetNamedTimeZoneEpochNanoseconds(_systemTimeZoneIdentifier_, ℝ(YearFromTime(_t_)), ℝ(MonthFromTime(_t_)) + 1, ℝ(DateFromTime(_t_)), ℝ(HourFromTime(_t_)), ℝ(MinFromTime(_t_)), ℝ(SecFromTime(_t_)), ℝ(MillisecFromTime(_t_)), 0, 0).
             1. NOTE: The following steps ensure that when _t_ represents local time repeating multiple times at a negative time zone transition (e.g. when the daylight saving time ends or the time zone offset is decreased due to a time zone rule change) or skipped local time at a positive time zone transition (e.g. when the daylight saving time starts or the time zone offset is increased due to a time zone rule change), _t_ is interpreted using the time zone offset before the transition.
             1. If _possibleInstants_ is not empty, then
               1. Let _disambiguatedInstant_ be _possibleInstants_[0].
             1. Else,
               1. NOTE: _t_ represents a local time skipped at a positive time zone transition (e.g. due to daylight saving time starting or a time zone rule change increasing the UTC offset).
-              1. [declared="tBefore"] Let _possibleInstantsBefore_ be GetNamedTimeZoneEpochNanoseconds(_systemTimeZoneIdentifier_, ℝ(YearFromTime(_tBefore_)), ℝ(MonthFromTime(_tBefore_)) + 1, ℝ(DateFromTime(_tBefore_)), ℝ(HourFromTime(_tBefore_)), ℝ(MinFromTime(_tBefore_)), ℝ(SecFromTime(_tBefore_)), ℝ(msFromTime(_tBefore_)), 0, 0), where _tBefore_ is the largest integral Number &lt; _t_ for which _possibleInstantsBefore_ is not empty (i.e., _tBefore_ represents the last local time before the transition).
+              1. [declared="tBefore"] Let _possibleInstantsBefore_ be GetNamedTimeZoneEpochNanoseconds(_systemTimeZoneIdentifier_, ℝ(YearFromTime(_tBefore_)), ℝ(MonthFromTime(_tBefore_)) + 1, ℝ(DateFromTime(_tBefore_)), ℝ(HourFromTime(_tBefore_)), ℝ(MinFromTime(_tBefore_)), ℝ(SecFromTime(_tBefore_)), ℝ(MillisecFromTime(_tBefore_)), 0, 0), where _tBefore_ is the largest integral Number &lt; _t_ for which _possibleInstantsBefore_ is not empty (i.e., _tBefore_ represents the last local time before the transition).
               1. Let _disambiguatedInstant_ be the last element of _possibleInstantsBefore_.
             1. Let _offsetNs_ be GetNamedTimeZoneOffsetNanoseconds(_systemTimeZoneIdentifier_, _disambiguatedInstant_).
           1. Let _offsetMs_ be truncate(_offsetNs_ / 10<sup>6</sup>).
@@ -34483,7 +34483,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
           1. Let _t_ be _dateObject_.[[DateValue]].
           1. If _t_ is *NaN*, return *NaN*.
-          1. Return msFromTime(LocalTime(_t_)).
+          1. Return MillisecFromTime(LocalTime(_t_)).
         </emu-alg>
       </emu-clause>
 
@@ -34601,7 +34601,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
           1. Let _t_ be _dateObject_.[[DateValue]].
           1. If _t_ is *NaN*, return *NaN*.
-          1. Return msFromTime(_t_).
+          1. Return MillisecFromTime(_t_).
         </emu-alg>
       </emu-clause>
 
@@ -34695,7 +34695,7 @@ THH:mm:ss.sss
           1. Set _t_ to LocalTime(_t_).
           1. If _min_ is not present, let _m_ be MinFromTime(_t_).
           1. If _sec_ is not present, let _s_ be SecFromTime(_t_).
-          1. If _ms_ is not present, let _milli_ be msFromTime(_t_).
+          1. If _ms_ is not present, let _milli_ be MillisecFromTime(_t_).
           1. Let _date_ be MakeDate(Day(_t_), MakeTime(_h_, _m_, _s_, _milli_)).
           1. Let _u_ be TimeClip(UTC(_date_)).
           1. Set _dateObject_.[[DateValue]] to _u_.
@@ -34737,7 +34737,7 @@ THH:mm:ss.sss
           1. If _t_ is *NaN*, return *NaN*.
           1. Set _t_ to LocalTime(_t_).
           1. If _sec_ is not present, let _s_ be SecFromTime(_t_).
-          1. If _ms_ is not present, let _milli_ be msFromTime(_t_).
+          1. If _ms_ is not present, let _milli_ be MillisecFromTime(_t_).
           1. Let _date_ be MakeDate(Day(_t_), MakeTime(HourFromTime(_t_), _m_, _s_, _milli_)).
           1. Let _u_ be TimeClip(UTC(_date_)).
           1. Set _dateObject_.[[DateValue]] to _u_.
@@ -34783,7 +34783,7 @@ THH:mm:ss.sss
           1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_).
           1. If _t_ is *NaN*, return *NaN*.
           1. Set _t_ to LocalTime(_t_).
-          1. If _ms_ is not present, let _milli_ be msFromTime(_t_).
+          1. If _ms_ is not present, let _milli_ be MillisecFromTime(_t_).
           1. Let _date_ be MakeDate(Day(_t_), MakeTime(HourFromTime(_t_), MinFromTime(_t_), _s_, _milli_)).
           1. Let _u_ be TimeClip(UTC(_date_)).
           1. Set _dateObject_.[[DateValue]] to _u_.
@@ -34860,7 +34860,7 @@ THH:mm:ss.sss
           1. If _t_ is *NaN*, return *NaN*.
           1. If _min_ is not present, let _m_ be MinFromTime(_t_).
           1. If _sec_ is not present, let _s_ be SecFromTime(_t_).
-          1. If _ms_ is not present, let _milli_ be msFromTime(_t_).
+          1. If _ms_ is not present, let _milli_ be MillisecFromTime(_t_).
           1. Let _date_ be MakeDate(Day(_t_), MakeTime(_h_, _m_, _s_, _milli_)).
           1. Let _v_ be TimeClip(_date_).
           1. Set _dateObject_.[[DateValue]] to _v_.
@@ -34900,7 +34900,7 @@ THH:mm:ss.sss
           1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_).
           1. If _t_ is *NaN*, return *NaN*.
           1. If _sec_ is not present, let _s_ be SecFromTime(_t_).
-          1. If _ms_ is not present, let _milli_ be msFromTime(_t_).
+          1. If _ms_ is not present, let _milli_ be MillisecFromTime(_t_).
           1. Let _date_ be MakeDate(Day(_t_), MakeTime(HourFromTime(_t_), _m_, _s_, _milli_)).
           1. Let _v_ be TimeClip(_date_).
           1. Set _dateObject_.[[DateValue]] to _v_.
@@ -34944,7 +34944,7 @@ THH:mm:ss.sss
           1. Let _s_ be ? ToNumber(_sec_).
           1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_).
           1. If _t_ is *NaN*, return *NaN*.
-          1. If _ms_ is not present, let _milli_ be msFromTime(_t_).
+          1. If _ms_ is not present, let _milli_ be MillisecFromTime(_t_).
           1. Let _date_ be MakeDate(Day(_t_), MakeTime(HourFromTime(_t_), MinFromTime(_t_), _s_, _milli_)).
           1. Let _v_ be TimeClip(_date_).
           1. Set _dateObject_.[[DateValue]] to _v_.

--- a/spec.html
+++ b/spec.html
@@ -33408,26 +33408,7 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-daysinyear" type="abstract operation" oldids="eqn-DaysInYear,sec-year-number">
-        <h1>
-          DaysInYear (
-            _y_: an integral Number,
-          ): *365*<sub>𝔽</sub> or *366*<sub>𝔽</sub>
-        </h1>
-        <dl class="header">
-          <dt>description</dt>
-          <dd>It returns the number of days in year _y_. Leap years have 366 days; all other years have 365.</dd>
-        </dl>
-        <emu-alg>
-          1. Let _ry_ be ℝ(_y_).
-          1. If (_ry_ modulo 400) = 0, return *366*<sub>𝔽</sub>.
-          1. If (_ry_ modulo 100) = 0, return *365*<sub>𝔽</sub>.
-          1. If (_ry_ modulo 4) = 0, return *366*<sub>𝔽</sub>.
-          1. Return *365*<sub>𝔽</sub>.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-dayfromyear" type="abstract operation" oldids="eqn-DaysFromYear">
+      <emu-clause id="sec-dayfromyear" type="abstract operation" oldids="eqn-DaysFromYear,sec-year-number">
         <h1>
           DayFromYear (
             _y_: an integral Number,
@@ -33491,7 +33472,7 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-inleapyear" type="abstract operation" oldids="eqn-InLeapYear">
+      <emu-clause id="sec-inleapyear" type="abstract operation" oldids="eqn-InLeapYear,sec-daysinyear,eqn-DaysInYear">
         <h1>
           InLeapYear (
             _t_: a finite time value,
@@ -33502,7 +33483,10 @@
           <dd>It returns *1*<sub>𝔽</sub> if _t_ is within a leap year and *+0*<sub>𝔽</sub> otherwise.</dd>
         </dl>
         <emu-alg>
-          1. If DaysInYear(YearFromTime(_t_)) is *366*<sub>𝔽</sub>, return *1*<sub>𝔽</sub>.
+          1. Let _ry_ be ℝ(YearFromTime(_t_)).
+          1. If (_ry_ modulo 400) = 0, return *1*<sub>𝔽</sub>.
+          1. If (_ry_ modulo 100) = 0, return *+0*<sub>𝔽</sub>.
+          1. If (_ry_ modulo 4) = 0, return *1*<sub>𝔽</sub>.
           1. Return *+0*<sub>𝔽</sub>.
         </emu-alg>
       </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -33923,11 +33923,11 @@
         </dl>
         <emu-alg>
           1. If _hour_ is not finite, _min_ is not finite, _sec_ is not finite, or _ms_ is not finite, return *NaN*.
-          1. Let _h_ be 𝔽(! ToIntegerOrInfinity(_hour_)).
-          1. Let _m_ be 𝔽(! ToIntegerOrInfinity(_min_)).
-          1. Let _s_ be 𝔽(! ToIntegerOrInfinity(_sec_)).
-          1. Let _milli_ be 𝔽(! ToIntegerOrInfinity(_ms_)).
-          1. Return ((_h_ × 𝔽(msPerHour) + _m_ × 𝔽(msPerMinute)) + _s_ × 𝔽(msPerSecond)) + _milli_.
+          1. Let _h_ be ! ToIntegerOrInfinity(_hour_).
+          1. Let _m_ be ! ToIntegerOrInfinity(_min_).
+          1. Let _s_ be ! ToIntegerOrInfinity(_sec_).
+          1. Let _milli_ be ! ToIntegerOrInfinity(_ms_).
+          1. Return ((𝔽(_h_) × 𝔽(msPerHour) + 𝔽(_m_) × 𝔽(msPerMinute)) + 𝔽(_s_) × 𝔽(msPerSecond)) + 𝔽(_milli_).
         </emu-alg>
         <emu-note>
           <p>The arithmetic in MakeTime is floating-point arithmetic, which is not associative, so the operations must be performed in the correct order.</p>
@@ -33948,14 +33948,14 @@
         </dl>
         <emu-alg>
           1. If _year_ is not finite, _month_ is not finite, or _date_ is not finite, return *NaN*.
-          1. Let _y_ be 𝔽(! ToIntegerOrInfinity(_year_)).
-          1. Let _m_ be 𝔽(! ToIntegerOrInfinity(_month_)).
-          1. Let _dt_ be 𝔽(! ToIntegerOrInfinity(_date_)).
-          1. Let _ym_ be _y_ + 𝔽(floor(ℝ(_m_) / 12)).
+          1. Let _y_ be ! ToIntegerOrInfinity(_year_).
+          1. Let _m_ be ! ToIntegerOrInfinity(_month_).
+          1. Let _dt_ be ! ToIntegerOrInfinity(_date_).
+          1. Let _ym_ be 𝔽(_y_) + 𝔽(floor(_m_ / 12)).
           1. If _ym_ is not finite, return *NaN*.
-          1. Let _mn_ be 𝔽(ℝ(_m_) modulo 12).
-          1. Find a finite time value _t_ such that 𝔽(YearFromTime(_t_)) is _ym_, 𝔽(MonthFromTime(_t_)) is _mn_, and 𝔽(DateFromTime(_t_)) is *1*<sub>𝔽</sub>; but if this is not possible (because some argument is out of range), return *NaN*.
-          1. Return 𝔽(Day(_t_)) + _dt_ - *1*<sub>𝔽</sub>.
+          1. Let _mn_ be _m_ modulo 12.
+          1. Find a finite time value _t_ such that YearFromTime(_t_) is ℝ(_ym_), MonthFromTime(_t_) is _mn_, and DateFromTime(_t_) is 1; but if this is not possible (because some argument is out of range), return *NaN*.
+          1. Return 𝔽(Day(_t_)) + 𝔽(_dt_) - *1*<sub>𝔽</sub>.
         </emu-alg>
       </emu-clause>
 
@@ -35065,9 +35065,9 @@ THH:mm:ss.sss
             1. Let _weekday_ be the Name of the entry in <emu-xref href="#sec-todatestring-day-names"></emu-xref> whose WeekDay Index = WeekDay(_tv_).
             1. Let _month_ be the Name of the entry in <emu-xref href="#sec-todatestring-month-names"></emu-xref> whose Month Index = MonthFromTime(_tv_).
             1. Let _day_ be ToZeroPaddedDecimalString(DateFromTime(_tv_), 2).
-            1. Let _yv_ be 𝔽(YearFromTime(_tv_)).
-            1. If _yv_ is *+0*<sub>𝔽</sub> or _yv_ > *+0*<sub>𝔽</sub>, let _yearSign_ be the empty String; else let _yearSign_ be *"-"*.
-            1. Let _paddedYear_ be ToZeroPaddedDecimalString(abs(ℝ(_yv_)), 4).
+            1. Let _yv_ be YearFromTime(_tv_).
+            1. If _yv_ ≥ 0, let _yearSign_ be the empty String; else let _yearSign_ be *"-"*.
+            1. Let _paddedYear_ be ToZeroPaddedDecimalString(abs(_yv_), 4).
             1. Return the string-concatenation of _weekday_, the code unit 0x0020 (SPACE), _month_, the code unit 0x0020 (SPACE), _day_, the code unit 0x0020 (SPACE), _yearSign_, and _paddedYear_.
           </emu-alg>
           <emu-table id="sec-todatestring-day-names" caption="Names of days of the week">
@@ -35266,15 +35266,15 @@ THH:mm:ss.sss
               1. Let _offsetNs_ be ParseTimeZoneOffsetString(_systemTimeZoneIdentifier_).
             1. Else,
               1. Let _offsetNs_ be GetNamedTimeZoneOffsetNanoseconds(_systemTimeZoneIdentifier_, ℤ(ℝ(_tv_) × 10<sup>6</sup>)).
-            1. Let _offset_ be 𝔽(truncate(_offsetNs_ / 10<sup>6</sup>)).
-            1. If _offset_ is *+0*<sub>𝔽</sub> or _offset_ > *+0*<sub>𝔽</sub>, then
+            1. Let _offset_ be truncate(_offsetNs_ / 10<sup>6</sup>).
+            1. If _offset_ ≥ 0, then
               1. Let _offsetSign_ be *"+"*.
               1. Let _absOffset_ be _offset_.
             1. Else,
               1. Let _offsetSign_ be *"-"*.
               1. Let _absOffset_ be -_offset_.
-            1. Let _offsetMin_ be ToZeroPaddedDecimalString(MinFromTime(_absOffset_), 2).
-            1. Let _offsetHour_ be ToZeroPaddedDecimalString(HourFromTime(_absOffset_), 2).
+            1. Let _offsetMin_ be ToZeroPaddedDecimalString(MinFromTime(𝔽(_absOffset_)), 2).
+            1. Let _offsetHour_ be ToZeroPaddedDecimalString(HourFromTime(𝔽(_absOffset_)), 2).
             1. Let _tzName_ be an implementation-defined string that is either the empty String or the string-concatenation of the code unit 0x0020 (SPACE), the code unit 0x0028 (LEFT PARENTHESIS), an implementation-defined timezone name, and the code unit 0x0029 (RIGHT PARENTHESIS).
             1. Return the string-concatenation of _offsetSign_, _offsetHour_, _offsetMin_, and _tzName_.
           </emu-alg>
@@ -35321,9 +35321,9 @@ THH:mm:ss.sss
           1. Let _weekday_ be the Name of the entry in <emu-xref href="#sec-todatestring-day-names"></emu-xref> whose WeekDay Index = WeekDay(_tv_).
           1. Let _month_ be the Name of the entry in <emu-xref href="#sec-todatestring-month-names"></emu-xref> whose Month Index = MonthFromTime(_tv_).
           1. Let _day_ be ToZeroPaddedDecimalString(DateFromTime(_tv_), 2).
-          1. Let _yv_ be 𝔽(YearFromTime(_tv_)).
-          1. If _yv_ is *+0*<sub>𝔽</sub> or _yv_ > *+0*<sub>𝔽</sub>, let _yearSign_ be the empty String; else let _yearSign_ be *"-"*.
-          1. Let _paddedYear_ be ToZeroPaddedDecimalString(abs(ℝ(_yv_)), 4).
+          1. Let _yv_ be YearFromTime(_tv_).
+          1. If _yv_ ≥ 0, let _yearSign_ be the empty String; else let _yearSign_ be *"-"*.
+          1. Let _paddedYear_ be ToZeroPaddedDecimalString(abs(_yv_), 4).
           1. Return the string-concatenation of _weekday_, *","*, the code unit 0x0020 (SPACE), _day_, the code unit 0x0020 (SPACE), _month_, the code unit 0x0020 (SPACE), _yearSign_, _paddedYear_, the code unit 0x0020 (SPACE), and TimeString(_tv_).
         </emu-alg>
       </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -52150,7 +52150,7 @@ THH:mm:ss.sss
     <emu-alg>
       1. If _eventA_ and _eventB_ are not the same Shared Data Block event, then
         1. If it is not the case that both _eventA_ happens-before _eventB_ in _execution_ and _eventB_ happens-before _eventA_ in _execution_, then
-          1. If _eventA_ and _eventB_ are both WriteSharedMemory or ReadModifyWriteSharedMemory events and _eventA_ and _eventB_ do not have disjoint memory ranges, then
+          1. If _eventA_ is either a WriteSharedMemory or ReadModifyWriteSharedMemory event, _eventB_ is either a WriteSharedMemory or ReadModifyWriteSharedMemory event, and _eventA_ and _eventB_ do not have disjoint memory ranges, then
             1. Return *true*.
           1. If _eventA_ reads-from _eventB_ in _execution_ or _eventB_ reads-from _eventA_ in _execution_, then
             1. Return *true*.

--- a/spec.html
+++ b/spec.html
@@ -35063,7 +35063,7 @@ THH:mm:ss.sss
           </dl>
           <emu-alg>
             1. Let _weekday_ be the Name of the entry in <emu-xref href="#sec-todatestring-day-names"></emu-xref> whose WeekDay Index = WeekDay(_tv_).
-            1. Let _month_ be the Name of the entry in <emu-xref href="#sec-todatestring-month-names"></emu-xref> with the Number 𝔽(MonthFromTime(_tv_)).
+            1. Let _month_ be the Name of the entry in <emu-xref href="#sec-todatestring-month-names"></emu-xref> whose Month Index = MonthFromTime(_tv_).
             1. Let _day_ be ToZeroPaddedDecimalString(DateFromTime(_tv_), 2).
             1. Let _yv_ be 𝔽(YearFromTime(_tv_)).
             1. If _yv_ is *+0*<sub>𝔽</sub> or _yv_ > *+0*<sub>𝔽</sub>, let _yearSign_ be the empty String; else let _yearSign_ be *"-"*.
@@ -35145,7 +35145,7 @@ THH:mm:ss.sss
               <thead>
                 <tr>
                   <th>
-                    Number
+                    Month Index
                   </th>
                   <th>
                     Name
@@ -35154,7 +35154,7 @@ THH:mm:ss.sss
               </thead>
               <tr>
                 <td>
-                  *+0*<sub>𝔽</sub>
+                  0
                 </td>
                 <td>
                   *"Jan"*
@@ -35162,7 +35162,7 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  *1*<sub>𝔽</sub>
+                  1
                 </td>
                 <td>
                   *"Feb"*
@@ -35170,7 +35170,7 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  *2*<sub>𝔽</sub>
+                  2
                 </td>
                 <td>
                   *"Mar"*
@@ -35178,7 +35178,7 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  *3*<sub>𝔽</sub>
+                  3
                 </td>
                 <td>
                   *"Apr"*
@@ -35186,7 +35186,7 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  *4*<sub>𝔽</sub>
+                  4
                 </td>
                 <td>
                   *"May"*
@@ -35194,7 +35194,7 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  *5*<sub>𝔽</sub>
+                  5
                 </td>
                 <td>
                   *"Jun"*
@@ -35202,7 +35202,7 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  *6*<sub>𝔽</sub>
+                  6
                 </td>
                 <td>
                   *"Jul"*
@@ -35210,7 +35210,7 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  *7*<sub>𝔽</sub>
+                  7
                 </td>
                 <td>
                   *"Aug"*
@@ -35218,7 +35218,7 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  *8*<sub>𝔽</sub>
+                  8
                 </td>
                 <td>
                   *"Sep"*
@@ -35226,7 +35226,7 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  *9*<sub>𝔽</sub>
+                  9
                 </td>
                 <td>
                   *"Oct"*
@@ -35234,7 +35234,7 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  *10*<sub>𝔽</sub>
+                  10
                 </td>
                 <td>
                   *"Nov"*
@@ -35242,7 +35242,7 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  *11*<sub>𝔽</sub>
+                  11
                 </td>
                 <td>
                   *"Dec"*
@@ -35319,7 +35319,7 @@ THH:mm:ss.sss
           1. Let _tv_ be _dateObject_.[[DateValue]].
           1. If _tv_ is *NaN*, return *"Invalid Date"*.
           1. Let _weekday_ be the Name of the entry in <emu-xref href="#sec-todatestring-day-names"></emu-xref> whose WeekDay Index = WeekDay(_tv_).
-          1. Let _month_ be the Name of the entry in <emu-xref href="#sec-todatestring-month-names"></emu-xref> with the Number 𝔽(MonthFromTime(_tv_)).
+          1. Let _month_ be the Name of the entry in <emu-xref href="#sec-todatestring-month-names"></emu-xref> whose Month Index = MonthFromTime(_tv_).
           1. Let _day_ be ToZeroPaddedDecimalString(DateFromTime(_tv_), 2).
           1. Let _yv_ be 𝔽(YearFromTime(_tv_)).
           1. If _yv_ is *+0*<sub>𝔽</sub> or _yv_ > *+0*<sub>𝔽</sub>, let _yearSign_ be the empty String; else let _yearSign_ be *"-"*.

--- a/spec.html
+++ b/spec.html
@@ -33447,14 +33447,14 @@
         <h1>
           YearFromTime (
             _t_: a finite time value,
-          ): an integral Number
+          ): an integer
         </h1>
         <dl class="header">
           <dt>description</dt>
           <dd>It returns the year in which _t_ falls.</dd>
         </dl>
         <emu-alg>
-          1. [declared="y"] Return the largest integral Number _y_ (closest to +∞) such that TimeFromYear(ℝ(_y_)) ≤ _t_.
+          1. [declared="y"] Return the largest integer _y_ (closest to +∞) such that TimeFromYear(_y_) ≤ _t_.
         </emu-alg>
       </emu-clause>
 
@@ -33467,7 +33467,7 @@
         <dl class="header">
         </dl>
         <emu-alg>
-          1. Return 𝔽(Day(_t_)) - 𝔽(DayFromYear(ℝ(YearFromTime(_t_)))).
+          1. Return 𝔽(Day(_t_)) - 𝔽(DayFromYear(YearFromTime(_t_))).
         </emu-alg>
       </emu-clause>
 
@@ -33482,10 +33482,10 @@
           <dd>It returns *1*<sub>𝔽</sub> if _t_ is within a leap year and *+0*<sub>𝔽</sub> otherwise.</dd>
         </dl>
         <emu-alg>
-          1. Let _ry_ be ℝ(YearFromTime(_t_)).
-          1. If (_ry_ modulo 400) = 0, return *1*<sub>𝔽</sub>.
-          1. If (_ry_ modulo 100) = 0, return *+0*<sub>𝔽</sub>.
-          1. If (_ry_ modulo 4) = 0, return *1*<sub>𝔽</sub>.
+          1. Let _y_ be YearFromTime(_t_).
+          1. If (_y_ modulo 400) = 0, return *1*<sub>𝔽</sub>.
+          1. If (_y_ modulo 100) = 0, return *+0*<sub>𝔽</sub>.
+          1. If (_y_ modulo 4) = 0, return *1*<sub>𝔽</sub>.
           1. Return *+0*<sub>𝔽</sub>.
         </emu-alg>
       </emu-clause>
@@ -33873,13 +33873,13 @@
           1. If IsTimeZoneOffsetString(_systemTimeZoneIdentifier_) is *true*, then
             1. Let _offsetNs_ be ParseTimeZoneOffsetString(_systemTimeZoneIdentifier_).
           1. Else,
-            1. Let _possibleInstants_ be GetNamedTimeZoneEpochNanoseconds(_systemTimeZoneIdentifier_, ℝ(YearFromTime(_t_)), ℝ(MonthFromTime(_t_)) + 1, ℝ(DateFromTime(_t_)), ℝ(HourFromTime(_t_)), ℝ(MinFromTime(_t_)), ℝ(SecFromTime(_t_)), ℝ(MillisecFromTime(_t_)), 0, 0).
+            1. Let _possibleInstants_ be GetNamedTimeZoneEpochNanoseconds(_systemTimeZoneIdentifier_, YearFromTime(_t_), ℝ(MonthFromTime(_t_)) + 1, ℝ(DateFromTime(_t_)), ℝ(HourFromTime(_t_)), ℝ(MinFromTime(_t_)), ℝ(SecFromTime(_t_)), ℝ(MillisecFromTime(_t_)), 0, 0).
             1. NOTE: The following steps ensure that when _t_ represents local time repeating multiple times at a negative time zone transition (e.g. when the daylight saving time ends or the time zone offset is decreased due to a time zone rule change) or skipped local time at a positive time zone transition (e.g. when the daylight saving time starts or the time zone offset is increased due to a time zone rule change), _t_ is interpreted using the time zone offset before the transition.
             1. If _possibleInstants_ is not empty, then
               1. Let _disambiguatedInstant_ be _possibleInstants_[0].
             1. Else,
               1. NOTE: _t_ represents a local time skipped at a positive time zone transition (e.g. due to daylight saving time starting or a time zone rule change increasing the UTC offset).
-              1. [declared="tBefore"] Let _possibleInstantsBefore_ be GetNamedTimeZoneEpochNanoseconds(_systemTimeZoneIdentifier_, ℝ(YearFromTime(_tBefore_)), ℝ(MonthFromTime(_tBefore_)) + 1, ℝ(DateFromTime(_tBefore_)), ℝ(HourFromTime(_tBefore_)), ℝ(MinFromTime(_tBefore_)), ℝ(SecFromTime(_tBefore_)), ℝ(MillisecFromTime(_tBefore_)), 0, 0), where _tBefore_ is the largest integral Number &lt; _t_ for which _possibleInstantsBefore_ is not empty (i.e., _tBefore_ represents the last local time before the transition).
+              1. [declared="tBefore"] Let _possibleInstantsBefore_ be GetNamedTimeZoneEpochNanoseconds(_systemTimeZoneIdentifier_, YearFromTime(_tBefore_), ℝ(MonthFromTime(_tBefore_)) + 1, ℝ(DateFromTime(_tBefore_)), ℝ(HourFromTime(_tBefore_)), ℝ(MinFromTime(_tBefore_)), ℝ(SecFromTime(_tBefore_)), ℝ(MillisecFromTime(_tBefore_)), 0, 0), where _tBefore_ is the largest integral Number &lt; _t_ for which _possibleInstantsBefore_ is not empty (i.e., _tBefore_ represents the last local time before the transition).
               1. Let _disambiguatedInstant_ be the last element of _possibleInstantsBefore_.
             1. Let _offsetNs_ be GetNamedTimeZoneOffsetNanoseconds(_systemTimeZoneIdentifier_, _disambiguatedInstant_).
           1. Let _offsetMs_ be truncate(_offsetNs_ / 10<sup>6</sup>).
@@ -33954,7 +33954,7 @@
           1. Let _ym_ be _y_ + 𝔽(floor(ℝ(_m_) / 12)).
           1. If _ym_ is not finite, return *NaN*.
           1. Let _mn_ be 𝔽(ℝ(_m_) modulo 12).
-          1. Find a finite time value _t_ such that YearFromTime(_t_) is _ym_, MonthFromTime(_t_) is _mn_, and DateFromTime(_t_) is *1*<sub>𝔽</sub>; but if this is not possible (because some argument is out of range), return *NaN*.
+          1. Find a finite time value _t_ such that 𝔽(YearFromTime(_t_)) is _ym_, MonthFromTime(_t_) is _mn_, and DateFromTime(_t_) is *1*<sub>𝔽</sub>; but if this is not possible (because some argument is out of range), return *NaN*.
           1. Return 𝔽(Day(_t_)) + _dt_ - *1*<sub>𝔽</sub>.
         </emu-alg>
       </emu-clause>
@@ -34458,7 +34458,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
           1. Let _t_ be _dateObject_.[[DateValue]].
           1. If _t_ is *NaN*, return *NaN*.
-          1. Return YearFromTime(LocalTime(_t_)).
+          1. Return 𝔽(YearFromTime(LocalTime(_t_))).
         </emu-alg>
       </emu-clause>
 
@@ -34576,7 +34576,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
           1. Let _t_ be _dateObject_.[[DateValue]].
           1. If _t_ is *NaN*, return *NaN*.
-          1. Return YearFromTime(_t_).
+          1. Return 𝔽(YearFromTime(_t_)).
         </emu-alg>
       </emu-clause>
 
@@ -34650,7 +34650,7 @@ THH:mm:ss.sss
           1. Let _dt_ be ? ToNumber(_date_).
           1. If _t_ is *NaN*, return *NaN*.
           1. Set _t_ to LocalTime(_t_).
-          1. Let _newDate_ be MakeDate(MakeDay(YearFromTime(_t_), MonthFromTime(_t_), _dt_), 𝔽(TimeWithinDay(_t_))).
+          1. Let _newDate_ be MakeDate(MakeDay(𝔽(YearFromTime(_t_)), MonthFromTime(_t_), _dt_), 𝔽(TimeWithinDay(_t_))).
           1. Let _u_ be TimeClip(UTC(_newDate_)).
           1. Set _dateObject_.[[DateValue]] to _u_.
           1. Return _u_.
@@ -34760,7 +34760,7 @@ THH:mm:ss.sss
           1. If _t_ is *NaN*, return *NaN*.
           1. Set _t_ to LocalTime(_t_).
           1. If _date_ is not present, let _dt_ be DateFromTime(_t_).
-          1. Let _newDate_ be MakeDate(MakeDay(YearFromTime(_t_), _m_, _dt_), 𝔽(TimeWithinDay(_t_))).
+          1. Let _newDate_ be MakeDate(MakeDay(𝔽(YearFromTime(_t_)), _m_, _dt_), 𝔽(TimeWithinDay(_t_))).
           1. Let _u_ be TimeClip(UTC(_newDate_)).
           1. Set _dateObject_.[[DateValue]] to _u_.
           1. Return _u_.
@@ -34816,7 +34816,7 @@ THH:mm:ss.sss
           1. Let _t_ be _dateObject_.[[DateValue]].
           1. Let _dt_ be ? ToNumber(_date_).
           1. If _t_ is *NaN*, return *NaN*.
-          1. Let _newDate_ be MakeDate(MakeDay(YearFromTime(_t_), MonthFromTime(_t_), _dt_), 𝔽(TimeWithinDay(_t_))).
+          1. Let _newDate_ be MakeDate(MakeDay(𝔽(YearFromTime(_t_)), MonthFromTime(_t_), _dt_), 𝔽(TimeWithinDay(_t_))).
           1. Let _v_ be TimeClip(_newDate_).
           1. Set _dateObject_.[[DateValue]] to _v_.
           1. Return _v_.
@@ -34922,7 +34922,7 @@ THH:mm:ss.sss
           1. If _date_ is present, let _dt_ be ? ToNumber(_date_).
           1. If _t_ is *NaN*, return *NaN*.
           1. If _date_ is not present, let _dt_ be DateFromTime(_t_).
-          1. Let _newDate_ be MakeDate(MakeDay(YearFromTime(_t_), _m_, _dt_), 𝔽(TimeWithinDay(_t_))).
+          1. Let _newDate_ be MakeDate(MakeDay(𝔽(YearFromTime(_t_)), _m_, _dt_), 𝔽(TimeWithinDay(_t_))).
           1. Let _v_ be TimeClip(_newDate_).
           1. Set _dateObject_.[[DateValue]] to _v_.
           1. Return _v_.
@@ -35065,7 +35065,7 @@ THH:mm:ss.sss
             1. Let _weekday_ be the Name of the entry in <emu-xref href="#sec-todatestring-day-names"></emu-xref> with the Number WeekDay(_tv_).
             1. Let _month_ be the Name of the entry in <emu-xref href="#sec-todatestring-month-names"></emu-xref> with the Number MonthFromTime(_tv_).
             1. Let _day_ be ToZeroPaddedDecimalString(ℝ(DateFromTime(_tv_)), 2).
-            1. Let _yv_ be YearFromTime(_tv_).
+            1. Let _yv_ be 𝔽(YearFromTime(_tv_)).
             1. If _yv_ is *+0*<sub>𝔽</sub> or _yv_ > *+0*<sub>𝔽</sub>, let _yearSign_ be the empty String; else let _yearSign_ be *"-"*.
             1. Let _paddedYear_ be ToZeroPaddedDecimalString(abs(ℝ(_yv_)), 4).
             1. Return the string-concatenation of _weekday_, the code unit 0x0020 (SPACE), _month_, the code unit 0x0020 (SPACE), _day_, the code unit 0x0020 (SPACE), _yearSign_, and _paddedYear_.
@@ -35321,7 +35321,7 @@ THH:mm:ss.sss
           1. Let _weekday_ be the Name of the entry in <emu-xref href="#sec-todatestring-day-names"></emu-xref> with the Number WeekDay(_tv_).
           1. Let _month_ be the Name of the entry in <emu-xref href="#sec-todatestring-month-names"></emu-xref> with the Number MonthFromTime(_tv_).
           1. Let _day_ be ToZeroPaddedDecimalString(ℝ(DateFromTime(_tv_)), 2).
-          1. Let _yv_ be YearFromTime(_tv_).
+          1. Let _yv_ be 𝔽(YearFromTime(_tv_)).
           1. If _yv_ is *+0*<sub>𝔽</sub> or _yv_ > *+0*<sub>𝔽</sub>, let _yearSign_ be the empty String; else let _yearSign_ be *"-"*.
           1. Let _paddedYear_ be ToZeroPaddedDecimalString(abs(ℝ(_yv_)), 4).
           1. Return the string-concatenation of _weekday_, *","*, the code unit 0x0020 (SPACE), _day_, the code unit 0x0020 (SPACE), _month_, the code unit 0x0020 (SPACE), _yearSign_, _paddedYear_, the code unit 0x0020 (SPACE), and TimeString(_tv_).
@@ -53332,7 +53332,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
           1. Let _t_ be _dateObject_.[[DateValue]].
           1. If _t_ is *NaN*, return *NaN*.
-          1. Return YearFromTime(LocalTime(_t_)) - *1900*<sub>𝔽</sub>.
+          1. Return 𝔽(YearFromTime(LocalTime(_t_))) - *1900*<sub>𝔽</sub>.
         </emu-alg>
       </emu-annex>
 

--- a/spec.html
+++ b/spec.html
@@ -33372,10 +33372,10 @@
         <emu-eqn id="eqn-HoursPerDay" aoid="HoursPerDay">HoursPerDay = 24</emu-eqn>
         <emu-eqn id="eqn-MinutesPerHour" aoid="MinutesPerHour">MinutesPerHour = 60</emu-eqn>
         <emu-eqn id="eqn-SecondsPerMinute" aoid="SecondsPerMinute">SecondsPerMinute = 60</emu-eqn>
-        <emu-eqn id="eqn-msPerSecond" aoid="msPerSecond">msPerSecond = *1000*<sub>𝔽</sub></emu-eqn>
-        <emu-eqn id="eqn-msPerMinute" aoid="msPerMinute">msPerMinute = *60000*<sub>𝔽</sub> = msPerSecond × 𝔽(SecondsPerMinute)</emu-eqn>
-        <emu-eqn id="eqn-msPerHour" aoid="msPerHour">msPerHour = *3600000*<sub>𝔽</sub> = msPerMinute × 𝔽(MinutesPerHour)</emu-eqn>
-        <emu-eqn id="eqn-msPerDay" aoid="msPerDay">msPerDay = *86400000*<sub>𝔽</sub> = msPerHour × 𝔽(HoursPerDay)</emu-eqn>
+        <emu-eqn id="eqn-msPerSecond" aoid="msPerSecond">msPerSecond = 1000</emu-eqn>
+        <emu-eqn id="eqn-msPerMinute" aoid="msPerMinute">msPerMinute = 60000 = msPerSecond × SecondsPerMinute</emu-eqn>
+        <emu-eqn id="eqn-msPerHour" aoid="msPerHour">msPerHour = 3600000 = msPerMinute × MinutesPerHour</emu-eqn>
+        <emu-eqn id="eqn-msPerDay" aoid="msPerDay">msPerDay = 86400000 = msPerHour × HoursPerDay</emu-eqn>
       </emu-clause>
 
       <emu-clause id="sec-day" type="abstract operation" oldids="eqn-Day,sec-day-number-and-time-within-day">
@@ -33389,7 +33389,7 @@
           <dd>It returns the day number of the day in which _t_ falls.</dd>
         </dl>
         <emu-alg>
-          1. Return 𝔽(floor(ℝ(_t_ / msPerDay))).
+          1. Return 𝔽(floor(ℝ(_t_) / msPerDay)).
         </emu-alg>
       </emu-clause>
 
@@ -33397,14 +33397,14 @@
         <h1>
           TimeWithinDay (
             _t_: a finite time value,
-          ): an integral Number in the interval from *+0*<sub>𝔽</sub> (inclusive) to msPerDay (exclusive)
+          ): an integral Number in the interval from *+0*<sub>𝔽</sub> (inclusive) to 𝔽(msPerDay) (exclusive)
         </h1>
         <dl class="header">
           <dt>description</dt>
           <dd>It returns the number of milliseconds since the start of the day in which _t_ falls.</dd>
         </dl>
         <emu-alg>
-          1. Return 𝔽(ℝ(_t_) modulo ℝ(msPerDay)).
+          1. Return 𝔽(ℝ(_t_) modulo msPerDay).
         </emu-alg>
       </emu-clause>
 
@@ -33440,7 +33440,7 @@
           <dd>It returns the time value of the start of year _y_.</dd>
         </dl>
         <emu-alg>
-          1. Return msPerDay × DayFromYear(_y_).
+          1. Return 𝔽(msPerDay) × DayFromYear(_y_).
         </emu-alg>
       </emu-clause>
 
@@ -33576,7 +33576,7 @@
           <dd>It returns the hour of the day in which _t_ falls.</dd>
         </dl>
         <emu-alg>
-          1. Return 𝔽(floor(ℝ(_t_ / msPerHour)) modulo HoursPerDay).
+          1. Return 𝔽(floor(ℝ(_t_) / msPerHour) modulo HoursPerDay).
         </emu-alg>
       </emu-clause>
 
@@ -33591,7 +33591,7 @@
           <dd>It returns the minute of the hour in which _t_ falls.</dd>
         </dl>
         <emu-alg>
-          1. Return 𝔽(floor(ℝ(_t_ / msPerMinute)) modulo MinutesPerHour).
+          1. Return 𝔽(floor(ℝ(_t_) / msPerMinute) modulo MinutesPerHour).
         </emu-alg>
       </emu-clause>
 
@@ -33606,7 +33606,7 @@
           <dd>It returns the second of the minute in which _t_ falls.</dd>
         </dl>
         <emu-alg>
-          1. Return 𝔽(floor(ℝ(_t_ / msPerSecond)) modulo SecondsPerMinute).
+          1. Return 𝔽(floor(ℝ(_t_) / msPerSecond) modulo SecondsPerMinute).
         </emu-alg>
       </emu-clause>
 
@@ -33621,7 +33621,7 @@
           <dd>It returns the millisecond of the second in which _t_ falls.</dd>
         </dl>
         <emu-alg>
-          1. Return 𝔽(ℝ(_t_) modulo ℝ(msPerSecond)).
+          1. Return 𝔽(ℝ(_t_) modulo msPerSecond).
         </emu-alg>
       </emu-clause>
 
@@ -33928,7 +33928,7 @@
           1. Let _m_ be 𝔽(! ToIntegerOrInfinity(_min_)).
           1. Let _s_ be 𝔽(! ToIntegerOrInfinity(_sec_)).
           1. Let _milli_ be 𝔽(! ToIntegerOrInfinity(_ms_)).
-          1. Return ((_h_ × msPerHour + _m_ × msPerMinute) + _s_ × msPerSecond) + _milli_.
+          1. Return ((_h_ × 𝔽(msPerHour) + _m_ × 𝔽(msPerMinute)) + _s_ × 𝔽(msPerSecond)) + _milli_.
         </emu-alg>
         <emu-note>
           <p>The arithmetic in MakeTime is floating-point arithmetic, which is not associative, so the operations must be performed in the correct order.</p>
@@ -33973,7 +33973,7 @@
         </dl>
         <emu-alg>
           1. If _day_ is not finite or _time_ is not finite, return *NaN*.
-          1. Let _tv_ be _day_ × msPerDay + _time_.
+          1. Let _tv_ be _day_ × 𝔽(msPerDay) + _time_.
           1. If _tv_ is not finite, return *NaN*.
           1. Return _tv_.
         </emu-alg>
@@ -34541,7 +34541,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
           1. Let _t_ be _dateObject_.[[DateValue]].
           1. If _t_ is *NaN*, return *NaN*.
-          1. Return (_t_ - LocalTime(_t_)) / msPerMinute.
+          1. Return (_t_ - LocalTime(_t_)) / 𝔽(msPerMinute).
         </emu-alg>
       </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -33494,28 +33494,28 @@
         <h1>
           MonthFromTime (
             _t_: a finite time value,
-          ): an integral Number in the inclusive interval from *+0*<sub>𝔽</sub> to *11*<sub>𝔽</sub>
+          ): an integer in the inclusive interval from 0 to 11
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It returns a Number identifying the month in which _t_ falls. A month value of *+0*<sub>𝔽</sub> specifies January; *1*<sub>𝔽</sub> specifies February; *2*<sub>𝔽</sub> specifies March; *3*<sub>𝔽</sub> specifies April; *4*<sub>𝔽</sub> specifies May; *5*<sub>𝔽</sub> specifies June; *6*<sub>𝔽</sub> specifies July; *7*<sub>𝔽</sub> specifies August; *8*<sub>𝔽</sub> specifies September; *9*<sub>𝔽</sub> specifies October; *10*<sub>𝔽</sub> specifies November; and *11*<sub>𝔽</sub> specifies December. Note that <emu-eqn>MonthFromTime(*+0*<sub>𝔽</sub>) = *+0*<sub>𝔽</sub></emu-eqn>, corresponding to Thursday, 1 January 1970.</dd>
+          <dd>It returns a Number identifying the month in which _t_ falls. A month value of 0 specifies January; 1 specifies February; 2 specifies March; 3 specifies April; 4 specifies May; 5 specifies June; 6 specifies July; 7 specifies August; 8 specifies September; 9 specifies October; 10 specifies November; and 11 specifies December. Note that <emu-eqn>MonthFromTime(*+0*<sub>𝔽</sub>) = 0</emu-eqn>, corresponding to Thursday, 1 January 1970.</dd>
         </dl>
         <emu-alg>
-          1. Let _inLeapYear_ be 𝔽(InLeapYear(_t_)).
-          1. Let _dayWithinYear_ be 𝔽(DayWithinYear(_t_)).
-          1. If _dayWithinYear_ &lt; *31*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
-          1. If _dayWithinYear_ &lt; *59*<sub>𝔽</sub> + _inLeapYear_, return *1*<sub>𝔽</sub>.
-          1. If _dayWithinYear_ &lt; *90*<sub>𝔽</sub> + _inLeapYear_, return *2*<sub>𝔽</sub>.
-          1. If _dayWithinYear_ &lt; *120*<sub>𝔽</sub> + _inLeapYear_, return *3*<sub>𝔽</sub>.
-          1. If _dayWithinYear_ &lt; *151*<sub>𝔽</sub> + _inLeapYear_, return *4*<sub>𝔽</sub>.
-          1. If _dayWithinYear_ &lt; *181*<sub>𝔽</sub> + _inLeapYear_, return *5*<sub>𝔽</sub>.
-          1. If _dayWithinYear_ &lt; *212*<sub>𝔽</sub> + _inLeapYear_, return *6*<sub>𝔽</sub>.
-          1. If _dayWithinYear_ &lt; *243*<sub>𝔽</sub> + _inLeapYear_, return *7*<sub>𝔽</sub>.
-          1. If _dayWithinYear_ &lt; *273*<sub>𝔽</sub> + _inLeapYear_, return *8*<sub>𝔽</sub>.
-          1. If _dayWithinYear_ &lt; *304*<sub>𝔽</sub> + _inLeapYear_, return *9*<sub>𝔽</sub>.
-          1. If _dayWithinYear_ &lt; *334*<sub>𝔽</sub> + _inLeapYear_, return *10*<sub>𝔽</sub>.
-          1. Assert: _dayWithinYear_ &lt; *365*<sub>𝔽</sub> + _inLeapYear_.
-          1. Return *11*<sub>𝔽</sub>.
+          1. Let _inLeapYear_ be InLeapYear(_t_).
+          1. Let _dayWithinYear_ be DayWithinYear(_t_).
+          1. If _dayWithinYear_ &lt; 31, return 0.
+          1. If _dayWithinYear_ &lt; 59 + _inLeapYear_, return 1.
+          1. If _dayWithinYear_ &lt; 90 + _inLeapYear_, return 2.
+          1. If _dayWithinYear_ &lt; 120 + _inLeapYear_, return 3.
+          1. If _dayWithinYear_ &lt; 151 + _inLeapYear_, return 4.
+          1. If _dayWithinYear_ &lt; 181 + _inLeapYear_, return 5.
+          1. If _dayWithinYear_ &lt; 212 + _inLeapYear_, return 6.
+          1. If _dayWithinYear_ &lt; 243 + _inLeapYear_, return 7.
+          1. If _dayWithinYear_ &lt; 273 + _inLeapYear_, return 8.
+          1. If _dayWithinYear_ &lt; 304 + _inLeapYear_, return 9.
+          1. If _dayWithinYear_ &lt; 334 + _inLeapYear_, return 10.
+          1. Assert: _dayWithinYear_ &lt; 365 + _inLeapYear_.
+          1. Return 11.
         </emu-alg>
       </emu-clause>
 
@@ -33532,7 +33532,7 @@
         <emu-alg>
           1. Let _inLeapYear_ be 𝔽(InLeapYear(_t_)).
           1. Let _dayWithinYear_ be 𝔽(DayWithinYear(_t_)).
-          1. Let _month_ be MonthFromTime(_t_).
+          1. Let _month_ be 𝔽(MonthFromTime(_t_)).
           1. If _month_ is *+0*<sub>𝔽</sub>, return _dayWithinYear_ + *1*<sub>𝔽</sub>.
           1. If _month_ is *1*<sub>𝔽</sub>, return _dayWithinYear_ - *30*<sub>𝔽</sub>.
           1. If _month_ is *2*<sub>𝔽</sub>, return _dayWithinYear_ - *58*<sub>𝔽</sub> - _inLeapYear_.
@@ -33873,13 +33873,13 @@
           1. If IsTimeZoneOffsetString(_systemTimeZoneIdentifier_) is *true*, then
             1. Let _offsetNs_ be ParseTimeZoneOffsetString(_systemTimeZoneIdentifier_).
           1. Else,
-            1. Let _possibleInstants_ be GetNamedTimeZoneEpochNanoseconds(_systemTimeZoneIdentifier_, YearFromTime(_t_), ℝ(MonthFromTime(_t_)) + 1, ℝ(DateFromTime(_t_)), ℝ(HourFromTime(_t_)), ℝ(MinFromTime(_t_)), ℝ(SecFromTime(_t_)), ℝ(MillisecFromTime(_t_)), 0, 0).
+            1. Let _possibleInstants_ be GetNamedTimeZoneEpochNanoseconds(_systemTimeZoneIdentifier_, YearFromTime(_t_), MonthFromTime(_t_) + 1, ℝ(DateFromTime(_t_)), ℝ(HourFromTime(_t_)), ℝ(MinFromTime(_t_)), ℝ(SecFromTime(_t_)), ℝ(MillisecFromTime(_t_)), 0, 0).
             1. NOTE: The following steps ensure that when _t_ represents local time repeating multiple times at a negative time zone transition (e.g. when the daylight saving time ends or the time zone offset is decreased due to a time zone rule change) or skipped local time at a positive time zone transition (e.g. when the daylight saving time starts or the time zone offset is increased due to a time zone rule change), _t_ is interpreted using the time zone offset before the transition.
             1. If _possibleInstants_ is not empty, then
               1. Let _disambiguatedInstant_ be _possibleInstants_[0].
             1. Else,
               1. NOTE: _t_ represents a local time skipped at a positive time zone transition (e.g. due to daylight saving time starting or a time zone rule change increasing the UTC offset).
-              1. [declared="tBefore"] Let _possibleInstantsBefore_ be GetNamedTimeZoneEpochNanoseconds(_systemTimeZoneIdentifier_, YearFromTime(_tBefore_), ℝ(MonthFromTime(_tBefore_)) + 1, ℝ(DateFromTime(_tBefore_)), ℝ(HourFromTime(_tBefore_)), ℝ(MinFromTime(_tBefore_)), ℝ(SecFromTime(_tBefore_)), ℝ(MillisecFromTime(_tBefore_)), 0, 0), where _tBefore_ is the largest integral Number &lt; _t_ for which _possibleInstantsBefore_ is not empty (i.e., _tBefore_ represents the last local time before the transition).
+              1. [declared="tBefore"] Let _possibleInstantsBefore_ be GetNamedTimeZoneEpochNanoseconds(_systemTimeZoneIdentifier_, YearFromTime(_tBefore_), MonthFromTime(_tBefore_) + 1, ℝ(DateFromTime(_tBefore_)), ℝ(HourFromTime(_tBefore_)), ℝ(MinFromTime(_tBefore_)), ℝ(SecFromTime(_tBefore_)), ℝ(MillisecFromTime(_tBefore_)), 0, 0), where _tBefore_ is the largest integral Number &lt; _t_ for which _possibleInstantsBefore_ is not empty (i.e., _tBefore_ represents the last local time before the transition).
               1. Let _disambiguatedInstant_ be the last element of _possibleInstantsBefore_.
             1. Let _offsetNs_ be GetNamedTimeZoneOffsetNanoseconds(_systemTimeZoneIdentifier_, _disambiguatedInstant_).
           1. Let _offsetMs_ be truncate(_offsetNs_ / 10<sup>6</sup>).
@@ -33954,7 +33954,7 @@
           1. Let _ym_ be _y_ + 𝔽(floor(ℝ(_m_) / 12)).
           1. If _ym_ is not finite, return *NaN*.
           1. Let _mn_ be 𝔽(ℝ(_m_) modulo 12).
-          1. Find a finite time value _t_ such that 𝔽(YearFromTime(_t_)) is _ym_, MonthFromTime(_t_) is _mn_, and DateFromTime(_t_) is *1*<sub>𝔽</sub>; but if this is not possible (because some argument is out of range), return *NaN*.
+          1. Find a finite time value _t_ such that 𝔽(YearFromTime(_t_)) is _ym_, 𝔽(MonthFromTime(_t_)) is _mn_, and DateFromTime(_t_) is *1*<sub>𝔽</sub>; but if this is not possible (because some argument is out of range), return *NaN*.
           1. Return 𝔽(Day(_t_)) + _dt_ - *1*<sub>𝔽</sub>.
         </emu-alg>
       </emu-clause>
@@ -34506,7 +34506,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
           1. Let _t_ be _dateObject_.[[DateValue]].
           1. If _t_ is *NaN*, return *NaN*.
-          1. Return MonthFromTime(LocalTime(_t_)).
+          1. Return 𝔽(MonthFromTime(LocalTime(_t_))).
         </emu-alg>
       </emu-clause>
 
@@ -34624,7 +34624,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
           1. Let _t_ be _dateObject_.[[DateValue]].
           1. If _t_ is *NaN*, return *NaN*.
-          1. Return MonthFromTime(_t_).
+          1. Return 𝔽(MonthFromTime(_t_)).
         </emu-alg>
       </emu-clause>
 
@@ -34650,7 +34650,7 @@ THH:mm:ss.sss
           1. Let _dt_ be ? ToNumber(_date_).
           1. If _t_ is *NaN*, return *NaN*.
           1. Set _t_ to LocalTime(_t_).
-          1. Let _newDate_ be MakeDate(MakeDay(𝔽(YearFromTime(_t_)), MonthFromTime(_t_), _dt_), 𝔽(TimeWithinDay(_t_))).
+          1. Let _newDate_ be MakeDate(MakeDay(𝔽(YearFromTime(_t_)), 𝔽(MonthFromTime(_t_)), _dt_), 𝔽(TimeWithinDay(_t_))).
           1. Let _u_ be TimeClip(UTC(_newDate_)).
           1. Set _dateObject_.[[DateValue]] to _u_.
           1. Return _u_.
@@ -34666,7 +34666,7 @@ THH:mm:ss.sss
           1. Let _t_ be _dateObject_.[[DateValue]].
           1. Let _y_ be ? ToNumber(_year_).
           1. If _t_ is *NaN*, set _t_ to *+0*<sub>𝔽</sub>; else set _t_ to LocalTime(_t_).
-          1. If _month_ is present, let _m_ be ? ToNumber(_month_); else let _m_ be MonthFromTime(_t_).
+          1. If _month_ is present, let _m_ be ? ToNumber(_month_); else let _m_ be 𝔽(MonthFromTime(_t_)).
           1. If _date_ is present, let _dt_ be ? ToNumber(_date_); else let _dt_ be DateFromTime(_t_).
           1. Let _newDate_ be MakeDate(MakeDay(_y_, _m_, _dt_), 𝔽(TimeWithinDay(_t_))).
           1. Let _u_ be TimeClip(UTC(_newDate_)).
@@ -34816,7 +34816,7 @@ THH:mm:ss.sss
           1. Let _t_ be _dateObject_.[[DateValue]].
           1. Let _dt_ be ? ToNumber(_date_).
           1. If _t_ is *NaN*, return *NaN*.
-          1. Let _newDate_ be MakeDate(MakeDay(𝔽(YearFromTime(_t_)), MonthFromTime(_t_), _dt_), 𝔽(TimeWithinDay(_t_))).
+          1. Let _newDate_ be MakeDate(MakeDay(𝔽(YearFromTime(_t_)), 𝔽(MonthFromTime(_t_)), _dt_), 𝔽(TimeWithinDay(_t_))).
           1. Let _v_ be TimeClip(_newDate_).
           1. Set _dateObject_.[[DateValue]] to _v_.
           1. Return _v_.
@@ -34832,7 +34832,7 @@ THH:mm:ss.sss
           1. Let _t_ be _dateObject_.[[DateValue]].
           1. If _t_ is *NaN*, set _t_ to *+0*<sub>𝔽</sub>.
           1. Let _y_ be ? ToNumber(_year_).
-          1. If _month_ is present, let _m_ be ? ToNumber(_month_); else let _m_ be MonthFromTime(_t_).
+          1. If _month_ is present, let _m_ be ? ToNumber(_month_); else let _m_ be 𝔽(MonthFromTime(_t_)).
           1. If _date_ is present, let _dt_ be ? ToNumber(_date_); else let _dt_ be DateFromTime(_t_).
           1. Let _newDate_ be MakeDate(MakeDay(_y_, _m_, _dt_), 𝔽(TimeWithinDay(_t_))).
           1. Let _v_ be TimeClip(_newDate_).
@@ -35063,7 +35063,7 @@ THH:mm:ss.sss
           </dl>
           <emu-alg>
             1. Let _weekday_ be the Name of the entry in <emu-xref href="#sec-todatestring-day-names"></emu-xref> with the Number WeekDay(_tv_).
-            1. Let _month_ be the Name of the entry in <emu-xref href="#sec-todatestring-month-names"></emu-xref> with the Number MonthFromTime(_tv_).
+            1. Let _month_ be the Name of the entry in <emu-xref href="#sec-todatestring-month-names"></emu-xref> with the Number 𝔽(MonthFromTime(_tv_)).
             1. Let _day_ be ToZeroPaddedDecimalString(ℝ(DateFromTime(_tv_)), 2).
             1. Let _yv_ be 𝔽(YearFromTime(_tv_)).
             1. If _yv_ is *+0*<sub>𝔽</sub> or _yv_ > *+0*<sub>𝔽</sub>, let _yearSign_ be the empty String; else let _yearSign_ be *"-"*.
@@ -35319,7 +35319,7 @@ THH:mm:ss.sss
           1. Let _tv_ be _dateObject_.[[DateValue]].
           1. If _tv_ is *NaN*, return *"Invalid Date"*.
           1. Let _weekday_ be the Name of the entry in <emu-xref href="#sec-todatestring-day-names"></emu-xref> with the Number WeekDay(_tv_).
-          1. Let _month_ be the Name of the entry in <emu-xref href="#sec-todatestring-month-names"></emu-xref> with the Number MonthFromTime(_tv_).
+          1. Let _month_ be the Name of the entry in <emu-xref href="#sec-todatestring-month-names"></emu-xref> with the Number 𝔽(MonthFromTime(_tv_)).
           1. Let _day_ be ToZeroPaddedDecimalString(ℝ(DateFromTime(_tv_)), 2).
           1. Let _yv_ be 𝔽(YearFromTime(_tv_)).
           1. If _yv_ is *+0*<sub>𝔽</sub> or _yv_ > *+0*<sub>𝔽</sub>, let _yearSign_ be the empty String; else let _yearSign_ be *"-"*.
@@ -53349,7 +53349,7 @@ THH:mm:ss.sss
           1. Let _year_ be ? ToNumber(_year_).
           1. If _time_ is *NaN*, set _time_ to *+0*<sub>𝔽</sub>; else set _time_ to LocalTime(_time_).
           1. Let _fullYear_ be MakeFullYear(_year_).
-          1. Let _day_ be MakeDay(_fullYear_, MonthFromTime(_time_), DateFromTime(_time_)).
+          1. Let _day_ be MakeDay(_fullYear_, 𝔽(MonthFromTime(_time_)), DateFromTime(_time_)).
           1. Let _date_ be MakeDate(_day_, 𝔽(TimeWithinDay(_time_))).
           1. Let _utcTimestamp_ be TimeClip(UTC(_date_)).
           1. Set _dateObject_.[[DateValue]] to _utcTimestamp_.

--- a/spec.html
+++ b/spec.html
@@ -33523,29 +33523,29 @@
         <h1>
           DateFromTime (
             _t_: a finite time value,
-          ): an integral Number in the inclusive interval from *1*<sub>𝔽</sub> to *31*<sub>𝔽</sub>
+          ): an integer in the inclusive interval from 1 to 31
         </h1>
         <dl class="header">
           <dt>description</dt>
           <dd>It returns the day of the month in which _t_ falls.</dd>
         </dl>
         <emu-alg>
-          1. Let _inLeapYear_ be 𝔽(InLeapYear(_t_)).
-          1. Let _dayWithinYear_ be 𝔽(DayWithinYear(_t_)).
-          1. Let _month_ be 𝔽(MonthFromTime(_t_)).
-          1. If _month_ is *+0*<sub>𝔽</sub>, return _dayWithinYear_ + *1*<sub>𝔽</sub>.
-          1. If _month_ is *1*<sub>𝔽</sub>, return _dayWithinYear_ - *30*<sub>𝔽</sub>.
-          1. If _month_ is *2*<sub>𝔽</sub>, return _dayWithinYear_ - *58*<sub>𝔽</sub> - _inLeapYear_.
-          1. If _month_ is *3*<sub>𝔽</sub>, return _dayWithinYear_ - *89*<sub>𝔽</sub> - _inLeapYear_.
-          1. If _month_ is *4*<sub>𝔽</sub>, return _dayWithinYear_ - *119*<sub>𝔽</sub> - _inLeapYear_.
-          1. If _month_ is *5*<sub>𝔽</sub>, return _dayWithinYear_ - *150*<sub>𝔽</sub> - _inLeapYear_.
-          1. If _month_ is *6*<sub>𝔽</sub>, return _dayWithinYear_ - *180*<sub>𝔽</sub> - _inLeapYear_.
-          1. If _month_ is *7*<sub>𝔽</sub>, return _dayWithinYear_ - *211*<sub>𝔽</sub> - _inLeapYear_.
-          1. If _month_ is *8*<sub>𝔽</sub>, return _dayWithinYear_ - *242*<sub>𝔽</sub> - _inLeapYear_.
-          1. If _month_ is *9*<sub>𝔽</sub>, return _dayWithinYear_ - *272*<sub>𝔽</sub> - _inLeapYear_.
-          1. If _month_ is *10*<sub>𝔽</sub>, return _dayWithinYear_ - *303*<sub>𝔽</sub> - _inLeapYear_.
-          1. Assert: _month_ is *11*<sub>𝔽</sub>.
-          1. Return _dayWithinYear_ - *333*<sub>𝔽</sub> - _inLeapYear_.
+          1. Let _inLeapYear_ be InLeapYear(_t_).
+          1. Let _dayWithinYear_ be DayWithinYear(_t_).
+          1. Let _month_ be MonthFromTime(_t_).
+          1. If _month_ is 0, return _dayWithinYear_ + 1.
+          1. If _month_ is 1, return _dayWithinYear_ - 30.
+          1. If _month_ is 2, return _dayWithinYear_ - 58 - _inLeapYear_.
+          1. If _month_ is 3, return _dayWithinYear_ - 89 - _inLeapYear_.
+          1. If _month_ is 4, return _dayWithinYear_ - 119 - _inLeapYear_.
+          1. If _month_ is 5, return _dayWithinYear_ - 150 - _inLeapYear_.
+          1. If _month_ is 6, return _dayWithinYear_ - 180 - _inLeapYear_.
+          1. If _month_ is 7, return _dayWithinYear_ - 211 - _inLeapYear_.
+          1. If _month_ is 8, return _dayWithinYear_ - 242 - _inLeapYear_.
+          1. If _month_ is 9, return _dayWithinYear_ - 272 - _inLeapYear_.
+          1. If _month_ is 10, return _dayWithinYear_ - 303 - _inLeapYear_.
+          1. Assert: _month_ is 11.
+          1. Return _dayWithinYear_ - 333 - _inLeapYear_.
         </emu-alg>
       </emu-clause>
 
@@ -33873,13 +33873,13 @@
           1. If IsTimeZoneOffsetString(_systemTimeZoneIdentifier_) is *true*, then
             1. Let _offsetNs_ be ParseTimeZoneOffsetString(_systemTimeZoneIdentifier_).
           1. Else,
-            1. Let _possibleInstants_ be GetNamedTimeZoneEpochNanoseconds(_systemTimeZoneIdentifier_, YearFromTime(_t_), MonthFromTime(_t_) + 1, ℝ(DateFromTime(_t_)), ℝ(HourFromTime(_t_)), ℝ(MinFromTime(_t_)), ℝ(SecFromTime(_t_)), ℝ(MillisecFromTime(_t_)), 0, 0).
+            1. Let _possibleInstants_ be GetNamedTimeZoneEpochNanoseconds(_systemTimeZoneIdentifier_, YearFromTime(_t_), MonthFromTime(_t_) + 1, DateFromTime(_t_), ℝ(HourFromTime(_t_)), ℝ(MinFromTime(_t_)), ℝ(SecFromTime(_t_)), ℝ(MillisecFromTime(_t_)), 0, 0).
             1. NOTE: The following steps ensure that when _t_ represents local time repeating multiple times at a negative time zone transition (e.g. when the daylight saving time ends or the time zone offset is decreased due to a time zone rule change) or skipped local time at a positive time zone transition (e.g. when the daylight saving time starts or the time zone offset is increased due to a time zone rule change), _t_ is interpreted using the time zone offset before the transition.
             1. If _possibleInstants_ is not empty, then
               1. Let _disambiguatedInstant_ be _possibleInstants_[0].
             1. Else,
               1. NOTE: _t_ represents a local time skipped at a positive time zone transition (e.g. due to daylight saving time starting or a time zone rule change increasing the UTC offset).
-              1. [declared="tBefore"] Let _possibleInstantsBefore_ be GetNamedTimeZoneEpochNanoseconds(_systemTimeZoneIdentifier_, YearFromTime(_tBefore_), MonthFromTime(_tBefore_) + 1, ℝ(DateFromTime(_tBefore_)), ℝ(HourFromTime(_tBefore_)), ℝ(MinFromTime(_tBefore_)), ℝ(SecFromTime(_tBefore_)), ℝ(MillisecFromTime(_tBefore_)), 0, 0), where _tBefore_ is the largest integral Number &lt; _t_ for which _possibleInstantsBefore_ is not empty (i.e., _tBefore_ represents the last local time before the transition).
+              1. [declared="tBefore"] Let _possibleInstantsBefore_ be GetNamedTimeZoneEpochNanoseconds(_systemTimeZoneIdentifier_, YearFromTime(_tBefore_), MonthFromTime(_tBefore_) + 1, DateFromTime(_tBefore_), ℝ(HourFromTime(_tBefore_)), ℝ(MinFromTime(_tBefore_)), ℝ(SecFromTime(_tBefore_)), ℝ(MillisecFromTime(_tBefore_)), 0, 0), where _tBefore_ is the largest integral Number &lt; _t_ for which _possibleInstantsBefore_ is not empty (i.e., _tBefore_ represents the last local time before the transition).
               1. Let _disambiguatedInstant_ be the last element of _possibleInstantsBefore_.
             1. Let _offsetNs_ be GetNamedTimeZoneOffsetNanoseconds(_systemTimeZoneIdentifier_, _disambiguatedInstant_).
           1. Let _offsetMs_ be truncate(_offsetNs_ / 10<sup>6</sup>).
@@ -33954,7 +33954,7 @@
           1. Let _ym_ be _y_ + 𝔽(floor(ℝ(_m_) / 12)).
           1. If _ym_ is not finite, return *NaN*.
           1. Let _mn_ be 𝔽(ℝ(_m_) modulo 12).
-          1. Find a finite time value _t_ such that 𝔽(YearFromTime(_t_)) is _ym_, 𝔽(MonthFromTime(_t_)) is _mn_, and DateFromTime(_t_) is *1*<sub>𝔽</sub>; but if this is not possible (because some argument is out of range), return *NaN*.
+          1. Find a finite time value _t_ such that 𝔽(YearFromTime(_t_)) is _ym_, 𝔽(MonthFromTime(_t_)) is _mn_, and 𝔽(DateFromTime(_t_)) is *1*<sub>𝔽</sub>; but if this is not possible (because some argument is out of range), return *NaN*.
           1. Return 𝔽(Day(_t_)) + _dt_ - *1*<sub>𝔽</sub>.
         </emu-alg>
       </emu-clause>
@@ -34434,7 +34434,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
           1. Let _t_ be _dateObject_.[[DateValue]].
           1. If _t_ is *NaN*, return *NaN*.
-          1. Return DateFromTime(LocalTime(_t_)).
+          1. Return 𝔽(DateFromTime(LocalTime(_t_))).
         </emu-alg>
       </emu-clause>
 
@@ -34552,7 +34552,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
           1. Let _t_ be _dateObject_.[[DateValue]].
           1. If _t_ is *NaN*, return *NaN*.
-          1. Return DateFromTime(_t_).
+          1. Return 𝔽(DateFromTime(_t_)).
         </emu-alg>
       </emu-clause>
 
@@ -34667,7 +34667,7 @@ THH:mm:ss.sss
           1. Let _y_ be ? ToNumber(_year_).
           1. If _t_ is *NaN*, set _t_ to *+0*<sub>𝔽</sub>; else set _t_ to LocalTime(_t_).
           1. If _month_ is present, let _m_ be ? ToNumber(_month_); else let _m_ be 𝔽(MonthFromTime(_t_)).
-          1. If _date_ is present, let _dt_ be ? ToNumber(_date_); else let _dt_ be DateFromTime(_t_).
+          1. If _date_ is present, let _dt_ be ? ToNumber(_date_); else let _dt_ be 𝔽(DateFromTime(_t_)).
           1. Let _newDate_ be MakeDate(MakeDay(_y_, _m_, _dt_), 𝔽(TimeWithinDay(_t_))).
           1. Let _u_ be TimeClip(UTC(_newDate_)).
           1. Set _dateObject_.[[DateValue]] to _u_.
@@ -34759,7 +34759,7 @@ THH:mm:ss.sss
           1. If _date_ is present, let _dt_ be ? ToNumber(_date_).
           1. If _t_ is *NaN*, return *NaN*.
           1. Set _t_ to LocalTime(_t_).
-          1. If _date_ is not present, let _dt_ be DateFromTime(_t_).
+          1. If _date_ is not present, let _dt_ be 𝔽(DateFromTime(_t_)).
           1. Let _newDate_ be MakeDate(MakeDay(𝔽(YearFromTime(_t_)), _m_, _dt_), 𝔽(TimeWithinDay(_t_))).
           1. Let _u_ be TimeClip(UTC(_newDate_)).
           1. Set _dateObject_.[[DateValue]] to _u_.
@@ -34833,7 +34833,7 @@ THH:mm:ss.sss
           1. If _t_ is *NaN*, set _t_ to *+0*<sub>𝔽</sub>.
           1. Let _y_ be ? ToNumber(_year_).
           1. If _month_ is present, let _m_ be ? ToNumber(_month_); else let _m_ be 𝔽(MonthFromTime(_t_)).
-          1. If _date_ is present, let _dt_ be ? ToNumber(_date_); else let _dt_ be DateFromTime(_t_).
+          1. If _date_ is present, let _dt_ be ? ToNumber(_date_); else let _dt_ be 𝔽(DateFromTime(_t_)).
           1. Let _newDate_ be MakeDate(MakeDay(_y_, _m_, _dt_), 𝔽(TimeWithinDay(_t_))).
           1. Let _v_ be TimeClip(_newDate_).
           1. Set _dateObject_.[[DateValue]] to _v_.
@@ -34921,7 +34921,7 @@ THH:mm:ss.sss
           1. Let _m_ be ? ToNumber(_month_).
           1. If _date_ is present, let _dt_ be ? ToNumber(_date_).
           1. If _t_ is *NaN*, return *NaN*.
-          1. If _date_ is not present, let _dt_ be DateFromTime(_t_).
+          1. If _date_ is not present, let _dt_ be 𝔽(DateFromTime(_t_)).
           1. Let _newDate_ be MakeDate(MakeDay(𝔽(YearFromTime(_t_)), _m_, _dt_), 𝔽(TimeWithinDay(_t_))).
           1. Let _v_ be TimeClip(_newDate_).
           1. Set _dateObject_.[[DateValue]] to _v_.
@@ -35064,7 +35064,7 @@ THH:mm:ss.sss
           <emu-alg>
             1. Let _weekday_ be the Name of the entry in <emu-xref href="#sec-todatestring-day-names"></emu-xref> with the Number WeekDay(_tv_).
             1. Let _month_ be the Name of the entry in <emu-xref href="#sec-todatestring-month-names"></emu-xref> with the Number 𝔽(MonthFromTime(_tv_)).
-            1. Let _day_ be ToZeroPaddedDecimalString(ℝ(DateFromTime(_tv_)), 2).
+            1. Let _day_ be ToZeroPaddedDecimalString(DateFromTime(_tv_), 2).
             1. Let _yv_ be 𝔽(YearFromTime(_tv_)).
             1. If _yv_ is *+0*<sub>𝔽</sub> or _yv_ > *+0*<sub>𝔽</sub>, let _yearSign_ be the empty String; else let _yearSign_ be *"-"*.
             1. Let _paddedYear_ be ToZeroPaddedDecimalString(abs(ℝ(_yv_)), 4).
@@ -35320,7 +35320,7 @@ THH:mm:ss.sss
           1. If _tv_ is *NaN*, return *"Invalid Date"*.
           1. Let _weekday_ be the Name of the entry in <emu-xref href="#sec-todatestring-day-names"></emu-xref> with the Number WeekDay(_tv_).
           1. Let _month_ be the Name of the entry in <emu-xref href="#sec-todatestring-month-names"></emu-xref> with the Number 𝔽(MonthFromTime(_tv_)).
-          1. Let _day_ be ToZeroPaddedDecimalString(ℝ(DateFromTime(_tv_)), 2).
+          1. Let _day_ be ToZeroPaddedDecimalString(DateFromTime(_tv_), 2).
           1. Let _yv_ be 𝔽(YearFromTime(_tv_)).
           1. If _yv_ is *+0*<sub>𝔽</sub> or _yv_ > *+0*<sub>𝔽</sub>, let _yearSign_ be the empty String; else let _yearSign_ be *"-"*.
           1. Let _paddedYear_ be ToZeroPaddedDecimalString(abs(ℝ(_yv_)), 4).
@@ -53349,7 +53349,7 @@ THH:mm:ss.sss
           1. Let _year_ be ? ToNumber(_year_).
           1. If _time_ is *NaN*, set _time_ to *+0*<sub>𝔽</sub>; else set _time_ to LocalTime(_time_).
           1. Let _fullYear_ be MakeFullYear(_year_).
-          1. Let _day_ be MakeDay(_fullYear_, 𝔽(MonthFromTime(_time_)), DateFromTime(_time_)).
+          1. Let _day_ be MakeDay(_fullYear_, 𝔽(MonthFromTime(_time_)), 𝔽(DateFromTime(_time_))).
           1. Let _date_ be MakeDate(_day_, 𝔽(TimeWithinDay(_time_))).
           1. Let _utcTimestamp_ be TimeClip(UTC(_date_)).
           1. Set _dateObject_.[[DateValue]] to _utcTimestamp_.

--- a/spec.html
+++ b/spec.html
@@ -33583,14 +33583,14 @@
         <h1>
           MinFromTime (
             _t_: a finite time value,
-          ): an integral Number in the inclusive interval from *+0*<sub>𝔽</sub> to *59*<sub>𝔽</sub>
+          ): an integer in the inclusive interval from 0 to 59
         </h1>
         <dl class="header">
           <dt>description</dt>
           <dd>It returns the minute of the hour in which _t_ falls.</dd>
         </dl>
         <emu-alg>
-          1. Return 𝔽(floor(ℝ(_t_) / msPerMinute) modulo MinutesPerHour).
+          1. Return floor(ℝ(_t_) / msPerMinute) modulo MinutesPerHour.
         </emu-alg>
       </emu-clause>
 
@@ -33873,13 +33873,13 @@
           1. If IsTimeZoneOffsetString(_systemTimeZoneIdentifier_) is *true*, then
             1. Let _offsetNs_ be ParseTimeZoneOffsetString(_systemTimeZoneIdentifier_).
           1. Else,
-            1. Let _possibleInstants_ be GetNamedTimeZoneEpochNanoseconds(_systemTimeZoneIdentifier_, YearFromTime(_t_), MonthFromTime(_t_) + 1, DateFromTime(_t_), HourFromTime(_t_), ℝ(MinFromTime(_t_)), ℝ(SecFromTime(_t_)), ℝ(MillisecFromTime(_t_)), 0, 0).
+            1. Let _possibleInstants_ be GetNamedTimeZoneEpochNanoseconds(_systemTimeZoneIdentifier_, YearFromTime(_t_), MonthFromTime(_t_) + 1, DateFromTime(_t_), HourFromTime(_t_), MinFromTime(_t_), ℝ(SecFromTime(_t_)), ℝ(MillisecFromTime(_t_)), 0, 0).
             1. NOTE: The following steps ensure that when _t_ represents local time repeating multiple times at a negative time zone transition (e.g. when the daylight saving time ends or the time zone offset is decreased due to a time zone rule change) or skipped local time at a positive time zone transition (e.g. when the daylight saving time starts or the time zone offset is increased due to a time zone rule change), _t_ is interpreted using the time zone offset before the transition.
             1. If _possibleInstants_ is not empty, then
               1. Let _disambiguatedInstant_ be _possibleInstants_[0].
             1. Else,
               1. NOTE: _t_ represents a local time skipped at a positive time zone transition (e.g. due to daylight saving time starting or a time zone rule change increasing the UTC offset).
-              1. [declared="tBefore"] Let _possibleInstantsBefore_ be GetNamedTimeZoneEpochNanoseconds(_systemTimeZoneIdentifier_, YearFromTime(_tBefore_), MonthFromTime(_tBefore_) + 1, DateFromTime(_tBefore_), HourFromTime(_tBefore_), ℝ(MinFromTime(_tBefore_)), ℝ(SecFromTime(_tBefore_)), ℝ(MillisecFromTime(_tBefore_)), 0, 0), where _tBefore_ is the largest integral Number &lt; _t_ for which _possibleInstantsBefore_ is not empty (i.e., _tBefore_ represents the last local time before the transition).
+              1. [declared="tBefore"] Let _possibleInstantsBefore_ be GetNamedTimeZoneEpochNanoseconds(_systemTimeZoneIdentifier_, YearFromTime(_tBefore_), MonthFromTime(_tBefore_) + 1, DateFromTime(_tBefore_), HourFromTime(_tBefore_), MinFromTime(_tBefore_), ℝ(SecFromTime(_tBefore_)), ℝ(MillisecFromTime(_tBefore_)), 0, 0), where _tBefore_ is the largest integral Number &lt; _t_ for which _possibleInstantsBefore_ is not empty (i.e., _tBefore_ represents the last local time before the transition).
               1. Let _disambiguatedInstant_ be the last element of _possibleInstantsBefore_.
             1. Let _offsetNs_ be GetNamedTimeZoneOffsetNanoseconds(_systemTimeZoneIdentifier_, _disambiguatedInstant_).
           1. Let _offsetMs_ be truncate(_offsetNs_ / 10<sup>6</sup>).
@@ -34494,7 +34494,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
           1. Let _t_ be _dateObject_.[[DateValue]].
           1. If _t_ is *NaN*, return *NaN*.
-          1. Return MinFromTime(LocalTime(_t_)).
+          1. Return 𝔽(MinFromTime(LocalTime(_t_))).
         </emu-alg>
       </emu-clause>
 
@@ -34612,7 +34612,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
           1. Let _t_ be _dateObject_.[[DateValue]].
           1. If _t_ is *NaN*, return *NaN*.
-          1. Return MinFromTime(_t_).
+          1. Return 𝔽(MinFromTime(_t_)).
         </emu-alg>
       </emu-clause>
 
@@ -34692,7 +34692,7 @@ THH:mm:ss.sss
           1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_).
           1. If _t_ is *NaN*, return *NaN*.
           1. Set _t_ to LocalTime(_t_).
-          1. If _min_ is not present, let _m_ be MinFromTime(_t_).
+          1. If _min_ is not present, let _m_ be 𝔽(MinFromTime(_t_)).
           1. If _sec_ is not present, let _s_ be SecFromTime(_t_).
           1. If _ms_ is not present, let _milli_ be MillisecFromTime(_t_).
           1. Let _date_ be MakeDate(𝔽(Day(_t_)), MakeTime(_h_, _m_, _s_, _milli_)).
@@ -34716,7 +34716,7 @@ THH:mm:ss.sss
           1. Set _ms_ to ? ToNumber(_ms_).
           1. If _t_ is *NaN*, return *NaN*.
           1. Set _t_ to LocalTime(_t_).
-          1. Let _time_ be MakeTime(𝔽(HourFromTime(_t_)), MinFromTime(_t_), SecFromTime(_t_), _ms_).
+          1. Let _time_ be MakeTime(𝔽(HourFromTime(_t_)), 𝔽(MinFromTime(_t_)), SecFromTime(_t_), _ms_).
           1. Let _u_ be TimeClip(UTC(MakeDate(𝔽(Day(_t_)), _time_))).
           1. Set _dateObject_.[[DateValue]] to _u_.
           1. Return _u_.
@@ -34783,7 +34783,7 @@ THH:mm:ss.sss
           1. If _t_ is *NaN*, return *NaN*.
           1. Set _t_ to LocalTime(_t_).
           1. If _ms_ is not present, let _milli_ be MillisecFromTime(_t_).
-          1. Let _date_ be MakeDate(𝔽(Day(_t_)), MakeTime(𝔽(HourFromTime(_t_)), MinFromTime(_t_), _s_, _milli_)).
+          1. Let _date_ be MakeDate(𝔽(Day(_t_)), MakeTime(𝔽(HourFromTime(_t_)), 𝔽(MinFromTime(_t_)), _s_, _milli_)).
           1. Let _u_ be TimeClip(UTC(_date_)).
           1. Set _dateObject_.[[DateValue]] to _u_.
           1. Return _u_.
@@ -34857,7 +34857,7 @@ THH:mm:ss.sss
           1. If _sec_ is present, let _s_ be ? ToNumber(_sec_).
           1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_).
           1. If _t_ is *NaN*, return *NaN*.
-          1. If _min_ is not present, let _m_ be MinFromTime(_t_).
+          1. If _min_ is not present, let _m_ be 𝔽(MinFromTime(_t_)).
           1. If _sec_ is not present, let _s_ be SecFromTime(_t_).
           1. If _ms_ is not present, let _milli_ be MillisecFromTime(_t_).
           1. Let _date_ be MakeDate(𝔽(Day(_t_)), MakeTime(_h_, _m_, _s_, _milli_)).
@@ -34880,7 +34880,7 @@ THH:mm:ss.sss
           1. Let _t_ be _dateObject_.[[DateValue]].
           1. Set _ms_ to ? ToNumber(_ms_).
           1. If _t_ is *NaN*, return *NaN*.
-          1. Let _time_ be MakeTime(𝔽(HourFromTime(_t_)), MinFromTime(_t_), SecFromTime(_t_), _ms_).
+          1. Let _time_ be MakeTime(𝔽(HourFromTime(_t_)), 𝔽(MinFromTime(_t_)), SecFromTime(_t_), _ms_).
           1. Let _v_ be TimeClip(MakeDate(𝔽(Day(_t_)), _time_)).
           1. Set _dateObject_.[[DateValue]] to _v_.
           1. Return _v_.
@@ -34944,7 +34944,7 @@ THH:mm:ss.sss
           1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_).
           1. If _t_ is *NaN*, return *NaN*.
           1. If _ms_ is not present, let _milli_ be MillisecFromTime(_t_).
-          1. Let _date_ be MakeDate(𝔽(Day(_t_)), MakeTime(𝔽(HourFromTime(_t_)), MinFromTime(_t_), _s_, _milli_)).
+          1. Let _date_ be MakeDate(𝔽(Day(_t_)), MakeTime(𝔽(HourFromTime(_t_)), 𝔽(MinFromTime(_t_)), _s_, _milli_)).
           1. Let _v_ be TimeClip(_date_).
           1. Set _dateObject_.[[DateValue]] to _v_.
           1. Return _v_.
@@ -35047,7 +35047,7 @@ THH:mm:ss.sss
           </dl>
           <emu-alg>
             1. Let _hour_ be ToZeroPaddedDecimalString(HourFromTime(_tv_), 2).
-            1. Let _minute_ be ToZeroPaddedDecimalString(ℝ(MinFromTime(_tv_)), 2).
+            1. Let _minute_ be ToZeroPaddedDecimalString(MinFromTime(_tv_), 2).
             1. Let _second_ be ToZeroPaddedDecimalString(ℝ(SecFromTime(_tv_)), 2).
             1. Return the string-concatenation of _hour_, *":"*, _minute_, *":"*, _second_, the code unit 0x0020 (SPACE), and *"GMT"*.
           </emu-alg>
@@ -35273,7 +35273,7 @@ THH:mm:ss.sss
             1. Else,
               1. Let _offsetSign_ be *"-"*.
               1. Let _absOffset_ be -_offset_.
-            1. Let _offsetMin_ be ToZeroPaddedDecimalString(ℝ(MinFromTime(_absOffset_)), 2).
+            1. Let _offsetMin_ be ToZeroPaddedDecimalString(MinFromTime(_absOffset_), 2).
             1. Let _offsetHour_ be ToZeroPaddedDecimalString(HourFromTime(_absOffset_), 2).
             1. Let _tzName_ be an implementation-defined string that is either the empty String or the string-concatenation of the code unit 0x0020 (SPACE), the code unit 0x0028 (LEFT PARENTHESIS), an implementation-defined timezone name, and the code unit 0x0029 (RIGHT PARENTHESIS).
             1. Return the string-concatenation of _offsetSign_, _offsetHour_, _offsetMin_, and _tzName_.

--- a/spec.html
+++ b/spec.html
@@ -33431,7 +33431,7 @@
       <emu-clause id="sec-timefromyear" type="abstract operation" oldids="eqn-TimeFromYear">
         <h1>
           TimeFromYear (
-            _y_: an integral Number,
+            _y_: an integer,
           ): a time value
         </h1>
         <dl class="header">
@@ -33439,7 +33439,7 @@
           <dd>It returns the time value of the start of year _y_.</dd>
         </dl>
         <emu-alg>
-          1. Return 𝔽(msPerDay × DayFromYear(ℝ(_y_))).
+          1. Return 𝔽(msPerDay × DayFromYear(_y_)).
         </emu-alg>
       </emu-clause>
 
@@ -33454,7 +33454,7 @@
           <dd>It returns the year in which _t_ falls.</dd>
         </dl>
         <emu-alg>
-          1. [declared="y"] Return the largest integral Number _y_ (closest to +∞) such that TimeFromYear(_y_) ≤ _t_.
+          1. [declared="y"] Return the largest integral Number _y_ (closest to +∞) such that TimeFromYear(ℝ(_y_)) ≤ _t_.
         </emu-alg>
       </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -34124,26 +34124,7 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-daysinyear" type="abstract operation" oldids="eqn-DaysInYear,sec-year-number">
-        <h1>
-          DaysInYear (
-            _y_: an integral Number,
-          ): *365*<sub>𝔽</sub> or *366*<sub>𝔽</sub>
-        </h1>
-        <dl class="header">
-          <dt>description</dt>
-          <dd>It returns the number of days in year _y_. Leap years have 366 days; all other years have 365.</dd>
-        </dl>
-        <emu-alg>
-          1. Let _ry_ be ℝ(_y_).
-          1. If (_ry_ modulo 400) = 0, return *366*<sub>𝔽</sub>.
-          1. If (_ry_ modulo 100) = 0, return *365*<sub>𝔽</sub>.
-          1. If (_ry_ modulo 4) = 0, return *366*<sub>𝔽</sub>.
-          1. Return *365*<sub>𝔽</sub>.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-dayfromyear" type="abstract operation" oldids="eqn-DaysFromYear">
+      <emu-clause id="sec-dayfromyear" type="abstract operation" oldids="eqn-DaysFromYear,sec-year-number">
         <h1>
           DayFromYear (
             _y_: an integral Number,
@@ -34207,7 +34188,7 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-inleapyear" type="abstract operation" oldids="eqn-InLeapYear">
+      <emu-clause id="sec-inleapyear" type="abstract operation" oldids="eqn-InLeapYear,sec-daysinyear,eqn-DaysInYear">
         <h1>
           InLeapYear (
             _tv_: a finite time value,
@@ -34218,7 +34199,10 @@
           <dd>It returns *1*<sub>𝔽</sub> if _tv_ is within a leap year and *+0*<sub>𝔽</sub> otherwise.</dd>
         </dl>
         <emu-alg>
-          1. If DaysInYear(YearFromTime(_tv_)) is *366*<sub>𝔽</sub>, return *1*<sub>𝔽</sub>.
+          1. Let _ry_ be ℝ(YearFromTime(_tv_)).
+          1. If (_ry_ modulo 400) = 0, return *1*<sub>𝔽</sub>.
+          1. If (_ry_ modulo 100) = 0, return *+0*<sub>𝔽</sub>.
+          1. If (_ry_ modulo 4) = 0, return *1*<sub>𝔽</sub>.
           1. Return *+0*<sub>𝔽</sub>.
         </emu-alg>
       </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -34326,9 +34326,9 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-msfromtime" type="abstract operation" oldids="eqn-msFromTime">
+      <emu-clause id="sec-millisecfromtime" type="abstract operation" oldids="sec-msfromtime,eqn-msFromTime">
         <h1>
-          msFromTime (
+          MillisecFromTime (
             _tv_: a finite time value,
           ): an integral Number in the inclusive interval from *+0*<sub>𝔽</sub> to *999*<sub>𝔽</sub>
         </h1>
@@ -34590,13 +34590,13 @@
           1. If IsTimeZoneOffsetString(_systemTimeZoneIdentifier_) is *true*, then
             1. Let _offsetNs_ be ParseTimeZoneOffsetString(_systemTimeZoneIdentifier_).
           1. Else,
-            1. Let _possibleInstants_ be GetNamedTimeZoneEpochNanoseconds(_systemTimeZoneIdentifier_, ℝ(YearFromTime(_t_)), ℝ(MonthFromTime(_t_)) + 1, ℝ(DateFromTime(_t_)), ℝ(HourFromTime(_t_)), ℝ(MinFromTime(_t_)), ℝ(SecFromTime(_t_)), ℝ(msFromTime(_t_)), 0, 0).
+            1. Let _possibleInstants_ be GetNamedTimeZoneEpochNanoseconds(_systemTimeZoneIdentifier_, ℝ(YearFromTime(_t_)), ℝ(MonthFromTime(_t_)) + 1, ℝ(DateFromTime(_t_)), ℝ(HourFromTime(_t_)), ℝ(MinFromTime(_t_)), ℝ(SecFromTime(_t_)), ℝ(MillisecFromTime(_t_)), 0, 0).
             1. NOTE: The following steps ensure that when _t_ represents local time repeating multiple times at a negative time zone transition (e.g. when the daylight saving time ends or the time zone offset is decreased due to a time zone rule change) or skipped local time at a positive time zone transition (e.g. when the daylight saving time starts or the time zone offset is increased due to a time zone rule change), _t_ is interpreted using the time zone offset before the transition.
             1. If _possibleInstants_ is not empty, then
               1. Let _disambiguatedInstant_ be _possibleInstants_[0].
             1. Else,
               1. NOTE: _t_ represents a local time skipped at a positive time zone transition (e.g. due to daylight saving time starting or a time zone rule change increasing the UTC offset).
-              1. [declared="tBefore"] Let _possibleInstantsBefore_ be GetNamedTimeZoneEpochNanoseconds(_systemTimeZoneIdentifier_, ℝ(YearFromTime(_tBefore_)), ℝ(MonthFromTime(_tBefore_)) + 1, ℝ(DateFromTime(_tBefore_)), ℝ(HourFromTime(_tBefore_)), ℝ(MinFromTime(_tBefore_)), ℝ(SecFromTime(_tBefore_)), ℝ(msFromTime(_tBefore_)), 0, 0), where _tBefore_ is the largest integral Number &lt; _t_ for which _possibleInstantsBefore_ is not empty (i.e., _tBefore_ represents the last local time before the transition).
+              1. [declared="tBefore"] Let _possibleInstantsBefore_ be GetNamedTimeZoneEpochNanoseconds(_systemTimeZoneIdentifier_, ℝ(YearFromTime(_tBefore_)), ℝ(MonthFromTime(_tBefore_)) + 1, ℝ(DateFromTime(_tBefore_)), ℝ(HourFromTime(_tBefore_)), ℝ(MinFromTime(_tBefore_)), ℝ(SecFromTime(_tBefore_)), ℝ(MillisecFromTime(_tBefore_)), 0, 0), where _tBefore_ is the largest integral Number &lt; _t_ for which _possibleInstantsBefore_ is not empty (i.e., _tBefore_ represents the last local time before the transition).
               1. Let _disambiguatedInstant_ be the last element of _possibleInstantsBefore_.
             1. Let _offsetNs_ be GetNamedTimeZoneOffsetNanoseconds(_systemTimeZoneIdentifier_, _disambiguatedInstant_).
           1. Let _offsetMs_ be truncate(_offsetNs_ / nsPerMillisecond).
@@ -35199,7 +35199,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
           1. If _tv_ is *NaN*, return *NaN*.
-          1. Return msFromTime(LocalTime(_tv_)).
+          1. Return MillisecFromTime(LocalTime(_tv_)).
         </emu-alg>
       </emu-clause>
 
@@ -35317,7 +35317,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
           1. If _tv_ is *NaN*, return *NaN*.
-          1. Return msFromTime(_tv_).
+          1. Return MillisecFromTime(_tv_).
         </emu-alg>
       </emu-clause>
 
@@ -35411,7 +35411,7 @@ THH:mm:ss.sss
           1. Set _tv_ to LocalTime(_tv_).
           1. If _min_ is not present, let _m_ be MinFromTime(_tv_).
           1. If _sec_ is not present, let _s_ be SecFromTime(_tv_).
-          1. If _ms_ is not present, let _milli_ be msFromTime(_tv_).
+          1. If _ms_ is not present, let _milli_ be MillisecFromTime(_tv_).
           1. Let _date_ be MakeDate(Day(_tv_), MakeTime(_h_, _m_, _s_, _milli_)).
           1. Let _u_ be TimeClip(UTC(_date_)).
           1. Set _dateObj_.[[DateValue]] to _u_.
@@ -35453,7 +35453,7 @@ THH:mm:ss.sss
           1. If _tv_ is *NaN*, return *NaN*.
           1. Set _tv_ to LocalTime(_tv_).
           1. If _sec_ is not present, let _s_ be SecFromTime(_tv_).
-          1. If _ms_ is not present, let _milli_ be msFromTime(_tv_).
+          1. If _ms_ is not present, let _milli_ be MillisecFromTime(_tv_).
           1. Let _date_ be MakeDate(Day(_tv_), MakeTime(HourFromTime(_tv_), _m_, _s_, _milli_)).
           1. Let _u_ be TimeClip(UTC(_date_)).
           1. Set _dateObj_.[[DateValue]] to _u_.
@@ -35499,7 +35499,7 @@ THH:mm:ss.sss
           1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_).
           1. If _tv_ is *NaN*, return *NaN*.
           1. Set _tv_ to LocalTime(_tv_).
-          1. If _ms_ is not present, let _milli_ be msFromTime(_tv_).
+          1. If _ms_ is not present, let _milli_ be MillisecFromTime(_tv_).
           1. Let _date_ be MakeDate(Day(_tv_), MakeTime(HourFromTime(_tv_), MinFromTime(_tv_), _s_, _milli_)).
           1. Let _u_ be TimeClip(UTC(_date_)).
           1. Set _dateObj_.[[DateValue]] to _u_.
@@ -35576,7 +35576,7 @@ THH:mm:ss.sss
           1. If _tv_ is *NaN*, return *NaN*.
           1. If _min_ is not present, let _m_ be MinFromTime(_tv_).
           1. If _sec_ is not present, let _s_ be SecFromTime(_tv_).
-          1. If _ms_ is not present, let _milli_ be msFromTime(_tv_).
+          1. If _ms_ is not present, let _milli_ be MillisecFromTime(_tv_).
           1. Let _date_ be MakeDate(Day(_tv_), MakeTime(_h_, _m_, _s_, _milli_)).
           1. Let _v_ be TimeClip(_date_).
           1. Set _dateObj_.[[DateValue]] to _v_.
@@ -35616,7 +35616,7 @@ THH:mm:ss.sss
           1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_).
           1. If _tv_ is *NaN*, return *NaN*.
           1. If _sec_ is not present, let _s_ be SecFromTime(_tv_).
-          1. If _ms_ is not present, let _milli_ be msFromTime(_tv_).
+          1. If _ms_ is not present, let _milli_ be MillisecFromTime(_tv_).
           1. Let _date_ be MakeDate(Day(_tv_), MakeTime(HourFromTime(_tv_), _m_, _s_, _milli_)).
           1. Let _v_ be TimeClip(_date_).
           1. Set _dateObj_.[[DateValue]] to _v_.
@@ -35660,7 +35660,7 @@ THH:mm:ss.sss
           1. Let _s_ be ? ToNumber(_sec_).
           1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_).
           1. If _tv_ is *NaN*, return *NaN*.
-          1. If _ms_ is not present, let _milli_ be msFromTime(_tv_).
+          1. If _ms_ is not present, let _milli_ be MillisecFromTime(_tv_).
           1. Let _date_ be MakeDate(Day(_tv_), MakeTime(HourFromTime(_tv_), MinFromTime(_tv_), _s_, _milli_)).
           1. Let _v_ be TimeClip(_date_).
           1. Set _dateObj_.[[DateValue]] to _v_.

--- a/spec.html
+++ b/spec.html
@@ -34085,11 +34085,11 @@
         <emu-eqn id="eqn-HoursPerDay" aoid="HoursPerDay">HoursPerDay = 24</emu-eqn>
         <emu-eqn id="eqn-MinutesPerHour" aoid="MinutesPerHour">MinutesPerHour = 60</emu-eqn>
         <emu-eqn id="eqn-SecondsPerMinute" aoid="SecondsPerMinute">SecondsPerMinute = 60</emu-eqn>
-        <emu-eqn id="eqn-msPerSecond" aoid="msPerSecond">msPerSecond = *1000*<sub>𝔽</sub></emu-eqn>
-        <emu-eqn id="eqn-msPerMinute" aoid="msPerMinute">msPerMinute = *60000*<sub>𝔽</sub> = msPerSecond × 𝔽(SecondsPerMinute)</emu-eqn>
-        <emu-eqn id="eqn-msPerHour" aoid="msPerHour">msPerHour = *3600000*<sub>𝔽</sub> = msPerMinute × 𝔽(MinutesPerHour)</emu-eqn>
-        <emu-eqn id="eqn-msPerDay" aoid="msPerDay">msPerDay = *86400000*<sub>𝔽</sub> = msPerHour × 𝔽(HoursPerDay)</emu-eqn>
-        <emu-eqn id="eqn-nsPerSecond" aoid="nsPerSecond">nsPerSecond = 10<sup>6</sup> × ℝ(msPerSecond) = 10<sup>9</sup></emu-eqn>
+        <emu-eqn id="eqn-msPerSecond" aoid="msPerSecond">msPerSecond = 1000</emu-eqn>
+        <emu-eqn id="eqn-msPerMinute" aoid="msPerMinute">msPerMinute = 60000 = msPerSecond × SecondsPerMinute</emu-eqn>
+        <emu-eqn id="eqn-msPerHour" aoid="msPerHour">msPerHour = 3600000 = msPerMinute × MinutesPerHour</emu-eqn>
+        <emu-eqn id="eqn-msPerDay" aoid="msPerDay">msPerDay = 86400000 = msPerHour × HoursPerDay</emu-eqn>
+        <emu-eqn id="eqn-nsPerSecond" aoid="nsPerSecond">nsPerSecond = 10<sup>6</sup> × msPerSecond = 10<sup>9</sup></emu-eqn>
         <emu-eqn id="eqn-nsPerMillisecond" aoid="nsPerMillisecond">nsPerMillisecond = 10<sup>6</sup></emu-eqn>
         <emu-eqn id="eqn-nsPerMicrosecond" aoid="nsPerMicrosecond">nsPerMicrosecond = 10<sup>3</sup></emu-eqn>
       </emu-clause>
@@ -34098,14 +34098,14 @@
         <h1>
           Day (
             _tv_: a finite time value,
-          ): an integral Number
+          ): an integer
         </h1>
         <dl class="header">
           <dt>description</dt>
           <dd>It returns the day number of the day in which _tv_ falls.</dd>
         </dl>
         <emu-alg>
-          1. Return 𝔽(floor(ℝ(_tv_ / msPerDay))).
+          1. Return floor(ℝ(_tv_) / msPerDay).
         </emu-alg>
       </emu-clause>
 
@@ -34113,42 +34113,41 @@
         <h1>
           TimeWithinDay (
             _tv_: a finite time value,
-          ): an integral Number in the interval from *+0*<sub>𝔽</sub> (inclusive) to msPerDay (exclusive)
+          ): an integer in the interval from 0 (inclusive) to msPerDay (exclusive)
         </h1>
         <dl class="header">
           <dt>description</dt>
           <dd>It returns the number of milliseconds since the start of the day in which _tv_ falls.</dd>
         </dl>
         <emu-alg>
-          1. Return 𝔽(ℝ(_tv_) modulo ℝ(msPerDay)).
+          1. Return ℝ(_tv_) modulo msPerDay.
         </emu-alg>
       </emu-clause>
 
       <emu-clause id="sec-dayfromyear" type="abstract operation" oldids="eqn-DaysFromYear,sec-year-number">
         <h1>
           DayFromYear (
-            _y_: an integral Number,
-          ): an integral Number
+            _y_: an integer,
+          ): an integer
         </h1>
         <dl class="header">
           <dt>description</dt>
           <dd>It returns the day number of the first day of year _y_.</dd>
         </dl>
         <emu-alg>
-          1. Let _ry_ be ℝ(_y_).
           1. [declared="numberYears1,numberYears4,numberYears100,numberYears400"] NOTE: In the following steps, _numberYears1_, _numberYears4_, _numberYears100_, and _numberYears400_ represent the number of years divisible by 1, 4, 100, and 400, respectively, that occur between the epoch and the start of year _y_. The number is negative if _y_ is before the epoch.
-          1. Let _numberYears1_ be (_ry_ - 1970).
-          1. Let _numberYears4_ be floor((_ry_ - 1969) / 4).
-          1. Let _numberYears100_ be floor((_ry_ - 1901) / 100).
-          1. Let _numberYears400_ be floor((_ry_ - 1601) / 400).
-          1. Return 𝔽(365 × _numberYears1_ + _numberYears4_ - _numberYears100_ + _numberYears400_).
+          1. Let _numberYears1_ be (_y_ - 1970).
+          1. Let _numberYears4_ be floor((_y_ - 1969) / 4).
+          1. Let _numberYears100_ be floor((_y_ - 1901) / 100).
+          1. Let _numberYears400_ be floor((_y_ - 1601) / 400).
+          1. Return 365 × _numberYears1_ + _numberYears4_ - _numberYears100_ + _numberYears400_.
         </emu-alg>
       </emu-clause>
 
       <emu-clause id="sec-timefromyear" type="abstract operation" oldids="eqn-TimeFromYear">
         <h1>
           TimeFromYear (
-            _y_: an integral Number,
+            _y_: an integer,
           ): a time value
         </h1>
         <dl class="header">
@@ -34156,7 +34155,7 @@
           <dd>It returns the time value of the start of year _y_.</dd>
         </dl>
         <emu-alg>
-          1. Return msPerDay × DayFromYear(_y_).
+          1. Return 𝔽(msPerDay × DayFromYear(_y_)).
         </emu-alg>
       </emu-clause>
 
@@ -34164,14 +34163,14 @@
         <h1>
           YearFromTime (
             _tv_: a finite time value,
-          ): an integral Number
+          ): an integer
         </h1>
         <dl class="header">
           <dt>description</dt>
           <dd>It returns the year in which _tv_ falls.</dd>
         </dl>
         <emu-alg>
-          1. [declared="y"] Return the largest integral Number _y_ (closest to +∞) such that TimeFromYear(_y_) ≤ _tv_.
+          1. [declared="y"] Return the largest integer _y_ (closest to +∞) such that TimeFromYear(_y_) ≤ _tv_.
         </emu-alg>
       </emu-clause>
 
@@ -34179,7 +34178,7 @@
         <h1>
           DayWithinYear (
             _tv_: a finite time value,
-          ): an integral Number in the inclusive interval from *+0*<sub>𝔽</sub> to *365*<sub>𝔽</sub>
+          ): an integer in the inclusive interval from 0 to 365
         </h1>
         <dl class="header">
         </dl>
@@ -34192,18 +34191,18 @@
         <h1>
           InLeapYear (
             _tv_: a finite time value,
-          ): *+0*<sub>𝔽</sub> or *1*<sub>𝔽</sub>
+          ): 0 or 1
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It returns *1*<sub>𝔽</sub> if _tv_ is within a leap year and *+0*<sub>𝔽</sub> otherwise.</dd>
+          <dd>It returns 1 if _tv_ is within a leap year and 0 otherwise.</dd>
         </dl>
         <emu-alg>
-          1. Let _ry_ be ℝ(YearFromTime(_tv_)).
-          1. If (_ry_ modulo 400) = 0, return *1*<sub>𝔽</sub>.
-          1. If (_ry_ modulo 100) = 0, return *+0*<sub>𝔽</sub>.
-          1. If (_ry_ modulo 4) = 0, return *1*<sub>𝔽</sub>.
-          1. Return *+0*<sub>𝔽</sub>.
+          1. Let _y_ be YearFromTime(_tv_).
+          1. If (_y_ modulo 400) = 0, return 1.
+          1. If (_y_ modulo 100) = 0, return 0.
+          1. If (_y_ modulo 4) = 0, return 1.
+          1. Return 0.
         </emu-alg>
       </emu-clause>
 
@@ -34211,28 +34210,28 @@
         <h1>
           MonthFromTime (
             _tv_: a finite time value,
-          ): an integral Number in the inclusive interval from *+0*<sub>𝔽</sub> to *11*<sub>𝔽</sub>
+          ): an integer in the inclusive interval from 0 to 11
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It returns a Number identifying the month in which _tv_ falls. A month value of *+0*<sub>𝔽</sub> specifies January; *1*<sub>𝔽</sub> specifies February; *2*<sub>𝔽</sub> specifies March; *3*<sub>𝔽</sub> specifies April; *4*<sub>𝔽</sub> specifies May; *5*<sub>𝔽</sub> specifies June; *6*<sub>𝔽</sub> specifies July; *7*<sub>𝔽</sub> specifies August; *8*<sub>𝔽</sub> specifies September; *9*<sub>𝔽</sub> specifies October; *10*<sub>𝔽</sub> specifies November; and *11*<sub>𝔽</sub> specifies December. Note that <emu-eqn>MonthFromTime(*+0*<sub>𝔽</sub>) = *+0*<sub>𝔽</sub></emu-eqn>, corresponding to Thursday, 1 January 1970.</dd>
+          <dd>It returns an integer identifying the month in which _tv_ falls. A month value of 0 specifies January; 1 specifies February; 2 specifies March; 3 specifies April; 4 specifies May; 5 specifies June; 6 specifies July; 7 specifies August; 8 specifies September; 9 specifies October; 10 specifies November; and 11 specifies December. Note that <emu-eqn>MonthFromTime(*+0*<sub>𝔽</sub>) = 0</emu-eqn>, corresponding to Thursday, 1 January 1970.</dd>
         </dl>
         <emu-alg>
           1. Let _inLeapYear_ be InLeapYear(_tv_).
           1. Let _dayWithinYear_ be DayWithinYear(_tv_).
-          1. If _dayWithinYear_ &lt; *31*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
-          1. If _dayWithinYear_ &lt; *59*<sub>𝔽</sub> + _inLeapYear_, return *1*<sub>𝔽</sub>.
-          1. If _dayWithinYear_ &lt; *90*<sub>𝔽</sub> + _inLeapYear_, return *2*<sub>𝔽</sub>.
-          1. If _dayWithinYear_ &lt; *120*<sub>𝔽</sub> + _inLeapYear_, return *3*<sub>𝔽</sub>.
-          1. If _dayWithinYear_ &lt; *151*<sub>𝔽</sub> + _inLeapYear_, return *4*<sub>𝔽</sub>.
-          1. If _dayWithinYear_ &lt; *181*<sub>𝔽</sub> + _inLeapYear_, return *5*<sub>𝔽</sub>.
-          1. If _dayWithinYear_ &lt; *212*<sub>𝔽</sub> + _inLeapYear_, return *6*<sub>𝔽</sub>.
-          1. If _dayWithinYear_ &lt; *243*<sub>𝔽</sub> + _inLeapYear_, return *7*<sub>𝔽</sub>.
-          1. If _dayWithinYear_ &lt; *273*<sub>𝔽</sub> + _inLeapYear_, return *8*<sub>𝔽</sub>.
-          1. If _dayWithinYear_ &lt; *304*<sub>𝔽</sub> + _inLeapYear_, return *9*<sub>𝔽</sub>.
-          1. If _dayWithinYear_ &lt; *334*<sub>𝔽</sub> + _inLeapYear_, return *10*<sub>𝔽</sub>.
-          1. Assert: _dayWithinYear_ &lt; *365*<sub>𝔽</sub> + _inLeapYear_.
-          1. Return *11*<sub>𝔽</sub>.
+          1. If _dayWithinYear_ &lt; 31, return 0.
+          1. If _dayWithinYear_ &lt; 59 + _inLeapYear_, return 1.
+          1. If _dayWithinYear_ &lt; 90 + _inLeapYear_, return 2.
+          1. If _dayWithinYear_ &lt; 120 + _inLeapYear_, return 3.
+          1. If _dayWithinYear_ &lt; 151 + _inLeapYear_, return 4.
+          1. If _dayWithinYear_ &lt; 181 + _inLeapYear_, return 5.
+          1. If _dayWithinYear_ &lt; 212 + _inLeapYear_, return 6.
+          1. If _dayWithinYear_ &lt; 243 + _inLeapYear_, return 7.
+          1. If _dayWithinYear_ &lt; 273 + _inLeapYear_, return 8.
+          1. If _dayWithinYear_ &lt; 304 + _inLeapYear_, return 9.
+          1. If _dayWithinYear_ &lt; 334 + _inLeapYear_, return 10.
+          1. Assert: _dayWithinYear_ &lt; 365 + _inLeapYear_.
+          1. Return 11.
         </emu-alg>
       </emu-clause>
 
@@ -34240,7 +34239,7 @@
         <h1>
           DateFromTime (
             _tv_: a finite time value,
-          ): an integral Number in the inclusive interval from *1*<sub>𝔽</sub> to *31*<sub>𝔽</sub>
+          ): an integer in the inclusive interval from 1 to 31
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -34250,19 +34249,19 @@
           1. Let _inLeapYear_ be InLeapYear(_tv_).
           1. Let _dayWithinYear_ be DayWithinYear(_tv_).
           1. Let _month_ be MonthFromTime(_tv_).
-          1. If _month_ is *+0*<sub>𝔽</sub>, return _dayWithinYear_ + *1*<sub>𝔽</sub>.
-          1. If _month_ is *1*<sub>𝔽</sub>, return _dayWithinYear_ - *30*<sub>𝔽</sub>.
-          1. If _month_ is *2*<sub>𝔽</sub>, return _dayWithinYear_ - *58*<sub>𝔽</sub> - _inLeapYear_.
-          1. If _month_ is *3*<sub>𝔽</sub>, return _dayWithinYear_ - *89*<sub>𝔽</sub> - _inLeapYear_.
-          1. If _month_ is *4*<sub>𝔽</sub>, return _dayWithinYear_ - *119*<sub>𝔽</sub> - _inLeapYear_.
-          1. If _month_ is *5*<sub>𝔽</sub>, return _dayWithinYear_ - *150*<sub>𝔽</sub> - _inLeapYear_.
-          1. If _month_ is *6*<sub>𝔽</sub>, return _dayWithinYear_ - *180*<sub>𝔽</sub> - _inLeapYear_.
-          1. If _month_ is *7*<sub>𝔽</sub>, return _dayWithinYear_ - *211*<sub>𝔽</sub> - _inLeapYear_.
-          1. If _month_ is *8*<sub>𝔽</sub>, return _dayWithinYear_ - *242*<sub>𝔽</sub> - _inLeapYear_.
-          1. If _month_ is *9*<sub>𝔽</sub>, return _dayWithinYear_ - *272*<sub>𝔽</sub> - _inLeapYear_.
-          1. If _month_ is *10*<sub>𝔽</sub>, return _dayWithinYear_ - *303*<sub>𝔽</sub> - _inLeapYear_.
-          1. Assert: _month_ is *11*<sub>𝔽</sub>.
-          1. Return _dayWithinYear_ - *333*<sub>𝔽</sub> - _inLeapYear_.
+          1. If _month_ = 0, return _dayWithinYear_ + 1.
+          1. If _month_ = 1, return _dayWithinYear_ - 30.
+          1. If _month_ = 2, return _dayWithinYear_ - 58 - _inLeapYear_.
+          1. If _month_ = 3, return _dayWithinYear_ - 89 - _inLeapYear_.
+          1. If _month_ = 4, return _dayWithinYear_ - 119 - _inLeapYear_.
+          1. If _month_ = 5, return _dayWithinYear_ - 150 - _inLeapYear_.
+          1. If _month_ = 6, return _dayWithinYear_ - 180 - _inLeapYear_.
+          1. If _month_ = 7, return _dayWithinYear_ - 211 - _inLeapYear_.
+          1. If _month_ = 8, return _dayWithinYear_ - 242 - _inLeapYear_.
+          1. If _month_ = 9, return _dayWithinYear_ - 272 - _inLeapYear_.
+          1. If _month_ = 10, return _dayWithinYear_ - 303 - _inLeapYear_.
+          1. Assert: _month_ = 11.
+          1. Return _dayWithinYear_ - 333 - _inLeapYear_.
         </emu-alg>
       </emu-clause>
 
@@ -34270,14 +34269,14 @@
         <h1>
           WeekDay (
             _tv_: a finite time value,
-          ): an integral Number in the inclusive interval from *+0*<sub>𝔽</sub> to *6*<sub>𝔽</sub>
+          ): an integer in the inclusive interval from 0 to 6
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It returns a Number identifying the day of the week in which _tv_ falls. A weekday value of *+0*<sub>𝔽</sub> specifies Sunday; *1*<sub>𝔽</sub> specifies Monday; *2*<sub>𝔽</sub> specifies Tuesday; *3*<sub>𝔽</sub> specifies Wednesday; *4*<sub>𝔽</sub> specifies Thursday; *5*<sub>𝔽</sub> specifies Friday; and *6*<sub>𝔽</sub> specifies Saturday. Note that <emu-eqn>WeekDay(*+0*<sub>𝔽</sub>) = *4*<sub>𝔽</sub></emu-eqn>, corresponding to Thursday, 1 January 1970.</dd>
+          <dd>It returns an integer identifying the day of the week in which _tv_ falls. A weekday value of 0 specifies Sunday; 1 specifies Monday; 2 specifies Tuesday; 3 specifies Wednesday; 4 specifies Thursday; 5 specifies Friday; and 6 specifies Saturday. Note that <emu-eqn>WeekDay(*+0*<sub>𝔽</sub>) = 4</emu-eqn>, corresponding to Thursday, 1 January 1970.</dd>
         </dl>
         <emu-alg>
-          1. Return 𝔽(ℝ(Day(_tv_) + *4*<sub>𝔽</sub>) modulo 7).
+          1. Return (Day(_tv_) + 4) modulo 7.
         </emu-alg>
       </emu-clause>
 
@@ -34285,14 +34284,14 @@
         <h1>
           HourFromTime (
             _tv_: a finite time value,
-          ): an integral Number in the inclusive interval from *+0*<sub>𝔽</sub> to *23*<sub>𝔽</sub>
+          ): an integer in the inclusive interval from 0 to 23
         </h1>
         <dl class="header">
           <dt>description</dt>
           <dd>It returns the hour of the day in which _tv_ falls.</dd>
         </dl>
         <emu-alg>
-          1. Return 𝔽(floor(ℝ(_tv_ / msPerHour)) modulo HoursPerDay).
+          1. Return floor(ℝ(_tv_) / msPerHour) modulo HoursPerDay.
         </emu-alg>
       </emu-clause>
 
@@ -34300,14 +34299,14 @@
         <h1>
           MinFromTime (
             _tv_: a finite time value,
-          ): an integral Number in the inclusive interval from *+0*<sub>𝔽</sub> to *59*<sub>𝔽</sub>
+          ): an integer in the inclusive interval from 0 to 59
         </h1>
         <dl class="header">
           <dt>description</dt>
           <dd>It returns the minute of the hour in which _tv_ falls.</dd>
         </dl>
         <emu-alg>
-          1. Return 𝔽(floor(ℝ(_tv_ / msPerMinute)) modulo MinutesPerHour).
+          1. Return floor(ℝ(_tv_) / msPerMinute) modulo MinutesPerHour.
         </emu-alg>
       </emu-clause>
 
@@ -34315,14 +34314,14 @@
         <h1>
           SecFromTime (
             _tv_: a finite time value,
-          ): an integral Number in the inclusive interval from *+0*<sub>𝔽</sub> to *59*<sub>𝔽</sub>
+          ): an integer in the inclusive interval from 0 to 59
         </h1>
         <dl class="header">
           <dt>description</dt>
           <dd>It returns the second of the minute in which _tv_ falls.</dd>
         </dl>
         <emu-alg>
-          1. Return 𝔽(floor(ℝ(_tv_ / msPerSecond)) modulo SecondsPerMinute).
+          1. Return floor(ℝ(_tv_) / msPerSecond) modulo SecondsPerMinute.
         </emu-alg>
       </emu-clause>
 
@@ -34330,14 +34329,14 @@
         <h1>
           MillisecFromTime (
             _tv_: a finite time value,
-          ): an integral Number in the inclusive interval from *+0*<sub>𝔽</sub> to *999*<sub>𝔽</sub>
+          ): an integer in the inclusive interval from 0 to 999
         </h1>
         <dl class="header">
           <dt>description</dt>
           <dd>It returns the millisecond of the second in which _tv_ falls.</dd>
         </dl>
         <emu-alg>
-          1. Return 𝔽(ℝ(_tv_) modulo ℝ(msPerSecond)).
+          1. Return ℝ(_tv_) modulo msPerSecond.
         </emu-alg>
       </emu-clause>
 
@@ -34590,13 +34589,13 @@
           1. If IsTimeZoneOffsetString(_systemTimeZoneIdentifier_) is *true*, then
             1. Let _offsetNs_ be ParseTimeZoneOffsetString(_systemTimeZoneIdentifier_).
           1. Else,
-            1. Let _possibleInstants_ be GetNamedTimeZoneEpochNanoseconds(_systemTimeZoneIdentifier_, ℝ(YearFromTime(_t_)), ℝ(MonthFromTime(_t_)) + 1, ℝ(DateFromTime(_t_)), ℝ(HourFromTime(_t_)), ℝ(MinFromTime(_t_)), ℝ(SecFromTime(_t_)), ℝ(MillisecFromTime(_t_)), 0, 0).
+            1. Let _possibleInstants_ be GetNamedTimeZoneEpochNanoseconds(_systemTimeZoneIdentifier_, YearFromTime(_t_), MonthFromTime(_t_) + 1, DateFromTime(_t_), HourFromTime(_t_), MinFromTime(_t_), SecFromTime(_t_), MillisecFromTime(_t_), 0, 0).
             1. NOTE: The following steps ensure that when _t_ represents local time repeating multiple times at a negative time zone transition (e.g. when the daylight saving time ends or the time zone offset is decreased due to a time zone rule change) or skipped local time at a positive time zone transition (e.g. when the daylight saving time starts or the time zone offset is increased due to a time zone rule change), _t_ is interpreted using the time zone offset before the transition.
             1. If _possibleInstants_ is not empty, then
               1. Let _disambiguatedInstant_ be _possibleInstants_[0].
             1. Else,
               1. NOTE: _t_ represents a local time skipped at a positive time zone transition (e.g. due to daylight saving time starting or a time zone rule change increasing the UTC offset).
-              1. [declared="tBefore"] Let _possibleInstantsBefore_ be GetNamedTimeZoneEpochNanoseconds(_systemTimeZoneIdentifier_, ℝ(YearFromTime(_tBefore_)), ℝ(MonthFromTime(_tBefore_)) + 1, ℝ(DateFromTime(_tBefore_)), ℝ(HourFromTime(_tBefore_)), ℝ(MinFromTime(_tBefore_)), ℝ(SecFromTime(_tBefore_)), ℝ(MillisecFromTime(_tBefore_)), 0, 0), where _tBefore_ is the largest integral Number &lt; _t_ for which _possibleInstantsBefore_ is not empty (i.e., _tBefore_ represents the last local time before the transition).
+              1. [declared="tBefore"] Let _possibleInstantsBefore_ be GetNamedTimeZoneEpochNanoseconds(_systemTimeZoneIdentifier_, YearFromTime(_tBefore_), MonthFromTime(_tBefore_) + 1, DateFromTime(_tBefore_), HourFromTime(_tBefore_), MinFromTime(_tBefore_), SecFromTime(_tBefore_), MillisecFromTime(_tBefore_), 0, 0), where _tBefore_ is the largest integral Number &lt; _t_ for which _possibleInstantsBefore_ is not empty (i.e., _tBefore_ represents the last local time before the transition).
               1. Let _disambiguatedInstant_ be the last element of _possibleInstantsBefore_.
             1. Let _offsetNs_ be GetNamedTimeZoneOffsetNanoseconds(_systemTimeZoneIdentifier_, _disambiguatedInstant_).
           1. Let _offsetMs_ be truncate(_offsetNs_ / nsPerMillisecond).
@@ -34640,11 +34639,11 @@
         </dl>
         <emu-alg>
           1. If _hour_ is not finite, _min_ is not finite, _sec_ is not finite, or _ms_ is not finite, return *NaN*.
-          1. Let _h_ be 𝔽(! ToIntegerOrInfinity(_hour_)).
-          1. Let _m_ be 𝔽(! ToIntegerOrInfinity(_min_)).
-          1. Let _s_ be 𝔽(! ToIntegerOrInfinity(_sec_)).
-          1. Let _milli_ be 𝔽(! ToIntegerOrInfinity(_ms_)).
-          1. Return ((_h_ × msPerHour + _m_ × msPerMinute) + _s_ × msPerSecond) + _milli_.
+          1. Let _h_ be ! ToIntegerOrInfinity(_hour_).
+          1. Let _m_ be ! ToIntegerOrInfinity(_min_).
+          1. Let _s_ be ! ToIntegerOrInfinity(_sec_).
+          1. Let _milli_ be ! ToIntegerOrInfinity(_ms_).
+          1. Return ((𝔽(_h_) × 𝔽(msPerHour) + 𝔽(_m_) × 𝔽(msPerMinute)) + 𝔽(_s_) × 𝔽(msPerSecond)) + 𝔽(_milli_).
         </emu-alg>
         <emu-note>
           <p>The arithmetic in MakeTime is floating-point arithmetic, which is not associative, so the operations must be performed in the correct order.</p>
@@ -34665,14 +34664,14 @@
         </dl>
         <emu-alg>
           1. If _year_ is not finite, _month_ is not finite, or _date_ is not finite, return *NaN*.
-          1. Let _y_ be 𝔽(! ToIntegerOrInfinity(_year_)).
-          1. Let _m_ be 𝔽(! ToIntegerOrInfinity(_month_)).
-          1. Let _dt_ be 𝔽(! ToIntegerOrInfinity(_date_)).
-          1. Let _ym_ be _y_ + 𝔽(floor(ℝ(_m_) / 12)).
+          1. Let _y_ be ! ToIntegerOrInfinity(_year_).
+          1. Let _m_ be ! ToIntegerOrInfinity(_month_).
+          1. Let _dt_ be ! ToIntegerOrInfinity(_date_).
+          1. Let _ym_ be 𝔽(_y_) + 𝔽(floor(_m_ / 12)).
           1. If _ym_ is not finite, return *NaN*.
-          1. Let _mn_ be 𝔽(ℝ(_m_) modulo 12).
-          1. Find a finite time value _tv_ such that YearFromTime(_tv_) is _ym_, MonthFromTime(_tv_) is _mn_, and DateFromTime(_tv_) is *1*<sub>𝔽</sub>; but if this is not possible (because some argument is out of range), return *NaN*.
-          1. Return Day(_tv_) + _dt_ - *1*<sub>𝔽</sub>.
+          1. Let _mn_ be _m_ modulo 12.
+          1. Find a finite time value _tv_ such that YearFromTime(_tv_) = ℝ(_ym_), MonthFromTime(_tv_) = _mn_, and DateFromTime(_tv_) = 1; but if this is not possible (because some argument is out of range), return *NaN*.
+          1. Return 𝔽(Day(_tv_)) + 𝔽(_dt_) - *1*<sub>𝔽</sub>.
         </emu-alg>
       </emu-clause>
 
@@ -34689,7 +34688,7 @@
         </dl>
         <emu-alg>
           1. If _day_ is not finite or _time_ is not finite, return *NaN*.
-          1. Let _tv_ be _day_ × msPerDay + _time_.
+          1. Let _tv_ be _day_ × 𝔽(msPerDay) + _time_.
           1. If _tv_ is not finite, return *NaN*.
           1. Return _tv_.
         </emu-alg>
@@ -35151,7 +35150,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
           1. If _tv_ is *NaN*, return *NaN*.
-          1. Return DateFromTime(LocalTime(_tv_)).
+          1. Return 𝔽(DateFromTime(LocalTime(_tv_))).
         </emu-alg>
       </emu-clause>
 
@@ -35163,7 +35162,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
           1. If _tv_ is *NaN*, return *NaN*.
-          1. Return WeekDay(LocalTime(_tv_)).
+          1. Return 𝔽(WeekDay(LocalTime(_tv_))).
         </emu-alg>
       </emu-clause>
 
@@ -35175,7 +35174,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
           1. If _tv_ is *NaN*, return *NaN*.
-          1. Return YearFromTime(LocalTime(_tv_)).
+          1. Return 𝔽(YearFromTime(LocalTime(_tv_))).
         </emu-alg>
       </emu-clause>
 
@@ -35187,7 +35186,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
           1. If _tv_ is *NaN*, return *NaN*.
-          1. Return HourFromTime(LocalTime(_tv_)).
+          1. Return 𝔽(HourFromTime(LocalTime(_tv_))).
         </emu-alg>
       </emu-clause>
 
@@ -35199,7 +35198,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
           1. If _tv_ is *NaN*, return *NaN*.
-          1. Return MillisecFromTime(LocalTime(_tv_)).
+          1. Return 𝔽(MillisecFromTime(LocalTime(_tv_))).
         </emu-alg>
       </emu-clause>
 
@@ -35211,7 +35210,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
           1. If _tv_ is *NaN*, return *NaN*.
-          1. Return MinFromTime(LocalTime(_tv_)).
+          1. Return 𝔽(MinFromTime(LocalTime(_tv_))).
         </emu-alg>
       </emu-clause>
 
@@ -35223,7 +35222,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
           1. If _tv_ is *NaN*, return *NaN*.
-          1. Return MonthFromTime(LocalTime(_tv_)).
+          1. Return 𝔽(MonthFromTime(LocalTime(_tv_))).
         </emu-alg>
       </emu-clause>
 
@@ -35235,7 +35234,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
           1. If _tv_ is *NaN*, return *NaN*.
-          1. Return SecFromTime(LocalTime(_tv_)).
+          1. Return 𝔽(SecFromTime(LocalTime(_tv_))).
         </emu-alg>
       </emu-clause>
 
@@ -35257,7 +35256,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
           1. If _tv_ is *NaN*, return *NaN*.
-          1. Return (_tv_ - LocalTime(_tv_)) / msPerMinute.
+          1. Return (_tv_ - LocalTime(_tv_)) / 𝔽(msPerMinute).
         </emu-alg>
       </emu-clause>
 
@@ -35269,7 +35268,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
           1. If _tv_ is *NaN*, return *NaN*.
-          1. Return DateFromTime(_tv_).
+          1. Return 𝔽(DateFromTime(_tv_)).
         </emu-alg>
       </emu-clause>
 
@@ -35281,7 +35280,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
           1. If _tv_ is *NaN*, return *NaN*.
-          1. Return WeekDay(_tv_).
+          1. Return 𝔽(WeekDay(_tv_)).
         </emu-alg>
       </emu-clause>
 
@@ -35293,7 +35292,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
           1. If _tv_ is *NaN*, return *NaN*.
-          1. Return YearFromTime(_tv_).
+          1. Return 𝔽(YearFromTime(_tv_)).
         </emu-alg>
       </emu-clause>
 
@@ -35305,7 +35304,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
           1. If _tv_ is *NaN*, return *NaN*.
-          1. Return HourFromTime(_tv_).
+          1. Return 𝔽(HourFromTime(_tv_)).
         </emu-alg>
       </emu-clause>
 
@@ -35317,7 +35316,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
           1. If _tv_ is *NaN*, return *NaN*.
-          1. Return MillisecFromTime(_tv_).
+          1. Return 𝔽(MillisecFromTime(_tv_)).
         </emu-alg>
       </emu-clause>
 
@@ -35329,7 +35328,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
           1. If _tv_ is *NaN*, return *NaN*.
-          1. Return MinFromTime(_tv_).
+          1. Return 𝔽(MinFromTime(_tv_)).
         </emu-alg>
       </emu-clause>
 
@@ -35341,7 +35340,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
           1. If _tv_ is *NaN*, return *NaN*.
-          1. Return MonthFromTime(_tv_).
+          1. Return 𝔽(MonthFromTime(_tv_)).
         </emu-alg>
       </emu-clause>
 
@@ -35353,7 +35352,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
           1. If _tv_ is *NaN*, return *NaN*.
-          1. Return SecFromTime(_tv_).
+          1. Return 𝔽(SecFromTime(_tv_)).
         </emu-alg>
       </emu-clause>
 
@@ -35367,7 +35366,7 @@ THH:mm:ss.sss
           1. Let _dt_ be ? ToNumber(_date_).
           1. If _tv_ is *NaN*, return *NaN*.
           1. Set _tv_ to LocalTime(_tv_).
-          1. Let _newDate_ be MakeDate(MakeDay(YearFromTime(_tv_), MonthFromTime(_tv_), _dt_), TimeWithinDay(_tv_)).
+          1. Let _newDate_ be MakeDate(MakeDay(𝔽(YearFromTime(_tv_)), 𝔽(MonthFromTime(_tv_)), _dt_), 𝔽(TimeWithinDay(_tv_))).
           1. Let _u_ be TimeClip(UTC(_newDate_)).
           1. Set _dateObj_.[[DateValue]] to _u_.
           1. Return _u_.
@@ -35383,9 +35382,9 @@ THH:mm:ss.sss
           1. Let _tv_ be _dateObj_.[[DateValue]].
           1. Let _y_ be ? ToNumber(_year_).
           1. If _tv_ is *NaN*, set _tv_ to *+0*<sub>𝔽</sub>; else set _tv_ to LocalTime(_tv_).
-          1. If _month_ is present, let _m_ be ? ToNumber(_month_); else let _m_ be MonthFromTime(_tv_).
-          1. If _date_ is present, let _dt_ be ? ToNumber(_date_); else let _dt_ be DateFromTime(_tv_).
-          1. Let _newDate_ be MakeDate(MakeDay(_y_, _m_, _dt_), TimeWithinDay(_tv_)).
+          1. If _month_ is present, let _m_ be ? ToNumber(_month_); else let _m_ be 𝔽(MonthFromTime(_tv_)).
+          1. If _date_ is present, let _dt_ be ? ToNumber(_date_); else let _dt_ be 𝔽(DateFromTime(_tv_)).
+          1. Let _newDate_ be MakeDate(MakeDay(_y_, _m_, _dt_), 𝔽(TimeWithinDay(_tv_))).
           1. Let _u_ be TimeClip(UTC(_newDate_)).
           1. Set _dateObj_.[[DateValue]] to _u_.
           1. Return _u_.
@@ -35409,10 +35408,10 @@ THH:mm:ss.sss
           1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_).
           1. If _tv_ is *NaN*, return *NaN*.
           1. Set _tv_ to LocalTime(_tv_).
-          1. If _min_ is not present, let _m_ be MinFromTime(_tv_).
-          1. If _sec_ is not present, let _s_ be SecFromTime(_tv_).
-          1. If _ms_ is not present, let _milli_ be MillisecFromTime(_tv_).
-          1. Let _date_ be MakeDate(Day(_tv_), MakeTime(_h_, _m_, _s_, _milli_)).
+          1. If _min_ is not present, let _m_ be 𝔽(MinFromTime(_tv_)).
+          1. If _sec_ is not present, let _s_ be 𝔽(SecFromTime(_tv_)).
+          1. If _ms_ is not present, let _milli_ be 𝔽(MillisecFromTime(_tv_)).
+          1. Let _date_ be MakeDate(𝔽(Day(_tv_)), MakeTime(_h_, _m_, _s_, _milli_)).
           1. Let _u_ be TimeClip(UTC(_date_)).
           1. Set _dateObj_.[[DateValue]] to _u_.
           1. Return _u_.
@@ -35433,8 +35432,8 @@ THH:mm:ss.sss
           1. Set _ms_ to ? ToNumber(_ms_).
           1. If _tv_ is *NaN*, return *NaN*.
           1. Set _tv_ to LocalTime(_tv_).
-          1. Let _time_ be MakeTime(HourFromTime(_tv_), MinFromTime(_tv_), SecFromTime(_tv_), _ms_).
-          1. Let _u_ be TimeClip(UTC(MakeDate(Day(_tv_), _time_))).
+          1. Let _time_ be MakeTime(𝔽(HourFromTime(_tv_)), 𝔽(MinFromTime(_tv_)), 𝔽(SecFromTime(_tv_)), _ms_).
+          1. Let _u_ be TimeClip(UTC(MakeDate(𝔽(Day(_tv_)), _time_))).
           1. Set _dateObj_.[[DateValue]] to _u_.
           1. Return _u_.
         </emu-alg>
@@ -35452,9 +35451,9 @@ THH:mm:ss.sss
           1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_).
           1. If _tv_ is *NaN*, return *NaN*.
           1. Set _tv_ to LocalTime(_tv_).
-          1. If _sec_ is not present, let _s_ be SecFromTime(_tv_).
-          1. If _ms_ is not present, let _milli_ be MillisecFromTime(_tv_).
-          1. Let _date_ be MakeDate(Day(_tv_), MakeTime(HourFromTime(_tv_), _m_, _s_, _milli_)).
+          1. If _sec_ is not present, let _s_ be 𝔽(SecFromTime(_tv_)).
+          1. If _ms_ is not present, let _milli_ be 𝔽(MillisecFromTime(_tv_)).
+          1. Let _date_ be MakeDate(𝔽(Day(_tv_)), MakeTime(𝔽(HourFromTime(_tv_)), _m_, _s_, _milli_)).
           1. Let _u_ be TimeClip(UTC(_date_)).
           1. Set _dateObj_.[[DateValue]] to _u_.
           1. Return _u_.
@@ -35476,8 +35475,8 @@ THH:mm:ss.sss
           1. If _date_ is present, let _dt_ be ? ToNumber(_date_).
           1. If _tv_ is *NaN*, return *NaN*.
           1. Set _tv_ to LocalTime(_tv_).
-          1. If _date_ is not present, let _dt_ be DateFromTime(_tv_).
-          1. Let _newDate_ be MakeDate(MakeDay(YearFromTime(_tv_), _m_, _dt_), TimeWithinDay(_tv_)).
+          1. If _date_ is not present, let _dt_ be 𝔽(DateFromTime(_tv_)).
+          1. Let _newDate_ be MakeDate(MakeDay(𝔽(YearFromTime(_tv_)), _m_, _dt_), 𝔽(TimeWithinDay(_tv_))).
           1. Let _u_ be TimeClip(UTC(_newDate_)).
           1. Set _dateObj_.[[DateValue]] to _u_.
           1. Return _u_.
@@ -35499,8 +35498,8 @@ THH:mm:ss.sss
           1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_).
           1. If _tv_ is *NaN*, return *NaN*.
           1. Set _tv_ to LocalTime(_tv_).
-          1. If _ms_ is not present, let _milli_ be MillisecFromTime(_tv_).
-          1. Let _date_ be MakeDate(Day(_tv_), MakeTime(HourFromTime(_tv_), MinFromTime(_tv_), _s_, _milli_)).
+          1. If _ms_ is not present, let _milli_ be 𝔽(MillisecFromTime(_tv_)).
+          1. Let _date_ be MakeDate(𝔽(Day(_tv_)), MakeTime(𝔽(HourFromTime(_tv_)), 𝔽(MinFromTime(_tv_)), _s_, _milli_)).
           1. Let _u_ be TimeClip(UTC(_date_)).
           1. Set _dateObj_.[[DateValue]] to _u_.
           1. Return _u_.
@@ -35533,7 +35532,7 @@ THH:mm:ss.sss
           1. Let _tv_ be _dateObj_.[[DateValue]].
           1. Let _dt_ be ? ToNumber(_date_).
           1. If _tv_ is *NaN*, return *NaN*.
-          1. Let _newDate_ be MakeDate(MakeDay(YearFromTime(_tv_), MonthFromTime(_tv_), _dt_), TimeWithinDay(_tv_)).
+          1. Let _newDate_ be MakeDate(MakeDay(𝔽(YearFromTime(_tv_)), 𝔽(MonthFromTime(_tv_)), _dt_), 𝔽(TimeWithinDay(_tv_))).
           1. Let _v_ be TimeClip(_newDate_).
           1. Set _dateObj_.[[DateValue]] to _v_.
           1. Return _v_.
@@ -35549,9 +35548,9 @@ THH:mm:ss.sss
           1. Let _tv_ be _dateObj_.[[DateValue]].
           1. If _tv_ is *NaN*, set _tv_ to *+0*<sub>𝔽</sub>.
           1. Let _y_ be ? ToNumber(_year_).
-          1. If _month_ is present, let _m_ be ? ToNumber(_month_); else let _m_ be MonthFromTime(_tv_).
-          1. If _date_ is present, let _dt_ be ? ToNumber(_date_); else let _dt_ be DateFromTime(_tv_).
-          1. Let _newDate_ be MakeDate(MakeDay(_y_, _m_, _dt_), TimeWithinDay(_tv_)).
+          1. If _month_ is present, let _m_ be ? ToNumber(_month_); else let _m_ be 𝔽(MonthFromTime(_tv_)).
+          1. If _date_ is present, let _dt_ be ? ToNumber(_date_); else let _dt_ be 𝔽(DateFromTime(_tv_)).
+          1. Let _newDate_ be MakeDate(MakeDay(_y_, _m_, _dt_), 𝔽(TimeWithinDay(_tv_))).
           1. Let _v_ be TimeClip(_newDate_).
           1. Set _dateObj_.[[DateValue]] to _v_.
           1. Return _v_.
@@ -35574,10 +35573,10 @@ THH:mm:ss.sss
           1. If _sec_ is present, let _s_ be ? ToNumber(_sec_).
           1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_).
           1. If _tv_ is *NaN*, return *NaN*.
-          1. If _min_ is not present, let _m_ be MinFromTime(_tv_).
-          1. If _sec_ is not present, let _s_ be SecFromTime(_tv_).
-          1. If _ms_ is not present, let _milli_ be MillisecFromTime(_tv_).
-          1. Let _date_ be MakeDate(Day(_tv_), MakeTime(_h_, _m_, _s_, _milli_)).
+          1. If _min_ is not present, let _m_ be 𝔽(MinFromTime(_tv_)).
+          1. If _sec_ is not present, let _s_ be 𝔽(SecFromTime(_tv_)).
+          1. If _ms_ is not present, let _milli_ be 𝔽(MillisecFromTime(_tv_)).
+          1. Let _date_ be MakeDate(𝔽(Day(_tv_)), MakeTime(_h_, _m_, _s_, _milli_)).
           1. Let _v_ be TimeClip(_date_).
           1. Set _dateObj_.[[DateValue]] to _v_.
           1. Return _v_.
@@ -35597,8 +35596,8 @@ THH:mm:ss.sss
           1. Let _tv_ be _dateObj_.[[DateValue]].
           1. Set _ms_ to ? ToNumber(_ms_).
           1. If _tv_ is *NaN*, return *NaN*.
-          1. Let _time_ be MakeTime(HourFromTime(_tv_), MinFromTime(_tv_), SecFromTime(_tv_), _ms_).
-          1. Let _v_ be TimeClip(MakeDate(Day(_tv_), _time_)).
+          1. Let _time_ be MakeTime(𝔽(HourFromTime(_tv_)), 𝔽(MinFromTime(_tv_)), 𝔽(SecFromTime(_tv_)), _ms_).
+          1. Let _v_ be TimeClip(MakeDate(𝔽(Day(_tv_)), _time_)).
           1. Set _dateObj_.[[DateValue]] to _v_.
           1. Return _v_.
         </emu-alg>
@@ -35615,9 +35614,9 @@ THH:mm:ss.sss
           1. If _sec_ is present, let _s_ be ? ToNumber(_sec_).
           1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_).
           1. If _tv_ is *NaN*, return *NaN*.
-          1. If _sec_ is not present, let _s_ be SecFromTime(_tv_).
-          1. If _ms_ is not present, let _milli_ be MillisecFromTime(_tv_).
-          1. Let _date_ be MakeDate(Day(_tv_), MakeTime(HourFromTime(_tv_), _m_, _s_, _milli_)).
+          1. If _sec_ is not present, let _s_ be 𝔽(SecFromTime(_tv_)).
+          1. If _ms_ is not present, let _milli_ be 𝔽(MillisecFromTime(_tv_)).
+          1. Let _date_ be MakeDate(𝔽(Day(_tv_)), MakeTime(𝔽(HourFromTime(_tv_)), _m_, _s_, _milli_)).
           1. Let _v_ be TimeClip(_date_).
           1. Set _dateObj_.[[DateValue]] to _v_.
           1. Return _v_.
@@ -35638,8 +35637,8 @@ THH:mm:ss.sss
           1. Let _m_ be ? ToNumber(_month_).
           1. If _date_ is present, let _dt_ be ? ToNumber(_date_).
           1. If _tv_ is *NaN*, return *NaN*.
-          1. If _date_ is not present, let _dt_ be DateFromTime(_tv_).
-          1. Let _newDate_ be MakeDate(MakeDay(YearFromTime(_tv_), _m_, _dt_), TimeWithinDay(_tv_)).
+          1. If _date_ is not present, let _dt_ be 𝔽(DateFromTime(_tv_)).
+          1. Let _newDate_ be MakeDate(MakeDay(𝔽(YearFromTime(_tv_)), _m_, _dt_), 𝔽(TimeWithinDay(_tv_))).
           1. Let _v_ be TimeClip(_newDate_).
           1. Set _dateObj_.[[DateValue]] to _v_.
           1. Return _v_.
@@ -35660,8 +35659,8 @@ THH:mm:ss.sss
           1. Let _s_ be ? ToNumber(_sec_).
           1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_).
           1. If _tv_ is *NaN*, return *NaN*.
-          1. If _ms_ is not present, let _milli_ be MillisecFromTime(_tv_).
-          1. Let _date_ be MakeDate(Day(_tv_), MakeTime(HourFromTime(_tv_), MinFromTime(_tv_), _s_, _milli_)).
+          1. If _ms_ is not present, let _milli_ be 𝔽(MillisecFromTime(_tv_)).
+          1. Let _date_ be MakeDate(𝔽(Day(_tv_)), MakeTime(𝔽(HourFromTime(_tv_)), 𝔽(MinFromTime(_tv_)), _s_, _milli_)).
           1. Let _v_ be TimeClip(_date_).
           1. Set _dateObj_.[[DateValue]] to _v_.
           1. Return _v_.
@@ -35763,9 +35762,9 @@ THH:mm:ss.sss
           <dl class="header">
           </dl>
           <emu-alg>
-            1. Let _hour_ be ToZeroPaddedDecimalString(ℝ(HourFromTime(_tv_)), 2).
-            1. Let _minute_ be ToZeroPaddedDecimalString(ℝ(MinFromTime(_tv_)), 2).
-            1. Let _second_ be ToZeroPaddedDecimalString(ℝ(SecFromTime(_tv_)), 2).
+            1. Let _hour_ be ToZeroPaddedDecimalString(HourFromTime(_tv_), 2).
+            1. Let _minute_ be ToZeroPaddedDecimalString(MinFromTime(_tv_), 2).
+            1. Let _second_ be ToZeroPaddedDecimalString(SecFromTime(_tv_), 2).
             1. Return the string-concatenation of _hour_, *":"*, _minute_, *":"*, _second_, the code unit 0x0020 (SPACE), and *"GMT"*.
           </emu-alg>
         </emu-clause>
@@ -35779,12 +35778,12 @@ THH:mm:ss.sss
           <dl class="header">
           </dl>
           <emu-alg>
-            1. Let _weekday_ be the Name of the entry in <emu-xref href="#sec-todatestring-day-names"></emu-xref> with the Number WeekDay(_tv_).
-            1. Let _month_ be the Name of the entry in <emu-xref href="#sec-todatestring-month-names"></emu-xref> with the Number MonthFromTime(_tv_).
-            1. Let _day_ be ToZeroPaddedDecimalString(ℝ(DateFromTime(_tv_)), 2).
+            1. Let _weekday_ be the Name of the entry in <emu-xref href="#sec-todatestring-day-names"></emu-xref> whose WeekDay Index = WeekDay(_tv_).
+            1. Let _month_ be the Name of the entry in <emu-xref href="#sec-todatestring-month-names"></emu-xref> whose Month Index = MonthFromTime(_tv_).
+            1. Let _day_ be ToZeroPaddedDecimalString(DateFromTime(_tv_), 2).
             1. Let _yv_ be YearFromTime(_tv_).
-            1. If _yv_ is *+0*<sub>𝔽</sub> or _yv_ > *+0*<sub>𝔽</sub>, let _yearSign_ be the empty String; else let _yearSign_ be *"-"*.
-            1. Let _paddedYear_ be ToZeroPaddedDecimalString(abs(ℝ(_yv_)), 4).
+            1. If _yv_ ≥ 0, let _yearSign_ be the empty String; else let _yearSign_ be *"-"*.
+            1. Let _paddedYear_ be ToZeroPaddedDecimalString(abs(_yv_), 4).
             1. Return the string-concatenation of _weekday_, the code unit 0x0020 (SPACE), _month_, the code unit 0x0020 (SPACE), _day_, the code unit 0x0020 (SPACE), _yearSign_, and _paddedYear_.
           </emu-alg>
           <emu-table id="sec-todatestring-day-names" caption="Names of days of the week">
@@ -35792,7 +35791,7 @@ THH:mm:ss.sss
               <thead>
                 <tr>
                   <th>
-                    Number
+                    WeekDay Index
                   </th>
                   <th>
                     Name
@@ -35801,7 +35800,7 @@ THH:mm:ss.sss
               </thead>
               <tr>
                 <td>
-                  *+0*<sub>𝔽</sub>
+                  0
                 </td>
                 <td>
                   *"Sun"*
@@ -35809,7 +35808,7 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  *1*<sub>𝔽</sub>
+                  1
                 </td>
                 <td>
                   *"Mon"*
@@ -35817,7 +35816,7 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  *2*<sub>𝔽</sub>
+                  2
                 </td>
                 <td>
                   *"Tue"*
@@ -35825,7 +35824,7 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  *3*<sub>𝔽</sub>
+                  3
                 </td>
                 <td>
                   *"Wed"*
@@ -35833,7 +35832,7 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  *4*<sub>𝔽</sub>
+                  4
                 </td>
                 <td>
                   *"Thu"*
@@ -35841,7 +35840,7 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  *5*<sub>𝔽</sub>
+                  5
                 </td>
                 <td>
                   *"Fri"*
@@ -35849,7 +35848,7 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  *6*<sub>𝔽</sub>
+                  6
                 </td>
                 <td>
                   *"Sat"*
@@ -35862,7 +35861,7 @@ THH:mm:ss.sss
               <thead>
                 <tr>
                   <th>
-                    Number
+                    Month Index
                   </th>
                   <th>
                     Name
@@ -35871,7 +35870,7 @@ THH:mm:ss.sss
               </thead>
               <tr>
                 <td>
-                  *+0*<sub>𝔽</sub>
+                  0
                 </td>
                 <td>
                   *"Jan"*
@@ -35879,7 +35878,7 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  *1*<sub>𝔽</sub>
+                  1
                 </td>
                 <td>
                   *"Feb"*
@@ -35887,7 +35886,7 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  *2*<sub>𝔽</sub>
+                  2
                 </td>
                 <td>
                   *"Mar"*
@@ -35895,7 +35894,7 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  *3*<sub>𝔽</sub>
+                  3
                 </td>
                 <td>
                   *"Apr"*
@@ -35903,7 +35902,7 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  *4*<sub>𝔽</sub>
+                  4
                 </td>
                 <td>
                   *"May"*
@@ -35911,7 +35910,7 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  *5*<sub>𝔽</sub>
+                  5
                 </td>
                 <td>
                   *"Jun"*
@@ -35919,7 +35918,7 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  *6*<sub>𝔽</sub>
+                  6
                 </td>
                 <td>
                   *"Jul"*
@@ -35927,7 +35926,7 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  *7*<sub>𝔽</sub>
+                  7
                 </td>
                 <td>
                   *"Aug"*
@@ -35935,7 +35934,7 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  *8*<sub>𝔽</sub>
+                  8
                 </td>
                 <td>
                   *"Sep"*
@@ -35943,7 +35942,7 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  *9*<sub>𝔽</sub>
+                  9
                 </td>
                 <td>
                   *"Oct"*
@@ -35951,7 +35950,7 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  *10*<sub>𝔽</sub>
+                  10
                 </td>
                 <td>
                   *"Nov"*
@@ -35959,7 +35958,7 @@ THH:mm:ss.sss
               </tr>
               <tr>
                 <td>
-                  *11*<sub>𝔽</sub>
+                  11
                 </td>
                 <td>
                   *"Dec"*
@@ -35983,15 +35982,15 @@ THH:mm:ss.sss
               1. Let _offsetNs_ be ParseTimeZoneOffsetString(_systemTimeZoneIdentifier_).
             1. Else,
               1. Let _offsetNs_ be GetNamedTimeZoneOffsetNanoseconds(_systemTimeZoneIdentifier_, ℤ(ℝ(_tv_) × nsPerMillisecond)).
-            1. Let _offset_ be 𝔽(truncate(_offsetNs_ / nsPerMillisecond)).
-            1. If _offset_ is *+0*<sub>𝔽</sub> or _offset_ > *+0*<sub>𝔽</sub>, then
+            1. Let _offset_ be truncate(_offsetNs_ / nsPerMillisecond).
+            1. If _offset_ ≥ 0, then
               1. Let _offsetSign_ be *"+"*.
               1. Let _absOffset_ be _offset_.
             1. Else,
               1. Let _offsetSign_ be *"-"*.
               1. Let _absOffset_ be -_offset_.
-            1. Let _offsetMin_ be ToZeroPaddedDecimalString(ℝ(MinFromTime(_absOffset_)), 2).
-            1. Let _offsetHour_ be ToZeroPaddedDecimalString(ℝ(HourFromTime(_absOffset_)), 2).
+            1. Let _offsetMin_ be ToZeroPaddedDecimalString(MinFromTime(𝔽(_absOffset_)), 2).
+            1. Let _offsetHour_ be ToZeroPaddedDecimalString(HourFromTime(𝔽(_absOffset_)), 2).
             1. Let _tzName_ be an implementation-defined string that is either the empty String or the string-concatenation of the code unit 0x0020 (SPACE), the code unit 0x0028 (LEFT PARENTHESIS), an implementation-defined timezone name, and the code unit 0x0029 (RIGHT PARENTHESIS).
             1. Return the string-concatenation of _offsetSign_, _offsetHour_, _offsetMin_, and _tzName_.
           </emu-alg>
@@ -36035,12 +36034,12 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
           1. If _tv_ is *NaN*, return *"Invalid Date"*.
-          1. Let _weekday_ be the Name of the entry in <emu-xref href="#sec-todatestring-day-names"></emu-xref> with the Number WeekDay(_tv_).
-          1. Let _month_ be the Name of the entry in <emu-xref href="#sec-todatestring-month-names"></emu-xref> with the Number MonthFromTime(_tv_).
-          1. Let _day_ be ToZeroPaddedDecimalString(ℝ(DateFromTime(_tv_)), 2).
+          1. Let _weekday_ be the Name of the entry in <emu-xref href="#sec-todatestring-day-names"></emu-xref> whose WeekDay Index = WeekDay(_tv_).
+          1. Let _month_ be the Name of the entry in <emu-xref href="#sec-todatestring-month-names"></emu-xref> whose Month Index = MonthFromTime(_tv_).
+          1. Let _day_ be ToZeroPaddedDecimalString(DateFromTime(_tv_), 2).
           1. Let _yv_ be YearFromTime(_tv_).
-          1. If _yv_ is *+0*<sub>𝔽</sub> or _yv_ > *+0*<sub>𝔽</sub>, let _yearSign_ be the empty String; else let _yearSign_ be *"-"*.
-          1. Let _paddedYear_ be ToZeroPaddedDecimalString(abs(ℝ(_yv_)), 4).
+          1. If _yv_ ≥ 0, let _yearSign_ be the empty String; else let _yearSign_ be *"-"*.
+          1. Let _paddedYear_ be ToZeroPaddedDecimalString(abs(_yv_), 4).
           1. Return the string-concatenation of _weekday_, *","*, the code unit 0x0020 (SPACE), _day_, the code unit 0x0020 (SPACE), _month_, the code unit 0x0020 (SPACE), _yearSign_, _paddedYear_, the code unit 0x0020 (SPACE), and TimeString(_tv_).
         </emu-alg>
       </emu-clause>
@@ -54605,7 +54604,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
           1. If _tv_ is *NaN*, return *NaN*.
-          1. Return YearFromTime(LocalTime(_tv_)) - *1900*<sub>𝔽</sub>.
+          1. Return 𝔽(YearFromTime(LocalTime(_tv_))) - *1900*<sub>𝔽</sub>.
         </emu-alg>
       </emu-annex>
 
@@ -54622,8 +54621,8 @@ THH:mm:ss.sss
           1. Let _year_ be ? ToNumber(_year_).
           1. If _time_ is *NaN*, set _time_ to *+0*<sub>𝔽</sub>; else set _time_ to LocalTime(_time_).
           1. Let _fullYear_ be MakeFullYear(_year_).
-          1. Let _day_ be MakeDay(_fullYear_, MonthFromTime(_time_), DateFromTime(_time_)).
-          1. Let _date_ be MakeDate(_day_, TimeWithinDay(_time_)).
+          1. Let _day_ be MakeDay(_fullYear_, 𝔽(MonthFromTime(_time_)), 𝔽(DateFromTime(_time_))).
+          1. Let _date_ be MakeDate(_day_, 𝔽(TimeWithinDay(_time_))).
           1. Let _utcTimestamp_ be TimeClip(UTC(_date_)).
           1. Set _dateObj_.[[DateValue]] to _utcTimestamp_.
           1. Return _utcTimestamp_.


### PR DESCRIPTION
This is a follow-up to PR #3092.

The first two commits:
- inline `DaysInYear` into `InLeapYear`, and
- rename `msFromTime` as `MillisecFromTime`

as suggested at the bottom of [this comment](https://github.com/tc39/ecma262/pull/3092#issue-1741670416).

---

The remaining commits try to shift things in this area from integral Numbers to mathematical integers, as suggested by [michaelficarra](https://github.com/tc39/ecma262/pull/3092#pullrequestreview-1463817571) and [syg](https://github.com/tc39/ecma262/pull/3092#pullrequestreview-1538020382).

Note that this doesn't have much effect on the space in which arithmetic is done. Mostly it just avoids unnecessary conversions between the two. Roughly, the idea is to delay 𝔽 calls as much as reasonable.

(I've submitted this part as one commit per AO, in case that helps with review, but I expect I'll squash them down to one commit for merging.)

---

Effects on downstream specs:
None for WebIDL and HTML.

In Ecma 402, Table 8 uses WeekDay() and the various FooFromTime() AOs to set the fields of the record returned by ToLocalTime(). Since this PR changes the return value of these AOs from an integral Number to a mathematical integer, we might expect that 402 would need to change. However, the uses of ToLocalTime (in FormatDateTimePattern and PartitionDateTimeRangePattern) actually seem happier with mathematical values than Numbers in these fields.

As for the Temporal proposal, I'll let others decide whether this PR makes things better or worse for it.