### PR TITLE
Markup: Eliminate unnecessary <emu-xref> elements

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1145,13 +1145,13 @@
       <p>ECMAScript operations that do not interpret String contents apply no further semantics. Operations that do interpret String values treat each element as a single UTF-16 code unit. However, ECMAScript does not restrict the value of or relationships between these code units, so operations that further interpret String contents as sequences of Unicode code points encoded in UTF-16 must account for ill-formed subsequences. Such operations apply special treatment to every code unit with a numeric value in the inclusive interval from 0xD800 to 0xDBFF (defined by the Unicode Standard as a <dfn id="leading-surrogate" variants="leading surrogates">leading surrogate</dfn>, or more formally as a <dfn id="high-surrogate-code-unit" variants="high-surrogate code units">high-surrogate code unit</dfn>) and every code unit with a numeric value in the inclusive interval from 0xDC00 to 0xDFFF (defined as a <dfn id="trailing-surrogate" variants="trailing surrogates">trailing surrogate</dfn>, or more formally as a <dfn id="low-surrogate-code-unit" variants="low-surrogate code units">low-surrogate code unit</dfn>) using the following rules:</p>
       <ul>
         <li>
-          A code unit that is not a <emu-xref href="#leading-surrogate"></emu-xref> and not a <emu-xref href="#trailing-surrogate"></emu-xref> is interpreted as a code point with the same value.
+          A code unit that is not a leading surrogate and not a trailing surrogate is interpreted as a code point with the same value.
         </li>
         <li>
-          A sequence of two code units, where the first code unit _c1_ is a <emu-xref href="#leading-surrogate"></emu-xref> and the second code unit _c2_ a <emu-xref href="#trailing-surrogate"></emu-xref>, is a <dfn id="surrogate-pair" variants="surrogate pairs">surrogate pair</dfn> and is interpreted as a code point with the value (_c1_ - 0xD800) × 0x400 + (_c2_ - 0xDC00) + 0x10000. (See <emu-xref href="#sec-utf16decodesurrogatepair"></emu-xref>)
+          A sequence of two code units, where the first code unit _c1_ is a leading surrogate and the second code unit _c2_ a trailing surrogate, is a <dfn id="surrogate-pair" variants="surrogate pairs">surrogate pair</dfn> and is interpreted as a code point with the value (_c1_ - 0xD800) × 0x400 + (_c2_ - 0xDC00) + 0x10000. (See <emu-xref href="#sec-utf16decodesurrogatepair"></emu-xref>)
         </li>
         <li>
-          A code unit that is a <emu-xref href="#leading-surrogate"></emu-xref> or <emu-xref href="#trailing-surrogate"></emu-xref>, but is not part of a <emu-xref href="#surrogate-pair"></emu-xref>, is interpreted as a code point with the same value.
+          A code unit that is a leading surrogate or trailing surrogate, but is not part of a surrogate pair, is interpreted as a code point with the same value.
         </li>
       </ul>
       <p>The function `String.prototype.normalize` (see <emu-xref href="#sec-string.prototype.normalize"></emu-xref>) can be used to explicitly normalize a String value. `String.prototype.localeCompare` (see <emu-xref href="#sec-string.prototype.localecompare"></emu-xref>) internally normalizes String values, but no other operations implicitly normalize the strings upon which they operate. Operation results are not language- and/or locale-sensitive unless stated otherwise.</p>
@@ -2709,7 +2709,7 @@
       <p>The properties of an object are uniquely identified using property keys. A <dfn variants="property keys">property key</dfn> is either a String or a Symbol. All Strings and Symbols, including the empty String, are valid as property keys. A <dfn id="property-name">property name</dfn> is a property key that is a String.</p>
       <p>An <dfn id="integer-index" variants="integer indices,integer-indexed">integer index</dfn> is a property name _n_ such that CanonicalNumericIndexString(_n_) returns an integral Number in the inclusive interval from *+0*<sub>𝔽</sub> to 𝔽(2<sup>53</sup> - 1). An <dfn id="array-index" variants="array indices">array index</dfn> is an integer index _n_ such that CanonicalNumericIndexString(_n_) returns an integral Number in the inclusive interval from *+0*<sub>𝔽</sub> to 𝔽(2<sup>32</sup> - 2).</p>
       <emu-note>
-        <p>Every non-negative <emu-xref href="#safe-integer">safe integer</emu-xref> has a corresponding integer index. Every 32-bit unsigned integer except <emu-eqn>2<sup>32</sup> - 1</emu-eqn> has a corresponding array index. *"-0"* is neither an integer index nor an array index.</p>
+        <p>Every non-negative safe integer has a corresponding integer index. Every 32-bit unsigned integer except <emu-eqn>2<sup>32</sup> - 1</emu-eqn> has a corresponding array index. *"-0"* is neither an integer index nor an array index.</p>
       </emu-note>
       <p>Property keys are used to access properties and their values. There are two kinds of access for properties: <em>get</em> and <em>set</em>, corresponding to value retrieval and assignment, respectively. The properties accessible via get and set access includes both <em>own properties</em> that are a direct part of an object and <em>inherited properties</em> which are provided by another associated object via a property inheritance relationship. Inherited properties may be either own or inherited properties of the associated object. Each own property of an object must each have a key value that is distinct from the key values of the other own properties of that object.</p>
       <p>All objects are logically collections of properties, but there are multiple forms of objects that differ in their semantics for accessing and manipulating their properties. Please see <emu-xref href="#sec-object-internal-methods-and-internal-slots"></emu-xref> for definitions of the multiple forms of objects.</p>
@@ -11999,8 +11999,8 @@
 
       <p>An implementation of HostEnqueuePromiseJob must conform to the requirements in <emu-xref href="#sec-jobs"></emu-xref> as well as the following:</p>
       <ul>
-        <li>If _realm_ is not *null*, each time _job_ is invoked the implementation must perform implementation-defined steps such that execution is <emu-xref href="#job-preparedtoevaluatecode">prepared to evaluate ECMAScript code</emu-xref> at the time of _job_'s invocation.</li>
-        <li>Let _scriptOrModule_ be GetActiveScriptOrModule() at the time HostEnqueuePromiseJob is invoked. If _realm_ is not *null*, each time _job_ is invoked the implementation must perform implementation-defined steps such that _scriptOrModule_ is the <emu-xref href="#job-activescriptormodule">active script or module</emu-xref> at the time of _job_'s invocation.</li>
+        <li>If _realm_ is not *null*, each time _job_ is invoked the implementation must perform implementation-defined steps such that execution is prepared to evaluate ECMAScript code at the time of _job_'s invocation.</li>
+        <li>Let _scriptOrModule_ be GetActiveScriptOrModule() at the time HostEnqueuePromiseJob is invoked. If _realm_ is not *null*, each time _job_ is invoked the implementation must perform implementation-defined steps such that _scriptOrModule_ is the active script or module at the time of _job_'s invocation.</li>
         <li>Jobs must run in the same order as the HostEnqueuePromiseJob invocations that scheduled them.</li>
       </ul>
 
@@ -14495,7 +14495,7 @@
     <emu-clause id="sec-integer-indexed-exotic-objects">
       <h1>Integer-Indexed Exotic Objects</h1>
       <p>An Integer-Indexed exotic object is an exotic object that performs special handling of integer index property keys.</p>
-      <p><emu-xref href="#integer-indexed-exotic-object">Integer-Indexed exotic objects</emu-xref> have the same internal slots as ordinary objects and additionally [[ViewedArrayBuffer]], [[ArrayLength]], [[ByteOffset]], [[ContentType]], and [[TypedArrayName]] internal slots.</p>
+      <p>Integer-Indexed exotic objects have the same internal slots as ordinary objects and additionally [[ViewedArrayBuffer]], [[ArrayLength]], [[ByteOffset]], [[ContentType]], and [[TypedArrayName]] internal slots.</p>
       <p>An object is an <dfn id="integer-indexed-exotic-object" variants="Integer-Indexed exotic objects">Integer-Indexed exotic object</dfn> if its [[GetOwnProperty]], [[HasProperty]], [[DefineOwnProperty]], [[Get]], [[Set]], [[Delete]], and [[OwnPropertyKeys]] internal methods use the definitions in this section, and its other essential internal methods use the definitions found in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>. These methods are installed by IntegerIndexedObjectCreate.</p>
 
       <emu-clause id="sec-integer-indexed-exotic-objects-getownproperty-p" type="internal method">
@@ -14717,7 +14717,7 @@
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It is used to specify the creation of new <emu-xref href="#integer-indexed-exotic-object">Integer-Indexed exotic objects</emu-xref>.</dd>
+          <dd>It is used to specify the creation of new Integer-Indexed exotic objects.</dd>
         </dl>
         <emu-alg>
           1. Let _internalSlotsList_ be « [[Prototype]], [[Extensible]], [[ViewedArrayBuffer]], [[TypedArrayName]], [[ContentType]], [[ByteLength]], [[ByteOffset]], [[ArrayLength]] ».
@@ -15989,10 +15989,10 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>Two code units that form a UTF-16 <emu-xref href="#surrogate-pair"></emu-xref> are converted to a code point.</dd>
+        <dd>Two code units that form a UTF-16 surrogate pair are converted to a code point.</dd>
       </dl>
       <emu-alg>
-        1. Assert: _lead_ is a <emu-xref href="#leading-surrogate"></emu-xref> and _trail_ is a <emu-xref href="#trailing-surrogate"></emu-xref>.
+        1. Assert: _lead_ is a leading surrogate and _trail_ is a trailing surrogate.
         1. Let _cp_ be (_lead_ - 0xD800) × 0x400 + (_trail_ - 0xDC00) + 0x10000.
         1. Return the code point _cp_.
       </emu-alg>
@@ -16014,12 +16014,12 @@
         1. Assert: _position_ ≥ 0 and _position_ &lt; _size_.
         1. Let _first_ be the code unit at index _position_ within _string_.
         1. Let _cp_ be the code point whose numeric value is the numeric value of _first_.
-        1. If _first_ is neither a <emu-xref href="#leading-surrogate"></emu-xref> nor a <emu-xref href="#trailing-surrogate"></emu-xref>, then
+        1. If _first_ is neither a leading surrogate nor a trailing surrogate, then
           1. Return the Record { [[CodePoint]]: _cp_, [[CodeUnitCount]]: 1, [[IsUnpairedSurrogate]]: *false* }.
-        1. If _first_ is a <emu-xref href="#trailing-surrogate"></emu-xref> or _position_ + 1 = _size_, then
+        1. If _first_ is a trailing surrogate or _position_ + 1 = _size_, then
           1. Return the Record { [[CodePoint]]: _cp_, [[CodeUnitCount]]: 1, [[IsUnpairedSurrogate]]: *true* }.
         1. Let _second_ be the code unit at index _position_ + 1 within _string_.
-        1. If _second_ is not a <emu-xref href="#trailing-surrogate"></emu-xref>, then
+        1. If _second_ is not a trailing surrogate, then
           1. Return the Record { [[CodePoint]]: _cp_, [[CodeUnitCount]]: 1, [[IsUnpairedSurrogate]]: *true* }.
         1. Set _cp_ to UTF16SurrogatePairToCodePoint(_first_, _second_).
         1. Return the Record { [[CodePoint]]: _cp_, [[CodeUnitCount]]: 2, [[IsUnpairedSurrogate]]: *false* }.
@@ -34500,7 +34500,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-string.prototype.codepointat">
         <h1>String.prototype.codePointAt ( _pos_ )</h1>
         <emu-note>
-          <p>This method returns a non-negative integral Number less than or equal to *0x10FFFF*<sub>𝔽</sub> that is the numeric value of the UTF-16 encoded code point (<emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>) starting at the string element at index _pos_ within the String resulting from converting this object to a String. If there is no element at that index, the result is *undefined*. If a valid UTF-16 <emu-xref href="#surrogate-pair"></emu-xref> does not begin at _pos_, the result is the code unit at _pos_.</p>
+          <p>This method returns a non-negative integral Number less than or equal to *0x10FFFF*<sub>𝔽</sub> that is the numeric value of the UTF-16 encoded code point (<emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>) starting at the string element at index _pos_ within the String resulting from converting this object to a String. If there is no element at that index, the result is *undefined*. If a valid UTF-16 surrogate pair does not begin at _pos_, the result is the code unit at _pos_.</p>
         </emu-note>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
@@ -41667,7 +41667,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-properties-of-typedarray-instances">
       <h1>Properties of _TypedArray_ Instances</h1>
-      <p>_TypedArray_ instances are <emu-xref href="#integer-indexed-exotic-object">Integer-Indexed exotic objects</emu-xref>. Each _TypedArray_ instance inherits properties from the corresponding _TypedArray_ prototype object. Each _TypedArray_ instance has the following internal slots: [[TypedArrayName]], [[ViewedArrayBuffer]], [[ByteLength]], [[ByteOffset]], and [[ArrayLength]].</p>
+      <p>_TypedArray_ instances are Integer-Indexed exotic objects. Each _TypedArray_ instance inherits properties from the corresponding _TypedArray_ prototype object. Each _TypedArray_ instance has the following internal slots: [[TypedArrayName]], [[ViewedArrayBuffer]], [[ByteLength]], [[ByteOffset]], and [[ArrayLength]].</p>
     </emu-clause>
   </emu-clause>
 </emu-clause>
@@ -45095,7 +45095,7 @@ THH:mm:ss.sss
           1. For each code point _C_ of StringToCodePoints(_value_), do
             1. If _C_ is listed in the “Code Point” column of <emu-xref href="#table-json-single-character-escapes"></emu-xref>, then
               1. Set _product_ to the string-concatenation of _product_ and the escape sequence for _C_ as specified in the “Escape Sequence” column of the corresponding row.
-            1. Else if _C_ has a numeric value less than 0x0020 (SPACE) or _C_ has the same numeric value as a <emu-xref href="#leading-surrogate"></emu-xref> or <emu-xref href="#trailing-surrogate"></emu-xref>, then
+            1. Else if _C_ has a numeric value less than 0x0020 (SPACE) or _C_ has the same numeric value as a leading surrogate or trailing surrogate, then
               1. Let _unit_ be the code unit whose numeric value is the numeric value of _C_.
               1. Set _product_ to the string-concatenation of _product_ and UnicodeEscape(_unit_).
             1. Else,


### PR DESCRIPTION
Don't use an `<emu-xref>` element when ecmarkup will auto-link the text.