### PR TITLE
Normative bug fix: Fix RevalidateAtomicAccess to check against byte length

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -44212,19 +44212,19 @@ THH:mm:ss.sss
         <h1>
           RevalidateAtomicAccess (
             _typedArray_: an Integer-Indexed exotic object,
-            _indexedPosition_: an integer,
+            _byteIndexInBuffer_: an integer,
           ): either a normal completion containing ~unused~ or a throw completion
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>This operation revalidates the index for atomic operations after all argument coercions are performed in Atomics methods, argument coercions can have arbitrary side effects, which could cause the buffer to become out of bounds. This operation does not throw when _typedArray_'s backing buffer is a SharedArrayBuffer.</dd>
+          <dd>This operation revalidates the index within the backing buffer for atomic operations after all argument coercions are performed in Atomics methods, as argument coercions can have arbitrary side effects, which could cause the buffer to become out of bounds. This operation does not throw when _typedArray_'s backing buffer is a SharedArrayBuffer.</dd>
         </dl>
         <emu-alg>
           1. Let _iieoRecord_ be MakeIntegerIndexedObjectWithBufferWitnessRecord(_typedArray_, ~unordered~).
           1. NOTE: Bounds checking is not a synchronizing operation when _typedArray_'s backing buffer is a growable SharedArrayBuffer.
           1. If IsIntegerIndexedObjectOutOfBounds(_iieoRecord_) is *true*, throw a *TypeError* exception.
-          1. Let _length_ be IntegerIndexedObjectLength(_iieoRecord_).
-          1. If _indexedPosition_ ≥ _length_, throw a *RangeError* exception.
+          1. Assert: _byteIndexInBuffer_ ≥ _typedArray_.[[ByteOffset]].
+          1. If _byteIndexInBuffer_ ≥ _iieoRecord_.[[CachedBufferByteLength]], throw a *RangeError* exception.
           1. Return ~unused~.
         </emu-alg>
       </emu-clause>


### PR DESCRIPTION
Fixes #3199.

Marking this as editorial because the current spec text always fails and is obviously a bug.

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
