### PR TITLE
Editorial: fix formatting of note step in DayFromYear

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -32439,7 +32439,7 @@
         </dl>
         <emu-alg>
           1. Let _ry_ be ℝ(_y_).
-          1. NOTE: In the following steps, each `_numYearsN_` is the number of years divisible by N that occur between the epoch and the start of year _y_. (The number is negative if _y_ is before the epoch.)
+          1. [declared="numYears1,numYears4,numYears100,numYears400"] NOTE: In the following steps, _numYears1_, _numYears4_, _numYears100_, and _numYears400_ represent the number of years divisible by 1, 4, 100, and 400, respectively, that occur between the epoch and the start of year _y_. The number is negative if _y_ is before the epoch.
           1. Let _numYears1_ be (_ry_ - 1970).
           1. Let _numYears4_ be floor((_ry_ - 1969) / 4).
           1. Let _numYears100_ be floor((_ry_ - 1901) / 100).


### PR DESCRIPTION
Alternative to #3183, as discussed in editor call. Fixes #3180. Closes #3183.