### PR TITLE
Editorial: More changes for comparisons

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -2355,7 +2355,7 @@
           <dl class="header">
           </dl>
           <emu-alg>
-            1. If _x_ is *0*<sub>ℤ</sub>, return *0*<sub>ℤ</sub>.
+            1. If _x_ = *0*<sub>ℤ</sub>, return *0*<sub>ℤ</sub>.
             1. Return -_x_.
           </emu-alg>
         </emu-clause>
@@ -2386,7 +2386,7 @@
           </dl>
           <emu-alg>
             1. If _exponent_ &lt; *0*<sub>ℤ</sub>, throw a *RangeError* exception.
-            1. If _base_ is *0*<sub>ℤ</sub> and _exponent_ is *0*<sub>ℤ</sub>, return *1*<sub>ℤ</sub>.
+            1. If _base_ = *0*<sub>ℤ</sub> and _exponent_ = *0*<sub>ℤ</sub>, return *1*<sub>ℤ</sub>.
             1. Return _base_ raised to the power _exponent_.
           </emu-alg>
         </emu-clause>
@@ -2416,7 +2416,7 @@
           <dl class="header">
           </dl>
           <emu-alg>
-            1. If _y_ is *0*<sub>ℤ</sub>, throw a *RangeError* exception.
+            1. If _y_ = *0*<sub>ℤ</sub>, throw a *RangeError* exception.
             1. Let _quotient_ be ℝ(_x_) / ℝ(_y_).
             1. Return ℤ(truncate(_quotient_)).
           </emu-alg>
@@ -2432,8 +2432,8 @@
           <dl class="header">
           </dl>
           <emu-alg>
-            1. If _d_ is *0*<sub>ℤ</sub>, throw a *RangeError* exception.
-            1. If _n_ is *0*<sub>ℤ</sub>, return *0*<sub>ℤ</sub>.
+            1. If _d_ = *0*<sub>ℤ</sub>, throw a *RangeError* exception.
+            1. If _n_ = *0*<sub>ℤ</sub>, return *0*<sub>ℤ</sub>.
             1. Let _quotient_ be ℝ(_n_) / ℝ(_d_).
             1. Let _q_ be ℤ(truncate(_quotient_)).
             1. Return _n_ - (_d_ × _q_).
@@ -13697,7 +13697,7 @@
           1. NOTE: A separate Environment Record is needed to ensure that bindings created by direct eval calls in the formal parameter list are outside the environment where parameters are declared.
           1. Let _calleeEnv_ be the LexicalEnvironment of _calleeContext_.
           1. Let _env_ be NewDeclarativeEnvironment(_calleeEnv_).
-          1. Assert: The VariableEnvironment of _calleeContext_ is _calleeEnv_.
+          1. Assert: The VariableEnvironment of _calleeContext_ and _calleeEnv_ are the same Environment Record.
           1. Set the LexicalEnvironment of _calleeContext_ to _env_.
         1. For each String _paramName_ of _parameterNames_, do
           1. Let _alreadyDeclared_ be ! _env_.HasBinding(_paramName_).
@@ -22327,7 +22327,7 @@
                 1. Repeat, while _O_.[[RemainingKeys]] is not empty,
                   1. Let _r_ be the first element of _O_.[[RemainingKeys]].
                   1. Remove the first element from _O_.[[RemainingKeys]].
-                  1. If there does not exist an element _v_ of _O_.[[VisitedKeys]] such that SameValue(_r_, _v_) is *true*, then
+                  1. If _O_.[[VisitedKeys]] does not contain _r_, then
                     1. Let _desc_ be ? <emu-meta effects="user-code">_object_.[[GetOwnProperty]]</emu-meta>(_r_).
                     1. If _desc_ is not *undefined*, then
                       1. Append _r_ to _O_.[[VisitedKeys]].
@@ -26684,7 +26684,7 @@
                 1. Set _m_.[[Status]] to ~evaluated~.
                 1. Set _m_.[[EvaluationError]] to _result_.
               1. Assert: _module_.[[Status]] is ~evaluated~.
-              1. Assert: _module_.[[EvaluationError]] is _result_.
+              1. Assert: _module_.[[EvaluationError]] and _result_ are the same Completion Record.
               1. Perform ! Call(_capability_.[[Reject]], *undefined*, « _result_.[[Value]] »).
             1. Else,
               1. Assert: _module_.[[Status]] is either ~evaluating-async~ or ~evaluated~.
@@ -26843,7 +26843,7 @@
               1. Set _module_.[[AsyncEvaluation]] to *false*.
               1. Set _module_.[[Status]] to ~evaluated~.
               1. If _module_.[[TopLevelCapability]] is not ~empty~, then
-                1. Assert: _module_.[[CycleRoot]] is _module_.
+                1. Assert: _module_.[[CycleRoot]] and _module_ are the same Module Record.
                 1. Perform ! Call(_module_.[[TopLevelCapability]].[[Resolve]], *undefined*, « *undefined* »).
               1. Let _execList_ be a new empty List.
               1. Perform GatherAvailableAncestors(_module_, _execList_).
@@ -26861,7 +26861,7 @@
                   1. Else,
                     1. Set _m_.[[Status]] to ~evaluated~.
                     1. If _m_.[[TopLevelCapability]] is not ~empty~, then
-                      1. Assert: _m_.[[CycleRoot]] is _m_.
+                      1. Assert: _m_.[[CycleRoot]] and _m_ are the same Module Record.
                       1. Perform ! Call(_m_.[[TopLevelCapability]].[[Resolve]], *undefined*, « *undefined* »).
               1. Return ~unused~.
             </emu-alg>
@@ -26888,7 +26888,7 @@
               1. For each Cyclic Module Record _m_ of _module_.[[AsyncParentModules]], do
                 1. Perform AsyncModuleExecutionRejected(_m_, _error_).
               1. If _module_.[[TopLevelCapability]] is not ~empty~, then
-                1. Assert: _module_.[[CycleRoot]] is _module_.
+                1. Assert: _module_.[[CycleRoot]] and _module_ are the same Module Record.
                 1. Perform ! Call(_module_.[[TopLevelCapability]].[[Reject]], *undefined*, « _error_ »).
               1. Return ~unused~.
             </emu-alg>
@@ -27869,7 +27869,7 @@
               1. Let _requestedModule_ be GetImportedModule(_module_, _e_.[[ModuleRequest]]).
               1. Let _starNames_ be _requestedModule_.GetExportedNames(_exportStarSet_).
               1. For each element _n_ of _starNames_, do
-                1. If SameValue(_n_, *"default"*) is *false*, then
+                1. If _n_ is not *"default"*, then
                   1. If _exportedNames_ does not contain _n_, then
                     1. Append _n_ to _exportedNames_.
             1. Return _exportedNames_.
@@ -27901,16 +27901,16 @@
             1. Assert: _module_.[[Status]] is not ~new~.
             1. If _resolveSet_ is not present, set _resolveSet_ to a new empty List.
             1. For each Record { [[Module]], [[ExportName]] } _r_ of _resolveSet_, do
-              1. If _module_ and _r_.[[Module]] are the same Module Record and SameValue(_exportName_, _r_.[[ExportName]]) is *true*, then
+              1. If _module_ and _r_.[[Module]] are the same Module Record and _exportName_ is _r_.[[ExportName]], then
                 1. Assert: This is a circular import request.
                 1. Return *null*.
             1. Append the Record { [[Module]]: _module_, [[ExportName]]: _exportName_ } to _resolveSet_.
             1. For each ExportEntry Record _e_ of _module_.[[LocalExportEntries]], do
-              1. If SameValue(_exportName_, _e_.[[ExportName]]) is *true*, then
+              1. If _e_.[[ExportName]] is _exportName_, then
                 1. Assert: _module_ provides the direct binding for this export.
                 1. Return ResolvedBinding Record { [[Module]]: _module_, [[BindingName]]: _e_.[[LocalName]] }.
             1. For each ExportEntry Record _e_ of _module_.[[IndirectExportEntries]], do
-              1. If SameValue(_exportName_, _e_.[[ExportName]]) is *true*, then
+              1. If _e_.[[ExportName]] is _exportName_, then
                 1. Assert: _e_.[[ModuleRequest]] is not *null*.
                 1. Let _importedModule_ be GetImportedModule(_module_, _e_.[[ModuleRequest]]).
                 1. If _e_.[[ImportName]] is ~all~, then
@@ -27919,7 +27919,7 @@
                 1. Else,
                   1. Assert: _module_ imports a specific binding for this export.
                   1. Return _importedModule_.ResolveExport(_e_.[[ImportName]], _resolveSet_).
-            1. If SameValue(_exportName_, *"default"*) is *true*, then
+            1. If _exportName_ is *"default"*, then
               1. Assert: A `default` export was not explicitly defined by this module.
               1. Return *null*.
               1. NOTE: A `default` export cannot be provided by an `export * from "mod"` declaration.
@@ -27937,7 +27937,7 @@
                   1. Assert: There is more than one `*` import that includes the requested name.
                   1. If _resolution_.[[Module]] and _starResolution_.[[Module]] are not the same Module Record, return ~ambiguous~.
                   1. If _resolution_.[[BindingName]] is not _starResolution_.[[BindingName]] and either _resolution_.[[BindingName]] or _starResolution_.[[BindingName]] is ~namespace~, return ~ambiguous~.
-                  1. If _resolution_.[[BindingName]] is a String, _starResolution_.[[BindingName]] is a String, and SameValue(_resolution_.[[BindingName]], _starResolution_.[[BindingName]]) is *false*, return ~ambiguous~.
+                  1. If _resolution_.[[BindingName]] is a String, _starResolution_.[[BindingName]] is a String, and _resolution_.[[BindingName]] is not _starResolution_.[[BindingName]], return ~ambiguous~.
             1. Return _starResolution_.
           </emu-alg>
         </emu-clause>
@@ -28979,7 +28979,7 @@
                 1. NOTE: `eval` will not create a global var declaration that would be shadowed by a global lexical declaration.
             1. Let _thisEnv_ be _lexEnv_.
             1. Assert: The following loop will terminate.
-            1. Repeat, while _thisEnv_ is not _varEnv_,
+            1. Repeat, while _thisEnv_ and _varEnv_ are not the same Environment Record,
               1. If _thisEnv_ is not an Object Environment Record, then
                 1. NOTE: The environment of with statements cannot contain any lexical declaration so it doesn't need to be checked for var/let hoisting conflicts.
                 1. For each element _name_ of _varNames_, do
@@ -30575,7 +30575,7 @@
         <emu-alg>
           1. Let _stringKey_ be ? ToString(_key_).
           1. For each element _e_ of the GlobalSymbolRegistry List, do
-            1. If SameValue(_e_.[[Key]], _stringKey_) is *true*, return _e_.[[Symbol]].
+            1. If _e_.[[Key]] is _stringKey_, return _e_.[[Symbol]].
           1. Assert: GlobalSymbolRegistry does not currently contain an entry for _stringKey_.
           1. Let _newSymbol_ be a new Symbol whose [[Description]] is _stringKey_.
           1. Append the Record { [[Key]]: _stringKey_, [[Symbol]]: _newSymbol_ } to the GlobalSymbolRegistry List.
@@ -37970,7 +37970,7 @@ THH:mm:ss.sss
           1. If _rx_ is not an Object, throw a *TypeError* exception.
           1. Let _S_ be ? ToString(_string_).
           1. Let _previousLastIndex_ be ? Get(_rx_, *"lastIndex"*).
-          1. If SameValue(_previousLastIndex_, *+0*<sub>𝔽</sub>) is *false*, then
+          1. If _previousLastIndex_ is not *+0*<sub>𝔽</sub>, then
             1. Perform ? Set(_rx_, *"lastIndex"*, *+0*<sub>𝔽</sub>, *true*).
           1. Let _result_ be ? RegExpExec(_rx_, _S_).
           1. Let _currentLastIndex_ be ? Get(_rx_, *"lastIndex"*).
@@ -39818,7 +39818,7 @@ THH:mm:ss.sss
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
           1. Let _relativeStart_ be ? ToIntegerOrInfinity(_start_).
-          1. If _relativeStart_ is -∞, let _actualStart_ be 0.
+          1. If _relativeStart_ = -∞, let _actualStart_ be 0.
           1. Else if _relativeStart_ &lt; 0, let _actualStart_ be max(_len_ + _relativeStart_, 0).
           1. Else, let _actualStart_ be min(_relativeStart_, _len_).
           1. Let _insertCount_ be the number of elements in _items_.
@@ -39926,7 +39926,7 @@ THH:mm:ss.sss
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_,
             1. Let _Pk_ be ! ToString(𝔽(_k_)).
-            1. If _k_ is _actualIndex_, let _fromValue_ be _value_.
+            1. If _k_ = _actualIndex_, let _fromValue_ be _value_.
             1. Else, let _fromValue_ be ? Get(_O_, _Pk_).
             1. Perform ! CreateDataPropertyOrThrow(_A_, _Pk_, _fromValue_).
             1. Set _k_ to _k_ + 1.
@@ -41234,7 +41234,7 @@ THH:mm:ss.sss
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_,
             1. Let _Pk_ be ! ToString(𝔽(_k_)).
-            1. If _k_ is _actualIndex_, let _fromValue_ be _numericValue_.
+            1. If _k_ = _actualIndex_, let _fromValue_ be _numericValue_.
             1. Else, let _fromValue_ be ! Get(_O_, _Pk_).
             1. Perform ! Set(_A_, _Pk_, _fromValue_, *true*).
             1. Set _k_ to _k_ + 1.
@@ -44546,7 +44546,7 @@ THH:mm:ss.sss
             1. Perform ! CreateDataPropertyOrThrow(_resultObject_, *"async"*, *false*).
             1. Perform ! CreateDataPropertyOrThrow(_resultObject_, *"value"*, *"not-equal"*).
             1. Return _resultObject_.
-          1. If _t_ is 0 and _mode_ is ~async~, then
+          1. If _t_ = 0 and _mode_ is ~async~, then
             1. NOTE: There is no special handling of synchronous immediate timeouts. Asynchronous immediate timeouts have special handling in order to fail fast and avoid unnecessary Promise jobs.
             1. Perform LeaveCriticalSection(_WL_).
             1. Perform ! CreateDataPropertyOrThrow(_resultObject_, *"async"*, *false*).
@@ -49103,7 +49103,7 @@ THH:mm:ss.sss
           1. If _R_.[[NoTear]] is *true*, then
             1. Assert: The remainder of dividing _R_.[[ByteIndex]] by _R_.[[ElementSize]] is 0.
             1. For each event _W_ such that _execution_.[[ReadsFrom]] contains (_R_, _W_) and _W_.[[NoTear]] is *true*, do
-              1. If _R_ and _W_ have equal ranges and there exists an event _V_ such that _V_ and _W_ have equal ranges, _V_.[[NoTear]] is *true*, _W_ is not _V_, and _execution_.[[ReadsFrom]] contains (_R_, _V_), then
+              1. If _R_ and _W_ have equal ranges and there exists an event _V_ such that _V_ and _W_ have equal ranges, _V_.[[NoTear]] is *true*, _W_ and _V_ are not the same Shared Data Block event, and _execution_.[[ReadsFrom]] contains (_R_, _V_), then
                 1. Return *false*.
         1. Return *true*.
       </emu-alg>
@@ -49163,7 +49163,7 @@ THH:mm:ss.sss
     <h1>Races</h1>
     <p>For an execution _execution_, two events _E_ and _D_ in SharedDataBlockEventSet(_execution_) are in a race if the following algorithm returns *true*.</p>
     <emu-alg>
-      1. If _E_ is not _D_, then
+      1. If _E_ and _D_ are not the same Shared Data Block event, then
         1. If the pairs (_E_, _D_) and (_D_, _E_) are not in _execution_.[[HappensBefore]], then
           1. If _E_ and _D_ are both WriteSharedMemory or ReadModifyWriteSharedMemory events and _E_ and _D_ do not have disjoint ranges, then
             1. Return *true*.


### PR DESCRIPTION
... in line with PR #2877 and PR #3202.

The first commit changes:
  `_X_ and _Y_ are [not] the same {Realm,Module} Record`
to just:
  `_X_ is [not] _Y_`

The second commit changes:
  `SameValue(_X_, _Y_) is {*true*,*false*}`
to
  `_X_ is [not] _Y_`
when the two values are both Strings, or else one is a String and the other is a String or `*null*`.