### PR TITLE
Editorial: Remove `?` from `|X?| is [not] present`

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -20911,7 +20911,7 @@
           1. Let _P_ be StringValue of |IdentifierReference|.
           1. Let _lref_ be ? ResolveBinding(_P_).
           1. Let _v_ be ? GetV(_value_, _P_).
-          1. If |Initializer?| is present and _v_ is *undefined*, then
+          1. If |Initializer| is present and _v_ is *undefined*, then
             1. If IsAnonymousFunctionDefinition(|Initializer|) is *true*, then
               1. Set _v_ to ? NamedEvaluation of |Initializer| with argument _P_.
             1. Else,
@@ -24785,7 +24785,7 @@
       </emu-grammar>
       <emu-alg>
         1. Let _name_ be ? Evaluation of |ClassElementName|.
-        1. If |Initializer?| is present, then
+        1. If |Initializer| is present, then
           1. Let _formalParameterList_ be an instance of the production <emu-grammar>FormalParameters : [empty]</emu-grammar>.
           1. Let _env_ be the LexicalEnvironment of the running execution context.
           1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
@@ -24901,14 +24901,14 @@
           1. Perform ! _classEnv_.CreateImmutableBinding(_classBinding_, *true*).
         1. Let _outerPrivateEnvironment_ be the running execution context's PrivateEnvironment.
         1. Let _classPrivateEnvironment_ be NewPrivateEnvironment(_outerPrivateEnvironment_).
-        1. If |ClassBody?| is present, then
-          1. For each String _dn_ of the PrivateBoundIdentifiers of |ClassBody?|, do
+        1. If |ClassBody| is present, then
+          1. For each String _dn_ of the PrivateBoundIdentifiers of |ClassBody|, do
             1. If _classPrivateEnvironment_.[[Names]] contains a Private Name _pn_ such that _pn_.[[Description]] is _dn_, then
               1. Assert: This is only possible for getter/setter pairs.
             1. Else,
               1. Let _name_ be a new Private Name whose [[Description]] is _dn_.
               1. Append _name_ to _classPrivateEnvironment_.[[Names]].
-        1. If |ClassHeritage?| is not present, then
+        1. If |ClassHeritage| is not present, then
           1. Let _protoParent_ be %Object.prototype%.
           1. Let _constructorParent_ be %Function.prototype%.
         1. Else,
@@ -24927,7 +24927,7 @@
             1. If _protoParent_ is not an Object and _protoParent_ is not *null*, throw a *TypeError* exception.
             1. Let _constructorParent_ be _superclass_.
         1. Let _proto_ be OrdinaryObjectCreate(_protoParent_).
-        1. If |ClassBody?| is not present, let _constructor_ be ~empty~.
+        1. If |ClassBody| is not present, let _constructor_ be ~empty~.
         1. Else, let _constructor_ be ConstructorMethod of |ClassBody|.
         1. Set the running execution context's LexicalEnvironment to _classEnv_.
         1. Set the running execution context's PrivateEnvironment to _classPrivateEnvironment_.
@@ -24953,9 +24953,9 @@
           1. Perform MakeClassConstructor(_F_).
           1. Perform SetFunctionName(_F_, _className_).
         1. Perform MakeConstructor(_F_, *false*, _proto_).
-        1. If |ClassHeritage?| is present, set _F_.[[ConstructorKind]] to ~derived~.
+        1. If |ClassHeritage| is present, set _F_.[[ConstructorKind]] to ~derived~.
         1. Perform CreateMethodProperty(_proto_, *"constructor"*, _F_).
-        1. If |ClassBody?| is not present, let _elements_ be a new empty List.
+        1. If |ClassBody| is not present, let _elements_ be a new empty List.
         1. Else, let _elements_ be NonConstructorElements of |ClassBody|.
         1. Let _instancePrivateMethods_ be a new empty List.
         1. Let _staticPrivateMethods_ be a new empty List.


### PR DESCRIPTION
When an SDO definition is associated with a production that has `X?` on the RHS, the algorithm sometimes says:
    `if |X| is [not] present`
and sometimes says:
    `if |X?| is [not] present`

In the status quo, there are 78 occurrences of the former, vs only 7 of the latter, so change the latter to the former. (Most of them are in `ClassDefinitionEvaluation`.)

(Also, eliminate '?' from `the PrivateBoundIdentifiers of |ClassBody?|`.) 