### PR TITLE
Editorial: Introduce IsStrict() abstract operation

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -9699,7 +9699,7 @@
       </dl>
       <emu-grammar>IdentifierReference : Identifier</emu-grammar>
       <emu-alg>
-        1. If this |IdentifierReference| is contained in strict mode code and StringValue of |Identifier| is either *"eval"* or *"arguments"*, return ~invalid~.
+        1. If IsStrict(this |IdentifierReference|) is *true* and StringValue of |Identifier| is either *"eval"* or *"arguments"*, return ~invalid~.
         1. Return ~simple~.
       </emu-alg>
       <emu-grammar>
@@ -11841,7 +11841,7 @@
         1. If _env_ is not present or _env_ is *undefined*, then
           1. Set _env_ to the running execution context's LexicalEnvironment.
         1. Assert: _env_ is an Environment Record.
-        1. If the source text matched by the syntactic production that is being evaluated is contained in strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
+        1. Let _strict_ be IsStrict(the syntactic production that is being evaluated).
         1. Return ? GetIdentifierReference(_env_, _name_, _strict_).
       </emu-alg>
       <emu-note>
@@ -13477,7 +13477,7 @@
         1. Set _F_.[[SourceText]] to _sourceText_.
         1. Set _F_.[[FormalParameters]] to _ParameterList_.
         1. Set _F_.[[ECMAScriptCode]] to _Body_.
-        1. If the source text matched by _Body_ is strict mode code, let _Strict_ be *true*; else let _Strict_ be *false*.
+        1. Let _Strict_ be IsStrict(_Body_).
         1. Set _F_.[[Strict]] to _Strict_.
         1. If _thisMode_ is ~lexical-this~, set _F_.[[ThisMode]] to ~lexical~.
         1. Else if _Strict_ is *true*, set _F_.[[ThisMode]] to ~strict~.
@@ -16209,6 +16209,19 @@
         </li>
       </ul>
       <p>ECMAScript code that is not strict mode code is called <dfn id="non-strict-code">non-strict code</dfn>.</p>
+
+      <emu-clause id="sec-isstrict" type="abstract operation">
+        <h1>
+          Static Semantics: IsStrict (
+            _node_: a Parse Node,
+          ): a Boolean
+        </h1>
+        <dl class="header">
+        </dl>
+        <emu-alg>
+          1. If the source text matched by _node_ is strict mode code, return *true*; else return *false*.
+        </emu-alg>
+      </emu-clause>
     </emu-clause>
 
     <emu-clause id="sec-non-ecmascript-functions">
@@ -16878,7 +16891,7 @@
           DecimalIntegerLiteral :: NonOctalDecimalIntegerLiteral
         </emu-grammar>
         <ul>
-          <li>It is a Syntax Error if the source text matched by this production is strict mode code.</li>
+          <li>It is a Syntax Error if IsStrict(this production) is *true*.</li>
         </ul>
         <emu-note>In non-strict code, this syntax is Legacy.</emu-note>
       </emu-clause>
@@ -17145,7 +17158,7 @@
             NonOctalDecimalEscapeSequence
         </emu-grammar>
         <ul>
-          <li>It is a Syntax Error if the source text matched by this production is strict mode code.</li>
+          <li>It is a Syntax Error if IsStrict(this production) is *true*.</li>
         </ul>
         <emu-note>In non-strict code, this syntax is Legacy.</emu-note>
         <emu-note>
@@ -18002,7 +18015,7 @@
       <emu-grammar>BindingIdentifier : Identifier</emu-grammar>
       <ul>
         <li>
-          It is a Syntax Error if the source text matched by this production is contained in strict mode code and the StringValue of |Identifier| is either *"arguments"* or *"eval"*.
+          It is a Syntax Error if IsStrict(this production) is *true* and the StringValue of |Identifier| is either *"arguments"* or *"eval"*.
         </li>
       </ul>
       <emu-grammar>
@@ -18014,7 +18027,7 @@
       </emu-grammar>
       <ul>
         <li>
-          It is a Syntax Error if the source text matched by this production is contained in strict mode code.
+          It is a Syntax Error if IsStrict(this production) is *true*.
         </li>
       </ul>
       <emu-grammar>
@@ -18063,7 +18076,7 @@
       <emu-grammar>Identifier : IdentifierName but not ReservedWord</emu-grammar>
       <ul>
         <li>
-          It is a Syntax Error if this phrase is contained in strict mode code and the StringValue of |IdentifierName| is one of *"implements"*, *"interface"*, *"let"*, *"package"*, *"private"*, *"protected"*, *"public"*, *"static"*, or *"yield"*.
+          It is a Syntax Error if IsStrict(this phrase) is *true* and the StringValue of |IdentifierName| is one of *"implements"*, *"interface"*, *"let"*, *"package"*, *"private"*, *"protected"*, *"public"*, *"static"*, or *"yield"*.
         </li>
         <li>
           It is a Syntax Error if the goal symbol of the syntactic grammar is |Module| and the StringValue of |IdentifierName| is *"await"*.
@@ -19096,14 +19109,14 @@
         <emu-alg>
           1. Let _baseReference_ be ? Evaluation of |MemberExpression|.
           1. Let _baseValue_ be ? GetValue(_baseReference_).
-          1. If the source text matched by this |MemberExpression| is strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
+          1. Let _strict_ be IsStrict(this |MemberExpression|).
           1. Return ? EvaluatePropertyAccessWithExpressionKey(_baseValue_, |Expression|, _strict_).
         </emu-alg>
         <emu-grammar>MemberExpression : MemberExpression `.` IdentifierName</emu-grammar>
         <emu-alg>
           1. Let _baseReference_ be ? Evaluation of |MemberExpression|.
           1. Let _baseValue_ be ? GetValue(_baseReference_).
-          1. If the source text matched by this |MemberExpression| is strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
+          1. Let _strict_ be IsStrict(this |MemberExpression|).
           1. Return EvaluatePropertyAccessWithIdentifierKey(_baseValue_, |IdentifierName|, _strict_).
         </emu-alg>
         <emu-grammar>MemberExpression : MemberExpression `.` PrivateIdentifier</emu-grammar>
@@ -19117,14 +19130,14 @@
         <emu-alg>
           1. Let _baseReference_ be ? Evaluation of |CallExpression|.
           1. Let _baseValue_ be ? GetValue(_baseReference_).
-          1. If the source text matched by this |CallExpression| is strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
+          1. Let _strict_ be IsStrict(this |CallExpression|).
           1. Return ? EvaluatePropertyAccessWithExpressionKey(_baseValue_, |Expression|, _strict_).
         </emu-alg>
         <emu-grammar>CallExpression : CallExpression `.` IdentifierName</emu-grammar>
         <emu-alg>
           1. Let _baseReference_ be ? Evaluation of |CallExpression|.
           1. Let _baseValue_ be ? GetValue(_baseReference_).
-          1. If the source text matched by this |CallExpression| is strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
+          1. Let _strict_ be IsStrict(this |CallExpression|).
           1. Return EvaluatePropertyAccessWithIdentifierKey(_baseValue_, |IdentifierName|, _strict_).
         </emu-alg>
         <emu-grammar>CallExpression : CallExpression `.` PrivateIdentifier</emu-grammar>
@@ -19225,7 +19238,7 @@
               1. Let _argList_ be ? ArgumentListEvaluation of _arguments_.
               1. If _argList_ has no elements, return *undefined*.
               1. Let _evalArg_ be the first element of _argList_.
-              1. If the source text matched by this |CallExpression| is strict mode code, let _strictCaller_ be *true*. Otherwise let _strictCaller_ be *false*.
+              1. If IsStrict(this |CallExpression|) is *true*, let _strictCaller_ be *true*. Otherwise let _strictCaller_ be *false*.
               1. [id="step-callexpression-evaluation-direct-eval"] Return ? PerformEval(_evalArg_, _strictCaller_, *true*).
           1. Let _thisCall_ be this |CallExpression|.
           1. Let _tailCall_ be IsInTailPosition(_thisCall_).
@@ -19284,7 +19297,7 @@
           1. Let _propertyNameReference_ be ? Evaluation of |Expression|.
           1. Let _propertyNameValue_ be ? GetValue(_propertyNameReference_).
           1. Let _propertyKey_ be ? ToPropertyKey(_propertyNameValue_).
-          1. If the source text matched by this |SuperProperty| is strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
+          1. Let _strict_ be IsStrict(this |SuperProperty|).
           1. Return ? MakeSuperPropertyReference(_actualThis_, _propertyKey_, _strict_).
         </emu-alg>
         <emu-grammar>SuperProperty : `super` `.` IdentifierName</emu-grammar>
@@ -19292,7 +19305,7 @@
           1. Let _env_ be GetThisEnvironment().
           1. Let _actualThis_ be ? _env_.GetThisBinding().
           1. Let _propertyKey_ be StringValue of |IdentifierName|.
-          1. If the source text matched by this |SuperProperty| is strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
+          1. Let _strict_ be IsStrict(this |SuperProperty|).
           1. Return ? MakeSuperPropertyReference(_actualThis_, _propertyKey_, _strict_).
         </emu-alg>
         <emu-grammar>SuperCall : `super` Arguments</emu-grammar>
@@ -19475,12 +19488,12 @@
         </emu-alg>
         <emu-grammar>OptionalChain : `?.` `[` Expression `]`</emu-grammar>
         <emu-alg>
-          1. If the source text matched by this |OptionalChain| is strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
+          1. Let _strict_ be IsStrict(this |OptionalChain|).
           1. Return ? EvaluatePropertyAccessWithExpressionKey(_baseValue_, |Expression|, _strict_).
         </emu-alg>
         <emu-grammar>OptionalChain : `?.` IdentifierName</emu-grammar>
         <emu-alg>
-          1. If the source text matched by this |OptionalChain| is strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
+          1. Let _strict_ be IsStrict(this |OptionalChain|).
           1. Return EvaluatePropertyAccessWithIdentifierKey(_baseValue_, |IdentifierName|, _strict_).
         </emu-alg>
         <emu-grammar>OptionalChain : `?.` PrivateIdentifier</emu-grammar>
@@ -19502,7 +19515,7 @@
           1. Let _optionalChain_ be |OptionalChain|.
           1. Let _newReference_ be ? ChainEvaluation of _optionalChain_ with arguments _baseValue_ and _baseReference_.
           1. Let _newValue_ be ? GetValue(_newReference_).
-          1. If the source text matched by this |OptionalChain| is strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
+          1. Let _strict_ be IsStrict(this |OptionalChain|).
           1. Return ? EvaluatePropertyAccessWithExpressionKey(_newValue_, |Expression|, _strict_).
         </emu-alg>
         <emu-grammar>OptionalChain : OptionalChain `.` IdentifierName</emu-grammar>
@@ -19510,7 +19523,7 @@
           1. Let _optionalChain_ be |OptionalChain|.
           1. Let _newReference_ be ? ChainEvaluation of _optionalChain_ with arguments _baseValue_ and _baseReference_.
           1. Let _newValue_ be ? GetValue(_newReference_).
-          1. If the source text matched by this |OptionalChain| is strict mode code, let _strict_ be *true*; else let _strict_ be *false*.
+          1. Let _strict_ be IsStrict(this |OptionalChain|).
           1. Return EvaluatePropertyAccessWithIdentifierKey(_newValue_, |IdentifierName|, _strict_).
         </emu-alg>
         <emu-grammar>OptionalChain : OptionalChain `.` PrivateIdentifier</emu-grammar>
@@ -19816,7 +19829,7 @@
         <emu-grammar>UnaryExpression : `delete` UnaryExpression</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the |UnaryExpression| is contained in strict mode code and the derived |UnaryExpression| is <emu-grammar>PrimaryExpression : IdentifierReference</emu-grammar>, <emu-grammar>MemberExpression : MemberExpression `.` PrivateIdentifier</emu-grammar>, <emu-grammar>CallExpression : CallExpression `.` PrivateIdentifier</emu-grammar>, <emu-grammar>OptionalChain : `?.` PrivateIdentifier</emu-grammar>, or <emu-grammar>OptionalChain : OptionalChain `.` PrivateIdentifier</emu-grammar>.
+            It is a Syntax Error if IsStrict(the |UnaryExpression|) is *true* and the derived |UnaryExpression| is <emu-grammar>PrimaryExpression : IdentifierReference</emu-grammar>, <emu-grammar>MemberExpression : MemberExpression `.` PrivateIdentifier</emu-grammar>, <emu-grammar>CallExpression : CallExpression `.` PrivateIdentifier</emu-grammar>, <emu-grammar>OptionalChain : `?.` PrivateIdentifier</emu-grammar>, or <emu-grammar>OptionalChain : OptionalChain `.` PrivateIdentifier</emu-grammar>.
           </li>
           <li>
             <p>
@@ -22536,7 +22549,7 @@
       <emu-grammar>WithStatement : `with` `(` Expression `)` Statement</emu-grammar>
       <ul>
         <li>
-          It is a Syntax Error if the source text matched by this production is contained in strict mode code.
+          It is a Syntax Error if IsStrict(this production) is *true*.
         </li>
         <li>
           It is a Syntax Error if IsLabelledFunction(|Statement|) is *true*.
@@ -23324,10 +23337,10 @@
       </emu-grammar>
       <ul>
         <li>
-          If the source text matched by |FormalParameters| is strict mode code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.
+          If IsStrict(|FormalParameters|) is *true*, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.
         </li>
         <li>
-          If |BindingIdentifier| is present and the source text matched by |BindingIdentifier| is strict mode code, it is a Syntax Error if the StringValue of |BindingIdentifier| is either *"eval"* or *"arguments"*.
+          If |BindingIdentifier| is present and IsStrict(|BindingIdentifier|) is *true*, it is a Syntax Error if the StringValue of |BindingIdentifier| is either *"eval"* or *"arguments"*.
         </li>
         <li>
           It is a Syntax Error if FunctionBodyContainsUseStrict of |FunctionBody| is *true* and IsSimpleParameterList of |FormalParameters| is *false*.
@@ -23893,10 +23906,10 @@
       </emu-grammar>
       <ul>
         <li>
-          If the source text matched by |FormalParameters| is strict mode code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.
+          If IsStrict(|FormalParameters|) is *true*, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.
         </li>
         <li>
-          If |BindingIdentifier| is present and the source text matched by |BindingIdentifier| is strict mode code, it is a Syntax Error if the StringValue of |BindingIdentifier| is either *"eval"* or *"arguments"*.
+          If |BindingIdentifier| is present and IsStrict(|BindingIdentifier|) is *true*, it is a Syntax Error if the StringValue of |BindingIdentifier| is either *"eval"* or *"arguments"*.
         </li>
         <li>
           It is a Syntax Error if FunctionBodyContainsUseStrict of |GeneratorBody| is *true* and IsSimpleParameterList of |FormalParameters| is *false*.
@@ -24134,8 +24147,8 @@
           `async` `function` `*` BindingIdentifier? `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
       </emu-grammar>
       <ul>
-        <li>If the source text matched by |FormalParameters| is strict mode code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.</li>
-        <li>If |BindingIdentifier| is present and the source text matched by |BindingIdentifier| is strict mode code, it is a Syntax Error if the StringValue of |BindingIdentifier| is either *"eval"* or *"arguments"*.</li>
+        <li>If IsStrict(|FormalParameters|) is *true*, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.</li>
+        <li>If |BindingIdentifier| is present and IsStrict(|BindingIdentifier|) is *true*, it is a Syntax Error if the StringValue of |BindingIdentifier| is either *"eval"* or *"arguments"*.</li>
         <li>It is a Syntax Error if FunctionBodyContainsUseStrict of |AsyncGeneratorBody| is *true* and IsSimpleParameterList of |FormalParameters| is *false*.</li>
         <li>It is a Syntax Error if any element of the BoundNames of |FormalParameters| also occurs in the LexicallyDeclaredNames of |AsyncGeneratorBody|.</li>
         <li>It is a Syntax Error if |FormalParameters| Contains |YieldExpression| is *true*.</li>
@@ -25080,8 +25093,8 @@
       <ul>
         <li>It is a Syntax Error if FunctionBodyContainsUseStrict of |AsyncFunctionBody| is *true* and IsSimpleParameterList of |FormalParameters| is *false*.</li>
         <li>It is a Syntax Error if |FormalParameters| Contains |AwaitExpression| is *true*.</li>
-        <li>If the source text matched by |FormalParameters| is strict mode code, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.</li>
-        <li>If |BindingIdentifier| is present and the source text matched by |BindingIdentifier| is strict mode code, it is a Syntax Error if the StringValue of |BindingIdentifier| is either *"eval"* or *"arguments"*.</li>
+        <li>If IsStrict(|FormalParameters|) is *true*, the Early Error rules for <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar> are applied.</li>
+        <li>If |BindingIdentifier| is present and IsStrict(|BindingIdentifier|) is *true*, it is a Syntax Error if the StringValue of |BindingIdentifier| is either *"eval"* or *"arguments"*.</li>
         <li>It is a Syntax Error if any element of the BoundNames of |FormalParameters| also occurs in the LexicallyDeclaredNames of |AsyncFunctionBody|.</li>
         <li>It is a Syntax Error if |FormalParameters| Contains |SuperProperty| is *true*.</li>
         <li>It is a Syntax Error if |AsyncFunctionBody| Contains |SuperProperty| is *true*.</li>
@@ -25353,7 +25366,7 @@
       <dl class="header">
       </dl>
       <emu-alg>
-        1. If the source text matched by _call_ is non-strict code, return *false*.
+        1. If IsStrict(_call_) is *false*, return *false*.
         1. If _call_ is not contained within a |FunctionBody|, a |ConciseBody|, or an |AsyncConciseBody|, return *false*.
         1. Let _body_ be the |FunctionBody|, |ConciseBody|, or |AsyncConciseBody| that most closely contains _call_.
         1. If _body_ is the |FunctionBody| of a |GeneratorBody|, return *false*.
@@ -25767,8 +25780,8 @@
       </ul>
     </emu-clause>
 
-    <emu-clause id="sec-static-semantics-isstrict" type="sdo">
-      <h1>Static Semantics: IsStrict ( ): a Boolean</h1>
+    <emu-clause id="sec-scriptisstrict" oldids="sec-static-semantics-isstrict" type="sdo">
+      <h1>Static Semantics: ScriptIsStrict ( ): a Boolean</h1>
       <dl class="header">
       </dl>
       <emu-grammar>Script : ScriptBody?</emu-grammar>
@@ -28907,7 +28920,7 @@
             1. If _inDerivedConstructor_ is *false* and _body_ Contains |SuperCall|, throw a *SyntaxError* exception.
             1. If _inClassFieldInitializer_ is *true* and ContainsArguments of _body_ is *true*, throw a *SyntaxError* exception.
           1. If _strictCaller_ is *true*, let _strictEval_ be *true*.
-          1. Else, let _strictEval_ be IsStrict of _script_.
+          1. Else, let _strictEval_ be ScriptIsStrict of _script_.
           1. Let _runningContext_ be the running execution context.
           1. NOTE: If _direct_ is *true*, _runningContext_ will be the execution context that performed the direct eval. If _direct_ is *false*, _runningContext_ will be the execution context for the invocation of the `eval` function.
           1. If _direct_ is *true*, then
@@ -50523,7 +50536,7 @@ THH:mm:ss.sss
         <p>During GlobalDeclarationInstantiation the following steps are performed in place of step <emu-xref href="#step-globaldeclarationinstantiation-web-compat-insertion-point"></emu-xref>:</p>
         <emu-alg replaces-step="step-globaldeclarationinstantiation-web-compat-insertion-point">
           1. Perform the following steps:
-            1. Let _strict_ be IsStrict of _script_.
+            1. Let _strict_ be ScriptIsStrict of _script_.
             1. If _strict_ is *false*, then
               1. Let _declaredFunctionOrVarNames_ be the list-concatenation of _declaredFunctionNames_ and _declaredVarNames_.
               1. For each |FunctionDeclaration| _f_ that is directly contained in the |StatementList| of a |Block|, |CaseClause|, or |DefaultClause| Contained within _script_, do
@@ -50594,7 +50607,7 @@ THH:mm:ss.sss
         <emu-grammar>Block : `{` StatementList `}`</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the LexicallyDeclaredNames of |StatementList| contains any duplicate entries<ins>, unless the source text matched by this production is not strict mode code and the duplicate entries are only bound by FunctionDeclarations</ins>.
+            It is a Syntax Error if the LexicallyDeclaredNames of |StatementList| contains any duplicate entries<ins>, unless IsStrict(this production) is *false* and the duplicate entries are only bound by FunctionDeclarations</ins>.
           </li>
           <li>
             It is a Syntax Error if any element of the LexicallyDeclaredNames of |StatementList| also occurs in the VarDeclaredNames of |StatementList|.
@@ -50608,7 +50621,7 @@ THH:mm:ss.sss
         <emu-grammar>SwitchStatement : `switch` `(` Expression `)` CaseBlock</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the LexicallyDeclaredNames of |CaseBlock| contains any duplicate entries<ins>, unless the source text matched by this production is not strict mode code and the duplicate entries are only bound by FunctionDeclarations</ins>.
+            It is a Syntax Error if the LexicallyDeclaredNames of |CaseBlock| contains any duplicate entries<ins>, unless IsStrict(this production) is *false* and the duplicate entries are only bound by FunctionDeclarations</ins>.
           </li>
           <li>
             It is a Syntax Error if any element of the LexicallyDeclaredNames of |CaseBlock| also occurs in the VarDeclaredNames of |CaseBlock|.


### PR DESCRIPTION
I've broken it out into ~6~ 5 commits in case that helps review.

----
commit 1:

Rename the existing SDO "IsStrict" to "ScriptIsStrict", because it's specific to Scripts, and I want the general name for the general operation.

----
commit 2:

The algorithms in the spec have 7 occurrences of:
```
X is contained in strict mode code
```
and 22 occurrences of:
```
X is strict mode code
```
This commit changes all of the former to the latter.

It isn't obvious whether or not this is a trivial change.

At first, I thought it was non-trivial, with the following reasoning: Clearly, you can have islands of strict mode code (SMC) within a sea of non-SMC. So, for such an island, it seems like it *is* SMC, but it's not *contained in* SMC, it's contained in non-SMC. (And so, this commit's change might cause the conditions to admit cases they currently don't, when X is SMC but isn't contained in SMC.)

However, consider test262's `language/statements/function/name-eval-strict-body.js`, which is basically:
```
/*---
negative
  phase: parse
  type: SyntaxError
flags: [noStrict]
---*/
$DONOTEVALUATE();
function eval() { 'use strict'; }
```
which throws a SyntaxError because (roughly speaking) 'eval' isn't allowed as the name of a strict mode function.

In more detail:
- The `[noStrict]` means that the global code is non-SMC.

- The 'use strict' means that the source text matched by:
  - the FunctionBody,
  - the (empty) FormalParameters, and
  - the BindingIdentifier

  are all SMC. 

- The relevant early error rule is from [13.1.1 Static Semantics: Early Errors](), for `BindingIdentifier : Identifier`:
> It is a Syntax Error if the source text matched by this production is contained in strict mode code and the StringValue of |Identifier| is either **"arguments"** or **"eval"**.

So in order for this error to apply, we must conclude that the source text matched by `BindingIdentifier` is *contained in* SMC. We can readily agree that it *is* SMC, but "contained in" is trickier: is `eval` contained in `eval`? Or maybe the idea is that `eval` is part of all the SMC associated with the function decl.

Anyhow, it seems like, as far as the spec is concerned, "is contained in SMC" means the same as "is SMC", 

----
commit #3:

Normally, we say "the source text matched by X is strict mode code", but 3 spots leave out "the source text matched by". I think that's just a mistake, so this commit inserts the missing text. 

----
commit #4:

With the relevant pseudocode mostly consistified, introduce the IsStrict() abstract operation.

----
commit #5:

Change:
```
If IsStrict(X) is *true*, let _strict_ be *true*; else let _strict_ be *false*.
```
to just:
```
Let _strict_ be IsStrict(X).
```

----
commit #6: [Dropped Oct 28]

`IsStrict(this production)`
sounds odd, like it's asking whether a production is strict. So this commit changes such usages to
`IsStrict(this |Foo|)`
where possible (i.e., when the associated productions have only one LHS symbol), and to
`IsStrict(this phrase)`
otherwise.
