### PR TITLE
Editorial: call MakeClassConstructor on default class constructor

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -13419,7 +13419,7 @@
             a Boolean
           </td>
           <td>
-            Indicates whether the function is a class constructor. (If *true*, invoking the function's [[Call]] will immediately throw a *TypeError* exception.)
+            Indicates whether the function is a class constructor. This field also appears on built-in functions, but it is only *true* for derived class constructors. (If *true*, invoking the function's [[Call]] will immediately throw a *TypeError* exception.)
           </td>
         </tr>
       </table>
@@ -13741,7 +13741,7 @@
     <emu-clause id="sec-makeclassconstructor" type="abstract operation">
       <h1>
         MakeClassConstructor (
-          _F_: an ECMAScript function object,
+          _F_: a function object,
         ): ~unused~
       </h1>
       <dl class="header">
@@ -13989,6 +13989,7 @@
     <ul>
       <li>[[Realm]], a Realm Record that represents the realm in which the function was created.</li>
       <li>[[InitialName]], a String that is the initial name of the function. It is used by <emu-xref href="#sec-function.prototype.tostring"></emu-xref>.</li>
+      <li>[[IsClassConstructor]], indicates whether the function is a derived class constructor. This field also appears on ECMAScript functions. (If *true*, invoking the function's [[Call]] will immediately throw a *TypeError* exception.)</li>
     </ul>
     <p>The initial value of a built-in function object's [[Prototype]] internal slot is %Function.prototype%, unless otherwise specified.</p>
     <p>A built-in function object must have a [[Call]] internal method that conforms to the definition in <emu-xref href="#sec-built-in-function-objects-call-thisargument-argumentslist"></emu-xref>.</p>
@@ -14086,6 +14087,7 @@
         1. Set _func_.[[Extensible]] to *true*.
         1. Set _func_.[[Realm]] to _realm_.
         1. Set _func_.[[InitialName]] to *null*.
+        1. Set _func_.[[IsClassConstructor]] to *false*.
         1. Perform SetFunctionLength(_func_, _length_).
         1. If _prefix_ is not present, then
           1. Perform SetFunctionName(_func_, _name_).
@@ -25220,9 +25222,9 @@
         1. Else,
           1. Let _constructorInfo_ be ! DefineMethod of _constructor_ with arguments _proto_ and _constructorParent_.
           1. Let _F_ be _constructorInfo_.[[Closure]].
-          1. Perform MakeClassConstructor(_F_).
           1. Perform SetFunctionName(_F_, _className_).
         1. Perform MakeConstructor(_F_, *false*, _proto_).
+        1. Perform MakeClassConstructor(_F_).
         1. If |ClassHeritage| is present, set _F_.[[ConstructorKind]] to ~derived~.
         1. Perform ! DefineMethodProperty(_proto_, *"constructor"*, _F_, *false*).
         1. If |ClassBody| is not present, let _elements_ be a new empty List.


### PR DESCRIPTION
The new pattern-matching proposal expects `[[IsClassConstructor]]` to be true for class constructors. The current spec only sets this field for ECMAScript functions. This PR expands it to default class constructors.

This should be an editorial change.