### PR TITLE
Meta: bump ecmarkup to 18.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://tc39.es/ecma262/#sec-copyright-and-software-license",
       "dependencies": {
-        "ecmarkup": "^18.0.0"
+        "ecmarkup": "^18.1.0"
       },
       "devDependencies": {
         "glob": "^7.1.6",
@@ -724,9 +724,9 @@
       }
     },
     "node_modules/ecmarkup": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-18.0.0.tgz",
-      "integrity": "sha512-VSItKQ+39dv1FeR1YbGGlJ/rx17wsPSkS7morrOCwLGHh+7ehy89hao+rQ0/ptiBAN3nbytXzwUBUTC3XNmxaA==",
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-18.1.0.tgz",
+      "integrity": "sha512-0ngQ2YYizUkswKZcCn8g8BlCoaEAN8R2DOZfupk0k2lnIWzUZJNxjld4lt97YTJxcZxVTMERmukZ8svBSz9UcQ==",
       "dependencies": {
         "chalk": "^4.1.2",
         "command-line-args": "^5.2.0",
@@ -2940,9 +2940,9 @@
       }
     },
     "ecmarkup": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-18.0.0.tgz",
-      "integrity": "sha512-VSItKQ+39dv1FeR1YbGGlJ/rx17wsPSkS7morrOCwLGHh+7ehy89hao+rQ0/ptiBAN3nbytXzwUBUTC3XNmxaA==",
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-18.1.0.tgz",
+      "integrity": "sha512-0ngQ2YYizUkswKZcCn8g8BlCoaEAN8R2DOZfupk0k2lnIWzUZJNxjld4lt97YTJxcZxVTMERmukZ8svBSz9UcQ==",
       "requires": {
         "chalk": "^4.1.2",
         "command-line-args": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "license": "SEE LICENSE IN https://tc39.es/ecma262/#sec-copyright-and-software-license",
   "homepage": "https://tc39.es/ecma262/",
   "dependencies": {
-    "ecmarkup": "^18.0.0"
+    "ecmarkup": "^18.1.0"
   },
   "devDependencies": {
     "glob": "^7.1.6",


### PR DESCRIPTION
Unblocks https://github.com/tc39/ecma262/pull/3163 by inclusion of https://github.com/tc39/ecmarkup/pull/558.

Unblocks https://github.com/tc39/ecma262/pull/3175 by inclusion of https://github.com/tc39/ecmarkup/pull/559. #3175 will need to be updated to add the `skip global checks` attribute to `DetachArrayBuffer` so that ecmarkup knows not to try to apply whole-program analysis to it.