### PR TITLE
Editorial: Define template literal bad-escape syntax errors at top level

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -18635,18 +18635,18 @@
       <emu-grammar type="definition">
         TemplateLiteral[Yield, Await, Tagged] :
           NoSubstitutionTemplate
-          SubstitutionTemplate[?Yield, ?Await, ?Tagged]
+          SubstitutionTemplate[?Yield, ?Await]
 
-        SubstitutionTemplate[Yield, Await, Tagged] :
-          TemplateHead Expression[+In, ?Yield, ?Await] TemplateSpans[?Yield, ?Await, ?Tagged]
+        SubstitutionTemplate[Yield, Await] :
+          TemplateHead Expression[+In, ?Yield, ?Await] TemplateSpans[?Yield, ?Await]
 
-        TemplateSpans[Yield, Await, Tagged] :
+        TemplateSpans[Yield, Await] :
           TemplateTail
-          TemplateMiddleList[?Yield, ?Await, ?Tagged] TemplateTail
+          TemplateMiddleList[?Yield, ?Await] TemplateTail
 
-        TemplateMiddleList[Yield, Await, Tagged] :
+        TemplateMiddleList[Yield, Await] :
           TemplateMiddle Expression[+In, ?Yield, ?Await]
-          TemplateMiddleList[?Yield, ?Await, ?Tagged] TemplateMiddle Expression[+In, ?Yield, ?Await]
+          TemplateMiddleList[?Yield, ?Await] TemplateMiddle Expression[+In, ?Yield, ?Await]
       </emu-grammar>
 
       <emu-clause id="sec-static-semantics-template-early-errors" oldids="sec-primary-expression-template-literals-static-semantics-early-errors">
@@ -18661,7 +18661,7 @@
         </ul>
 
         <emu-grammar>
-          TemplateLiteral[Yield, Await, Tagged] : SubstitutionTemplate[?Yield, ?Await, ?Tagged]
+          TemplateLiteral[Yield, Await, Tagged] : SubstitutionTemplate[?Yield, ?Await]
         </emu-grammar>
         <ul>
           <li>

--- a/spec.html
+++ b/spec.html
@@ -18656,7 +18656,7 @@
         </emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the <sub>[Tagged]</sub> parameter was not set and |NoSubstitutionTemplate| Contains |NotEscapeSequence|.
+            It is a Syntax Error if the <sub>[Tagged]</sub> parameter was not set and the result of TemplateStrings of |TemplateLiteral| with argument *false* contains *undefined*.
           </li>
         </ul>
 
@@ -18665,36 +18665,10 @@
         </emu-grammar>
         <ul>
           <li>
+            It is a Syntax Error if the <sub>[Tagged]</sub> parameter was not set and the result of TemplateStrings of |TemplateLiteral| with argument *false* contains *undefined*.
+          </li>
+          <li>
             It is a Syntax Error if the number of elements in the result of TemplateStrings of |TemplateLiteral| with argument *false* is greater than or equal to 2<sup>32</sup>.
-          </li>
-        </ul>
-
-        <emu-grammar>
-          SubstitutionTemplate[Yield, Await, Tagged] : TemplateHead Expression[+In, ?Yield, ?Await] TemplateSpans[?Yield, ?Await, ?Tagged]
-        </emu-grammar>
-        <ul>
-          <li>
-            It is a Syntax Error if the <sub>[Tagged]</sub> parameter was not set and |TemplateHead| Contains |NotEscapeSequence|.
-          </li>
-        </ul>
-
-        <emu-grammar>
-          TemplateSpans[Yield, Await, Tagged] : TemplateTail
-        </emu-grammar>
-        <ul>
-          <li>
-            It is a Syntax Error if the <sub>[Tagged]</sub> parameter was not set and |TemplateTail| Contains |NotEscapeSequence|.
-          </li>
-        </ul>
-
-        <emu-grammar>
-          TemplateMiddleList[Yield, Await, Tagged] :
-            TemplateMiddle Expression[+In, ?Yield, ?Await]
-            TemplateMiddleList[?Yield, ?Await, ?Tagged] TemplateMiddle Expression[+In, ?Yield, ?Await]
-        </emu-grammar>
-        <ul>
-          <li>
-            It is a Syntax Error if the <sub>[Tagged]</sub> parameter was not set and |TemplateMiddle| Contains |NotEscapeSequence|.
           </li>
         </ul>
       </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -19289,7 +19289,7 @@
         </emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the <sub>[Tagged]</sub> parameter was not set and |NoSubstitutionTemplate| Contains |NotEscapeSequence|.
+            It is a Syntax Error if the <sub>[Tagged]</sub> parameter was not set and the TemplateStrings of |TemplateLiteral| with argument *false* contains *undefined*.
           </li>
         </ul>
 
@@ -19298,36 +19298,10 @@
         </emu-grammar>
         <ul>
           <li>
+            It is a Syntax Error if the <sub>[Tagged]</sub> parameter was not set and the TemplateStrings of |TemplateLiteral| with argument *false* contains *undefined*.
+          </li>
+          <li>
             It is a Syntax Error if the number of elements in the TemplateStrings of |TemplateLiteral| with argument *false* is greater than or equal to 2<sup>32</sup>.
-          </li>
-        </ul>
-
-        <emu-grammar>
-          SubstitutionTemplate[Yield, Await, Tagged] : TemplateHead Expression[+In, ?Yield, ?Await] TemplateSpans[?Yield, ?Await, ?Tagged]
-        </emu-grammar>
-        <ul>
-          <li>
-            It is a Syntax Error if the <sub>[Tagged]</sub> parameter was not set and |TemplateHead| Contains |NotEscapeSequence|.
-          </li>
-        </ul>
-
-        <emu-grammar>
-          TemplateSpans[Yield, Await, Tagged] : TemplateTail
-        </emu-grammar>
-        <ul>
-          <li>
-            It is a Syntax Error if the <sub>[Tagged]</sub> parameter was not set and |TemplateTail| Contains |NotEscapeSequence|.
-          </li>
-        </ul>
-
-        <emu-grammar>
-          TemplateMiddleList[Yield, Await, Tagged] :
-            TemplateMiddle Expression[+In, ?Yield, ?Await]
-            TemplateMiddleList[?Yield, ?Await, ?Tagged] TemplateMiddle Expression[+In, ?Yield, ?Await]
-        </emu-grammar>
-        <ul>
-          <li>
-            It is a Syntax Error if the <sub>[Tagged]</sub> parameter was not set and |TemplateMiddle| Contains |NotEscapeSequence|.
           </li>
         </ul>
       </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -19289,7 +19289,7 @@
         </emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the <sub>[Tagged]</sub> parameter was not set and the TemplateStrings of |TemplateLiteral| with argument *false* contains *undefined*.
+            It is a Syntax Error if the <sub>[Tagged]</sub> parameter was not set and the TemplateStrings of |TemplateLiteral| with argument ~cooked~ contains *undefined*.
           </li>
         </ul>
 
@@ -19298,10 +19298,10 @@
         </emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the <sub>[Tagged]</sub> parameter was not set and the TemplateStrings of |TemplateLiteral| with argument *false* contains *undefined*.
+            It is a Syntax Error if the <sub>[Tagged]</sub> parameter was not set and the TemplateStrings of |TemplateLiteral| with argument ~cooked~ contains *undefined*.
           </li>
           <li>
-            It is a Syntax Error if the number of elements in the TemplateStrings of |TemplateLiteral| with argument *false* is greater than or equal to 2<sup>32</sup>.
+            It is a Syntax Error if the number of elements in the TemplateStrings of |TemplateLiteral| with argument ~cooked~ is greater than or equal to 2<sup>32</sup>.
           </li>
         </ul>
       </emu-clause>
@@ -19309,39 +19309,39 @@
       <emu-clause id="sec-static-semantics-templatestrings" type="sdo">
         <h1>
           Static Semantics: TemplateStrings (
-            _raw_: a Boolean,
+            _escapes_: ~raw~ or ~cooked~,
           ): a List of either Strings or *undefined*
         </h1>
         <dl class="header">
         </dl>
         <emu-grammar>TemplateLiteral : NoSubstitutionTemplate</emu-grammar>
         <emu-alg>
-          1. Return « TemplateString(|NoSubstitutionTemplate|, _raw_) ».
+          1. Return « TemplateString(|NoSubstitutionTemplate|, _escapes_) ».
         </emu-alg>
         <emu-grammar>SubstitutionTemplate : TemplateHead Expression TemplateSpans</emu-grammar>
         <emu-alg>
-          1. Let _head_ be « TemplateString(|TemplateHead|, _raw_) ».
-          1. Let _tail_ be the TemplateStrings of |TemplateSpans| with argument _raw_.
+          1. Let _head_ be « TemplateString(|TemplateHead|, _escapes_) ».
+          1. Let _tail_ be the TemplateStrings of |TemplateSpans| with argument _escapes_.
           1. Return the list-concatenation of _head_ and _tail_.
         </emu-alg>
         <emu-grammar>TemplateSpans : TemplateTail</emu-grammar>
         <emu-alg>
-          1. Return « TemplateString(|TemplateTail|, _raw_) ».
+          1. Return « TemplateString(|TemplateTail|, _escapes_) ».
         </emu-alg>
         <emu-grammar>TemplateSpans : TemplateMiddleList TemplateTail</emu-grammar>
         <emu-alg>
-          1. Let _middle_ be the TemplateStrings of |TemplateMiddleList| with argument _raw_.
-          1. Let _tail_ be « TemplateString(|TemplateTail|, _raw_) ».
+          1. Let _middle_ be the TemplateStrings of |TemplateMiddleList| with argument _escapes_.
+          1. Let _tail_ be « TemplateString(|TemplateTail|, _escapes_) ».
           1. Return the list-concatenation of _middle_ and _tail_.
         </emu-alg>
         <emu-grammar>TemplateMiddleList : TemplateMiddle Expression</emu-grammar>
         <emu-alg>
-          1. Return « TemplateString(|TemplateMiddle|, _raw_) ».
+          1. Return « TemplateString(|TemplateMiddle|, _escapes_) ».
         </emu-alg>
         <emu-grammar>TemplateMiddleList : TemplateMiddleList TemplateMiddle Expression</emu-grammar>
         <emu-alg>
-          1. Let _front_ be the TemplateStrings of |TemplateMiddleList| with argument _raw_.
-          1. Let _last_ be « TemplateString(|TemplateMiddle|, _raw_) ».
+          1. Let _front_ be the TemplateStrings of |TemplateMiddleList| with argument _escapes_.
+          1. Let _last_ be « TemplateString(|TemplateMiddle|, _escapes_) ».
           1. Return the list-concatenation of _front_ and _last_.
         </emu-alg>
       </emu-clause>
@@ -19350,20 +19350,17 @@
         <h1>
           Static Semantics: TemplateString (
             _templateToken_: a |NoSubstitutionTemplate| Parse Node, a |TemplateHead| Parse Node, a |TemplateMiddle| Parse Node, or a |TemplateTail| Parse Node,
-            _raw_: a Boolean,
+            _escapes_: ~raw~ or ~cooked~,
           ): a String or *undefined*
         </h1>
         <dl class="header">
         </dl>
         <emu-alg>
-          1. If _raw_ is *true*, then
-            1. Let _string_ be the TRV of _templateToken_.
-          1. Else,
-            1. Let _string_ be the TV of _templateToken_.
-          1. Return _string_.
+          1. If _escapes_ is ~raw~, return the TRV of _templateToken_.
+          1. Return the TV of _templateToken_.
         </emu-alg>
         <emu-note>
-          <p>This operation returns *undefined* if _raw_ is *false* and _templateToken_ contains a |NotEscapeSequence|. In all other cases, it returns a String.</p>
+          <p>This operation returns *undefined* if _escapes_ is ~raw~ and _templateToken_ contains a |NotEscapeSequence|. In all other cases, it returns a String.</p>
         </emu-note>
       </emu-clause>
 
@@ -19381,9 +19378,9 @@
           1. For each element _element_ of _templateRegistry_, do
             1. If _element_.[[Site]] is the same Parse Node as _templateLiteral_, then
               1. Return _element_.[[Array]].
-          1. Let _rawStrings_ be the TemplateStrings of _templateLiteral_ with argument *true*.
+          1. Let _rawStrings_ be the TemplateStrings of _templateLiteral_ with argument ~raw~.
           1. Assert: _rawStrings_ is a List of Strings.
-          1. Let _cookedStrings_ be the TemplateStrings of _templateLiteral_ with argument *false*.
+          1. Let _cookedStrings_ be the TemplateStrings of _templateLiteral_ with argument ~cooked~.
           1. Let _count_ be the number of elements in the List _cookedStrings_.
           1. Assert: _count_ ≤ 2<sup>32</sup> - 1.
           1. Let _template_ be ! ArrayCreate(_count_).

--- a/spec.html
+++ b/spec.html
@@ -19268,18 +19268,18 @@
       <emu-grammar type="definition">
         TemplateLiteral[Yield, Await, Tagged] :
           NoSubstitutionTemplate
-          SubstitutionTemplate[?Yield, ?Await, ?Tagged]
+          SubstitutionTemplate[?Yield, ?Await]
 
-        SubstitutionTemplate[Yield, Await, Tagged] :
-          TemplateHead Expression[+In, ?Yield, ?Await] TemplateSpans[?Yield, ?Await, ?Tagged]
+        SubstitutionTemplate[Yield, Await] :
+          TemplateHead Expression[+In, ?Yield, ?Await] TemplateSpans[?Yield, ?Await]
 
-        TemplateSpans[Yield, Await, Tagged] :
+        TemplateSpans[Yield, Await] :
           TemplateTail
-          TemplateMiddleList[?Yield, ?Await, ?Tagged] TemplateTail
+          TemplateMiddleList[?Yield, ?Await] TemplateTail
 
-        TemplateMiddleList[Yield, Await, Tagged] :
+        TemplateMiddleList[Yield, Await] :
           TemplateMiddle Expression[+In, ?Yield, ?Await]
-          TemplateMiddleList[?Yield, ?Await, ?Tagged] TemplateMiddle Expression[+In, ?Yield, ?Await]
+          TemplateMiddleList[?Yield, ?Await] TemplateMiddle Expression[+In, ?Yield, ?Await]
       </emu-grammar>
 
       <emu-clause id="sec-static-semantics-template-early-errors" oldids="sec-primary-expression-template-literals-static-semantics-early-errors">
@@ -19294,7 +19294,7 @@
         </ul>
 
         <emu-grammar>
-          TemplateLiteral[Yield, Await, Tagged] : SubstitutionTemplate[?Yield, ?Await, ?Tagged]
+          TemplateLiteral[Yield, Await, Tagged] : SubstitutionTemplate[?Yield, ?Await]
         </emu-grammar>
         <ul>
           <li>

--- a/spec.html
+++ b/spec.html
@@ -19338,7 +19338,7 @@
         </emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the <sub>[Tagged]</sub> parameter was not set and |NoSubstitutionTemplate| Contains |NotEscapeSequence|.
+            It is a Syntax Error if the <sub>[Tagged]</sub> parameter was not set and the TemplateStrings of |TemplateLiteral| with argument *false* contains *undefined*.
           </li>
         </ul>
 
@@ -19347,36 +19347,10 @@
         </emu-grammar>
         <ul>
           <li>
+            It is a Syntax Error if the <sub>[Tagged]</sub> parameter was not set and the TemplateStrings of |TemplateLiteral| with argument *false* contains *undefined*.
+          </li>
+          <li>
             It is a Syntax Error if the number of elements in the TemplateStrings of |TemplateLiteral| with argument *false* is greater than or equal to 2<sup>32</sup>.
-          </li>
-        </ul>
-
-        <emu-grammar>
-          SubstitutionTemplate[Yield, Await, Tagged] : TemplateHead Expression[+In, ?Yield, ?Await] TemplateSpans[?Yield, ?Await, ?Tagged]
-        </emu-grammar>
-        <ul>
-          <li>
-            It is a Syntax Error if the <sub>[Tagged]</sub> parameter was not set and |TemplateHead| Contains |NotEscapeSequence|.
-          </li>
-        </ul>
-
-        <emu-grammar>
-          TemplateSpans[Yield, Await, Tagged] : TemplateTail
-        </emu-grammar>
-        <ul>
-          <li>
-            It is a Syntax Error if the <sub>[Tagged]</sub> parameter was not set and |TemplateTail| Contains |NotEscapeSequence|.
-          </li>
-        </ul>
-
-        <emu-grammar>
-          TemplateMiddleList[Yield, Await, Tagged] :
-            TemplateMiddle Expression[+In, ?Yield, ?Await]
-            TemplateMiddleList[?Yield, ?Await, ?Tagged] TemplateMiddle Expression[+In, ?Yield, ?Await]
-        </emu-grammar>
-        <ul>
-          <li>
-            It is a Syntax Error if the <sub>[Tagged]</sub> parameter was not set and |TemplateMiddle| Contains |NotEscapeSequence|.
           </li>
         </ul>
       </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -19338,7 +19338,7 @@
         </emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the <sub>[Tagged]</sub> parameter was not set and the TemplateStrings of |TemplateLiteral| with argument *false* contains *undefined*.
+            It is a Syntax Error if the <sub>[Tagged]</sub> parameter was not set and the TemplateStrings of |TemplateLiteral| with argument ~cooked~ contains *undefined*.
           </li>
         </ul>
 
@@ -19347,10 +19347,10 @@
         </emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the <sub>[Tagged]</sub> parameter was not set and the TemplateStrings of |TemplateLiteral| with argument *false* contains *undefined*.
+            It is a Syntax Error if the <sub>[Tagged]</sub> parameter was not set and the TemplateStrings of |TemplateLiteral| with argument ~cooked~ contains *undefined*.
           </li>
           <li>
-            It is a Syntax Error if the number of elements in the TemplateStrings of |TemplateLiteral| with argument *false* is greater than or equal to 2<sup>32</sup>.
+            It is a Syntax Error if the number of elements in the TemplateStrings of |TemplateLiteral| with argument ~cooked~ is greater than or equal to 2<sup>32</sup>.
           </li>
         </ul>
       </emu-clause>
@@ -19358,39 +19358,39 @@
       <emu-clause id="sec-static-semantics-templatestrings" type="sdo">
         <h1>
           Static Semantics: TemplateStrings (
-            _raw_: a Boolean,
+            _escapes_: ~raw~ or ~cooked~,
           ): a List of either Strings or *undefined*
         </h1>
         <dl class="header">
         </dl>
         <emu-grammar>TemplateLiteral : NoSubstitutionTemplate</emu-grammar>
         <emu-alg>
-          1. Return « TemplateString(|NoSubstitutionTemplate|, _raw_) ».
+          1. Return « TemplateString(|NoSubstitutionTemplate|, _escapes_) ».
         </emu-alg>
         <emu-grammar>SubstitutionTemplate : TemplateHead Expression TemplateSpans</emu-grammar>
         <emu-alg>
-          1. Let _head_ be « TemplateString(|TemplateHead|, _raw_) ».
-          1. Let _tail_ be the TemplateStrings of |TemplateSpans| with argument _raw_.
+          1. Let _head_ be « TemplateString(|TemplateHead|, _escapes_) ».
+          1. Let _tail_ be the TemplateStrings of |TemplateSpans| with argument _escapes_.
           1. Return the list-concatenation of _head_ and _tail_.
         </emu-alg>
         <emu-grammar>TemplateSpans : TemplateTail</emu-grammar>
         <emu-alg>
-          1. Return « TemplateString(|TemplateTail|, _raw_) ».
+          1. Return « TemplateString(|TemplateTail|, _escapes_) ».
         </emu-alg>
         <emu-grammar>TemplateSpans : TemplateMiddleList TemplateTail</emu-grammar>
         <emu-alg>
-          1. Let _middle_ be the TemplateStrings of |TemplateMiddleList| with argument _raw_.
-          1. Let _tail_ be « TemplateString(|TemplateTail|, _raw_) ».
+          1. Let _middle_ be the TemplateStrings of |TemplateMiddleList| with argument _escapes_.
+          1. Let _tail_ be « TemplateString(|TemplateTail|, _escapes_) ».
           1. Return the list-concatenation of _middle_ and _tail_.
         </emu-alg>
         <emu-grammar>TemplateMiddleList : TemplateMiddle Expression</emu-grammar>
         <emu-alg>
-          1. Return « TemplateString(|TemplateMiddle|, _raw_) ».
+          1. Return « TemplateString(|TemplateMiddle|, _escapes_) ».
         </emu-alg>
         <emu-grammar>TemplateMiddleList : TemplateMiddleList TemplateMiddle Expression</emu-grammar>
         <emu-alg>
-          1. Let _front_ be the TemplateStrings of |TemplateMiddleList| with argument _raw_.
-          1. Let _last_ be « TemplateString(|TemplateMiddle|, _raw_) ».
+          1. Let _front_ be the TemplateStrings of |TemplateMiddleList| with argument _escapes_.
+          1. Let _last_ be « TemplateString(|TemplateMiddle|, _escapes_) ».
           1. Return the list-concatenation of _front_ and _last_.
         </emu-alg>
       </emu-clause>
@@ -19399,20 +19399,17 @@
         <h1>
           Static Semantics: TemplateString (
             _templateToken_: a |NoSubstitutionTemplate| Parse Node, a |TemplateHead| Parse Node, a |TemplateMiddle| Parse Node, or a |TemplateTail| Parse Node,
-            _raw_: a Boolean,
+            _escapes_: ~raw~ or ~cooked~,
           ): a String or *undefined*
         </h1>
         <dl class="header">
         </dl>
         <emu-alg>
-          1. If _raw_ is *true*, then
-            1. Let _string_ be the TRV of _templateToken_.
-          1. Else,
-            1. Let _string_ be the TV of _templateToken_.
-          1. Return _string_.
+          1. If _escapes_ is ~raw~, return the TRV of _templateToken_.
+          1. Return the TV of _templateToken_.
         </emu-alg>
         <emu-note>
-          <p>This operation returns *undefined* if _raw_ is *false* and _templateToken_ contains a |NotEscapeSequence|. In all other cases, it returns a String.</p>
+          <p>This operation returns *undefined* if _escapes_ is ~raw~ and _templateToken_ contains a |NotEscapeSequence|. In all other cases, it returns a String.</p>
         </emu-note>
       </emu-clause>
 
@@ -19430,9 +19427,9 @@
           1. For each element _element_ of _templateRegistry_, do
             1. If _element_.[[Site]] is the same Parse Node as _templateLiteral_, then
               1. Return _element_.[[Array]].
-          1. Let _rawStrings_ be the TemplateStrings of _templateLiteral_ with argument *true*.
+          1. Let _rawStrings_ be the TemplateStrings of _templateLiteral_ with argument ~raw~.
           1. Assert: _rawStrings_ is a List of Strings.
-          1. Let _cookedStrings_ be the TemplateStrings of _templateLiteral_ with argument *false*.
+          1. Let _cookedStrings_ be the TemplateStrings of _templateLiteral_ with argument ~cooked~.
           1. Let _count_ be the number of elements in the List _cookedStrings_.
           1. Assert: _count_ ≤ 2<sup>32</sup> - 1.
           1. Let _template_ be ! ArrayCreate(_count_).

--- a/spec.html
+++ b/spec.html
@@ -19317,18 +19317,18 @@
       <emu-grammar type="definition">
         TemplateLiteral[Yield, Await, Tagged] :
           NoSubstitutionTemplate
-          SubstitutionTemplate[?Yield, ?Await, ?Tagged]
+          SubstitutionTemplate[?Yield, ?Await]
 
-        SubstitutionTemplate[Yield, Await, Tagged] :
-          TemplateHead Expression[+In, ?Yield, ?Await] TemplateSpans[?Yield, ?Await, ?Tagged]
+        SubstitutionTemplate[Yield, Await] :
+          TemplateHead Expression[+In, ?Yield, ?Await] TemplateSpans[?Yield, ?Await]
 
-        TemplateSpans[Yield, Await, Tagged] :
+        TemplateSpans[Yield, Await] :
           TemplateTail
-          TemplateMiddleList[?Yield, ?Await, ?Tagged] TemplateTail
+          TemplateMiddleList[?Yield, ?Await] TemplateTail
 
-        TemplateMiddleList[Yield, Await, Tagged] :
+        TemplateMiddleList[Yield, Await] :
           TemplateMiddle Expression[+In, ?Yield, ?Await]
-          TemplateMiddleList[?Yield, ?Await, ?Tagged] TemplateMiddle Expression[+In, ?Yield, ?Await]
+          TemplateMiddleList[?Yield, ?Await] TemplateMiddle Expression[+In, ?Yield, ?Await]
       </emu-grammar>
 
       <emu-clause id="sec-static-semantics-template-early-errors" oldids="sec-primary-expression-template-literals-static-semantics-early-errors">
@@ -19343,7 +19343,7 @@
         </ul>
 
         <emu-grammar>
-          TemplateLiteral[Yield, Await, Tagged] : SubstitutionTemplate[?Yield, ?Await, ?Tagged]
+          TemplateLiteral[Yield, Await, Tagged] : SubstitutionTemplate[?Yield, ?Await]
         </emu-grammar>
         <ul>
           <li>


### PR DESCRIPTION
The TemplateStrings SDO provides all necessary information to detect invalid use of [|NotEscapeSequence|](https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#prod-NotEscapeSequence) in e.g. ```foo = `\xz`;```, and is already used in a similar way for the "too many substitutions" syntax errors.

This PR also refactors TemplateStrings and TemplateString parameters to avoid boolean traps (`_raw_: a Boolean` → `_escapes_: ~raw~ or ~cooked~`), which can be removed if we consider that to be out of scope.