### PR TITLE
Normative: Provide source text to HostEnsureCanCompileStrings

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -28936,7 +28936,7 @@
           1. If _x_ is not a String, return _x_.
           1. Let _evalRealm_ be the current Realm Record.
           1. NOTE: In the case of a direct eval, _evalRealm_ is the realm of both the caller of `eval` and of the `eval` function itself.
-          1. Perform ? HostEnsureCanCompileStrings(_evalRealm_).
+          1. Perform ? HostEnsureCanCompileStrings(_evalRealm_, « », _x_, _direct_).
           1. Let _inFunction_ be *false*.
           1. Let _inMethod_ be *false*.
           1. Let _inDerivedConstructor_ be *false*.
@@ -28999,12 +28999,19 @@
         <h1>
           HostEnsureCanCompileStrings (
             _calleeRealm_: a Realm Record,
+            _parameterStrings_: a List of Strings,
+            _bodyString_: a String,
+            _direct_: a Boolean,
           ): either a normal completion containing ~unused~ or a throw completion
         </h1>
         <dl class="header">
           <dt>description</dt>
           <dd>It allows host environments to block certain ECMAScript functions which allow developers to interpret and evaluate strings as ECMAScript code.</dd>
         </dl>
+        <p>
+          _parameterStrings_ represents the strings that, when using one of the function constructors, will be concatenated together to build the parameters list. _bodyString_ represents the function body or the string passed to an `eval` call.
+          _direct_ signifies whether the evaluation is a direct eval.
+        </p>
         <p>The default implementation of HostEnsureCanCompileStrings is to return NormalCompletion(~unused~).</p>
       </emu-clause>
 
@@ -30209,8 +30216,6 @@
             <dd>_constructor_ is the constructor function that is performing this action. _newTarget_ is the constructor that `new` was initially applied to. _parameterArgs_ and _bodyArg_ reflect the argument values that were passed to _constructor_.</dd>
           </dl>
           <emu-alg>
-            1. Let _currentRealm_ be the current Realm Record.
-            1. Perform ? HostEnsureCanCompileStrings(_currentRealm_).
             1. If _newTarget_ is *undefined*, set _newTarget_ to _constructor_.
             1. If _kind_ is ~normal~, then
               1. Let _prefix_ be *"function"*.
@@ -30238,22 +30243,26 @@
               1. Let _parameterSym_ be the grammar symbol |FormalParameters[+Yield, +Await]|.
               1. Let _fallbackProto_ be *"%AsyncGeneratorFunction.prototype%"*.
             1. Let _argCount_ be the number of elements in _parameterArgs_.
+            1. Let _bodyString_ be ? ToString(_bodyArg_).
+            1. Let _parameterStrings_ be a new empty List.
+            1. For each element _arg_ of _parameterArgs_, do
+              1. Append ? ToString(_arg_) to _parameterStrings_.
+            1. Let _currentRealm_ be the current Realm Record.
+            1. Perform ? HostEnsureCanCompileStrings(_currentRealm_, _parameterStrings_, _bodyString_, *false*).
             1. Let _P_ be the empty String.
             1. If _argCount_ > 0, then
-              1. Let _firstArg_ be _parameterArgs_[0].
-              1. Set _P_ to ? ToString(_firstArg_).
+              1. Set _P_ to _parameterStrings_[0].
               1. Let _k_ be 1.
               1. Repeat, while _k_ &lt; _argCount_,
-                1. Let _nextArg_ be _parameterArgs_[_k_].
-                1. Let _nextArgString_ be ? ToString(_nextArg_).
+                1. Let _nextArgString_ be _parameterStrings_[_k_].
                 1. Set _P_ to the string-concatenation of _P_, *","* (a comma), and _nextArgString_.
                 1. Set _k_ to _k_ + 1.
-            1. Let _bodyString_ be the string-concatenation of 0x000A (LINE FEED), ? ToString(_bodyArg_), and 0x000A (LINE FEED).
-            1. Let _sourceString_ be the string-concatenation of _prefix_, *" anonymous("*, _P_, 0x000A (LINE FEED), *") {"*, _bodyString_, and *"}"*.
+            1. Let _bodyParseString_ be the string-concatenation of 0x000A (LINE FEED), _bodyString_, and 0x000A (LINE FEED).
+            1. Let _sourceString_ be the string-concatenation of _prefix_, *" anonymous("*, _P_, 0x000A (LINE FEED), *") {"*, _bodyParseString_, and *"}"*.
             1. Let _sourceText_ be StringToCodePoints(_sourceString_).
             1. Let _parameters_ be ParseText(StringToCodePoints(_P_), _parameterSym_).
             1. If _parameters_ is a List of errors, throw a *SyntaxError* exception.
-            1. Let _body_ be ParseText(StringToCodePoints(_bodyString_), _bodySym_).
+            1. Let _body_ be ParseText(StringToCodePoints(_bodyParseString_), _bodySym_).
             1. If _body_ is a List of errors, throw a *SyntaxError* exception.
             1. NOTE: The parameters and body are parsed separately to ensure that each is valid alone. For example, `new Function("/*", "*/ ) {")` does not evaluate to a function.
             1. NOTE: If this step is reached, _sourceText_ must have the syntax of _exprSym_ (although the reverse implication does not hold). The purpose of the next two steps is to enforce any Early Error rules which apply to _exprSym_ directly.


### PR DESCRIPTION
This is based on Mike Samuel's work in #1498, but ultimately goes in a different direction. Due to #2670, this change can be made simpler than it previously was.

This change provides the source text to be evaluated, and the grammar symbol that should be used to parse it, to the host hook HostEnsureCanCompileStrings.

One example of where this is needed is for allowing a Content Security Policy to provide hashes for code executed via `eval()` or `new Function()`:
https://github.com/w3c/webappsec-csp/issues/623
This is useful on its own, but has come up again in the topic of ShadowRealm-HTML integration. In a ShadowRealm you can either execute code asynchronously, with ShadowRealm.p.importValue, or synchronously, with ShadowRealm.p.evaluate. Because the latter uses `eval()` inside the ShadowRealm, it's subject to CSP rules, so the only CSP policy that will let you execute synchronously in the realm is `unsafe-eval`.

~~The original purpose of #1498 was to support Trusted Types, which is still a goal of this PR.~~

This is a separate needs-consensus PR, rather than being part of the ShadowRealm proposal, because it's useful independently of ShadowRealm, and also ShadowRealm would go forward regardless of whether this goes forward.

Prior art: https://github.com/tc39/proposal-dynamic-code-brand-checks

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
