### PR TITLE
Editorial: Remove redundant text in Object Initializer

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -18399,9 +18399,6 @@
       <emu-note>
         <p>|MethodDefinition| is defined in <emu-xref href="#sec-method-definitions"></emu-xref>.</p>
       </emu-note>
-      <emu-note>
-        <p>In certain contexts, |ObjectLiteral| is used as a cover grammar for a more restricted secondary grammar. The |CoverInitializedName| production is necessary to fully cover these secondary grammars. However, use of this production results in an early Syntax Error in normal contexts where an actual |ObjectLiteral| is expected.</p>
-      </emu-note>
 
       <emu-clause id="sec-object-initializer-static-semantics-early-errors" oldids="sec-__proto__-property-names-in-object-initializers">
         <h1>Static Semantics: Early Errors</h1>
@@ -18414,7 +18411,9 @@
             It is a Syntax Error if PrivateBoundIdentifiers of |MethodDefinition| is not empty.
           </li>
         </ul>
-        <p>In addition to describing an actual object initializer the |ObjectLiteral| productions are also used as a cover grammar for |ObjectAssignmentPattern| and may be recognized as part of a |CoverParenthesizedExpressionAndArrowParameterList|. When |ObjectLiteral| appears in a context where |ObjectAssignmentPattern| is required the following Early Error rules are <b>not</b> applied. In addition, they are not applied when initially parsing a |CoverParenthesizedExpressionAndArrowParameterList| or |CoverCallExpressionAndAsyncArrowHead|.</p>
+        <emu-note>
+          <p>In addition to describing an actual object initializer the |ObjectLiteral| productions are also used as a cover grammar for |ObjectAssignmentPattern| and may be recognized as part of a |CoverParenthesizedExpressionAndArrowParameterList|. When |ObjectLiteral| appears in a context where |ObjectAssignmentPattern| is required the following Early Error rules are <b>not</b> applied. In addition, they are not applied when initially parsing a |CoverParenthesizedExpressionAndArrowParameterList| or |CoverCallExpressionAndAsyncArrowHead|.</p>
+        </emu-note>
         <emu-grammar>PropertyDefinition : CoverInitializedName</emu-grammar>
         <ul>
           <li>


### PR DESCRIPTION
Noticed in #3223, with which this has a conflict (trivially addressed by removing the containing \<emu-note>).