### PR TITLE
Normative: Remove [[VarNames]] from the global

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -10862,17 +10862,6 @@
                 <emu-not-ref>Contains</emu-not-ref> bindings for all declarations in global code for the associated realm code except for |FunctionDeclaration|, |GeneratorDeclaration|, |AsyncFunctionDeclaration|, |AsyncGeneratorDeclaration|, and |VariableDeclaration| bindings.
               </td>
             </tr>
-            <tr>
-              <td>
-                [[VarNames]]
-              </td>
-              <td>
-                a List of Strings
-              </td>
-              <td>
-                The string names bound by |FunctionDeclaration|, |GeneratorDeclaration|, |AsyncFunctionDeclaration|, |AsyncGeneratorDeclaration|, and |VariableDeclaration| declarations in global code for the associated realm.
-              </td>
-            </tr>
           </table>
         </emu-table>
         <emu-table id="table-additional-methods-of-global-environment-records" caption="Additional Methods of Global Environment Records" oldids="table-19">
@@ -11053,10 +11042,7 @@
             1. Let _globalObject_ be _ObjRec_.[[BindingObject]].
             1. Let _existingProp_ be ? HasOwnProperty(_globalObject_, _N_).
             1. If _existingProp_ is *true*, then
-              1. Let _status_ be ? <emu-meta effects="user-code">_ObjRec_.DeleteBinding</emu-meta>(_N_).
-              1. If _status_ is *true* and _envRec_.[[VarNames]] contains _N_, then
-                1. Remove _N_ from _envRec_.[[VarNames]].
-              1. Return _status_.
+              1. Return ? <emu-meta effects="user-code">_ObjRec_.DeleteBinding</emu-meta>(_N_).
             1. Return *true*.
           </emu-alg>
         </emu-clause>
@@ -11108,24 +11094,6 @@
           </dl>
           <emu-alg>
             1. Return _envRec_.[[GlobalThisValue]].
-          </emu-alg>
-        </emu-clause>
-
-        <emu-clause id="sec-hasvardeclaration" type="abstract operation">
-          <h1>
-            HasVarDeclaration (
-              _envRec_: a Global Environment Record,
-              _N_: a String,
-            ): a Boolean
-          </h1>
-          <dl class="header">
-            <dt>description</dt>
-            <dd>It determines if the argument identifier has a binding in _envRec_ that was created using a |VariableDeclaration|, |FunctionDeclaration|, |GeneratorDeclaration|, |AsyncFunctionDeclaration|, or |AsyncGeneratorDeclaration|.</dd>
-          </dl>
-          <emu-alg>
-            1. Let _varDeclaredNames_ be _envRec_.[[VarNames]].
-            1. If _varDeclaredNames_ contains _N_, return *true*.
-            1. Return *false*.
           </emu-alg>
         </emu-clause>
 
@@ -11222,7 +11190,7 @@
           </h1>
           <dl class="header">
             <dt>description</dt>
-            <dd>It creates and initializes a mutable binding in the associated Object Environment Record and records the bound name in the associated [[VarNames]] List. If a binding already exists, it is reused and assumed to be initialized.</dd>
+            <dd>It creates and initializes a mutable binding in the associated Object Environment Record. If a binding already exists, it is reused and assumed to be initialized.</dd>
           </dl>
           <emu-alg>
             1. Let _ObjRec_ be _envRec_.[[ObjectRecord]].
@@ -11232,8 +11200,6 @@
             1. If _hasProperty_ is *false* and _extensible_ is *true*, then
               1. Perform ? <emu-meta effects="user-code">_ObjRec_.CreateMutableBinding</emu-meta>(_N_, _D_).
               1. Perform ? <emu-meta effects="user-code">_ObjRec_.InitializeBinding</emu-meta>(_N_, *undefined*).
-            1. If _envRec_.[[VarNames]] does not contain _N_, then
-              1. Append _N_ to _envRec_.[[VarNames]].
             1. Return ~unused~.
           </emu-alg>
         </emu-clause>
@@ -11249,7 +11215,7 @@
           </h1>
           <dl class="header">
             <dt>description</dt>
-            <dd>It creates and initializes a mutable binding in the associated Object Environment Record and records the bound name in the associated [[VarNames]] List. If a binding already exists, it is replaced.</dd>
+            <dd>It creates and initializes a mutable binding in the associated Object Environment Record. If a binding already exists, it is replaced.</dd>
           </dl>
           <emu-alg>
             1. Let _ObjRec_ be _envRec_.[[ObjectRecord]].
@@ -11261,8 +11227,6 @@
               1. Let _desc_ be the PropertyDescriptor { [[Value]]: _V_ }.
             1. Perform ? DefinePropertyOrThrow(_globalObject_, _N_, _desc_).
             1. [id="step-createglobalfunctionbinding-set"] Perform ? Set(_globalObject_, _N_, _V_, *false*).
-            1. If _envRec_.[[VarNames]] does not contain _N_, then
-              1. Append _N_ to _envRec_.[[VarNames]].
             1. Return ~unused~.
           </emu-alg>
           <emu-note>
@@ -11480,7 +11444,6 @@
           1. Set _env_.[[ObjectRecord]] to _objRec_.
           1. Set _env_.[[GlobalThisValue]] to _thisValue_.
           1. Set _env_.[[DeclarativeRecord]] to _dclRec_.
-          1. Set _env_.[[VarNames]] to a new empty List.
           1. Set _env_.[[OuterEnv]] to *null*.
           1. Return _env_.
         </emu-alg>
@@ -26119,9 +26082,9 @@
         1. Let _lexNames_ be the LexicallyDeclaredNames of _script_.
         1. Let _varNames_ be the VarDeclaredNames of _script_.
         1. For each element _name_ of _lexNames_, do
-          1. If HasVarDeclaration(_env_, _name_) is *true*, throw a *SyntaxError* exception.
           1. If HasLexicalDeclaration(_env_, _name_) is *true*, throw a *SyntaxError* exception.
           1. Let _hasRestrictedGlobal_ be ? HasRestrictedGlobalProperty(_env_, _name_).
+          1. NOTE: Global `var` and `function` bindings (except those that are introduced by non-strict direct eval) are non-configurable and are therefore restricted global properties.
           1. If _hasRestrictedGlobal_ is *true*, throw a *SyntaxError* exception.
         1. For each element _name_ of _varNames_, do
           1. If HasLexicalDeclaration(_env_, _name_) is *true*, throw a *SyntaxError* exception.


### PR DESCRIPTION
I noticed this due to a recent test262 test from @shvaikalesh: https://github.com/tc39/test262/pull/3914

The explainer has been pulled into a proposal repo: https://github.com/tc39-transfer/proposal-redeclarable-global-eval-vars

This PR still serves as the spec draft.