### PR TITLE
Editorial: Use %GeneratorFunction.prototype.prototype% instead of Generator.prototype (#3230)

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -47370,20 +47370,20 @@ THH:mm:ss.sss
       </ul>
 
       <emu-clause id="sec-generator.prototype.constructor">
-        <h1>Generator.prototype.constructor</h1>
-        <p>The initial value of `Generator.prototype.constructor` is %GeneratorFunction.prototype%.</p>
+        <h1>%GeneratorFunction.prototype.prototype%.constructor</h1>
+        <p>The initial value of `%GeneratorFunction.prototype.prototype%.constructor` is %GeneratorFunction.prototype%.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
 
       <emu-clause id="sec-generator.prototype.next">
-        <h1>Generator.prototype.next ( _value_ )</h1>
+        <h1>%GeneratorFunction.prototype.prototype%.next ( _value_ )</h1>
         <emu-alg>
           1. Return ? GeneratorResume(*this* value, _value_, ~empty~).
         </emu-alg>
       </emu-clause>
 
       <emu-clause id="sec-generator.prototype.return">
-        <h1>Generator.prototype.return ( _value_ )</h1>
+        <h1>%GeneratorFunction.prototype.prototype%.return ( _value_ )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _g_ be the *this* value.
@@ -47393,7 +47393,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-generator.prototype.throw">
-        <h1>Generator.prototype.throw ( _exception_ )</h1>
+        <h1>%GeneratorFunction.prototype.prototype%.throw ( _exception_ )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _g_ be the *this* value.
@@ -47403,7 +47403,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-generator.prototype-@@tostringtag">
-        <h1>Generator.prototype [ @@toStringTag ]</h1>
+        <h1>%GeneratorFunction.prototype.prototype% [ @@toStringTag ]</h1>
         <p>The initial value of the @@toStringTag property is the String value *"Generator"*.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
@@ -47681,13 +47681,13 @@ THH:mm:ss.sss
       </ul>
 
       <emu-clause id="sec-asyncgenerator-prototype-constructor">
-        <h1>AsyncGenerator.prototype.constructor</h1>
-        <p>The initial value of `AsyncGenerator.prototype.constructor` is %AsyncGeneratorFunction.prototype%.</p>
+        <h1>%AsyncGeneratorFunction.prototype.prototype%.constructor</h1>
+        <p>The initial value of `%AsyncGeneratorFunction.prototype.prototype%.constructor` is %AsyncGeneratorFunction.prototype%.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
 
       <emu-clause id="sec-asyncgenerator-prototype-next">
-        <h1>AsyncGenerator.prototype.next ( _value_ )</h1>
+        <h1>%AsyncGeneratorFunction.prototype.prototype%.next ( _value_ )</h1>
         <emu-alg>
           1. Let _generator_ be the *this* value.
           1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
@@ -47709,7 +47709,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-asyncgenerator-prototype-return">
-        <h1>AsyncGenerator.prototype.return ( _value_ )</h1>
+        <h1>%AsyncGeneratorFunction.prototype.prototype%.return ( _value_ )</h1>
         <emu-alg>
           1. Let _generator_ be the *this* value.
           1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
@@ -47730,7 +47730,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-asyncgenerator-prototype-throw">
-        <h1>AsyncGenerator.prototype.throw ( _exception_ )</h1>
+        <h1>%AsyncGeneratorFunction.prototype.prototype%.throw ( _exception_ )</h1>
         <emu-alg>
           1. Let _generator_ be the *this* value.
           1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
@@ -47754,7 +47754,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-asyncgenerator-prototype-tostringtag">
-        <h1>AsyncGenerator.prototype [ @@toStringTag ]</h1>
+        <h1>%AsyncGeneratorFunction.prototype.prototype% [ @@toStringTag ]</h1>
         <p>The initial value of the @@toStringTag property is the String value *"AsyncGenerator"*.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>


### PR DESCRIPTION
Also Use `%AsyncGeneratorFunction.prototype.prototype%` instead of `AsyncGenerator.prototype`.

This depends on https://github.com/tc39/ecmarkup/pull/564