### PR TITLE
Editorial: Add missing period to `AsyncFunction.prototype.constructor` section

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -48270,7 +48270,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-async-function-prototype-properties-constructor">
         <h1>AsyncFunction.prototype.constructor</h1>
 
-        <p>The initial value of `AsyncFunction.prototype.constructor` is %AsyncFunction%</p>
+        <p>The initial value of `AsyncFunction.prototype.constructor` is %AsyncFunction%.</p>
 
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>


### PR DESCRIPTION
Fixes #3232