### PR TITLE
Editorial: Add %GeneratorPrototype% and %AsyncGeneratorPrototype% well-known intrinsics (#3230)

### DIFF
--- a/img/figure-2.svg
+++ b/img/figure-2.svg
@@ -76,14 +76,14 @@
 
     <!-- classes -->
 
-    <g transform="translate(320,90)">
+    <g transform="translate(370,90)">
       <rect class="class" x="0" y="0" width="160" height="30" />
       <g transform="translate(0,4)">
         <text x="80" y="16" text-anchor="middle">Object.prototype</text>
       </g>
     </g>
 
-    <g transform="translate(320,160)">
+    <g transform="translate(370,160)">
       <rect class="class" x="0" y="0" width="160" height="30" />
       <rect class="class" x="0" y="30" width="160" height="70" />
       <g transform="translate(0,4)">
@@ -97,7 +97,7 @@
       </g>
     </g>
 
-    <g transform="translate(290,300)">
+    <g transform="translate(340,300)">
       <rect class="class" x="0" y="0" width="220" height="30" />
       <rect class="class" x="0" y="30" width="220" height="40" />
       <g transform="translate(0,4)">
@@ -138,12 +138,12 @@
       </g>
     </g>
 
-    <g transform="translate(600,300)">
-      <rect class="class" x="0" y="0" width="280" height="30" />
-      <rect class="class" x="0" y="30" width="280" height="24" />
-      <rect class="class" x="0" y="54" width="280" height="56" />
+    <g transform="translate(670,300)">
+      <rect class="class" x="0" y="0" width="210" height="30" />
+      <rect class="class" x="0" y="30" width="210" height="24" />
+      <rect class="class" x="0" y="54" width="210" height="56" />
       <g transform="translate(0,4)">
-        <text x="140" y="16" text-anchor="middle">%GeneratorFunction.prototype.prototype%</text>
+        <text x="110" y="16" text-anchor="middle">%GeneratorPrototype%</text>
       </g>
       <g transform="translate(4,32)">
         <text x="0" y="16">@@toStringTag = "Generator"</text>
@@ -157,7 +157,7 @@
 
     <!-- objects -->
 
-    <g transform="translate(320,440)">
+    <g transform="translate(370,440)">
       <rect class="object" x="0" y="0" width="160" height="50" />
       <g transform="translate(0,4)">
         <text x="80" y="16" text-anchor="middle">«callable»</text>
@@ -181,7 +181,7 @@
 
     <!-- notes -->
 
-    <g transform="translate(320,20)">
+    <g transform="translate(370,20)">
       <path class="note" d="M 0,0 V 50 H 160 V 10 h -10 10 l -10,-10 v 10 -10 z" />
       <g transform="translate(4,4)">
         <text x="0" y="16">[[Prototype]] of</text>
@@ -189,7 +189,7 @@
       </g>
     </g>
 
-    <g transform="translate(530,200)">
+    <g transform="translate(570,200)">
       <path class="note" d="M 0,0 V 80 H 220 V 10 h -10 10 l -10,-10 v 10 -10 z" />
       <g transform="translate(4,4)">
         <text x="0" y="16">%GeneratorFunction.prototype%</text>
@@ -213,7 +213,7 @@
       </g>
     </g>
 
-    <g transform="translate(320,520)">
+    <g transform="translate(370,520)">
       <path class="note" d="M 0,0 V 60 H 160 V 10 h -10 10 l -10,-10 v 10 -10 z" />
       <g transform="translate(4,4)">
         <text x="0" y="16">A typical generator</text>
@@ -222,7 +222,7 @@
       </g>
     </g>
 
-    <g transform="translate(560,560)">
+    <g transform="translate(570,560)">
       <path class="note" d="M 0,0 V 120 H 320 V 10 h -10 10 l -10,-10 v 10 -10 z" />
       <g transform="translate(4,4)">
         <text x="0" y="16">Each Generator Function has an associated</text>
@@ -242,14 +242,14 @@
       <path class="proto-slot-arrowend" d="M 0,0 L 9,5 L 0,10 z" />
     </marker>
 
-    <path class="proto-slot-arrow" d="M 400,160 V 120" />
-    <path class="proto-slot-arrow" d="M 400,300 V 260" />
-    <path class="proto-slot-arrow" d="M 400,440 V 370" />
+    <path class="proto-slot-arrow" d="M 450,160 V 120" />
+    <path class="proto-slot-arrow" d="M 450,300 V 260" />
+    <path class="proto-slot-arrow" d="M 450,440 V 370" />
 
-    <path class="proto-slot-arrow" d="M 100,200 V 175 H 320" />
+    <path class="proto-slot-arrow" d="M 100,200 V 175 H 370" />
     <path class="proto-slot-arrow" d="M 100,300 V 260" />
 
-    <path class="proto-slot-arrow" d="M 800,120 V 105 H 480" />
+    <path class="proto-slot-arrow" d="M 800,120 V 105 H 530" />
     <path class="proto-slot-arrow" d="M 800,300 V 180" />
     <path class="proto-slot-arrow" d="M 800,440 V 410" />
     <path class="proto-slot-arrow" d="M 800,500 V 470" />
@@ -268,31 +268,31 @@
       <path class="prototype-arrowend" d="M 0,0 L 9,5 L 0,10" />
     </marker>
 
-    <path class="prototype-constructor-arrow" d="M 180,315 H 290" />
-    <text x="285" y="306" text-anchor="end">constructor</text>
+    <path class="prototype-constructor-arrow" d="M 180,315 H 340" />
+    <text x="335" y="306" text-anchor="end">constructor</text>
     <text x="185" y="334">prototype</text>
 
-    <path class="prototype-constructor-arrow" d="M 510,315 H 600" />
-    <text x="595" y="306" text-anchor="end">constructor</text>
-    <text x="515" y="334">prototype</text>
+    <path class="prototype-constructor-arrow" d="M 560,315 H 670" />
+    <text x="665" y="306" text-anchor="end">constructor</text>
+    <text x="565" y="334">prototype</text>
 
-    <path class="prototype-arrow" d="M 480,455 H 720" />
-    <text x="485" y="470">prototype</text>
+    <path class="prototype-arrow" d="M 530,455 H 720" />
+    <text x="535" y="470">prototype</text>
 
     <!-- instance arrows -->
 
-    <path class="instance-arrow" d="M 320,440 L 180,360" />
-    <text x="280" y="410">instanceof</text>
+    <path class="instance-arrow" d="M 370,440 L 180,360" />
+    <text x="330" y="420">instanceof</text>
 
-    <path class="instance-arrow" d="M 720,500 L 480,490" />
+    <path class="instance-arrow" d="M 720,500 L 530,490" />
     <text x="715" y="516" text-anchor="end">instanceof</text>
 
     <!-- note lines -->
 
-    <path class="note-arrow" d="M 400,70 V 90" />
-    <path class="note-arrow" d="M 400,520 V 490" />
+    <path class="note-arrow" d="M 450,70 V 90" />
+    <path class="note-arrow" d="M 450,520 V 490" />
 
-    <path class="note-arrow" d="M 510,300 L 530,280" />
+    <path class="note-arrow" d="M 560,300 L 570,280" />
 
     <path class="note-arrow" d="M 100,400 V 360" />
 

--- a/spec.html
+++ b/spec.html
@@ -3307,7 +3307,17 @@
               <td>
               </td>
               <td>
-                The constructor of async iterator objects (<emu-xref href="#sec-asyncgeneratorfunction-constructor"></emu-xref>)
+                The constructor of async generator function objects (<emu-xref href="#sec-asyncgeneratorfunction-constructor"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %AsyncGeneratorPrototype%
+              </td>
+              <td>
+              </td>
+              <td>
+                The prototype of async generator objects (<emu-xref href="#sec-asyncgenerator-objects"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3535,7 +3545,17 @@
               <td>
               </td>
               <td>
-                The constructor of Generators (<emu-xref href="#sec-generatorfunction-constructor"></emu-xref>)
+                The constructor of generator function objects (<emu-xref href="#sec-generatorfunction-constructor"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %GeneratorPrototype%
+              </td>
+              <td>
+              </td>
+              <td>
+                The prototype of generator objects (<emu-xref href="#sec-generator-objects"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -47336,7 +47356,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-generatorfunction.prototype.prototype">
         <h1>GeneratorFunction.prototype.prototype</h1>
-        <p>The initial value of `GeneratorFunction.prototype.prototype` is the Generator prototype object.</p>
+        <p>The initial value of `GeneratorFunction.prototype.prototype` is %GeneratorPrototype%.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
 
@@ -47438,7 +47458,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-asyncgeneratorfunction-prototype-prototype">
         <h1>AsyncGeneratorFunction.prototype.prototype</h1>
-        <p>The initial value of `AsyncGeneratorFunction.prototype.prototype` is the AsyncGenerator prototype object.</p>
+        <p>The initial value of `AsyncGeneratorFunction.prototype.prototype` is %AsyncGeneratorPrototype%.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
 
@@ -47478,12 +47498,12 @@ THH:mm:ss.sss
 
   <emu-clause id="sec-generator-objects">
     <h1>Generator Objects</h1>
-    <p>A Generator is an instance of a generator function and conforms to both the <i>Iterator</i> and <i>Iterable</i> interfaces.</p>
-    <p>Generator instances directly inherit properties from the object that is the initial value of the *"prototype"* property of the Generator function that created the instance. Generator instances indirectly inherit properties from the Generator Prototype intrinsic, %GeneratorFunction.prototype.prototype%.</p>
+    <p>A Generator is created by calling a generator function and conforms to both the <i>Iterator</i> and <i>Iterable</i> interfaces.</p>
+    <p>Generator instances directly inherit properties from the initial value of the *"prototype"* property of the generator function that created the instance. Generator instances indirectly inherit properties from %GeneratorPrototype%.</p>
 
     <emu-clause id="sec-properties-of-generator-prototype">
-      <h1>Properties of the Generator Prototype Object</h1>
-      <p>The <dfn>Generator prototype object</dfn>:</p>
+      <h1>The %GeneratorPrototype% Object</h1>
+      <p>The <dfn>%GeneratorPrototype%</dfn> object:</p>
       <ul>
         <li>is <dfn>%GeneratorFunction.prototype.prototype%</dfn>.</li>
         <li>is an ordinary object.</li>
@@ -47493,20 +47513,20 @@ THH:mm:ss.sss
       </ul>
 
       <emu-clause id="sec-generator.prototype.constructor">
-        <h1>Generator.prototype.constructor</h1>
-        <p>The initial value of `Generator.prototype.constructor` is %GeneratorFunction.prototype%.</p>
+        <h1>%GeneratorPrototype%.constructor</h1>
+        <p>The initial value of %GeneratorPrototype%`.constructor` is %GeneratorFunction.prototype%.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
 
       <emu-clause id="sec-generator.prototype.next">
-        <h1>Generator.prototype.next ( _value_ )</h1>
+        <h1>%GeneratorPrototype%.next ( _value_ )</h1>
         <emu-alg>
           1. Return ? GeneratorResume(*this* value, _value_, ~empty~).
         </emu-alg>
       </emu-clause>
 
       <emu-clause id="sec-generator.prototype.return">
-        <h1>Generator.prototype.return ( _value_ )</h1>
+        <h1>%GeneratorPrototype%.return ( _value_ )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _g_ be the *this* value.
@@ -47516,7 +47536,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-generator.prototype.throw">
-        <h1>Generator.prototype.throw ( _exception_ )</h1>
+        <h1>%GeneratorPrototype%.throw ( _exception_ )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _g_ be the *this* value.
@@ -47526,7 +47546,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-generator.prototype-@@tostringtag">
-        <h1>Generator.prototype [ @@toStringTag ]</h1>
+        <h1>%GeneratorPrototype% [ @@toStringTag ]</h1>
         <p>The initial value of the @@toStringTag property is the String value *"Generator"*.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
@@ -47788,13 +47808,13 @@ THH:mm:ss.sss
 
   <emu-clause id="sec-asyncgenerator-objects">
     <h1>AsyncGenerator Objects</h1>
-    <p>An AsyncGenerator is an instance of an async generator function and conforms to both the AsyncIterator and AsyncIterable interfaces.</p>
+    <p>An AsyncGenerator is created by calling an async generator function and conforms to both the AsyncIterator and AsyncIterable interfaces.</p>
 
-    <p>AsyncGenerator instances directly inherit properties from the object that is the initial value of the *"prototype"* property of the AsyncGenerator function that created the instance. AsyncGenerator instances indirectly inherit properties from the AsyncGenerator Prototype intrinsic, %AsyncGeneratorFunction.prototype.prototype%.</p>
+    <p>AsyncGenerator instances directly inherit properties from the initial value of the *"prototype"* property of the async generator function that created the instance. AsyncGenerator instances indirectly inherit properties from %AsyncGeneratorPrototype%.</p>
 
     <emu-clause id="sec-properties-of-asyncgenerator-prototype">
-      <h1>Properties of the AsyncGenerator Prototype Object</h1>
-      <p>The <dfn>AsyncGenerator prototype object</dfn>:</p>
+      <h1>The %AsyncGeneratorPrototype% Object</h1>
+      <p>The <dfn>%AsyncGeneratorPrototype%</dfn> object:</p>
       <ul>
         <li>is <dfn>%AsyncGeneratorFunction.prototype.prototype%</dfn>.</li>
         <li>is an ordinary object.</li>
@@ -47804,13 +47824,13 @@ THH:mm:ss.sss
       </ul>
 
       <emu-clause id="sec-asyncgenerator-prototype-constructor">
-        <h1>AsyncGenerator.prototype.constructor</h1>
-        <p>The initial value of `AsyncGenerator.prototype.constructor` is %AsyncGeneratorFunction.prototype%.</p>
+        <h1>%AsyncGeneratorPrototype%.constructor</h1>
+        <p>The initial value of %AsyncGeneratorPrototype%`.constructor` is %AsyncGeneratorFunction.prototype%.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
 
       <emu-clause id="sec-asyncgenerator-prototype-next">
-        <h1>AsyncGenerator.prototype.next ( _value_ )</h1>
+        <h1>%AsyncGeneratorPrototype%.next ( _value_ )</h1>
         <emu-alg>
           1. Let _generator_ be the *this* value.
           1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
@@ -47832,7 +47852,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-asyncgenerator-prototype-return">
-        <h1>AsyncGenerator.prototype.return ( _value_ )</h1>
+        <h1>%AsyncGeneratorPrototype%.return ( _value_ )</h1>
         <emu-alg>
           1. Let _generator_ be the *this* value.
           1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
@@ -47853,7 +47873,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-asyncgenerator-prototype-throw">
-        <h1>AsyncGenerator.prototype.throw ( _exception_ )</h1>
+        <h1>%AsyncGeneratorPrototype%.throw ( _exception_ )</h1>
         <emu-alg>
           1. Let _generator_ be the *this* value.
           1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
@@ -47877,7 +47897,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-asyncgenerator-prototype-tostringtag">
-        <h1>AsyncGenerator.prototype [ @@toStringTag ]</h1>
+        <h1>%AsyncGeneratorPrototype% [ @@toStringTag ]</h1>
         <p>The initial value of the @@toStringTag property is the String value *"AsyncGenerator"*.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>


### PR DESCRIPTION
This supersedes https://github.com/tc39/ecma262/pull/3234

This is effectively same as https://github.com/tc39/ecma262/pull/3234, but in order to avoid the readability issue, added dedicate well-known intrinsics for Generator prototype and Async generator prototype, that's used in the same way as %SetIteratorPrototype%.

  * All occurrences of "Generator Prototype" and "Generator.prototype" are replaced with %GeneratorPrototype%
  * All occurrences of "AsyncGenerator Prototype" and "AsyncGenerator.prototype" are replaced with %AsyncGeneratorPrototype%
  * Related ids are updated, with moving the old ids into `oldids` attribute
  * Also tweaked the description of Generator and AsyncGenerator to avoid the confusion from "instance of"+"generator function"
