### PR TITLE
Editorial: Fix _TypedArray_.prototype.constructor value notation

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -35291,7 +35291,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-typedarray.prototype.constructor">
         <h1>_TypedArray_.prototype.constructor</h1>
-        <p>The initial value of a _TypedArray_`.prototype.constructor` is the corresponding %TypedArray% intrinsic object.</p>
+        <p>The initial value of a _TypedArray_`.prototype.constructor` is the corresponding %_TypedArray_% intrinsic object.</p>
       </emu-clause>
     </emu-clause>
 


### PR DESCRIPTION
The spec has 2 `TypedArray` notations, one is the `%TypedArray%` and the other is `<var>TypedArray</var>` (noted as `_TypedArray_` in the source in some case).

The one with `<var>` is the value of `Int8Array` etc, and the one without `<var>` is the value of `Object.getPrototypeOf(Int8Array)`.

Those 2 seem to be mixed up in the following paragraph.

https://tc39.es/ecma262/#sec-typedarray.prototype.constructor
```
        <p>The initial value of a _TypedArray_`.prototype.constructor` is the corresponding %TypedArray% intrinsic object.</p>
```

`Int8Array.prototype.constructor` must be `Int8Array`, but `%TypedArray%` there means the value of `Object.getPrototypeOf(Int8Array)`.

The possibility is that the combination with "the corresponding ... intrinsic object" part somehow points `Int8Array`, but it doesn't match with `_NativeError_` case below, that uses "the corresponding intrinsic object" with `%_NativeError_%` notation, where `%_NativeError_%` notation sounds like it points `SyntaxError`.

https://tc39.es/ecma262/#sec-nativeerror.prototype.constructor
```
          <p>The initial value of the *"constructor"* property of the prototype for a given _NativeError_ constructor is the corresponding intrinsic object %_NativeError_% (<emu-xref href="#sec-nativeerror-constructors"></emu-xref>).</p>

```

So I assume the `_TypedArray_.prototype.constructor` paragraph should say `the corresponding %_TypedArray_% intrinsic object`, or maybe `the corresponding intrinsic object %_TypedArray_%` to match with `_NativeError_` case.
