### PR TITLE
Normative: Allow Annex B scripts to start with `-->`

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -49708,6 +49708,15 @@ THH:mm:ss.sss
       <p>The syntax and semantics of <emu-xref href="#sec-comments"></emu-xref> is extended as follows except that this extension is not allowed when parsing source text using the goal symbol |Module|:</p>
       <h2>Syntax</h2>
       <emu-grammar type="definition">
+        InputElementHashbangOrRegExp ::
+          WhiteSpace
+          LineTerminator
+          Comment
+          CommonToken
+          HashbangComment
+          RegularExpressionLiteral
+          HTMLCloseComment
+
         Comment ::
           MultiLineComment
           SingleLineComment


### PR DESCRIPTION
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->

This PR updates the spec to match web reality (tested in Safari, Firefox, and Chrome -- XS does not implement HTML comments).

Annex B allows HTML closing comments (`--> foo`) after a line terminator, potentially preceded by other comments or spaces ([`SingleLineHTMLCloseComment`](https://tc39.es/ecma262/#prod-annexB-SingleLineHTMLCloseComment)). However, browsers also support them at the beginning of scripts. Some test cases:
- ```js
  eval("--> foo\nconsole.log(123)");
  ```
- ```html
  <script>--> foo
  console.log(123);
  </script>
  ```
- ```html
  <script src="./script.js"></script>
  ```
  ```js
  --> foo
  console.log(123);
  ```
- ```js
  eval("/* comment */ --> foo\nconsole.log(123)");
  ```
- (this case is already supported by the current spec)
  ```js
  eval("/* com\nment */ --> foo\nconsole.log(123)");
  ```

This PR accomplishes this by adding `HTMLCloseComment` to `InputElementHashbangOrRegExp` in Annex B, where `InputElementHashbangOrRegExp` is the parsing goal used for the first token in the script.

---

**EDIT** There is already a PR fixing this, by @leobalter (#1493), but it was stuck on discussing how to specify this. My version has the advantage of not introducing any new spec language, but I'm happy to close this PR if we find the original one more editorially appealing.

Notes from discussing this in the past: https://github.com/tc39/notes/blob/main/meetings/2019-03/mar-26.md#normative-createdynamicfunction-early-concatenates-body