### PR TITLE
Editorial: avoid using % notation with an alias

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -31103,7 +31103,7 @@
 
         <emu-clause id="sec-nativeerror.prototype.constructor">
           <h1>_NativeError_.prototype.constructor</h1>
-          <p>The initial value of the *"constructor"* property of the prototype for a given _NativeError_ constructor is the corresponding intrinsic object %_NativeError_% (<emu-xref href="#sec-nativeerror-constructors"></emu-xref>).</p>
+          <p>The initial value of the *"constructor"* property of the prototype for a given _NativeError_ constructor is the constructor itself.</p>
         </emu-clause>
 
         <emu-clause id="sec-nativeerror.prototype.message">
@@ -41743,7 +41743,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-typedarray.prototype.constructor">
         <h1>_TypedArray_.prototype.constructor</h1>
-        <p>The initial value of a _TypedArray_`.prototype.constructor` is the corresponding %TypedArray% intrinsic object.</p>
+        <p>The initial value of the *"constructor"* property of the prototype for a given _TypedArray_ constructor is the constructor itself.</p>
       </emu-clause>
     </emu-clause>
 


### PR DESCRIPTION
This includes an alternative fix to #3243 as discussed in editor call. Closes #3243.