### PR TITLE
Editorial: document that functions are objects

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -2713,6 +2713,7 @@
       </emu-note>
       <p>Property keys are used to access properties and their values. There are two kinds of access for properties: <em>get</em> and <em>set</em>, corresponding to value retrieval and assignment, respectively. The properties accessible via get and set access includes both <em>own properties</em> that are a direct part of an object and <em>inherited properties</em> which are provided by another associated object via a property inheritance relationship. Inherited properties may be either own or inherited properties of the associated object. Each own property of an object must each have a key value that is distinct from the key values of the other own properties of that object.</p>
       <p>All objects are logically collections of properties, but there are multiple forms of objects that differ in their semantics for accessing and manipulating their properties. Please see <emu-xref href="#sec-object-internal-methods-and-internal-slots"></emu-xref> for definitions of the multiple forms of objects.</p>
+      <p>In addition, some objects are callable; these are referred to as functions or function objects and are described further below. All functions in ECMAScript are members of the Object type.</p>
 
       <emu-clause id="sec-property-attributes">
         <h1>Property Attributes</h1>


### PR DESCRIPTION
The phrase "is an object" links to [The Object Type](https://tc39.es/ecma262/multipage/ecmascript-data-types-and-values.html#sec-object-type), but if someone is clicking that link they probably want to know the answer to the question "are functions objects in this sense".  The answer is yes, but to discern that from the current section you need to go down to between two tables in the [Object Internal Methods and Internal Slots](https://tc39.es/ecma262/multipage/ecmascript-data-types-and-values.html#sec-object-internal-methods-and-internal-slots) subsection and find the "Table 5 summarizes additional essential internal methods that are supported by objects that may be called as functions. A function object is an object that supports the [[Call]] internal method" bit.

This PR adds a paragraph pointing out that functions are objects to the introduction of the Object Type section, where it has some hope of being seen.

