### PR TITLE
Editorial: fix an invariant for [[GetOwnProperty]]

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -3110,7 +3110,7 @@
             If _P_ is described as a non-configurable, non-writable own data property, all future calls to [[GetOwnProperty]] ( _P_ ) must return Property Descriptor whose [[Value]] is SameValue as _P_'s [[Value]] attribute.
           </li>
           <li>
-            If _P_'s attributes other than [[Writable]] may change over time or if the property might be deleted, then _P_'s [[Configurable]] attribute must be *true*.
+            If _P_'s attributes other than [[Writable]] and [[Value]] may change over time, or if the property might be deleted, then _P_'s [[Configurable]] attribute must be *true*.
           </li>
           <li>
             If the [[Writable]] attribute may change from *false* to *true*, then the [[Configurable]] attribute must be *true*.


### PR DESCRIPTION
Fixes #3253.

Calling this editorial because it's not currently coherent with text in the surrounding section. It's debatably normative though.

The constraints are sometimes worded in a slightly confusing way. The intended constraints on GetOwnProperty are:

- No constraints on how `configurable: true` properties can change
- `configurable: false` + `writable: true` properties can change value and can become non-writable, but no other changes are allowed
- `configurable: false` + (`writable: false` or accessor) properties cannot change in any way
- properties cannot be created on non-extensible objects

These are clearly the intended constraints, especially if you read the NOTE:

> As a consequence of the third invariant, if a property is described as a [data property](https://tc39.es/ecma262/multipage/ecmascript-data-types-and-values.html#sec-object-type) and it may return different values over time, then either or both of the [[Writable]] and [[Configurable]] attributes must be true even if no mechanism to change the value is exposed via the other essential internal methods.

Currently the wording for one of the invariants says that if any property other than [[Writable]] can change then it must be configurable. But that doesn't match the intended constraints: in fact the [[Value]] should be able to change as well when the property is writable, even for non-configurable properties.

(The fact that [[Value]] can't change for non-writable non-configurable properties is already covered by the invariant before this one.)

---

Sidebar: maybe we should rework this section to be easier to understand.