### PR TITLE
Normative: Recompute count in TA.p.slice

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -41112,6 +41112,7 @@ THH:mm:ss.sss
             1. If IsTypedArrayOutOfBounds(_taRecord_) is *true*, throw a *TypeError* exception.
             1. Set _len_ to TypedArrayLength(_taRecord_).
             1. Set _final_ to min(_final_, _len_).
+            1. Set _count_ to max(_final_ - _k_, 0).
             1. Let _srcType_ be TypedArrayElementType(_O_).
             1. Let _targetType_ be TypedArrayElementType(_A_).
             1. If _srcType_ is _targetType_, then
@@ -41122,7 +41123,7 @@ THH:mm:ss.sss
               1. Let _srcByteOffset_ be _O_.[[ByteOffset]].
               1. Let _srcByteIndex_ be (_k_ × _elementSize_) + _srcByteOffset_.
               1. Let _targetByteIndex_ be _A_.[[ByteOffset]].
-              1. Let _limit_ be _targetByteIndex_ + min(_count_, _len_) × _elementSize_.
+              1. Let _limit_ be _targetByteIndex_ + (_count_ × _elementSize_).
               1. Repeat, while _targetByteIndex_ &lt; _limit_,
                 1. Let _value_ be GetValueFromBuffer(_srcBuffer_, _srcByteIndex_, ~uint8~, *true*, ~unordered~).
                 1. Perform SetValueInBuffer(_targetBuffer_, _targetByteIndex_, ~uint8~, _value_, *true*, ~unordered~).


### PR DESCRIPTION
Closes #3248.

The current algorithm has a bug that can result in OOB reads in the source TA, because _count_ is not correctly recomputed when the source TA is resized during evaluation of the species constructor.

(It is currently bounded by _len_, which is recomputed, but this is incorrect because the bounds of the copy loop is not on the length, but instead on how many bytes need to be copied.)

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
