### PR TITLE
Editorial: Update some stale ECMA links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ If you wish to submit a proposal or make a significant PR, and you are not a rep
 
 Ecma TC39 accepts contributions from non-member individuals who have accepted the TC39 copyright and patent policies. Currently all ECMAScript related technical work is done by the TC39 RF TG (Royalty Free Task Group), for which the following IPR policies apply:
 
-  * [Ecma International RF Patent Policy](https://ecma-international.org/memento/Policies/Ecma_Royalty-Free_Patent_Policy_Extension_Option.htm)
-  * [Ecma International Software Copyright Policy](https://ecma-international.org/memento/Policies/Ecma_Policy_on_Submission_Inclusion_and_Licensing_of_Software.htm) ([PDF](https://ecma-international.org/memento/Policies/Ecma_Policy_on_Submission_Inclusion_and_Licensing_of_Software.pdf))
+  * [Ecma International RF Patent Policy](https://ecma-international.org/policies/by-ipr/royalty-free-patent-policy-extension-option/)
+  * [Ecma International Software Copyright Policy](https://ecma-international.org/policies/by-ipr/ecma-international-policy-on-submission-inclusion-and-licensing-of-software/) ([PDF](https://www.ecma-international.org/wp-content/uploads/Ecma_Policy_on_Submission_Inclusion_and_Licensing_of_Software.pdf))
 
 [Matrix chat room]: https://github.com/tc39/how-we-work/blob/HEAD/matrix-guide.md

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
 This repository is licensed according to Ecma International TC39's [Intellectual Property Policy](https://github.com/tc39/how-we-work/blob/HEAD/ip.md). In particular:
 - Natural language text is licensed under the "Alternative copyright notice" of the [Ecma text copyright policy](https://www.ecma-international.org/memento/Ecma%20copyright%20faq.htm).
-- Source code is licensed under Ecma's MIT-style [Ecma International Policy on Submission, Inclusion and Licensing of Software](https://www.ecma-international.org/memento/Policies/Ecma_Policy_on_Submission_Inclusion_and_Licensing_of_Software.htm).
+- Source code is licensed under Ecma's MIT-style [Ecma International Policy on Submission, Inclusion and Licensing of Software](https://ecma-international.org/policies/by-ipr/ecma-international-policy-on-submission-inclusion-and-licensing-of-software/).
 - Contributions are only accepted from either representatives of Ecma members or signatories of TC39's [Contributor Form](https://tc39.github.io/agreements/contributor/).


### PR DESCRIPTION
The RF Patent Policy link still works, but redirects to an updated URL. The Software Policy link has stopped working.

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
