### PR TITLE
Editorial: Eliminate 6 `<p>` elements that say when to apply early error rules

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -20452,16 +20452,12 @@
     <emu-clause id="sec-assignment-operators-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
       <emu-grammar>AssignmentExpression : LeftHandSideExpression `=` AssignmentExpression</emu-grammar>
-      <p>If |LeftHandSideExpression| is either an |ObjectLiteral| or an |ArrayLiteral|, the following Early Error rules are applied:</p>
       <ul>
         <li>
-          |LeftHandSideExpression| must cover an |AssignmentPattern|.
+          If |LeftHandSideExpression| is either an |ObjectLiteral| or an |ArrayLiteral|, |LeftHandSideExpression| must cover an |AssignmentPattern|.
         </li>
-      </ul>
-      <p>If |LeftHandSideExpression| is neither an |ObjectLiteral| nor an |ArrayLiteral|, the following Early Error rule is applied:</p>
-      <ul>
         <li>
-          It is a Syntax Error if AssignmentTargetType of |LeftHandSideExpression| is not ~simple~.
+          If |LeftHandSideExpression| is neither an |ObjectLiteral| nor an |ArrayLiteral|, it is a Syntax Error if AssignmentTargetType of |LeftHandSideExpression| is not ~simple~.
         </li>
       </ul>
       <emu-grammar>
@@ -20725,16 +20721,12 @@
           </li>
         </ul>
         <emu-grammar>DestructuringAssignmentTarget : LeftHandSideExpression</emu-grammar>
-        <p>If |LeftHandSideExpression| is either an |ObjectLiteral| or an |ArrayLiteral|, the following Early Error rules are applied:</p>
         <ul>
           <li>
-            |LeftHandSideExpression| must cover an |AssignmentPattern|.
+            If |LeftHandSideExpression| is either an |ObjectLiteral| or an |ArrayLiteral|, |LeftHandSideExpression| must cover an |AssignmentPattern|.
           </li>
-        </ul>
-        <p>If |LeftHandSideExpression| is neither an |ObjectLiteral| nor an |ArrayLiteral|, the following Early Error rule is applied:</p>
-        <ul>
           <li>
-            It is a Syntax Error if AssignmentTargetType of |LeftHandSideExpression| is not ~simple~.
+            If |LeftHandSideExpression| is neither an |ObjectLiteral| nor an |ArrayLiteral|, it is a Syntax Error if AssignmentTargetType of |LeftHandSideExpression| is not ~simple~.
           </li>
         </ul>
       </emu-clause>
@@ -21921,16 +21913,12 @@
             `for` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
             `for` `await` `(` LeftHandSideExpression `of` AssignmentExpression `)` Statement
         </emu-grammar>
-        <p>If |LeftHandSideExpression| is either an |ObjectLiteral| or an |ArrayLiteral|, the following Early Error rules are applied:</p>
         <ul>
           <li>
-            |LeftHandSideExpression| must cover an |AssignmentPattern|.
+            If |LeftHandSideExpression| is either an |ObjectLiteral| or an |ArrayLiteral|, |LeftHandSideExpression| must cover an |AssignmentPattern|.
           </li>
-        </ul>
-        <p>If |LeftHandSideExpression| is neither an |ObjectLiteral| nor an |ArrayLiteral|, the following Early Error rule is applied:</p>
-        <ul>
           <li>
-            It is a Syntax Error if AssignmentTargetType of |LeftHandSideExpression| is not ~simple~.
+            If |LeftHandSideExpression| is neither an |ObjectLiteral| nor an |ArrayLiteral|, it is a Syntax Error if AssignmentTargetType of |LeftHandSideExpression| is not ~simple~.
           </li>
         </ul>
         <emu-grammar>


### PR DESCRIPTION
Normally, an early error rule consists of:
- an `<emu-grammar>` (with 1 or more productions), and
- a `<ul>` (with 1 or more "it is a Syntax Error" or "must cover" statements).

However, in a few cases, there is also a `<p>` that says when the rule is applied.

One such case is in [13.2.5.1](https://tc39.es/ecma262/#sec-object-initializer-static-semantics-early-errors), which PR #3227 will eliminate. This PR eliminates the remaining cases. These occur in [13.15.1](https://tc39.es/ecma262/#sec-assignment-operators-static-semantics-early-errors), [13.15.5.1](https://tc39.es/ecma262/#sec-destructuring-assignment-static-semantics-early-errors), and [14.7.5.1](https://tc39.es/ecma262/#sec-for-in-and-for-of-statements-static-semantics-early-errors), and are all of the form:
```
<emu-grammar>
  (1 or more productions involving LeftHandSideExpression)
</emu-grammar>
<p>If |LeftHandSideExpression| is either an |ObjectLiteral| or
   an |ArrayLiteral|, the following Early Error rules are applied:</p>
<ul>
  <li>
    |LeftHandSideExpression| must cover an |AssignmentPattern|.
  </li>
</ul>
<p>If |LeftHandSideExpression| is neither an |ObjectLiteral| nor
     an |ArrayLiteral|, the following Early Error rule is applied:</p>
<ul>
  <li>
    It is a Syntax Error if AssignmentTargetType of
      |LeftHandSideExpression| is not ~simple~.
  </li>
</ul>
```

This PR takes each `<p>` and 'inlines' it into the subsequent `<li>`. (And then fuses the two `<ul>`.)
