### PR TITLE
Editorial: Introduce AO combining IteratorStep and IteratorValue

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -6813,10 +6813,10 @@
           1. If _k_ ≥ 2<sup>53</sup> - 1, then
             1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
             1. Return ? IteratorClose(_iteratorRecord_, _error_).
-          1. Let _next_ be ? IteratorStep(_iteratorRecord_).
-          1. If _next_ is *false*, then
+          1. Let _next_ be ? IteratorStepValue(_iteratorRecord_).
+          1. If _next_ is ~done~, then
             1. Return _groups_.
-          1. Let _value_ be ? IteratorValue(_next_).
+          1. Let _value_ be _next_.
           1. Let _key_ be Completion(Call(_callbackfn_, *undefined*, « _value_, 𝔽(_k_) »)).
           1. IfAbruptCloseIterator(_key_, _iteratorRecord_).
           1. If _keyCoercion_ is ~property~, then
@@ -6994,6 +6994,37 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-iteratorstepvalue" type="abstract operation">
+      <h1>
+        IteratorStepValue (
+          _iteratorRecord_: an Iterator Record,
+        ): either a normal completion containing either an ECMAScript language value or ~done~, or a throw completion
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It requests the next value from _iteratorRecord_.[[Iterator]] by calling _iteratorRecord_.[[NextMethod]] and returns either ~done~ indicating that the iterator has reached its end or the value from the IteratorResult object if a next value is available.</dd>
+      </dl>
+      <emu-alg>
+        1. Let _result_ be Completion(IteratorNext(_iteratorRecord_)).
+        1. If _result_ is a throw completion, then
+          1. Set _iteratorRecord_.[[Done]] to *true*.
+          1. Return ? _result_.
+        1. Set _result_ to ! _result_.
+        1. Let _done_ be Completion(IteratorComplete(_result_)).
+        1. If _done_ is a throw completion, then
+          1. Set _iteratorRecord_.[[Done]] to *true*.
+          1. Return ? _done_.
+        1. Set _done_ to ! _done_.
+        1. If _done_ is *true*, then
+          1. Set _iteratorRecord_.[[Done]] to *true*.
+          1. Return ~done~.
+        1. Let _value_ be Completion(Get(_result_, *"value"*)).
+        1. If _value_ is a throw completion, then
+          1. Set _iteratorRecord_.[[Done]] to *true*.
+        1. Return ? _value_.
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-iteratorclose" type="abstract operation">
       <h1>
         IteratorClose (
@@ -7113,13 +7144,11 @@
       </dl>
       <emu-alg>
         1. Let _values_ be a new empty List.
-        1. Let _next_ be *true*.
-        1. Repeat, while _next_ is not *false*,
-          1. Set _next_ to ? IteratorStep(_iteratorRecord_).
-          1. If _next_ is not *false*, then
-            1. Let _nextValue_ be ? IteratorValue(_next_).
-            1. Append _nextValue_ to _values_.
-        1. Return _values_.
+        1. Repeat,
+          1. Let _next_ be ? IteratorStepValue(_iteratorRecord_).
+          1. If _next_ is ~done~, then
+            1. Return _values_.
+          1. Append _next_ to _values_.
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -9556,15 +9585,9 @@
         1. Let _lhs_ be ? ResolveBinding(_bindingId_, _environment_).
         1. Let _v_ be *undefined*.
         1. If _iteratorRecord_.[[Done]] is *false*, then
-          1. Let _next_ be Completion(IteratorStep(_iteratorRecord_)).
-          1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
-          1. ReturnIfAbrupt(_next_).
-          1. If _next_ is *false*, then
-            1. Set _iteratorRecord_.[[Done]] to *true*.
-          1. Else,
-            1. Set _v_ to Completion(IteratorValue(_next_)).
-            1. If _v_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
-            1. ReturnIfAbrupt(_v_).
+          1. Let _next_ be ? IteratorStepValue(_iteratorRecord_).
+          1. If _next_ is not ~done~, then
+            1. Set _v_ to _next_.
         1. If |Initializer| is present and _v_ is *undefined*, then
           1. If IsAnonymousFunctionDefinition(|Initializer|) is *true*, then
             1. Set _v_ to ? NamedEvaluation of |Initializer| with argument _bindingId_.
@@ -9578,15 +9601,9 @@
       <emu-alg>
         1. Let _v_ be *undefined*.
         1. If _iteratorRecord_.[[Done]] is *false*, then
-          1. Let _next_ be Completion(IteratorStep(_iteratorRecord_)).
-          1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
-          1. ReturnIfAbrupt(_next_).
-          1. If _next_ is *false*, then
-            1. Set _iteratorRecord_.[[Done]] to *true*.
-          1. Else,
-            1. Set _v_ to Completion(IteratorValue(_next_)).
-            1. If _v_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
-            1. ReturnIfAbrupt(_v_).
+          1. Let _next_ be ? IteratorStepValue(_iteratorRecord_).
+          1. If _next_ is not ~done~, then
+            1. Set _v_ to _next_.
         1. If |Initializer| is present and _v_ is *undefined*, then
           1. Let _defaultValue_ be ? Evaluation of |Initializer|.
           1. Set _v_ to ? GetValue(_defaultValue_).
@@ -9598,18 +9615,13 @@
         1. Let _A_ be ! ArrayCreate(0).
         1. Let _n_ be 0.
         1. Repeat,
+          1. Let _next_ be ~done~.
           1. If _iteratorRecord_.[[Done]] is *false*, then
-            1. Let _next_ be Completion(IteratorStep(_iteratorRecord_)).
-            1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
-            1. ReturnIfAbrupt(_next_).
-            1. If _next_ is *false*, set _iteratorRecord_.[[Done]] to *true*.
-          1. If _iteratorRecord_.[[Done]] is *true*, then
+            1. Set _next_ to ? IteratorStepValue(_iteratorRecord_).
+          1. If _next_ is ~done~, then
             1. If _environment_ is *undefined*, return ? PutValue(_lhs_, _A_).
             1. Return ? InitializeReferencedBinding(_lhs_, _A_).
-          1. Let _nextValue_ be Completion(IteratorValue(_next_)).
-          1. If _nextValue_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
-          1. ReturnIfAbrupt(_nextValue_).
-          1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_n_)), _nextValue_).
+          1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_n_)), _next_).
           1. Set _n_ to _n_ + 1.
       </emu-alg>
       <emu-grammar>BindingRestElement : `...` BindingPattern</emu-grammar>
@@ -9617,17 +9629,12 @@
         1. Let _A_ be ! ArrayCreate(0).
         1. Let _n_ be 0.
         1. Repeat,
+          1. Let _next_ be ~done~.
           1. If _iteratorRecord_.[[Done]] is *false*, then
-            1. Let _next_ be Completion(IteratorStep(_iteratorRecord_)).
-            1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
-            1. ReturnIfAbrupt(_next_).
-            1. If _next_ is *false*, set _iteratorRecord_.[[Done]] to *true*.
-          1. If _iteratorRecord_.[[Done]] is *true*, then
+            1. Set _next_ to ? IteratorStepValue(_iteratorRecord_).
+          1. If _next_ is ~done~, then
             1. Return ? BindingInitialization of |BindingPattern| with arguments _A_ and _environment_.
-          1. Let _nextValue_ be Completion(IteratorValue(_next_)).
-          1. If _nextValue_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
-          1. ReturnIfAbrupt(_nextValue_).
-          1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_n_)), _nextValue_).
+          1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_n_)), _next_).
           1. Set _n_ to _n_ + 1.
       </emu-alg>
       <emu-grammar>FormalParameters : [empty]</emu-grammar>
@@ -9648,15 +9655,9 @@
       <emu-alg>
         1. Let _v_ be *undefined*.
         1. Assert: _iteratorRecord_.[[Done]] is *false*.
-        1. Let _next_ be Completion(IteratorStep(_iteratorRecord_)).
-        1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
-        1. ReturnIfAbrupt(_next_).
-        1. If _next_ is *false*, then
-          1. Set _iteratorRecord_.[[Done]] to *true*.
-        1. Else,
-          1. Set _v_ to Completion(IteratorValue(_next_)).
-          1. If _v_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
-          1. ReturnIfAbrupt(_v_).
+        1. Let _next_ be ? IteratorStepValue(_iteratorRecord_).
+        1. If _next_ is not ~done~, then
+          1. Set _v_ to _next_.
         1. Return ? BindingInitialization of |BindingIdentifier| with arguments _v_ and _environment_.
       </emu-alg>
       <emu-grammar>ArrowParameters : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
@@ -9670,15 +9671,9 @@
       <emu-alg>
         1. Let _v_ be *undefined*.
         1. Assert: _iteratorRecord_.[[Done]] is *false*.
-        1. Let _next_ be Completion(IteratorStep(_iteratorRecord_)).
-        1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
-        1. ReturnIfAbrupt(_next_).
-        1. If _next_ is *false*, then
-          1. Set _iteratorRecord_.[[Done]] to *true*.
-        1. Else,
-          1. Set _v_ to Completion(IteratorValue(_next_)).
-          1. If _v_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
-          1. ReturnIfAbrupt(_v_).
+        1. Let _next_ be ? IteratorStepValue(_iteratorRecord_).
+        1. If _next_ is not ~done~, then
+          1. Set _v_ to _next_.
         1. Return ? BindingInitialization of |BindingIdentifier| with arguments _v_ and _environment_.
       </emu-alg>
     </emu-clause>
@@ -18378,10 +18373,9 @@
           1. Let _spreadObj_ be ? GetValue(_spreadRef_).
           1. Let _iteratorRecord_ be ? GetIterator(_spreadObj_, ~sync~).
           1. Repeat,
-            1. Let _next_ be ? IteratorStep(_iteratorRecord_).
-            1. If _next_ is *false*, return _nextIndex_.
-            1. Let _nextValue_ be ? IteratorValue(_next_).
-            1. Perform ! CreateDataPropertyOrThrow(_array_, ! ToString(𝔽(_nextIndex_)), _nextValue_).
+            1. Let _next_ be ? IteratorStepValue(_iteratorRecord_).
+            1. If _next_ is ~done~, return _nextIndex_.
+            1. Perform ! CreateDataPropertyOrThrow(_array_, ! ToString(𝔽(_nextIndex_)), _next_).
             1. Set _nextIndex_ to _nextIndex_ + 1.
         </emu-alg>
         <emu-note>
@@ -19425,10 +19419,9 @@
           1. Let _spreadObj_ be ? GetValue(_spreadRef_).
           1. Let _iteratorRecord_ be ? GetIterator(_spreadObj_, ~sync~).
           1. Repeat,
-            1. Let _next_ be ? IteratorStep(_iteratorRecord_).
-            1. If _next_ is *false*, return _list_.
-            1. Let _nextArg_ be ? IteratorValue(_next_).
-            1. Append _nextArg_ to _list_.
+            1. Let _next_ be ? IteratorStepValue(_iteratorRecord_).
+            1. If _next_ is ~done~, return _list_.
+            1. Append _next_ to _list_.
         </emu-alg>
         <emu-grammar>ArgumentList : ArgumentList `,` AssignmentExpression</emu-grammar>
         <emu-alg>
@@ -19443,10 +19436,9 @@
           1. Let _spreadRef_ be ? Evaluation of |AssignmentExpression|.
           1. Let _iteratorRecord_ be ? GetIterator(? GetValue(_spreadRef_), ~sync~).
           1. Repeat,
-            1. Let _next_ be ? IteratorStep(_iteratorRecord_).
-            1. If _next_ is *false*, return _precedingArgs_.
-            1. Let _nextArg_ be ? IteratorValue(_next_).
-            1. Append _nextArg_ to _precedingArgs_.
+            1. Let _next_ be ? IteratorStepValue(_iteratorRecord_).
+            1. If _next_ is ~done~, return _precedingArgs_.
+            1. Append _next_ to _precedingArgs_.
         </emu-alg>
         <emu-grammar>TemplateLiteral : NoSubstitutionTemplate</emu-grammar>
         <emu-alg>
@@ -21010,15 +21002,9 @@
           1. If |DestructuringAssignmentTarget| is neither an |ObjectLiteral| nor an |ArrayLiteral|, then
             1. Let _lref_ be ? Evaluation of |DestructuringAssignmentTarget|.
           1. If _iteratorRecord_.[[Done]] is *false*, then
-            1. Let _next_ be Completion(IteratorStep(_iteratorRecord_)).
-            1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
-            1. ReturnIfAbrupt(_next_).
-            1. If _next_ is *false*, then
-              1. Set _iteratorRecord_.[[Done]] to *true*.
-            1. Else,
-              1. Let _value_ be Completion(IteratorValue(_next_)).
-              1. If _value_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
-              1. ReturnIfAbrupt(_value_).
+            1. Let _next_ be ? IteratorStepValue(_iteratorRecord_).
+            1. If _next_ is not ~done~, then
+              1. Let _value_ be _next_.
           1. If _iteratorRecord_.[[Done]] is *true*, let _value_ be *undefined*.
           1. If |Initializer| is present and _value_ is *undefined*, then
             1. If IsAnonymousFunctionDefinition(|Initializer|) is *true* and IsIdentifierRef of |DestructuringAssignmentTarget| is *true*, then
@@ -21043,16 +21029,9 @@
           1. Let _A_ be ! ArrayCreate(0).
           1. Let _n_ be 0.
           1. Repeat, while _iteratorRecord_.[[Done]] is *false*,
-            1. Let _next_ be Completion(IteratorStep(_iteratorRecord_)).
-            1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
-            1. ReturnIfAbrupt(_next_).
-            1. If _next_ is *false*, then
-              1. Set _iteratorRecord_.[[Done]] to *true*.
-            1. Else,
-              1. Let _nextValue_ be Completion(IteratorValue(_next_)).
-              1. If _nextValue_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
-              1. ReturnIfAbrupt(_nextValue_).
-              1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_n_)), _nextValue_).
+            1. Let _next_ be ? IteratorStepValue(_iteratorRecord_).
+            1. If _next_ is not ~done~, then
+              1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_n_)), _next_).
               1. Set _n_ to _n_ + 1.
           1. If |DestructuringAssignmentTarget| is neither an |ObjectLiteral| nor an |ArrayLiteral|, then
             1. Return ? PutValue(_lref_, _A_).
@@ -38639,16 +38618,15 @@ THH:mm:ss.sss
                 1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
                 1. Return ? IteratorClose(_iteratorRecord_, _error_).
               1. Let _Pk_ be ! ToString(𝔽(_k_)).
-              1. Let _next_ be ? IteratorStep(_iteratorRecord_).
-              1. If _next_ is *false*, then
+              1. Let _next_ be ? IteratorStepValue(_iteratorRecord_).
+              1. If _next_ is ~done~, then
                 1. Perform ? Set(_A_, *"length"*, 𝔽(_k_), *true*).
                 1. Return _A_.
-              1. Let _nextValue_ be ? IteratorValue(_next_).
               1. If _mapping_ is *true*, then
-                1. Let _mappedValue_ be Completion(Call(_mapfn_, _thisArg_, « _nextValue_, 𝔽(_k_) »)).
+                1. Let _mappedValue_ be Completion(Call(_mapfn_, _thisArg_, « _next_, 𝔽(_k_) »)).
                 1. IfAbruptCloseIterator(_mappedValue_, _iteratorRecord_).
               1. Else,
-                1. Let _mappedValue_ be _nextValue_.
+                1. Let _mappedValue_ be _next_.
               1. Let _defineStatus_ be Completion(CreateDataPropertyOrThrow(_A_, _Pk_, _mappedValue_)).
               1. IfAbruptCloseIterator(_defineStatus_, _iteratorRecord_).
               1. Set _k_ to _k_ + 1.
@@ -41808,15 +41786,14 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _iteratorRecord_ be ? GetIterator(_iterable_, ~sync~).
           1. Repeat,
-            1. Let _next_ be ? IteratorStep(_iteratorRecord_).
-            1. If _next_ is *false*, return _target_.
-            1. Let _nextItem_ be ? IteratorValue(_next_).
-            1. If _nextItem_ is not an Object, then
+            1. Let _next_ be ? IteratorStepValue(_iteratorRecord_).
+            1. If _next_ is ~done~, return _target_.
+            1. If _next_ is not an Object, then
               1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
               1. Return ? IteratorClose(_iteratorRecord_, _error_).
-            1. Let _k_ be Completion(Get(_nextItem_, *"0"*)).
+            1. Let _k_ be Completion(Get(_next_, *"0"*)).
             1. IfAbruptCloseIterator(_k_, _iteratorRecord_).
-            1. Let _v_ be Completion(Get(_nextItem_, *"1"*)).
+            1. Let _v_ be Completion(Get(_next_, *"1"*)).
             1. IfAbruptCloseIterator(_v_, _iteratorRecord_).
             1. Let _status_ be Completion(Call(_adder_, _target_, « _k_, _v_ »)).
             1. IfAbruptCloseIterator(_status_, _iteratorRecord_).
@@ -42141,10 +42118,9 @@ THH:mm:ss.sss
           1. If IsCallable(_adder_) is *false*, throw a *TypeError* exception.
           1. Let _iteratorRecord_ be ? GetIterator(_iterable_, ~sync~).
           1. Repeat,
-            1. Let _next_ be ? IteratorStep(_iteratorRecord_).
-            1. If _next_ is *false*, return _set_.
-            1. Let _nextValue_ be ? IteratorValue(_next_).
-            1. Let _status_ be Completion(Call(_adder_, _set_, « _nextValue_ »)).
+            1. Let _next_ be ? IteratorStepValue(_iteratorRecord_).
+            1. If _next_ is ~done~, return _set_.
+            1. Let _status_ be Completion(Call(_adder_, _set_, « _next_ »)).
             1. IfAbruptCloseIterator(_status_, _iteratorRecord_).
         </emu-alg>
       </emu-clause>
@@ -42580,10 +42556,9 @@ THH:mm:ss.sss
           1. If IsCallable(_adder_) is *false*, throw a *TypeError* exception.
           1. Let _iteratorRecord_ be ? GetIterator(_iterable_, ~sync~).
           1. Repeat,
-            1. Let _next_ be ? IteratorStep(_iteratorRecord_).
-            1. If _next_ is *false*, return _set_.
-            1. Let _nextValue_ be ? IteratorValue(_next_).
-            1. Let _status_ be Completion(Call(_adder_, _set_, « _nextValue_ »)).
+            1. Let _next_ be ? IteratorStepValue(_iteratorRecord_).
+            1. If _next_ is ~done~, return _set_.
+            1. Let _status_ be Completion(Call(_adder_, _set_, « _next_ »)).
             1. IfAbruptCloseIterator(_status_, _iteratorRecord_).
         </emu-alg>
       </emu-clause>
@@ -46658,21 +46633,15 @@ THH:mm:ss.sss
             1. Let _remainingElementsCount_ be the Record { [[Value]]: 1 }.
             1. Let _index_ be 0.
             1. Repeat,
-              1. Let _next_ be Completion(IteratorStep(_iteratorRecord_)).
-              1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
-              1. ReturnIfAbrupt(_next_).
-              1. If _next_ is *false*, then
-                1. Set _iteratorRecord_.[[Done]] to *true*.
+              1. Let _next_ be ? IteratorStepValue(_iteratorRecord_).
+              1. If _next_ is ~done~, then
                 1. Set _remainingElementsCount_.[[Value]] to _remainingElementsCount_.[[Value]] - 1.
                 1. If _remainingElementsCount_.[[Value]] = 0, then
                   1. Let _valuesArray_ be CreateArrayFromList(_values_).
                   1. Perform ? Call(_resultCapability_.[[Resolve]], *undefined*, « _valuesArray_ »).
                 1. Return _resultCapability_.[[Promise]].
-              1. Let _nextValue_ be Completion(IteratorValue(_next_)).
-              1. If _nextValue_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
-              1. ReturnIfAbrupt(_nextValue_).
               1. Append *undefined* to _values_.
-              1. Let _nextPromise_ be ? Call(_promiseResolve_, _constructor_, « _nextValue_ »).
+              1. Let _nextPromise_ be ? Call(_promiseResolve_, _constructor_, « _next_ »).
               1. Let _steps_ be the algorithm steps defined in <emu-xref href="#sec-promise.all-resolve-element-functions" title></emu-xref>.
               1. Let _length_ be the number of non-optional parameters of the function definition in <emu-xref href="#sec-promise.all-resolve-element-functions" title></emu-xref>.
               1. Let _onFulfilled_ be CreateBuiltinFunction(_steps_, _length_, *""*, « [[AlreadyCalled]], [[Index]], [[Values]], [[Capability]], [[RemainingElements]] »).
@@ -46746,21 +46715,15 @@ THH:mm:ss.sss
             1. Let _remainingElementsCount_ be the Record { [[Value]]: 1 }.
             1. Let _index_ be 0.
             1. Repeat,
-              1. Let _next_ be Completion(IteratorStep(_iteratorRecord_)).
-              1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
-              1. ReturnIfAbrupt(_next_).
-              1. If _next_ is *false*, then
-                1. Set _iteratorRecord_.[[Done]] to *true*.
+              1. Let _next_ be ? IteratorStepValue(_iteratorRecord_).
+              1. If _next_ is ~done~, then
                 1. Set _remainingElementsCount_.[[Value]] to _remainingElementsCount_.[[Value]] - 1.
                 1. If _remainingElementsCount_.[[Value]] = 0, then
                   1. Let _valuesArray_ be CreateArrayFromList(_values_).
                   1. Perform ? Call(_resultCapability_.[[Resolve]], *undefined*, « _valuesArray_ »).
                 1. Return _resultCapability_.[[Promise]].
-              1. Let _nextValue_ be Completion(IteratorValue(_next_)).
-              1. If _nextValue_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
-              1. ReturnIfAbrupt(_nextValue_).
               1. Append *undefined* to _values_.
-              1. Let _nextPromise_ be ? Call(_promiseResolve_, _constructor_, « _nextValue_ »).
+              1. Let _nextPromise_ be ? Call(_promiseResolve_, _constructor_, « _next_ »).
               1. Let _stepsFulfilled_ be the algorithm steps defined in <emu-xref href="#sec-promise.allsettled-resolve-element-functions" title></emu-xref>.
               1. Let _lengthFulfilled_ be the number of non-optional parameters of the function definition in <emu-xref href="#sec-promise.allsettled-resolve-element-functions" title></emu-xref>.
               1. Let _onFulfilled_ be CreateBuiltinFunction(_stepsFulfilled_, _lengthFulfilled_, *""*, « [[AlreadyCalled]], [[Index]], [[Values]], [[Capability]], [[RemainingElements]] »).
@@ -46873,22 +46836,16 @@ THH:mm:ss.sss
             1. Let _remainingElementsCount_ be the Record { [[Value]]: 1 }.
             1. Let _index_ be 0.
             1. Repeat,
-              1. Let _next_ be Completion(IteratorStep(_iteratorRecord_)).
-              1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
-              1. ReturnIfAbrupt(_next_).
-              1. If _next_ is *false*, then
-                1. Set _iteratorRecord_.[[Done]] to *true*.
+              1. Let _next_ be ? IteratorStepValue(_iteratorRecord_).
+              1. If _next_ is ~done~, then
                 1. Set _remainingElementsCount_.[[Value]] to _remainingElementsCount_.[[Value]] - 1.
                 1. If _remainingElementsCount_.[[Value]] = 0, then
                   1. Let _error_ be a newly created *AggregateError* object.
                   1. Perform ! DefinePropertyOrThrow(_error_, *"errors"*, PropertyDescriptor { [[Configurable]]: *true*, [[Enumerable]]: *false*, [[Writable]]: *true*, [[Value]]: CreateArrayFromList(_errors_) }).
                   1. Return ThrowCompletion(_error_).
                 1. Return _resultCapability_.[[Promise]].
-              1. Let _nextValue_ be Completion(IteratorValue(_next_)).
-              1. If _nextValue_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
-              1. ReturnIfAbrupt(_nextValue_).
               1. Append *undefined* to _errors_.
-              1. Let _nextPromise_ be ? Call(_promiseResolve_, _constructor_, « _nextValue_ »).
+              1. Let _nextPromise_ be ? Call(_promiseResolve_, _constructor_, « _next_ »).
               1. Let _stepsRejected_ be the algorithm steps defined in <emu-xref href="#sec-promise.any-reject-element-functions" title></emu-xref>.
               1. Let _lengthRejected_ be the number of non-optional parameters of the function definition in <emu-xref href="#sec-promise.any-reject-element-functions" title></emu-xref>.
               1. Let _onRejected_ be CreateBuiltinFunction(_stepsRejected_, _lengthRejected_, *""*, « [[AlreadyCalled]], [[Index]], [[Errors]], [[Capability]], [[RemainingElements]] »).
@@ -46969,16 +46926,10 @@ THH:mm:ss.sss
           </dl>
           <emu-alg>
             1. Repeat,
-              1. Let _next_ be Completion(IteratorStep(_iteratorRecord_)).
-              1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
-              1. ReturnIfAbrupt(_next_).
-              1. If _next_ is *false*, then
-                1. Set _iteratorRecord_.[[Done]] to *true*.
+              1. Let _next_ be ? IteratorStepValue(_iteratorRecord_).
+              1. If _next_ is ~done~, then
                 1. Return _resultCapability_.[[Promise]].
-              1. Let _nextValue_ be Completion(IteratorValue(_next_)).
-              1. If _nextValue_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
-              1. ReturnIfAbrupt(_nextValue_).
-              1. Let _nextPromise_ be ? Call(_promiseResolve_, _constructor_, « _nextValue_ »).
+              1. Let _nextPromise_ be ? Call(_promiseResolve_, _constructor_, « _next_ »).
               1. Perform ? Invoke(_nextPromise_, *"then"*, « _resultCapability_.[[Resolve]], _resultCapability_.[[Reject]] »).
           </emu-alg>
         </emu-clause>


### PR DESCRIPTION
"IteratorStepValue" isn't a _great_ name, but I'm worried that sticking with IteratorStep will lead to a bunch of confusing documentation/comments, so I didn't want to reuse it.

In the cases which deal with completion records explicitly you might have to think for a second to convince yourself the change doesn't actually affect behavior.

The only 2 remaining uses of IteratorStep are in the elisions in `[a, /* hole */, b] = iterable`. Ordinarily I'd inline it into those and delete the AO, but I want to update 402 and proposals to use the new AO before doing that.

There are still 8 uses of IteratorValue: 7 in `yield*`, 1 in the AsyncFromSyncIterator wrapper. `yield*` could probably use a cleanup too, but not in this PR.