### PR TITLE
Editorial: refer to binary64 values by their official name in more places

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1064,7 +1064,7 @@
       <ul>
         <li><dfn id="mathematical-value" variants="mathematical value,mathematical values">Mathematical values</dfn>: Arbitrary real numbers, used as the default numeric type.</li>
         <li><dfn id="extended-mathematical-value" variants="extended mathematical value,extended mathematical values">Extended mathematical values</dfn>: Mathematical values together with +∞ and -∞.</li>
-        <li><em>Numbers</em>: IEEE 754-2019 double-precision floating point values.</li>
+        <li><em>Numbers</em>: IEEE 754-2019 binary64 (double-precision floating point) values.</li>
         <li><em>BigInts</em>: ECMAScript language values representing arbitrary integers in a one-to-one correspondence.</li>
       </ul>
 
@@ -1820,7 +1820,7 @@
 
       <emu-clause id="sec-ecmascript-language-types-number-type">
         <h1>The Number Type</h1>
-        <p>The <dfn variants="is a Number,is not a Number">Number type</dfn> has exactly 18,437,736,874,454,810,627 (that is, <emu-eqn>2<sup>64</sup> - 2<sup>53</sup> + 3</emu-eqn>) values, representing the double-precision 64-bit format IEEE 754-2019 values as specified in the IEEE Standard for Binary Floating-Point Arithmetic, except that the 9,007,199,254,740,990 (that is, <emu-eqn>2<sup>53</sup> - 2</emu-eqn>) distinct “Not-a-Number” values of the IEEE Standard are represented in ECMAScript as a single special *NaN* value. (Note that the *NaN* value is produced by the program expression `NaN`.) In some implementations, external code might be able to detect a difference between various Not-a-Number values, but such behaviour is implementation-defined; to ECMAScript code, all *NaN* values are indistinguishable from each other.</p>
+        <p>The <dfn variants="is a Number,is not a Number">Number type</dfn> has exactly 18,437,736,874,454,810,627 (that is, <emu-eqn>2<sup>64</sup> - 2<sup>53</sup> + 3</emu-eqn>) values, representing the double-precision floating point IEEE 754-2019 binary64 values as specified in the IEEE Standard for Binary Floating-Point Arithmetic, except that the 9,007,199,254,740,990 (that is, <emu-eqn>2<sup>53</sup> - 2</emu-eqn>) distinct “Not-a-Number” values of the IEEE Standard are represented in ECMAScript as a single special *NaN* value. (Note that the *NaN* value is produced by the program expression `NaN`.) In some implementations, external code might be able to detect a difference between various Not-a-Number values, but such behaviour is implementation-defined; to ECMAScript code, all *NaN* values are indistinguishable from each other.</p>
         <emu-note>
           <p>The bit pattern that might be observed in an ArrayBuffer (see <emu-xref href="#sec-arraybuffer-objects"></emu-xref>) or a SharedArrayBuffer (see <emu-xref href="#sec-sharedarraybuffer-objects"></emu-xref>) after a Number value has been stored into it is not necessarily the same as the internal representation of that Number value used by the ECMAScript implementation.</p>
         </emu-note>


### PR DESCRIPTION
The official name has been binary64 since IEEE 754-2008. We already use that name in a few places. This uses that name in 2 additional places where I felt such rigour was important.