### PR TITLE
Editorial: avoid multiple declarations of an alias

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -21001,11 +21001,11 @@
         <emu-alg>
           1. If |DestructuringAssignmentTarget| is neither an |ObjectLiteral| nor an |ArrayLiteral|, then
             1. Let _lref_ be ? Evaluation of |DestructuringAssignmentTarget|.
+          1. Let _value_ be *undefined*.
           1. If _iteratorRecord_.[[Done]] is *false*, then
             1. Let _next_ be ? IteratorStepValue(_iteratorRecord_).
             1. If _next_ is not ~done~, then
-              1. Let _value_ be _next_.
-          1. If _iteratorRecord_.[[Done]] is *true*, let _value_ be *undefined*.
+              1. Set _value_ to _next_.
           1. If |Initializer| is present and _value_ is *undefined*, then
             1. If IsAnonymousFunctionDefinition(|Initializer|) is *true* and IsIdentifierRef of |DestructuringAssignmentTarget| is *true*, then
               1. Let _v_ be ? NamedEvaluation of |Initializer| with argument _lref_.[[ReferencedName]].


### PR DESCRIPTION
This fixes a bug where we can reach the declaration of `value` not-exactly-once. That is in editorial issue. Fixed using the pattern we already use in many other places, often with the alias `v`.

Done on top of #3268 as to not conflict. Marking as draft until that is merged.