### PR TITLE
Editorial: Simplify algorithms by making (Async)IteratorClose idempotent

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -7038,6 +7038,7 @@
       </dl>
       <emu-alg>
         1. Assert: _iteratorRecord_.[[Iterator]] is an Object.
+        1. If _iteratorRecord_.[[Done]] is *true*, return ? _completion_.
         1. Let _iterator_ be _iteratorRecord_.[[Iterator]].
         1. Let _innerResult_ be Completion(GetMethod(_iterator_, *"return"*)).
         1. If _innerResult_ is a normal completion, then
@@ -7078,6 +7079,7 @@
       </dl>
       <emu-alg>
         1. Assert: _iteratorRecord_.[[Iterator]] is an Object.
+        1. If _iteratorRecord_.[[Done]] is *true*, return ? _completion_.
         1. Let _iterator_ be _iteratorRecord_.[[Iterator]].
         1. Let _innerResult_ be Completion(GetMethod(_iterator_, *"return"*)).
         1. If _innerResult_ is a normal completion, then
@@ -9483,8 +9485,7 @@
       <emu-alg>
         1. Let _iteratorRecord_ be ? GetIterator(_value_, ~sync~).
         1. Let _result_ be Completion(IteratorBindingInitialization of |ArrayBindingPattern| with arguments _iteratorRecord_ and _environment_).
-        1. If _iteratorRecord_.[[Done]] is *false*, return ? IteratorClose(_iteratorRecord_, _result_).
-        1. Return ? _result_.
+        1. Return ? IteratorClose(_iteratorRecord_, _result_).
       </emu-alg>
       <emu-grammar>ObjectBindingPattern : `{` `}`</emu-grammar>
       <emu-alg>
@@ -20853,8 +20854,7 @@
         <emu-alg>
           1. Let _iteratorRecord_ be ? GetIterator(_value_, ~sync~).
           1. Let _result_ be Completion(IteratorDestructuringAssignmentEvaluation of |Elision| with argument _iteratorRecord_).
-          1. If _iteratorRecord_.[[Done]] is *false*, return ? IteratorClose(_iteratorRecord_, _result_).
-          1. Return _result_.
+          1. Return ? IteratorClose(_iteratorRecord_, _result_).
         </emu-alg>
         <emu-grammar>ArrayAssignmentPattern : `[` Elision? AssignmentRestElement `]`</emu-grammar>
         <emu-alg>
@@ -20865,23 +20865,20 @@
               1. Assert: _iteratorRecord_.[[Done]] is *true*.
               1. Return ? _status_.
           1. Let _result_ be Completion(IteratorDestructuringAssignmentEvaluation of |AssignmentRestElement| with argument _iteratorRecord_).
-          1. If _iteratorRecord_.[[Done]] is *false*, return ? IteratorClose(_iteratorRecord_, _result_).
-          1. Return _result_.
+          1. Return ? IteratorClose(_iteratorRecord_, _result_).
         </emu-alg>
         <emu-grammar>ArrayAssignmentPattern : `[` AssignmentElementList `]`</emu-grammar>
         <emu-alg>
           1. Let _iteratorRecord_ be ? GetIterator(_value_, ~sync~).
           1. Let _result_ be Completion(IteratorDestructuringAssignmentEvaluation of |AssignmentElementList| with argument _iteratorRecord_).
-          1. If _iteratorRecord_.[[Done]] is *false*, return ? IteratorClose(_iteratorRecord_, _result_).
-          1. Return _result_.
+          1. Return ? IteratorClose(_iteratorRecord_, _result_).
         </emu-alg>
         <emu-grammar>ArrayAssignmentPattern : `[` AssignmentElementList `,` Elision? AssignmentRestElement? `]`</emu-grammar>
         <emu-alg>
           1. Let _iteratorRecord_ be ? GetIterator(_value_, ~sync~).
           1. Let _status_ be Completion(IteratorDestructuringAssignmentEvaluation of |AssignmentElementList| with argument _iteratorRecord_).
           1. If _status_ is an abrupt completion, then
-            1. If _iteratorRecord_.[[Done]] is *false*, return ? IteratorClose(_iteratorRecord_, _status_).
-            1. Return ? _status_.
+            1. Return ? IteratorClose(_iteratorRecord_, _status_).
           1. If |Elision| is present, then
             1. Set _status_ to Completion(IteratorDestructuringAssignmentEvaluation of |Elision| with argument _iteratorRecord_).
             1. If _status_ is an abrupt completion, then
@@ -20889,8 +20886,7 @@
               1. Return ? _status_.
           1. If |AssignmentRestElement| is present, then
             1. Set _status_ to Completion(IteratorDestructuringAssignmentEvaluation of |AssignmentRestElement| with argument _iteratorRecord_).
-          1. If _iteratorRecord_.[[Done]] is *false*, return ? IteratorClose(_iteratorRecord_, _status_).
-          1. Return ? _status_.
+          1. Return ? IteratorClose(_iteratorRecord_, _status_).
         </emu-alg>
       </emu-clause>
 
@@ -46594,7 +46590,7 @@ THH:mm:ss.sss
           1. IfAbruptRejectPromise(_iteratorRecord_, _promiseCapability_).
           1. Let _result_ be Completion(PerformPromiseAll(_iteratorRecord_, _C_, _promiseCapability_, _promiseResolve_)).
           1. If _result_ is an abrupt completion, then
-            1. If _iteratorRecord_.[[Done]] is *false*, set _result_ to Completion(IteratorClose(_iteratorRecord_, _result_)).
+            1. Set _result_ to Completion(IteratorClose(_iteratorRecord_, _result_)).
             1. IfAbruptRejectPromise(_result_, _promiseCapability_).
           1. Return ? _result_.
         </emu-alg>
@@ -46691,7 +46687,7 @@ THH:mm:ss.sss
           1. IfAbruptRejectPromise(_iteratorRecord_, _promiseCapability_).
           1. Let _result_ be Completion(PerformPromiseAllSettled(_iteratorRecord_, _C_, _promiseCapability_, _promiseResolve_)).
           1. If _result_ is an abrupt completion, then
-            1. If _iteratorRecord_.[[Done]] is *false*, set _result_ to Completion(IteratorClose(_iteratorRecord_, _result_)).
+            1. Set _result_ to Completion(IteratorClose(_iteratorRecord_, _result_)).
             1. IfAbruptRejectPromise(_result_, _promiseCapability_).
           1. Return ? _result_.
         </emu-alg>
@@ -46812,7 +46808,7 @@ THH:mm:ss.sss
           1. IfAbruptRejectPromise(_iteratorRecord_, _promiseCapability_).
           1. Let _result_ be Completion(PerformPromiseAny(_iteratorRecord_, _C_, _promiseCapability_, _promiseResolve_)).
           1. If _result_ is an abrupt completion, then
-            1. If _iteratorRecord_.[[Done]] is *false*, set _result_ to Completion(IteratorClose(_iteratorRecord_, _result_)).
+            1. Set _result_ to Completion(IteratorClose(_iteratorRecord_, _result_)).
             1. IfAbruptRejectPromise(_result_, _promiseCapability_).
           1. Return ? _result_.
         </emu-alg>
@@ -46902,7 +46898,7 @@ THH:mm:ss.sss
           1. IfAbruptRejectPromise(_iteratorRecord_, _promiseCapability_).
           1. Let _result_ be Completion(PerformPromiseRace(_iteratorRecord_, _C_, _promiseCapability_, _promiseResolve_)).
           1. If _result_ is an abrupt completion, then
-            1. If _iteratorRecord_.[[Done]] is *false*, set _result_ to Completion(IteratorClose(_iteratorRecord_, _result_)).
+            1. Set _result_ to Completion(IteratorClose(_iteratorRecord_, _result_)).
             1. IfAbruptRejectPromise(_result_, _promiseCapability_).
           1. Return ? _result_.
         </emu-alg>


### PR DESCRIPTION
This removes a lot of encapsulation-piercing _iteratorRecord_.[[Done]] checks.