### PR TITLE
Meta: fix ecma text copyright link

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,5 @@
 This repository is licensed according to Ecma International TC39's [Intellectual Property Policy](https://github.com/tc39/how-we-work/blob/HEAD/ip.md). In particular:
-- Natural language text is licensed under the "Alternative copyright notice" of the [Ecma text copyright policy](https://www.ecma-international.org/memento/Ecma%20copyright%20faq.htm).
+
+- Natural language text is licensed under the [Alternative copyright notice of the Ecma text copyright policy](https://ecma-international.org/policies/by-ipr/ecma-text-copyright-policy/#alternative-copyright-notice).
 - Source code is licensed under Ecma's MIT-style [Ecma International Policy on Submission, Inclusion and Licensing of Software](https://www.ecma-international.org/memento/Policies/Ecma_Policy_on_Submission_Inclusion_and_Licensing_of_Software.htm).
 - Contributions are only accepted from either representatives of Ecma members or signatories of TC39's [Contributor Form](https://tc39.github.io/agreements/contributor/).


### PR DESCRIPTION
old link is dead.  also eliminated the scare quotes
