### PR TITLE
Editorial: replace the only instance of CreateMethodProperty with DefineMethodProperty

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -6117,29 +6117,6 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-createmethodproperty" type="abstract operation">
-      <h1>
-        CreateMethodProperty (
-          _O_: an Object,
-          _P_: a property key,
-          _V_: an ECMAScript language value,
-        ): ~unused~
-      </h1>
-      <dl class="header">
-        <dt>description</dt>
-        <dd>It is used to create a new own property of an ordinary object.</dd>
-      </dl>
-      <emu-alg>
-        1. Assert: _O_ is an ordinary, extensible object with no non-configurable properties.
-        1. Let _newDesc_ be the PropertyDescriptor { [[Value]]: _V_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.
-        1. Perform ! DefinePropertyOrThrow(_O_, _P_, _newDesc_).
-        1. Return ~unused~.
-      </emu-alg>
-      <emu-note>
-        <p>This abstract operation creates a property whose attributes are set to the same defaults used for built-in methods and methods defined using class declaration syntax. Normally, the property will not already exist. If it does exist, DefinePropertyOrThrow is guaranteed to complete normally.</p>
-      </emu-note>
-    </emu-clause>
-
     <emu-clause id="sec-createdatapropertyorthrow" type="abstract operation">
       <h1>
         CreateDataPropertyOrThrow (
@@ -24956,7 +24933,7 @@
           1. Perform SetFunctionName(_F_, _className_).
         1. Perform MakeConstructor(_F_, *false*, _proto_).
         1. If |ClassHeritage| is present, set _F_.[[ConstructorKind]] to ~derived~.
-        1. Perform CreateMethodProperty(_proto_, *"constructor"*, _F_).
+        1. Perform ! DefineMethodProperty(_proto_, *"constructor"*, _F_, *false*).
         1. If |ClassBody| is not present, let _elements_ be a new empty List.
         1. Else, let _elements_ be NonConstructorElements of |ClassBody|.
         1. Let _instancePrivateMethods_ be a new empty List.


### PR DESCRIPTION
This should be landed after #2814.

This AO was only used in one place, and it's just a specialized form of one of the two branches in DefineMethodProperty (it was already only ever setting a function, on a configurable property on a normal object, with a hardcoded enumerable false), so this seemed like a good change.