### PR TITLE
Markup: coercing primitives to numerics is not user code in IsLessThan

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -5934,8 +5934,8 @@
             1. If _nx_ is *undefined*, return *undefined*.
             1. Return BigInt::lessThan(_nx_, _py_).
           1. NOTE: Because _px_ and _py_ are primitive values, evaluation order is not important.
-          1. Let _nx_ be ? ToNumeric(_px_).
-          1. Let _ny_ be ? ToNumeric(_py_).
+          1. Let _nx_ be ? <emu-meta suppress-effects="user-code">ToNumeric(_px_)</emu-meta>.
+          1. Let _ny_ be ? <emu-meta suppress-effects="user-code">ToNumeric(_py_)</emu-meta>.
           1. If Type(_nx_) is Type(_ny_), then
             1. If _nx_ is a Number, then
               1. Return Number::lessThan(_nx_, _ny_).


### PR DESCRIPTION
In [IsLessThan](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-islessthan), first both values are coerced to primitives, and then those are later possibly coerced to numerics. The second part can throw (if given a Symbol), but cannot invoke user code, as you can tell from the note immediately before these steps.