### PR TITLE
Editorial: Describe changes in ES2024

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -99,6 +99,7 @@
   <p>ECMAScript 2021, the 12<sup>th</sup> edition, introduced the `replaceAll` method for Strings; `Promise.any`, a Promise combinator that short-circuits when an input value is fulfilled; `AggregateError`, a new Error type to represent multiple errors at once; logical assignment operators (`??=`, `&&=`, `||=`); `WeakRef`, for referring to a target object without preserving it from garbage collection, and `FinalizationRegistry`, to manage registration and unregistration of cleanup operations performed when target objects are garbage collected; separators for numeric literals (`1_000`); and `Array.prototype.sort` was made more precise, reducing the amount of cases that result in an implementation-defined sort order.</p>
   <p>ECMAScript 2022, the 13<sup>th</sup> edition, introduced top-level `await`, allowing the keyword to be used at the top level of modules; new class elements: public and private instance fields, public and private static fields, private instance methods and accessors, and private static methods and accessors; static blocks inside classes, to perform per-class evaluation initialization; the `#x in obj` syntax, to test for presence of private fields on objects; regular expression match indices via the `/d` flag, which provides start and end indices for matched substrings; the `cause` property on `Error` objects, which can be used to record a causation chain in errors; the `at` method for Strings, Arrays, and TypedArrays, which allows relative indexing; and `Object.hasOwn`, a convenient alternative to `Object.prototype.hasOwnProperty`.</p>
   <p>ECMAScript 2023, the 14<sup>th</sup> edition, introduced the `toSorted`, `toReversed`, `with`, `findLast`, and `findLastIndex` methods on `Array.prototype` and `TypedArray.prototype`, as well as the `toSpliced` method on `Array.prototype`; added support for `#!` comments at the beginning of files to better facilitate executable ECMAScript files; and allowed the use of most Symbols as keys in weak collections.</p>
+  <p>ECMAScript 2024, the 15<sup>th</sup> edition, added facilities for resizing and transferring ArrayBuffers and SharedArrayBuffers; added a new RegExp `/v` flag for creating RegExps with more advanced features for working with sets of strings; and introduced the `Promise.withResolvers` convenience method for constructing Promises, the `Object.groupBy` and `Map.groupBy` methods for aggregating data, the `Atomics.waitAsync` method for asynchronously waiting for a change to shared memory, and the `String.prototype.isWellFormed` and `String.prototype.toWellFormed` methods for checking and ensuring that strings contain only well-formed Unicode.</p>
   <p>Dozens of individuals representing many organizations have made very significant contributions within Ecma TC39 to the development of this edition and to the prior editions. In addition, a vibrant community has emerged supporting TC39's ECMAScript efforts. This community has reviewed numerous drafts, filed thousands of bug reports, performed implementation experiments, contributed test suites, and educated the world-wide developer community about ECMAScript. Unfortunately, it is impossible to identify and acknowledge every person and organization who has contributed to this effort.</p>
   <p>
     Allen Wirfs-Brock<br>
@@ -114,15 +115,15 @@
   </p>
   <p>
     Shu-yu Guo<br>
-    ECMA-262, Project Editor, 12<sup>th</sup> through 14<sup>th</sup> Editions
+    ECMA-262, Project Editor, 12<sup>th</sup> through 15<sup>th</sup> Editions
   </p>
   <p>
     Michael Ficarra<br>
-    ECMA-262, Project Editor, 12<sup>th</sup> through 14<sup>th</sup> Editions
+    ECMA-262, Project Editor, 12<sup>th</sup> through 15<sup>th</sup> Editions
   </p>
   <p>
     Kevin Gibbons<br>
-    ECMA-262, Project Editor, 12<sup>th</sup> through 14<sup>th</sup> Editions
+    ECMA-262, Project Editor, 12<sup>th</sup> through 15<sup>th</sup> Editions
   </p>
 </emu-intro>
 


### PR DESCRIPTION
Of the normative changes:
```
git log --oneline --grep=Normative $(git merge-base main es2023)..main
```
```
44bb0e0d Normative: add ArrayBuffer.prototype.{detached,transfer,transferToFixedLength} (#3175)
197f1245 Normative: Allow Annex B scripts to start with `-->` (#3244)
b07ca066 Normative: Provide source text to HostEnsureCanCompileStrings (#3222)
22de3740 Normative: Recompute count in TA.p.slice (#3255)
11cbf729 Normative: add `Promise.withResolvers` (#3179)
3a9c9dcb Normative: add `Object.groupBy` and `Map.groupBy` (#3176)
5eaee2f3 Normative: Update GetSubstitution to match reality (#3157)
a9ae96ed Normative: Add resizable ArrayBuffer and growable SharedArrayBuffer (#3116)
53454a9a Normative: Make HasCallInTailPosition for ImportCall always return false (#3106)
26b23696 Normative: Add RegExp `v` flag
3330e231 Normative: Add Atomics.waitAsync (#3049)
25f97441 Normative: Disallow ArrayBuffers bigger than 2**53 (#3052)
d95f42d5 Normative: integrate well-formed Unicode strings proposal (#3039)
```
I've described those I considered significant enough to be worth mentioning, in no particular order.