### PR TITLE
Normative: Restore params/body ToString order in `new Function`

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -30167,10 +30167,10 @@
               1. Let _parameterSym_ be the grammar symbol |FormalParameters[+Yield, +Await]|.
               1. Let _fallbackProto_ be *"%AsyncGeneratorFunction.prototype%"*.
             1. Let _argCount_ be the number of elements in _parameterArgs_.
-            1. Let _bodyString_ be ? ToString(_bodyArg_).
             1. Let _parameterStrings_ be a new empty List.
             1. For each element _arg_ of _parameterArgs_, do
               1. Append ? ToString(_arg_) to _parameterStrings_.
+            1. Let _bodyString_ be ? ToString(_bodyArg_).
             1. Let _currentRealm_ be the current Realm Record.
             1. Perform ? HostEnsureCanCompileStrings(_currentRealm_, _parameterStrings_, _bodyString_, *false*).
             1. Let _P_ be the empty String.


### PR DESCRIPTION
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->

https://github.com/tc39/ecma262/pull/3222 (cc @ptomato) accidentally changed the `new Function` implementation to stringify the body _before_ the parameters, rather than after. This change was introduced in [this force-push to that PR](https://github.com/tc39/ecma262/compare/639273d8c16879dbe6f8d3a6770dcc7fc2b7f393..af086c85de3fa2a8a68f6232d5ce1443fb729c96), as part of the response to https://github.com/tc39/ecma262/pull/3222#discussion_r1445101746, but it was unnecessary (and unrelated) for Kevin's request.

Being accidental, this change was never discussed in plenary ([slides](https://docs.google.com/presentation/d/1MRItYS_b1hwKstlqlfoD8mgbecS2OkTSiPFVWHs3Y_8), [notes 1](https://github.com/tc39/notes/blob/main/meetings/2023-11/november-27.md#provide-source-text-to-hostensurecancompilestrings-pr-3222), [notes 2](https://github.com/tc39/notes/blob/main/meetings/2023-11/november-29.md#provide-source-text-to-hostensurecancompilestrings-pr-continuation)). If anything, the slide that got consensus (slide 25) mentions that we "stringify the parameters and the body", and not the other way around.

The behavior restored by this PR is also tested by test262:
- https://github.com/tc39/test262/blob/main/test/built-ins/Function/S15.3.2.1_A3_T1.js
- https://github.com/tc39/test262/blob/main/test/built-ins/Function/S15.3.2.1_A3_T3.js

This bug was cought by @jedel1043, that already implemented it in Boa (https://github.com/boa-dev/boa/pull/3690).

I marked this as normative, but I don't think it needs to go through plenary because it simply reverses a normative change that was never presented for consensus.