### PR TITLE
Editorial: Remove "message" property from list of Error differences

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -30859,7 +30859,7 @@
   <emu-clause id="sec-error-objects">
     <h1>Error Objects</h1>
     <p>Instances of Error objects are thrown as exceptions when runtime errors occur. The Error objects may also serve as base objects for user-defined exception classes.</p>
-    <p>When an ECMAScript implementation detects a runtime error, it throws a new instance of one of the _NativeError_ objects defined in <emu-xref href="#sec-native-error-types-used-in-this-standard"></emu-xref> or a new instance of AggregateError object defined in <emu-xref href="#sec-aggregate-error-objects"></emu-xref>. Each of these objects has the structure described below, differing only in the name used as the constructor name instead of _NativeError_, in the *"name"* property of the prototype object, in the implementation-defined *"message"* property of the prototype object, and in the presence of the %AggregateError%-specific *"errors"* property.</p>
+    <p>When an ECMAScript implementation detects a runtime error, it throws a new instance of one of the _NativeError_ objects defined in <emu-xref href="#sec-native-error-types-used-in-this-standard"></emu-xref> or a new instance of the AggregateError object defined in <emu-xref href="#sec-aggregate-error-objects"></emu-xref>.</p>
 
     <emu-clause id="sec-error-constructor">
       <h1>The Error Constructor</h1>
@@ -30991,7 +30991,7 @@
 
     <emu-clause id="sec-nativeerror-object-structure">
       <h1>_NativeError_ Object Structure</h1>
-      <p>When an ECMAScript implementation detects a runtime error, it throws a new instance of one of the _NativeError_ objects defined in <emu-xref href="#sec-native-error-types-used-in-this-standard"></emu-xref>. Each of these objects has the structure described below, differing only in the name used as the constructor name instead of _NativeError_, in the *"name"* property of the prototype object, and in the implementation-defined *"message"* property of the prototype object.</p>
+      <p>Each of these objects has the structure described below, differing only in the name used as the constructor name and in the *"name"* property of the prototype object.</p>
       <p>For each error object, references to _NativeError_ in the definition should be replaced with the appropriate error object name from <emu-xref href="#sec-native-error-types-used-in-this-standard"></emu-xref>.</p>
 
       <emu-clause id="sec-nativeerror-constructors">


### PR DESCRIPTION
As noted in https://github.com/tc39/ecma262/issues/1794#issuecomment-558868977 the language about an `implementation-defined "message"` property in the _NativeError_ section is an outdated holdover from ES3, since the definition was changed to be the empty string in ES5. The outdated language was subsequently duplicated to the Error section in #2040.

Since the message prototype property is defined to be the empty string for all Error types, I thought it would be least confusing to remove it from the "differing only in ..." list entirely.

I am also inclined to update `only in the name used as the constructor name instead of _NativeError_` to `only in the constructor name` in the Error Objects copy, since that clause isn't specific to _NativeError_.  I can roll that into this PR or open a new one if that sounds good.