### PR TITLE
Editorial: Remove redundant type assertion from AsyncBlockStart

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -48290,7 +48290,6 @@ THH:mm:ss.sss
         <dl class="header">
         </dl>
         <emu-alg>
-          1. Assert: _promiseCapability_ is a PromiseCapability Record.
           1. Let _runningContext_ be the running execution context.
           1. Let _closure_ be a new Abstract Closure with no parameters that captures _promiseCapability_ and _asyncBody_ and performs the following steps when called:
             1. Let _acAsyncContext_ be the running execution context.


### PR DESCRIPTION
This is already established via the parameter type annotation.

![image](https://github.com/tc39/ecma262/assets/19366641/7e36fd61-8ca6-4f1b-b690-d536e6581658)
