### PR TITLE
Normative: Integrate "dynamic code brand checks" proposal

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -19444,7 +19444,7 @@
               1. If _argList_ has no elements, return *undefined*.
               1. Let _evalArg_ be the first element of _argList_.
               1. If IsStrict(this |CallExpression|) is *true*, let _strictCaller_ be *true*; else let _strictCaller_ be *false*.
-              1. [id="step-callexpression-evaluation-direct-eval"] Return ? PerformEval(_evalArg_, _strictCaller_, *true*).
+              1. [id="step-callexpression-evaluation-direct-eval"] Return ? PerformEval(_evalArg_, _strictCaller_, ~direct-eval~).
           1. Let _thisCall_ be this |CallExpression|.
           1. Let _tailCall_ be IsInTailPosition(_thisCall_).
           1. Return ? EvaluateCall(_func_, _ref_, _arguments_, _tailCall_).
@@ -29808,7 +29808,7 @@
       <p>This function is the <dfn>%eval%</dfn> intrinsic object.</p>
       <p>It performs the following steps when called:</p>
       <emu-alg>
-        1. Return ? PerformEval(_source_, *false*, *false*).
+        1. Return ? PerformEval(_source_, *false*, ~indirect-eval~).
       </emu-alg>
 
       <emu-clause id="sec-performeval" type="abstract operation" oldids="sec-performeval-rules-outside-functions,sec-performeval-rules-outside-methods,sec-performeval-rules-outside-constructors">
@@ -29816,22 +29816,29 @@
           PerformEval (
             _source_: an ECMAScript language value,
             _strictCaller_: a Boolean,
-            _direct_: a Boolean,
+            _direct_: ~direct-eval~ or ~indirect-eval~,
           ): either a normal completion containing an ECMAScript language value or a throw completion
         </h1>
         <dl class="header">
         </dl>
         <emu-alg>
-          1. Assert: If _direct_ is *false*, then _strictCaller_ is also *false*.
-          1. If _source_ is not a String, return _source_.
+          1. Assert: If _direct_ is ~indirect-eval~, then _strictCaller_ is *false*.
+          1. If _source_ is a String, then
+            1. Let _sourceStr_ be _source_.
+          1. Else if _source_ is an Object, then
+            1. Let _code_ be HostGetCodeForEval(_source_).
+            1. If _code_ is a String, let _sourceStr_ be _code_.
+            1. Else, return _source_.
+          1. Else,
+            1. Return _source_.
           1. Let _evalRealm_ be the current Realm Record.
           1. NOTE: In the case of a direct eval, _evalRealm_ is the realm of both the caller of `eval` and of the `eval` function itself.
-          1. Perform ? HostEnsureCanCompileStrings(_evalRealm_, « », _source_, _direct_).
+          1. Perform ? HostEnsureCanCompileStrings(_evalRealm_, « », _sourceStr_, _sourceStr_, _direct_, « », _source_).
           1. Let _inFunction_ be *false*.
           1. Let _inMethod_ be *false*.
           1. Let _inDerivedConstructor_ be *false*.
           1. Let _inClassFieldInitializer_ be *false*.
-          1. If _direct_ is *true*, then
+          1. If _direct_ is ~direct-eval~, then
             1. Let _thisEnvRec_ be GetThisEnvironment().
             1. If _thisEnvRec_ is a Function Environment Record, then
               1. Let _func_ be _thisEnvRec_.[[FunctionObject]].
@@ -29841,7 +29848,7 @@
               1. Let _classFieldInitializerName_ be _func_.[[ClassFieldInitializerName]].
               1. If _classFieldInitializerName_ is not ~empty~, set _inClassFieldInitializer_ to *true*.
           1. Perform the following substeps in an implementation-defined order, possibly interleaving parsing and error detection:
-            1. Let _script_ be ParseText(_source_, |Script|).
+            1. Let _script_ be ParseText(_sourceStr_, |Script|).
             1. If _script_ is a List of errors, throw a *SyntaxError* exception.
             1. If _script_ Contains |ScriptBody| is *false*, return *undefined*.
             1. Let _body_ be the |ScriptBody| of _script_.
@@ -29852,8 +29859,8 @@
           1. If _strictCaller_ is *true*, let _strictEval_ be *true*.
           1. Else, let _strictEval_ be ScriptIsStrict of _script_.
           1. Let _runningContext_ be the running execution context.
-          1. NOTE: If _direct_ is *true*, _runningContext_ will be the execution context that performed the direct eval. If _direct_ is *false*, _runningContext_ will be the execution context for the invocation of the `eval` function.
-          1. If _direct_ is *true*, then
+          1. NOTE: If _direct_ is ~direct-eval~, _runningContext_ will be the execution context that performed the direct eval. If _direct_ is ~indirect-eval~, _runningContext_ will be the execution context for the invocation of the `eval` function.
+          1. If _direct_ is ~direct-eval~, then
             1. Let _lexEnv_ be NewDeclarativeEnvironment(_runningContext_'s LexicalEnvironment).
             1. Let _varEnv_ be _runningContext_'s VariableEnvironment.
             1. Let _privateEnv_ be _runningContext_'s PrivateEnvironment.
@@ -29891,7 +29898,10 @@
             _calleeRealm_: a Realm Record,
             _parameterStrings_: a List of Strings,
             _bodyString_: a String,
-            _direct_: a Boolean,
+            _codeString_: a String,
+            _compilationType_: ~direct-eval~, ~indirect-eval~, or ~function~,
+            _parameterArgs: a List of ECMAScript language values,
+            _bodyArg_: an ECMAScript language value,
           ): either a normal completion containing ~unused~ or a throw completion
         </h1>
         <dl class="header">
@@ -29899,10 +29909,28 @@
           <dd>It allows host environments to block certain ECMAScript functions which allow developers to interpret and evaluate strings as ECMAScript code.</dd>
         </dl>
         <p>
-          _parameterStrings_ represents the strings that, when using one of the function constructors, will be concatenated together to build the parameters list. _bodyString_ represents the function body or the string passed to an `eval` call.
-          _direct_ signifies whether the evaluation is a direct eval.
+          _parameterStrings_ represents the strings that, when using one of the function constructors, will be concatenated together to build the parameters list.
+          _bodyString_ represents the function body or the string passed to an `eval` call.
+          _codeString_ represents the compiled string for a Function or the string passed to an `eval` call.
+          _parameterArgs_ are the values passed as the leading parameters to one of the Function constructors. _bodyArg_ is either the final parameter passed to one of the Function constructors or the value passed to an `eval` call.
         </p>
         <p>The default implementation of HostEnsureCanCompileStrings is to return NormalCompletion(~unused~).</p>
+      </emu-clause>
+
+      <emu-clause id="sec-hostgetcodeforeval" type="host-defined abstract operation">
+        <h1>
+          HostGetCodeForEval (
+            _argument_: an Object,
+          ): a String or ~no-code~
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It allows host environments to return a String of code from _argument_ to be used by eval, rather than eval returning _argument_.</dd>
+        </dl>
+        <p>
+          _argument_ represents the Object to be checked for code.
+        </p>
+        <p>The default implementation of HostGetCodeForEval is to return ~no-code~.</p>
       </emu-clause>
 
       <emu-clause id="sec-evaldeclarationinstantiation" type="abstract operation" oldids="sec-web-compat-evaldeclarationinstantiation">
@@ -31179,7 +31207,6 @@
               1. Append ? ToString(_arg_) to _parameterStrings_.
             1. Let _bodyString_ be ? ToString(_bodyArg_).
             1. Let _currentRealm_ be the current Realm Record.
-            1. Perform ? HostEnsureCanCompileStrings(_currentRealm_, _parameterStrings_, _bodyString_, *false*).
             1. Let _parameterString_ be the empty String.
             1. If _argCount_ > 0, then
               1. Set _parameterString_ to _parameterStrings_[0].
@@ -31190,6 +31217,7 @@
                 1. Set _k_ to _k_ + 1.
             1. Let _bodyParseString_ be the string-concatenation of 0x000A (LINE FEED), _bodyString_, and 0x000A (LINE FEED).
             1. Let _sourceString_ be the string-concatenation of _prefix_, *" anonymous("*, _parameterString_, 0x000A (LINE FEED), *") {"*, _bodyParseString_, and *"}"*.
+            1. Perform ? HostEnsureCanCompileStrings(_currentRealm_, _parameterStrings_, _bodyString_, _sourceString_, ~function~, _parameterArgs_, _bodyArg_).
             1. Let _sourceText_ be StringToCodePoints(_sourceString_).
             1. Let _parameters_ be ParseText(_parameterString_, _parameterSym_).
             1. If _parameters_ is a List of errors, throw a *SyntaxError* exception.
@@ -53683,6 +53711,7 @@ THH:mm:ss.sss
     <p><b>HostGetImportMetaProperties(...)</b></p>
     <p><b>HostGrowSharedArrayBuffer(...)</b></p>
     <p><b>HostHasSourceTextAvailable(...)</b></p>
+    <p><b>HostGetCodeForEval(...)</b></p>
     <p><b>HostLoadImportedModule(...)</b></p>
     <p><b>HostGetSupportedImportAttributes(...)</b></p>
     <p><b>HostMakeJobCallback(...)</b></p>

--- a/spec.html
+++ b/spec.html
@@ -29927,9 +29927,7 @@
           <dt>description</dt>
           <dd>It allows host environments to return a String of code from _argument_ to be used by eval, rather than eval returning _argument_.</dd>
         </dl>
-        <p>
-          _argument_ represents the Object to be checked for code.
-        </p>
+        <p>_argument_ represents the Object to be checked for code.</p>
         <p>The default implementation of HostGetCodeForEval is to return ~no-code~.</p>
       </emu-clause>
 


### PR DESCRIPTION
This change introduces a new HostGetCodeForEval host hook, this is used to allow evaluating certain objects.

This change also provides the compilation type and the original arguments, to the host hook HostEnsureCanCompileStrings.

This PR upstreams ~~a reduced version of~~ the https://github.com/tc39/proposal-dynamic-code-brand-checks proposal 

Closes https://github.com/tc39/ecma262/pull/1498, https://github.com/tc39/ecma262/issues/938
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
