### PR TITLE
Editorial: Mention the special status of U+0085 NEXT LINE

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -16371,7 +16371,7 @@
       <p>U+0020 (SPACE) and U+00A0 (NO-BREAK SPACE) code points are part of &lt;USP>.</p>
     </emu-note>
     <emu-note>
-      <p>Other than for the code points listed in <emu-xref href="#table-white-space-code-points"></emu-xref>, ECMAScript |WhiteSpace| intentionally excludes all code points that have the Unicode “White_Space” property but which are not classified in general category “Space_Separator” (“Zs”).</p>
+      <p>Other than the code points listed in <emu-xref href="#table-white-space-code-points"></emu-xref>, ECMAScript |WhiteSpace| intentionally excludes all code points that have the Unicode “White_Space” property but which are not classified in general category “Space_Separator” (“Zs”). As of Unicode 15.1.0, the only such code point that is not a <emu-xref href="#sec-line-terminators">line terminator</emu-xref> is U+0085 (NEXT LINE).</p>
     </emu-note>
     <h2>Syntax</h2>
     <emu-grammar type="definition">


### PR DESCRIPTION
It is the only character that has property "White_Space" but is not matched by either [|WhiteSpace|](https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#prod-WhiteSpace) or [|LineTerminator|](https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#prod-LineTerminator), which leads to issues such as https://github.com/tc39/proposal-regexp-v-flag/issues/37 .

Similarly, we might also consider documenting the special status of U+FEFF ZERO WIDTH NO-BREAK SPACE as the only character matched by |WhiteSpace| that does not have property "White_Space".