### PR TITLE
Editorial: Insert "the" before SDO-names

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -4982,7 +4982,7 @@
           <emu-alg>
             1. Let _literal_ be ParseText(_str_, |StringNumericLiteral|).
             1. If _literal_ is a List of errors, return *NaN*.
-            1. Return StringNumericValue of _literal_.
+            1. Return the StringNumericValue of _literal_.
           </emu-alg>
         </emu-clause>
 
@@ -4999,7 +4999,7 @@
           </emu-alg>
           <emu-grammar>StringNumericLiteral ::: StrWhiteSpace? StrNumericLiteral StrWhiteSpace?</emu-grammar>
           <emu-alg>
-            1. Return StringNumericValue of |StrNumericLiteral|.
+            1. Return the StringNumericValue of |StrNumericLiteral|.
           </emu-alg>
           <emu-grammar>StrNumericLiteral ::: NonDecimalIntegerLiteral</emu-grammar>
           <emu-alg>
@@ -5007,7 +5007,7 @@
           </emu-alg>
           <emu-grammar>StrDecimalLiteral ::: `-` StrUnsignedDecimalLiteral</emu-grammar>
           <emu-alg>
-            1. Let _a_ be StringNumericValue of |StrUnsignedDecimalLiteral|.
+            1. Let _a_ be the StringNumericValue of |StrUnsignedDecimalLiteral|.
             1. If _a_ is *+0*<sub>𝔽</sub>, return *-0*<sub>𝔽</sub>.
             1. Return -_a_.
           </emu-alg>
@@ -5017,27 +5017,27 @@
           </emu-alg>
           <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits `.` DecimalDigits? ExponentPart?</emu-grammar>
           <emu-alg>
-            1. Let _a_ be MV of the first |DecimalDigits|.
+            1. Let _a_ be the MV of the first |DecimalDigits|.
             1. If the second |DecimalDigits| is present, then
-              1. Let _b_ be MV of the second |DecimalDigits|.
+              1. Let _b_ be the MV of the second |DecimalDigits|.
               1. Let _n_ be the number of code points in the second |DecimalDigits|.
             1. Else,
               1. Let _b_ be 0.
               1. Let _n_ be 0.
-            1. If |ExponentPart| is present, let _e_ be MV of |ExponentPart|. Otherwise, let _e_ be 0.
+            1. If |ExponentPart| is present, let _e_ be the MV of |ExponentPart|. Otherwise, let _e_ be 0.
             1. Return RoundMVResult((_a_ + (_b_ × 10<sup>-_n_</sup>)) × 10<sup>_e_</sup>).
           </emu-alg>
           <emu-grammar>StrUnsignedDecimalLiteral ::: `.` DecimalDigits ExponentPart?</emu-grammar>
           <emu-alg>
-            1. Let _b_ be MV of |DecimalDigits|.
-            1. If |ExponentPart| is present, let _e_ be MV of |ExponentPart|. Otherwise, let _e_ be 0.
+            1. Let _b_ be the MV of |DecimalDigits|.
+            1. If |ExponentPart| is present, let _e_ be the MV of |ExponentPart|. Otherwise, let _e_ be 0.
             1. Let _n_ be the number of code points in |DecimalDigits|.
             1. Return RoundMVResult(_b_ × 10<sup>_e_ - _n_</sup>).
           </emu-alg>
           <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits ExponentPart?</emu-grammar>
           <emu-alg>
-            1. Let _a_ be MV of |DecimalDigits|.
-            1. If |ExponentPart| is present, let _e_ be MV of |ExponentPart|. Otherwise, let _e_ be 0.
+            1. Let _a_ be the MV of |DecimalDigits|.
+            1. If |ExponentPart| is present, let _e_ be the MV of |ExponentPart|. Otherwise, let _e_ be 0.
             1. Return RoundMVResult(_a_ × 10<sup>_e_</sup>).
           </emu-alg>
         </emu-clause>
@@ -7194,8 +7194,8 @@
       </emu-alg>
       <emu-grammar>VariableDeclarationList : VariableDeclarationList `,` VariableDeclaration</emu-grammar>
       <emu-alg>
-        1. Let _names1_ be BoundNames of |VariableDeclarationList|.
-        1. Let _names2_ be BoundNames of |VariableDeclaration|.
+        1. Let _names1_ be the BoundNames of |VariableDeclarationList|.
+        1. Let _names2_ be the BoundNames of |VariableDeclaration|.
         1. Return the list-concatenation of _names1_ and _names2_.
       </emu-alg>
       <emu-grammar>VariableDeclaration : BindingIdentifier Initializer?</emu-grammar>
@@ -7212,8 +7212,8 @@
       </emu-alg>
       <emu-grammar>ObjectBindingPattern : `{` BindingPropertyList `,` BindingRestProperty `}`</emu-grammar>
       <emu-alg>
-        1. Let _names1_ be BoundNames of |BindingPropertyList|.
-        1. Let _names2_ be BoundNames of |BindingRestProperty|.
+        1. Let _names1_ be the BoundNames of |BindingPropertyList|.
+        1. Let _names2_ be the BoundNames of |BindingRestProperty|.
         1. Return the list-concatenation of _names1_ and _names2_.
       </emu-alg>
       <emu-grammar>ArrayBindingPattern : `[` Elision? `]`</emu-grammar>
@@ -7230,25 +7230,25 @@
       </emu-alg>
       <emu-grammar>ArrayBindingPattern : `[` BindingElementList `,` Elision? BindingRestElement `]`</emu-grammar>
       <emu-alg>
-        1. Let _names1_ be BoundNames of |BindingElementList|.
-        1. Let _names2_ be BoundNames of |BindingRestElement|.
+        1. Let _names1_ be the BoundNames of |BindingElementList|.
+        1. Let _names2_ be the BoundNames of |BindingRestElement|.
         1. Return the list-concatenation of _names1_ and _names2_.
       </emu-alg>
       <emu-grammar>BindingPropertyList : BindingPropertyList `,` BindingProperty</emu-grammar>
       <emu-alg>
-        1. Let _names1_ be BoundNames of |BindingPropertyList|.
-        1. Let _names2_ be BoundNames of |BindingProperty|.
+        1. Let _names1_ be the BoundNames of |BindingPropertyList|.
+        1. Let _names2_ be the BoundNames of |BindingProperty|.
         1. Return the list-concatenation of _names1_ and _names2_.
       </emu-alg>
       <emu-grammar>BindingElementList : BindingElementList `,` BindingElisionElement</emu-grammar>
       <emu-alg>
-        1. Let _names1_ be BoundNames of |BindingElementList|.
-        1. Let _names2_ be BoundNames of |BindingElisionElement|.
+        1. Let _names1_ be the BoundNames of |BindingElementList|.
+        1. Let _names2_ be the BoundNames of |BindingElisionElement|.
         1. Return the list-concatenation of _names1_ and _names2_.
       </emu-alg>
       <emu-grammar>BindingElisionElement : Elision? BindingElement</emu-grammar>
       <emu-alg>
-        1. Return BoundNames of |BindingElement|.
+        1. Return the BoundNames of |BindingElement|.
       </emu-alg>
       <emu-grammar>BindingProperty : PropertyName `:` BindingElement</emu-grammar>
       <emu-alg>
@@ -7280,14 +7280,14 @@
       </emu-alg>
       <emu-grammar>FormalParameters : FormalParameterList `,` FunctionRestParameter</emu-grammar>
       <emu-alg>
-        1. Let _names1_ be BoundNames of |FormalParameterList|.
-        1. Let _names2_ be BoundNames of |FunctionRestParameter|.
+        1. Let _names1_ be the BoundNames of |FormalParameterList|.
+        1. Let _names2_ be the BoundNames of |FunctionRestParameter|.
         1. Return the list-concatenation of _names1_ and _names2_.
       </emu-alg>
       <emu-grammar>FormalParameterList : FormalParameterList `,` FormalParameter</emu-grammar>
       <emu-alg>
-        1. Let _names1_ be BoundNames of |FormalParameterList|.
-        1. Let _names2_ be BoundNames of |FormalParameter|.
+        1. Let _names1_ be the BoundNames of |FormalParameterList|.
+        1. Let _names2_ be the BoundNames of |FormalParameter|.
         1. Return the list-concatenation of _names1_ and _names2_.
       </emu-alg>
       <emu-grammar>ArrowParameters : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
@@ -7504,13 +7504,13 @@
       </emu-alg>
       <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
       <emu-alg>
-        1. Let _names1_ be LexicallyDeclaredNames of |StatementList|.
-        1. Let _names2_ be LexicallyDeclaredNames of |StatementListItem|.
+        1. Let _names1_ be the LexicallyDeclaredNames of |StatementList|.
+        1. Let _names2_ be the LexicallyDeclaredNames of |StatementListItem|.
         1. Return the list-concatenation of _names1_ and _names2_.
       </emu-alg>
       <emu-grammar>StatementListItem : Statement</emu-grammar>
       <emu-alg>
-        1. If |Statement| is <emu-grammar>Statement : LabelledStatement</emu-grammar>, return LexicallyDeclaredNames of |LabelledStatement|.
+        1. If |Statement| is <emu-grammar>Statement : LabelledStatement</emu-grammar>, return the LexicallyDeclaredNames of |LabelledStatement|.
         1. Return a new empty List.
       </emu-alg>
       <emu-grammar>StatementListItem : Declaration</emu-grammar>
@@ -7525,15 +7525,15 @@
       <emu-alg>
         1. If the first |CaseClauses| is present, let _names1_ be the LexicallyDeclaredNames of the first |CaseClauses|.
         1. Else, let _names1_ be a new empty List.
-        1. Let _names2_ be LexicallyDeclaredNames of |DefaultClause|.
+        1. Let _names2_ be the LexicallyDeclaredNames of |DefaultClause|.
         1. If the second |CaseClauses| is present, let _names3_ be the LexicallyDeclaredNames of the second |CaseClauses|.
         1. Else, let _names3_ be a new empty List.
         1. Return the list-concatenation of _names1_, _names2_, and _names3_.
       </emu-alg>
       <emu-grammar>CaseClauses : CaseClauses CaseClause</emu-grammar>
       <emu-alg>
-        1. Let _names1_ be LexicallyDeclaredNames of |CaseClauses|.
-        1. Let _names2_ be LexicallyDeclaredNames of |CaseClause|.
+        1. Let _names1_ be the LexicallyDeclaredNames of |CaseClauses|.
+        1. Let _names2_ be the LexicallyDeclaredNames of |CaseClause|.
         1. Return the list-concatenation of _names1_ and _names2_.
       </emu-alg>
       <emu-grammar>CaseClause : `case` Expression `:` StatementList?</emu-grammar>
@@ -7556,7 +7556,7 @@
       </emu-alg>
       <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
       <emu-alg>
-        1. Return BoundNames of |FunctionDeclaration|.
+        1. Return the BoundNames of |FunctionDeclaration|.
       </emu-alg>
       <emu-grammar>FunctionStatementList : [empty]</emu-grammar>
       <emu-alg>
@@ -7564,7 +7564,7 @@
       </emu-alg>
       <emu-grammar>FunctionStatementList : StatementList</emu-grammar>
       <emu-alg>
-        1. Return TopLevelLexicallyDeclaredNames of |StatementList|.
+        1. Return the TopLevelLexicallyDeclaredNames of |StatementList|.
       </emu-alg>
       <emu-grammar>ClassStaticBlockStatementList : [empty]</emu-grammar>
       <emu-alg>
@@ -7590,7 +7590,7 @@
       </emu-alg>
       <emu-grammar>ScriptBody : StatementList</emu-grammar>
       <emu-alg>
-        1. Return TopLevelLexicallyDeclaredNames of |StatementList|.
+        1. Return the TopLevelLexicallyDeclaredNames of |StatementList|.
       </emu-alg>
       <emu-note>
         <p>At the top level of a |Script|, function declarations are treated like var declarations rather than like lexical declarations.</p>
@@ -7600,8 +7600,8 @@
       </emu-note>
       <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
       <emu-alg>
-        1. Let _names1_ be LexicallyDeclaredNames of |ModuleItemList|.
-        1. Let _names2_ be LexicallyDeclaredNames of |ModuleItem|.
+        1. Let _names1_ be the LexicallyDeclaredNames of |ModuleItemList|.
+        1. Let _names2_ be the LexicallyDeclaredNames of |ModuleItem|.
         1. Return the list-concatenation of _names1_ and _names2_.
       </emu-alg>
       <emu-grammar>ModuleItem : ImportDeclaration</emu-grammar>
@@ -7615,7 +7615,7 @@
       </emu-alg>
       <emu-grammar>ModuleItem : StatementListItem</emu-grammar>
       <emu-alg>
-        1. Return LexicallyDeclaredNames of |StatementListItem|.
+        1. Return the LexicallyDeclaredNames of |StatementListItem|.
       </emu-alg>
       <emu-note>
         <p>At the top level of a |Module|, function declarations are treated like lexical declarations rather than like var declarations.</p>
@@ -7628,18 +7628,18 @@
       </dl>
       <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
       <emu-alg>
-        1. Let _declarations1_ be LexicallyScopedDeclarations of |StatementList|.
-        1. Let _declarations2_ be LexicallyScopedDeclarations of |StatementListItem|.
+        1. Let _declarations1_ be the LexicallyScopedDeclarations of |StatementList|.
+        1. Let _declarations2_ be the LexicallyScopedDeclarations of |StatementListItem|.
         1. Return the list-concatenation of _declarations1_ and _declarations2_.
       </emu-alg>
       <emu-grammar>StatementListItem : Statement</emu-grammar>
       <emu-alg>
-        1. If |Statement| is <emu-grammar>Statement : LabelledStatement</emu-grammar>, return LexicallyScopedDeclarations of |LabelledStatement|.
+        1. If |Statement| is <emu-grammar>Statement : LabelledStatement</emu-grammar>, return the LexicallyScopedDeclarations of |LabelledStatement|.
         1. Return a new empty List.
       </emu-alg>
       <emu-grammar>StatementListItem : Declaration</emu-grammar>
       <emu-alg>
-        1. Return a List whose sole element is DeclarationPart of |Declaration|.
+        1. Return a List whose sole element is the DeclarationPart of |Declaration|.
       </emu-alg>
       <emu-grammar>CaseBlock : `{` `}`</emu-grammar>
       <emu-alg>
@@ -7649,15 +7649,15 @@
       <emu-alg>
         1. If the first |CaseClauses| is present, let _declarations1_ be the LexicallyScopedDeclarations of the first |CaseClauses|.
         1. Else, let _declarations1_ be a new empty List.
-        1. Let _declarations2_ be LexicallyScopedDeclarations of |DefaultClause|.
+        1. Let _declarations2_ be the LexicallyScopedDeclarations of |DefaultClause|.
         1. If the second |CaseClauses| is present, let _declarations3_ be the LexicallyScopedDeclarations of the second |CaseClauses|.
         1. Else, let _declarations3_ be a new empty List.
         1. Return the list-concatenation of _declarations1_, _declarations2_, and _declarations3_.
       </emu-alg>
       <emu-grammar>CaseClauses : CaseClauses CaseClause</emu-grammar>
       <emu-alg>
-        1. Let _declarations1_ be LexicallyScopedDeclarations of |CaseClauses|.
-        1. Let _declarations2_ be LexicallyScopedDeclarations of |CaseClause|.
+        1. Let _declarations1_ be the LexicallyScopedDeclarations of |CaseClauses|.
+        1. Let _declarations2_ be the LexicallyScopedDeclarations of |CaseClause|.
         1. Return the list-concatenation of _declarations1_ and _declarations2_.
       </emu-alg>
       <emu-grammar>CaseClause : `case` Expression `:` StatementList?</emu-grammar>
@@ -7714,7 +7714,7 @@
       </emu-alg>
       <emu-grammar>ScriptBody : StatementList</emu-grammar>
       <emu-alg>
-        1. Return TopLevelLexicallyScopedDeclarations of |StatementList|.
+        1. Return the TopLevelLexicallyScopedDeclarations of |StatementList|.
       </emu-alg>
       <emu-grammar>Module : [empty]</emu-grammar>
       <emu-alg>
@@ -7722,8 +7722,8 @@
       </emu-alg>
       <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
       <emu-alg>
-        1. Let _declarations1_ be LexicallyScopedDeclarations of |ModuleItemList|.
-        1. Let _declarations2_ be LexicallyScopedDeclarations of |ModuleItem|.
+        1. Let _declarations1_ be the LexicallyScopedDeclarations of |ModuleItemList|.
+        1. Let _declarations2_ be the LexicallyScopedDeclarations of |ModuleItem|.
         1. Return the list-concatenation of _declarations1_ and _declarations2_.
       </emu-alg>
       <emu-grammar>ModuleItem : ImportDeclaration</emu-grammar>
@@ -7741,11 +7741,11 @@
       </emu-alg>
       <emu-grammar>ExportDeclaration : `export` Declaration</emu-grammar>
       <emu-alg>
-        1. Return a List whose sole element is DeclarationPart of |Declaration|.
+        1. Return a List whose sole element is the DeclarationPart of |Declaration|.
       </emu-alg>
       <emu-grammar>ExportDeclaration : `export` `default` HoistableDeclaration</emu-grammar>
       <emu-alg>
-        1. Return a List whose sole element is DeclarationPart of |HoistableDeclaration|.
+        1. Return a List whose sole element is the DeclarationPart of |HoistableDeclaration|.
       </emu-alg>
       <emu-grammar>ExportDeclaration : `export` `default` ClassDeclaration</emu-grammar>
       <emu-alg>
@@ -7780,8 +7780,8 @@
       </emu-alg>
       <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
       <emu-alg>
-        1. Let _names1_ be VarDeclaredNames of |StatementList|.
-        1. Let _names2_ be VarDeclaredNames of |StatementListItem|.
+        1. Let _names1_ be the VarDeclaredNames of |StatementList|.
+        1. Let _names2_ be the VarDeclaredNames of |StatementListItem|.
         1. Return the list-concatenation of _names1_ and _names2_.
       </emu-alg>
       <emu-grammar>StatementListItem : Declaration</emu-grammar>
@@ -7790,12 +7790,12 @@
       </emu-alg>
       <emu-grammar>VariableStatement : `var` VariableDeclarationList `;`</emu-grammar>
       <emu-alg>
-        1. Return BoundNames of |VariableDeclarationList|.
+        1. Return the BoundNames of |VariableDeclarationList|.
       </emu-alg>
       <emu-grammar>IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
       <emu-alg>
-        1. Let _names1_ be VarDeclaredNames of the first |Statement|.
-        1. Let _names2_ be VarDeclaredNames of the second |Statement|.
+        1. Let _names1_ be the VarDeclaredNames of the first |Statement|.
+        1. Let _names2_ be the VarDeclaredNames of the second |Statement|.
         1. Return the list-concatenation of _names1_ and _names2_.
       </emu-alg>
       <emu-grammar>IfStatement : `if` `(` Expression `)` Statement</emu-grammar>
@@ -7816,8 +7816,8 @@
       </emu-alg>
       <emu-grammar>ForStatement : `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement</emu-grammar>
       <emu-alg>
-        1. Let _names1_ be BoundNames of |VariableDeclarationList|.
-        1. Let _names2_ be VarDeclaredNames of |Statement|.
+        1. Let _names1_ be the BoundNames of |VariableDeclarationList|.
+        1. Let _names2_ be the VarDeclaredNames of |Statement|.
         1. Return the list-concatenation of _names1_ and _names2_.
       </emu-alg>
       <emu-grammar>ForStatement : `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement</emu-grammar>
@@ -7866,15 +7866,15 @@
       <emu-alg>
         1. If the first |CaseClauses| is present, let _names1_ be the VarDeclaredNames of the first |CaseClauses|.
         1. Else, let _names1_ be a new empty List.
-        1. Let _names2_ be VarDeclaredNames of |DefaultClause|.
+        1. Let _names2_ be the VarDeclaredNames of |DefaultClause|.
         1. If the second |CaseClauses| is present, let _names3_ be the VarDeclaredNames of the second |CaseClauses|.
         1. Else, let _names3_ be a new empty List.
         1. Return the list-concatenation of _names1_, _names2_, and _names3_.
       </emu-alg>
       <emu-grammar>CaseClauses : CaseClauses CaseClause</emu-grammar>
       <emu-alg>
-        1. Let _names1_ be VarDeclaredNames of |CaseClauses|.
-        1. Let _names2_ be VarDeclaredNames of |CaseClause|.
+        1. Let _names1_ be the VarDeclaredNames of |CaseClauses|.
+        1. Let _names2_ be the VarDeclaredNames of |CaseClause|.
         1. Return the list-concatenation of _names1_ and _names2_.
       </emu-alg>
       <emu-grammar>CaseClause : `case` Expression `:` StatementList?</emu-grammar>
@@ -7897,21 +7897,21 @@
       </emu-alg>
       <emu-grammar>TryStatement : `try` Block Catch</emu-grammar>
       <emu-alg>
-        1. Let _names1_ be VarDeclaredNames of |Block|.
-        1. Let _names2_ be VarDeclaredNames of |Catch|.
+        1. Let _names1_ be the VarDeclaredNames of |Block|.
+        1. Let _names2_ be the VarDeclaredNames of |Catch|.
         1. Return the list-concatenation of _names1_ and _names2_.
       </emu-alg>
       <emu-grammar>TryStatement : `try` Block Finally</emu-grammar>
       <emu-alg>
-        1. Let _names1_ be VarDeclaredNames of |Block|.
-        1. Let _names2_ be VarDeclaredNames of |Finally|.
+        1. Let _names1_ be the VarDeclaredNames of |Block|.
+        1. Let _names2_ be the VarDeclaredNames of |Finally|.
         1. Return the list-concatenation of _names1_ and _names2_.
       </emu-alg>
       <emu-grammar>TryStatement : `try` Block Catch Finally</emu-grammar>
       <emu-alg>
-        1. Let _names1_ be VarDeclaredNames of |Block|.
-        1. Let _names2_ be VarDeclaredNames of |Catch|.
-        1. Let _names3_ be VarDeclaredNames of |Finally|.
+        1. Let _names1_ be the VarDeclaredNames of |Block|.
+        1. Let _names2_ be the VarDeclaredNames of |Catch|.
+        1. Let _names3_ be the VarDeclaredNames of |Finally|.
         1. Return the list-concatenation of _names1_, _names2_, and _names3_.
       </emu-alg>
       <emu-grammar>Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
@@ -7924,7 +7924,7 @@
       </emu-alg>
       <emu-grammar>FunctionStatementList : StatementList</emu-grammar>
       <emu-alg>
-        1. Return TopLevelVarDeclaredNames of |StatementList|.
+        1. Return the TopLevelVarDeclaredNames of |StatementList|.
       </emu-alg>
       <emu-grammar>ClassStaticBlockStatementList : [empty]</emu-grammar>
       <emu-alg>
@@ -7950,12 +7950,12 @@
       </emu-alg>
       <emu-grammar>ScriptBody : StatementList</emu-grammar>
       <emu-alg>
-        1. Return TopLevelVarDeclaredNames of |StatementList|.
+        1. Return the TopLevelVarDeclaredNames of |StatementList|.
       </emu-alg>
       <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
       <emu-alg>
-        1. Let _names1_ be VarDeclaredNames of |ModuleItemList|.
-        1. Let _names2_ be VarDeclaredNames of |ModuleItem|.
+        1. Let _names1_ be the VarDeclaredNames of |ModuleItemList|.
+        1. Let _names2_ be the VarDeclaredNames of |ModuleItem|.
         1. Return the list-concatenation of _names1_ and _names2_.
       </emu-alg>
       <emu-grammar>ModuleItem : ImportDeclaration</emu-grammar>
@@ -7964,7 +7964,7 @@
       </emu-alg>
       <emu-grammar>ModuleItem : ExportDeclaration</emu-grammar>
       <emu-alg>
-        1. If |ExportDeclaration| is `export` |VariableStatement|, return BoundNames of |ExportDeclaration|.
+        1. If |ExportDeclaration| is `export` |VariableStatement|, return the BoundNames of |ExportDeclaration|.
         1. Return a new empty List.
       </emu-alg>
     </emu-clause>
@@ -7992,8 +7992,8 @@
       </emu-alg>
       <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
       <emu-alg>
-        1. Let _declarations1_ be VarScopedDeclarations of |StatementList|.
-        1. Let _declarations2_ be VarScopedDeclarations of |StatementListItem|.
+        1. Let _declarations1_ be the VarScopedDeclarations of |StatementList|.
+        1. Let _declarations2_ be the VarScopedDeclarations of |StatementListItem|.
         1. Return the list-concatenation of _declarations1_ and _declarations2_.
       </emu-alg>
       <emu-grammar>StatementListItem : Declaration</emu-grammar>
@@ -8006,13 +8006,13 @@
       </emu-alg>
       <emu-grammar>VariableDeclarationList : VariableDeclarationList `,` VariableDeclaration</emu-grammar>
       <emu-alg>
-        1. Let _declarations1_ be VarScopedDeclarations of |VariableDeclarationList|.
+        1. Let _declarations1_ be the VarScopedDeclarations of |VariableDeclarationList|.
         1. Return the list-concatenation of _declarations1_ and « |VariableDeclaration| ».
       </emu-alg>
       <emu-grammar>IfStatement : `if` `(` Expression `)` Statement `else` Statement</emu-grammar>
       <emu-alg>
-        1. Let _declarations1_ be VarScopedDeclarations of the first |Statement|.
-        1. Let _declarations2_ be VarScopedDeclarations of the second |Statement|.
+        1. Let _declarations1_ be the VarScopedDeclarations of the first |Statement|.
+        1. Let _declarations2_ be the VarScopedDeclarations of the second |Statement|.
         1. Return the list-concatenation of _declarations1_ and _declarations2_.
       </emu-alg>
       <emu-grammar>IfStatement : `if` `(` Expression `)` Statement</emu-grammar>
@@ -8033,8 +8033,8 @@
       </emu-alg>
       <emu-grammar>ForStatement : `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement</emu-grammar>
       <emu-alg>
-        1. Let _declarations1_ be VarScopedDeclarations of |VariableDeclarationList|.
-        1. Let _declarations2_ be VarScopedDeclarations of |Statement|.
+        1. Let _declarations1_ be the VarScopedDeclarations of |VariableDeclarationList|.
+        1. Let _declarations2_ be the VarScopedDeclarations of |Statement|.
         1. Return the list-concatenation of _declarations1_ and _declarations2_.
       </emu-alg>
       <emu-grammar>ForStatement : `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement</emu-grammar>
@@ -8061,7 +8061,7 @@
       </emu-grammar>
       <emu-alg>
         1. Let _declarations1_ be « |ForBinding| ».
-        1. Let _declarations2_ be VarScopedDeclarations of |Statement|.
+        1. Let _declarations2_ be the VarScopedDeclarations of |Statement|.
         1. Return the list-concatenation of _declarations1_ and _declarations2_.
       </emu-alg>
       <emu-note>
@@ -8083,15 +8083,15 @@
       <emu-alg>
         1. If the first |CaseClauses| is present, let _declarations1_ be the VarScopedDeclarations of the first |CaseClauses|.
         1. Else, let _declarations1_ be a new empty List.
-        1. Let _declarations2_ be VarScopedDeclarations of |DefaultClause|.
+        1. Let _declarations2_ be the VarScopedDeclarations of |DefaultClause|.
         1. If the second |CaseClauses| is present, let _declarations3_ be the VarScopedDeclarations of the second |CaseClauses|.
         1. Else, let _declarations3_ be a new empty List.
         1. Return the list-concatenation of _declarations1_, _declarations2_, and _declarations3_.
       </emu-alg>
       <emu-grammar>CaseClauses : CaseClauses CaseClause</emu-grammar>
       <emu-alg>
-        1. Let _declarations1_ be VarScopedDeclarations of |CaseClauses|.
-        1. Let _declarations2_ be VarScopedDeclarations of |CaseClause|.
+        1. Let _declarations1_ be the VarScopedDeclarations of |CaseClauses|.
+        1. Let _declarations2_ be the VarScopedDeclarations of |CaseClause|.
         1. Return the list-concatenation of _declarations1_ and _declarations2_.
       </emu-alg>
       <emu-grammar>CaseClause : `case` Expression `:` StatementList?</emu-grammar>
@@ -8114,21 +8114,21 @@
       </emu-alg>
       <emu-grammar>TryStatement : `try` Block Catch</emu-grammar>
       <emu-alg>
-        1. Let _declarations1_ be VarScopedDeclarations of |Block|.
-        1. Let _declarations2_ be VarScopedDeclarations of |Catch|.
+        1. Let _declarations1_ be the VarScopedDeclarations of |Block|.
+        1. Let _declarations2_ be the VarScopedDeclarations of |Catch|.
         1. Return the list-concatenation of _declarations1_ and _declarations2_.
       </emu-alg>
       <emu-grammar>TryStatement : `try` Block Finally</emu-grammar>
       <emu-alg>
-        1. Let _declarations1_ be VarScopedDeclarations of |Block|.
-        1. Let _declarations2_ be VarScopedDeclarations of |Finally|.
+        1. Let _declarations1_ be the VarScopedDeclarations of |Block|.
+        1. Let _declarations2_ be the VarScopedDeclarations of |Finally|.
         1. Return the list-concatenation of _declarations1_ and _declarations2_.
       </emu-alg>
       <emu-grammar>TryStatement : `try` Block Catch Finally</emu-grammar>
       <emu-alg>
-        1. Let _declarations1_ be VarScopedDeclarations of |Block|.
-        1. Let _declarations2_ be VarScopedDeclarations of |Catch|.
-        1. Let _declarations3_ be VarScopedDeclarations of |Finally|.
+        1. Let _declarations1_ be the VarScopedDeclarations of |Block|.
+        1. Let _declarations2_ be the VarScopedDeclarations of |Catch|.
+        1. Let _declarations3_ be the VarScopedDeclarations of |Finally|.
         1. Return the list-concatenation of _declarations1_, _declarations2_, and _declarations3_.
       </emu-alg>
       <emu-grammar>Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
@@ -8167,7 +8167,7 @@
       </emu-alg>
       <emu-grammar>ScriptBody : StatementList</emu-grammar>
       <emu-alg>
-        1. Return TopLevelVarScopedDeclarations of |StatementList|.
+        1. Return the TopLevelVarScopedDeclarations of |StatementList|.
       </emu-alg>
       <emu-grammar>Module : [empty]</emu-grammar>
       <emu-alg>
@@ -8175,8 +8175,8 @@
       </emu-alg>
       <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
       <emu-alg>
-        1. Let _declarations1_ be VarScopedDeclarations of |ModuleItemList|.
-        1. Let _declarations2_ be VarScopedDeclarations of |ModuleItem|.
+        1. Let _declarations1_ be the VarScopedDeclarations of |ModuleItemList|.
+        1. Let _declarations2_ be the VarScopedDeclarations of |ModuleItem|.
         1. Return the list-concatenation of _declarations1_ and _declarations2_.
       </emu-alg>
       <emu-grammar>ModuleItem : ImportDeclaration</emu-grammar>
@@ -8185,7 +8185,7 @@
       </emu-alg>
       <emu-grammar>ModuleItem : ExportDeclaration</emu-grammar>
       <emu-alg>
-        1. If |ExportDeclaration| is `export` |VariableStatement|, return VarScopedDeclarations of |VariableStatement|.
+        1. If |ExportDeclaration| is `export` |VariableStatement|, return the VarScopedDeclarations of |VariableStatement|.
         1. Return a new empty List.
       </emu-alg>
     </emu-clause>
@@ -8196,8 +8196,8 @@
       </dl>
       <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
       <emu-alg>
-        1. Let _names1_ be TopLevelLexicallyDeclaredNames of |StatementList|.
-        1. Let _names2_ be TopLevelLexicallyDeclaredNames of |StatementListItem|.
+        1. Let _names1_ be the TopLevelLexicallyDeclaredNames of |StatementList|.
+        1. Let _names2_ be the TopLevelLexicallyDeclaredNames of |StatementListItem|.
         1. Return the list-concatenation of _names1_ and _names2_.
       </emu-alg>
       <emu-grammar>StatementListItem : Statement</emu-grammar>
@@ -8221,8 +8221,8 @@
       </dl>
       <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
       <emu-alg>
-        1. Let _declarations1_ be TopLevelLexicallyScopedDeclarations of |StatementList|.
-        1. Let _declarations2_ be TopLevelLexicallyScopedDeclarations of |StatementListItem|.
+        1. Let _declarations1_ be the TopLevelLexicallyScopedDeclarations of |StatementList|.
+        1. Let _declarations2_ be the TopLevelLexicallyScopedDeclarations of |StatementListItem|.
         1. Return the list-concatenation of _declarations1_ and _declarations2_.
       </emu-alg>
       <emu-grammar>StatementListItem : Statement</emu-grammar>
@@ -8243,8 +8243,8 @@
       </dl>
       <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
       <emu-alg>
-        1. Let _names1_ be TopLevelVarDeclaredNames of |StatementList|.
-        1. Let _names2_ be TopLevelVarDeclaredNames of |StatementListItem|.
+        1. Let _names1_ be the TopLevelVarDeclaredNames of |StatementList|.
+        1. Let _names2_ be the TopLevelVarDeclaredNames of |StatementListItem|.
         1. Return the list-concatenation of _names1_ and _names2_.
       </emu-alg>
       <emu-grammar>StatementListItem : Declaration</emu-grammar>
@@ -8255,8 +8255,8 @@
       </emu-alg>
       <emu-grammar>StatementListItem : Statement</emu-grammar>
       <emu-alg>
-        1. If |Statement| is <emu-grammar>Statement : LabelledStatement</emu-grammar>, return TopLevelVarDeclaredNames of |Statement|.
-        1. Return VarDeclaredNames of |Statement|.
+        1. If |Statement| is <emu-grammar>Statement : LabelledStatement</emu-grammar>, return the TopLevelVarDeclaredNames of |Statement|.
+        1. Return the VarDeclaredNames of |Statement|.
       </emu-alg>
       <emu-note>
         <p>At the top level of a function or script, inner function declarations are treated like var declarations.</p>
@@ -8267,12 +8267,12 @@
       </emu-alg>
       <emu-grammar>LabelledItem : Statement</emu-grammar>
       <emu-alg>
-        1. If |Statement| is <emu-grammar>Statement : LabelledStatement</emu-grammar>, return TopLevelVarDeclaredNames of |Statement|.
-        1. Return VarDeclaredNames of |Statement|.
+        1. If |Statement| is <emu-grammar>Statement : LabelledStatement</emu-grammar>, return the TopLevelVarDeclaredNames of |Statement|.
+        1. Return the VarDeclaredNames of |Statement|.
       </emu-alg>
       <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
       <emu-alg>
-        1. Return BoundNames of |FunctionDeclaration|.
+        1. Return the BoundNames of |FunctionDeclaration|.
       </emu-alg>
     </emu-clause>
 
@@ -8282,19 +8282,19 @@
       </dl>
       <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
       <emu-alg>
-        1. Let _declarations1_ be TopLevelVarScopedDeclarations of |StatementList|.
-        1. Let _declarations2_ be TopLevelVarScopedDeclarations of |StatementListItem|.
+        1. Let _declarations1_ be the TopLevelVarScopedDeclarations of |StatementList|.
+        1. Let _declarations2_ be the TopLevelVarScopedDeclarations of |StatementListItem|.
         1. Return the list-concatenation of _declarations1_ and _declarations2_.
       </emu-alg>
       <emu-grammar>StatementListItem : Statement</emu-grammar>
       <emu-alg>
-        1. If |Statement| is <emu-grammar>Statement : LabelledStatement</emu-grammar>, return TopLevelVarScopedDeclarations of |Statement|.
-        1. Return VarScopedDeclarations of |Statement|.
+        1. If |Statement| is <emu-grammar>Statement : LabelledStatement</emu-grammar>, return the TopLevelVarScopedDeclarations of |Statement|.
+        1. Return the VarScopedDeclarations of |Statement|.
       </emu-alg>
       <emu-grammar>StatementListItem : Declaration</emu-grammar>
       <emu-alg>
         1. If |Declaration| is <emu-grammar>Declaration : HoistableDeclaration</emu-grammar>, then
-          1. Let _declaration_ be DeclarationPart of |HoistableDeclaration|.
+          1. Let _declaration_ be the DeclarationPart of |HoistableDeclaration|.
           1. Return « _declaration_ ».
         1. Return a new empty List.
       </emu-alg>
@@ -8304,8 +8304,8 @@
       </emu-alg>
       <emu-grammar>LabelledItem : Statement</emu-grammar>
       <emu-alg>
-        1. If |Statement| is <emu-grammar>Statement : LabelledStatement</emu-grammar>, return TopLevelVarScopedDeclarations of |Statement|.
-        1. Return VarScopedDeclarations of |Statement|.
+        1. If |Statement| is <emu-grammar>Statement : LabelledStatement</emu-grammar>, return the TopLevelVarScopedDeclarations of |Statement|.
+        1. Return the VarScopedDeclarations of |Statement|.
       </emu-alg>
       <emu-grammar>LabelledItem : FunctionDeclaration</emu-grammar>
       <emu-alg>
@@ -9446,7 +9446,7 @@
       </emu-note>
       <emu-grammar>BindingIdentifier : Identifier</emu-grammar>
       <emu-alg>
-        1. Let _name_ be StringValue of |Identifier|.
+        1. Let _name_ be the StringValue of |Identifier|.
         1. Return ? InitializeBoundName(_name_, _value_, _environment_).
       </emu-alg>
       <emu-grammar>BindingIdentifier : `yield`</emu-grammar>
@@ -9564,7 +9564,7 @@
       </emu-alg>
       <emu-grammar>SingleNameBinding : BindingIdentifier Initializer?</emu-grammar>
       <emu-alg>
-        1. Let _bindingId_ be StringValue of |BindingIdentifier|.
+        1. Let _bindingId_ be the StringValue of |BindingIdentifier|.
         1. Let _lhs_ be ? ResolveBinding(_bindingId_, _environment_).
         1. Let _v_ be *undefined*.
         1. If _iteratorRecord_.[[Done]] is *false*, then
@@ -9667,7 +9667,7 @@
       </dl>
       <emu-grammar>IdentifierReference : Identifier</emu-grammar>
       <emu-alg>
-        1. If IsStrict(this |IdentifierReference|) is *true* and StringValue of |Identifier| is either *"eval"* or *"arguments"*, return ~invalid~.
+        1. If IsStrict(this |IdentifierReference|) is *true* and the StringValue of |Identifier| is either *"eval"* or *"arguments"*, return ~invalid~.
         1. Return ~simple~.
       </emu-alg>
       <emu-grammar>
@@ -9695,7 +9695,7 @@
       </emu-grammar>
       <emu-alg>
         1. Let _expr_ be the |ParenthesizedExpression| that is covered by |CoverParenthesizedExpressionAndArrowParameterList|.
-        1. Return AssignmentTargetType of _expr_.
+        1. Return the AssignmentTargetType of _expr_.
       </emu-alg>
       <emu-grammar>
         PrimaryExpression :
@@ -9825,7 +9825,7 @@
       </dl>
       <emu-grammar>PropertyDefinition : IdentifierReference</emu-grammar>
       <emu-alg>
-        1. Return StringValue of |IdentifierReference|.
+        1. Return the StringValue of |IdentifierReference|.
       </emu-alg>
       <emu-grammar>PropertyDefinition : `...` AssignmentExpression</emu-grammar>
       <emu-alg>
@@ -9833,11 +9833,11 @@
       </emu-alg>
       <emu-grammar>PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar>
       <emu-alg>
-        1. Return PropName of |PropertyName|.
+        1. Return the PropName of |PropertyName|.
       </emu-alg>
       <emu-grammar>LiteralPropertyName : IdentifierName</emu-grammar>
       <emu-alg>
-        1. Return StringValue of |IdentifierName|.
+        1. Return the StringValue of |IdentifierName|.
       </emu-alg>
       <emu-grammar>LiteralPropertyName : StringLiteral</emu-grammar>
       <emu-alg>
@@ -9859,15 +9859,15 @@
           `set` ClassElementName `(` PropertySetParameterList `)` `{` FunctionBody `}`
       </emu-grammar>
       <emu-alg>
-        1. Return PropName of |ClassElementName|.
+        1. Return the PropName of |ClassElementName|.
       </emu-alg>
       <emu-grammar>GeneratorMethod : `*` ClassElementName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
-        1. Return PropName of |ClassElementName|.
+        1. Return the PropName of |ClassElementName|.
       </emu-alg>
       <emu-grammar>AsyncGeneratorMethod : `async` `*` ClassElementName `(` UniqueFormalParameters `)` `{` AsyncGeneratorBody `}`</emu-grammar>
       <emu-alg>
-        1. Return PropName of |ClassElementName|.
+        1. Return the PropName of |ClassElementName|.
       </emu-alg>
       <emu-grammar>ClassElement : ClassStaticBlock</emu-grammar>
       <emu-alg>
@@ -9881,13 +9881,13 @@
         AsyncMethod : `async` ClassElementName `(` UniqueFormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
       <emu-alg>
-        1. Return PropName of |ClassElementName|.
+        1. Return the PropName of |ClassElementName|.
       </emu-alg>
       <emu-grammar>
         FieldDefinition : ClassElementName Initializer?
       </emu-grammar>
       <emu-alg>
-        1. Return PropName of |ClassElementName|.
+        1. Return the PropName of |ClassElementName|.
       </emu-alg>
       <emu-grammar>
         ClassElementName : PrivateIdentifier
@@ -16567,13 +16567,13 @@
         <emu-grammar>IdentifierStart :: `\` UnicodeEscapeSequence</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if IdentifierCodePoint of |UnicodeEscapeSequence| is not some Unicode code point matched by the |IdentifierStartChar| lexical grammar production.
+            It is a Syntax Error if the IdentifierCodePoint of |UnicodeEscapeSequence| is not some Unicode code point matched by the |IdentifierStartChar| lexical grammar production.
           </li>
         </ul>
         <emu-grammar>IdentifierPart :: `\` UnicodeEscapeSequence</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if IdentifierCodePoint of |UnicodeEscapeSequence| is not some Unicode code point matched by the |IdentifierPartChar| lexical grammar production.
+            It is a Syntax Error if the IdentifierCodePoint of |UnicodeEscapeSequence| is not some Unicode code point matched by the |IdentifierPartChar| lexical grammar production.
           </li>
         </ul>
       </emu-clause>
@@ -16584,13 +16584,13 @@
         </dl>
         <emu-grammar>IdentifierName :: IdentifierStart</emu-grammar>
         <emu-alg>
-          1. Let _cp_ be IdentifierCodePoint of |IdentifierStart|.
+          1. Let _cp_ be the IdentifierCodePoint of |IdentifierStart|.
           1. Return « _cp_ ».
         </emu-alg>
         <emu-grammar>IdentifierName :: IdentifierName IdentifierPart</emu-grammar>
         <emu-alg>
-          1. Let _cps_ be IdentifierCodePoints of the derived |IdentifierName|.
-          1. Let _cp_ be IdentifierCodePoint of |IdentifierPart|.
+          1. Let _cps_ be the IdentifierCodePoints of the derived |IdentifierName|.
+          1. Let _cp_ be the IdentifierCodePoint of |IdentifierPart|.
           1. Return the list-concatenation of _cps_ and « _cp_ ».
         </emu-alg>
       </emu-clause>
@@ -17537,10 +17537,10 @@
           `u` `{` CodePoint [lookahead &notin; HexDigit] [lookahead != `}`]
 
         NotCodePoint ::
-          HexDigits[~Sep] [> but only if MV of |HexDigits| > 0x10FFFF]
+          HexDigits[~Sep] [> but only if the MV of |HexDigits| > 0x10FFFF]
 
         CodePoint ::
-          HexDigits[~Sep] [> but only if MV of |HexDigits| &le; 0x10FFFF]
+          HexDigits[~Sep] [> but only if the MV of |HexDigits| &le; 0x10FFFF]
       </emu-grammar>
       <emu-note>
         <p>|TemplateSubstitutionTail| is used by the |InputElementTemplateTail| alternative lexical goal.</p>
@@ -18035,10 +18035,10 @@
       </emu-grammar>
       <ul>
         <li>
-          It is a Syntax Error if this production has a <sub>[Yield]</sub> parameter and StringValue of |Identifier| is *"yield"*.
+          It is a Syntax Error if this production has a <sub>[Yield]</sub> parameter and the StringValue of |Identifier| is *"yield"*.
         </li>
         <li>
-          It is a Syntax Error if this production has an <sub>[Await]</sub> parameter and StringValue of |Identifier| is *"await"*.
+          It is a Syntax Error if this production has an <sub>[Await]</sub> parameter and the StringValue of |Identifier| is *"await"*.
         </li>
       </ul>
       <emu-grammar>Identifier : IdentifierName but not ReservedWord</emu-grammar>
@@ -18054,7 +18054,7 @@
         </li>
       </ul>
       <emu-note>
-        <p>StringValue of |IdentifierName| normalizes any Unicode escape sequences in |IdentifierName| hence such escapes cannot be used to write an |Identifier| whose code point sequence is the same as a |ReservedWord|.</p>
+        <p>The StringValue of |IdentifierName| normalizes any Unicode escape sequences in |IdentifierName| hence such escapes cannot be used to write an |Identifier| whose code point sequence is the same as a |ReservedWord|.</p>
       </emu-note>
     </emu-clause>
 
@@ -18068,7 +18068,7 @@
           IdentifierName IdentifierPart
       </emu-grammar>
       <emu-alg>
-        1. Let _idTextUnescaped_ be IdentifierCodePoints of |IdentifierName|.
+        1. Let _idTextUnescaped_ be the IdentifierCodePoints of |IdentifierName|.
         1. Return CodePointsToString(_idTextUnescaped_).
       </emu-alg>
       <emu-grammar>
@@ -18399,7 +18399,7 @@
             It is a Syntax Error if HasDirectSuper of |MethodDefinition| is *true*.
           </li>
           <li>
-            It is a Syntax Error if PrivateBoundIdentifiers of |MethodDefinition| is not empty.
+            It is a Syntax Error if the PrivateBoundIdentifiers of |MethodDefinition| is not empty.
           </li>
         </ul>
         <p>In addition to describing an actual object initializer the |ObjectLiteral| productions are also used as a cover grammar for |ObjectAssignmentPattern| and may be recognized as part of a |CoverParenthesizedExpressionAndArrowParameterList|. When |ObjectLiteral| appears in a context where |ObjectAssignmentPattern| is required the following Early Error rules are <b>not</b> applied. In addition, they are not applied when initially parsing a |CoverParenthesizedExpressionAndArrowParameterList| or |CoverCallExpressionAndAsyncArrowHead|.</p>
@@ -18419,7 +18419,7 @@
         </emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if PropertyNameList of |PropertyDefinitionList| contains any duplicate entries for *"__proto__"* and at least two of those entries were obtained from productions of the form <emu-grammar>PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar>. This rule is not applied if this |ObjectLiteral| is contained within a |Script| that is being parsed for JSON.parse (see step <emu-xref href="#step-json-parse-parse"></emu-xref> of <emu-xref href="#sec-json.parse">JSON.parse</emu-xref>).
+            It is a Syntax Error if the PropertyNameList of |PropertyDefinitionList| contains any duplicate entries for *"__proto__"* and at least two of those entries were obtained from productions of the form <emu-grammar>PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar>. This rule is not applied if this |ObjectLiteral| is contained within a |Script| that is being parsed for JSON.parse (see step <emu-xref href="#step-json-parse-parse"></emu-xref> of <emu-xref href="#sec-json.parse">JSON.parse</emu-xref>).
           </li>
         </ul>
         <emu-note>
@@ -18447,14 +18447,14 @@
         </dl>
         <emu-grammar>PropertyDefinitionList : PropertyDefinition</emu-grammar>
         <emu-alg>
-          1. Let _propName_ be PropName of |PropertyDefinition|.
+          1. Let _propName_ be the PropName of |PropertyDefinition|.
           1. If _propName_ is ~empty~, return a new empty List.
           1. Return « _propName_ ».
         </emu-alg>
         <emu-grammar>PropertyDefinitionList : PropertyDefinitionList `,` PropertyDefinition</emu-grammar>
         <emu-alg>
-          1. Let _list_ be PropertyNameList of |PropertyDefinitionList|.
-          1. Let _propName_ be PropName of |PropertyDefinition|.
+          1. Let _list_ be the PropertyNameList of |PropertyDefinitionList|.
+          1. Let _propName_ be the PropName of |PropertyDefinition|.
           1. If _propName_ is ~empty~, return _list_.
           1. Return the list-concatenation of _list_ and « _propName_ ».
         </emu-alg>
@@ -18478,7 +18478,7 @@
         </emu-alg>
         <emu-grammar>LiteralPropertyName : IdentifierName</emu-grammar>
         <emu-alg>
-          1. Return StringValue of |IdentifierName|.
+          1. Return the StringValue of |IdentifierName|.
         </emu-alg>
         <emu-grammar>LiteralPropertyName : StringLiteral</emu-grammar>
         <emu-alg>
@@ -18521,7 +18521,7 @@
         </emu-alg>
         <emu-grammar>PropertyDefinition : IdentifierReference</emu-grammar>
         <emu-alg>
-          1. Let _propName_ be StringValue of |IdentifierReference|.
+          1. Let _propName_ be the StringValue of |IdentifierReference|.
           1. Let _exprValue_ be ? Evaluation of |IdentifierReference|.
           1. Let _propValue_ be ? GetValue(_exprValue_).
           1. Assert: _object_ is an ordinary, extensible object with no non-configurable properties.
@@ -18593,11 +18593,11 @@
           <dd>It determines if its argument is a valid regular expression literal.</dd>
         </dl>
         <emu-alg>
-          1. Let _flags_ be FlagText of _literal_.
+          1. Let _flags_ be the FlagText of _literal_.
           1. If _flags_ contains any code points other than `d`, `g`, `i`, `m`, `s`, `u`, `v`, or `y`, or if _flags_ contains any code point more than once, return *false*.
           1. If _flags_ contains `u`, let _u_ be *true*; else let _u_ be *false*.
           1. If _flags_ contains `v`, let _v_ be *true*; else let _v_ be *false*.
-          1. Let _patternText_ be BodyText of _literal_.
+          1. Let _patternText_ be the BodyText of _literal_.
           1. If _u_ is *false* and _v_ is *false*, then
             1. Let _stringValue_ be CodePointsToString(_patternText_).
             1. Set _patternText_ to the sequence of code points resulting from interpreting each of the 16-bit elements of _stringValue_ as a Unicode BMP code point. UTF-16 decoding is not applied to the elements.
@@ -18653,7 +18653,7 @@
         </emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the number of elements in the result of TemplateStrings of |TemplateLiteral| with argument *false* is greater than or equal to 2<sup>32</sup>.
+            It is a Syntax Error if the number of elements in the TemplateStrings of |TemplateLiteral| with argument *false* is greater than or equal to 2<sup>32</sup>.
           </li>
         </ul>
 
@@ -18702,7 +18702,7 @@
         <emu-grammar>SubstitutionTemplate : TemplateHead Expression TemplateSpans</emu-grammar>
         <emu-alg>
           1. Let _head_ be « TemplateString(|TemplateHead|, _raw_) ».
-          1. Let _tail_ be TemplateStrings of |TemplateSpans| with argument _raw_.
+          1. Let _tail_ be the TemplateStrings of |TemplateSpans| with argument _raw_.
           1. Return the list-concatenation of _head_ and _tail_.
         </emu-alg>
         <emu-grammar>TemplateSpans : TemplateTail</emu-grammar>
@@ -18711,7 +18711,7 @@
         </emu-alg>
         <emu-grammar>TemplateSpans : TemplateMiddleList TemplateTail</emu-grammar>
         <emu-alg>
-          1. Let _middle_ be TemplateStrings of |TemplateMiddleList| with argument _raw_.
+          1. Let _middle_ be the TemplateStrings of |TemplateMiddleList| with argument _raw_.
           1. Let _tail_ be « TemplateString(|TemplateTail|, _raw_) ».
           1. Return the list-concatenation of _middle_ and _tail_.
         </emu-alg>
@@ -18721,7 +18721,7 @@
         </emu-alg>
         <emu-grammar>TemplateMiddleList : TemplateMiddleList TemplateMiddle Expression</emu-grammar>
         <emu-alg>
-          1. Let _front_ be TemplateStrings of |TemplateMiddleList| with argument _raw_.
+          1. Let _front_ be the TemplateStrings of |TemplateMiddleList| with argument _raw_.
           1. Let _last_ be « TemplateString(|TemplateMiddle|, _raw_) ».
           1. Return the list-concatenation of _front_ and _last_.
         </emu-alg>
@@ -18762,9 +18762,9 @@
           1. For each element _e_ of _templateRegistry_, do
             1. If _e_.[[Site]] is the same Parse Node as _templateLiteral_, then
               1. Return _e_.[[Array]].
-          1. Let _rawStrings_ be TemplateStrings of _templateLiteral_ with argument *true*.
+          1. Let _rawStrings_ be the TemplateStrings of _templateLiteral_ with argument *true*.
           1. Assert: _rawStrings_ is a List of Strings.
-          1. Let _cookedStrings_ be TemplateStrings of _templateLiteral_ with argument *false*.
+          1. Let _cookedStrings_ be the TemplateStrings of _templateLiteral_ with argument *false*.
           1. Let _count_ be the number of elements in the List _cookedStrings_.
           1. Assert: _count_ ≤ 2<sup>32</sup> - 1.
           1. Let _template_ be ! ArrayCreate(_count_).
@@ -19068,7 +19068,7 @@
         <div class="rhs">
           |CallExpression| `[` &lt;<i>identifier-name-string</i>> `]`
         </div>
-        <p>where &lt;<i>identifier-name-string</i>> is the result of evaluating StringValue of |IdentifierName|.</p>
+        <p>where &lt;<i>identifier-name-string</i>> is the StringValue of |IdentifierName|.</p>
       </emu-note>
 
       <emu-clause id="sec-property-accessors-runtime-semantics-evaluation" type="sdo">
@@ -19147,7 +19147,7 @@
       <dl class="header">
       </dl>
       <emu-alg>
-        1. Let _propertyNameString_ be StringValue of _identifierName_.
+        1. Let _propertyNameString_ be the StringValue of _identifierName_.
         1. Return the Reference Record { [[Base]]: _baseValue_, [[ReferencedName]]: _propertyNameString_, [[Strict]]: _strict_, [[ThisValue]]: ~empty~ }.
       </emu-alg>
     </emu-clause>
@@ -19272,7 +19272,7 @@
         <emu-alg>
           1. Let _env_ be GetThisEnvironment().
           1. Let _actualThis_ be ? _env_.GetThisBinding().
-          1. Let _propertyKey_ be StringValue of |IdentifierName|.
+          1. Let _propertyKey_ be the StringValue of |IdentifierName|.
           1. Let _strict_ be IsStrict(this |SuperProperty|).
           1. Return ? MakeSuperPropertyReference(_actualThis_, _propertyKey_, _strict_).
         </emu-alg>
@@ -19676,7 +19676,7 @@
       </emu-grammar>
       <ul>
         <li>
-          It is an early Syntax Error if AssignmentTargetType of |LeftHandSideExpression| is not ~simple~.
+          It is an early Syntax Error if the AssignmentTargetType of |LeftHandSideExpression| is not ~simple~.
         </li>
       </ul>
 
@@ -19687,7 +19687,7 @@
       </emu-grammar>
       <ul>
         <li>
-          It is an early Syntax Error if AssignmentTargetType of |UnaryExpression| is not ~simple~.
+          It is an early Syntax Error if the AssignmentTargetType of |UnaryExpression| is not ~simple~.
         </li>
       </ul>
     </emu-clause>
@@ -20461,7 +20461,7 @@
           If |LeftHandSideExpression| is either an |ObjectLiteral| or an |ArrayLiteral|, |LeftHandSideExpression| must cover an |AssignmentPattern|.
         </li>
         <li>
-          If |LeftHandSideExpression| is neither an |ObjectLiteral| nor an |ArrayLiteral|, it is a Syntax Error if AssignmentTargetType of |LeftHandSideExpression| is not ~simple~.
+          If |LeftHandSideExpression| is neither an |ObjectLiteral| nor an |ArrayLiteral|, it is a Syntax Error if the AssignmentTargetType of |LeftHandSideExpression| is not ~simple~.
         </li>
       </ul>
       <emu-grammar>
@@ -20473,7 +20473,7 @@
       </emu-grammar>
       <ul>
         <li>
-          It is a Syntax Error if AssignmentTargetType of |LeftHandSideExpression| is not ~simple~.
+          It is a Syntax Error if the AssignmentTargetType of |LeftHandSideExpression| is not ~simple~.
         </li>
       </ul>
     </emu-clause>
@@ -20715,7 +20715,7 @@
         <emu-grammar>AssignmentProperty : IdentifierReference Initializer?</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if AssignmentTargetType of |IdentifierReference| is not ~simple~.
+            It is a Syntax Error if the AssignmentTargetType of |IdentifierReference| is not ~simple~.
           </li>
         </ul>
         <emu-grammar>AssignmentRestProperty : `...` DestructuringAssignmentTarget</emu-grammar>
@@ -20730,7 +20730,7 @@
             If |LeftHandSideExpression| is either an |ObjectLiteral| or an |ArrayLiteral|, |LeftHandSideExpression| must cover an |AssignmentPattern|.
           </li>
           <li>
-            If |LeftHandSideExpression| is neither an |ObjectLiteral| nor an |ArrayLiteral|, it is a Syntax Error if AssignmentTargetType of |LeftHandSideExpression| is not ~simple~.
+            If |LeftHandSideExpression| is neither an |ObjectLiteral| nor an |ArrayLiteral|, it is a Syntax Error if the AssignmentTargetType of |LeftHandSideExpression| is not ~simple~.
           </li>
         </ul>
       </emu-clause>
@@ -20839,7 +20839,7 @@
 
         <emu-grammar>AssignmentProperty : IdentifierReference Initializer?</emu-grammar>
         <emu-alg>
-          1. Let _P_ be StringValue of |IdentifierReference|.
+          1. Let _P_ be the StringValue of |IdentifierReference|.
           1. Let _lref_ be ? ResolveBinding(_P_).
           1. Let _v_ be ? GetV(_value_, _P_).
           1. If |Initializer| is present and _v_ is *undefined*, then
@@ -21263,7 +21263,7 @@
         </emu-note>
         <emu-grammar>LexicalBinding : BindingIdentifier Initializer</emu-grammar>
         <emu-alg>
-          1. Let _bindingId_ be StringValue of |BindingIdentifier|.
+          1. Let _bindingId_ be the StringValue of |BindingIdentifier|.
           1. Let _lhs_ be ! ResolveBinding(_bindingId_).
           1. If IsAnonymousFunctionDefinition(|Initializer|) is *true*, then
             1. Let _value_ be ? NamedEvaluation of |Initializer| with argument _bindingId_.
@@ -21320,7 +21320,7 @@
         </emu-alg>
         <emu-grammar>VariableDeclaration : BindingIdentifier Initializer</emu-grammar>
         <emu-alg>
-          1. Let _bindingId_ be StringValue of |BindingIdentifier|.
+          1. Let _bindingId_ be the StringValue of |BindingIdentifier|.
           1. Let _lhs_ be ? ResolveBinding(_bindingId_).
           1. If IsAnonymousFunctionDefinition(|Initializer|) is *true*, then
             1. Let _value_ be ? NamedEvaluation of |Initializer| with argument _bindingId_.
@@ -21467,7 +21467,7 @@
         </emu-alg>
         <emu-grammar>SingleNameBinding : BindingIdentifier Initializer?</emu-grammar>
         <emu-alg>
-          1. Let _bindingId_ be StringValue of |BindingIdentifier|.
+          1. Let _bindingId_ be the StringValue of |BindingIdentifier|.
           1. Let _lhs_ be ? ResolveBinding(_bindingId_, _environment_).
           1. Let _v_ be ? GetV(_value_, _propertyName_).
           1. If |Initializer| is present and _v_ is *undefined*, then
@@ -21922,7 +21922,7 @@
             If |LeftHandSideExpression| is either an |ObjectLiteral| or an |ArrayLiteral|, |LeftHandSideExpression| must cover an |AssignmentPattern|.
           </li>
           <li>
-            If |LeftHandSideExpression| is neither an |ObjectLiteral| nor an |ArrayLiteral|, it is a Syntax Error if AssignmentTargetType of |LeftHandSideExpression| is not ~simple~.
+            If |LeftHandSideExpression| is neither an |ObjectLiteral| nor an |ArrayLiteral|, it is a Syntax Error if the AssignmentTargetType of |LeftHandSideExpression| is not ~simple~.
           </li>
         </ul>
         <emu-grammar>
@@ -22180,7 +22180,7 @@
                 1. Let _status_ be Completion(ForDeclarationBindingInitialization of _lhs_ with arguments _nextValue_ and _iterationEnv_).
               1. Else,
                 1. Assert: _lhs_ binds a single name.
-                1. Let _lhsName_ be the sole element of BoundNames of _lhs_.
+                1. Let _lhsName_ be the sole element of the BoundNames of _lhs_.
                 1. Let _lhsRef_ be ! ResolveBinding(_lhsName_).
                 1. Let _status_ be Completion(InitializeReferencedBinding(_lhsRef_, _nextValue_)).
             1. If _status_ is an abrupt completion, then
@@ -22214,7 +22214,7 @@
             `await`
         </emu-grammar>
         <emu-alg>
-          1. Let _bindingId_ be StringValue of |BindingIdentifier|.
+          1. Let _bindingId_ be the StringValue of |BindingIdentifier|.
           1. Return ? ResolveBinding(_bindingId_).
         </emu-alg>
       </emu-clause>
@@ -22874,7 +22874,7 @@
       <emu-grammar>Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
       <ul>
         <li>
-          It is a Syntax Error if BoundNames of |CatchParameter| contains any duplicate elements.
+          It is a Syntax Error if the BoundNames of |CatchParameter| contains any duplicate elements.
         </li>
         <li>
           It is a Syntax Error if any element of the BoundNames of |CatchParameter| also occurs in the LexicallyDeclaredNames of |Block|.
@@ -23009,13 +23009,13 @@
       <emu-grammar>UniqueFormalParameters : FormalParameters</emu-grammar>
       <ul>
         <li>
-          It is a Syntax Error if BoundNames of |FormalParameters| contains any duplicate elements.
+          It is a Syntax Error if the BoundNames of |FormalParameters| contains any duplicate elements.
         </li>
       </ul>
       <emu-grammar>FormalParameters : FormalParameterList</emu-grammar>
       <ul>
         <li>
-          It is a Syntax Error if IsSimpleParameterList of |FormalParameterList| is *false* and BoundNames of |FormalParameterList| contains any duplicate elements.
+          It is a Syntax Error if IsSimpleParameterList of |FormalParameterList| is *false* and the BoundNames of |FormalParameterList| contains any duplicate elements.
         </li>
       </ul>
       <emu-note>
@@ -23236,7 +23236,7 @@
       </emu-alg>
       <emu-grammar>FormalParameters : FormalParameterList `,` FunctionRestParameter</emu-grammar>
       <emu-alg>
-        1. Return ExpectedArgumentCount of |FormalParameterList|.
+        1. Return the ExpectedArgumentCount of |FormalParameterList|.
       </emu-alg>
       <emu-note>
         <p>The ExpectedArgumentCount of a |FormalParameterList| is the number of |FormalParameters| to the left of either the rest parameter or the first |FormalParameter| with an Initializer. A |FormalParameter| without an initializer is allowed after the first parameter with an initializer but such parameters are considered to be optional with *undefined* as their default value.</p>
@@ -23248,7 +23248,7 @@
       </emu-alg>
       <emu-grammar>FormalParameterList : FormalParameterList `,` FormalParameter</emu-grammar>
       <emu-alg>
-        1. Let _count_ be ExpectedArgumentCount of |FormalParameterList|.
+        1. Let _count_ be the ExpectedArgumentCount of |FormalParameterList|.
         1. If HasInitializer of |FormalParameterList| is *true* or HasInitializer of |FormalParameter| is *true*, return _count_.
         1. Return _count_ + 1.
       </emu-alg>
@@ -23259,7 +23259,7 @@
       <emu-grammar>ArrowParameters : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
       <emu-alg>
         1. Let _formals_ be the |ArrowFormalParameters| that is covered by |CoverParenthesizedExpressionAndArrowParameterList|.
-        1. Return ExpectedArgumentCount of _formals_.
+        1. Return the ExpectedArgumentCount of _formals_.
       </emu-alg>
       <emu-grammar>PropertySetParameterList : FormalParameter</emu-grammar>
       <emu-alg>
@@ -23389,7 +23389,7 @@
       </dl>
       <emu-grammar>FunctionDeclaration : `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
-        1. Let _name_ be StringValue of |BindingIdentifier|.
+        1. Let _name_ be the StringValue of |BindingIdentifier|.
         1. Let _sourceText_ be the source text matched by |FunctionDeclaration|.
         1. Let _F_ be OrdinaryFunctionCreate(%Function.prototype%, _sourceText_, |FormalParameters|, |FunctionBody|, ~non-lexical-this~, _env_, _privateEnv_).
         1. Perform SetFunctionName(_F_, _name_).
@@ -23431,7 +23431,7 @@
       <emu-grammar>FunctionExpression : `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
         1. Assert: _name_ is not present.
-        1. Set _name_ to StringValue of |BindingIdentifier|.
+        1. Set _name_ to the StringValue of |BindingIdentifier|.
         1. Let _outerEnv_ be the running execution context's LexicalEnvironment.
         1. Let _funcEnv_ be NewDeclarativeEnvironment(_outerEnv_).
         1. Perform ! _funcEnv_.CreateImmutableBinding(_name_, *false*).
@@ -23629,7 +23629,7 @@
       <emu-grammar>MethodDefinition : `set` ClassElementName `(` PropertySetParameterList `)` `{` FunctionBody `}`</emu-grammar>
       <ul>
         <li>
-          It is a Syntax Error if BoundNames of |PropertySetParameterList| contains any duplicate elements.
+          It is a Syntax Error if the BoundNames of |PropertySetParameterList| contains any duplicate elements.
         </li>
         <li>
           It is a Syntax Error if FunctionBodyContainsUseStrict of |FunctionBody| is *true* and IsSimpleParameterList of |PropertySetParameterList| is *false*.
@@ -23933,7 +23933,7 @@
       </dl>
       <emu-grammar>GeneratorDeclaration : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
-        1. Let _name_ be StringValue of |BindingIdentifier|.
+        1. Let _name_ be the StringValue of |BindingIdentifier|.
         1. Let _sourceText_ be the source text matched by |GeneratorDeclaration|.
         1. Let _F_ be OrdinaryFunctionCreate(%GeneratorFunction.prototype%, _sourceText_, |FormalParameters|, |GeneratorBody|, ~non-lexical-this~, _env_, _privateEnv_).
         1. Perform SetFunctionName(_F_, _name_).
@@ -23978,7 +23978,7 @@
       <emu-grammar>GeneratorExpression : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. Assert: _name_ is not present.
-        1. Set _name_ to StringValue of |BindingIdentifier|.
+        1. Set _name_ to the StringValue of |BindingIdentifier|.
         1. Let _outerEnv_ be the running execution context's LexicalEnvironment.
         1. Let _funcEnv_ be NewDeclarativeEnvironment(_outerEnv_).
         1. Perform ! _funcEnv_.CreateImmutableBinding(_name_, *false*).
@@ -24162,7 +24162,7 @@
         AsyncGeneratorDeclaration : `async` `function` `*` BindingIdentifier `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
       </emu-grammar>
       <emu-alg>
-        1. Let _name_ be StringValue of |BindingIdentifier|.
+        1. Let _name_ be the StringValue of |BindingIdentifier|.
         1. Let _sourceText_ be the source text matched by |AsyncGeneratorDeclaration|.
         1. Let _F_ be OrdinaryFunctionCreate(%AsyncGeneratorFunction.prototype%, _sourceText_, |FormalParameters|, |AsyncGeneratorBody|, ~non-lexical-this~, _env_, _privateEnv_).
         1. Perform SetFunctionName(_F_, _name_).
@@ -24213,7 +24213,7 @@
       </emu-grammar>
       <emu-alg>
         1. Assert: _name_ is not present.
-        1. Set _name_ to StringValue of |BindingIdentifier|.
+        1. Set _name_ to the StringValue of |BindingIdentifier|.
         1. Let _outerEnv_ be the running execution context's LexicalEnvironment.
         1. Let _funcEnv_ be NewDeclarativeEnvironment(_outerEnv_).
         1. Perform ! _funcEnv_.CreateImmutableBinding(_name_, *false*).
@@ -24301,7 +24301,7 @@
         <li>
           <p>It is a Syntax Error if |ClassHeritage| is not present and the following algorithm returns *true*:</p>
           <emu-alg>
-            1. Let _constructor_ be ConstructorMethod of |ClassBody|.
+            1. Let _constructor_ be the ConstructorMethod of |ClassBody|.
             1. If _constructor_ is ~empty~, return *false*.
             1. Return HasDirectSuper of _constructor_.
           </emu-alg>
@@ -24310,19 +24310,19 @@
       <emu-grammar>ClassBody : ClassElementList</emu-grammar>
       <ul>
         <li>
-          It is a Syntax Error if PrototypePropertyNameList of |ClassElementList| contains more than one occurrence of *"constructor"*.
+          It is a Syntax Error if the PrototypePropertyNameList of |ClassElementList| contains more than one occurrence of *"constructor"*.
         </li>
         <li>
-          It is a Syntax Error if PrivateBoundIdentifiers of |ClassElementList| contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries, and the getter and setter are either both static or both non-static.
+          It is a Syntax Error if the PrivateBoundIdentifiers of |ClassElementList| contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries, and the getter and setter are either both static or both non-static.
         </li>
       </ul>
       <emu-grammar>ClassElement : MethodDefinition</emu-grammar>
       <ul>
         <li>
-          It is a Syntax Error if PropName of |MethodDefinition| is not *"constructor"* and HasDirectSuper of |MethodDefinition| is *true*.
+          It is a Syntax Error if the PropName of |MethodDefinition| is not *"constructor"* and HasDirectSuper of |MethodDefinition| is *true*.
         </li>
         <li>
-          It is a Syntax Error if PropName of |MethodDefinition| is *"constructor"* and SpecialMethod of |MethodDefinition| is *true*.
+          It is a Syntax Error if the PropName of |MethodDefinition| is *"constructor"* and SpecialMethod of |MethodDefinition| is *true*.
         </li>
       </ul>
       <emu-grammar>ClassElement : `static` MethodDefinition</emu-grammar>
@@ -24331,19 +24331,19 @@
           It is a Syntax Error if HasDirectSuper of |MethodDefinition| is *true*.
         </li>
         <li>
-          It is a Syntax Error if PropName of |MethodDefinition| is *"prototype"*.
+          It is a Syntax Error if the PropName of |MethodDefinition| is *"prototype"*.
         </li>
       </ul>
 
       <emu-grammar>ClassElement : FieldDefinition `;`</emu-grammar>
       <ul>
-        <li>It is a Syntax Error if PropName of |FieldDefinition| is *"constructor"*.</li>
+        <li>It is a Syntax Error if the PropName of |FieldDefinition| is *"constructor"*.</li>
       </ul>
 
       <emu-grammar>ClassElement : `static` FieldDefinition `;`</emu-grammar>
       <ul>
         <li>
-          It is a Syntax Error if PropName of |FieldDefinition| is either *"prototype"* or *"constructor"*.
+          It is a Syntax Error if the PropName of |FieldDefinition| is either *"prototype"* or *"constructor"*.
         </li>
       </ul>
 
@@ -24358,7 +24358,7 @@
 
       <emu-grammar>ClassElementName : PrivateIdentifier</emu-grammar>
       <ul>
-        <li>It is a Syntax Error if StringValue of |PrivateIdentifier| is *"#constructor"*.</li>
+        <li>It is a Syntax Error if the StringValue of |PrivateIdentifier| is *"#constructor"*.</li>
       </ul>
 
       <emu-grammar>ClassStaticBlockBody : ClassStaticBlockStatementList</emu-grammar>
@@ -24396,7 +24396,7 @@
       </dl>
       <emu-grammar>ClassElement : MethodDefinition</emu-grammar>
       <emu-alg>
-        1. If PropName of |MethodDefinition| is *"constructor"*, return ~constructor-method~.
+        1. If the PropName of |MethodDefinition| is *"constructor"*, return ~constructor-method~.
         1. Return ~non-constructor-method~.
       </emu-alg>
       <emu-grammar>
@@ -24424,14 +24424,14 @@
       </dl>
       <emu-grammar>ClassElementList : ClassElement</emu-grammar>
       <emu-alg>
-        1. If ClassElementKind of |ClassElement| is ~constructor-method~, return |ClassElement|.
+        1. If the ClassElementKind of |ClassElement| is ~constructor-method~, return |ClassElement|.
         1. Return ~empty~.
       </emu-alg>
       <emu-grammar>ClassElementList : ClassElementList ClassElement</emu-grammar>
       <emu-alg>
-        1. Let _head_ be ConstructorMethod of |ClassElementList|.
+        1. Let _head_ be the ConstructorMethod of |ClassElementList|.
         1. If _head_ is not ~empty~, return _head_.
-        1. If ClassElementKind of |ClassElement| is ~constructor-method~, return |ClassElement|.
+        1. If the ClassElementKind of |ClassElement| is ~constructor-method~, return |ClassElement|.
         1. Return ~empty~.
       </emu-alg>
       <emu-note>
@@ -24475,14 +24475,14 @@
       </dl>
       <emu-grammar>ClassElementList : ClassElement</emu-grammar>
       <emu-alg>
-        1. If ClassElementKind of |ClassElement| is ~non-constructor-method~, then
+        1. If the ClassElementKind of |ClassElement| is ~non-constructor-method~, then
           1. Return « |ClassElement| ».
         1. Return a new empty List.
       </emu-alg>
       <emu-grammar>ClassElementList : ClassElementList ClassElement</emu-grammar>
       <emu-alg>
-        1. Let _list_ be NonConstructorElements of |ClassElementList|.
-        1. If ClassElementKind of |ClassElement| is ~non-constructor-method~, then
+        1. Let _list_ be the NonConstructorElements of |ClassElementList|.
+        1. If the ClassElementKind of |ClassElement| is ~non-constructor-method~, then
           1. Append |ClassElement| to the end of _list_.
         1. Return _list_.
       </emu-alg>
@@ -24494,15 +24494,15 @@
       </dl>
       <emu-grammar>ClassElementList : ClassElement</emu-grammar>
       <emu-alg>
-        1. Let _propName_ be PropName of |ClassElement|.
+        1. Let _propName_ be the PropName of |ClassElement|.
         1. If _propName_ is ~empty~, return a new empty List.
         1. If IsStatic of |ClassElement| is *true*, return a new empty List.
         1. Return « _propName_ ».
       </emu-alg>
       <emu-grammar>ClassElementList : ClassElementList ClassElement</emu-grammar>
       <emu-alg>
-        1. Let _list_ be PrototypePropertyNameList of |ClassElementList|.
-        1. Let _propName_ be PropName of |ClassElement|.
+        1. Let _list_ be the PrototypePropertyNameList of |ClassElementList|.
+        1. Let _propName_ be the PropName of |ClassElement|.
         1. If _propName_ is ~empty~, return _list_.
         1. If IsStatic of |ClassElement| is *true*, return _list_.
         1. Return the list-concatenation of _list_ and « _propName_ ».
@@ -24554,7 +24554,7 @@
 
       <emu-grammar>ClassBody : ClassElementList</emu-grammar>
       <emu-alg>
-        1. Let _newNames_ be the list-concatenation of _names_ and PrivateBoundIdentifiers of |ClassBody|.
+        1. Let _newNames_ be the list-concatenation of _names_ and the PrivateBoundIdentifiers of |ClassBody|.
         1. Return AllPrivateIdentifiersValid of |ClassElementList| with argument _newNames_.
       </emu-alg>
 
@@ -24574,7 +24574,7 @@
         FieldDefinition : ClassElementName Initializer?
       </emu-grammar>
       <emu-alg>
-        1. Return PrivateBoundIdentifiers of |ClassElementName|.
+        1. Return the PrivateBoundIdentifiers of |ClassElementName|.
       </emu-alg>
 
       <emu-grammar>
@@ -24600,8 +24600,8 @@
         ClassElementList : ClassElementList ClassElement
       </emu-grammar>
       <emu-alg>
-        1. Let _names1_ be PrivateBoundIdentifiers of |ClassElementList|.
-        1. Let _names2_ be PrivateBoundIdentifiers of |ClassElement|.
+        1. Let _names1_ be the PrivateBoundIdentifiers of |ClassElementList|.
+        1. Let _names2_ be the PrivateBoundIdentifiers of |ClassElement|.
         1. Return the list-concatenation of _names1_ and _names2_.
       </emu-alg>
 
@@ -24621,7 +24621,7 @@
           `async` `*` ClassElementName `(` UniqueFormalParameters `)` `{` AsyncGeneratorBody `}`
       </emu-grammar>
       <emu-alg>
-        1. Return PrivateBoundIdentifiers of |ClassElementName|.
+        1. Return the PrivateBoundIdentifiers of |ClassElementName|.
       </emu-alg>
     </emu-clause>
 
@@ -24795,7 +24795,7 @@
 
       <emu-grammar>ClassElement : ClassStaticBlock</emu-grammar>
       <emu-alg>
-        1. Return ClassStaticBlockDefinitionEvaluation of |ClassStaticBlock| with argument _object_.
+        1. Return the ClassStaticBlockDefinitionEvaluation of |ClassStaticBlock| with argument _object_.
       </emu-alg>
 
       <emu-grammar>
@@ -24855,7 +24855,7 @@
             1. Let _constructorParent_ be _superclass_.
         1. Let _proto_ be OrdinaryObjectCreate(_protoParent_).
         1. If |ClassBody| is not present, let _constructor_ be ~empty~.
-        1. Else, let _constructor_ be ConstructorMethod of |ClassBody|.
+        1. Else, let _constructor_ be the ConstructorMethod of |ClassBody|.
         1. Set the running execution context's LexicalEnvironment to _classEnv_.
         1. Set the running execution context's PrivateEnvironment to _classPrivateEnvironment_.
         1. If _constructor_ is ~empty~, then
@@ -24883,7 +24883,7 @@
         1. If |ClassHeritage| is present, set _F_.[[ConstructorKind]] to ~derived~.
         1. Perform ! DefineMethodProperty(_proto_, *"constructor"*, _F_, *false*).
         1. If |ClassBody| is not present, let _elements_ be a new empty List.
-        1. Else, let _elements_ be NonConstructorElements of |ClassBody|.
+        1. Else, let _elements_ be the NonConstructorElements of |ClassBody|.
         1. Let _instancePrivateMethods_ be a new empty List.
         1. Let _staticPrivateMethods_ be a new empty List.
         1. Let _instanceFields_ be a new empty List.
@@ -24943,7 +24943,7 @@
       </dl>
       <emu-grammar>ClassDeclaration : `class` BindingIdentifier ClassTail</emu-grammar>
       <emu-alg>
-        1. Let _className_ be StringValue of |BindingIdentifier|.
+        1. Let _className_ be the StringValue of |BindingIdentifier|.
         1. Let _value_ be ? ClassDefinitionEvaluation of |ClassTail| with arguments _className_ and _className_.
         1. Set _value_.[[SourceText]] to the source text matched by |ClassDeclaration|.
         1. Let _env_ be the running execution context's LexicalEnvironment.
@@ -24979,14 +24979,14 @@
       </emu-alg>
       <emu-grammar>ClassExpression : `class` BindingIdentifier ClassTail</emu-grammar>
       <emu-alg>
-        1. Let _className_ be StringValue of |BindingIdentifier|.
+        1. Let _className_ be the StringValue of |BindingIdentifier|.
         1. Let _value_ be ? ClassDefinitionEvaluation of |ClassTail| with arguments _className_ and _className_.
         1. Set _value_.[[SourceText]] to the source text matched by |ClassExpression|.
         1. Return _value_.
       </emu-alg>
       <emu-grammar>ClassElementName : PrivateIdentifier</emu-grammar>
       <emu-alg>
-        1. Let _privateIdentifier_ be StringValue of |PrivateIdentifier|.
+        1. Let _privateIdentifier_ be the StringValue of |PrivateIdentifier|.
         1. Let _privateEnvRec_ be the running execution context's PrivateEnvironment.
         1. Let _names_ be _privateEnvRec_.[[Names]].
         1. Assert: Exactly one element of _names_ is a Private Name whose [[Description]] is _privateIdentifier_.
@@ -25084,7 +25084,7 @@
         AsyncFunctionDeclaration : `async` `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
       </emu-grammar>
       <emu-alg>
-        1. Let _name_ be StringValue of |BindingIdentifier|.
+        1. Let _name_ be the StringValue of |BindingIdentifier|.
         1. Let _sourceText_ be the source text matched by |AsyncFunctionDeclaration|.
         1. Let _F_ be OrdinaryFunctionCreate(%AsyncFunction.prototype%, _sourceText_, |FormalParameters|, |AsyncFunctionBody|, ~non-lexical-this~, _env_, _privateEnv_).
         1. Perform SetFunctionName(_F_, _name_).
@@ -25126,7 +25126,7 @@
       </emu-grammar>
       <emu-alg>
         1. Assert: _name_ is not present.
-        1. Set _name_ to StringValue of |BindingIdentifier|.
+        1. Set _name_ to the StringValue of |BindingIdentifier|.
         1. Let _outerEnv_ be the LexicalEnvironment of the running execution context.
         1. Let _funcEnv_ be NewDeclarativeEnvironment(_outerEnv_).
         1. Perform ! _funcEnv_.CreateImmutableBinding(_name_, *false*).
@@ -26035,7 +26035,7 @@
         </emu-note>
         <emu-grammar>ModuleExportName : StringLiteral</emu-grammar>
         <ul>
-          <li>It is a Syntax Error if IsStringWellFormedUnicode(the SV of |StringLiteral|) is *false*.</li>
+          <li>It is a Syntax Error if IsStringWellFormedUnicode(SV of |StringLiteral|) is *false*.</li>
         </ul>
       </emu-clause>
 
@@ -26067,12 +26067,12 @@
         </emu-alg>
         <emu-grammar>ModuleItemList : ModuleItem</emu-grammar>
         <emu-alg>
-          1. Return ModuleRequests of |ModuleItem|.
+          1. Return the ModuleRequests of |ModuleItem|.
         </emu-alg>
         <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
         <emu-alg>
-          1. Let _moduleNames_ be ModuleRequests of |ModuleItemList|.
-          1. Let _additionalNames_ be ModuleRequests of |ModuleItem|.
+          1. Let _moduleNames_ be the ModuleRequests of |ModuleItemList|.
+          1. Let _additionalNames_ be the ModuleRequests of |ModuleItem|.
           1. For each String _name_ of _additionalNames_, do
             1. If _moduleNames_ does not contain _name_, then
               1. Append _name_ to _moduleNames_.
@@ -26084,7 +26084,7 @@
         </emu-alg>
         <emu-grammar>ImportDeclaration : `import` ImportClause FromClause `;`</emu-grammar>
         <emu-alg>
-          1. Return ModuleRequests of |FromClause|.
+          1. Return the ModuleRequests of |FromClause|.
         </emu-alg>
         <emu-grammar>ModuleSpecifier : StringLiteral</emu-grammar>
         <emu-alg>
@@ -27799,12 +27799,12 @@
             1. Let _body_ be ParseText(_sourceText_, |Module|).
             1. If _body_ is a List of errors, return _body_.
             1. Let _requestedModules_ be the ModuleRequests of _body_.
-            1. Let _importEntries_ be ImportEntries of _body_.
+            1. Let _importEntries_ be the ImportEntries of _body_.
             1. Let _importedBoundNames_ be ImportedLocalNames(_importEntries_).
             1. Let _indirectExportEntries_ be a new empty List.
             1. Let _localExportEntries_ be a new empty List.
             1. Let _starExportEntries_ be a new empty List.
-            1. Let _exportEntries_ be ExportEntries of _body_.
+            1. Let _exportEntries_ be the ExportEntries of _body_.
             1. For each ExportEntry Record _ee_ of _exportEntries_, do
               1. If _ee_.[[ModuleRequest]] is *null*, then
                 1. If _importedBoundNames_ does not contain _ee_.[[LocalName]], then
@@ -28243,8 +28243,8 @@
         </emu-alg>
         <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
         <emu-alg>
-          1. Let _entries1_ be ImportEntries of |ModuleItemList|.
-          1. Let _entries2_ be ImportEntries of |ModuleItem|.
+          1. Let _entries1_ be the ImportEntries of |ModuleItemList|.
+          1. Let _entries2_ be the ImportEntries of |ModuleItem|.
           1. Return the list-concatenation of _entries1_ and _entries2_.
         </emu-alg>
         <emu-grammar>
@@ -28257,8 +28257,8 @@
         </emu-alg>
         <emu-grammar>ImportDeclaration : `import` ImportClause FromClause `;`</emu-grammar>
         <emu-alg>
-          1. Let _module_ be the sole element of ModuleRequests of |FromClause|.
-          1. Return ImportEntriesForModule of |ImportClause| with argument _module_.
+          1. Let _module_ be the sole element of the ModuleRequests of |FromClause|.
+          1. Return the ImportEntriesForModule of |ImportClause| with argument _module_.
         </emu-alg>
         <emu-grammar>ImportDeclaration : `import` ModuleSpecifier `;`</emu-grammar>
         <emu-alg>
@@ -28276,19 +28276,19 @@
         </dl>
         <emu-grammar>ImportClause : ImportedDefaultBinding `,` NameSpaceImport</emu-grammar>
         <emu-alg>
-          1. Let _entries1_ be ImportEntriesForModule of |ImportedDefaultBinding| with argument _module_.
-          1. Let _entries2_ be ImportEntriesForModule of |NameSpaceImport| with argument _module_.
+          1. Let _entries1_ be the ImportEntriesForModule of |ImportedDefaultBinding| with argument _module_.
+          1. Let _entries2_ be the ImportEntriesForModule of |NameSpaceImport| with argument _module_.
           1. Return the list-concatenation of _entries1_ and _entries2_.
         </emu-alg>
         <emu-grammar>ImportClause : ImportedDefaultBinding `,` NamedImports</emu-grammar>
         <emu-alg>
-          1. Let _entries1_ be ImportEntriesForModule of |ImportedDefaultBinding| with argument _module_.
-          1. Let _entries2_ be ImportEntriesForModule of |NamedImports| with argument _module_.
+          1. Let _entries1_ be the ImportEntriesForModule of |ImportedDefaultBinding| with argument _module_.
+          1. Let _entries2_ be the ImportEntriesForModule of |NamedImports| with argument _module_.
           1. Return the list-concatenation of _entries1_ and _entries2_.
         </emu-alg>
         <emu-grammar>ImportedDefaultBinding : ImportedBinding</emu-grammar>
         <emu-alg>
-          1. Let _localName_ be the sole element of BoundNames of |ImportedBinding|.
+          1. Let _localName_ be the sole element of the BoundNames of |ImportedBinding|.
           1. Let _defaultEntry_ be the ImportEntry Record { [[ModuleRequest]]: _module_, [[ImportName]]: *"default"*, [[LocalName]]: _localName_ }.
           1. Return « _defaultEntry_ ».
         </emu-alg>
@@ -28310,7 +28310,7 @@
         </emu-alg>
         <emu-grammar>ImportSpecifier : ImportedBinding</emu-grammar>
         <emu-alg>
-          1. Let _localName_ be the sole element of BoundNames of |ImportedBinding|.
+          1. Let _localName_ be the sole element of the BoundNames of |ImportedBinding|.
           1. Let _entry_ be the ImportEntry Record { [[ModuleRequest]]: _module_, [[ImportName]]: _localName_, [[LocalName]]: _localName_ }.
           1. Return « _entry_ ».
         </emu-alg>
@@ -28361,10 +28361,10 @@
         <emu-grammar>ExportDeclaration : `export` NamedExports `;`</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if ReferencedBindings of |NamedExports| contains any |StringLiteral|s.
+            It is a Syntax Error if the ReferencedBindings of |NamedExports| contains any |StringLiteral|s.
           </li>
           <li>
-            For each |IdentifierName| _n_ in ReferencedBindings of |NamedExports|: It is a Syntax Error if StringValue of _n_ is a |ReservedWord| or the StringValue of _n_ is one of *"implements"*, *"interface"*, *"let"*, *"package"*, *"private"*, *"protected"*, *"public"*, or *"static"*.
+            For each |IdentifierName| _n_ in the ReferencedBindings of |NamedExports|: It is a Syntax Error if the StringValue of _n_ is a |ReservedWord| or the StringValue of _n_ is one of *"implements"*, *"interface"*, *"let"*, *"package"*, *"private"*, *"protected"*, *"public"*, or *"static"*.
           </li>
         </ul>
         <emu-note>
@@ -28381,8 +28381,8 @@
         </emu-note>
         <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
         <emu-alg>
-          1. Let _names1_ be ExportedBindings of |ModuleItemList|.
-          1. Let _names2_ be ExportedBindings of |ModuleItem|.
+          1. Let _names1_ be the ExportedBindings of |ModuleItemList|.
+          1. Let _names2_ be the ExportedBindings of |ModuleItem|.
           1. Return the list-concatenation of _names1_ and _names2_.
         </emu-alg>
         <emu-grammar>
@@ -28450,8 +28450,8 @@
         </emu-note>
         <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
         <emu-alg>
-          1. Let _names1_ be ExportedNames of |ModuleItemList|.
-          1. Let _names2_ be ExportedNames of |ModuleItem|.
+          1. Let _names1_ be the ExportedNames of |ModuleItemList|.
+          1. Let _names2_ be the ExportedNames of |ModuleItem|.
           1. Return the list-concatenation of _names1_ and _names2_.
         </emu-alg>
         <emu-grammar>ModuleItem : ExportDeclaration</emu-grammar>
@@ -28529,8 +28529,8 @@
         </emu-alg>
         <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
         <emu-alg>
-          1. Let _entries1_ be ExportEntries of |ModuleItemList|.
-          1. Let _entries2_ be ExportEntries of |ModuleItem|.
+          1. Let _entries1_ be the ExportEntries of |ModuleItemList|.
+          1. Let _entries2_ be the ExportEntries of |ModuleItem|.
           1. Return the list-concatenation of _entries1_ and _entries2_.
         </emu-alg>
         <emu-grammar>
@@ -28543,12 +28543,12 @@
         </emu-alg>
         <emu-grammar>ExportDeclaration : `export` ExportFromClause FromClause `;`</emu-grammar>
         <emu-alg>
-          1. Let _module_ be the sole element of ModuleRequests of |FromClause|.
-          1. Return ExportEntriesForModule of |ExportFromClause| with argument _module_.
+          1. Let _module_ be the sole element of the ModuleRequests of |FromClause|.
+          1. Return the ExportEntriesForModule of |ExportFromClause| with argument _module_.
         </emu-alg>
         <emu-grammar>ExportDeclaration : `export` NamedExports `;`</emu-grammar>
         <emu-alg>
-          1. Return ExportEntriesForModule of |NamedExports| with argument *null*.
+          1. Return the ExportEntriesForModule of |NamedExports| with argument *null*.
         </emu-alg>
         <emu-grammar>ExportDeclaration : `export` VariableStatement</emu-grammar>
         <emu-alg>
@@ -28568,13 +28568,13 @@
         </emu-alg>
         <emu-grammar>ExportDeclaration : `export` `default` HoistableDeclaration</emu-grammar>
         <emu-alg>
-          1. Let _names_ be BoundNames of |HoistableDeclaration|.
+          1. Let _names_ be the BoundNames of |HoistableDeclaration|.
           1. Let _localName_ be the sole element of _names_.
           1. Return a List whose sole element is a new ExportEntry Record { [[ModuleRequest]]: *null*, [[ImportName]]: *null*, [[LocalName]]: _localName_, [[ExportName]]: *"default"* }.
         </emu-alg>
         <emu-grammar>ExportDeclaration : `export` `default` ClassDeclaration</emu-grammar>
         <emu-alg>
-          1. Let _names_ be BoundNames of |ClassDeclaration|.
+          1. Let _names_ be the BoundNames of |ClassDeclaration|.
           1. Let _localName_ be the sole element of _names_.
           1. Return a List whose sole element is a new ExportEntry Record { [[ModuleRequest]]: *null*, [[ImportName]]: *null*, [[LocalName]]: _localName_, [[ExportName]]: *"default"* }.
         </emu-alg>
@@ -28695,7 +28695,7 @@
         <emu-grammar>ExportDeclaration : `export` `default` ClassDeclaration</emu-grammar>
         <emu-alg>
           1. Let _value_ be ? BindingClassDeclarationEvaluation of |ClassDeclaration|.
-          1. Let _className_ be the sole element of BoundNames of |ClassDeclaration|.
+          1. Let _className_ be the sole element of the BoundNames of |ClassDeclaration|.
           1. If _className_ is *"\*default\*"*, then
             1. Let _env_ be the running execution context's LexicalEnvironment.
             1. Perform ? InitializeBoundName(*"\*default\*"*, _value_, _env_).
@@ -29087,7 +29087,7 @@
         1. Let _trimmedPrefix_ be the longest prefix of _trimmed_ that satisfies the syntax of a |StrDecimalLiteral|, which might be _trimmed_ itself. If there is no such prefix, return *NaN*.
         1. Let _parsedNumber_ be ParseText(_trimmedPrefix_, |StrDecimalLiteral|).
         1. Assert: _parsedNumber_ is a Parse Node.
-        1. Return StringNumericValue of _parsedNumber_.
+        1. Return the StringNumericValue of _parsedNumber_.
       </emu-alg>
       <emu-note>
         <p>This function may interpret only a leading portion of _string_ as a Number value; it ignores any code units that cannot be interpreted as part of the notation of a decimal literal, and no indication is given that any such code units were ignored.</p>
@@ -35698,7 +35698,7 @@ THH:mm:ss.sss
             It is a Syntax Error if CountLeftCapturingParensWithin(|Pattern|) ≥ 2<sup>32</sup> - 1.
           </li>
           <li>
-            It is a Syntax Error if |Pattern| contains two or more |GroupSpecifier|s for which CapturingGroupName of |GroupSpecifier| is the same.
+            It is a Syntax Error if |Pattern| contains two or more |GroupSpecifier|s for which the CapturingGroupName of |GroupSpecifier| is the same.
           </li>
         </ul>
         <emu-grammar>QuantifierPrefix :: `{` DecimalDigits `,` DecimalDigits `}`</emu-grammar>
@@ -35746,7 +35746,7 @@ THH:mm:ss.sss
         <emu-grammar>RegExpIdentifierStart :: UnicodeLeadSurrogate UnicodeTrailSurrogate</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if RegExpIdentifierCodePoint of |RegExpIdentifierStart| is not matched by the |UnicodeIDStart| lexical grammar production.
+            It is a Syntax Error if the RegExpIdentifierCodePoint of |RegExpIdentifierStart| is not matched by the |UnicodeIDStart| lexical grammar production.
           </li>
         </ul>
         <emu-grammar>RegExpIdentifierPart :: `\` RegExpUnicodeEscapeSequence</emu-grammar>
@@ -35758,7 +35758,7 @@ THH:mm:ss.sss
         <emu-grammar>RegExpIdentifierPart :: UnicodeLeadSurrogate UnicodeTrailSurrogate</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if RegExpIdentifierCodePoint of |RegExpIdentifierPart| is not matched by the |UnicodeIDContinue| lexical grammar production.
+            It is a Syntax Error if the RegExpIdentifierCodePoint of |RegExpIdentifierPart| is not matched by the |UnicodeIDContinue| lexical grammar production.
           </li>
         </ul>
         <emu-grammar>UnicodePropertyValueExpression :: UnicodePropertyName `=` UnicodePropertyValue</emu-grammar>
@@ -36209,7 +36209,7 @@ THH:mm:ss.sss
           GroupName :: `&lt;` RegExpIdentifierName `&gt;`
         </emu-grammar>
         <emu-alg>
-          1. Let _idTextUnescaped_ be RegExpIdentifierCodePoints of |RegExpIdentifierName|.
+          1. Let _idTextUnescaped_ be the RegExpIdentifierCodePoints of |RegExpIdentifierName|.
           1. Return CodePointsToString(_idTextUnescaped_).
         </emu-alg>
       </emu-clause>
@@ -36220,13 +36220,13 @@ THH:mm:ss.sss
         </dl>
         <emu-grammar>RegExpIdentifierName :: RegExpIdentifierStart</emu-grammar>
         <emu-alg>
-          1. Let _cp_ be RegExpIdentifierCodePoint of |RegExpIdentifierStart|.
+          1. Let _cp_ be the RegExpIdentifierCodePoint of |RegExpIdentifierStart|.
           1. Return « _cp_ ».
         </emu-alg>
         <emu-grammar>RegExpIdentifierName :: RegExpIdentifierName RegExpIdentifierPart</emu-grammar>
         <emu-alg>
-          1. Let _cps_ be RegExpIdentifierCodePoints of the derived |RegExpIdentifierName|.
-          1. Let _cp_ be RegExpIdentifierCodePoint of |RegExpIdentifierPart|.
+          1. Let _cps_ be the RegExpIdentifierCodePoints of the derived |RegExpIdentifierName|.
+          1. Let _cp_ be the RegExpIdentifierCodePoint of |RegExpIdentifierPart|.
           1. Return the list-concatenation of _cps_ and « _cp_ ».
         </emu-alg>
       </emu-clause>
@@ -50487,7 +50487,7 @@ THH:mm:ss.sss
         <emu-alg replaces-step="step-functiondeclarationinstantiation-web-compat-insertion-point">
           1. If _strict_ is *false*, then
             1. For each |FunctionDeclaration| _f_ that is directly contained in the |StatementList| of a |Block|, |CaseClause|, or |DefaultClause|, do
-              1. Let _F_ be StringValue of the |BindingIdentifier| of _f_.
+              1. Let _F_ be the StringValue of the |BindingIdentifier| of _f_.
               1. If replacing the |FunctionDeclaration| _f_ with a |VariableStatement| that has _F_ as a |BindingIdentifier| would not produce any Early Errors for _func_ and _parameterNames_ does not contain _F_, then
                 1. NOTE: A var binding for _F_ is only instantiated here if it is neither a VarDeclaredName, the name of a formal parameter, or another |FunctionDeclaration|.
                 1. If _instantiatedVarNames_ does not contain _F_ and _F_ is not *"arguments"*, then
@@ -50512,7 +50512,7 @@ THH:mm:ss.sss
             1. If _strict_ is *false*, then
               1. Let _declaredFunctionOrVarNames_ be the list-concatenation of _declaredFunctionNames_ and _declaredVarNames_.
               1. For each |FunctionDeclaration| _f_ that is directly contained in the |StatementList| of a |Block|, |CaseClause|, or |DefaultClause| Contained within _script_, do
-                1. Let _F_ be StringValue of the |BindingIdentifier| of _f_.
+                1. Let _F_ be the StringValue of the |BindingIdentifier| of _f_.
                 1. If replacing the |FunctionDeclaration| _f_ with a |VariableStatement| that has _F_ as a |BindingIdentifier| would not produce any Early Errors for _script_, then
                   1. If _env_.HasLexicalDeclaration(_F_) is *false*, then
                     1. Let _fnDefinable_ be ? _env_.CanDeclareGlobalVar(_F_).
@@ -50537,7 +50537,7 @@ THH:mm:ss.sss
           1. If _strict_ is *false*, then
             1. Let _declaredFunctionOrVarNames_ be the list-concatenation of _declaredFunctionNames_ and _declaredVarNames_.
             1. For each |FunctionDeclaration| _f_ that is directly contained in the |StatementList| of a |Block|, |CaseClause|, or |DefaultClause| Contained within _body_, do
-              1. Let _F_ be StringValue of the |BindingIdentifier| of _f_.
+              1. Let _F_ be the StringValue of the |BindingIdentifier| of _f_.
               1. If replacing the |FunctionDeclaration| _f_ with a |VariableStatement| that has _F_ as a |BindingIdentifier| would not produce any Early Errors for _body_, then
                 1. Let _bindingExists_ be *false*.
                 1. Let _thisEnv_ be _lexEnv_.
@@ -50639,7 +50639,7 @@ THH:mm:ss.sss
       <emu-grammar>Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
       <ul>
         <li>
-          It is a Syntax Error if BoundNames of |CatchParameter| contains any duplicate elements.
+          It is a Syntax Error if the BoundNames of |CatchParameter| contains any duplicate elements.
         </li>
         <li>
           It is a Syntax Error if any element of the BoundNames of |CatchParameter| also occurs in the LexicallyDeclaredNames of |Block|.
@@ -50712,7 +50712,7 @@ THH:mm:ss.sss
       <p>The runtime semantics of ForInOfLoopEvaluation in <emu-xref href="#sec-runtime-semantics-forinofloopevaluation"></emu-xref> are augmented with the following:</p>
       <emu-grammar>ForInOfStatement : `for` `(` `var` BindingIdentifier Initializer `in` Expression `)` Statement</emu-grammar>
       <emu-alg>
-        1. Let _bindingId_ be StringValue of |BindingIdentifier|.
+        1. Let _bindingId_ be the StringValue of |BindingIdentifier|.
         1. Let _lhs_ be ? ResolveBinding(_bindingId_).
         1. If IsAnonymousFunctionDefinition(|Initializer|) is *true*, then
           1. Let _value_ be ? NamedEvaluation of |Initializer| with argument _bindingId_.
@@ -50818,7 +50818,7 @@ THH:mm:ss.sss
       Strict mode code may not include a |WithStatement|. The occurrence of a |WithStatement| in such a context is a *SyntaxError* (<emu-xref href="#sec-with-statement-static-semantics-early-errors"></emu-xref>).
     </li>
     <li>
-      It is a *SyntaxError* if a |CatchParameter| occurs within strict mode code and BoundNames of |CatchParameter| contains either `eval` or `arguments` (<emu-xref href="#sec-try-statement-static-semantics-early-errors"></emu-xref>).
+      It is a *SyntaxError* if a |CatchParameter| occurs within strict mode code and the BoundNames of |CatchParameter| contains either `eval` or `arguments` (<emu-xref href="#sec-try-statement-static-semantics-early-errors"></emu-xref>).
     </li>
     <li>
       It is a *SyntaxError* if the same |BindingIdentifier| appears more than once in the |FormalParameters| of a strict function. An attempt to create such a function using a Function, Generator, or AsyncFunction constructor is a *SyntaxError* (<emu-xref href="#sec-function-definitions-static-semantics-early-errors"></emu-xref>, <emu-xref href="#sec-createdynamicfunction"></emu-xref>).


### PR DESCRIPTION
E.g., change:
> 1. Return the BoundNames of |Foo|.

to:
> 1. Return BoundNames of |Foo|.

----

This PR is divided into 4 commits, depending on:
- whether the occurrence is in pseudocode or prose, and
- whether it's at the start or middle of a sentence ("The" vs "the").

since those are factors that might conceivably affect how you feel about the removal.

For the origin of this PR, see the discussion at https://github.com/tc39/ecma262/pull/3210#discussion_r1491684924 and following (re `the second "the"`).

----

Personally, I've got mixed feelings about this PR: I like the consistification, but I think the status quo is slightly easier to read. One possibility would be to include "The" in the name of some SDOs, e.g.
> 1. Return TheBoundNames of |Foo|.

Another possibility would be use a more punctuation-based syntax for SDO invocations (e.g.,
> 1. Return |Foo|.BoundNames().

from https://github.com/bterlson/ecma262/pull/3/files). It isn't necessarily easier to read, but the syntax signals that it should be read more like a programming language (as with AO invocations).