### PR TITLE
More tweaks for the iterator handling AOs

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -6865,7 +6865,7 @@
               a Boolean
             </td>
             <td>
-              Whether the iterator has been closed.
+              Whether the iterator has completed or been closed.
             </td>
           </tr>
         </table>
@@ -6925,10 +6925,16 @@
       </dl>
       <emu-alg>
         1. If _value_ is not present, then
-          1. Let _result_ be ? Call(_iteratorRecord_.[[NextMethod]], _iteratorRecord_.[[Iterator]]).
+          1. Let _result_ be Completion(Call(_iteratorRecord_.[[NextMethod]], _iteratorRecord_.[[Iterator]])).
         1. Else,
-          1. Let _result_ be ? Call(_iteratorRecord_.[[NextMethod]], _iteratorRecord_.[[Iterator]], « _value_ »).
-        1. If _result_ is not an Object, throw a *TypeError* exception.
+          1. Let _result_ be Completion(Call(_iteratorRecord_.[[NextMethod]], _iteratorRecord_.[[Iterator]], « _value_ »)).
+        1. If _result_ is a throw completion, then
+          1. Set _iteratorRecord_.[[Done]] to *true*.
+          1. Return ? _result_.
+        1. Set _result_ to ! _result_.
+        1. If _result_ is not an Object, then
+          1. Set _iteratorRecord_.[[Done]] to *true*.
+          1. Throw a *TypeError* exception.
         1. Return _result_.
       </emu-alg>
     </emu-clause>
@@ -6963,16 +6969,22 @@
       <h1>
         IteratorStep (
           _iteratorRecord_: an Iterator Record,
-        ): either a normal completion containing either an Object or *false*, or a throw completion
+        ): either a normal completion containing either an Object or ~done~, or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It requests the next value from _iteratorRecord_.[[Iterator]] by calling _iteratorRecord_.[[NextMethod]] and returns either *false* indicating that the iterator has reached its end or the IteratorResult object if a next value is available.</dd>
+        <dd>It requests the next value from _iteratorRecord_.[[Iterator]] by calling _iteratorRecord_.[[NextMethod]] and returns either ~done~ indicating that the iterator has reached its end or the IteratorResult object if a next value is available.</dd>
       </dl>
       <emu-alg>
         1. Let _result_ be ? IteratorNext(_iteratorRecord_).
-        1. Let _done_ be ? IteratorComplete(_result_).
-        1. If _done_ is *true*, return *false*.
+        1. Let _done_ be Completion(IteratorComplete(_result_)).
+        1. If _done_ is a throw completion, then
+          1. Set _iteratorRecord_.[[Done]] to *true*.
+          1. Return ? _done_.
+        1. Set _done_ to ! _done_.
+        1. If _done_ is *true*, then
+          1. Set _iteratorRecord_.[[Done]] to *true*.
+          1. Return ~done~.
         1. Return _result_.
       </emu-alg>
     </emu-clause>
@@ -6988,20 +7000,10 @@
         <dd>It requests the next value from _iteratorRecord_.[[Iterator]] by calling _iteratorRecord_.[[NextMethod]] and returns either ~done~ indicating that the iterator has reached its end or the value from the IteratorResult object if a next value is available.</dd>
       </dl>
       <emu-alg>
-        1. Let _result_ be Completion(IteratorNext(_iteratorRecord_)).
-        1. If _result_ is a throw completion, then
-          1. Set _iteratorRecord_.[[Done]] to *true*.
-          1. Return ? _result_.
-        1. Set _result_ to ! _result_.
-        1. Let _done_ be Completion(IteratorComplete(_result_)).
-        1. If _done_ is a throw completion, then
-          1. Set _iteratorRecord_.[[Done]] to *true*.
-          1. Return ? _done_.
-        1. Set _done_ to ! _done_.
-        1. If _done_ is *true*, then
-          1. Set _iteratorRecord_.[[Done]] to *true*.
+        1. Let _result_ be ? IteratorStep(_iteratorRecord_).
+        1. If _result_ is ~done~, then
           1. Return ~done~.
-        1. Let _value_ be Completion(Get(_result_, *"value"*)).
+        1. Let _value_ be Completion(IteratorValue(_result_)).
         1. If _value_ is a throw completion, then
           1. Set _iteratorRecord_.[[Done]] to *true*.
         1. Return ? _value_.
@@ -20907,20 +20909,14 @@
         <emu-grammar>Elision : `,`</emu-grammar>
         <emu-alg>
           1. If _iteratorRecord_.[[Done]] is *false*, then
-            1. Let _next_ be Completion(IteratorStep(_iteratorRecord_)).
-            1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
-            1. ReturnIfAbrupt(_next_).
-            1. If _next_ is *false*, set _iteratorRecord_.[[Done]] to *true*.
+            1. Perform ? IteratorStep(_iteratorRecord_).
           1. Return ~unused~.
         </emu-alg>
         <emu-grammar>Elision : Elision `,`</emu-grammar>
         <emu-alg>
           1. Perform ? IteratorDestructuringAssignmentEvaluation of |Elision| with argument _iteratorRecord_.
           1. If _iteratorRecord_.[[Done]] is *false*, then
-            1. Let _next_ be Completion(IteratorStep(_iteratorRecord_)).
-            1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
-            1. ReturnIfAbrupt(_next_).
-            1. If _next_ is *false*, set _iteratorRecord_.[[Done]] to *true*.
+            1. Perform ? IteratorStep(_iteratorRecord_).
           1. Return ~unused~.
         </emu-alg>
         <emu-grammar>AssignmentElement : DestructuringAssignmentTarget Initializer?</emu-grammar>


### PR DESCRIPTION
The iterator protocol has a bunch of helper AOs. But almost everything just uses `IteratorStepValue` (introduced in https://github.com/tc39/ecma262/pull/3268) and `IteratorClose`; the exceptions are

- `IteratorStep` still gets used when you need to iterate but don't care about the value - specifically, it gets used for `[foo, , bar] = baz` [destructurings with elisions](https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-runtime-semantics-iteratordestructuringassignmentevaluation), and in some of the iterator helper proposals (e.g. [`.drop`](https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.drop)), which will need updating.
- `IteratorNext` gets used in [`%AsyncFromSyncIteratorPrototype%.next`](https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-%asyncfromsynciteratorprototype%.next) (the thing which handles `for await` over a sync iterator)
- `IteratorComplete` and `IteratorValue` get used in [`for of`](https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#sec-runtime-semantics-forin-div-ofbodyevaluation-lhs-stmt-iterator-lhskind-labelset) and [`yield *`](https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-generator-function-definitions-runtime-semantics-evaluation) so that they can share logic between sync vs async iteration, plus in [`%AsyncFromSyncIteratorPrototype`](https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-asyncfromsynciteratorcontinuation).

This PR changes `IteratorStep` and `IteratorNext` so that they set the `[[Done]]` slot on the Iterator Record to `true` when some part of the protocol throws or the iterator result object's `.done` is found to be `true`, consistent with how `IteratorStepValue` behaves. (I'd previously considered eliminating `IteratorStep` entirely, but "I need to advance this iterator but I don't care about the value" is a coherent thing and does come up sometimes.)

Of the above uses, only the "destructurings with elisions" case actually care whether the `[[Done]]` slot gets set to `true`, which it was previously doing explicitly. Still, it seems nicer to handle these uniformly, such that manipulation of that slot is done only in the iterator AOs themselves.

This also incidentally eliminates 2 of the remaining 4 explicit uses of the ReturnIfAbrupt macro (cf https://github.com/tc39/ecma262/pull/1573#issuecomment-1913042895), the last two being in [`[[Call]]`](https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-ecmascript-function-objects-call-thisargument-argumentslist) and [`[[Construct]]`](https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-ecmascript-function-objects-construct-argumentslist-newtarget) for ECMAScript function objects.