### PR TITLE
Editorial: Do away with IsPropertyKey AO.

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -2710,7 +2710,7 @@
           An <dfn variants="accessor properties">accessor property</dfn> associates a key value with one or two accessor functions, and a set of Boolean attributes. The accessor functions are used to store or retrieve an ECMAScript language value that is associated with the property.
         </li>
       </ul>
-      <p>The properties of an object are uniquely identified using property keys. A <dfn variants="property keys">property key</dfn> is either a String or a Symbol. All Strings and Symbols, including the empty String, are valid as property keys. A <dfn id="property-name">property name</dfn> is a property key that is a String.</p>
+      <p>The properties of an object are uniquely identified using property keys. A <dfn variants="property keys" oldids="sec-ispropertykey">property key</dfn> is either a String or a Symbol. All Strings and Symbols, including the empty String, are valid as property keys. A <dfn id="property-name">property name</dfn> is a property key that is a String.</p>
       <p>An <dfn id="integer-index" variants="integer indices,integer-indexed">integer index</dfn> is a property name _n_ such that CanonicalNumericIndexString(_n_) returns an integral Number in the inclusive interval from *+0*<sub>𝔽</sub> to 𝔽(2<sup>53</sup> - 1). An <dfn id="array-index" variants="array indices">array index</dfn> is an integer index _n_ such that CanonicalNumericIndexString(_n_) returns an integral Number in the inclusive interval from *+0*<sub>𝔽</sub> to 𝔽(2<sup>32</sup> - 2).</p>
       <emu-note>
         <p>Every non-negative safe integer has a corresponding integer index. Every 32-bit unsigned integer except <emu-eqn>2<sup>32</sup> - 1</emu-eqn> has a corresponding array index. *"-0"* is neither an integer index nor an array index.</p>
@@ -5795,23 +5795,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-ispropertykey" type="abstract operation">
-      <h1>
-        IsPropertyKey (
-          _argument_: an ECMAScript language value,
-        ): a Boolean
-      </h1>
-      <dl class="header">
-        <dt>description</dt>
-        <dd>It determines if _argument_ is a value that may be used as a property key.</dd>
-      </dl>
-      <emu-alg>
-        1. If _argument_ is a String, return *true*.
-        1. If _argument_ is a Symbol, return *true*.
-        1. Return *false*.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-isregexp" type="abstract operation">
       <h1>
         IsRegExp (
@@ -6745,7 +6728,7 @@
         1. If _fieldName_ is a Private Name, then
           1. Perform ? PrivateFieldAdd(_receiver_, _fieldName_, _initValue_).
         1. Else,
-          1. Assert: IsPropertyKey(_fieldName_) is *true*.
+          1. Assert: _fieldName_ is a property key.
           1. Perform ? CreateDataPropertyOrThrow(_receiver_, _fieldName_, _initValue_).
         1. Return ~unused~.
       </emu-alg>
@@ -12702,7 +12685,7 @@
           <dd>It returns *true* if and only if _Desc_ can be applied as the property of an object with specified _extensibility_ and current property _current_ while upholding <emu-xref href="#sec-invariants-of-the-essential-internal-methods">invariants</emu-xref>. When such application is possible and _O_ is not *undefined*, it is performed for the property named _P_ (which is created if necessary).</dd>
         </dl>
         <emu-alg>
-          1. Assert: IsPropertyKey(_P_) is *true*.
+          1. Assert: _P_ is a property key.
           1. If _current_ is *undefined*, then
             1. If _extensible_ is *false*, return *false*.
             1. If _O_ is *undefined*, return *true*.


### PR DESCRIPTION
Per @michaelficarra's suggestion [here](https://github.com/tc39/ecma262/pull/3307#discussion_r1575464392), let's just replace the AO `IsPropertyKey` with the phrasing "is a property key", given that "property key" is a well-defined term.