### PR TITLE
Editorial: remove some "are both" usages

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -20459,7 +20459,7 @@
       <emu-alg>
         1. If |LeftHandSideExpression| is neither an |ObjectLiteral| nor an |ArrayLiteral|, then
           1. Let _lref_ be ? Evaluation of |LeftHandSideExpression|.
-          1. If IsAnonymousFunctionDefinition(|AssignmentExpression|) and IsIdentifierRef of |LeftHandSideExpression| are both *true*, then
+          1. If IsAnonymousFunctionDefinition(|AssignmentExpression|) is *true* and IsIdentifierRef of |LeftHandSideExpression| is *true*, then
             1. Let _rval_ be ? NamedEvaluation of |AssignmentExpression| with argument _lref_.[[ReferencedName]].
           1. Else,
             1. Let _rref_ be ? Evaluation of |AssignmentExpression|.
@@ -20950,7 +20950,7 @@
             1. Let _lref_ be ? Evaluation of |DestructuringAssignmentTarget|.
           1. Let _v_ be ? GetV(_value_, _propertyName_).
           1. If |Initializer| is present and _v_ is *undefined*, then
-            1. If IsAnonymousFunctionDefinition(|Initializer|) and IsIdentifierRef of |DestructuringAssignmentTarget| are both *true*, then
+            1. If IsAnonymousFunctionDefinition(|Initializer|) is *true* and IsIdentifierRef of |DestructuringAssignmentTarget| is *true*, then
               1. Let _rhsValue_ be ? NamedEvaluation of |Initializer| with argument _lref_.[[ReferencedName]].
             1. Else,
               1. Let _defaultValue_ be ? Evaluation of |Initializer|.


### PR DESCRIPTION
This doesn't remove all occurrences, but the other occurrences are either in prose/asserts or we talked about them and they are justified because they form a nice pattern of spec steps. Typically, we avoid using this structure.

Additionally, this particular test is done in 6 places, 4 of which are already using our preferred phrasing.