### PR TITLE
Layering: the [[Realm]] of a Script Record cannot be *undefined*

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -25787,10 +25787,10 @@
               [[Realm]]
             </td>
             <td>
-              a Realm Record or *undefined*
+              a Realm Record
             </td>
             <td>
-              The realm within which this script was created. *undefined* if not yet assigned.
+              The realm within which this script was created.
             </td>
           </tr>
           <tr>
@@ -25834,7 +25834,7 @@
       <h1>
         ParseScript (
           _sourceText_: ECMAScript source text,
-          _realm_: a Realm Record or *undefined*,
+          _realm_: a Realm Record,
           _hostDefined_: anything,
         ): a Script Record or a non-empty List of *SyntaxError* objects
       </h1>


### PR DESCRIPTION
Fixes https://github.com/tc39/ecma262/issues/3326.

As mentioned in that issue, the editors suspect this was a refactoring issue, since it does not appear to ever actually have been possible for this to be `*undefined*`, and in any case is not assigned later. The only caller of ParseScript known to us is [in HTML](https://html.spec.whatwg.org/multipage/webappapis.html#creating-scripts), which passes the realm of an environment settings object, which (I believe) cannot be `*undefined*`, so this restriction on types matches what the consumer actually passed.