### PR TITLE
Meta: integrate aspell for spelling checks

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,0 +1,22 @@
+name: 'ecma-262'
+
+on: [pull_request]
+
+jobs:
+  spellcheck:
+    name: 'check for newly-introduced spelling errors'
+    runs-on: ubuntu-latest
+
+    steps:
+      - run: sudo apt-get install aspell
+      - uses: actions/checkout@v3
+        with:
+          # Number of commits to fetch. 0 indicates all history for all branches and tags.
+          # Default: 1
+          fetch-depth: 0
+      - uses: ljharb/actions/node/install@d9f477827ed71a259056764107f74afc29febcae
+        name: 'nvm install lts/* && npm ci'
+        with:
+          node-version: lts/*
+          use-npm-ci: true
+      - run: node scripts/spellcheck.mjs origin/"${GITHUB_BASE_REF}"

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 out/
 vendor/esmeta
 test*.js
+aspell.txt
 
 # lockfiles we don't use are ignored
 npm-shrinkwrap.json

--- a/scripts/spellcheck.mjs
+++ b/scripts/spellcheck.mjs
@@ -1,0 +1,72 @@
+import { promisify } from 'node:util';
+import { exec } from 'node:child_process';
+const execP = promisify(exec);
+import { writeFile } from 'node:fs/promises';
+
+const MIN_WORD_SIZE = 3;
+
+const BASE_REF = process.argv[2];
+const ASPELL_OPTS = [
+  '--add-html-check=alt,title,caption,variants',
+  '--ignore-case',
+  '--master=en_GB-ize',
+  '--mode=html',
+  '--run-together',
+  '--run-together-limit=99',
+  '--run-together-min=2',
+  'list',
+].join(' ');
+
+function makeDict(words) {
+  return `personal_ws-1.1 en ${words.length}\n${words.join('\n')}`;
+}
+
+function lines(text) {
+  if (text.length === 0) return [];
+  return text.split('\n');
+}
+
+console.log(`base ref: ${BASE_REF}`);
+
+let { stdout } = await execP(`git show "${BASE_REF}":spec.html | aspell ${ASPELL_OPTS} | sort -fu`);
+
+let existingWords = lines(stdout.trim());
+
+let existingComponents = Array.from(new Set(
+  existingWords
+    .flatMap(word => [...word.matchAll(/(?:^[a-z]|[A-Z])[a-z]{2,}/g)])
+    .map(([w]) => w.toLowerCase())
+));
+
+({ stdout } = await execP(`echo ${existingComponents.map(w => JSON.stringify(w)).join(' ')} | aspell ${ASPELL_OPTS} | sort -fu`));
+
+let existingComponentsReduced = lines(stdout.trim());
+
+await writeFile('aspell.txt', makeDict(existingComponentsReduced));
+
+({ stdout } = await execP(`echo ${existingWords.map(w => JSON.stringify(w)).join(' ')} | aspell --personal=./aspell.txt ${ASPELL_OPTS}`));
+
+let novel = [...existingComponentsReduced, ...lines(stdout.trim())].filter(w => w.length >= MIN_WORD_SIZE);
+novel.sort();
+console.log(`\npreviously used novel words: ${novel.join(', ')}`);
+await writeFile('aspell.txt', makeDict(novel));
+
+({ stdout } = await execP(`aspell --personal=./aspell.txt ${ASPELL_OPTS} list <spec.html | sort -u`));
+let misspellings = lines(stdout.trim()).filter(w => w.length >= MIN_WORD_SIZE);
+
+if (misspellings.length > 0) {
+  console.log(`\nmisspellings: ${misspellings.join(', ')}`);
+  let pattern = misspellings.map(w => `-e ${JSON.stringify(w)}`).join(' --or ');
+  ({ stdout } = await execP(`git grep --line-number --column --fixed-strings --only-matching ${pattern} -- spec.html`));
+
+  console.log('');
+
+  let info = lines(stdout.trim());
+  for (let warning of info) {
+    let [match, file, line, col, typo] = warning.match(/^([^:]+):(\d+):(\d+):(.*)$/);
+    let title = 'Potential Typo';
+    let message = `${JSON.stringify(typo)} is not a previously used word or composed of previously used words. Perhaps it is a typo?`;
+    // https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-a-warning-message
+    console.log(`::warning file=${file},line=${line},endLine=${line},col=${col},endColumn=${col + typo.length},title=${title}::${message}`);
+  }
+}

--- a/spec.html
+++ b/spec.html
@@ -709,7 +709,7 @@
             ReturnStatement
             ExpressionStatement
         </emu-grammar>
-        <p>Multiple parameters produce a combinatory number of productions, not all of which are necessarily referenced in a complete grammar.</p>
+        <p>Multiple parameters produce a combinatoric number of productions, not all of which are necessarily referenced in a complete grammar.</p>
         <p>References to nonterminals on the right-hand side of a production can also be parameterized. For example:</p>
         <emu-grammar type="definition" example>
           StatementList :
@@ -1120,7 +1120,7 @@
 
 <emu-clause id="sec-ecmascript-data-types-and-values" aoid="Type">
   <h1>ECMAScript Data Types and Values</h1>
-  <p>Algorithms within this specification manipulate values each of which has an associated type. The possible value types are exactly those defined in this clause. Types are further subclassified into ECMAScript language types and specification types.</p>
+  <p>Algorithms within this specification manipulate values each of which has an associated type. The possible value types are exactly those defined in this clause. Types are further classified into ECMAScript language types and specification types.</p>
   <p>Within this specification, the notation “Type(_x_)” is used as shorthand for “the <em>type</em> of _x_” where “type” refers to the ECMAScript language and specification types defined in this clause.</p>
 
   <emu-clause id="sec-ecmascript-language-types">
@@ -2107,10 +2107,10 @@
           <dl class="header">
           </dl>
           <emu-alg>
-            1. Let _lnum_ be ! ToInt32(_x_).
-            1. Let _rnum_ be ! ToUint32(_y_).
-            1. Let _shiftCount_ be ℝ(_rnum_) modulo 32.
-            1. Return the result of left shifting _lnum_ by _shiftCount_ bits. The mathematical value of the result is exactly representable as a 32-bit two's complement bit string.
+            1. Let _lNum_ be ! ToInt32(_x_).
+            1. Let _rNum_ be ! ToUint32(_y_).
+            1. Let _shiftCount_ be ℝ(_rNum_) modulo 32.
+            1. Return the result of left shifting _lNum_ by _shiftCount_ bits. The mathematical value of the result is exactly representable as a 32-bit two's complement bit string.
           </emu-alg>
         </emu-clause>
 
@@ -2124,10 +2124,10 @@
           <dl class="header">
           </dl>
           <emu-alg>
-            1. Let _lnum_ be ! ToInt32(_x_).
-            1. Let _rnum_ be ! ToUint32(_y_).
-            1. Let _shiftCount_ be ℝ(_rnum_) modulo 32.
-            1. Return the result of performing a sign-extending right shift of _lnum_ by _shiftCount_ bits. The most significant bit is propagated. The mathematical value of the result is exactly representable as a 32-bit two's complement bit string.
+            1. Let _lNum_ be ! ToInt32(_x_).
+            1. Let _rNum_ be ! ToUint32(_y_).
+            1. Let _shiftCount_ be ℝ(_rNum_) modulo 32.
+            1. Return the result of performing a sign-extending right shift of _lNum_ by _shiftCount_ bits. The most significant bit is propagated. The mathematical value of the result is exactly representable as a 32-bit two's complement bit string.
           </emu-alg>
         </emu-clause>
 
@@ -2141,10 +2141,10 @@
           <dl class="header">
           </dl>
           <emu-alg>
-            1. Let _lnum_ be ! ToUint32(_x_).
-            1. Let _rnum_ be ! ToUint32(_y_).
-            1. Let _shiftCount_ be ℝ(_rnum_) modulo 32.
-            1. Return the result of performing a zero-filling right shift of _lnum_ by _shiftCount_ bits. Vacated bits are filled with zero. The mathematical value of the result is exactly representable as a 32-bit unsigned bit string.
+            1. Let _lNum_ be ! ToUint32(_x_).
+            1. Let _rNum_ be ! ToUint32(_y_).
+            1. Let _shiftCount_ be ℝ(_rNum_) modulo 32.
+            1. Return the result of performing a zero-filling right shift of _lNum_ by _shiftCount_ bits. Vacated bits are filled with zero. The mathematical value of the result is exactly representable as a 32-bit unsigned bit string.
           </emu-alg>
         </emu-clause>
 
@@ -2238,17 +2238,17 @@
           <dl class="header">
           </dl>
           <emu-alg>
-            1. Let _lnum_ be ! ToInt32(_x_).
-            1. Let _rnum_ be ! ToInt32(_y_).
-            1. Let _lbits_ be the 32-bit two's complement bit string representing ℝ(_lnum_).
-            1. Let _rbits_ be the 32-bit two's complement bit string representing ℝ(_rnum_).
+            1. Let _lNum_ be ! ToInt32(_x_).
+            1. Let _rNum_ be ! ToInt32(_y_).
+            1. Let _lBits_ be the 32-bit two's complement bit string representing ℝ(_lNum_).
+            1. Let _rBits_ be the 32-bit two's complement bit string representing ℝ(_rNum_).
             1. If _op_ is `&amp;`, then
-              1. Let _result_ be the result of applying the bitwise AND operation to _lbits_ and _rbits_.
+              1. Let _result_ be the result of applying the bitwise AND operation to _lBits_ and _rBits_.
             1. Else if _op_ is `^`, then
-              1. Let _result_ be the result of applying the bitwise exclusive OR (XOR) operation to _lbits_ and _rbits_.
+              1. Let _result_ be the result of applying the bitwise exclusive OR (XOR) operation to _lBits_ and _rBits_.
             1. Else,
               1. Assert: _op_ is `|`.
-              1. Let _result_ be the result of applying the bitwise inclusive OR operation to _lbits_ and _rbits_.
+              1. Let _result_ be the result of applying the bitwise inclusive OR operation to _lBits_ and _rBits_.
             1. Return the Number value for the integer represented by the 32-bit two's complement bit string _result_.
           </emu-alg>
         </emu-clause>
@@ -4394,9 +4394,9 @@
         <dl class="header">
         </dl>
         <emu-alg>
-          1. Let _privEnv_ be the running execution context's PrivateEnvironment.
-          1. Assert: _privEnv_ is not *null*.
-          1. Let _privateName_ be ResolvePrivateIdentifier(_privEnv_, _privateIdentifier_).
+          1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+          1. Assert: _privateEnv_ is not *null*.
+          1. Let _privateName_ be ResolvePrivateIdentifier(_privateEnv_, _privateIdentifier_).
           1. Return the Reference Record { [[Base]]: _baseValue_, [[ReferencedName]]: _privateName_, [[Strict]]: *true*, [[ThisValue]]: ~empty~ }.
         </emu-alg>
       </emu-clause>
@@ -4573,10 +4573,10 @@
     <emu-clause id="sec-data-blocks">
       <h1>Data Blocks</h1>
       <p>The <dfn variants="Data Blocks">Data Block</dfn> specification type is used to describe a distinct and mutable sequence of byte-sized (8 bit) numeric values. A <dfn variants="byte values">byte value</dfn> is an integer in the inclusive interval from 0 to 255. A Data Block value is created with a fixed number of bytes that each have the initial value 0.</p>
-      <p>For notational convenience within this specification, an array-like syntax can be used to access the individual bytes of a Data Block value. This notation presents a Data Block value as a 0-origined <emu-not-ref>integer-indexed</emu-not-ref> sequence of bytes. For example, if _db_ is a 5 byte Data Block value then _db_[2] can be used to access its 3<sup>rd</sup> byte.</p>
+      <p>For notational convenience within this specification, an array-like syntax can be used to access the individual bytes of a Data Block value. This notation presents a Data Block value as a 0-based <emu-not-ref>integer-indexed</emu-not-ref> sequence of bytes. For example, if _db_ is a 5 byte Data Block value then _db_[2] can be used to access its 3<sup>rd</sup> byte.</p>
       <p>A data block that resides in memory that can be referenced from multiple agents concurrently is designated a <dfn variants="Shared Data Blocks">Shared Data Block</dfn>. A Shared Data Block has an identity (for the purposes of equality testing Shared Data Block values) that is <em>address-free</em>: it is tied not to the virtual addresses the block is mapped to in any process, but to the set of locations in memory that the block represents. Two data blocks are equal only if the sets of the locations they contain are equal; otherwise, they are not equal and the intersection of the sets of locations they contain is empty. Finally, Shared Data Blocks can be distinguished from Data Blocks.</p>
       <p>The semantics of Shared Data Blocks is defined using Shared Data Block events by the memory model. Abstract operations below introduce Shared Data Block events and act as the interface between evaluation semantics and the event semantics of the memory model. The events form a candidate execution, on which the memory model acts as a filter. Please consult the memory model for full semantics.</p>
-      <p>Shared Data Block events are modeled by Records, defined in the memory model.</p>
+      <p>Shared Data Block events are modelled by Records, defined in the memory model.</p>
       <p>The following abstract operations are used in this specification to operate upon Data Block values:</p>
 
       <emu-clause id="sec-createbytedatablock" type="abstract operation">
@@ -6820,7 +6820,7 @@
       <h1>
         GroupBy (
           _items_: an ECMAScript language value,
-          _callbackfn_: an ECMAScript language value,
+          _callback_: an ECMAScript language value,
           _keyCoercion_: ~property~ or ~collection~,
         ): either a normal completion containing a List of Records with fields [[Key]] (an ECMAScript language value) and [[Elements]] (a List of ECMAScript language values), or a throw completion
       </h1>
@@ -6828,7 +6828,7 @@
       </dl>
       <emu-alg>
         1. Perform ? RequireObjectCoercible(_items_).
-        1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
+        1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
         1. Let _groups_ be a new empty List.
         1. Let _iteratorRecord_ be ? GetIterator(_items_, ~sync~).
         1. Let _k_ be 0.
@@ -6840,7 +6840,7 @@
           1. If _next_ is ~done~, then
             1. Return _groups_.
           1. Let _value_ be _next_.
-          1. Let _key_ be Completion(Call(_callbackfn_, *undefined*, « _value_, 𝔽(_k_) »)).
+          1. Let _key_ be Completion(Call(_callback_, *undefined*, « _value_, 𝔽(_k_) »)).
           1. IfAbruptCloseIterator(_key_, _iteratorRecord_).
           1. If _keyCoercion_ is ~property~, then
             1. Set _key_ to Completion(ToPropertyKey(_key_)).
@@ -6984,26 +6984,26 @@
     <emu-clause id="sec-iteratorcomplete" type="abstract operation">
       <h1>
         IteratorComplete (
-          _iterResult_: an Object,
+          _iteratorResult_: an Object,
         ): either a normal completion containing a Boolean or a throw completion
       </h1>
       <dl class="header">
       </dl>
       <emu-alg>
-        1. Return ToBoolean(? Get(_iterResult_, *"done"*)).
+        1. Return ToBoolean(? Get(_iteratorResult_, *"done"*)).
       </emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-iteratorvalue" type="abstract operation">
       <h1>
         IteratorValue (
-          _iterResult_: an Object,
+          _iteratorResult_: an Object,
         ): either a normal completion containing an ECMAScript language value or a throw completion
       </h1>
       <dl class="header">
       </dl>
       <emu-alg>
-        1. Return ? Get(_iterResult_, *"value"*).
+        1. Return ? Get(_iteratorResult_, *"value"*).
       </emu-alg>
     </emu-clause>
 
@@ -7121,7 +7121,7 @@
 
     <emu-clause id="sec-createiterresultobject" type="abstract operation">
       <h1>
-        CreateIterResultObject (
+        CreateIteratorResultObject (
           _value_: an ECMAScript language value,
           _done_: a Boolean,
         ): an Object that conforms to the <i>IteratorResult</i> interface
@@ -7151,7 +7151,7 @@
       <emu-alg>
         1. Let _closure_ be a new Abstract Closure with no parameters that captures _list_ and performs the following steps when called:
           1. For each element _E_ of _list_, do
-            1. Perform ? GeneratorYield(CreateIterResultObject(_E_, *false*)).
+            1. Perform ? GeneratorYield(CreateIteratorResultObject(_E_, *false*)).
           1. Return NormalCompletion(*undefined*).
         1. Let _iterator_ be CreateIteratorFromClosure(_closure_, ~empty~, %IteratorPrototype%).
         1. Return the Iterator Record { [[Iterator]]: _iterator_, [[NextMethod]]: %GeneratorFunction.prototype.prototype.next%, [[Done]]: *false* }.
@@ -11518,34 +11518,34 @@
       <emu-clause id="sec-newprivateenvironment" type="abstract operation">
         <h1>
           NewPrivateEnvironment (
-            _outerPrivEnv_: a PrivateEnvironment Record or *null*,
+            _outerPrivateEnv_: a PrivateEnvironment Record or *null*,
           ): a PrivateEnvironment Record
         </h1>
         <dl class="header">
         </dl>
         <emu-alg>
           1. Let _names_ be a new empty List.
-          1. Return the PrivateEnvironment Record { [[OuterPrivateEnvironment]]: _outerPrivEnv_, [[Names]]: _names_ }.
+          1. Return the PrivateEnvironment Record { [[OuterPrivateEnvironment]]: _outerPrivateEnv_, [[Names]]: _names_ }.
         </emu-alg>
       </emu-clause>
 
       <emu-clause id="sec-resolve-private-identifier" type="abstract operation">
         <h1>
           ResolvePrivateIdentifier (
-            _privEnv_: a PrivateEnvironment Record,
+            _privateEnv_: a PrivateEnvironment Record,
             _identifier_: a String,
           ): a Private Name
         </h1>
         <dl class="header">
         </dl>
         <emu-alg>
-          1. Let _names_ be _privEnv_.[[Names]].
+          1. Let _names_ be _privateEnv_.[[Names]].
           1. For each Private Name _pn_ of _names_, do
             1. If _pn_.[[Description]] is _identifier_, then
               1. Return _pn_.
-          1. Let _outerPrivEnv_ be _privEnv_.[[OuterPrivateEnvironment]].
-          1. Assert: _outerPrivEnv_ is not *null*.
-          1. Return ResolvePrivateIdentifier(_outerPrivEnv_, _identifier_).
+          1. Let _outerPrivateEnv_ be _privateEnv_.[[OuterPrivateEnvironment]].
+          1. Assert: _outerPrivateEnv_ is not *null*.
+          1. Return ResolvePrivateIdentifier(_outerPrivateEnv_, _identifier_).
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -12571,7 +12571,7 @@
           1. Return *true*.
         </emu-alg>
         <emu-note>
-          <p>The loop in step <emu-xref href="#step-ordinarysetprototypeof-loop"></emu-xref> guarantees that there will be no circularities in any prototype chain that only includes objects that use the ordinary object definitions for [[GetPrototypeOf]] and [[SetPrototypeOf]].</p>
+          <p>The loop in step <emu-xref href="#step-ordinarysetprototypeof-loop"></emu-xref> guarantees that there will be no cycles in any prototype chain that only includes objects that use the ordinary object definitions for [[GetPrototypeOf]] and [[SetPrototypeOf]].</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -17851,7 +17851,7 @@
 
           AsyncArrowFunction[In, Yield, Await] :
             `async` [no LineTerminator here] AsyncArrowBindingIdentifier[?Yield] [no LineTerminator here] `=>` AsyncConciseBody[?In]
-            CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await] [no LineTerminator here] `=>` AsyncConciseBody[?In] #callcover
+            CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await] [no LineTerminator here] `=>` AsyncConciseBody[?In] #callCover
 
           AsyncArrowHead :
             `async` [no LineTerminator here] ArrowFormalParameters[~Yield, +Await]
@@ -18209,7 +18209,7 @@
         AsyncGeneratorExpression
         RegularExpressionLiteral
         TemplateLiteral[?Yield, ?Await, ~Tagged]
-        CoverParenthesizedExpressionAndArrowParameterList[?Yield, ?Await] #parencover
+        CoverParenthesizedExpressionAndArrowParameterList[?Yield, ?Await] #parenCover
 
       CoverParenthesizedExpressionAndArrowParameterList[Yield, Await] :
         `(` Expression[+In, ?Yield, ?Await] `)`
@@ -18998,7 +18998,7 @@
         `new` NewExpression[?Yield, ?Await]
 
       CallExpression[Yield, Await] :
-        CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await] #callcover
+        CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await] #callCover
         SuperCall[?Yield, ?Await]
         ImportCall[?Yield, ?Await]
         CallExpression[?Yield, ?Await] Arguments[?Yield, ?Await]
@@ -20190,66 +20190,66 @@
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>RelationalExpression : RelationalExpression `&lt;` ShiftExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be ? Evaluation of |RelationalExpression|.
-        1. Let _lval_ be ? GetValue(_lref_).
-        1. Let _rref_ be ? Evaluation of |ShiftExpression|.
-        1. Let _rval_ be ? GetValue(_rref_).
-        1. Let _r_ be ? IsLessThan(_lval_, _rval_, *true*).
+        1. Let _lRef_ be ? Evaluation of |RelationalExpression|.
+        1. Let _lVal_ be ? GetValue(_lRef_).
+        1. Let _rRef_ be ? Evaluation of |ShiftExpression|.
+        1. Let _rVal_ be ? GetValue(_rRef_).
+        1. Let _r_ be ? IsLessThan(_lVal_, _rVal_, *true*).
         1. If _r_ is *undefined*, return *false*. Otherwise, return _r_.
       </emu-alg>
       <emu-grammar>RelationalExpression : RelationalExpression `&gt;` ShiftExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be ? Evaluation of |RelationalExpression|.
-        1. Let _lval_ be ? GetValue(_lref_).
-        1. Let _rref_ be ? Evaluation of |ShiftExpression|.
-        1. Let _rval_ be ? GetValue(_rref_).
-        1. Let _r_ be ? IsLessThan(_rval_, _lval_, *false*).
+        1. Let _lRef_ be ? Evaluation of |RelationalExpression|.
+        1. Let _lVal_ be ? GetValue(_lRef_).
+        1. Let _rRef_ be ? Evaluation of |ShiftExpression|.
+        1. Let _rVal_ be ? GetValue(_rRef_).
+        1. Let _r_ be ? IsLessThan(_rVal_, _lVal_, *false*).
         1. If _r_ is *undefined*, return *false*. Otherwise, return _r_.
       </emu-alg>
       <emu-grammar>RelationalExpression : RelationalExpression `&lt;=` ShiftExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be ? Evaluation of |RelationalExpression|.
-        1. Let _lval_ be ? GetValue(_lref_).
-        1. Let _rref_ be ? Evaluation of |ShiftExpression|.
-        1. Let _rval_ be ? GetValue(_rref_).
-        1. Let _r_ be ? IsLessThan(_rval_, _lval_, *false*).
+        1. Let _lRef_ be ? Evaluation of |RelationalExpression|.
+        1. Let _lVal_ be ? GetValue(_lRef_).
+        1. Let _rRef_ be ? Evaluation of |ShiftExpression|.
+        1. Let _rVal_ be ? GetValue(_rRef_).
+        1. Let _r_ be ? IsLessThan(_rVal_, _lVal_, *false*).
         1. If _r_ is either *true* or *undefined*, return *false*. Otherwise, return *true*.
       </emu-alg>
       <emu-grammar>RelationalExpression : RelationalExpression `&gt;=` ShiftExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be ? Evaluation of |RelationalExpression|.
-        1. Let _lval_ be ? GetValue(_lref_).
-        1. Let _rref_ be ? Evaluation of |ShiftExpression|.
-        1. Let _rval_ be ? GetValue(_rref_).
-        1. Let _r_ be ? IsLessThan(_lval_, _rval_, *true*).
+        1. Let _lRef_ be ? Evaluation of |RelationalExpression|.
+        1. Let _lVal_ be ? GetValue(_lRef_).
+        1. Let _rRef_ be ? Evaluation of |ShiftExpression|.
+        1. Let _rVal_ be ? GetValue(_rRef_).
+        1. Let _r_ be ? IsLessThan(_lVal_, _rVal_, *true*).
         1. If _r_ is either *true* or *undefined*, return *false*. Otherwise, return *true*.
       </emu-alg>
       <emu-grammar>RelationalExpression : RelationalExpression `instanceof` ShiftExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be ? Evaluation of |RelationalExpression|.
-        1. Let _lval_ be ? GetValue(_lref_).
-        1. Let _rref_ be ? Evaluation of |ShiftExpression|.
-        1. Let _rval_ be ? GetValue(_rref_).
-        1. Return ? InstanceofOperator(_lval_, _rval_).
+        1. Let _lRef_ be ? Evaluation of |RelationalExpression|.
+        1. Let _lVal_ be ? GetValue(_lRef_).
+        1. Let _rRef_ be ? Evaluation of |ShiftExpression|.
+        1. Let _rVal_ be ? GetValue(_rRef_).
+        1. Return ? InstanceofOperator(_lVal_, _rVal_).
       </emu-alg>
       <emu-grammar>RelationalExpression : RelationalExpression `in` ShiftExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be ? Evaluation of |RelationalExpression|.
-        1. Let _lval_ be ? GetValue(_lref_).
-        1. Let _rref_ be ? Evaluation of |ShiftExpression|.
-        1. Let _rval_ be ? GetValue(_rref_).
-        1. If _rval_ is not an Object, throw a *TypeError* exception.
-        1. Return ? HasProperty(_rval_, ? ToPropertyKey(_lval_)).
+        1. Let _lRef_ be ? Evaluation of |RelationalExpression|.
+        1. Let _lVal_ be ? GetValue(_lRef_).
+        1. Let _rRef_ be ? Evaluation of |ShiftExpression|.
+        1. Let _rVal_ be ? GetValue(_rRef_).
+        1. If _rVal_ is not an Object, throw a *TypeError* exception.
+        1. Return ? HasProperty(_rVal_, ? ToPropertyKey(_lVal_)).
       </emu-alg>
       <emu-grammar>RelationalExpression : PrivateIdentifier `in` ShiftExpression</emu-grammar>
       <emu-alg>
         1. Let _privateIdentifier_ be the StringValue of |PrivateIdentifier|.
-        1. Let _rref_ be ? Evaluation of |ShiftExpression|.
-        1. Let _rval_ be ? GetValue(_rref_).
-        1. If _rval_ is not an Object, throw a *TypeError* exception.
+        1. Let _rRef_ be ? Evaluation of |ShiftExpression|.
+        1. Let _rVal_ be ? GetValue(_rRef_).
+        1. If _rVal_ is not an Object, throw a *TypeError* exception.
         1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
         1. Let _privateName_ be ResolvePrivateIdentifier(_privateEnv_, _privateIdentifier_).
-        1. If PrivateElementFind(_rval_, _privateName_) is not ~empty~, return *true*.
+        1. If PrivateElementFind(_rVal_, _privateName_) is not ~empty~, return *true*.
         1. Return *false*.
       </emu-alg>
     </emu-clause>
@@ -20298,36 +20298,36 @@
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>EqualityExpression : EqualityExpression `==` RelationalExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be ? Evaluation of |EqualityExpression|.
-        1. Let _lval_ be ? GetValue(_lref_).
-        1. Let _rref_ be ? Evaluation of |RelationalExpression|.
-        1. Let _rval_ be ? GetValue(_rref_).
-        1. Return ? IsLooselyEqual(_rval_, _lval_).
+        1. Let _lRef_ be ? Evaluation of |EqualityExpression|.
+        1. Let _lVal_ be ? GetValue(_lRef_).
+        1. Let _rRef_ be ? Evaluation of |RelationalExpression|.
+        1. Let _rVal_ be ? GetValue(_rRef_).
+        1. Return ? IsLooselyEqual(_rVal_, _lVal_).
       </emu-alg>
       <emu-grammar>EqualityExpression : EqualityExpression `!=` RelationalExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be ? Evaluation of |EqualityExpression|.
-        1. Let _lval_ be ? GetValue(_lref_).
-        1. Let _rref_ be ? Evaluation of |RelationalExpression|.
-        1. Let _rval_ be ? GetValue(_rref_).
-        1. Let _r_ be ? IsLooselyEqual(_rval_, _lval_).
+        1. Let _lRef_ be ? Evaluation of |EqualityExpression|.
+        1. Let _lVal_ be ? GetValue(_lRef_).
+        1. Let _rRef_ be ? Evaluation of |RelationalExpression|.
+        1. Let _rVal_ be ? GetValue(_rRef_).
+        1. Let _r_ be ? IsLooselyEqual(_rVal_, _lVal_).
         1. If _r_ is *true*, return *false*. Otherwise, return *true*.
       </emu-alg>
       <emu-grammar>EqualityExpression : EqualityExpression `===` RelationalExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be ? Evaluation of |EqualityExpression|.
-        1. Let _lval_ be ? GetValue(_lref_).
-        1. Let _rref_ be ? Evaluation of |RelationalExpression|.
-        1. Let _rval_ be ? GetValue(_rref_).
-        1. Return IsStrictlyEqual(_rval_, _lval_).
+        1. Let _lRef_ be ? Evaluation of |EqualityExpression|.
+        1. Let _lVal_ be ? GetValue(_lRef_).
+        1. Let _rRef_ be ? Evaluation of |RelationalExpression|.
+        1. Let _rVal_ be ? GetValue(_rRef_).
+        1. Return IsStrictlyEqual(_rVal_, _lVal_).
       </emu-alg>
       <emu-grammar>EqualityExpression : EqualityExpression `!==` RelationalExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be ? Evaluation of |EqualityExpression|.
-        1. Let _lval_ be ? GetValue(_lref_).
-        1. Let _rref_ be ? Evaluation of |RelationalExpression|.
-        1. Let _rval_ be ? GetValue(_rref_).
-        1. Let _r_ be IsStrictlyEqual(_rval_, _lval_).
+        1. Let _lRef_ be ? Evaluation of |EqualityExpression|.
+        1. Let _lVal_ be ? GetValue(_lRef_).
+        1. Let _rRef_ be ? Evaluation of |RelationalExpression|.
+        1. Let _rVal_ be ? GetValue(_rRef_).
+        1. Let _r_ be IsStrictlyEqual(_rVal_, _lVal_).
         1. If _r_ is *true*, return *false*. Otherwise, return *true*.
       </emu-alg>
       <emu-note>
@@ -20437,31 +20437,29 @@
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>LogicalANDExpression : LogicalANDExpression `&amp;&amp;` BitwiseORExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be ? Evaluation of |LogicalANDExpression|.
-        1. Let _lval_ be ? GetValue(_lref_).
-        1. Let _lbool_ be ToBoolean(_lval_).
-        1. If _lbool_ is *false*, return _lval_.
-        1. Let _rref_ be ? Evaluation of |BitwiseORExpression|.
-        1. Return ? GetValue(_rref_).
+        1. Let _lRef_ be ? Evaluation of |LogicalANDExpression|.
+        1. Let _lVal_ be ? GetValue(_lRef_).
+        1. If ToBoolean(_lVal_) is *false*, return _lVal_.
+        1. Let _rRef_ be ? Evaluation of |BitwiseORExpression|.
+        1. Return ? GetValue(_rRef_).
       </emu-alg>
       <emu-grammar>LogicalORExpression : LogicalORExpression `||` LogicalANDExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be ? Evaluation of |LogicalORExpression|.
-        1. Let _lval_ be ? GetValue(_lref_).
-        1. Let _lbool_ be ToBoolean(_lval_).
-        1. If _lbool_ is *true*, return _lval_.
-        1. Let _rref_ be ? Evaluation of |LogicalANDExpression|.
-        1. Return ? GetValue(_rref_).
+        1. Let _lRef_ be ? Evaluation of |LogicalORExpression|.
+        1. Let _lVal_ be ? GetValue(_lRef_).
+        1. If ToBoolean(_lVal_) is *true*, return _lVal_.
+        1. Let _rRef_ be ? Evaluation of |LogicalANDExpression|.
+        1. Return ? GetValue(_rRef_).
       </emu-alg>
       <emu-grammar>CoalesceExpression : CoalesceExpressionHead `??` BitwiseORExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be ? Evaluation of |CoalesceExpressionHead|.
-        1. Let _lval_ be ? GetValue(_lref_).
-        1. If _lval_ is either *undefined* or *null*, then
-          1. Let _rref_ be ? Evaluation of |BitwiseORExpression|.
-          1. Return ? GetValue(_rref_).
+        1. Let _lRef_ be ? Evaluation of |CoalesceExpressionHead|.
+        1. Let _lVal_ be ? GetValue(_lRef_).
+        1. If _lVal_ is either *undefined* or *null*, then
+          1. Let _rRef_ be ? Evaluation of |BitwiseORExpression|.
+          1. Return ? GetValue(_rRef_).
         1. Else,
-          1. Return _lval_.
+          1. Return _lVal_.
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -20482,9 +20480,9 @@
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>ConditionalExpression : ShortCircuitExpression `?` AssignmentExpression `:` AssignmentExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be ? Evaluation of |ShortCircuitExpression|.
-        1. Let _lval_ be ToBoolean(? GetValue(_lref_)).
-        1. If _lval_ is *true*, then
+        1. Let _lRef_ be ? Evaluation of |ShortCircuitExpression|.
+        1. Let _lVal_ be ToBoolean(? GetValue(_lRef_)).
+        1. If _lVal_ is *true*, then
           1. Let _trueRef_ be ? Evaluation of the first |AssignmentExpression|.
           1. Return ? GetValue(_trueRef_).
         1. Else,
@@ -20544,27 +20542,27 @@
       <emu-grammar>AssignmentExpression : LeftHandSideExpression `=` AssignmentExpression</emu-grammar>
       <emu-alg>
         1. If |LeftHandSideExpression| is neither an |ObjectLiteral| nor an |ArrayLiteral|, then
-          1. Let _lref_ be ? Evaluation of |LeftHandSideExpression|.
+          1. Let _lRef_ be ? Evaluation of |LeftHandSideExpression|.
           1. If IsAnonymousFunctionDefinition(|AssignmentExpression|) is *true* and IsIdentifierRef of |LeftHandSideExpression| is *true*, then
             1. Let _lhs_ be the StringValue of |LeftHandSideExpression|.
-            1. Let _rval_ be ? NamedEvaluation of |AssignmentExpression| with argument _lhs_.
+            1. Let _rVal_ be ? NamedEvaluation of |AssignmentExpression| with argument _lhs_.
           1. Else,
-            1. Let _rref_ be ? Evaluation of |AssignmentExpression|.
-            1. Let _rval_ be ? GetValue(_rref_).
-          1. [id="step-assignmentexpression-evaluation-simple-putvalue"] Perform ? PutValue(_lref_, _rval_).
-          1. Return _rval_.
+            1. Let _rRef_ be ? Evaluation of |AssignmentExpression|.
+            1. Let _rVal_ be ? GetValue(_rRef_).
+          1. [id="step-assignmentexpression-evaluation-simple-putvalue"] Perform ? PutValue(_lRef_, _rVal_).
+          1. Return _rVal_.
         1. Let _assignmentPattern_ be the |AssignmentPattern| that is covered by |LeftHandSideExpression|.
-        1. Let _rref_ be ? Evaluation of |AssignmentExpression|.
-        1. Let _rval_ be ? GetValue(_rref_).
-        1. Perform ? DestructuringAssignmentEvaluation of _assignmentPattern_ with argument _rval_.
-        1. Return _rval_.
+        1. Let _rRef_ be ? Evaluation of |AssignmentExpression|.
+        1. Let _rVal_ be ? GetValue(_rRef_).
+        1. Perform ? DestructuringAssignmentEvaluation of _assignmentPattern_ with argument _rVal_.
+        1. Return _rVal_.
       </emu-alg>
       <emu-grammar>AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be ? Evaluation of |LeftHandSideExpression|.
-        1. [id="step-assignmentexpression-evaluation-compound-getvalue"] Let _lval_ be ? GetValue(_lref_).
-        1. Let _rref_ be ? Evaluation of |AssignmentExpression|.
-        1. Let _rval_ be ? GetValue(_rref_).
+        1. Let _lRef_ be ? Evaluation of |LeftHandSideExpression|.
+        1. [id="step-assignmentexpression-evaluation-compound-getvalue"] Let _lVal_ be ? GetValue(_lRef_).
+        1. Let _rRef_ be ? Evaluation of |AssignmentExpression|.
+        1. Let _rVal_ be ? GetValue(_rRef_).
         1. Let _assignmentOpText_ be the source text matched by |AssignmentOperator|.
         1. Let _opText_ be the sequence of Unicode code points associated with _assignmentOpText_ in the following table:
           <figure>
@@ -20587,94 +20585,92 @@
               <tr><td> `|=`               </td><td> `|`            </td></tr>
             </table>
           </figure>
-        1. Let _r_ be ? ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
-        1. [id="step-assignmentexpression-evaluation-compound-putvalue"] Perform ? PutValue(_lref_, _r_).
+        1. Let _r_ be ? ApplyStringOrNumericBinaryOperator(_lVal_, _opText_, _rVal_).
+        1. [id="step-assignmentexpression-evaluation-compound-putvalue"] Perform ? PutValue(_lRef_, _r_).
         1. Return _r_.
       </emu-alg>
       <emu-grammar>AssignmentExpression : LeftHandSideExpression `&amp;&amp;=` AssignmentExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be ? Evaluation of |LeftHandSideExpression|.
-        1. [id="step-assignmentexpression-evaluation-lgcl-and-getvalue"] Let _lval_ be ? GetValue(_lref_).
-        1. Let _lbool_ be ToBoolean(_lval_).
-        1. If _lbool_ is *false*, return _lval_.
+        1. Let _lRef_ be ? Evaluation of |LeftHandSideExpression|.
+        1. [id="step-assignmentexpression-evaluation-lgcl-and-getvalue"] Let _lVal_ be ? GetValue(_lRef_).
+        1. If ToBoolean(_lVal_) is *false*, return _lVal_.
         1. If IsAnonymousFunctionDefinition(|AssignmentExpression|) is *true* and IsIdentifierRef of |LeftHandSideExpression| is *true*, then
           1. Let _lhs_ be the StringValue of |LeftHandSideExpression|.
-          1. Let _rval_ be ? NamedEvaluation of |AssignmentExpression| with argument _lhs_.
+          1. Let _rVal_ be ? NamedEvaluation of |AssignmentExpression| with argument _lhs_.
         1. Else,
-          1. Let _rref_ be ? Evaluation of |AssignmentExpression|.
-          1. Let _rval_ be ? GetValue(_rref_).
-        1. [id="step-assignmentexpression-evaluation-lgcl-and-putvalue"] Perform ? PutValue(_lref_, _rval_).
-        1. Return _rval_.
+          1. Let _rRef_ be ? Evaluation of |AssignmentExpression|.
+          1. Let _rVal_ be ? GetValue(_rRef_).
+        1. [id="step-assignmentexpression-evaluation-lgcl-and-putvalue"] Perform ? PutValue(_lRef_, _rVal_).
+        1. Return _rVal_.
       </emu-alg>
       <emu-grammar>AssignmentExpression : LeftHandSideExpression `||=` AssignmentExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be ? Evaluation of |LeftHandSideExpression|.
-        1. [id="step-assignmentexpression-evaluation-lgcl-or-getvalue"] Let _lval_ be ? GetValue(_lref_).
-        1. Let _lbool_ be ToBoolean(_lval_).
-        1. If _lbool_ is *true*, return _lval_.
+        1. Let _lRef_ be ? Evaluation of |LeftHandSideExpression|.
+        1. [id="step-assignmentexpression-evaluation-lgcl-or-getvalue"] Let _lVal_ be ? GetValue(_lRef_).
+        1. If ToBoolean(_lVal_) is *true*, return _lVal_.
         1. If IsAnonymousFunctionDefinition(|AssignmentExpression|) is *true* and IsIdentifierRef of |LeftHandSideExpression| is *true*, then
           1. Let _lhs_ be the StringValue of |LeftHandSideExpression|.
-          1. Let _rval_ be ? NamedEvaluation of |AssignmentExpression| with argument _lhs_.
+          1. Let _rVal_ be ? NamedEvaluation of |AssignmentExpression| with argument _lhs_.
         1. Else,
-          1. Let _rref_ be ? Evaluation of |AssignmentExpression|.
-          1. Let _rval_ be ? GetValue(_rref_).
-        1. [id="step-assignmentexpression-evaluation-lgcl-or-putvalue"] Perform ? PutValue(_lref_, _rval_).
-        1. Return _rval_.
+          1. Let _rRef_ be ? Evaluation of |AssignmentExpression|.
+          1. Let _rVal_ be ? GetValue(_rRef_).
+        1. [id="step-assignmentexpression-evaluation-lgcl-or-putvalue"] Perform ? PutValue(_lRef_, _rVal_).
+        1. Return _rVal_.
       </emu-alg>
       <emu-grammar>AssignmentExpression : LeftHandSideExpression `??=` AssignmentExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be ? Evaluation of |LeftHandSideExpression|.
-        1. [id="step-assignmentexpression-evaluation-lgcl-nullish-getvalue"] Let _lval_ be ? GetValue(_lref_).
-        1. If _lval_ is neither *undefined* nor *null*, return _lval_.
+        1. Let _lRef_ be ? Evaluation of |LeftHandSideExpression|.
+        1. [id="step-assignmentexpression-evaluation-lgcl-nullish-getvalue"] Let _lVal_ be ? GetValue(_lRef_).
+        1. If _lVal_ is neither *undefined* nor *null*, return _lVal_.
         1. If IsAnonymousFunctionDefinition(|AssignmentExpression|) is *true* and IsIdentifierRef of |LeftHandSideExpression| is *true*, then
           1. Let _lhs_ be the StringValue of |LeftHandSideExpression|.
-          1. Let _rval_ be ? NamedEvaluation of |AssignmentExpression| with argument _lhs_.
+          1. Let _rVal_ be ? NamedEvaluation of |AssignmentExpression| with argument _lhs_.
         1. Else,
-          1. Let _rref_ be ? Evaluation of |AssignmentExpression|.
-          1. Let _rval_ be ? GetValue(_rref_).
-        1. [id="step-assignmentexpression-evaluation-lgcl-nullish-putvalue"] Perform ? PutValue(_lref_, _rval_).
-        1. Return _rval_.
+          1. Let _rRef_ be ? Evaluation of |AssignmentExpression|.
+          1. Let _rVal_ be ? GetValue(_rRef_).
+        1. [id="step-assignmentexpression-evaluation-lgcl-nullish-putvalue"] Perform ? PutValue(_lRef_, _rVal_).
+        1. Return _rVal_.
       </emu-alg>
       <emu-note>
-        <p>When this expression occurs within strict mode code, it is a runtime error if _lref_ in step <emu-xref href="#step-assignmentexpression-evaluation-simple-putvalue"></emu-xref>, <emu-xref href="#step-assignmentexpression-evaluation-compound-getvalue"></emu-xref>, <emu-xref href="#step-assignmentexpression-evaluation-lgcl-and-getvalue"></emu-xref>, <emu-xref href="#step-assignmentexpression-evaluation-lgcl-or-getvalue"></emu-xref>, <emu-xref href="#step-assignmentexpression-evaluation-lgcl-nullish-getvalue"></emu-xref> is an unresolvable reference. If it is, a *ReferenceError* exception is thrown. Additionally, it is a runtime error if the _lref_ in step <emu-xref href="#step-assignmentexpression-evaluation-compound-putvalue"></emu-xref>, <emu-xref href="#step-assignmentexpression-evaluation-lgcl-and-putvalue"></emu-xref>, <emu-xref href="#step-assignmentexpression-evaluation-lgcl-or-putvalue"></emu-xref>, <emu-xref href="#step-assignmentexpression-evaluation-lgcl-nullish-putvalue"></emu-xref> is a reference to a data property with the attribute value { [[Writable]]: *false* }, to an accessor property with the attribute value { [[Set]]: *undefined* }, or to a non-existent property of an object for which the IsExtensible predicate returns the value *false*. In these cases a *TypeError* exception is thrown.</p>
+        <p>When this expression occurs within strict mode code, it is a runtime error if _lRef_ in step <emu-xref href="#step-assignmentexpression-evaluation-simple-putvalue"></emu-xref>, <emu-xref href="#step-assignmentexpression-evaluation-compound-getvalue"></emu-xref>, <emu-xref href="#step-assignmentexpression-evaluation-lgcl-and-getvalue"></emu-xref>, <emu-xref href="#step-assignmentexpression-evaluation-lgcl-or-getvalue"></emu-xref>, <emu-xref href="#step-assignmentexpression-evaluation-lgcl-nullish-getvalue"></emu-xref> is an unresolvable reference. If it is, a *ReferenceError* exception is thrown. Additionally, it is a runtime error if the _lRef_ in step <emu-xref href="#step-assignmentexpression-evaluation-compound-putvalue"></emu-xref>, <emu-xref href="#step-assignmentexpression-evaluation-lgcl-and-putvalue"></emu-xref>, <emu-xref href="#step-assignmentexpression-evaluation-lgcl-or-putvalue"></emu-xref>, <emu-xref href="#step-assignmentexpression-evaluation-lgcl-nullish-putvalue"></emu-xref> is a reference to a data property with the attribute value { [[Writable]]: *false* }, to an accessor property with the attribute value { [[Set]]: *undefined* }, or to a non-existent property of an object for which the IsExtensible predicate returns the value *false*. In these cases a *TypeError* exception is thrown.</p>
       </emu-note>
     </emu-clause>
 
     <emu-clause id="sec-applystringornumericbinaryoperator" type="abstract operation">
       <h1>
         ApplyStringOrNumericBinaryOperator (
-          _lval_: an ECMAScript language value,
+          _lVal_: an ECMAScript language value,
           _opText_: `**`, `*`, `/`, `%`, `+`, `-`, `&lt;&lt;`, `&gt;&gt;`, `&gt;&gt;&gt;`, `&amp;`, `^`, or `|`,
-          _rval_: an ECMAScript language value,
+          _rVal_: an ECMAScript language value,
         ): either a normal completion containing either a String, a BigInt, or a Number, or a throw completion
       </h1>
       <dl class="header">
       </dl>
       <emu-alg>
         1. If _opText_ is `+`, then
-          1. [id="step-binary-op-toprimitive-lval"] Let _lprim_ be ? ToPrimitive(_lval_).
-          1. [id="step-binary-op-toprimitive-rval"] Let _rprim_ be ? ToPrimitive(_rval_).
-          1. [id="step-binary-op-string-check"] If _lprim_ is a String or _rprim_ is a String, then
-            1. Let _lstr_ be ? ToString(_lprim_).
-            1. Let _rstr_ be ? ToString(_rprim_).
-            1. Return the string-concatenation of _lstr_ and _rstr_.
-          1. Set _lval_ to _lprim_.
-          1. Set _rval_ to _rprim_.
+          1. [id="step-binary-op-toprimitive-lval"] Let _lPrim_ be ? ToPrimitive(_lVal_).
+          1. [id="step-binary-op-toprimitive-rval"] Let _rPrim_ be ? ToPrimitive(_rVal_).
+          1. [id="step-binary-op-string-check"] If _lPrim_ is a String or _rPrim_ is a String, then
+            1. Let _lStr_ be ? ToString(_lPrim_).
+            1. Let _rStr_ be ? ToString(_rPrim_).
+            1. Return the string-concatenation of _lStr_ and _rStr_.
+          1. Set _lVal_ to _lPrim_.
+          1. Set _rVal_ to _rPrim_.
         1. NOTE: At this point, it must be a numeric operation.
-        1. Let _lnum_ be ? ToNumeric(_lval_).
-        1. Let _rnum_ be ? ToNumeric(_rval_).
-        1. If Type(_lnum_) is not Type(_rnum_), throw a *TypeError* exception.
-        1. If _lnum_ is a BigInt, then
-          1. If _opText_ is `**`, return ? BigInt::exponentiate(_lnum_, _rnum_).
-          1. If _opText_ is `/`, return ? BigInt::divide(_lnum_, _rnum_).
-          1. If _opText_ is `%`, return ? BigInt::remainder(_lnum_, _rnum_).
-          1. If _opText_ is `>>>`, return ? BigInt::unsignedRightShift(_lnum_, _rnum_).
-        1. Let _operation_ be the abstract operation associated with _opText_ and Type(_lnum_) in the following table:
+        1. Let _lNum_ be ? ToNumeric(_lVal_).
+        1. Let _rNum_ be ? ToNumeric(_rVal_).
+        1. If Type(_lNum_) is not Type(_rNum_), throw a *TypeError* exception.
+        1. If _lNum_ is a BigInt, then
+          1. If _opText_ is `**`, return ? BigInt::exponentiate(_lNum_, _rNum_).
+          1. If _opText_ is `/`, return ? BigInt::divide(_lNum_, _rNum_).
+          1. If _opText_ is `%`, return ? BigInt::remainder(_lNum_, _rNum_).
+          1. If _opText_ is `>>>`, return ? BigInt::unsignedRightShift(_lNum_, _rNum_).
+        1. Let _operation_ be the abstract operation associated with _opText_ and Type(_lNum_) in the following table:
           <figure>
             <!-- emu-format ignore -->
             <table class="lightweight-table">
               <thead>
-                <tr><th> _opText_       </th><th> Type(_lnum_) </th><th> _operation_                </th></tr>
+                <tr><th> _opText_       </th><th> Type(_lNum_) </th><th> _operation_                </th></tr>
               </thead>
               <tr><td> `**`           </td><td> Number       </td><td> Number::exponentiate       </td></tr>
               <tr><td> `*`            </td><td> Number       </td><td> Number::multiply           </td></tr>
@@ -20698,7 +20694,7 @@
               <tr><td> `|`            </td><td> BigInt       </td><td> BigInt::bitwiseOR          </td></tr>
             </table>
           </figure>
-        1. Return _operation_(_lnum_, _rnum_).
+        1. Return _operation_(_lNum_, _rNum_).
       </emu-alg>
       <emu-note>
         <p>No hint is provided in the calls to ToPrimitive in steps <emu-xref href="#step-binary-op-toprimitive-lval"></emu-xref> and <emu-xref href="#step-binary-op-toprimitive-rval"></emu-xref>. All standard objects except Dates handle the absence of a hint as if ~number~ were given; Dates handle the absence of a hint as if ~string~ were given. Exotic objects may handle the absence of a hint in some other manner.</p>
@@ -20719,11 +20715,11 @@
       <dl class="header">
       </dl>
       <emu-alg>
-        1. Let _lref_ be ? Evaluation of _leftOperand_.
-        1. Let _lval_ be ? GetValue(_lref_).
-        1. Let _rref_ be ? Evaluation of _rightOperand_.
-        1. Let _rval_ be ? GetValue(_rref_).
-        1. Return ? ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+        1. Let _lRef_ be ? Evaluation of _leftOperand_.
+        1. Let _lVal_ be ? GetValue(_lRef_).
+        1. Let _rRef_ be ? Evaluation of _rightOperand_.
+        1. Let _rVal_ be ? GetValue(_rRef_).
+        1. Return ? ApplyStringOrNumericBinaryOperator(_lVal_, _opText_, _rVal_).
       </emu-alg>
     </emu-clause>
 
@@ -20909,7 +20905,7 @@
         <emu-grammar>AssignmentProperty : IdentifierReference Initializer?</emu-grammar>
         <emu-alg>
           1. Let _P_ be the StringValue of |IdentifierReference|.
-          1. Let _lref_ be ? ResolveBinding(_P_).
+          1. Let _lRef_ be ? ResolveBinding(_P_).
           1. Let _v_ be ? GetV(_value_, _P_).
           1. If |Initializer| is present and _v_ is *undefined*, then
             1. If IsAnonymousFunctionDefinition(|Initializer|) is *true*, then
@@ -20917,7 +20913,7 @@
             1. Else,
               1. Let _defaultValue_ be ? Evaluation of |Initializer|.
               1. Set _v_ to ? GetValue(_defaultValue_).
-          1. Perform ? PutValue(_lref_, _v_).
+          1. Perform ? PutValue(_lRef_, _v_).
           1. Return « _P_ ».
         </emu-alg>
 
@@ -20940,10 +20936,10 @@
         </dl>
         <emu-grammar>AssignmentRestProperty : `...` DestructuringAssignmentTarget</emu-grammar>
         <emu-alg>
-          1. Let _lref_ be ? Evaluation of |DestructuringAssignmentTarget|.
+          1. Let _lRef_ be ? Evaluation of |DestructuringAssignmentTarget|.
           1. Let _restObj_ be OrdinaryObjectCreate(%Object.prototype%).
           1. Perform ? CopyDataProperties(_restObj_, _value_, _excludedNames_).
-          1. Return ? PutValue(_lref_, _restObj_).
+          1. Return ? PutValue(_lRef_, _restObj_).
         </emu-alg>
       </emu-clause>
 
@@ -20989,7 +20985,7 @@
         <emu-grammar>AssignmentElement : DestructuringAssignmentTarget Initializer?</emu-grammar>
         <emu-alg>
           1. If |DestructuringAssignmentTarget| is neither an |ObjectLiteral| nor an |ArrayLiteral|, then
-            1. Let _lref_ be ? Evaluation of |DestructuringAssignmentTarget|.
+            1. Let _lRef_ be ? Evaluation of |DestructuringAssignmentTarget|.
           1. Let _value_ be *undefined*.
           1. If _iteratorRecord_.[[Done]] is *false*, then
             1. Let _next_ be ? IteratorStepValue(_iteratorRecord_).
@@ -21007,7 +21003,7 @@
           1. If |DestructuringAssignmentTarget| is either an |ObjectLiteral| or an |ArrayLiteral|, then
             1. Let _nestedAssignmentPattern_ be the |AssignmentPattern| that is covered by |DestructuringAssignmentTarget|.
             1. Return ? DestructuringAssignmentEvaluation of _nestedAssignmentPattern_ with argument _v_.
-          1. Return ? PutValue(_lref_, _v_).
+          1. Return ? PutValue(_lRef_, _v_).
         </emu-alg>
         <emu-note>
           <p>Left to right evaluation order is maintained by evaluating a |DestructuringAssignmentTarget| that is not a destructuring pattern prior to accessing the iterator or evaluating the |Initializer|.</p>
@@ -21015,7 +21011,7 @@
         <emu-grammar>AssignmentRestElement : `...` DestructuringAssignmentTarget</emu-grammar>
         <emu-alg>
           1. If |DestructuringAssignmentTarget| is neither an |ObjectLiteral| nor an |ArrayLiteral|, then
-            1. Let _lref_ be ? Evaluation of |DestructuringAssignmentTarget|.
+            1. Let _lRef_ be ? Evaluation of |DestructuringAssignmentTarget|.
           1. Let _A_ be ! ArrayCreate(0).
           1. Let _n_ be 0.
           1. Repeat, while _iteratorRecord_.[[Done]] is *false*,
@@ -21024,7 +21020,7 @@
               1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_n_)), _next_).
               1. Set _n_ to _n_ + 1.
           1. If |DestructuringAssignmentTarget| is neither an |ObjectLiteral| nor an |ArrayLiteral|, then
-            1. Return ? PutValue(_lref_, _A_).
+            1. Return ? PutValue(_lRef_, _A_).
           1. Let _nestedAssignmentPattern_ be the |AssignmentPattern| that is covered by |DestructuringAssignmentTarget|.
           1. Return ? DestructuringAssignmentEvaluation of _nestedAssignmentPattern_ with argument _A_.
         </emu-alg>
@@ -21042,7 +21038,7 @@
         <emu-grammar>AssignmentElement : DestructuringAssignmentTarget Initializer?</emu-grammar>
         <emu-alg>
           1. If |DestructuringAssignmentTarget| is neither an |ObjectLiteral| nor an |ArrayLiteral|, then
-            1. Let _lref_ be ? Evaluation of |DestructuringAssignmentTarget|.
+            1. Let _lRef_ be ? Evaluation of |DestructuringAssignmentTarget|.
           1. Let _v_ be ? GetV(_value_, _propertyName_).
           1. If |Initializer| is present and _v_ is *undefined*, then
             1. If IsAnonymousFunctionDefinition(|Initializer|) is *true* and IsIdentifierRef of |DestructuringAssignmentTarget| is *true*, then
@@ -21056,7 +21052,7 @@
           1. If |DestructuringAssignmentTarget| is either an |ObjectLiteral| or an |ArrayLiteral|, then
             1. Let _assignmentPattern_ be the |AssignmentPattern| that is covered by |DestructuringAssignmentTarget|.
             1. Return ? DestructuringAssignmentEvaluation of _assignmentPattern_ with argument _rhsValue_.
-          1. Return ? PutValue(_lref_, _rhsValue_).
+          1. Return ? PutValue(_lRef_, _rhsValue_).
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -21075,10 +21071,10 @@
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>Expression : Expression `,` AssignmentExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be ? Evaluation of |Expression|.
-        1. Perform ? GetValue(_lref_).
-        1. Let _rref_ be ? Evaluation of |AssignmentExpression|.
-        1. Return ? GetValue(_rref_).
+        1. Let _lRef_ be ? Evaluation of |Expression|.
+        1. Perform ? GetValue(_lRef_).
+        1. Let _rRef_ be ? Evaluation of |AssignmentExpression|.
+        1. Return ? GetValue(_rRef_).
       </emu-alg>
       <emu-note>
         <p>GetValue must be called even though its value is not used because it may have observable side-effects.</p>
@@ -21401,8 +21397,8 @@
         <emu-grammar>VariableDeclaration : BindingPattern Initializer</emu-grammar>
         <emu-alg>
           1. Let _rhs_ be ? Evaluation of |Initializer|.
-          1. Let _rval_ be ? GetValue(_rhs_).
-          1. Return ? BindingInitialization of |BindingPattern| with arguments _rval_ and *undefined*.
+          1. Let _rVal_ be ? GetValue(_rhs_).
+          1. Return ? BindingInitialization of |BindingPattern| with arguments _rVal_ and *undefined*.
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -22388,11 +22384,11 @@
                     1. Let _desc_ be ? <emu-meta effects="user-code">_object_.[[GetOwnProperty]]</emu-meta>(_r_).
                     1. If _desc_ is not *undefined*, then
                       1. Append _r_ to _O_.[[VisitedKeys]].
-                      1. If _desc_.[[Enumerable]] is *true*, return CreateIterResultObject(_r_, *false*).
+                      1. If _desc_.[[Enumerable]] is *true*, return CreateIteratorResultObject(_r_, *false*).
                 1. Set _object_ to ? <emu-meta effects="user-code">_object_.[[GetPrototypeOf]]()</emu-meta>.
                 1. Set _O_.[[Object]] to _object_.
                 1. Set _O_.[[ObjectWasVisited]] to *false*.
-                1. If _object_ is *null*, return CreateIterResultObject(*undefined*, *true*).
+                1. If _object_ is *null*, return CreateIteratorResultObject(*undefined*, *true*).
             </emu-alg>
           </emu-clause>
         </emu-clause>
@@ -23553,7 +23549,7 @@
 
       ArrowParameters[Yield, Await] :
         BindingIdentifier[?Yield, ?Await]
-        CoverParenthesizedExpressionAndArrowParameterList[?Yield, ?Await] #parencover
+        CoverParenthesizedExpressionAndArrowParameterList[?Yield, ?Await] #parenCover
 
       ConciseBody[In] :
         [lookahead != `{`] ExpressionBody[?In, ~Await]
@@ -25223,9 +25219,9 @@
       </emu-grammar>
       <emu-alg>
         1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
-        1. Let _declResult_ be Completion(FunctionDeclarationInstantiation(_functionObject_, _argumentsList_)).
-        1. If _declResult_ is an abrupt completion, then
-          1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, « _declResult_.[[Value]] »).
+        1. Let _completion_ be Completion(FunctionDeclarationInstantiation(_functionObject_, _argumentsList_)).
+        1. If _completion_ is an abrupt completion, then
+          1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, « _completion_.[[Value]] »).
         1. Else,
           1. Perform AsyncFunctionStart(_promiseCapability_, |FunctionBody|).
         1. Return Completion Record { [[Type]]: ~return~, [[Value]]: _promiseCapability_.[[Promise]], [[Target]]: ~empty~ }.
@@ -25258,7 +25254,7 @@
     <emu-grammar type="definition">
       AsyncArrowFunction[In, Yield, Await] :
         `async` [no LineTerminator here] AsyncArrowBindingIdentifier[?Yield] [no LineTerminator here] `=>` AsyncConciseBody[?In]
-        CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await] [no LineTerminator here] `=>` AsyncConciseBody[?In] #callcover
+        CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await] [no LineTerminator here] `=>` AsyncConciseBody[?In] #callCover
 
       AsyncConciseBody[In] :
         [lookahead != `{`] ExpressionBody[?In, +Await]
@@ -25330,9 +25326,9 @@
       </emu-grammar>
       <emu-alg>
         1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
-        1. Let _declResult_ be Completion(FunctionDeclarationInstantiation(_functionObject_, _argumentsList_)).
-        1. If _declResult_ is an abrupt completion, then
-          1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, « _declResult_.[[Value]] »).
+        1. Let _completion_ be Completion(FunctionDeclarationInstantiation(_functionObject_, _argumentsList_)).
+        1. If _completion_ is an abrupt completion, then
+          1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, « _completion_.[[Value]] »).
         1. Else,
           1. Perform AsyncFunctionStart(_promiseCapability_, |ExpressionBody|).
         1. Return Completion Record { [[Type]]: ~return~, [[Value]]: _promiseCapability_.[[Promise]], [[Target]]: ~empty~ }.
@@ -26991,7 +26987,7 @@
           <ul>
             <li>Evaluation must be only performed once, as it can cause side effects; it is thus important to remember whether evaluation has already been performed, even if unsuccessfully. (In the error case, it makes sense to also remember the exception because otherwise subsequent Evaluate() calls would have to synthesize a new one.)</li>
             <li>Linking, on the other hand, is side-effect-free, and thus even if it fails, it can be retried at a later time with no issues.</li>
-            <li>Loading closely interacts with the host, and it may be desiderable for some of them to allow users to retry failed loads (for example, if the failure is caused by temporarily bad network conditions).</li>
+            <li>Loading closely interacts with the host, and it may be desirable for some of them to allow users to retry failed loads (for example, if the failure is caused by temporarily bad network conditions).</li>
           </ul>
 
           <p>Now, consider a module graph with a cycle:</p>
@@ -27008,7 +27004,7 @@
 
           <p>Now consider a case where _A_ has a linking error; for example, it tries to import a binding from _C_ that does not exist. In that case, the above steps still occur, including the early return from the second call to InnerModuleLinking on _A_. However, once we unwind back to the original InnerModuleLinking on _A_, it fails during InitializeEnvironment, namely right after _C_.ResolveExport(). The thrown *SyntaxError* exception propagates up to _A_.Link, which resets all modules that are currently on its _stack_ (these are always exactly the modules that are still ~linking~). Hence both _A_ and _B_ become ~unlinked~. Note that _C_ is left as ~linked~.</p>
 
-          <p>Alternatively, consider a case where _A_ has an evaluation error; for example, its source code throws an exception. In that case, the evaluation-time analog of the above steps still occurs, including the early return from the second call to InnerModuleEvaluation on _A_. However, once we unwind back to the original InnerModuleEvaluation on _A_, it fails by assumption. The exception thrown propagates up to _A_.Evaluate(), which records the error in all modules that are currently on its _stack_ (i.e., the modules that are still ~evaluating~) as well as via [[AsyncParentModules]], which form a chain for modules which contain or depend on top-level `await` through the whole dependency graph through the AsyncModuleExecutionRejected algorithm. Hence both _A_ and _B_ become ~evaluated~ and the exception is recorded in both _A_ and _B_'s [[EvaluationError]] fields, while _C_ is left as ~evaluated~ with no [[EvaluationError]].</p>
+          <p>Alternatively, consider a case where _A_ has an evaluation error; for example, its source code throws an exception. In that case, the evaluation-time analogue of the above steps still occurs, including the early return from the second call to InnerModuleEvaluation on _A_. However, once we unwind back to the original InnerModuleEvaluation on _A_, it fails by assumption. The exception thrown propagates up to _A_.Evaluate(), which records the error in all modules that are currently on its _stack_ (i.e., the modules that are still ~evaluating~) as well as via [[AsyncParentModules]], which form a chain for modules which contain or depend on top-level `await` through the whole dependency graph through the AsyncModuleExecutionRejected algorithm. Hence both _A_ and _B_ become ~evaluated~ and the exception is recorded in both _A_ and _B_'s [[EvaluationError]] fields, while _C_ is left as ~evaluated~ with no [[EvaluationError]].</p>
 
           <p>Lastly, consider a module graph with a cycle, where all modules complete asynchronously:</p>
           <emu-figure id="figure-module-graph-cycle-async" caption="An asynchronous cyclic module graph">
@@ -28957,7 +28953,7 @@
   <p>Each built-in function defined in this specification is created by calling the CreateBuiltinFunction abstract operation (<emu-xref href="#sec-createbuiltinfunction"></emu-xref>). The values of the _length_ and _name_ parameters are the initial values of the *"length"* and *"name"* properties as discussed below. The values of the _prefix_ parameter are similarly discussed below.</p>
   <p>Every built-in function object, including constructors, has a *"length"* property whose value is a non-negative integral Number. Unless otherwise specified, this value is the number of required parameters shown in the subclause heading for the function description. Optional parameters and rest parameters are not included in the parameter count.</p>
   <emu-note>
-    <p>For example, the function object that is the initial value of the *"map"* property of the Array prototype object is described under the subclause heading «Array.prototype.map (callbackFn [ , thisArg])» which shows the two named arguments callbackFn and thisArg, the latter being optional; therefore the value of the *"length"* property of that function object is *1*<sub>𝔽</sub>.</p>
+    <p>For example, the function object that is the initial value of the *"map"* property of the Array prototype object is described under the subclause heading «Array.prototype.map (callback [ , thisArg])» which shows the two named arguments callback and thisArg, the latter being optional; therefore the value of the *"length"* property of that function object is *1*<sub>𝔽</sub>.</p>
   </emu-note>
   <p>Unless otherwise specified, the *"length"* property of a built-in function object has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
   <p>Every built-in function object, including constructors, has a *"name"* property whose value is a String. Unless otherwise specified, this value is the name that is given to the function in this specification. Functions that are identified as anonymous functions use the empty String as the value of the *"name"* property. For functions that are specified as properties of objects, the name value is the property name string used to access the function. Functions that are specified as get or set accessor functions of built-in properties have *"get"* or *"set"* (respectively) passed to the _prefix_ parameter when calling CreateBuiltinFunction.</p>
@@ -29930,15 +29926,15 @@
       </emu-clause>
 
       <emu-clause id="sec-object.groupby">
-        <h1>Object.groupBy ( _items_, _callbackfn_ )</h1>
+        <h1>Object.groupBy ( _items_, _callback_ )</h1>
         <emu-note>
-          <p>_callbackfn_ should be a function that accepts two arguments. `groupBy` calls _callbackfn_ once for each element in _items_, in ascending order, and constructs a new object. Each value returned by _callbackfn_ is coerced to a property key. For each such property key, the result object has a property whose key is that property key and whose value is an array containing all the elements for which the _callbackfn_ return value coerced to that key.</p>
-          <p>_callbackfn_ is called with two arguments: the value of the element and the index of the element.</p>
+          <p>_callback_ should be a function that accepts two arguments. `groupBy` calls _callback_ once for each element in _items_, in ascending order, and constructs a new object. Each value returned by _callback_ is coerced to a property key. For each such property key, the result object has a property whose key is that property key and whose value is an array containing all the elements for which the _callback_ return value coerced to that key.</p>
+          <p>_callback_ is called with two arguments: the value of the element and the index of the element.</p>
           <p>The return value of `groupBy` is an object that does not inherit from %Object.prototype%.</p>
         </emu-note>
         <p>This function performs the following steps when called:</p>
         <emu-alg>
-          1. Let _groups_ be ? GroupBy(_items_, _callbackfn_, ~property~).
+          1. Let _groups_ be ? GroupBy(_items_, _callback_, ~property~).
           1. Let _obj_ be OrdinaryObjectCreate(*null*).
           1. For each Record { [[Key]], [[Elements]] } _g_ of _groups_, do
             1. Let _elements_ be CreateArrayFromList(_g_.[[Elements]]).
@@ -30374,7 +30370,7 @@
               1. Perform ! DefinePropertyOrThrow(_F_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
             1. Else if _kind_ is ~normal~, then
               1. Perform MakeConstructor(_F_).
-            1. NOTE: Functions whose _kind_ is ~async~ are not constructible and do not have a [[Construct]] internal method or a *"prototype"* property.
+            1. NOTE: Functions whose _kind_ is ~async~ are not constructable and do not have a [[Construct]] internal method or a *"prototype"* property.
             1. Return _F_.
           </emu-alg>
           <emu-note>
@@ -31144,14 +31140,14 @@
           <p>Each _NativeError_ function performs the following steps when called:</p>
           <emu-alg>
             1. If NewTarget is *undefined*, let _newTarget_ be the active function object; else let _newTarget_ be NewTarget.
-            1. [id="step-nativerror-ordinarycreatefromconstructor"] Let _O_ be ? OrdinaryCreateFromConstructor(_newTarget_, <code>"%<var>NativeError</var>.prototype%"</code>, « [[ErrorData]] »).
+            1. [id="step-nativeerror-ordinarycreatefromconstructor"] Let _O_ be ? OrdinaryCreateFromConstructor(_newTarget_, <code>"%<var>NativeError</var>.prototype%"</code>, « [[ErrorData]] »).
             1. If _message_ is not *undefined*, then
               1. Let _msg_ be ? ToString(_message_).
               1. Perform CreateNonEnumerableDataPropertyOrThrow(_O_, *"message"*, _msg_).
             1. Perform ? InstallErrorCause(_O_, _options_).
             1. Return _O_.
           </emu-alg>
-          <p>The actual value of the string passed in step <emu-xref href="#step-nativerror-ordinarycreatefromconstructor"></emu-xref> is either *"%EvalError.prototype%"*, *"%RangeError.prototype%"*, *"%ReferenceError.prototype%"*, *"%SyntaxError.prototype%"*, *"%TypeError.prototype%"*, or *"%URIError.prototype%"* corresponding to which _NativeError_ constructor is being defined.</p>
+          <p>The actual value of the string passed in step <emu-xref href="#step-nativeerror-ordinarycreatefromconstructor"></emu-xref> is either *"%EvalError.prototype%"*, *"%RangeError.prototype%"*, *"%ReferenceError.prototype%"*, *"%SyntaxError.prototype%"*, *"%TypeError.prototype%"*, or *"%URIError.prototype%"* corresponding to which _NativeError_ constructor is being defined.</p>
         </emu-clause>
       </emu-clause>
 
@@ -35499,7 +35495,7 @@ THH:mm:ss.sss
               1. Let _nextIndex_ be _position_ + _cp_.[[CodeUnitCount]].
               1. Let _resultString_ be the substring of _s_ from _position_ to _nextIndex_.
               1. Set _position_ to _nextIndex_.
-              1. Perform ? GeneratorYield(CreateIterResultObject(_resultString_, *false*)).
+              1. Perform ? GeneratorYield(CreateIteratorResultObject(_resultString_, *false*)).
             1. Return *undefined*.
           1. Return CreateIteratorFromClosure(_closure_, *"%StringIteratorPrototype%"*, %StringIteratorPrototype%).
         </emu-alg>
@@ -38084,15 +38080,15 @@ THH:mm:ss.sss
               1. Let _replacerArgs_ be the list-concatenation of « _matched_ », _captures_, and « 𝔽(_position_), _S_ ».
               1. If _namedCaptures_ is not *undefined*, then
                 1. Append _namedCaptures_ to _replacerArgs_.
-              1. Let _replValue_ be ? Call(_replaceValue_, *undefined*, _replacerArgs_).
-              1. Let _replacement_ be ? ToString(_replValue_).
+              1. Let _replacementValue_ be ? Call(_replaceValue_, *undefined*, _replacerArgs_).
+              1. Let _replacementString_ be ? ToString(_replacementValue_).
             1. Else,
               1. If _namedCaptures_ is not *undefined*, then
                 1. Set _namedCaptures_ to ? ToObject(_namedCaptures_).
-              1. Let _replacement_ be ? GetSubstitution(_matched_, _S_, _position_, _captures_, _namedCaptures_, _replaceValue_).
+              1. Let _replacementString_ be ? GetSubstitution(_matched_, _S_, _position_, _captures_, _namedCaptures_, _replaceValue_).
             1. If _position_ ≥ _nextSourcePosition_, then
               1. NOTE: _position_ should not normally move backwards. If it does, it is an indication of an ill-behaving RegExp subclass or use of an access triggered side-effect to change the global flag or other characteristics of _rx_. In such cases, the corresponding substitution is ignored.
-              1. Set _accumulatedResult_ to the string-concatenation of _accumulatedResult_, the substring of _S_ from _nextSourcePosition_ to _position_, and _replacement_.
+              1. Set _accumulatedResult_ to the string-concatenation of _accumulatedResult_, the substring of _S_ from _nextSourcePosition_ to _position_, and _replacementString_.
               1. Set _nextSourcePosition_ to _position_ + _matchLength_.
           1. If _nextSourcePosition_ ≥ _lengthS_, return _accumulatedResult_.
           1. Return the string-concatenation of _accumulatedResult_ and the substring of _S_ from _nextSourcePosition_.
@@ -38580,14 +38576,14 @@ THH:mm:ss.sss
               1. Let _match_ be ? RegExpExec(_R_, _S_).
               1. If _match_ is *null*, return *undefined*.
               1. If _global_ is *false*, then
-                1. Perform ? GeneratorYield(CreateIterResultObject(_match_, *false*)).
+                1. Perform ? GeneratorYield(CreateIteratorResultObject(_match_, *false*)).
                 1. Return *undefined*.
               1. Let _matchStr_ be ? ToString(? Get(_match_, *"0"*)).
               1. If _matchStr_ is the empty String, then
                 1. Let _thisIndex_ be ℝ(? ToLength(? Get(_R_, *"lastIndex"*))).
                 1. Let _nextIndex_ be AdvanceStringIndex(_S_, _thisIndex_, _fullUnicode_).
                 1. Perform ? Set(_R_, *"lastIndex"*, 𝔽(_nextIndex_), *true*).
-              1. Perform ? GeneratorYield(CreateIterResultObject(_match_, *false*)).
+              1. Perform ? GeneratorYield(CreateIteratorResultObject(_match_, *false*)).
           1. Return CreateIteratorFromClosure(_closure_, *"%RegExpStringIteratorPrototype%"*, %RegExpStringIteratorPrototype%).
         </emu-alg>
       </emu-clause>
@@ -38683,14 +38679,14 @@ THH:mm:ss.sss
       </ul>
 
       <emu-clause id="sec-array.from">
-        <h1>Array.from ( _items_ [ , _mapfn_ [ , _thisArg_ ] ] )</h1>
+        <h1>Array.from ( _items_ [ , _mapper_ [ , _thisArg_ ] ] )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _C_ be the *this* value.
-          1. If _mapfn_ is *undefined*, then
+          1. If _mapper_ is *undefined*, then
             1. Let _mapping_ be *false*.
           1. Else,
-            1. If IsCallable(_mapfn_) is *false*, throw a *TypeError* exception.
+            1. If IsCallable(_mapper_) is *false*, throw a *TypeError* exception.
             1. Let _mapping_ be *true*.
           1. Let _usingIterator_ be ? GetMethod(_items_, %Symbol.iterator%).
           1. If _usingIterator_ is not *undefined*, then
@@ -38710,7 +38706,7 @@ THH:mm:ss.sss
                 1. Perform ? Set(_A_, *"length"*, 𝔽(_k_), *true*).
                 1. Return _A_.
               1. If _mapping_ is *true*, then
-                1. Let _mappedValue_ be Completion(Call(_mapfn_, _thisArg_, « _next_, 𝔽(_k_) »)).
+                1. Let _mappedValue_ be Completion(Call(_mapper_, _thisArg_, « _next_, 𝔽(_k_) »)).
                 1. IfAbruptCloseIterator(_mappedValue_, _iteratorRecord_).
               1. Else,
                 1. Let _mappedValue_ be _next_.
@@ -38729,7 +38725,7 @@ THH:mm:ss.sss
             1. Let _Pk_ be ! ToString(𝔽(_k_)).
             1. Let _kValue_ be ? Get(_arrayLike_, _Pk_).
             1. If _mapping_ is *true*, then
-              1. Let _mappedValue_ be ? Call(_mapfn_, _thisArg_, « _kValue_, 𝔽(_k_) »).
+              1. Let _mappedValue_ be ? Call(_mapper_, _thisArg_, « _kValue_, 𝔽(_k_) »).
             1. Else,
               1. Let _mappedValue_ be _kValue_.
             1. Perform ? CreateDataPropertyOrThrow(_A_, _Pk_, _mappedValue_).
@@ -38944,26 +38940,26 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-array.prototype.every">
-        <h1>Array.prototype.every ( _callbackfn_ [ , _thisArg_ ] )</h1>
+        <h1>Array.prototype.every ( _callback_ [ , _thisArg_ ] )</h1>
         <emu-note>
-          <p>_callbackfn_ should be a function that accepts three arguments and returns a value that is coercible to a Boolean value. `every` calls _callbackfn_ once for each element present in the array, in ascending order, until it finds one where _callbackfn_ returns *false*. If such an element is found, `every` immediately returns *false*. Otherwise, `every` returns *true*. _callbackfn_ is called only for elements of the array which actually exist; it is not called for missing elements of the array.</p>
-          <p>If a _thisArg_ parameter is provided, it will be used as the *this* value for each invocation of _callbackfn_. If it is not provided, *undefined* is used instead.</p>
-          <p>_callbackfn_ is called with three arguments: the value of the element, the index of the element, and the object being traversed.</p>
-          <p>`every` does not directly mutate the object on which it is called but the object may be mutated by the calls to _callbackfn_.</p>
-          <p>The range of elements processed by `every` is set before the first call to _callbackfn_. Elements which are appended to the array after the call to `every` begins will not be visited by _callbackfn_. If existing elements of the array are changed, their value as passed to _callbackfn_ will be the value at the time `every` visits them; elements that are deleted after the call to `every` begins and before being visited are not visited. `every` acts like the "for all" quantifier in mathematics. In particular, for an empty array, it returns *true*.</p>
+          <p>_callback_ should be a function that accepts three arguments and returns a value that is coercible to a Boolean value. `every` calls _callback_ once for each element present in the array, in ascending order, until it finds one where _callback_ returns *false*. If such an element is found, `every` immediately returns *false*. Otherwise, `every` returns *true*. _callback_ is called only for elements of the array which actually exist; it is not called for missing elements of the array.</p>
+          <p>If a _thisArg_ parameter is provided, it will be used as the *this* value for each invocation of _callback_. If it is not provided, *undefined* is used instead.</p>
+          <p>_callback_ is called with three arguments: the value of the element, the index of the element, and the object being traversed.</p>
+          <p>`every` does not directly mutate the object on which it is called but the object may be mutated by the calls to _callback_.</p>
+          <p>The range of elements processed by `every` is set before the first call to _callback_. Elements which are appended to the array after the call to `every` begins will not be visited by _callback_. If existing elements of the array are changed, their value as passed to _callback_ will be the value at the time `every` visits them; elements that are deleted after the call to `every` begins and before being visited are not visited. `every` acts like the "for all" quantifier in mathematics. In particular, for an empty array, it returns *true*.</p>
         </emu-note>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
-          1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
+          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_,
             1. Let _Pk_ be ! ToString(𝔽(_k_)).
             1. Let _kPresent_ be ? HasProperty(_O_, _Pk_).
             1. If _kPresent_ is *true*, then
               1. Let _kValue_ be ? Get(_O_, _Pk_).
-              1. Let _testResult_ be ToBoolean(? Call(_callbackfn_, _thisArg_, « _kValue_, 𝔽(_k_), _O_ »)).
+              1. Let _testResult_ be ToBoolean(? Call(_callback_, _thisArg_, « _kValue_, 𝔽(_k_), _O_ »)).
               1. If _testResult_ is *false*, return *false*.
             1. Set _k_ to _k_ + 1.
           1. Return *true*.
@@ -39006,19 +39002,19 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-array.prototype.filter">
-        <h1>Array.prototype.filter ( _callbackfn_ [ , _thisArg_ ] )</h1>
+        <h1>Array.prototype.filter ( _callback_ [ , _thisArg_ ] )</h1>
         <emu-note>
-          <p>_callbackfn_ should be a function that accepts three arguments and returns a value that is coercible to a Boolean value. `filter` calls _callbackfn_ once for each element in the array, in ascending order, and constructs a new array of all the values for which _callbackfn_ returns *true*. _callbackfn_ is called only for elements of the array which actually exist; it is not called for missing elements of the array.</p>
-          <p>If a _thisArg_ parameter is provided, it will be used as the *this* value for each invocation of _callbackfn_. If it is not provided, *undefined* is used instead.</p>
-          <p>_callbackfn_ is called with three arguments: the value of the element, the index of the element, and the object being traversed.</p>
-          <p>`filter` does not directly mutate the object on which it is called but the object may be mutated by the calls to _callbackfn_.</p>
-          <p>The range of elements processed by `filter` is set before the first call to _callbackfn_. Elements which are appended to the array after the call to `filter` begins will not be visited by _callbackfn_. If existing elements of the array are changed their value as passed to _callbackfn_ will be the value at the time `filter` visits them; elements that are deleted after the call to `filter` begins and before being visited are not visited.</p>
+          <p>_callback_ should be a function that accepts three arguments and returns a value that is coercible to a Boolean value. `filter` calls _callback_ once for each element in the array, in ascending order, and constructs a new array of all the values for which _callback_ returns *true*. _callback_ is called only for elements of the array which actually exist; it is not called for missing elements of the array.</p>
+          <p>If a _thisArg_ parameter is provided, it will be used as the *this* value for each invocation of _callback_. If it is not provided, *undefined* is used instead.</p>
+          <p>_callback_ is called with three arguments: the value of the element, the index of the element, and the object being traversed.</p>
+          <p>`filter` does not directly mutate the object on which it is called but the object may be mutated by the calls to _callback_.</p>
+          <p>The range of elements processed by `filter` is set before the first call to _callback_. Elements which are appended to the array after the call to `filter` begins will not be visited by _callback_. If existing elements of the array are changed their value as passed to _callback_ will be the value at the time `filter` visits them; elements that are deleted after the call to `filter` begins and before being visited are not visited.</p>
         </emu-note>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
-          1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
+          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
           1. Let _A_ be ? ArraySpeciesCreate(_O_, 0).
           1. Let _k_ be 0.
           1. Let _to_ be 0.
@@ -39027,7 +39023,7 @@ THH:mm:ss.sss
             1. Let _kPresent_ be ? HasProperty(_O_, _Pk_).
             1. If _kPresent_ is *true*, then
               1. Let _kValue_ be ? Get(_O_, _Pk_).
-              1. Let _selected_ be ToBoolean(? Call(_callbackfn_, _thisArg_, « _kValue_, 𝔽(_k_), _O_ »)).
+              1. Let _selected_ be ToBoolean(? Call(_callback_, _thisArg_, « _kValue_, 𝔽(_k_), _O_ »)).
               1. If _selected_ is *true*, then
                 1. Perform ? CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_to_)), _kValue_).
                 1. Set _to_ to _to_ + 1.
@@ -39219,26 +39215,26 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-array.prototype.foreach">
-        <h1>Array.prototype.forEach ( _callbackfn_ [ , _thisArg_ ] )</h1>
+        <h1>Array.prototype.forEach ( _callback_ [ , _thisArg_ ] )</h1>
         <emu-note>
-          <p>_callbackfn_ should be a function that accepts three arguments. `forEach` calls _callbackfn_ once for each element present in the array, in ascending order. _callbackfn_ is called only for elements of the array which actually exist; it is not called for missing elements of the array.</p>
-          <p>If a _thisArg_ parameter is provided, it will be used as the *this* value for each invocation of _callbackfn_. If it is not provided, *undefined* is used instead.</p>
-          <p>_callbackfn_ is called with three arguments: the value of the element, the index of the element, and the object being traversed.</p>
-          <p>`forEach` does not directly mutate the object on which it is called but the object may be mutated by the calls to _callbackfn_.</p>
-          <p>The range of elements processed by `forEach` is set before the first call to _callbackfn_. Elements which are appended to the array after the call to `forEach` begins will not be visited by _callbackfn_. If existing elements of the array are changed, their value as passed to _callbackfn_ will be the value at the time `forEach` visits them; elements that are deleted after the call to `forEach` begins and before being visited are not visited.</p>
+          <p>_callback_ should be a function that accepts three arguments. `forEach` calls _callback_ once for each element present in the array, in ascending order. _callback_ is called only for elements of the array which actually exist; it is not called for missing elements of the array.</p>
+          <p>If a _thisArg_ parameter is provided, it will be used as the *this* value for each invocation of _callback_. If it is not provided, *undefined* is used instead.</p>
+          <p>_callback_ is called with three arguments: the value of the element, the index of the element, and the object being traversed.</p>
+          <p>`forEach` does not directly mutate the object on which it is called but the object may be mutated by the calls to _callback_.</p>
+          <p>The range of elements processed by `forEach` is set before the first call to _callback_. Elements which are appended to the array after the call to `forEach` begins will not be visited by _callback_. If existing elements of the array are changed, their value as passed to _callback_ will be the value at the time `forEach` visits them; elements that are deleted after the call to `forEach` begins and before being visited are not visited.</p>
         </emu-note>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
-          1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
+          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_,
             1. Let _Pk_ be ! ToString(𝔽(_k_)).
             1. Let _kPresent_ be ? HasProperty(_O_, _Pk_).
             1. If _kPresent_ is *true*, then
               1. Let _kValue_ be ? Get(_O_, _Pk_).
-              1. Perform ? Call(_callbackfn_, _thisArg_, « _kValue_, 𝔽(_k_), _O_ »).
+              1. Perform ? Call(_callback_, _thisArg_, « _kValue_, 𝔽(_k_), _O_ »).
             1. Set _k_ to _k_ + 1.
           1. Return *undefined*.
         </emu-alg>
@@ -39381,19 +39377,19 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-array.prototype.map">
-        <h1>Array.prototype.map ( _callbackfn_ [ , _thisArg_ ] )</h1>
+        <h1>Array.prototype.map ( _callback_ [ , _thisArg_ ] )</h1>
         <emu-note>
-          <p>_callbackfn_ should be a function that accepts three arguments. `map` calls _callbackfn_ once for each element in the array, in ascending order, and constructs a new Array from the results. _callbackfn_ is called only for elements of the array which actually exist; it is not called for missing elements of the array.</p>
-          <p>If a _thisArg_ parameter is provided, it will be used as the *this* value for each invocation of _callbackfn_. If it is not provided, *undefined* is used instead.</p>
-          <p>_callbackfn_ is called with three arguments: the value of the element, the index of the element, and the object being traversed.</p>
-          <p>`map` does not directly mutate the object on which it is called but the object may be mutated by the calls to _callbackfn_.</p>
-          <p>The range of elements processed by `map` is set before the first call to _callbackfn_. Elements which are appended to the array after the call to `map` begins will not be visited by _callbackfn_. If existing elements of the array are changed, their value as passed to _callbackfn_ will be the value at the time `map` visits them; elements that are deleted after the call to `map` begins and before being visited are not visited.</p>
+          <p>_callback_ should be a function that accepts three arguments. `map` calls _callback_ once for each element in the array, in ascending order, and constructs a new Array from the results. _callback_ is called only for elements of the array which actually exist; it is not called for missing elements of the array.</p>
+          <p>If a _thisArg_ parameter is provided, it will be used as the *this* value for each invocation of _callback_. If it is not provided, *undefined* is used instead.</p>
+          <p>_callback_ is called with three arguments: the value of the element, the index of the element, and the object being traversed.</p>
+          <p>`map` does not directly mutate the object on which it is called but the object may be mutated by the calls to _callback_.</p>
+          <p>The range of elements processed by `map` is set before the first call to _callback_. Elements which are appended to the array after the call to `map` begins will not be visited by _callback_. If existing elements of the array are changed, their value as passed to _callback_ will be the value at the time `map` visits them; elements that are deleted after the call to `map` begins and before being visited are not visited.</p>
         </emu-note>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
-          1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
+          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
           1. Let _A_ be ? ArraySpeciesCreate(_O_, _len_).
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_,
@@ -39401,7 +39397,7 @@ THH:mm:ss.sss
             1. Let _kPresent_ be ? HasProperty(_O_, _Pk_).
             1. If _kPresent_ is *true*, then
               1. Let _kValue_ be ? Get(_O_, _Pk_).
-              1. Let _mappedValue_ be ? Call(_callbackfn_, _thisArg_, « _kValue_, 𝔽(_k_), _O_ »).
+              1. Let _mappedValue_ be ? Call(_callback_, _thisArg_, « _kValue_, 𝔽(_k_), _O_ »).
               1. Perform ? CreateDataPropertyOrThrow(_A_, _Pk_, _mappedValue_).
             1. Set _k_ to _k_ + 1.
           1. Return _A_.
@@ -39461,18 +39457,18 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-array.prototype.reduce">
-        <h1>Array.prototype.reduce ( _callbackfn_ [ , _initialValue_ ] )</h1>
+        <h1>Array.prototype.reduce ( _callback_ [ , _initialValue_ ] )</h1>
         <emu-note>
-          <p>_callbackfn_ should be a function that takes four arguments. `reduce` calls the callback, as a function, once for each element after the first element present in the array, in ascending order.</p>
-          <p>_callbackfn_ is called with four arguments: the _previousValue_ (value from the previous call to _callbackfn_), the _currentValue_ (value of the current element), the _currentIndex_, and the object being traversed. The first time that callback is called, the _previousValue_ and _currentValue_ can be one of two values. If an _initialValue_ was supplied in the call to `reduce`, then _previousValue_ will be _initialValue_ and _currentValue_ will be the first value in the array. If no _initialValue_ was supplied, then _previousValue_ will be the first value in the array and _currentValue_ will be the second. It is a *TypeError* if the array contains no elements and _initialValue_ is not provided.</p>
-          <p>`reduce` does not directly mutate the object on which it is called but the object may be mutated by the calls to _callbackfn_.</p>
-          <p>The range of elements processed by `reduce` is set before the first call to _callbackfn_. Elements that are appended to the array after the call to `reduce` begins will not be visited by _callbackfn_. If existing elements of the array are changed, their value as passed to _callbackfn_ will be the value at the time `reduce` visits them; elements that are deleted after the call to `reduce` begins and before being visited are not visited.</p>
+          <p>_callback_ should be a function that takes four arguments. `reduce` calls the callback, as a function, once for each element after the first element present in the array, in ascending order.</p>
+          <p>_callback_ is called with four arguments: the _previousValue_ (value from the previous call to _callback_), the _currentValue_ (value of the current element), the _currentIndex_, and the object being traversed. The first time that callback is called, the _previousValue_ and _currentValue_ can be one of two values. If an _initialValue_ was supplied in the call to `reduce`, then _previousValue_ will be _initialValue_ and _currentValue_ will be the first value in the array. If no _initialValue_ was supplied, then _previousValue_ will be the first value in the array and _currentValue_ will be the second. It is a *TypeError* if the array contains no elements and _initialValue_ is not provided.</p>
+          <p>`reduce` does not directly mutate the object on which it is called but the object may be mutated by the calls to _callback_.</p>
+          <p>The range of elements processed by `reduce` is set before the first call to _callback_. Elements that are appended to the array after the call to `reduce` begins will not be visited by _callback_. If existing elements of the array are changed, their value as passed to _callback_ will be the value at the time `reduce` visits them; elements that are deleted after the call to `reduce` begins and before being visited are not visited.</p>
         </emu-note>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
-          1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
+          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
           1. If _len_ = 0 and _initialValue_ is not present, throw a *TypeError* exception.
           1. Let _k_ be 0.
           1. Let _accumulator_ be *undefined*.
@@ -39492,7 +39488,7 @@ THH:mm:ss.sss
             1. Let _kPresent_ be ? HasProperty(_O_, _Pk_).
             1. If _kPresent_ is *true*, then
               1. Let _kValue_ be ? Get(_O_, _Pk_).
-              1. Set _accumulator_ to ? Call(_callbackfn_, *undefined*, « _accumulator_, _kValue_, 𝔽(_k_), _O_ »).
+              1. Set _accumulator_ to ? Call(_callback_, *undefined*, « _accumulator_, _kValue_, 𝔽(_k_), _O_ »).
             1. Set _k_ to _k_ + 1.
           1. Return _accumulator_.
         </emu-alg>
@@ -39502,18 +39498,18 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-array.prototype.reduceright">
-        <h1>Array.prototype.reduceRight ( _callbackfn_ [ , _initialValue_ ] )</h1>
+        <h1>Array.prototype.reduceRight ( _callback_ [ , _initialValue_ ] )</h1>
         <emu-note>
-          <p>_callbackfn_ should be a function that takes four arguments. `reduceRight` calls the callback, as a function, once for each element after the first element present in the array, in descending order.</p>
-          <p>_callbackfn_ is called with four arguments: the _previousValue_ (value from the previous call to _callbackfn_), the _currentValue_ (value of the current element), the _currentIndex_, and the object being traversed. The first time the function is called, the _previousValue_ and _currentValue_ can be one of two values. If an _initialValue_ was supplied in the call to `reduceRight`, then _previousValue_ will be _initialValue_ and _currentValue_ will be the last value in the array. If no _initialValue_ was supplied, then _previousValue_ will be the last value in the array and _currentValue_ will be the second-to-last value. It is a *TypeError* if the array contains no elements and _initialValue_ is not provided.</p>
-          <p>`reduceRight` does not directly mutate the object on which it is called but the object may be mutated by the calls to _callbackfn_.</p>
-          <p>The range of elements processed by `reduceRight` is set before the first call to _callbackfn_. Elements that are appended to the array after the call to `reduceRight` begins will not be visited by _callbackfn_. If existing elements of the array are changed by _callbackfn_, their value as passed to _callbackfn_ will be the value at the time `reduceRight` visits them; elements that are deleted after the call to `reduceRight` begins and before being visited are not visited.</p>
+          <p>_callback_ should be a function that takes four arguments. `reduceRight` calls the callback, as a function, once for each element after the first element present in the array, in descending order.</p>
+          <p>_callback_ is called with four arguments: the _previousValue_ (value from the previous call to _callback_), the _currentValue_ (value of the current element), the _currentIndex_, and the object being traversed. The first time the function is called, the _previousValue_ and _currentValue_ can be one of two values. If an _initialValue_ was supplied in the call to `reduceRight`, then _previousValue_ will be _initialValue_ and _currentValue_ will be the last value in the array. If no _initialValue_ was supplied, then _previousValue_ will be the last value in the array and _currentValue_ will be the second-to-last value. It is a *TypeError* if the array contains no elements and _initialValue_ is not provided.</p>
+          <p>`reduceRight` does not directly mutate the object on which it is called but the object may be mutated by the calls to _callback_.</p>
+          <p>The range of elements processed by `reduceRight` is set before the first call to _callback_. Elements that are appended to the array after the call to `reduceRight` begins will not be visited by _callback_. If existing elements of the array are changed by _callback_, their value as passed to _callback_ will be the value at the time `reduceRight` visits them; elements that are deleted after the call to `reduceRight` begins and before being visited are not visited.</p>
         </emu-note>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
-          1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
+          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
           1. If _len_ = 0 and _initialValue_ is not present, throw a *TypeError* exception.
           1. Let _k_ be _len_ - 1.
           1. Let _accumulator_ be *undefined*.
@@ -39533,7 +39529,7 @@ THH:mm:ss.sss
             1. Let _kPresent_ be ? HasProperty(_O_, _Pk_).
             1. If _kPresent_ is *true*, then
               1. Let _kValue_ be ? Get(_O_, _Pk_).
-              1. Set _accumulator_ to ? Call(_callbackfn_, *undefined*, « _accumulator_, _kValue_, 𝔽(_k_), _O_ »).
+              1. Set _accumulator_ to ? Call(_callback_, *undefined*, « _accumulator_, _kValue_, 𝔽(_k_), _O_ »).
             1. Set _k_ to _k_ - 1.
           1. Return _accumulator_.
         </emu-alg>
@@ -39653,26 +39649,26 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-array.prototype.some">
-        <h1>Array.prototype.some ( _callbackfn_ [ , _thisArg_ ] )</h1>
+        <h1>Array.prototype.some ( _callback_ [ , _thisArg_ ] )</h1>
         <emu-note>
-          <p>_callbackfn_ should be a function that accepts three arguments and returns a value that is coercible to a Boolean value. `some` calls _callbackfn_ once for each element present in the array, in ascending order, until it finds one where _callbackfn_ returns *true*. If such an element is found, `some` immediately returns *true*. Otherwise, `some` returns *false*. _callbackfn_ is called only for elements of the array which actually exist; it is not called for missing elements of the array.</p>
-          <p>If a _thisArg_ parameter is provided, it will be used as the *this* value for each invocation of _callbackfn_. If it is not provided, *undefined* is used instead.</p>
-          <p>_callbackfn_ is called with three arguments: the value of the element, the index of the element, and the object being traversed.</p>
-          <p>`some` does not directly mutate the object on which it is called but the object may be mutated by the calls to _callbackfn_.</p>
-          <p>The range of elements processed by `some` is set before the first call to _callbackfn_. Elements that are appended to the array after the call to `some` begins will not be visited by _callbackfn_. If existing elements of the array are changed, their value as passed to _callbackfn_ will be the value at the time that `some` visits them; elements that are deleted after the call to `some` begins and before being visited are not visited. `some` acts like the "exists" quantifier in mathematics. In particular, for an empty array, it returns *false*.</p>
+          <p>_callback_ should be a function that accepts three arguments and returns a value that is coercible to a Boolean value. `some` calls _callback_ once for each element present in the array, in ascending order, until it finds one where _callback_ returns *true*. If such an element is found, `some` immediately returns *true*. Otherwise, `some` returns *false*. _callback_ is called only for elements of the array which actually exist; it is not called for missing elements of the array.</p>
+          <p>If a _thisArg_ parameter is provided, it will be used as the *this* value for each invocation of _callback_. If it is not provided, *undefined* is used instead.</p>
+          <p>_callback_ is called with three arguments: the value of the element, the index of the element, and the object being traversed.</p>
+          <p>`some` does not directly mutate the object on which it is called but the object may be mutated by the calls to _callback_.</p>
+          <p>The range of elements processed by `some` is set before the first call to _callback_. Elements that are appended to the array after the call to `some` begins will not be visited by _callback_. If existing elements of the array are changed, their value as passed to _callback_ will be the value at the time that `some` visits them; elements that are deleted after the call to `some` begins and before being visited are not visited. `some` acts like the "exists" quantifier in mathematics. In particular, for an empty array, it returns *false*.</p>
         </emu-note>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
-          1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
+          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_,
             1. Let _Pk_ be ! ToString(𝔽(_k_)).
             1. Let _kPresent_ be ? HasProperty(_O_, _Pk_).
             1. If _kPresent_ is *true*, then
               1. Let _kValue_ be ? Get(_O_, _Pk_).
-              1. Let _testResult_ be ToBoolean(? Call(_callbackfn_, _thisArg_, « _kValue_, 𝔽(_k_), _O_ »)).
+              1. Let _testResult_ be ToBoolean(? Call(_callback_, _thisArg_, « _kValue_, 𝔽(_k_), _O_ »)).
               1. If _testResult_ is *true*, return *true*.
             1. Set _k_ to _k_ + 1.
           1. Return *false*.
@@ -39683,15 +39679,15 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-array.prototype.sort" oldids="sec-sortcompare">
-        <h1>Array.prototype.sort ( _comparefn_ )</h1>
-        <p>This method sorts the elements of this array. The sort must be stable (that is, elements that compare equal must remain in their original order). If _comparefn_ is not *undefined*, it should be a function that accepts two arguments _x_ and _y_ and returns a negative Number if _x_ &lt; _y_, a positive Number if _x_ > _y_, or a zero otherwise.</p>
+        <h1>Array.prototype.sort ( _comparator_ )</h1>
+        <p>This method sorts the elements of this array. The sort must be stable (that is, elements that compare equal must remain in their original order). If _comparator_ is not *undefined*, it should be a function that accepts two arguments _x_ and _y_ and returns a negative Number if _x_ &lt; _y_, a positive Number if _x_ > _y_, or a zero otherwise.</p>
         <p>It performs the following steps when called:</p>
         <emu-alg>
-          1. [id="step-array-sort-comparefn"] If _comparefn_ is not *undefined* and IsCallable(_comparefn_) is *false*, throw a *TypeError* exception.
+          1. [id="step-array-sort-comparefn"] If _comparator_ is not *undefined* and IsCallable(_comparator_) is *false*, throw a *TypeError* exception.
           1. Let _obj_ be ? ToObject(*this* value).
           1. [id="step-array-sort-len"] Let _len_ be ? LengthOfArrayLike(_obj_).
-          1. Let _SortCompare_ be a new Abstract Closure with parameters (_x_, _y_) that captures _comparefn_ and performs the following steps when called:
-            1. Return ? CompareArrayElements(_x_, _y_, _comparefn_).
+          1. Let _SortCompare_ be a new Abstract Closure with parameters (_x_, _y_) that captures _comparator_ and performs the following steps when called:
+            1. Return ? CompareArrayElements(_x_, _y_, _comparator_).
           1. [id="step-array-sortindexedproperties"] Let _sortedList_ be ? SortIndexedProperties(_obj_, _len_, _SortCompare_, ~skip-holes~).
           1. Let _itemCount_ be the number of elements in _sortedList_.
           1. Let _j_ be 0.
@@ -39742,7 +39738,7 @@ THH:mm:ss.sss
             1. [id="step-array-sort"] Sort _items_ using an implementation-defined sequence of <emu-meta effects="user-code">calls to _SortCompare_</emu-meta>. If any such call returns an abrupt completion, stop before performing any further calls to _SortCompare_ and return that Completion Record.
             1. Return _items_.
           </emu-alg>
-          <p>The <dfn id="sort-order">sort order</dfn> is the ordering of _items_ after completion of step <emu-xref href="#step-array-sort"></emu-xref> of the algorithm above. The sort order is implementation-defined if _SortCompare_ is not a consistent comparator for the elements of _items_. When SortIndexedProperties is invoked by <emu-xref href="#sec-array.prototype.sort">Array.prototype.sort</emu-xref>, the sort order is also implementation-defined if _comparefn_ is *undefined*, and all applications of ToString, to any specific value passed as an argument to _SortCompare_, do not produce the same result.</p>
+          <p>The <dfn id="sort-order">sort order</dfn> is the ordering of _items_ after completion of step <emu-xref href="#step-array-sort"></emu-xref> of the algorithm above. The sort order is implementation-defined if _SortCompare_ is not a consistent comparator for the elements of _items_. When SortIndexedProperties is invoked by <emu-xref href="#sec-array.prototype.sort">Array.prototype.sort</emu-xref>, the sort order is also implementation-defined if _comparator_ is *undefined*, and all applications of ToString, to any specific value passed as an argument to _SortCompare_, do not produce the same result.</p>
           <p>Unless the sort order is specified to be implementation-defined, it must satisfy all of the following conditions:</p>
           <ul>
             <li>
@@ -39787,7 +39783,7 @@ THH:mm:ss.sss
             CompareArrayElements (
               _x_: an ECMAScript language value,
               _y_: an ECMAScript language value,
-              _comparefn_: a function object or *undefined*,
+              _comparator_: a function object or *undefined*,
             ): either a normal completion containing a Number or an abrupt completion
           </h1>
           <dl class="header">
@@ -39796,8 +39792,8 @@ THH:mm:ss.sss
             1. If _x_ and _y_ are both *undefined*, return *+0*<sub>𝔽</sub>.
             1. If _x_ is *undefined*, return *1*<sub>𝔽</sub>.
             1. If _y_ is *undefined*, return *-1*<sub>𝔽</sub>.
-            1. If _comparefn_ is not *undefined*, then
-              1. Let _v_ be ? ToNumber(? Call(_comparefn_, *undefined*, « _x_, _y_ »)).
+            1. If _comparator_ is not *undefined*, then
+              1. Let _v_ be ? ToNumber(? Call(_comparator_, *undefined*, « _x_, _y_ »)).
               1. If _v_ is *NaN*, return *+0*<sub>𝔽</sub>.
               1. Return _v_.
             1. [id="step-sortcompare-tostring-x"] Let _xString_ be ? ToString(_x_).
@@ -39933,15 +39929,15 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-array.prototype.tosorted">
-        <h1>Array.prototype.toSorted ( _comparefn_ )</h1>
+        <h1>Array.prototype.toSorted ( _comparator_ )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. If _comparefn_ is not *undefined* and IsCallable(_comparefn_) is *false*, throw a *TypeError* exception.
+          1. If _comparator_ is not *undefined* and IsCallable(_comparator_) is *false*, throw a *TypeError* exception.
           1. Let _O_ be ? ToObject(*this* value).
           1. Let _len_ be ? LengthOfArrayLike(_O_).
           1. Let _A_ be ? ArrayCreate(_len_).
-          1. Let _SortCompare_ be a new Abstract Closure with parameters (_x_, _y_) that captures _comparefn_ and performs the following steps when called:
-            1. Return ? CompareArrayElements(_x_, _y_, _comparefn_).
+          1. Let _SortCompare_ be a new Abstract Closure with parameters (_x_, _y_) that captures _comparator_ and performs the following steps when called:
+            1. Return ? CompareArrayElements(_x_, _y_, _comparator_).
           1. Let _sortedList_ be ? SortIndexedProperties(_O_, _len_, _SortCompare_, ~read-through-holes~).
           1. Let _j_ be 0.
           1. Repeat, while _j_ &lt; _len_,
@@ -40162,7 +40158,7 @@ THH:mm:ss.sss
                 1. Else,
                   1. Assert: _kind_ is ~key+value~.
                   1. Let _result_ be CreateArrayFromList(« _indexNumber_, _elementValue_ »).
-              1. Perform ? GeneratorYield(CreateIterResultObject(_result_, *false*)).
+              1. Perform ? GeneratorYield(CreateIteratorResultObject(_result_, *false*)).
               1. Set _index_ to _index_ + 1.
           1. Return CreateIteratorFromClosure(_closure_, *"%ArrayIteratorPrototype%"*, %ArrayIteratorPrototype%).
         </emu-alg>
@@ -40449,15 +40445,15 @@ THH:mm:ss.sss
       </ul>
 
       <emu-clause id="sec-%typedarray%.from">
-        <h1>%TypedArray%.from ( _source_ [ , _mapfn_ [ , _thisArg_ ] ] )</h1>
+        <h1>%TypedArray%.from ( _source_ [ , _mapper_ [ , _thisArg_ ] ] )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _C_ be the *this* value.
           1. If IsConstructor(_C_) is *false*, throw a *TypeError* exception.
-          1. If _mapfn_ is *undefined*, then
+          1. If _mapper_ is *undefined*, then
             1. Let _mapping_ be *false*.
           1. Else,
-            1. If IsCallable(_mapfn_) is *false*, throw a *TypeError* exception.
+            1. If IsCallable(_mapper_) is *false*, throw a *TypeError* exception.
             1. Let _mapping_ be *true*.
           1. Let _usingIterator_ be ? GetMethod(_source_, %Symbol.iterator%).
           1. If _usingIterator_ is not *undefined*, then
@@ -40470,7 +40466,7 @@ THH:mm:ss.sss
               1. Let _kValue_ be the first element of _values_.
               1. Remove the first element from _values_.
               1. If _mapping_ is *true*, then
-                1. Let _mappedValue_ be ? Call(_mapfn_, _thisArg_, « _kValue_, 𝔽(_k_) »).
+                1. Let _mappedValue_ be ? Call(_mapper_, _thisArg_, « _kValue_, 𝔽(_k_) »).
               1. Else,
                 1. Let _mappedValue_ be _kValue_.
               1. Perform ? Set(_targetObj_, _Pk_, _mappedValue_, *true*).
@@ -40486,7 +40482,7 @@ THH:mm:ss.sss
             1. Let _Pk_ be ! ToString(𝔽(_k_)).
             1. Let _kValue_ be ? Get(_arrayLike_, _Pk_).
             1. If _mapping_ is *true*, then
-              1. Let _mappedValue_ be ? Call(_mapfn_, _thisArg_, « _kValue_, 𝔽(_k_) »).
+              1. Let _mappedValue_ be ? Call(_mapper_, _thisArg_, « _kValue_, 𝔽(_k_) »).
             1. Else,
               1. Let _mappedValue_ be _kValue_.
             1. Perform ? Set(_targetObj_, _Pk_, _mappedValue_, *true*).
@@ -40665,19 +40661,19 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.every">
-        <h1>%TypedArray%.prototype.every ( _callbackfn_ [ , _thisArg_ ] )</h1>
+        <h1>%TypedArray%.prototype.every ( _callback_ [ , _thisArg_ ] )</h1>
         <p>The interpretation and use of the arguments of this method are the same as for `Array.prototype.every` as defined in <emu-xref href="#sec-array.prototype.every"></emu-xref>.</p>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Let _taRecord_ be ? ValidateTypedArray(_O_, ~seq-cst~).
           1. Let _len_ be TypedArrayLength(_taRecord_).
-          1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
+          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_,
             1. Let _Pk_ be ! ToString(𝔽(_k_)).
             1. Let _kValue_ be ! Get(_O_, _Pk_).
-            1. Let _testResult_ be ToBoolean(? Call(_callbackfn_, _thisArg_, « _kValue_, 𝔽(_k_), _O_ »)).
+            1. Let _testResult_ be ToBoolean(? Call(_callback_, _thisArg_, « _kValue_, 𝔽(_k_), _O_ »)).
             1. If _testResult_ is *false*, return *false*.
             1. Set _k_ to _k_ + 1.
           1. Return *true*.
@@ -40717,21 +40713,21 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.filter">
-        <h1>%TypedArray%.prototype.filter ( _callbackfn_ [ , _thisArg_ ] )</h1>
+        <h1>%TypedArray%.prototype.filter ( _callback_ [ , _thisArg_ ] )</h1>
         <p>The interpretation and use of the arguments of this method are the same as for `Array.prototype.filter` as defined in <emu-xref href="#sec-array.prototype.filter"></emu-xref>.</p>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Let _taRecord_ be ? ValidateTypedArray(_O_, ~seq-cst~).
           1. Let _len_ be TypedArrayLength(_taRecord_).
-          1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
+          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
           1. Let _kept_ be a new empty List.
           1. Let _captured_ be 0.
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_,
             1. Let _Pk_ be ! ToString(𝔽(_k_)).
             1. Let _kValue_ be ! Get(_O_, _Pk_).
-            1. Let _selected_ be ToBoolean(? Call(_callbackfn_, _thisArg_, « _kValue_, 𝔽(_k_), _O_ »)).
+            1. Let _selected_ be ToBoolean(? Call(_callback_, _thisArg_, « _kValue_, 𝔽(_k_), _O_ »)).
             1. If _selected_ is *true*, then
               1. Append _kValue_ to _kept_.
               1. Set _captured_ to _captured_ + 1.
@@ -40803,19 +40799,19 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.foreach">
-        <h1>%TypedArray%.prototype.forEach ( _callbackfn_ [ , _thisArg_ ] )</h1>
+        <h1>%TypedArray%.prototype.forEach ( _callback_ [ , _thisArg_ ] )</h1>
         <p>The interpretation and use of the arguments of this method are the same as for `Array.prototype.forEach` as defined in <emu-xref href="#sec-array.prototype.foreach"></emu-xref>.</p>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Let _taRecord_ be ? ValidateTypedArray(_O_, ~seq-cst~).
           1. Let _len_ be TypedArrayLength(_taRecord_).
-          1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
+          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_,
             1. Let _Pk_ be ! ToString(𝔽(_k_)).
             1. Let _kValue_ be ! Get(_O_, _Pk_).
-            1. Perform ? Call(_callbackfn_, _thisArg_, « _kValue_, 𝔽(_k_), _O_ »).
+            1. Perform ? Call(_callback_, _thisArg_, « _kValue_, 𝔽(_k_), _O_ »).
             1. Set _k_ to _k_ + 1.
           1. Return *undefined*.
         </emu-alg>
@@ -40954,20 +40950,20 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.map">
-        <h1>%TypedArray%.prototype.map ( _callbackfn_ [ , _thisArg_ ] )</h1>
+        <h1>%TypedArray%.prototype.map ( _callback_ [ , _thisArg_ ] )</h1>
         <p>The interpretation and use of the arguments of this method are the same as for `Array.prototype.map` as defined in <emu-xref href="#sec-array.prototype.map"></emu-xref>.</p>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Let _taRecord_ be ? ValidateTypedArray(_O_, ~seq-cst~).
           1. Let _len_ be TypedArrayLength(_taRecord_).
-          1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
+          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
           1. Let _A_ be ? TypedArraySpeciesCreate(_O_, « 𝔽(_len_) »).
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_,
             1. Let _Pk_ be ! ToString(𝔽(_k_)).
             1. Let _kValue_ be ! Get(_O_, _Pk_).
-            1. Let _mappedValue_ be ? Call(_callbackfn_, _thisArg_, « _kValue_, 𝔽(_k_), _O_ »).
+            1. Let _mappedValue_ be ? Call(_callback_, _thisArg_, « _kValue_, 𝔽(_k_), _O_ »).
             1. Perform ? Set(_A_, _Pk_, _mappedValue_, *true*).
             1. Set _k_ to _k_ + 1.
           1. Return _A_.
@@ -40976,14 +40972,14 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.reduce">
-        <h1>%TypedArray%.prototype.reduce ( _callbackfn_ [ , _initialValue_ ] )</h1>
+        <h1>%TypedArray%.prototype.reduce ( _callback_ [ , _initialValue_ ] )</h1>
         <p>The interpretation and use of the arguments of this method are the same as for `Array.prototype.reduce` as defined in <emu-xref href="#sec-array.prototype.reduce"></emu-xref>.</p>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Let _taRecord_ be ? ValidateTypedArray(_O_, ~seq-cst~).
           1. Let _len_ be TypedArrayLength(_taRecord_).
-          1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
+          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
           1. If _len_ = 0 and _initialValue_ is not present, throw a *TypeError* exception.
           1. Let _k_ be 0.
           1. Let _accumulator_ be *undefined*.
@@ -40996,7 +40992,7 @@ THH:mm:ss.sss
           1. Repeat, while _k_ &lt; _len_,
             1. Let _Pk_ be ! ToString(𝔽(_k_)).
             1. Let _kValue_ be ! Get(_O_, _Pk_).
-            1. Set _accumulator_ to ? Call(_callbackfn_, *undefined*, « _accumulator_, _kValue_, 𝔽(_k_), _O_ »).
+            1. Set _accumulator_ to ? Call(_callback_, *undefined*, « _accumulator_, _kValue_, 𝔽(_k_), _O_ »).
             1. Set _k_ to _k_ + 1.
           1. Return _accumulator_.
         </emu-alg>
@@ -41004,14 +41000,14 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.reduceright">
-        <h1>%TypedArray%.prototype.reduceRight ( _callbackfn_ [ , _initialValue_ ] )</h1>
+        <h1>%TypedArray%.prototype.reduceRight ( _callback_ [ , _initialValue_ ] )</h1>
         <p>The interpretation and use of the arguments of this method are the same as for `Array.prototype.reduceRight` as defined in <emu-xref href="#sec-array.prototype.reduceright"></emu-xref>.</p>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Let _taRecord_ be ? ValidateTypedArray(_O_, ~seq-cst~).
           1. Let _len_ be TypedArrayLength(_taRecord_).
-          1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
+          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
           1. If _len_ = 0 and _initialValue_ is not present, throw a *TypeError* exception.
           1. Let _k_ be _len_ - 1.
           1. Let _accumulator_ be *undefined*.
@@ -41024,7 +41020,7 @@ THH:mm:ss.sss
           1. Repeat, while _k_ ≥ 0,
             1. Let _Pk_ be ! ToString(𝔽(_k_)).
             1. Let _kValue_ be ! Get(_O_, _Pk_).
-            1. Set _accumulator_ to ? Call(_callbackfn_, *undefined*, « _accumulator_, _kValue_, 𝔽(_k_), _O_ »).
+            1. Set _accumulator_ to ? Call(_callback_, *undefined*, « _accumulator_, _kValue_, 𝔽(_k_), _O_ »).
             1. Set _k_ to _k_ - 1.
           1. Return _accumulator_.
         </emu-alg>
@@ -41215,19 +41211,19 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.some">
-        <h1>%TypedArray%.prototype.some ( _callbackfn_ [ , _thisArg_ ] )</h1>
+        <h1>%TypedArray%.prototype.some ( _callback_ [ , _thisArg_ ] )</h1>
         <p>The interpretation and use of the arguments of this method are the same as for `Array.prototype.some` as defined in <emu-xref href="#sec-array.prototype.some"></emu-xref>.</p>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Let _taRecord_ be ? ValidateTypedArray(_O_, ~seq-cst~).
           1. Let _len_ be TypedArrayLength(_taRecord_).
-          1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
+          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_,
             1. Let _Pk_ be ! ToString(𝔽(_k_)).
             1. Let _kValue_ be ! Get(_O_, _Pk_).
-            1. Let _testResult_ be ToBoolean(? Call(_callbackfn_, _thisArg_, « _kValue_, 𝔽(_k_), _O_ »)).
+            1. Let _testResult_ be ToBoolean(? Call(_callback_, _thisArg_, « _kValue_, 𝔽(_k_), _O_ »)).
             1. If _testResult_ is *true*, return *true*.
             1. Set _k_ to _k_ + 1.
           1. Return *false*.
@@ -41236,18 +41232,18 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.sort" oldids="sec-typedarraysortcompare">
-        <h1>%TypedArray%.prototype.sort ( _comparefn_ )</h1>
+        <h1>%TypedArray%.prototype.sort ( _comparator_ )</h1>
         <p>This is a distinct method that, except as described below, implements the same requirements as those of `Array.prototype.sort` as defined in <emu-xref href="#sec-array.prototype.sort"></emu-xref>. The implementation of this method may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose integer-indexed properties are not sparse.</p>
         <p>This method is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
         <p>It performs the following steps when called:</p>
         <emu-alg>
-          1. If _comparefn_ is not *undefined* and IsCallable(_comparefn_) is *false*, throw a *TypeError* exception.
+          1. If _comparator_ is not *undefined* and IsCallable(_comparator_) is *false*, throw a *TypeError* exception.
           1. Let _obj_ be the *this* value.
           1. Let _taRecord_ be ? ValidateTypedArray(_obj_, ~seq-cst~).
           1. Let _len_ be TypedArrayLength(_taRecord_).
           1. NOTE: The following closure performs a numeric comparison rather than the string comparison used in <emu-xref href="#sec-array.prototype.sort"></emu-xref>.
-          1. Let _SortCompare_ be a new Abstract Closure with parameters (_x_, _y_) that captures _comparefn_ and performs the following steps when called:
-            1. Return ? CompareTypedArrayElements(_x_, _y_, _comparefn_).
+          1. Let _SortCompare_ be a new Abstract Closure with parameters (_x_, _y_) that captures _comparator_ and performs the following steps when called:
+            1. Return ? CompareTypedArrayElements(_x_, _y_, _comparator_).
           1. Let _sortedList_ be ? SortIndexedProperties(_obj_, _len_, _SortCompare_, ~read-through-holes~).
           1. Let _j_ be 0.
           1. Repeat, while _j_ &lt; _len_,
@@ -41256,7 +41252,7 @@ THH:mm:ss.sss
           1. Return _obj_.
         </emu-alg>
         <emu-note>
-          <p>Because *NaN* always compares greater than any other value (see CompareTypedArrayElements), *NaN* property values always sort to the end of the result when _comparefn_ is not provided.</p>
+          <p>Because *NaN* always compares greater than any other value (see CompareTypedArrayElements), *NaN* property values always sort to the end of the result when _comparator_ is not provided.</p>
         </emu-note>
       </emu-clause>
 
@@ -41324,17 +41320,17 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-%typedarray%.prototype.tosorted">
-        <h1>%TypedArray%.prototype.toSorted ( _comparefn_ )</h1>
+        <h1>%TypedArray%.prototype.toSorted ( _comparator_ )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. If _comparefn_ is not *undefined* and IsCallable(_comparefn_) is *false*, throw a *TypeError* exception.
+          1. If _comparator_ is not *undefined* and IsCallable(_comparator_) is *false*, throw a *TypeError* exception.
           1. Let _O_ be the *this* value.
           1. Let _taRecord_ be ? ValidateTypedArray(_O_, ~seq-cst~).
           1. Let _len_ be TypedArrayLength(_taRecord_).
           1. Let _A_ be ? TypedArrayCreateSameType(_O_, « 𝔽(_len_) »).
           1. NOTE: The following closure performs a numeric comparison rather than the string comparison used in <emu-xref href="#sec-array.prototype.tosorted"></emu-xref>.
-          1. Let _SortCompare_ be a new Abstract Closure with parameters (_x_, _y_) that captures _comparefn_ and performs the following steps when called:
-            1. Return ? CompareTypedArrayElements(_x_, _y_, _comparefn_).
+          1. Let _SortCompare_ be a new Abstract Closure with parameters (_x_, _y_) that captures _comparator_ and performs the following steps when called:
+            1. Return ? CompareTypedArrayElements(_x_, _y_, _comparator_).
           1. Let _sortedList_ be ? SortIndexedProperties(_O_, _len_, _SortCompare_, ~read-through-holes~).
           1. Let _j_ be 0.
           1. Repeat, while _j_ &lt; _len_,
@@ -41520,15 +41516,15 @@ THH:mm:ss.sss
           CompareTypedArrayElements (
             _x_: a Number or a BigInt,
             _y_: a Number or a BigInt,
-            _comparefn_: a function object or *undefined*,
+            _comparator_: a function object or *undefined*,
           ): either a normal completion containing a Number or an abrupt completion
         </h1>
         <dl class="header">
         </dl>
         <emu-alg>
           1. Assert: _x_ is a Number and _y_ is a Number, or _x_ is a BigInt and _y_ is a BigInt.
-          1. If _comparefn_ is not *undefined*, then
-            1. Let _v_ be ? ToNumber(? Call(_comparefn_, *undefined*, « _x_, _y_ »)).
+          1. If _comparator_ is not *undefined*, then
+            1. Let _v_ be ? ToNumber(? Call(_comparator_, *undefined*, « _x_, _y_ »)).
             1. If _v_ is *NaN*, return *+0*<sub>𝔽</sub>.
             1. Return _v_.
           1. If _x_ and _y_ are both *NaN*, return *+0*<sub>𝔽</sub>.
@@ -41905,15 +41901,15 @@ THH:mm:ss.sss
       </ul>
 
       <emu-clause id="sec-map.groupby">
-        <h1>Map.groupBy ( _items_, _callbackfn_ )</h1>
+        <h1>Map.groupBy ( _items_, _callback_ )</h1>
         <emu-note>
-          <p>_callbackfn_ should be a function that accepts two arguments. `groupBy` calls _callbackfn_ once for each element in _items_, in ascending order, and constructs a new Map. Each value returned by _callbackfn_ is used as a key in the Map. For each such key, the result Map has an entry whose key is that key and whose value is an array containing all the elements for which _callbackfn_ returned that key.</p>
-          <p>_callbackfn_ is called with two arguments: the value of the element and the index of the element.</p>
+          <p>_callback_ should be a function that accepts two arguments. `groupBy` calls _callback_ once for each element in _items_, in ascending order, and constructs a new Map. Each value returned by _callback_ is used as a key in the Map. For each such key, the result Map has an entry whose key is that key and whose value is an array containing all the elements for which _callback_ returned that key.</p>
+          <p>_callback_ is called with two arguments: the value of the element and the index of the element.</p>
           <p>The return value of `groupBy` is a Map.</p>
         </emu-note>
         <p>This function performs the following steps when called:</p>
         <emu-alg>
-          1. Let _groups_ be ? GroupBy(_items_, _callbackfn_, ~collection~).
+          1. Let _groups_ be ? GroupBy(_items_, _callback_, ~collection~).
           1. Let _map_ be ! Construct(%Map%).
           1. For each Record { [[Key]], [[Elements]] } _g_ of _groups_, do
             1. Let _elements_ be CreateArrayFromList(_g_.[[Elements]]).
@@ -42002,12 +41998,12 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-map.prototype.foreach">
-        <h1>Map.prototype.forEach ( _callbackfn_ [ , _thisArg_ ] )</h1>
+        <h1>Map.prototype.forEach ( _callback_ [ , _thisArg_ ] )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _M_ be the *this* value.
           1. Perform ? RequireInternalSlot(_M_, [[MapData]]).
-          1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
+          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
           1. Let _entries_ be _M_.[[MapData]].
           1. Let _numEntries_ be the number of elements in _entries_.
           1. Let _index_ be 0.
@@ -42015,16 +42011,16 @@ THH:mm:ss.sss
             1. Let _e_ be _entries_[_index_].
             1. Set _index_ to _index_ + 1.
             1. If _e_.[[Key]] is not ~empty~, then
-              1. Perform ? Call(_callbackfn_, _thisArg_, « _e_.[[Value]], _e_.[[Key]], _M_ »).
-              1. NOTE: The number of elements in _entries_ may have increased during execution of _callbackfn_.
+              1. Perform ? Call(_callback_, _thisArg_, « _e_.[[Value]], _e_.[[Key]], _M_ »).
+              1. NOTE: The number of elements in _entries_ may have increased during execution of _callback_.
               1. Set _numEntries_ to the number of elements in _entries_.
           1. Return *undefined*.
         </emu-alg>
         <emu-note>
-          <p>_callbackfn_ should be a function that accepts three arguments. `forEach` calls _callbackfn_ once for each key/value pair present in the Map, in key insertion order. _callbackfn_ is called only for keys of the Map which actually exist; it is not called for keys that have been deleted from the Map.</p>
-          <p>If a _thisArg_ parameter is provided, it will be used as the *this* value for each invocation of _callbackfn_. If it is not provided, *undefined* is used instead.</p>
-          <p>_callbackfn_ is called with three arguments: the value of the item, the key of the item, and the Map being traversed.</p>
-          <p>`forEach` does not directly mutate the object on which it is called but the object may be mutated by the calls to _callbackfn_. Each entry of a map's [[MapData]] is only visited once. New keys added after the call to `forEach` begins are visited. A key will be revisited if it is deleted after it has been visited and then re-added before the `forEach` call completes. Keys that are deleted after the call to `forEach` begins and before being visited are not visited unless the key is added again before the `forEach` call completes.</p>
+          <p>_callback_ should be a function that accepts three arguments. `forEach` calls _callback_ once for each key/value pair present in the Map, in key insertion order. _callback_ is called only for keys of the Map which actually exist; it is not called for keys that have been deleted from the Map.</p>
+          <p>If a _thisArg_ parameter is provided, it will be used as the *this* value for each invocation of _callback_. If it is not provided, *undefined* is used instead.</p>
+          <p>_callback_ is called with three arguments: the value of the item, the key of the item, and the Map being traversed.</p>
+          <p>`forEach` does not directly mutate the object on which it is called but the object may be mutated by the calls to _callback_. Each entry of a map's [[MapData]] is only visited once. New keys added after the call to `forEach` begins are visited. A key will be revisited if it is deleted after it has been visited and then re-added before the `forEach` call completes. Keys that are deleted after the call to `forEach` begins and before being visited are not visited unless the key is added again before the `forEach` call completes.</p>
         </emu-note>
       </emu-clause>
 
@@ -42151,7 +42147,7 @@ THH:mm:ss.sss
                 1. Else,
                   1. Assert: _kind_ is ~key+value~.
                   1. Let _result_ be CreateArrayFromList(« _e_.[[Key]], _e_.[[Value]] »).
-                1. Perform ? GeneratorYield(CreateIterResultObject(_result_, *false*)).
+                1. Perform ? GeneratorYield(CreateIteratorResultObject(_result_, *false*)).
                 1. NOTE: The number of elements in _entries_ may have increased while execution of this abstract operation was paused by Yield.
                 1. Set _numEntries_ to the number of elements in _entries_.
             1. Return *undefined*.
@@ -42504,12 +42500,12 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-set.prototype.foreach">
-        <h1>Set.prototype.forEach ( _callbackfn_ [ , _thisArg_ ] )</h1>
+        <h1>Set.prototype.forEach ( _callback_ [ , _thisArg_ ] )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
           1. Perform ? RequireInternalSlot(_S_, [[SetData]]).
-          1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
+          1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
           1. Let _entries_ be _S_.[[SetData]].
           1. Let _numEntries_ be the number of elements in _entries_.
           1. Let _index_ be 0.
@@ -42517,17 +42513,17 @@ THH:mm:ss.sss
             1. Let _e_ be _entries_[_index_].
             1. Set _index_ to _index_ + 1.
             1. If _e_ is not ~empty~, then
-              1. Perform ? Call(_callbackfn_, _thisArg_, « _e_, _e_, _S_ »).
-              1. NOTE: The number of elements in _entries_ may have increased during execution of _callbackfn_.
+              1. Perform ? Call(_callback_, _thisArg_, « _e_, _e_, _S_ »).
+              1. NOTE: The number of elements in _entries_ may have increased during execution of _callback_.
               1. Set _numEntries_ to the number of elements in _entries_.
           1. Return *undefined*.
         </emu-alg>
         <emu-note>
-          <p>_callbackfn_ should be a function that accepts three arguments. `forEach` calls _callbackfn_ once for each value present in the Set object, in value insertion order. _callbackfn_ is called only for values of the Set which actually exist; it is not called for keys that have been deleted from the set.</p>
-          <p>If a _thisArg_ parameter is provided, it will be used as the *this* value for each invocation of _callbackfn_. If it is not provided, *undefined* is used instead.</p>
-          <p>_callbackfn_ is called with three arguments: the first two arguments are a value contained in the Set. The same value is passed for both arguments. The Set object being traversed is passed as the third argument.</p>
-          <p>The _callbackfn_ is called with three arguments to be consistent with the call back functions used by `forEach` methods for Map and Array. For Sets, each item value is considered to be both the key and the value.</p>
-          <p>`forEach` does not directly mutate the object on which it is called but the object may be mutated by the calls to _callbackfn_.</p>
+          <p>_callback_ should be a function that accepts three arguments. `forEach` calls _callback_ once for each value present in the Set object, in value insertion order. _callback_ is called only for values of the Set which actually exist; it is not called for keys that have been deleted from the set.</p>
+          <p>If a _thisArg_ parameter is provided, it will be used as the *this* value for each invocation of _callback_. If it is not provided, *undefined* is used instead.</p>
+          <p>_callback_ is called with three arguments: the first two arguments are a value contained in the Set. The same value is passed for both arguments. The Set object being traversed is passed as the third argument.</p>
+          <p>The _callback_ is called with three arguments to be consistent with the call back functions used by `forEach` methods for Map and Array. For Sets, each item value is considered to be both the key and the value.</p>
+          <p>`forEach` does not directly mutate the object on which it is called but the object may be mutated by the calls to _callback_.</p>
           <p>Each value is normally visited only once. However, a value will be revisited if it is deleted after it has been visited and then re-added before the `forEach` call completes. Values that are deleted after the call to `forEach` begins and before being visited are not visited unless the value is added again before the `forEach` call completes. New values added after the call to `forEach` begins are visited.</p>
         </emu-note>
       </emu-clause>
@@ -42778,10 +42774,10 @@ THH:mm:ss.sss
               1. If _e_ is not ~empty~, then
                 1. If _kind_ is ~key+value~, then
                   1. Let _result_ be CreateArrayFromList(« _e_, _e_ »).
-                  1. Perform ? GeneratorYield(CreateIterResultObject(_result_, *false*)).
+                  1. Perform ? GeneratorYield(CreateIteratorResultObject(_result_, *false*)).
                 1. Else,
                   1. Assert: _kind_ is ~value~.
-                  1. Perform ? GeneratorYield(CreateIterResultObject(_e_, *false*)).
+                  1. Perform ? GeneratorYield(CreateIteratorResultObject(_e_, *false*)).
                 1. NOTE: The number of elements in _entries_ may have increased while execution of this abstract operation was paused by Yield.
                 1. Set _numEntries_ to the number of elements in _entries_.
             1. Return *undefined*.
@@ -43117,7 +43113,7 @@ THH:mm:ss.sss
     <emu-clause id="sec-arraybuffer-notation">
       <h1>Notation</h1>
       <p>The descriptions below in this section, <emu-xref href="#sec-atomics-object"></emu-xref>, and <emu-xref href="#sec-memory-model"></emu-xref> use the read-modify-write modification function internal data structure.</p>
-      <p>A <dfn variants="read-modify-write modification functions">read-modify-write modification function</dfn> is a mathematical function that is notationally represented as an abstract closure that takes two Lists of byte values as arguments and returns a List of byte values. These abstract closures satisfy all of the following properties:</p>
+      <p>A <dfn variants="read-modify-write modification functions">read-modify-write modification function</dfn> is a mathematical function that is represented as an abstract closure that takes two Lists of byte values as arguments and returns a List of byte values. These abstract closures satisfy all of the following properties:</p>
       <ul>
         <li>They perform all their algorithm steps atomically.</li>
         <li>Their individual algorithm steps are not observable.</li>
@@ -43502,8 +43498,8 @@ THH:mm:ss.sss
             1. Let _rawBytes_ be a List whose elements are the 8 bytes that are the IEEE 754-2019 binary64 format encoding of _value_. The bytes are arranged in little endian order. If _value_ is *NaN*, _rawBytes_ may be set to any implementation chosen IEEE 754-2019 binary64 format Not-a-Number encoding. An implementation must always choose the same encoding for each implementation distinguishable *NaN* value.
           1. Else,
             1. Let _n_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for Element Type _type_.
-            1. Let _convOp_ be the abstract operation named in the Conversion Operation column in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for Element Type _type_.
-            1. Let _intValue_ be ℝ(_convOp_(_value_)).
+            1. Let _conversionOperation_ be the abstract operation named in the Conversion Operation column in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for Element Type _type_.
+            1. Let _intValue_ be ℝ(_conversionOperation_(_value_)).
             1. If _intValue_ ≥ 0, then
               1. Let _rawBytes_ be a List whose elements are the _n_-byte binary encoding of _intValue_. The bytes are ordered in little endian order.
             1. Else,
@@ -43814,7 +43810,7 @@ THH:mm:ss.sss
         <p>The following are guidelines for ECMAScript implementers implementing resizable ArrayBuffer.</p>
         <p>Resizable ArrayBuffer can be implemented as copying upon resize, as in-place growth via reserving virtual memory up front, or as a combination of both for different values of the constructor's *"maxByteLength"* option.</p>
         <p>If a host is multi-tenanted (i.e. it runs many ECMAScript applications simultaneously), such as a web browser, and its implementations choose to implement in-place growth by reserving virtual memory, we recommend that both 32-bit and 64-bit implementations throw for values of *"maxByteLength"* ≥ 1GiB to 1.5GiB. This is to reduce the likelihood a single application can exhaust the virtual memory address space and to reduce interoperability risk.</p>
-        <p>If a host does not have virtual memory, such as those running on embedded devices without an MMU, or if a host only implements resizing by copying, it may accept any <emu-not-ref>Number value for</emu-not-ref> the *"maxByteLength"* option. However, we recommend a *RangeError* be thrown if a memory block of the requested size can never be allocated. For example, if the requested size is greater than the maximium amount of usable memory on the device.</p>
+        <p>If a host does not have virtual memory, such as those running on embedded devices without an MMU, or if a host only implements resizing by copying, it may accept any <emu-not-ref>Number value for</emu-not-ref> the *"maxByteLength"* option. However, we recommend a *RangeError* be thrown if a memory block of the requested size can never be allocated. For example, if the requested size is greater than the maximum amount of usable memory on the device.</p>
       </emu-note>
     </emu-clause>
   </emu-clause>
@@ -45837,7 +45833,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. If _state_.[[Stack]] contains _value_, throw a *TypeError* exception because the structure is cyclical.
           1. Append _value_ to _state_.[[Stack]].
-          1. Let _stepback_ be _state_.[[Indent]].
+          1. Let _stepBack_ be _state_.[[Indent]].
           1. Set _state_.[[Indent]] to the string-concatenation of _state_.[[Indent]] and _state_.[[Gap]].
           1. If _state_.[[PropertyList]] is not *undefined*, then
             1. Let _K_ be _state_.[[PropertyList]].
@@ -45862,9 +45858,9 @@ THH:mm:ss.sss
             1. Else,
               1. Let _separator_ be the string-concatenation of the code unit 0x002C (COMMA), the code unit 0x000A (LINE FEED), and _state_.[[Indent]].
               1. Let _properties_ be the String value formed by concatenating all the element Strings of _partial_ with each adjacent pair of Strings separated with _separator_. The _separator_ String is not inserted either before the first String or after the last String.
-              1. Let _final_ be the string-concatenation of *"{"*, the code unit 0x000A (LINE FEED), _state_.[[Indent]], _properties_, the code unit 0x000A (LINE FEED), _stepback_, and *"}"*.
+              1. Let _final_ be the string-concatenation of *"{"*, the code unit 0x000A (LINE FEED), _state_.[[Indent]], _properties_, the code unit 0x000A (LINE FEED), _stepBack_, and *"}"*.
           1. Remove the last element of _state_.[[Stack]].
-          1. Set _state_.[[Indent]] to _stepback_.
+          1. Set _state_.[[Indent]] to _stepBack_.
           1. Return _final_.
         </emu-alg>
       </emu-clause>
@@ -45883,7 +45879,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. If _state_.[[Stack]] contains _value_, throw a *TypeError* exception because the structure is cyclical.
           1. Append _value_ to _state_.[[Stack]].
-          1. Let _stepback_ be _state_.[[Indent]].
+          1. Let _stepBack_ be _state_.[[Indent]].
           1. Set _state_.[[Indent]] to the string-concatenation of _state_.[[Indent]] and _state_.[[Gap]].
           1. Let _partial_ be a new empty List.
           1. Let _len_ be ? LengthOfArrayLike(_value_).
@@ -45904,9 +45900,9 @@ THH:mm:ss.sss
             1. Else,
               1. Let _separator_ be the string-concatenation of the code unit 0x002C (COMMA), the code unit 0x000A (LINE FEED), and _state_.[[Indent]].
               1. Let _properties_ be the String value formed by concatenating all the element Strings of _partial_ with each adjacent pair of Strings separated with _separator_. The _separator_ String is not inserted either before the first String or after the last String.
-              1. Let _final_ be the string-concatenation of *"["*, the code unit 0x000A (LINE FEED), _state_.[[Indent]], _properties_, the code unit 0x000A (LINE FEED), _stepback_, and *"]"*.
+              1. Let _final_ be the string-concatenation of *"["*, the code unit 0x000A (LINE FEED), _state_.[[Indent]], _properties_, the code unit 0x000A (LINE FEED), _stepBack_, and *"]"*.
           1. Remove the last element of _state_.[[Stack]].
-          1. Set _state_.[[Indent]] to _stepback_.
+          1. Set _state_.[[Indent]] to _stepBack_.
           1. Return _final_.
         </emu-alg>
         <emu-note>
@@ -46542,8 +46538,8 @@ THH:mm:ss.sss
             1. Let _return_ be Completion(GetMethod(_syncIterator_, *"return"*)).
             1. IfAbruptRejectPromise(_return_, _promiseCapability_).
             1. If _return_ is *undefined*, then
-              1. Let _iterResult_ be CreateIterResultObject(_value_, *true*).
-              1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, « _iterResult_ »).
+              1. Let _iteratorResult_ be CreateIteratorResultObject(_value_, *true*).
+              1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, « _iteratorResult_ »).
               1. Return _promiseCapability_.[[Promise]].
             1. If _value_ is present, then
               1. Let _result_ be Completion(Call(_return_, _syncIterator_, « _value_ »)).
@@ -46636,7 +46632,7 @@ THH:mm:ss.sss
           1. Let _valueWrapper_ be Completion(PromiseResolve(%Promise%, _value_)).
           1. IfAbruptRejectPromise(_valueWrapper_, _promiseCapability_).
           1. Let _unwrap_ be a new Abstract Closure with parameters (_v_) that captures _done_ and performs the following steps when called:
-            1. Return CreateIterResultObject(_v_, _done_).
+            1. Return CreateIteratorResultObject(_v_, _done_).
           1. Let _onFulfilled_ be CreateBuiltinFunction(_unwrap_, 1, *""*, « »).
           1. NOTE: _onFulfilled_ is used when processing the *"value"* property of an IteratorResult object in order to wait for its value if it is a promise and re-package the result in a new "unwrapped" IteratorResult object.
           1. Perform PerformPromiseThen(_valueWrapper_, _onFulfilled_, *undefined*, _promiseCapability_).
@@ -48113,7 +48109,7 @@ THH:mm:ss.sss
             1. Else,
               1. Assert: _result_ is a throw completion.
               1. Return ? _result_.
-            1. Return CreateIterResultObject(_resultValue_, *true*).
+            1. Return CreateIteratorResultObject(_resultValue_, *true*).
           1. Set the code evaluation state of _genContext_ such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
           1. Set _generator_.[[GeneratorContext]] to _genContext_.
           1. Set _generator_.[[GeneratorState]] to ~suspended-start~.
@@ -48153,7 +48149,7 @@ THH:mm:ss.sss
         </dl>
         <emu-alg>
           1. Let _state_ be ? GeneratorValidate(_generator_, _generatorBrand_).
-          1. If _state_ is ~completed~, return CreateIterResultObject(*undefined*, *true*).
+          1. If _state_ is ~completed~, return CreateIteratorResultObject(*undefined*, *true*).
           1. Assert: _state_ is either ~suspended-start~ or ~suspended-yield~.
           1. Let _genContext_ be _generator_.[[GeneratorContext]].
           1. Let _methodContext_ be the running execution context.
@@ -48184,7 +48180,7 @@ THH:mm:ss.sss
             1. Set _state_ to ~completed~.
           1. If _state_ is ~completed~, then
             1. If _abruptCompletion_ is a return completion, then
-              1. Return CreateIterResultObject(_abruptCompletion_.[[Value]], *true*).
+              1. Return CreateIteratorResultObject(_abruptCompletion_.[[Value]], *true*).
             1. Return ? _abruptCompletion_.
           1. Assert: _state_ is ~suspended-yield~.
           1. Let _genContext_ be _generator_.[[GeneratorContext]].
@@ -48214,7 +48210,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-generatoryield" type="abstract operation">
         <h1>
           GeneratorYield (
-            _iterNextObj_: an Object that conforms to the <i>IteratorResult</i> interface,
+            _iteratorResult_: an Object that conforms to the <i>IteratorResult</i> interface,
           ): either a normal completion containing an ECMAScript language value or an abrupt completion
         </h1>
         <dl class="header">
@@ -48227,7 +48223,7 @@ THH:mm:ss.sss
           1. Set _generator_.[[GeneratorState]] to ~suspended-yield~.
           1. Remove _genContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
           1. Let _callerContext_ be the running execution context.
-          1. Resume _callerContext_ passing NormalCompletion(_iterNextObj_). If _genContext_ is ever resumed again, let _resumptionValue_ be the Completion Record with which it is resumed.
+          1. Resume _callerContext_ passing NormalCompletion(_iteratorResult_). If _genContext_ is ever resumed again, let _resumptionValue_ be the Completion Record with which it is resumed.
           1. Assert: If control reaches here, then _genContext_ is the running execution context again.
           1. Return _resumptionValue_.
         </emu-alg>
@@ -48244,7 +48240,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _generatorKind_ be GetGeneratorKind().
           1. If _generatorKind_ is ~async~, return ? AsyncGeneratorYield(? Await(_value_)).
-          1. Otherwise, return ? GeneratorYield(CreateIterResultObject(_value_, *false*)).
+          1. Otherwise, return ? GeneratorYield(CreateIteratorResultObject(_value_, *false*)).
         </emu-alg>
       </emu-clause>
 
@@ -48311,7 +48307,7 @@ THH:mm:ss.sss
           1. IfAbruptRejectPromise(_result_, _promiseCapability_).
           1. Let _state_ be _generator_.[[AsyncGeneratorState]].
           1. If _state_ is ~completed~, then
-            1. Let _iteratorResult_ be CreateIterResultObject(*undefined*, *true*).
+            1. Let _iteratorResult_ be CreateIteratorResultObject(*undefined*, *true*).
             1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, « _iteratorResult_ »).
             1. Return _promiseCapability_.[[Promise]].
           1. Let _completion_ be NormalCompletion(_value_).
@@ -48538,10 +48534,10 @@ THH:mm:ss.sss
             1. If _realm_ is present, then
               1. Let _oldRealm_ be the running execution context's Realm.
               1. Set the running execution context's Realm to _realm_.
-              1. Let _iteratorResult_ be CreateIterResultObject(_value_, _done_).
+              1. Let _iteratorResult_ be CreateIteratorResultObject(_value_, _done_).
               1. Set the running execution context's Realm to _oldRealm_.
             1. Else,
-              1. Let _iteratorResult_ be CreateIterResultObject(_value_, _done_).
+              1. Let _iteratorResult_ be CreateIteratorResultObject(_value_, _done_).
             1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, « _iteratorResult_ »).
           1. Return ~unused~.
         </emu-alg>
@@ -48804,7 +48800,7 @@ THH:mm:ss.sss
     <emu-clause id="sec-async-function-instances">
       <h1>AsyncFunction Instances</h1>
 
-      <p>Every AsyncFunction instance is an ECMAScript function object and has the internal slots listed in <emu-xref href="#table-internal-slots-of-ecmascript-function-objects"></emu-xref>. The value of the [[IsClassConstructor]] internal slot for all such instances is *false*. AsyncFunction instances are not constructors and do not have a [[Construct]] internal method. AsyncFunction instances do not have a prototype property as they are not constructible.</p>
+      <p>Every AsyncFunction instance is an ECMAScript function object and has the internal slots listed in <emu-xref href="#table-internal-slots-of-ecmascript-function-objects"></emu-xref>. The value of the [[IsClassConstructor]] internal slot for all such instances is *false*. AsyncFunction instances are not constructors and do not have a [[Construct]] internal method. AsyncFunction instances do not have a prototype property as they are not constructable.</p>
       <p>Each AsyncFunction instance has the following own properties:</p>
 
       <emu-clause id="sec-async-function-instances-length">
@@ -49915,7 +49911,7 @@ THH:mm:ss.sss
     <emu-prodref name="CoverParenthesizedExpressionAndArrowParameterList"></emu-prodref>
     <p>
       When processing an instance of the production<br>
-      <emu-prodref name="PrimaryExpression" a="parencover"></emu-prodref><br>
+      <emu-prodref name="PrimaryExpression" a="parenCover"></emu-prodref><br>
       the interpretation of |CoverParenthesizedExpressionAndArrowParameterList| is refined using the following grammar:
     </p>
     <emu-prodref name="ParenthesizedExpression"></emu-prodref>
@@ -49946,7 +49942,7 @@ THH:mm:ss.sss
     <emu-prodref name="CallExpression"></emu-prodref>
     <p>
       When processing an instance of the production<br>
-      <emu-prodref name="CallExpression" a="callcover"></emu-prodref><br>
+      <emu-prodref name="CallExpression" a="callCover"></emu-prodref><br>
       the interpretation of |CoverCallExpressionAndAsyncArrowHead| is refined using the following grammar:
     </p>
     <emu-prodref name="CallMemberExpression"></emu-prodref>
@@ -50072,7 +50068,7 @@ THH:mm:ss.sss
     <emu-prodref name="ExpressionBody"></emu-prodref>
     <p>
       When processing an instance of the production<br>
-      <emu-prodref name="ArrowParameters" a="parencover"></emu-prodref><br>
+      <emu-prodref name="ArrowParameters" a="parenCover"></emu-prodref><br>
       the interpretation of |CoverParenthesizedExpressionAndArrowParameterList| is refined using the following grammar:
     </p>
     <emu-prodref name="ArrowFormalParameters"></emu-prodref>
@@ -50083,7 +50079,7 @@ THH:mm:ss.sss
     <emu-prodref name="CoverCallExpressionAndAsyncArrowHead"></emu-prodref>
     <p>
       When processing an instance of the production<br>
-      <emu-prodref name="AsyncArrowFunction" a="callcover"></emu-prodref><br>
+      <emu-prodref name="AsyncArrowFunction" a="callCover"></emu-prodref><br>
       the interpretation of |CoverCallExpressionAndAsyncArrowHead| is refined using the following grammar:
     </p>
     <emu-prodref name="AsyncArrowHead"></emu-prodref>
@@ -50790,11 +50786,11 @@ THH:mm:ss.sss
       </emu-annex>
 
       <emu-annex id="sec-string.prototype.fontcolor">
-        <h1>String.prototype.fontcolor ( _color_ )</h1>
+        <h1>String.prototype.fontcolor ( _colour_ )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
-          1. Return ? CreateHTML(_S_, *"font"*, *"color"*, _color_).
+          1. Return ? CreateHTML(_S_, *"font"*, *"color"*, _colour_).
         </emu-alg>
       </emu-annex>
 
@@ -51042,10 +51038,10 @@ THH:mm:ss.sss
                   1. Perform ! _varEnv_.InitializeBinding(_F_, *undefined*).
                   1. Append _F_ to _instantiatedVarNames_.
                 1. When the |FunctionDeclaration| _f_ is evaluated, perform the following steps in place of the |FunctionDeclaration| Evaluation algorithm provided in <emu-xref href="#sec-function-definitions-runtime-semantics-evaluation"></emu-xref>:
-                  1. Let _fenv_ be the running execution context's VariableEnvironment.
-                  1. Let _benv_ be the running execution context's LexicalEnvironment.
-                  1. Let _fobj_ be ! _benv_.GetBindingValue(_F_, *false*).
-                  1. Perform ! _fenv_.SetMutableBinding(_F_, _fobj_, *false*).
+                  1. Let _fEnv_ be the running execution context's VariableEnvironment.
+                  1. Let _bEnv_ be the running execution context's LexicalEnvironment.
+                  1. Let _fObj_ be ! _bEnv_.GetBindingValue(_F_, *false*).
+                  1. Perform ! _fEnv_.SetMutableBinding(_F_, _fObj_, *false*).
                   1. Return ~unused~.
         </emu-alg>
       </emu-annex>
@@ -51069,10 +51065,10 @@ THH:mm:ss.sss
                         1. Perform ? _env_.CreateGlobalVarBinding(_F_, *false*).
                         1. Append _F_ to _declaredFunctionOrVarNames_.
                       1. When the |FunctionDeclaration| _f_ is evaluated, perform the following steps in place of the |FunctionDeclaration| Evaluation algorithm provided in <emu-xref href="#sec-function-definitions-runtime-semantics-evaluation"></emu-xref>:
-                        1. Let _genv_ be the running execution context's VariableEnvironment.
-                        1. Let _benv_ be the running execution context's LexicalEnvironment.
-                        1. Let _fobj_ be ! _benv_.GetBindingValue(_F_, *false*).
-                        1. Perform ? <emu-meta effects="user-code">_genv_.SetMutableBinding</emu-meta>(_F_, _fobj_, *false*).
+                        1. Let _gEnv_ be the running execution context's VariableEnvironment.
+                        1. Let _bEnv_ be the running execution context's LexicalEnvironment.
+                        1. Let _fObj_ be ! _bEnv_.GetBindingValue(_F_, *false*).
+                        1. Perform ? <emu-meta effects="user-code">_gEnv_.SetMutableBinding</emu-meta>(_F_, _fObj_, *false*).
                         1. Return ~unused~.
         </emu-alg>
       </emu-annex>
@@ -51112,10 +51108,10 @@ THH:mm:ss.sss
                         1. Perform ! _varEnv_.InitializeBinding(_F_, *undefined*).
                     1. Append _F_ to _declaredFunctionOrVarNames_.
                   1. When the |FunctionDeclaration| _f_ is evaluated, perform the following steps in place of the |FunctionDeclaration| Evaluation algorithm provided in <emu-xref href="#sec-function-definitions-runtime-semantics-evaluation"></emu-xref>:
-                    1. Let _genv_ be the running execution context's VariableEnvironment.
-                    1. Let _benv_ be the running execution context's LexicalEnvironment.
-                    1. Let _fobj_ be ! _benv_.GetBindingValue(_F_, *false*).
-                    1. Perform ? <emu-meta effects="user-code">_genv_.SetMutableBinding</emu-meta>(_F_, _fobj_, *false*).
+                    1. Let _gEnv_ be the running execution context's VariableEnvironment.
+                    1. Let _bEnv_ be the running execution context's LexicalEnvironment.
+                    1. Let _fObj_ be ! _bEnv_.GetBindingValue(_F_, *false*).
+                    1. Perform ? <emu-meta effects="user-code">_gEnv_.SetMutableBinding</emu-meta>(_F_, _fObj_, *false*).
                     1. Return ~unused~.
         </emu-alg>
       </emu-annex>
@@ -51440,7 +51436,7 @@ THH:mm:ss.sss
   <p><emu-xref href="#sec-date.prototype.tostring"></emu-xref>: Previous editions did not specify the value returned by `Date.prototype.toString` when the time value is *NaN*. ECMAScript 2015 specifies the result to be the String value *"Invalid Date"*.</p>
   <p><emu-xref href="#sec-regexp-pattern-flags"></emu-xref>, <emu-xref href="#sec-escaperegexppattern"></emu-xref>: Any LineTerminator code points in the value of the *"source"* property of a RegExp instance must be expressed using an escape sequence. Edition 5.1 only required the escaping of `/`.</p>
   <p><emu-xref href="#sec-regexp.prototype-%symbol.match%"></emu-xref>, <emu-xref href="#sec-regexp.prototype-%symbol.replace%"></emu-xref>: In previous editions, the specifications for `String.prototype.match` and `String.prototype.replace` was incorrect for cases where the pattern argument was a RegExp value whose `global` flag is set. The previous specifications stated that for each attempt to match the pattern, if `lastIndex` did not change, it should be incremented by 1. The correct behaviour is that `lastIndex` should be incremented by 1 only if the pattern matched the empty String.</p>
-  <p><emu-xref href="#sec-array.prototype.sort"></emu-xref>: Previous editions did not specify how a *NaN* value returned by a _comparefn_ was interpreted by `Array.prototype.sort`. ECMAScript 2015 specifies that such as value is treated as if *+0*<sub>𝔽</sub> was returned from the _comparefn_. ECMAScript 2015 also specifies that ToNumber is applied to the result returned by a _comparefn_. In previous editions, the effect of a _comparefn_ result that is not a Number value was implementation-defined. In practice, implementations call ToNumber.</p>
+  <p><emu-xref href="#sec-array.prototype.sort"></emu-xref>: Previous editions did not specify how a *NaN* value returned by a _comparator_ was interpreted by `Array.prototype.sort`. ECMAScript 2015 specifies that such as value is treated as if *+0*<sub>𝔽</sub> was returned from the _comparator_. ECMAScript 2015 also specifies that ToNumber is applied to the result returned by a _comparator_. In previous editions, the effect of a _comparator_ result that is not a Number value was implementation-defined. In practice, implementations call ToNumber.</p>
 </emu-annex>
 
 <emu-annex id="sec-additions-and-changes-that-introduce-incompatibilities-with-prior-editions">


### PR DESCRIPTION
Integrates `aspell` to check the spelling in `spec.html`. Currently just a `package.json` script, but if we want this enforced during CI, we should be able to do that, too. Updates a bunch of spellings for a variety of reasons. Commits should be reviewed individually.