### PR TITLE
Editorial: remove unused step IDs

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -13809,7 +13809,7 @@
         1. Set the ScriptOrModule of _calleeContext_ to *null*.
         1. Perform any necessary implementation-defined initialization of _calleeContext_.
         1. Push _calleeContext_ onto the execution context stack; _calleeContext_ is now the running execution context.
-        1. [id="step-call-builtin-function-result"] Let _result_ be the Completion Record that is <emu-meta effects="user-code">the result of evaluating</emu-meta> _F_ in a manner that conforms to the specification of _F_. If _thisArgument_ is ~uninitialized~, the *this* value is uninitialized; otherwise, _thisArgument_ provides the *this* value. _argumentsList_ provides the named parameters. _newTarget_ provides the NewTarget value.
+        1. Let _result_ be the Completion Record that is <emu-meta effects="user-code">the result of evaluating</emu-meta> _F_ in a manner that conforms to the specification of _F_. If _thisArgument_ is ~uninitialized~, the *this* value is uninitialized; otherwise, _thisArgument_ provides the *this* value. _argumentsList_ provides the named parameters. _newTarget_ provides the NewTarget value.
         1. NOTE: If _F_ is defined in this document, “the specification of _F_” is the behaviour specified for it via algorithm steps or other means.
         1. Remove _calleeContext_ from the execution context stack and restore _callerContext_ as the running execution context.
         1. Return ? _result_.
@@ -39507,9 +39507,9 @@ THH:mm:ss.sss
         <p>This method sorts the elements of this array. The sort must be stable (that is, elements that compare equal must remain in their original order). If _comparefn_ is not *undefined*, it should be a function that accepts two arguments _x_ and _y_ and returns a negative Number if _x_ &lt; _y_, a positive Number if _x_ > _y_, or a zero otherwise.</p>
         <p>It performs the following steps when called:</p>
         <emu-alg>
-          1. [id="step-array-sort-comparefn"] If _comparefn_ is not *undefined* and IsCallable(_comparefn_) is *false*, throw a *TypeError* exception.
+          1. If _comparefn_ is not *undefined* and IsCallable(_comparefn_) is *false*, throw a *TypeError* exception.
           1. Let _obj_ be ? ToObject(*this* value).
-          1. [id="step-array-sort-len"] Let _len_ be ? LengthOfArrayLike(_obj_).
+          1. Let _len_ be ? LengthOfArrayLike(_obj_).
           1. Let _SortCompare_ be a new Abstract Closure with parameters (_x_, _y_) that captures _comparefn_ and performs the following steps when called:
             1. Return ? CompareArrayElements(_x_, _y_, _comparefn_).
           1. [id="step-array-sortindexedproperties"] Let _sortedList_ be ? SortIndexedProperties(_obj_, _len_, _SortCompare_, ~skip-holes~).


### PR DESCRIPTION
Ran this quick and dirty script to find them:

```sh
ack '\[id="([^"]+)"\]' spec.html --output='$1' | xargs -I '{}' bash -c "echo -n '{}: '; grep '{}' spec.html | wc -l"
```

Maybe this is something we should enforce in ecmarkup? We're not going to intentionally expect another spec to refer to an individual step, right?