### PR TITLE
Editorial: replace Type(...) notation with a proper Type AO

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1095,14 +1095,36 @@
   </emu-clause>
 </emu-clause>
 
-<emu-clause id="sec-ecmascript-data-types-and-values" aoid="Type">
+<emu-clause id="sec-ecmascript-data-types-and-values">
   <h1>ECMAScript Data Types and Values</h1>
   <p>Algorithms within this specification manipulate values each of which has an associated type. The possible value types are exactly those defined in this clause. Types are further subclassified into ECMAScript language types and specification types.</p>
-  <p>Within this specification, the notation “Type(_x_)” is used as shorthand for “the <em>type</em> of _x_” where “type” refers to the ECMAScript language and specification types defined in this clause.</p>
 
   <emu-clause id="sec-ecmascript-language-types">
     <h1>ECMAScript Language Types</h1>
     <p>An <dfn variants="ECMAScript language types">ECMAScript language type</dfn> corresponds to values that are directly manipulated by an ECMAScript programmer using the ECMAScript language. The ECMAScript language types are Undefined, Null, Boolean, String, Symbol, Number, BigInt, and Object. An <dfn variants="ECMAScript language values">ECMAScript language value</dfn> is a value that is characterized by an ECMAScript language type.</p>
+
+    <emu-clause id="sec-type-ao" type="abstract operation">
+      <h1>
+        Type (
+          _v_: an ECMAScript language value,
+        ): one of ~undefined~, ~null~, ~boolean~, ~string~, ~symbol~, ~number~, ~bigint~, or ~object~
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It classifies a value based on the ECMAScript language types defined in <emu-xref href="#sec-ecmascript-language-types"></emu-xref>.</dd>
+      </dl>
+      <emu-alg>
+        1. If _v_ is *undefined*, return ~undefined~.
+        1. If _v_ is *null*, return ~null~.
+        1. If _v_ is a Boolean, return ~boolean~.
+        1. If _v_ is a String, return ~string~.
+        1. If _v_ is a Symbol, return ~symbol~.
+        1. If _v_ is a Number, return ~number~.
+        1. If _v_ is a BigInt, return ~bigint~.
+        1. Assert: _v_ is an Object.
+        1. Return ~object~.
+      </emu-alg>
+    </emu-clause>
 
     <emu-clause id="sec-ecmascript-language-types-undefined-type">
       <h1>The Undefined Type</h1>
@@ -6429,7 +6451,7 @@
         <dd>It is used to create a List value whose elements are provided by the indexed properties of _obj_. _elementTypes_ contains the names of ECMAScript Language Types that are allowed for element values of the List that is created.</dd>
       </dl>
       <emu-alg>
-        1. If _elementTypes_ is not present, set _elementTypes_ to « Undefined, Null, Boolean, String, Symbol, Number, BigInt, Object ».
+        1. If _elementTypes_ is not present, set _elementTypes_ to « ~undefined~, ~null~, ~boolean~, ~string~, ~symbol~, ~number~, ~bigint~, ~object~ ».
         1. If _obj_ is not an Object, throw a *TypeError* exception.
         1. Let _len_ be ? LengthOfArrayLike(_obj_).
         1. Let _list_ be a new empty List.
@@ -15835,7 +15857,7 @@
         1. If _trap_ is *undefined*, then
           1. Return ? <emu-meta effects="user-code">_target_.[[OwnPropertyKeys]]()</emu-meta>.
         1. Let _trapResultArray_ be ? Call(_trap_, _handler_, « _target_ »).
-        1. Let _trapResult_ be ? CreateListFromArrayLike(_trapResultArray_, « String, Symbol »).
+        1. Let _trapResult_ be ? CreateListFromArrayLike(_trapResultArray_, « ~string~, ~symbol~ »).
         1. If _trapResult_ contains any duplicate entries, throw a *TypeError* exception.
         1. Let _extensibleTarget_ be ? IsExtensible(_target_).
         1. Let _targetKeys_ be ? <emu-meta effects="user-code">_target_.[[OwnPropertyKeys]]()</emu-meta>.
@@ -20648,28 +20670,28 @@
             <!-- emu-format ignore -->
             <table class="lightweight-table">
               <thead>
-                <tr><th> _opText_       </th><th> Type(_lnum_) </th><th> _operation_                </th></tr>
+                <tr><th> _opText_     </th><th> Type(_lnum_) </th><th> _operation_                </th></tr>
               </thead>
-              <tr><td> `**`           </td><td> Number       </td><td> Number::exponentiate       </td></tr>
-              <tr><td> `*`            </td><td> Number       </td><td> Number::multiply           </td></tr>
-              <tr><td> `*`            </td><td> BigInt       </td><td> BigInt::multiply           </td></tr>
-              <tr><td> `/`            </td><td> Number       </td><td> Number::divide             </td></tr>
-              <tr><td> `%`            </td><td> Number       </td><td> Number::remainder          </td></tr>
-              <tr><td> `+`            </td><td> Number       </td><td> Number::add                </td></tr>
-              <tr><td> `+`            </td><td> BigInt       </td><td> BigInt::add                </td></tr>
-              <tr><td> `-`            </td><td> Number       </td><td> Number::subtract           </td></tr>
-              <tr><td> `-`            </td><td> BigInt       </td><td> BigInt::subtract           </td></tr>
-              <tr><td> `&lt;&lt;`     </td><td> Number       </td><td> Number::leftShift          </td></tr>
-              <tr><td> `&lt;&lt;`     </td><td> BigInt       </td><td> BigInt::leftShift          </td></tr>
-              <tr><td> `&gt;&gt;`     </td><td> Number       </td><td> Number::signedRightShift   </td></tr>
-              <tr><td> `&gt;&gt;`     </td><td> BigInt       </td><td> BigInt::signedRightShift   </td></tr>
-              <tr><td> `&gt;&gt;&gt;` </td><td> Number       </td><td> Number::unsignedRightShift </td></tr>
-              <tr><td> `&amp;`        </td><td> Number       </td><td> Number::bitwiseAND         </td></tr>
-              <tr><td> `&amp;`        </td><td> BigInt       </td><td> BigInt::bitwiseAND         </td></tr>
-              <tr><td> `^`            </td><td> Number       </td><td> Number::bitwiseXOR         </td></tr>
-              <tr><td> `^`            </td><td> BigInt       </td><td> BigInt::bitwiseXOR         </td></tr>
-              <tr><td> `|`            </td><td> Number       </td><td> Number::bitwiseOR          </td></tr>
-              <tr><td> `|`            </td><td> BigInt       </td><td> BigInt::bitwiseOR          </td></tr>
+              <tr><td> `**`           </td><td> ~number~     </td><td> Number::exponentiate       </td></tr>
+              <tr><td> `*`            </td><td> ~number~     </td><td> Number::multiply           </td></tr>
+              <tr><td> `*`            </td><td> ~bigint~     </td><td> BigInt::multiply           </td></tr>
+              <tr><td> `/`            </td><td> ~number~     </td><td> Number::divide             </td></tr>
+              <tr><td> `%`            </td><td> ~number~     </td><td> Number::remainder          </td></tr>
+              <tr><td> `+`            </td><td> ~number~     </td><td> Number::add                </td></tr>
+              <tr><td> `+`            </td><td> ~bigint~     </td><td> BigInt::add                </td></tr>
+              <tr><td> `-`            </td><td> ~number~     </td><td> Number::subtract           </td></tr>
+              <tr><td> `-`            </td><td> ~bigint~     </td><td> BigInt::subtract           </td></tr>
+              <tr><td> `&lt;&lt;`     </td><td> ~number~     </td><td> Number::leftShift          </td></tr>
+              <tr><td> `&lt;&lt;`     </td><td> ~bigint~     </td><td> BigInt::leftShift          </td></tr>
+              <tr><td> `&gt;&gt;`     </td><td> ~number~     </td><td> Number::signedRightShift   </td></tr>
+              <tr><td> `&gt;&gt;`     </td><td> ~bigint~     </td><td> BigInt::signedRightShift   </td></tr>
+              <tr><td> `&gt;&gt;&gt;` </td><td> ~number~     </td><td> Number::unsignedRightShift </td></tr>
+              <tr><td> `&amp;`        </td><td> ~number~     </td><td> Number::bitwiseAND         </td></tr>
+              <tr><td> `&amp;`        </td><td> ~bigint~     </td><td> BigInt::bitwiseAND         </td></tr>
+              <tr><td> `^`            </td><td> ~number~     </td><td> Number::bitwiseXOR         </td></tr>
+              <tr><td> `^`            </td><td> ~bigint~     </td><td> BigInt::bitwiseXOR         </td></tr>
+              <tr><td> `|`            </td><td> ~number~     </td><td> Number::bitwiseOR          </td></tr>
+              <tr><td> `|`            </td><td> ~bigint~     </td><td> BigInt::bitwiseOR          </td></tr>
             </table>
           </figure>
         1. Return _operation_(_lnum_, _rnum_).

--- a/spec.html
+++ b/spec.html
@@ -6443,7 +6443,7 @@
       <h1>
         CreateListFromArrayLike (
           _obj_: an ECMAScript language value,
-          optional _elementTypes_: a List of either ~undefined~, ~null~, ~boolean~, ~string~, ~symbol~, ~number~, ~bigint~, or ~object~
+          optional _elementTypes_: a List of either ~undefined~, ~null~, ~boolean~, ~string~, ~symbol~, ~number~, ~bigint~, or ~object~,
         ): either a normal completion containing a List of ECMAScript language values or a throw completion
       </h1>
       <dl class="header">

--- a/spec.html
+++ b/spec.html
@@ -1107,7 +1107,7 @@
       <h1>
         Type (
           _v_: an ECMAScript language value,
-        ): one of ~undefined~, ~null~, ~boolean~, ~string~, ~symbol~, ~number~, ~bigint~, or ~object~
+        ): ~undefined~, ~null~, ~boolean~, ~string~, ~symbol~, ~number~, ~bigint~, or ~object~
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -6443,7 +6443,7 @@
       <h1>
         CreateListFromArrayLike (
           _obj_: an ECMAScript language value,
-          optional _elementTypes_: a List of names of ECMAScript Language Types,
+          optional _elementTypes_: a List of either ~undefined~, ~null~, ~boolean~, ~string~, ~symbol~, ~number~, ~bigint~, or ~object~
         ): either a normal completion containing a List of ECMAScript language values or a throw completion
       </h1>
       <dl class="header">


### PR DESCRIPTION
Fixes #2870. This aligns with our goal of reducing our core concepts.

1. I believe this is the last place where we reified ECMAScript language types. 
1. Fewer special forms and macros, more AOs.