### PR TITLE
Editorial: Better align GroupBy keyCoercion with CanonicalizeKeyedCollectionKey

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -6785,7 +6785,7 @@
         GroupBy (
           _items_: an ECMAScript language value,
           _callbackfn_: an ECMAScript language value,
-          _keyCoercion_: ~property~ or ~zero~,
+          _keyCoercion_: ~property~ or ~collection~,
         ): either a normal completion containing a List of Records with fields [[Key]] (an ECMAScript language value) and [[Elements]] (a List of ECMAScript language values), or a throw completion
       </h1>
       <dl class="header">
@@ -6810,7 +6810,7 @@
             1. Set _key_ to Completion(ToPropertyKey(_key_)).
             1. IfAbruptCloseIterator(_key_, _iteratorRecord_).
           1. Else,
-            1. Assert: _keyCoercion_ is ~zero~.
+            1. Assert: _keyCoercion_ is ~collection~.
             1. Set _key_ to CanonicalizeKeyedCollectionKey(_key_).
           1. Perform AddValueToKeyedGroup(_groups_, _key_, _value_).
           1. Set _k_ to _k_ + 1.
@@ -41743,7 +41743,7 @@ THH:mm:ss.sss
         </emu-note>
         <p>This function performs the following steps when called:</p>
         <emu-alg>
-          1. Let _groups_ be ? GroupBy(_items_, _callbackfn_, ~zero~).
+          1. Let _groups_ be ? GroupBy(_items_, _callbackfn_, ~collection~).
           1. Let _map_ be ! Construct(%Map%).
           1. For each Record { [[Key]], [[Elements]] } _g_ of _groups_, do
             1. Let _elements_ be CreateArrayFromList(_g_.[[Elements]]).


### PR DESCRIPTION
Ref #3337

Renames the _keyCoercion_ enumeration value corresponding with use of CanonicalizeKeyedCollectionKey from `~zero~` to `~collection~`, better describing its intent rather than its raw mechanics.