### PR TITLE
Editorial: Replace `IsIntegralNumber` AO with `is an integral Number`

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1056,7 +1056,7 @@
 
       <p>In the language of this specification, numerical values are distinguished among different numeric kinds using subscript suffixes. The subscript <sub>𝔽</sub> refers to Numbers, and the subscript <sub>ℤ</sub> refers to BigInts. Numeric values without a subscript suffix refer to mathematical values. This specification denotes most numeric values in base 10; it also uses numeric values of the form 0x followed by digits 0-9 or A-F as base-16 values.</p>
       <p>In general, when this specification refers to a numerical value, such as in the phrase, "the length of _y_" or "the integer represented by the four hexadecimal digits ...", without explicitly specifying a numeric kind, the phrase refers to a mathematical value. Phrases which refer to a Number or a BigInt value are explicitly annotated as such; for example, "the Number value for the number of code points in …" or "the BigInt value for …".</p>
-      <p>When the term <dfn id="integer" oldids="mathematical integer" variants="integers">integer</dfn> is used in this specification, it refers to a mathematical value which is in the set of integers, unless otherwise stated. When the term <dfn id="integral-number" variants="integral Numbers">integral Number</dfn> is used in this specification, it refers to a Number value whose mathematical value is in the set of integers.</p>
+      <p>When the term <dfn id="integer" oldids="mathematical integer" variants="integers">integer</dfn> is used in this specification, it refers to a mathematical value which is in the set of integers, unless otherwise stated. When the term <dfn id="integral-number" oldids="sec-isintegralnumber,sec-isinteger" variants="integral Numbers">integral Number</dfn> is used in this specification, it refers to a finite Number value whose mathematical value is in the set of integers.</p>
       <p>Numeric operators such as +, ×, =, and ≥ refer to those operations as determined by the type of the operands. When applied to mathematical values, the operators refer to the usual mathematical operations. When applied to extended mathematical values, the operators refer to the usual mathematical operations over the extended real numbers; indeterminate forms are not defined and their use in this specification should be considered an editorial error. When applied to Numbers, the operators refer to the relevant operations within IEEE 754-2019. When applied to BigInts, the operators refer to the usual mathematical operations applied to the mathematical value of the BigInt. Numeric operators applied to mixed-type operands (such as a Number and a mathematical value) are not defined and should be considered an editorial error in this specification.</p>
       <p>Conversions between mathematical values and Numbers or BigInts are always explicit in this document. A conversion from a mathematical value or extended mathematical value _x_ to a Number is denoted as "the Number value for _x_" or <emu-eqn id="𝔽" aoid="𝔽">𝔽(_x_)</emu-eqn>, and is defined in <emu-xref href="#sec-ecmascript-language-types-number-type"></emu-xref>. A conversion from an integer _x_ to a BigInt is denoted as "the <dfn id="bigint-value-for">BigInt value for</dfn> _x_" or <emu-eqn id="ℤ" aoid="ℤ">ℤ(_x_)</emu-eqn>. A conversion from a Number or BigInt _x_ to a mathematical value is denoted as "the <dfn id="mathematical-value-of">mathematical value of</dfn> _x_", or <emu-eqn id="ℝ" aoid="ℝ">ℝ(_x_)</emu-eqn>. The mathematical value of *+0*<sub>𝔽</sub> and *-0*<sub>𝔽</sub> is the mathematical value 0. The mathematical value of non-finite values is not defined. The <dfn id="extended-mathematical-value-of">extended mathematical value of</dfn> _x_ is the mathematical value of _x_ for finite values, and is +∞ and -∞ for *+∞*<sub>𝔽</sub> and *-∞*<sub>𝔽</sub> respectively; it is not defined for *NaN*.</p>
       <p>The mathematical function <emu-eqn id="eqn-abs" aoid="abs">abs(_x_)</emu-eqn> produces the absolute value of _x_, which is <emu-eqn>-_x_</emu-eqn> if _x_ &lt; 0 and otherwise is _x_ itself.</p>
@@ -5806,24 +5806,6 @@
       </dl>
       <emu-alg>
         1. Return ? <emu-meta effects="user-code">_O_.[[IsExtensible]]</emu-meta>().
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-isintegralnumber" type="abstract operation" oldids="sec-isinteger">
-      <h1>
-        IsIntegralNumber (
-          _argument_: an ECMAScript language value,
-        ): a Boolean
-      </h1>
-      <dl class="header">
-        <dt>description</dt>
-        <dd>It determines if _argument_ is a finite integral Number value.</dd>
-      </dl>
-      <emu-alg>
-        1. If _argument_ is not a Number, return *false*.
-        1. If _argument_ is not finite, return *false*.
-        1. If truncate(ℝ(_argument_)) ≠ ℝ(_argument_), return *false*.
-        1. Return *true*.
       </emu-alg>
     </emu-clause>
 
@@ -14297,7 +14279,7 @@
           1. If _P_ is not a String, return *undefined*.
           1. Let _index_ be CanonicalNumericIndexString(_P_).
           1. If _index_ is *undefined*, return *undefined*.
-          1. If IsIntegralNumber(_index_) is *false*, return *undefined*.
+          1. If _index_ is not an integral Number, return *undefined*.
           1. If _index_ is *-0*<sub>𝔽</sub>, return *undefined*.
           1. Let _str_ be _S_.[[StringData]].
           1. Assert: _str_ is a String.
@@ -14892,7 +14874,7 @@
         </dl>
         <emu-alg>
           1. If IsDetachedBuffer(_O_.[[ViewedArrayBuffer]]) is *true*, return *false*.
-          1. If IsIntegralNumber(_index_) is *false*, return *false*.
+          1. If _index_ is not an integral Number, return *false*.
           1. If _index_ is *-0*<sub>𝔽</sub>, return *false*.
           1. Let _taRecord_ be MakeTypedArrayWithBufferWitnessRecord(_O_, ~unordered~).
           1. NOTE: Bounds checking is not a synchronizing operation when _O_'s backing buffer is a growable SharedArrayBuffer.
@@ -31279,7 +31261,8 @@
         <h1>Number.isInteger ( _number_ )</h1>
         <p>This function performs the following steps when called:</p>
         <emu-alg>
-          1. Return IsIntegralNumber(_number_).
+          1. If _number_ is an integral Number, return *true*.
+          1. Return *false*.
         </emu-alg>
       </emu-clause>
 
@@ -31303,7 +31286,7 @@
         </emu-note>
         <p>This function performs the following steps when called:</p>
         <emu-alg>
-          1. If IsIntegralNumber(_number_) is *true*, then
+          1. If _number_ is an integral Number, then
             1. If abs(ℝ(_number_)) ≤ 2<sup>53</sup> - 1, return *true*.
           1. Return *false*.
         </emu-alg>
@@ -31618,7 +31601,7 @@
           <dl class="header">
           </dl>
           <emu-alg>
-            1. If IsIntegralNumber(_number_) is *false*, throw a *RangeError* exception.
+            1. If _number_ is not an integral Number, throw a *RangeError* exception.
             1. Return ℤ(ℝ(_number_)).
           </emu-alg>
         </emu-clause>
@@ -34473,7 +34456,7 @@ THH:mm:ss.sss
           1. Let _result_ be the empty String.
           1. For each element _next_ of _codePoints_, do
             1. Let _nextCP_ be ? ToNumber(_next_).
-            1. If IsIntegralNumber(_nextCP_) is *false*, throw a *RangeError* exception.
+            1. If _nextCP_ is not an integral Number, throw a *RangeError* exception.
             1. If ℝ(_nextCP_) &lt; 0 or ℝ(_nextCP_) > 0x10FFFF, throw a *RangeError* exception.
             1. Set _result_ to the string-concatenation of _result_ and UTF16EncodeCodePoint(ℝ(_nextCP_)).
           1. Assert: If _codePoints_ is empty, then _result_ is the empty String.


### PR DESCRIPTION
We've had a `<dfn>` for "integral Number" since PR #2007, and the status quo uses it about 80 times. So it's odd that we still have the AO `IsIntegralNumber` (which dates back to ES6 where it had the name `IsInteger`).

This PR replaces the few uses of `IsIntegralNumber` with `is an integral Number`.

It also inserts the word "finite" into the definition of "integral Number", as noted by bakkot.

(Compare to PR #3316 replacing `IsPropertyKey` with `is a property key`.)
