### PR TITLE
Normative: fully define Math.sqrt

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -31908,7 +31908,7 @@
     <emu-clause id="sec-function-properties-of-the-math-object">
       <h1>Function Properties of the Math Object</h1>
       <emu-note>
-        <p>The behaviour of the functions `acos`, `acosh`, `asin`, `asinh`, `atan`, `atanh`, `atan2`, `cbrt`, `cos`, `cosh`, `exp`, `expm1`, `hypot`, `log`, `log1p`, `log2`, `log10`, `pow`, `random`, `sin`, `sinh`, `sqrt`, `tan`, and `tanh` is not precisely specified here except to require specific results for certain argument values that represent boundary cases of interest. For other argument values, these functions are intended to compute approximations to the results of familiar mathematical functions, but some latitude is allowed in the choice of approximation algorithms. The general intent is that an implementer should be able to use the same mathematical library for ECMAScript on a given hardware platform that is available to C programmers on that platform.</p>
+        <p>The behaviour of the functions `acos`, `acosh`, `asin`, `asinh`, `atan`, `atanh`, `atan2`, `cbrt`, `cos`, `cosh`, `exp`, `expm1`, `hypot`, `log`, `log1p`, `log2`, `log10`, `pow`, `random`, `sin`, `sinh`, `tan`, and `tanh` is not precisely specified here except to require specific results for certain argument values that represent boundary cases of interest. For other argument values, these functions are intended to compute approximations to the results of familiar mathematical functions, but some latitude is allowed in the choice of approximation algorithms. The general intent is that an implementer should be able to use the same mathematical library for ECMAScript on a given hardware platform that is available to C programmers on that platform.</p>
         <p>Although the choice of algorithms is left to the implementation, it is recommended (but not specified by this standard) that implementations use the approximation algorithms for IEEE 754-2019 arithmetic contained in `fdlibm`, the freely distributable mathematical library from Sun Microsystems (<a href="http://www.netlib.org/fdlibm">http://www.netlib.org/fdlibm</a>).</p>
       </emu-note>
 
@@ -32381,7 +32381,7 @@
           1. Let _n_ be ? ToNumber(_x_).
           1. If _n_ is one of *NaN*, *+0*<sub>𝔽</sub>, *-0*<sub>𝔽</sub>, or *+∞*<sub>𝔽</sub>, return _n_.
           1. If _n_ &lt; *-0*<sub>𝔽</sub>, return *NaN*.
-          1. Return an implementation-approximated Number value representing the square root of ℝ(_n_).
+          1. Return 𝔽(the square root of ℝ(_n_)).
         </emu-alg>
       </emu-clause>
 


### PR DESCRIPTION
This matches the behaviour that web engines today already display with the WebAssembly `f64.sqrt` instruction.

/cc @sunfishcode