### PR TITLE
Editorial: remove some unnecessary "the result of" phrasing

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1867,7 +1867,7 @@
           </dl>
           <emu-alg>
             1. If _x_ is *NaN*, return *NaN*.
-            1. Return the result of negating _x_; that is, compute a Number with the same magnitude but opposite sign.
+            1. Return the negation of _x_; that is, compute a Number with the same magnitude but opposite sign.
           </emu-alg>
         </emu-clause>
 
@@ -1881,7 +1881,7 @@
           </dl>
           <emu-alg>
             1. Let _oldValue_ be ! ToInt32(_x_).
-            1. Return the result of applying bitwise complement to _oldValue_. The mathematical value of the result is exactly representable as a 32-bit two's complement bit string.
+            1. Return the bitwise complement of _oldValue_. The mathematical value of the result is exactly representable as a 32-bit two's complement bit string.
           </emu-alg>
         </emu-clause>
 
@@ -5620,7 +5620,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>If _argument_ is either *"-0"* or exactly matches the result of ToString(_n_) for some Number value _n_, it returns the respective Number value. Otherwise, it returns *undefined*.</dd>
+        <dd>If _argument_ is either *"-0"* or exactly matches ToString(_n_) for some Number value _n_, it returns the respective Number value. Otherwise, it returns *undefined*.</dd>
       </dl>
       <emu-alg>
         1. If _argument_ is *"-0"*, return *-0*<sub>𝔽</sub>.
@@ -31833,7 +31833,7 @@
           1. Let _n_ be ? ToNumber(_x_).
           1. If _n_ is *NaN*, _n_ > *1*<sub>𝔽</sub>, or _n_ &lt; *-1*<sub>𝔽</sub>, return *NaN*.
           1. If _n_ is *1*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
-          1. Return an implementation-approximated Number value representing the result of the inverse cosine of ℝ(_n_).
+          1. Return an implementation-approximated Number value representing the inverse cosine of ℝ(_n_).
         </emu-alg>
       </emu-clause>
 
@@ -31846,7 +31846,7 @@
           1. If _n_ is either *NaN* or *+∞*<sub>𝔽</sub>, return _n_.
           1. If _n_ is *1*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
           1. If _n_ &lt; *1*<sub>𝔽</sub>, return *NaN*.
-          1. Return an implementation-approximated Number value representing the result of the inverse hyperbolic cosine of ℝ(_n_).
+          1. Return an implementation-approximated Number value representing the inverse hyperbolic cosine of ℝ(_n_).
         </emu-alg>
       </emu-clause>
 
@@ -31858,7 +31858,7 @@
           1. Let _n_ be ? ToNumber(_x_).
           1. If _n_ is one of *NaN*, *+0*<sub>𝔽</sub>, or *-0*<sub>𝔽</sub>, return _n_.
           1. If _n_ > *1*<sub>𝔽</sub> or _n_ &lt; *-1*<sub>𝔽</sub>, return *NaN*.
-          1. Return an implementation-approximated Number value representing the result of the inverse sine of ℝ(_n_).
+          1. Return an implementation-approximated Number value representing the inverse sine of ℝ(_n_).
         </emu-alg>
       </emu-clause>
 
@@ -31869,7 +31869,7 @@
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
           1. If _n_ is not finite or _n_ is either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, return _n_.
-          1. Return an implementation-approximated Number value representing the result of the inverse hyperbolic sine of ℝ(_n_).
+          1. Return an implementation-approximated Number value representing the inverse hyperbolic sine of ℝ(_n_).
         </emu-alg>
       </emu-clause>
 
@@ -31882,7 +31882,7 @@
           1. If _n_ is one of *NaN*, *+0*<sub>𝔽</sub>, or *-0*<sub>𝔽</sub>, return _n_.
           1. If _n_ is *+∞*<sub>𝔽</sub>, return an implementation-approximated Number value representing π / 2.
           1. If _n_ is *-∞*<sub>𝔽</sub>, return an implementation-approximated Number value representing -π / 2.
-          1. Return an implementation-approximated Number value representing the result of the inverse tangent of ℝ(_n_).
+          1. Return an implementation-approximated Number value representing the inverse tangent of ℝ(_n_).
         </emu-alg>
       </emu-clause>
 
@@ -31896,7 +31896,7 @@
           1. If _n_ > *1*<sub>𝔽</sub> or _n_ &lt; *-1*<sub>𝔽</sub>, return *NaN*.
           1. If _n_ is *1*<sub>𝔽</sub>, return *+∞*<sub>𝔽</sub>.
           1. If _n_ is *-1*<sub>𝔽</sub>, return *-∞*<sub>𝔽</sub>.
-          1. Return an implementation-approximated Number value representing the result of the inverse hyperbolic tangent of ℝ(_n_).
+          1. Return an implementation-approximated Number value representing the inverse hyperbolic tangent of ℝ(_n_).
         </emu-alg>
       </emu-clause>
 
@@ -31949,7 +31949,7 @@
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
           1. If _n_ is not finite or _n_ is either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, return _n_.
-          1. Return an implementation-approximated Number value representing the result of the cube root of ℝ(_n_).
+          1. Return an implementation-approximated Number value representing the cube root of ℝ(_n_).
         </emu-alg>
       </emu-clause>
 
@@ -31990,7 +31990,7 @@
           1. Let _n_ be ? ToNumber(_x_).
           1. If _n_ is not finite, return *NaN*.
           1. If _n_ is either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, return *1*<sub>𝔽</sub>.
-          1. Return an implementation-approximated Number value representing the result of the cosine of ℝ(_n_).
+          1. Return an implementation-approximated Number value representing the cosine of ℝ(_n_).
         </emu-alg>
       </emu-clause>
 
@@ -32003,7 +32003,7 @@
           1. If _n_ is *NaN*, return *NaN*.
           1. If _n_ is either *+∞*<sub>𝔽</sub> or *-∞*<sub>𝔽</sub>, return *+∞*<sub>𝔽</sub>.
           1. If _n_ is either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, return *1*<sub>𝔽</sub>.
-          1. Return an implementation-approximated Number value representing the result of the hyperbolic cosine of ℝ(_n_).
+          1. Return an implementation-approximated Number value representing the hyperbolic cosine of ℝ(_n_).
         </emu-alg>
         <emu-note>
           <p>The value of `Math.cosh(x)` is the same as the value of `(Math.exp(x) + Math.exp(-x)) / 2`.</p>
@@ -32019,7 +32019,7 @@
           1. If _n_ is either *NaN* or *+∞*<sub>𝔽</sub>, return _n_.
           1. If _n_ is either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, return *1*<sub>𝔽</sub>.
           1. If _n_ is *-∞*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
-          1. Return an implementation-approximated Number value representing the result of the exponential function of ℝ(_n_).
+          1. Return an implementation-approximated Number value representing the exponential function of ℝ(_n_).
         </emu-alg>
       </emu-clause>
 
@@ -32031,7 +32031,8 @@
           1. Let _n_ be ? ToNumber(_x_).
           1. If _n_ is one of *NaN*, *+0*<sub>𝔽</sub>, *-0*<sub>𝔽</sub>, or *+∞*<sub>𝔽</sub>, return _n_.
           1. If _n_ is *-∞*<sub>𝔽</sub>, return *-1*<sub>𝔽</sub>.
-          1. Return an implementation-approximated Number value representing the result of subtracting 1 from the exponential function of ℝ(_n_).
+          1. Let _exp_ be the exponential function of ℝ(_n_).
+          1. Return an implementation-approximated Number value representing _exp_ - 1.
         </emu-alg>
       </emu-clause>
 
@@ -32109,7 +32110,7 @@
           1. If _n_ is *1*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
           1. If _n_ is either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, return *-∞*<sub>𝔽</sub>.
           1. If _n_ &lt; *-0*<sub>𝔽</sub>, return *NaN*.
-          1. Return an implementation-approximated Number value representing the result of the natural logarithm of ℝ(_n_).
+          1. Return an implementation-approximated Number value representing the natural logarithm of ℝ(_n_).
         </emu-alg>
       </emu-clause>
 
@@ -32122,7 +32123,7 @@
           1. If _n_ is one of *NaN*, *+0*<sub>𝔽</sub>, *-0*<sub>𝔽</sub>, or *+∞*<sub>𝔽</sub>, return _n_.
           1. If _n_ is *-1*<sub>𝔽</sub>, return *-∞*<sub>𝔽</sub>.
           1. If _n_ &lt; *-1*<sub>𝔽</sub>, return *NaN*.
-          1. Return an implementation-approximated Number value representing the result of the natural logarithm of 1 + ℝ(_n_).
+          1. Return an implementation-approximated Number value representing the natural logarithm of 1 + ℝ(_n_).
         </emu-alg>
       </emu-clause>
 
@@ -32136,7 +32137,7 @@
           1. If _n_ is *1*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
           1. If _n_ is either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, return *-∞*<sub>𝔽</sub>.
           1. If _n_ &lt; *-0*<sub>𝔽</sub>, return *NaN*.
-          1. Return an implementation-approximated Number value representing the result of the base 10 logarithm of ℝ(_n_).
+          1. Return an implementation-approximated Number value representing the base 10 logarithm of ℝ(_n_).
         </emu-alg>
       </emu-clause>
 
@@ -32150,7 +32151,7 @@
           1. If _n_ is *1*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
           1. If _n_ is either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, return *-∞*<sub>𝔽</sub>.
           1. If _n_ &lt; *-0*<sub>𝔽</sub>, return *NaN*.
-          1. Return an implementation-approximated Number value representing the result of the base 2 logarithm of ℝ(_n_).
+          1. Return an implementation-approximated Number value representing the base 2 logarithm of ℝ(_n_).
         </emu-alg>
       </emu-clause>
 
@@ -32253,7 +32254,7 @@
           1. Let _n_ be ? ToNumber(_x_).
           1. If _n_ is one of *NaN*, *+0*<sub>𝔽</sub>, or *-0*<sub>𝔽</sub>, return _n_.
           1. If _n_ is either *+∞*<sub>𝔽</sub> or *-∞*<sub>𝔽</sub>, return *NaN*.
-          1. Return an implementation-approximated Number value representing the result of the sine of ℝ(_n_).
+          1. Return an implementation-approximated Number value representing the sine of ℝ(_n_).
         </emu-alg>
       </emu-clause>
 
@@ -32264,7 +32265,7 @@
         <emu-alg>
           1. Let _n_ be ? ToNumber(_x_).
           1. If _n_ is not finite or _n_ is either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, return _n_.
-          1. Return an implementation-approximated Number value representing the result of the hyperbolic sine of ℝ(_n_).
+          1. Return an implementation-approximated Number value representing the hyperbolic sine of ℝ(_n_).
         </emu-alg>
         <emu-note>
           <p>The value of `Math.sinh(x)` is the same as the value of `(Math.exp(x) - Math.exp(-x)) / 2`.</p>
@@ -32279,7 +32280,7 @@
           1. Let _n_ be ? ToNumber(_x_).
           1. If _n_ is one of *NaN*, *+0*<sub>𝔽</sub>, *-0*<sub>𝔽</sub>, or *+∞*<sub>𝔽</sub>, return _n_.
           1. If _n_ &lt; *-0*<sub>𝔽</sub>, return *NaN*.
-          1. Return an implementation-approximated Number value representing the result of the square root of ℝ(_n_).
+          1. Return an implementation-approximated Number value representing the square root of ℝ(_n_).
         </emu-alg>
       </emu-clause>
 
@@ -32291,7 +32292,7 @@
           1. Let _n_ be ? ToNumber(_x_).
           1. If _n_ is one of *NaN*, *+0*<sub>𝔽</sub>, or *-0*<sub>𝔽</sub>, return _n_.
           1. If _n_ is either *+∞*<sub>𝔽</sub> or *-∞*<sub>𝔽</sub>, return *NaN*.
-          1. Return an implementation-approximated Number value representing the result of the tangent of ℝ(_n_).
+          1. Return an implementation-approximated Number value representing the tangent of ℝ(_n_).
         </emu-alg>
       </emu-clause>
 
@@ -32304,7 +32305,7 @@
           1. If _n_ is one of *NaN*, *+0*<sub>𝔽</sub>, or *-0*<sub>𝔽</sub>, return _n_.
           1. If _n_ is *+∞*<sub>𝔽</sub>, return *1*<sub>𝔽</sub>.
           1. If _n_ is *-∞*<sub>𝔽</sub>, return *-1*<sub>𝔽</sub>.
-          1. Return an implementation-approximated Number value representing the result of the hyperbolic tangent of ℝ(_n_).
+          1. Return an implementation-approximated Number value representing the hyperbolic tangent of ℝ(_n_).
         </emu-alg>
         <emu-note>
           <p>The value of `Math.tanh(x)` is the same as the value of `(Math.exp(x) - Math.exp(-x)) / (Math.exp(x) + Math.exp(-x))`.</p>
@@ -35267,7 +35268,7 @@ THH:mm:ss.sss
           1. Let _O_ be ? RequireObjectCoercible(*this* value).
           1. Let _S_ be ? ToString(_O_).
           1. Let _sText_ be StringToCodePoints(_S_).
-          1. Let _lowerText_ be the result of toLowercase(_sText_), according to the Unicode Default Case Conversion algorithm.
+          1. Let _lowerText_ be toLowercase(_sText_), according to the Unicode Default Case Conversion algorithm.
           1. Let _L_ be CodePointsToString(_lowerText_).
           1. Return _L_.
         </emu-alg>
@@ -37100,7 +37101,7 @@ THH:mm:ss.sss
             1. If _rer_.[[IgnoreCase]] is *false*, return _ch_.
             1. Assert: _ch_ is a UTF-16 code unit.
             1. Let _cp_ be the code point whose numeric value is the numeric value of _ch_.
-            1. Let _u_ be the result of toUppercase(« _cp_ »), according to the Unicode Default Case Conversion algorithm.
+            1. Let _u_ be toUppercase(« _cp_ »), according to the Unicode Default Case Conversion algorithm.
             1. Let _uStr_ be CodePointsToString(_u_).
             1. If the length of _uStr_ ≠ 1, return _ch_.
             1. Let _cu_ be _uStr_'s single code unit element.
@@ -39473,7 +39474,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-array.prototype.reverse">
         <h1>Array.prototype.reverse ( )</h1>
         <emu-note>
-          <p>This method rearranges the elements of the array so as to reverse their order. It returns the object as the result of the call.</p>
+          <p>This method rearranges the elements of the array so as to reverse their order. It returns the reversed array.</p>
         </emu-note>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
@@ -45080,7 +45081,7 @@ THH:mm:ss.sss
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>_op_ takes two List of byte values arguments and returns a List of byte values. This operation atomically loads a value, combines it with another value, and stores the result of the combination. It returns the loaded value.</dd>
+          <dd>_op_ takes two List of byte values arguments and returns a List of byte values. This operation atomically loads a value, combines it with another value, and stores the combination. It returns the loaded value.</dd>
         </dl>
         <emu-alg>
           1. Let _byteIndexInBuffer_ be ? ValidateAtomicAccessOnIntegerTypedArray(_typedArray_, _index_).


### PR DESCRIPTION
This aligns well with our editorial convention of avoiding "the value of".