### PR TITLE
Markup: also insert snapshot warning in multipage

### DIFF
--- a/scripts/snapshot_warning.html
+++ b/scripts/snapshot_warning.html
@@ -13,3 +13,13 @@
     living specification.
   </p>
 </details>
+<script>
+let base = "https://ci.tc39.es/preview/tc39/ecma262/sha/";
+if (
+  location.href.startsWith(base) &&
+  document.referrer.startsWith(base) &&
+  location.href.substring(base.length, base.length + 40) === document.referrer.substring(base.length, base.length + 40)
+) {
+  document.querySelector(".annoying-warning").open = false;
+}
+</script>


### PR DESCRIPTION
To avoid being too annoying it checks the referrer and collapses the warning when navigating within the same snapshot.