### PR TITLE
Editorial: add missing note for Annex B replacement

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -16505,7 +16505,9 @@
       SingleLineCommentChar ::
         SourceCharacter but not LineTerminator
     </emu-grammar>
-    <p>A number of productions in this section are given alternative definitions in section <emu-xref href="#sec-html-like-comments"></emu-xref></p>
+    <emu-note>
+      <p>A number of productions in this section are given alternative definitions in section <emu-xref href="#sec-html-like-comments"></emu-xref></p>
+    </emu-note>
   </emu-clause>
 
   <emu-clause id="sec-hashbang">
@@ -51014,6 +51016,7 @@ THH:mm:ss.sss
                   1. If _thisEnv_ is not an Object Environment Record, then
                     1. If ! _thisEnv_.HasBinding(_F_) is *true*, then
                       1. [id="step-evaldeclarationinstantiation-web-compat-bindingexists"] Let _bindingExists_ be *true*.
+                      1. NOTE: Annex <emu-xref href="#sec-variablestatements-in-catch-blocks"></emu-xref> defines alternate semantics for the above step.
                   1. Set _thisEnv_ to _thisEnv_.[[OuterEnv]].
                 1. If _bindingExists_ is *false* and _varEnv_ is a Global Environment Record, then
                   1. If _varEnv_.HasLexicalDeclaration(_F_) is *false*, then


### PR DESCRIPTION
We have a note that references back to every Annex B replacement we make, except for this one. Discovered while trying to make such a claim in a live presentation today 😩. Also fixes up one of the back-references to be in a note.