### PR TITLE
Editorial: Fix old bug in Annex B's changes to FunctionDeclarationInstantiation

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -51033,7 +51033,7 @@ THH:mm:ss.sss
         <p>During FunctionDeclarationInstantiation the following steps are performed in place of step <emu-xref href="#step-functiondeclarationinstantiation-web-compat-insertion-point"></emu-xref>:</p>
         <emu-alg replaces-step="step-functiondeclarationinstantiation-web-compat-insertion-point">
           1. If _strict_ is *false*, then
-            1. For each |FunctionDeclaration| _f_ that is directly contained in the |StatementList| of a |Block|, |CaseClause|, or |DefaultClause|, do
+            1. For each |FunctionDeclaration| _f_ that is directly contained in the |StatementList| of a |Block|, |CaseClause|, or |DefaultClause| Contained within _code_, do
               1. Let _F_ be the StringValue of the |BindingIdentifier| of _f_.
               1. If replacing the |FunctionDeclaration| _f_ with a |VariableStatement| that has _F_ as a |BindingIdentifier| would not produce any Early Errors for _func_ and _parameterNames_ does not contain _F_, then
                 1. NOTE: A var binding for _F_ is only instantiated here if it is neither a VarDeclaredName, the name of a formal parameter, or another |FunctionDeclaration|.

--- a/spec.html
+++ b/spec.html
@@ -51033,7 +51033,7 @@ THH:mm:ss.sss
         <p>During FunctionDeclarationInstantiation the following steps are performed in place of step <emu-xref href="#step-functiondeclarationinstantiation-web-compat-insertion-point"></emu-xref>:</p>
         <emu-alg replaces-step="step-functiondeclarationinstantiation-web-compat-insertion-point">
           1. If _strict_ is *false*, then
-            1. For each |FunctionDeclaration| _f_ that is directly contained in the |StatementList| of a |Block|, |CaseClause|, or |DefaultClause| Contained within _code_, do
+            1. For each |FunctionDeclaration| _f_ that is directly contained in the |StatementList| of any |Block|, |CaseClause|, or |DefaultClause| _x_ such that _code_ Contains _x_ is *true*, do
               1. Let _F_ be the StringValue of the |BindingIdentifier| of _f_.
               1. If replacing the |FunctionDeclaration| _f_ with a |VariableStatement| that has _F_ as a |BindingIdentifier| would not produce any Early Errors for _func_ and _parameterNames_ does not contain _F_, then
                 1. NOTE: A var binding for _F_ is only instantiated here if it is neither a VarDeclaredName, the name of a formal parameter, or another |FunctionDeclaration|.
@@ -51058,7 +51058,7 @@ THH:mm:ss.sss
             1. Let _strict_ be ScriptIsStrict of _script_.
             1. If _strict_ is *false*, then
               1. Let _declaredFunctionOrVarNames_ be the list-concatenation of _declaredFunctionNames_ and _declaredVarNames_.
-              1. For each |FunctionDeclaration| _f_ that is directly contained in the |StatementList| of a |Block|, |CaseClause|, or |DefaultClause| Contained within _script_, do
+              1. For each |FunctionDeclaration| _f_ that is directly contained in the |StatementList| of any |Block|, |CaseClause|, or |DefaultClause| _x_ such that _script_ Contains _x_ is *true*, do
                 1. Let _F_ be the StringValue of the |BindingIdentifier| of _f_.
                 1. If replacing the |FunctionDeclaration| _f_ with a |VariableStatement| that has _F_ as a |BindingIdentifier| would not produce any Early Errors for _script_, then
                   1. If _env_.HasLexicalDeclaration(_F_) is *false*, then
@@ -51083,7 +51083,7 @@ THH:mm:ss.sss
         <emu-alg replaces-step="step-evaldeclarationinstantiation-web-compat-insertion-point">
           1. If _strict_ is *false*, then
             1. Let _declaredFunctionOrVarNames_ be the list-concatenation of _declaredFunctionNames_ and _declaredVarNames_.
-            1. For each |FunctionDeclaration| _f_ that is directly contained in the |StatementList| of a |Block|, |CaseClause|, or |DefaultClause| Contained within _body_, do
+            1. For each |FunctionDeclaration| _f_ that is directly contained in the |StatementList| of any |Block|, |CaseClause|, or |DefaultClause| _x_ such that _body_ Contains _x_ is *true*, do
               1. Let _F_ be the StringValue of the |BindingIdentifier| of _f_.
               1. If replacing the |FunctionDeclaration| _f_ with a |VariableStatement| that has _F_ as a |BindingIdentifier| would not produce any Early Errors for _body_, then
                 1. Let _bindingExists_ be *false*.


### PR DESCRIPTION
This PR completes a small bugfix from 9 years ago.

Fixes #2663.

----

History:

2015-07-17:
@bakkot identifies a problem in Annex B's
"Changes to FunctionDeclarationInstantiation":
https://esdiscuss.org/topic/block-level-function-declarations-web-legacy-compatibility-bug

To remedy this, @allenwb submits bug 4427:
https://tc39.es/archives/bugzilla/4427/
in which he recommends changing
> For each FunctionDeclaration _f_ **in _varDeclarations_** that is directly contained in the |StatementList| of a |Block|, |CaseClause|, or |DefaultClause|,

to
> For each FunctionDeclaration _f_ that is directly contained in the |StatementList| of a |Block|, |CaseClause|, or |DefaultClause| **Contained within _code_**,

(emphasis mine).

2015-10-29:
@anba submits PR #141, claiming to fix bug 4427.
It deletes "in _varDeclarations_", but doesn't add "Contained within _code_".
My guess is, this was just an oversight.

2015-11-02:
PR #141 is merged to master as commit efbfc88.

2022-02-13:
@nicolo-ribaudo raises issue #2663 about this,
and says he'd open a PR to fix it, but I don't think that happened.

2024-06-26:
@gibson042 raises the problem again, in a commment on PR #2952:
https://github.com/tc39/ecma262/pull/2952#discussion_r1655601962
