### PR TITLE
Editorial: use conventional notation for referring to types in Tables 4 and 5

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -2911,7 +2911,7 @@
                 [[GetPrototypeOf]]
               </td>
               <td>
-                ( ) <b>→</b> Object | Null
+                ( ) <b>→</b> an Object or *null*
               </td>
               <td>
                 Determine the object that provides inherited properties for this object. A *null* value indicates that there are no inherited properties.
@@ -2922,7 +2922,7 @@
                 [[SetPrototypeOf]]
               </td>
               <td>
-                (Object | Null) <b>→</b> Boolean
+                (an Object or *null*) <b>→</b> a Boolean
               </td>
               <td>
                 Associate this object with another object that provides inherited properties. Passing *null* indicates that there are no inherited properties. Returns *true* indicating that the operation was completed successfully or *false* indicating that the operation was not successful.
@@ -2933,7 +2933,7 @@
                 [[IsExtensible]]
               </td>
               <td>
-                ( ) <b>→</b> Boolean
+                ( ) <b>→</b> a Boolean
               </td>
               <td>
                 Determine whether it is permitted to add additional properties to this object.
@@ -2944,7 +2944,7 @@
                 [[PreventExtensions]]
               </td>
               <td>
-                ( ) <b>→</b> Boolean
+                ( ) <b>→</b> a Boolean
               </td>
               <td>
                 Control whether new properties may be added to this object. Returns *true* if the operation was successful or *false* if the operation was unsuccessful.
@@ -2955,10 +2955,10 @@
                 [[GetOwnProperty]]
               </td>
               <td>
-                (_propertyKey_) <b>→</b> Undefined | Property Descriptor
+                (a property key) <b>→</b> a Property Descriptor or *undefined*
               </td>
               <td>
-                Return a Property Descriptor for the own property of this object whose key is _propertyKey_, or *undefined* if no such property exists.
+                Return a Property Descriptor for the own property of this object whose key is the passed property key, or *undefined* if no such property exists.
               </td>
             </tr>
             <tr>
@@ -2966,10 +2966,10 @@
                 [[DefineOwnProperty]]
               </td>
               <td>
-                (_propertyKey_, _PropertyDescriptor_) <b>→</b> Boolean
+                (a property key, a Property Descriptor) <b>→</b> a Boolean
               </td>
               <td>
-                Create or alter the own property, whose key is _propertyKey_, to have the state described by _PropertyDescriptor_. Return *true* if that property was successfully created/updated or *false* if the property could not be created or updated.
+                Create or alter the own property, whose key is the passed property key, to have the state described by the passed Property Descriptor. Return *true* if that property was successfully created/updated or *false* if the property could not be created or updated.
               </td>
             </tr>
             <tr>
@@ -2977,10 +2977,10 @@
                 [[HasProperty]]
               </td>
               <td>
-                (_propertyKey_) <b>→</b> Boolean
+                (a property key) <b>→</b> a Boolean
               </td>
               <td>
-                Return a Boolean value indicating whether this object already has either an own or inherited property whose key is _propertyKey_.
+                Return a Boolean value indicating whether this object already has either an own or inherited property whose key is the passed property key.
               </td>
             </tr>
             <tr>
@@ -2988,10 +2988,10 @@
                 [[Get]]
               </td>
               <td>
-                (_propertyKey_, _Receiver_) <b>→</b> <em>any</em>
+                (a property key, an ECMAScript language value) <b>→</b> an ECMAScript language value
               </td>
               <td>
-                Return the value of the property whose key is _propertyKey_ from this object. If any ECMAScript code must be executed to retrieve the property value, _Receiver_ is used as the *this* value when evaluating the code.
+                Return the value of the property of this object whose key is the passed property key. If any ECMAScript code must be executed to retrieve the property value, the value passed as the second parameter is used as the *this* value when evaluating the code.
               </td>
             </tr>
             <tr>
@@ -2999,10 +2999,10 @@
                 [[Set]]
               </td>
               <td>
-                (_propertyKey_, _value_, _Receiver_) <b>→</b> Boolean
+                (a property key, an ECMAScript Language value, an ECMAScript language value) <b>→</b> a Boolean
               </td>
               <td>
-                Set the value of the property whose key is _propertyKey_ to _value_. If any ECMAScript code must be executed to set the property value, _Receiver_ is used as the *this* value when evaluating the code. Returns *true* if the property value was set or *false* if it could not be set.
+                Set the value of the property whose key is the passed property key to the value passed as the second parameter. If any ECMAScript code must be executed to retrieve the property value, the value passed as the third parameter is used as the *this* value when evaluating the code. Returns *true* if the property value was set or *false* if it could not be set.
               </td>
             </tr>
             <tr>
@@ -3010,10 +3010,10 @@
                 [[Delete]]
               </td>
               <td>
-                (_propertyKey_) <b>→</b> Boolean
+                (a property key) <b>→</b> a Boolean
               </td>
               <td>
-                Remove the own property whose key is _propertyKey_ from this object. Return *false* if the property was not deleted and is still present. Return *true* if the property was deleted or is not present.
+                Remove the own property from this object whose key is the passed property key. Return *false* if the property was not deleted and is still present. Return *true* if the property was deleted or is not present.
               </td>
             </tr>
             <tr>
@@ -3021,7 +3021,7 @@
                 [[OwnPropertyKeys]]
               </td>
               <td>
-                ( ) <b>→</b> List of property keys
+                ( ) <b>→</b> a List of property keys
               </td>
               <td>
                 Return a List whose elements are all of the own property keys for the object.
@@ -3050,7 +3050,7 @@
                 [[Call]]
               </td>
               <td>
-                (<em>any</em>, a List of <em>any</em>) <b>→</b> <em>any</em>
+                (an ECMAScript language value, a List of ECMAScript language values) <b>→</b> an ECMAScript language value
               </td>
               <td>
                 Executes code associated with this object. Invoked via a function call expression. The arguments to the internal method are a *this* value and a List whose elements are the arguments passed to the function by a call expression. Objects that implement this internal method are <em>callable</em>.
@@ -3061,7 +3061,7 @@
                 [[Construct]]
               </td>
               <td>
-                (a List of <em>any</em>, Object) <b>→</b> Object
+                (a List of ECMAScript language values, an Object) <b>→</b> an Object
               </td>
               <td>
                 Creates an object. Invoked via the `new` operator or a `super` call. The first argument to the internal method is a List whose elements are the arguments of the constructor invocation or the `super` call. The second argument is the object to which the `new` operator was initially applied. Objects that implement this internal method are called <em>constructors</em>. A function object is not necessarily a constructor and such non-constructor function objects do not have a [[Construct]] internal method.


### PR DESCRIPTION
It makes it a little more verbose, but the table layout stays acceptable IMO.

<img width="1288" alt="image" src="https://github.com/tc39/ecma262/assets/218840/1bc74226-f335-4303-8bad-7dda7623f5c1">
