### PR TITLE
Editorial: Using Object instead of constructor in PromiseResolve

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -47515,7 +47515,7 @@ THH:mm:ss.sss
         <emu-clause id="sec-promise-resolve" type="abstract operation">
           <h1>
             PromiseResolve (
-              _C_: a constructor,
+              _C_: an Object,
               _x_: an ECMAScript language value,
             ): either a normal completion containing an ECMAScript language value or a throw completion
           </h1>


### PR DESCRIPTION
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->

The argument _C_ of the abstract operation [PromiseResolve](https://tc39.es/ecma262/#sec-promise-resolve) has type of Constructor in current spec. However, as following example, it allows an object as _C_ and throws an error 42 in 1.a. I think the type of _C_ should be an Object, not a constructor.
```js
var C = {}
var x = new Promise(function () {});
Object.defineProperty(x, 'constructor', { get: () => { throw 42; }});
Promise.resolve.call(C, x);
```