### PR TITLE
Editorial: Using non-negative integral Number instead of integral Number in ToLength

### DIFF
--- a/esmeta-ignore.json
+++ b/esmeta-ignore.json
@@ -28,7 +28,6 @@
   "GetThisValue",
   "InnerModuleEvaluation",
   "LabelledItem[1,0].LabelledEvaluation",
-  "LengthOfArrayLike",
   "MethodDefinition[0,0].DefineMethod",
   "ModuleNamespaceCreate",
   "OrdinaryFunctionCreate",

--- a/spec.html
+++ b/spec.html
@@ -5655,11 +5655,11 @@
       <h1>
         ToLength (
           _argument_: an ECMAScript language value,
-        ): either a normal completion containing an integral Number or a throw completion
+        ): either a normal completion containing a non-negative integral Number or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It clamps and truncates _argument_ to an integral Number suitable for use as the length of an array-like object.</dd>
+        <dd>It clamps and truncates _argument_ to a non-negative integral Number suitable for use as the length of an array-like object.</dd>
       </dl>
       <emu-alg>
         1. Let _len_ be ? ToIntegerOrInfinity(_argument_).


### PR DESCRIPTION
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->

In current ECMA262 specification, the abstract operation [`ToLength`](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-tolength) returns a integer or throw completion.   
However, I think that type of the return value of [`ToLength`](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-tolength) can be narrowed to a *non-negative* integer or throw completion.
