### PR TITLE
Editorial: Narrow `integer` into `non-negative integer` in return type of ExpectedArgumentCount

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -23286,7 +23286,7 @@
     </emu-clause>
 
     <emu-clause id="sec-static-semantics-expectedargumentcount" oldids="sec-function-definitions-static-semantics-expectedargumentcount,sec-arrow-function-definitions-static-semantics-expectedargumentcount,sec-method-definitions-static-semantics-expectedargumentcount,sec-async-arrow-function-definitions-static-semantics-ExpectedArgumentCount" type="sdo">
-      <h1>Static Semantics: ExpectedArgumentCount ( ): an integer</h1>
+      <h1>Static Semantics: ExpectedArgumentCount ( ): a non-negative integer</h1>
       <dl class="header">
       </dl>
       <emu-grammar>


### PR DESCRIPTION
I carefully assume that the return type of [`ExpectedArgumentCount`](https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-static-semantics-expectedargumentcount) can be narrowed into `non-negative integer`, which is `integer` in current specification. 
The reason why I suggest this PR is that the return type of the ExpectedArgumentCount is integer makes type mismatching in [`OrdinaryFunctionCreate`](https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-ordinaryfunctioncreate) and [`SetFunctionLength`](https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-setfunctionlength).
