### PR TITLE
Editorial: Add assertion that generatorKind is not non-generator

### DIFF
--- a/esmeta-ignore.json
+++ b/esmeta-ignore.json
@@ -8,6 +8,5 @@
   "GetViewByteLength",
   "INTRINSICS.Atomics.notify",
   "Record[SourceTextModuleRecord].ExecuteModule",
-  "TypedArrayLength",
-  "YieldExpression[2,0].Evaluation"
+  "TypedArrayLength"
 ]

--- a/spec.html
+++ b/spec.html
@@ -24254,6 +24254,7 @@
       <emu-grammar>YieldExpression : `yield` `*` AssignmentExpression</emu-grammar>
       <emu-alg>
         1. Let _generatorKind_ be GetGeneratorKind().
+        1. Assert: _generatorKind_ is either ~sync~ or ~async~.
         1. Let _exprRef_ be ? Evaluation of |AssignmentExpression|.
         1. Let _value_ be ? GetValue(_exprRef_).
         1. Let _iteratorRecord_ be ? GetIterator(_value_, _generatorKind_).


### PR DESCRIPTION
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
According to [runtime semantics of `_YieldExpression_ : yield * _AssignmentExpression_` evaluation](https://tc39.es/ecma262/#_ref_7471), `_generatorKind_` is NON-GENERATOR, SYNC, or ASYNC. However, the type of second parameter of [`GetIterator`](https://tc39.es/ecma262/#sec-getiterator) is SYNC or ASYNC in current specification. This is type-mismatch. I think [`GetGeneratorKind`](https://tc39.es/ecma262/#sec-getgeneratorkind) cannot return NON-GENERATOR in this case, so this PR includes adding assertion that `generatorKind` is not NON-GENERATOR.