### PR TITLE
Editorial: Widen parameter type of CreateDynamicFunction

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -30299,7 +30299,7 @@
           <h1>
             CreateDynamicFunction (
               _constructor_: a constructor,
-              _newTarget_: a constructor,
+              _newTarget_: a constructor or *undefined*,
               _kind_: ~normal~, ~generator~, ~async~, or ~async-generator~,
               _parameterArgs_: a List of ECMAScript language values,
               _bodyArg_: an ECMAScript language value,


### PR DESCRIPTION
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
According to the current specification, type of the `newTarget` in [`CreateDynamicFunction`](https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-createdynamicfunction) needs to be a `constructor`. However, there is the case that `newTarget` is **undefined** as follows:
```javascript
Function();
```
When this code executes, [`Function`](https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-function-p1-p2-pn-body) calls `CreateDynamicFunction` in third step as follows:
```html
<emu-alg>
1. Let _C_ be the active function object.
1. If _bodyArg_ is not present, set _bodyArg_ to the empty String.
1. Return ? CreateDynamicFunction(_C_, NewTarget, ~normal~, _parameterArgs_, _bodyArg_).
</emu-alg>
```

In this situation, **undefined** is assigned to `NewTarget` . Therefore, type-mismatch occurs in the parameter `newTarget` of `CreateDynamicFunction`. Therefore, I think that the parameter type of the `newTarget` should be widened into a constructor or **undefined**.