### PR TITLE
Editorial: Initialize [[GeneratorState]] and [[AsyncGeneratorState]]

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -23980,6 +23980,7 @@
         1. Perform ? FunctionDeclarationInstantiation(_functionObject_, _argumentsList_).
         1. Let _G_ be ? OrdinaryCreateFromConstructor(_functionObject_, *"%GeneratorFunction.prototype.prototype%"*, « [[GeneratorState]], [[GeneratorContext]], [[GeneratorBrand]] »).
         1. Set _G_.[[GeneratorBrand]] to ~empty~.
+        1. Set _G_.[[GeneratorState]] to ~suspended-start~.
         1. Perform GeneratorStart(_G_, |FunctionBody|).
         1. Return Completion Record { [[Type]]: ~return~, [[Value]]: _G_, [[Target]]: ~empty~ }.
       </emu-alg>
@@ -24207,6 +24208,7 @@
         1. Perform ? FunctionDeclarationInstantiation(_functionObject_, _argumentsList_).
         1. Let _generator_ be ? OrdinaryCreateFromConstructor(_functionObject_, *"%AsyncGeneratorFunction.prototype.prototype%"*, « [[AsyncGeneratorState]], [[AsyncGeneratorContext]], [[AsyncGeneratorQueue]], [[GeneratorBrand]] »).
         1. Set _generator_.[[GeneratorBrand]] to ~empty~.
+        1. Set _generator_.[[AsyncGeneratorState]] to ~suspended-start~.
         1. Perform AsyncGeneratorStart(_generator_, |FunctionBody|).
         1. Return Completion Record { [[Type]]: ~return~, [[Value]]: _generator_, [[Target]]: ~empty~ }.
       </emu-alg>
@@ -48045,7 +48047,7 @@ THH:mm:ss.sss
               [[GeneratorState]]
             </td>
             <td>
-              *undefined*, ~suspended-start~, ~suspended-yield~, ~executing~, or ~completed~
+              ~suspended-start~, ~suspended-yield~, ~executing~, or ~completed~
             </td>
             <td>
               The current execution state of the generator.
@@ -48090,7 +48092,7 @@ THH:mm:ss.sss
         <dl class="header">
         </dl>
         <emu-alg>
-          1. Assert: The value of _generator_.[[GeneratorState]] is *undefined*.
+          1. Assert: The value of _generator_.[[GeneratorState]] is ~suspended-start~.
           1. Let _genContext_ be the running execution context.
           1. Set the Generator component of _genContext_ to _generator_.
           1. Let _closure_ be a new Abstract Closure with no parameters that captures _generatorBody_ and performs the following steps when called:
@@ -48115,7 +48117,6 @@ THH:mm:ss.sss
             1. Return CreateIteratorResultObject(_resultValue_, *true*).
           1. Set the code evaluation state of _genContext_ such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
           1. Set _generator_.[[GeneratorContext]] to _genContext_.
-          1. Set _generator_.[[GeneratorState]] to ~suspended-start~.
           1. Return ~unused~.
         </emu-alg>
       </emu-clause>
@@ -48389,7 +48390,7 @@ THH:mm:ss.sss
           </thead>
           <tr>
             <td>[[AsyncGeneratorState]]</td>
-            <td>*undefined*, ~suspended-start~, ~suspended-yield~, ~executing~, ~draining-queue~, or ~completed~</td>
+            <td>~suspended-start~, ~suspended-yield~, ~executing~, ~draining-queue~, or ~completed~</td>
             <td>The current execution state of the async generator.</td>
           </tr>
           <tr>
@@ -48451,7 +48452,7 @@ THH:mm:ss.sss
         <dl class="header">
         </dl>
         <emu-alg>
-          1. Assert: _generator_.[[AsyncGeneratorState]] is *undefined*.
+          1. Assert: _generator_.[[AsyncGeneratorState]] is ~suspended-start~.
           1. Let _genContext_ be the running execution context.
           1. Set the Generator component of _genContext_ to _generator_.
           1. Let _closure_ be a new Abstract Closure with no parameters that captures _generatorBody_ and performs the following steps when called:
@@ -48472,7 +48473,6 @@ THH:mm:ss.sss
             1. Return *undefined*.
           1. Set the code evaluation state of _genContext_ such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
           1. Set _generator_.[[AsyncGeneratorContext]] to _genContext_.
-          1. Set _generator_.[[AsyncGeneratorState]] to ~suspended-start~.
           1. Set _generator_.[[AsyncGeneratorQueue]] to a new empty List.
           1. Return ~unused~.
         </emu-alg>


### PR DESCRIPTION
In the [GeneratorStart](https://tc39.es/ecma262/#sec-generatorstart) AO, the first step is the following assertion:
```
GeneratorStart (
  _generator_: a Generator,
  _generatorBody_: a |FunctionBody| Parse Node or an Abstract Closure with no parameters,
): ~unused~
...
1. Assert: The value of _generator_.[[GeneratorState]] is *undefined*.
```
However, in the [EvaluateGeneratorBody](https://tc39.es/ecma262/#sec-runtime-semantics-evaluategeneratorbody) SDO for [GeneratorBody](https://tc39.es/ecma262/#prod-GeneratorBody), there is no initialization of the `[[GeneratorState]]` internal slot for the variable `_G_` before passing it into the [GeneratorStart](https://tc39.es/ecma262/#sec-generatorstart) AO:
```
Runtime Semantics: EvaluateGeneratorBody (
  _functionObject_: an ECMAScript function object,
  _argumentsList_: a List of ECMAScript language values,
): a throw completion or a return completion
...
2. Let _G_ be ? OrdinaryCreateFromConstructor(_functionObject_, *"%GeneratorFunction.prototype.prototype%"*, « [[GeneratorState]], [[GeneratorContext]], [[GeneratorBrand]] »).
3. Set _G_.[[GeneratorBrand]] to ~empty~.
4. Perform GeneratorStart(_G_, |FunctionBody|).
...
```
I think we need to initialize the `[[GeneratorState]]` with `*undefined*`, similar to the following 5th step in the [CreateIteratorFromClosure](https://tc39.es/ecma262/#sec-createiteratorfromclosure) AO:
```
CreateIteratorFromClosure (
  _closure_: an Abstract Closure with no parameters,
  _generatorBrand_: a String or ~empty~,
  _generatorPrototype_: an Object,
): a Generator
...
3. Let _generator_ be OrdinaryObjectCreate(_generatorPrototype_, _internalSlotsList_).
4. Set _generator_.[[GeneratorBrand]] to _generatorBrand_.
5. Set _generator_.[[GeneratorState]] to *undefined*.
...
13. Perform GeneratorStart(_generator_, _closure_).
...
```
I found a similar issue in the [EvaluateAsyncGeneratorBody](https://tc39.es/ecma262/#sec-runtime-semantics-evaluateasyncgeneratorbody) SDO for the [AsyncGeneratorBody](https://tc39.es/ecma262/#prod-AsyncGeneratorBody).