### PR TITLE
Editorial: rename IDs that were embedded in emu-grammar elements back

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -17851,7 +17851,7 @@
 
           AsyncArrowFunction[In, Yield, Await] :
             `async` [no LineTerminator here] AsyncArrowBindingIdentifier[?Yield] [no LineTerminator here] `=>` AsyncConciseBody[?In]
-            CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await] [no LineTerminator here] `=>` AsyncConciseBody[?In] #callCover
+            CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await] [no LineTerminator here] `=>` AsyncConciseBody[?In] #callcover
 
           AsyncArrowHead :
             `async` [no LineTerminator here] ArrowFormalParameters[~Yield, +Await]
@@ -18209,7 +18209,7 @@
         AsyncGeneratorExpression
         RegularExpressionLiteral
         TemplateLiteral[?Yield, ?Await, ~Tagged]
-        CoverParenthesizedExpressionAndArrowParameterList[?Yield, ?Await] #parenCover
+        CoverParenthesizedExpressionAndArrowParameterList[?Yield, ?Await] #parencover
 
       CoverParenthesizedExpressionAndArrowParameterList[Yield, Await] :
         `(` Expression[+In, ?Yield, ?Await] `)`
@@ -18998,7 +18998,7 @@
         `new` NewExpression[?Yield, ?Await]
 
       CallExpression[Yield, Await] :
-        CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await] #callCover
+        CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await] #callcover
         SuperCall[?Yield, ?Await]
         ImportCall[?Yield, ?Await]
         CallExpression[?Yield, ?Await] Arguments[?Yield, ?Await]
@@ -23549,7 +23549,7 @@
 
       ArrowParameters[Yield, Await] :
         BindingIdentifier[?Yield, ?Await]
-        CoverParenthesizedExpressionAndArrowParameterList[?Yield, ?Await] #parenCover
+        CoverParenthesizedExpressionAndArrowParameterList[?Yield, ?Await] #parencover
 
       ConciseBody[In] :
         [lookahead != `{`] ExpressionBody[?In, ~Await]
@@ -25254,7 +25254,7 @@
     <emu-grammar type="definition">
       AsyncArrowFunction[In, Yield, Await] :
         `async` [no LineTerminator here] AsyncArrowBindingIdentifier[?Yield] [no LineTerminator here] `=>` AsyncConciseBody[?In]
-        CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await] [no LineTerminator here] `=>` AsyncConciseBody[?In] #callCover
+        CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await] [no LineTerminator here] `=>` AsyncConciseBody[?In] #callcover
 
       AsyncConciseBody[In] :
         [lookahead != `{`] ExpressionBody[?In, +Await]
@@ -49911,7 +49911,7 @@ THH:mm:ss.sss
     <emu-prodref name="CoverParenthesizedExpressionAndArrowParameterList"></emu-prodref>
     <p>
       When processing an instance of the production<br>
-      <emu-prodref name="PrimaryExpression" a="parenCover"></emu-prodref><br>
+      <emu-prodref name="PrimaryExpression" a="parencover"></emu-prodref><br>
       the interpretation of |CoverParenthesizedExpressionAndArrowParameterList| is refined using the following grammar:
     </p>
     <emu-prodref name="ParenthesizedExpression"></emu-prodref>
@@ -49942,7 +49942,7 @@ THH:mm:ss.sss
     <emu-prodref name="CallExpression"></emu-prodref>
     <p>
       When processing an instance of the production<br>
-      <emu-prodref name="CallExpression" a="callCover"></emu-prodref><br>
+      <emu-prodref name="CallExpression" a="callcover"></emu-prodref><br>
       the interpretation of |CoverCallExpressionAndAsyncArrowHead| is refined using the following grammar:
     </p>
     <emu-prodref name="CallMemberExpression"></emu-prodref>
@@ -50068,7 +50068,7 @@ THH:mm:ss.sss
     <emu-prodref name="ExpressionBody"></emu-prodref>
     <p>
       When processing an instance of the production<br>
-      <emu-prodref name="ArrowParameters" a="parenCover"></emu-prodref><br>
+      <emu-prodref name="ArrowParameters" a="parencover"></emu-prodref><br>
       the interpretation of |CoverParenthesizedExpressionAndArrowParameterList| is refined using the following grammar:
     </p>
     <emu-prodref name="ArrowFormalParameters"></emu-prodref>
@@ -50079,7 +50079,7 @@ THH:mm:ss.sss
     <emu-prodref name="CoverCallExpressionAndAsyncArrowHead"></emu-prodref>
     <p>
       When processing an instance of the production<br>
-      <emu-prodref name="AsyncArrowFunction" a="callCover"></emu-prodref><br>
+      <emu-prodref name="AsyncArrowFunction" a="callcover"></emu-prodref><br>
       the interpretation of |CoverCallExpressionAndAsyncArrowHead| is refined using the following grammar:
     </p>
     <emu-prodref name="AsyncArrowHead"></emu-prodref>


### PR DESCRIPTION
These were missed before landing https://github.com/tc39/ecma262/pull/3335.