### PR TITLE
Meta: do not npm audit in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ljharb/actions/node/install@d9f477827ed71a259056764107f74afc29febcae
-        name: 'nvm install lts/* && npm ci'
+        name: 'nvm install lts/* && npm ci --no-audit'
+        env:
+          NPM_CONFIG_AUDIT: false
         with:
           node-version: lts/*
           use-npm-ci: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ljharb/actions/node/install@d9f477827ed71a259056764107f74afc29febcae
-        name: 'nvm install lts/* && npm ci'
+        name: 'nvm install lts/* && npm ci --no-audit'
+        env:
+          NPM_CONFIG_AUDIT: false
         with:
           node-version: lts/*
           use-npm-ci: true

--- a/.github/workflows/enforce-format.yml
+++ b/.github/workflows/enforce-format.yml
@@ -10,7 +10,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ljharb/actions/node/install@d9f477827ed71a259056764107f74afc29febcae
-        name: 'nvm install lts/* && npm ci'
+        name: 'nvm install lts/* && npm ci --no-audit'
+        env:
+          NPM_CONFIG_AUDIT: false
         with:
           node-version: lts/*
           use-npm-ci: true

--- a/.github/workflows/ipr.yml
+++ b/.github/workflows/ipr.yml
@@ -16,7 +16,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ljharb/actions/node/install@d9f477827ed71a259056764107f74afc29febcae
-        name: 'nvm install lts/* && npm ci'
+        name: 'nvm install lts/* && npm ci --no-audit'
+        env:
+          NPM_CONFIG_AUDIT: false
         with:
           node-version: lts/*
           use-npm-ci: true

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -10,7 +10,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ljharb/actions/node/install@d9f477827ed71a259056764107f74afc29febcae
-        name: 'nvm install lts/* && npm ci'
+        name: 'nvm install lts/* && npm ci --no-audit'
+        env:
+          NPM_CONFIG_AUDIT: false
         with:
           node-version: lts/*
           use-npm-ci: true

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -20,7 +20,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ljharb/actions/node/install@d9f477827ed71a259056764107f74afc29febcae
-        name: 'nvm install lts/* && npm ci'
+        name: 'nvm install lts/* && npm ci --no-audit'
+        env:
+          NPM_CONFIG_AUDIT: false
         with:
           node-version: lts/*
           use-npm-ci: true

--- a/.github/workflows/publish-biblio.yml
+++ b/.github/workflows/publish-biblio.yml
@@ -24,7 +24,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --no-audit
 
       - name: Publish biblio
         run: scripts/publish-biblio.sh

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -15,7 +15,9 @@ jobs:
           # Default: 1
           fetch-depth: 0
       - uses: ljharb/actions/node/install@d9f477827ed71a259056764107f74afc29febcae
-        name: 'nvm install lts/* && npm ci'
+        name: 'nvm install lts/* && npm ci --no-audit'
+        env:
+          NPM_CONFIG_AUDIT: false
         with:
           node-version: lts/*
           use-npm-ci: true


### PR DESCRIPTION
This is just a waste of time in automation; it's crazy that it's the default behavior for `npm ci`.

~~edit: apparently the bit I changed is just the name of the step, not the actual command being run, oops~~ (fixed, thanks jordan)