### PR TITLE
Markup: Update broken link in `Number::toString`

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -2370,7 +2370,7 @@
             <p>Implementers of ECMAScript may find useful the paper and code written by David M. Gay for binary-to-decimal conversion of floating-point numbers:</p>
             <p>
               Gay, David M. Correctly Rounded Binary-Decimal and Decimal-Binary Conversions. Numerical Analysis, Manuscript 90-10. AT&amp;T Bell Laboratories (Murray Hill, New Jersey). 30 November 1990. Available as<br>
-              <a href="http://ampl.com/REFS/abstracts.html#rounding">http://ampl.com/REFS/abstracts.html#rounding</a>. Associated code available as<br>
+              <a href="https://ampl.com/_archive/first-website/REFS/rounding.pdf">https://ampl.com/_archive/first-website/REFS/rounding.pdf</a>. Associated code available as<br>
               <a href="http://netlib.sandia.gov/fp/dtoa.c">http://netlib.sandia.gov/fp/dtoa.c</a> and as<br>
               <a href="http://netlib.sandia.gov/fp/g_fmt.c">http://netlib.sandia.gov/fp/g_fmt.c</a> and may also be found at the various `netlib` mirror sites.
             </p>


### PR DESCRIPTION
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
This PR replaces the broken URL link  `http://ampl.com/REFS/abstracts.html#rounding` to the latest `https://ampl.com/_archive/first-website/REFS/rounding.pdf` in Note 3 of in Note 3 of https://tc39.es/ecma262/#sec-numeric-types-number-tostring

Fixes #3389
