### PR TITLE
Editorial: Assert that Evaluation in JSON.parse does not throw

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -45626,9 +45626,8 @@ THH:mm:ss.sss
         1. [id="step-json-parse-parse"] Let _script_ be ParseText(_scriptString_, |Script|).
         1. NOTE: The early error rules defined in <emu-xref href="#sec-object-initializer-static-semantics-early-errors"></emu-xref> have special handling for the above invocation of ParseText.
         1. Assert: _script_ is a Parse Node.
-        1. [id="step-json-parse-eval"] Let _completion_ be Completion(<emu-meta suppress-effects="user-code">Evaluation of _script_</emu-meta>).
+        1. [id="step-json-parse-eval"] Let _unfiltered_ be ! <emu-meta suppress-effects="user-code">Evaluation of _script_</emu-meta>.
         1. NOTE: The PropertyDefinitionEvaluation semantics defined in <emu-xref href="#sec-runtime-semantics-propertydefinitionevaluation"></emu-xref> have special handling for the above evaluation.
-        1. Let _unfiltered_ be _completion_.[[Value]].
         1. [id="step-json-parse-assert-type"] Assert: _unfiltered_ is either a String, a Number, a Boolean, an Object that is defined by either an |ArrayLiteral| or an |ObjectLiteral|, or *null*.
         1. If IsCallable(_reviver_) is *true*, then
           1. Let _root_ be OrdinaryObjectCreate(%Object.prototype%).


### PR DESCRIPTION
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->

Closes https://github.com/tc39/ecma262/issues/3392

When I opened that issue I was wrongly assuming that array literals longer than 2**32-1 would throw an error when evaluated. This is only true if the array contains holes in one of those too big indexes, which are not valid JSON syntax. What happens in the non-hole case is that the integer-indexed property gets defined without updating the array length, so it does not throw an error.

@michaelficarra and I went through the possible cases and we are confident this indeed never throws, so having ! instead of Completion(...) can help when reading the spec. If there were cases where it can throw, the current usage of Completion(...) is probably wrong anyway because you would want to re-throw the error (`?`), instead of using it as `_unfiltered_`.