### PR TITLE
Normative: extend iterator helper string rejection to all primitives, as per normative conventions

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -7000,14 +7000,13 @@
       <h1>
         GetIteratorFlattenable (
           _obj_: an ECMAScript language value,
-          _stringHandling_: ~iterate-strings~ or ~reject-strings~,
+          _primitiveHandling_: ~iterate-primitives~ or ~reject-primitives~,
         ): either a normal completion containing an Iterator Record or a throw completion
       </h1>
       <dl class="header">
       </dl>
       <emu-alg>
-        1. If _obj_ is not an Object, then
-          1. If _stringHandling_ is ~reject-strings~ or _obj_ is not a String, throw a *TypeError* exception.
+        1. If _primitiveHandling_ is ~reject-primitives~ and _obj_ is not an Object, throw a *TypeError* exception.
         1. Let _method_ be ? GetMethod(_obj_, %Symbol.iterator%).
         1. If _method_ is *undefined*, then
           1. Let _iterator_ be _obj_.
@@ -46574,7 +46573,7 @@ THH:mm:ss.sss
         <emu-clause id="sec-iterator.from">
           <h1>Iterator.from ( _O_ )</h1>
           <emu-alg>
-            1. Let _iteratorRecord_ be ? GetIteratorFlattenable(_O_, ~iterate-strings~).
+            1. Let _iteratorRecord_ be ? GetIteratorFlattenable(_O_, ~iterate-primitives~).
             1. Let _hasInstance_ be ? OrdinaryHasInstance(%Iterator%, _iteratorRecord_.[[Iterator]]).
             1. If _hasInstance_ is *true*, then
               1. Return _iteratorRecord_.[[Iterator]].
@@ -46813,7 +46812,7 @@ THH:mm:ss.sss
               1. If _value_ is ~done~, return *undefined*.
               1. Let _mapped_ be Completion(Call(_mapper_, *undefined*, « _value_, 𝔽(_counter_) »)).
               1. IfAbruptCloseIterator(_mapped_, _iterated_).
-              1. Let _innerIterator_ be Completion(GetIteratorFlattenable(_mapped_, ~reject-strings~)).
+              1. Let _innerIterator_ be Completion(GetIteratorFlattenable(_mapped_, ~reject-primitives~)).
               1. IfAbruptCloseIterator(_innerIterator_, _iterated_).
               1. Let _innerAlive_ be *true*.
               1. Repeat, while _innerAlive_ is *true*,


### PR DESCRIPTION
See https://github.com/tc39/how-we-work/blob/main/normative-conventions.md#reject-primitives-in-iterable-taking-positions. This is currently used by `Iterator.from` and `Iterator.prototype.flatMap`, but only `Iterator.prototype.flatMap` currently uses the rejection feature. Since [joint iteration](https://github.com/tc39/proposal-joint-iteration) and [iterator sequencing](https://github.com/tc39/proposal-iterator-sequencing) both defer to this AO, this will also impact those in-progress proposals and any other features that build off of this shared infrastructure.