### PR TITLE
Editorial: Remove unnecessary `undefined` type from property descriptor tests

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -4599,13 +4599,12 @@
       <emu-clause id="sec-isaccessordescriptor" type="abstract operation">
         <h1>
           IsAccessorDescriptor (
-            _Desc_: a Property Descriptor or *undefined*,
+            _Desc_: a Property Descriptor,
           ): a Boolean
         </h1>
         <dl class="header">
         </dl>
         <emu-alg>
-          1. If _Desc_ is *undefined*, return *false*.
           1. If _Desc_ has a [[Get]] field, return *true*.
           1. If _Desc_ has a [[Set]] field, return *true*.
           1. Return *false*.
@@ -4615,13 +4614,12 @@
       <emu-clause id="sec-isdatadescriptor" type="abstract operation">
         <h1>
           IsDataDescriptor (
-            _Desc_: a Property Descriptor or *undefined*,
+            _Desc_: a Property Descriptor,
           ): a Boolean
         </h1>
         <dl class="header">
         </dl>
         <emu-alg>
-          1. If _Desc_ is *undefined*, return *false*.
           1. If _Desc_ has a [[Value]] field, return *true*.
           1. If _Desc_ has a [[Writable]] field, return *true*.
           1. Return *false*.
@@ -4631,13 +4629,12 @@
       <emu-clause id="sec-isgenericdescriptor" type="abstract operation">
         <h1>
           IsGenericDescriptor (
-            _Desc_: a Property Descriptor or *undefined*,
+            _Desc_: a Property Descriptor,
           ): a Boolean
         </h1>
         <dl class="header">
         </dl>
         <emu-alg>
-          1. If _Desc_ is *undefined*, return *false*.
           1. If IsAccessorDescriptor(_Desc_) is *true*, return *false*.
           1. If IsDataDescriptor(_Desc_) is *true*, return *false*.
           1. Return *true*.
@@ -14253,6 +14250,7 @@
             1. Return ? ArraySetLength(_A_, _Desc_).
           1. Else if _P_ is an array index, then
             1. Let _lengthDesc_ be OrdinaryGetOwnProperty(_A_, *"length"*).
+            1. Assert: _lengthDesc_ is not *undefined*.
             1. Assert: IsDataDescriptor(_lengthDesc_) is *true*.
             1. Assert: _lengthDesc_.[[Configurable]] is *false*.
             1. Let _length_ be _lengthDesc_.[[Value]].
@@ -14342,6 +14340,7 @@
           1. If SameValueZero(_newLen_, _numberLen_) is *false*, throw a *RangeError* exception.
           1. Set _newLenDesc_.[[Value]] to _newLen_.
           1. Let _oldLenDesc_ be OrdinaryGetOwnProperty(_A_, *"length"*).
+          1. Assert: _oldLenDesc_ is not *undefined*.
           1. Assert: IsDataDescriptor(_oldLenDesc_) is *true*.
           1. Assert: _oldLenDesc_.[[Configurable]] is *false*.
           1. Let _oldLen_ be _oldLenDesc_.[[Value]].


### PR DESCRIPTION
`Is{Accessor,Data,Generic}Descriptor` are never called with `undefined`.

---

[StructuredSerializeInternal](https://html.spec.whatwg.org/#structuredserializeinternal) seems to be the only caller where `undefined` is ever used as an input. 