### PR TITLE
Editorial: OrdinaryDefineOwnProperty can't throw for ordinary objects and arrays

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -12671,14 +12671,14 @@
         [[DefineOwnProperty]] (
           _P_: a property key,
           _Desc_: a Property Descriptor,
-        ): either a normal completion containing a Boolean or a throw completion
+        ): a normal completion containing a Boolean
       </h1>
       <dl class="header">
         <dt>for</dt>
         <dd>an ordinary object _O_</dd>
       </dl>
       <emu-alg>
-        1. Return ? OrdinaryDefineOwnProperty(_O_, _P_, _Desc_).
+        1. Return ! OrdinaryDefineOwnProperty(_O_, _P_, _Desc_).
       </emu-alg>
 
       <emu-clause id="sec-ordinarydefineownproperty" type="abstract operation">
@@ -12690,6 +12690,8 @@
           ): either a normal completion containing a Boolean or a throw completion
         </h1>
         <dl class="header">
+          <dt>skip global checks</dt>
+          <dd>true</dd>
         </dl>
         <emu-alg>
           1. Let _current_ be ? <emu-meta effects="user-code">_O_.[[GetOwnProperty]]</emu-meta>(_P_).
@@ -14092,7 +14094,7 @@
               1. Set _succeeded_ to ! OrdinaryDefineOwnProperty(_A_, *"length"*, _lengthDesc_).
               1. Assert: _succeeded_ is *true*.
             1. Return *true*.
-          1. Return ? OrdinaryDefineOwnProperty(_A_, _P_, _Desc_).
+          1. Return ! OrdinaryDefineOwnProperty(_A_, _P_, _Desc_).
         </emu-alg>
       </emu-clause>
 


### PR DESCRIPTION
`OrdinaryDefineOwnProperty` can return an abrupt completion if either `O.[[GetOwnProperty]]` or `IsExtensible(O)` returns an abrupt completion. When `O` is an ordinary object or an array, neither `O.[[GetOwnProperty]]` nor `IsExtensible(O)` can return an abrupt completion, therefore `OrdinaryDefineOwnProperty` is infallible.
