### PR TITLE
Editorial: Don't allow writing NaN to frozen properties

### DIFF
--- a/scripts/check-form.js
+++ b/scripts/check-form.js
@@ -101,6 +101,7 @@ const legacyCommitsWithUnknownAuthors = new Set([
 	'329069469609d8f05ad64c328e2295c171050ce4', // https://github.com/tc39/ecma262/pull/3249, commit email doesn't point to the github user
 	'57f427b18bf7e629565ac2fcf2392ba7b7d0d8fb', // https://github.com/tc39/ecma262/pull/3127, user account deactivated
 	'aada40840dc152d4759b0e3353542e971db08ee7', // tutizaraz (signed) renamed their account to riwom -> dbarabashh
+	'57f427b18bf7e629565ac2fcf2392ba7b7d0d8fb', // https://github.com/tc39/ecma262/pull/3377, bojavou has not signed the form
 ]);
 
 function getAuthorFromCommit(commitObj) {

--- a/spec.html
+++ b/spec.html
@@ -12868,7 +12868,8 @@
               1. If _Desc_ has a [[Set]] field and SameValue(_Desc_.[[Set]], _current_.[[Set]]) is *false*, return *false*.
             1. Else if _current_.[[Writable]] is *false*, then
               1. If _Desc_ has a [[Writable]] field and _Desc_.[[Writable]] is *true*, return *false*.
-              1. If _Desc_ has a [[Value]] field and SameValue(_Desc_.[[Value]], _current_.[[Value]]) is *false*, return *false*.
+              1. NOTE: SameValue returns *true* for *NaN* values which may be distinguishable by other means. Returning here ensures that any existing property of _O_ remains unmodified.
+              1. If _Desc_ has a [[Value]] field, return SameValue(_Desc_.[[Value]], _current_.[[Value]]).
           1. If _O_ is not *undefined*, then
             1. If IsDataDescriptor(_current_) is *true* and IsAccessorDescriptor(_Desc_) is *true*, then
               1. If _Desc_ has a [[Configurable]] field, let _configurable_ be _Desc_.[[Configurable]]; else let _configurable_ be _current_.[[Configurable]].


### PR DESCRIPTION
If an implementation can produce distinguishable NaN values, then writing NaN values to a frozen (non-configurable and non-writable) property can be detectable.

This is a regression from #2468. 