### PR TITLE
Normative: simplify OrdinaryGetOwnProperty algorithm

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -12649,9 +12649,9 @@
         <dl class="header">
         </dl>
         <emu-alg>
-          1. If _O_ does not have an own property with key _P_, return *undefined*.
-          1. Let _D_ be a newly created Property Descriptor with no fields.
           1. Let _X_ be _O_'s own property whose key is _P_.
+          1. If _X_ is *undefined*, return *undefined*.
+          1. Let _D_ be a newly created Property Descriptor with no fields.
           1. If _X_ is a data property, then
             1. Set _D_.[[Value]] to the value of _X_'s [[Value]] attribute.
             1. Set _D_.[[Writable]] to the value of _X_'s [[Writable]] attribute.


### PR DESCRIPTION
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->

These two operations can be simplified.
- `If _O_ does not have an own property with key _P_, return *undefined*`
- `Let _X_ be _O_'s own property whose key is _P_.`

Because in the first step, we need to access `O[p]`, and in the second step, we need to access `O[p]` again. While implementers can simplify these two steps into one, wouldn't it be better to directly simplify the description of these steps?