### PR TITLE
Editorial: avoid field enumeration in ValidateAndApplyPropertyDescriptor

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -12759,7 +12759,13 @@
               1. If _Desc_ has a [[Enumerable]] field, let _enumerable_ be _Desc_.[[Enumerable]]; else let _enumerable_ be _current_.[[Enumerable]].
               1. Replace the property named _P_ of object _O_ with a data property whose [[Configurable]] and [[Enumerable]] attributes are set to _configurable_ and _enumerable_, respectively, and whose [[Value]] and [[Writable]] attributes are set to the value of the corresponding field in _Desc_ if _Desc_ has that field, or to the attribute's <emu-xref href="#table-object-property-attributes">default value</emu-xref> otherwise.
             1. Else,
-              1. For each field of _Desc_, set the corresponding attribute of the property named _P_ of object _O_ to the value of the field.
+              1. Let _prop_ be the property of object _O_ whose key is _P_.
+              1. If _Desc_ has a [[Configurable]] field, set the [[Configurable]] attribute of _prop_ to _Desc_.[[Configurable]].
+              1. If _Desc_ has a [[Enumerable]] field, set the [[Enumerable]] attribute of _prop_ to _Desc_.[[Enumerable]].
+              1. If _Desc_ has a [[Writable]] field, set the [[Writable]] attribute of _prop_ to _Desc_.[[Writable]].
+              1. If _Desc_ has a [[Value]] field, set the [[Value]] attribute of _prop_ to _Desc_.[[Value]].
+              1. If _Desc_ has a [[Get]] field, set the [[Get]] attribute of _prop_ to _Desc_.[[Get]].
+              1. If _Desc_ has a [[Set]] field, set the [[Set]] attribute of _prop_ to _Desc_.[[Set]].
           1. Return *true*.
         </emu-alg>
       </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -12761,7 +12761,7 @@
             1. Else,
               1. Let _prop_ be the property of object _O_ whose key is _P_.
               1. If _Desc_ has a [[Configurable]] field, set the [[Configurable]] attribute of _prop_ to _Desc_.[[Configurable]].
-              1. If _Desc_ has a [[Enumerable]] field, set the [[Enumerable]] attribute of _prop_ to _Desc_.[[Enumerable]].
+              1. If _Desc_ has an [[Enumerable]] field, set the [[Enumerable]] attribute of _prop_ to _Desc_.[[Enumerable]].
               1. If _Desc_ has a [[Writable]] field, set the [[Writable]] attribute of _prop_ to _Desc_.[[Writable]].
               1. If _Desc_ has a [[Value]] field, set the [[Value]] attribute of _prop_ to _Desc_.[[Value]].
               1. If _Desc_ has a [[Get]] field, set the [[Get]] attribute of _prop_ to _Desc_.[[Get]].


### PR DESCRIPTION
I didn't like the hand-waviness of enumerating Property Descriptor fields and then having to know that the corresponding property attribute is the one that is denoted the same as the Property Descriptor field. I prefer the explicitness here. There's similar opportunities to tighten up other hand-wavy steps in this AO, but none were as egregious as this one to me.