### PR TITLE
Editorial: [[HomeObject]] is always an ordinary object

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -10796,7 +10796,7 @@
         </emu-clause>
 
         <emu-clause id="sec-getsuperbase" type="concrete method">
-          <h1>GetSuperBase ( ): either a normal completion containing either an Object, *null*, or *undefined*, or a throw completion</h1>
+          <h1>GetSuperBase ( ): an Object, *null*, or *undefined*</h1>
           <dl class="header">
             <dt>for</dt>
             <dd>a Function Environment Record _envRec_</dd>
@@ -10804,8 +10804,8 @@
           <emu-alg>
             1. Let _home_ be _envRec_.[[FunctionObject]].[[HomeObject]].
             1. If _home_ is *undefined*, return *undefined*.
-            1. Assert: _home_ is an Object.
-            1. Return ? <emu-meta effects="user-code">_home_.[[GetPrototypeOf]]</emu-meta>().
+            1. Assert: _home_ is an ordinary object.
+            1. Return ! _home_.[[GetPrototypeOf]]().
           </emu-alg>
         </emu-clause>
       </emu-clause>
@@ -13718,6 +13718,7 @@
         <dd>It configures _F_ as a method.</dd>
       </dl>
       <emu-alg>
+        1. Assert: _homeObject_ is an ordinary object.
         1. Set _F_.[[HomeObject]] to _homeObject_.
         1. Return ~unused~.
       </emu-alg>
@@ -19446,7 +19447,7 @@
           1. Let _propertyNameValue_ be ? GetValue(_propertyNameReference_).
           1. Let _strict_ be IsStrict(this |SuperProperty|).
           1. NOTE: In most cases, ToPropertyKey will be performed on _propertyNameValue_ immediately after this step. However, in the case of `super[b] = c`, it will not be performed until after evaluation of `c`.
-          1. Return ? MakeSuperPropertyReference(_actualThis_, _propertyNameValue_, _strict_).
+          1. Return MakeSuperPropertyReference(_actualThis_, _propertyNameValue_, _strict_).
         </emu-alg>
         <emu-grammar>SuperProperty : `super` `.` IdentifierName</emu-grammar>
         <emu-alg>
@@ -19454,7 +19455,7 @@
           1. Let _actualThis_ be ? _env_.GetThisBinding().
           1. Let _propertyKey_ be the StringValue of |IdentifierName|.
           1. Let _strict_ be IsStrict(this |SuperProperty|).
-          1. Return ? MakeSuperPropertyReference(_actualThis_, _propertyKey_, _strict_).
+          1. Return MakeSuperPropertyReference(_actualThis_, _propertyKey_, _strict_).
         </emu-alg>
         <emu-grammar>SuperCall : `super` Arguments</emu-grammar>
         <emu-alg>
@@ -19493,14 +19494,14 @@
             _actualThis_: an ECMAScript language value,
             _propertyKey_: an ECMAScript language value,
             _strict_: a Boolean,
-          ): either a normal completion containing a Super Reference Record or a throw completion
+          ): a Super Reference Record
         </h1>
         <dl class="header">
         </dl>
         <emu-alg>
           1. Let _env_ be GetThisEnvironment().
           1. Assert: _env_.HasSuperBinding() is *true*.
-          1. Let _baseValue_ be ? _env_.GetSuperBase().
+          1. Let _baseValue_ be _env_.GetSuperBase().
           1. Return the Reference Record { [[Base]]: _baseValue_, [[ReferencedName]]: _propertyKey_, [[Strict]]: _strict_, [[ThisValue]]: _actualThis_ }.
         </emu-alg>
       </emu-clause>


### PR DESCRIPTION
`[[HomeObject]]` is always set to an ordinary object (or `undefined`). Assert this in `MakeMethod` and `GetSuperBase`. `GetSuperBase` and `MakeSuperPropertyReference` are now both also infallible.
