### PR TITLE
Editorial: `CreateListFromArrayLike`: change element type list to a 2-state enum

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -6471,7 +6471,7 @@
       <h1>
         CreateListFromArrayLike (
           _obj_: an ECMAScript language value,
-          optional _elementTypes_: a List of names of ECMAScript Language Types,
+          optional _requirePropertyKeys_: a boolean,
         ): either a normal completion containing a List of ECMAScript language values or a throw completion
       </h1>
       <dl class="header">
@@ -6479,7 +6479,6 @@
         <dd>It is used to create a List value whose elements are provided by the indexed properties of _obj_. _elementTypes_ contains the names of ECMAScript Language Types that are allowed for element values of the List that is created.</dd>
       </dl>
       <emu-alg>
-        1. If _elementTypes_ is not present, set _elementTypes_ to « Undefined, Null, Boolean, String, Symbol, Number, BigInt, Object ».
         1. If _obj_ is not an Object, throw a *TypeError* exception.
         1. Let _len_ be ? LengthOfArrayLike(_obj_).
         1. Let _list_ be a new empty List.
@@ -6487,7 +6486,7 @@
         1. Repeat, while _index_ &lt; _len_,
           1. Let _indexName_ be ! ToString(𝔽(_index_)).
           1. Let _next_ be ? Get(_obj_, _indexName_).
-          1. If _elementTypes_ does not contain Type(_next_), throw a *TypeError* exception.
+          1. If _requirePropertyKeys_ is *true* and _next_ is not a property key, throw a *TypeError* exception.
           1. Append _next_ to _list_.
           1. Set _index_ to _index_ + 1.
         1. Return _list_.
@@ -15885,7 +15884,7 @@
         1. If _trap_ is *undefined*, then
           1. Return ? <emu-meta effects="user-code">_target_.[[OwnPropertyKeys]]()</emu-meta>.
         1. Let _trapResultArray_ be ? Call(_trap_, _handler_, « _target_ »).
-        1. Let _trapResult_ be ? CreateListFromArrayLike(_trapResultArray_, « String, Symbol »).
+        1. Let _trapResult_ be ? CreateListFromArrayLike(_trapResultArray_, *true*).
         1. If _trapResult_ contains any duplicate entries, throw a *TypeError* exception.
         1. Let _extensibleTarget_ be ? IsExtensible(_target_).
         1. Let _targetKeys_ be ? <emu-meta effects="user-code">_target_.[[OwnPropertyKeys]]()</emu-meta>.


### PR DESCRIPTION
Per editor call discussion.

Related: #3339.