### PR TITLE
Editorial: add a ReturnCompletion AO, mirroring NormalCompletion/ThrowCompletion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://tc39.es/ecma262/#sec-copyright-and-software-license",
       "devDependencies": {
-        "ecmarkup": "^19.0.0",
+        "ecmarkup": "^19.1.0",
         "glob": "^7.1.6",
         "jsdom": "^15.0.0",
         "pagedjs": "^0.4.3",
@@ -1243,9 +1243,9 @@
       }
     },
     "node_modules/ecmarkup": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-19.0.0.tgz",
-      "integrity": "sha512-ncn5LXs46jPqcQSO/XdJCOOsdAvC8xT/Yebxted4qgpYWLisY4AEdOdZ4OXKgmPXGgWBqAgCSoV0obvEBEz8Hg==",
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-19.1.0.tgz",
+      "integrity": "sha512-+mh2vIcRCJtr8poJl64yulZkSSWpd7TQpORj+WVRmFe5omdS33eF94XjPa8QN0TiNz7gaCwJygKUF4COO142mA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "license": "SEE LICENSE IN https://tc39.es/ecma262/#sec-copyright-and-software-license",
   "homepage": "https://tc39.es/ecma262/",
   "devDependencies": {
-    "ecmarkup": "^19.0.0",
+    "ecmarkup": "^19.1.0",
     "glob": "^7.1.6",
     "jsdom": "^15.0.0",
     "pagedjs": "^0.4.3",

--- a/spec.html
+++ b/spec.html
@@ -1028,7 +1028,7 @@
         <h1>Implicit Normal Completion</h1>
         <p>In algorithms within abstract operations which are declared to return a Completion Record, and within all built-in functions, the returned value is first passed to NormalCompletion, and the result is used instead. This rule does not apply within the Completion algorithm or when the value being returned is clearly marked as a Completion Record in that step; these cases are:</p>
         <ul>
-          <li>when the result of applying Completion, NormalCompletion, or ThrowCompletion is directly returned</li>
+          <li>when the result of applying Completion, NormalCompletion, ThrowCompletion, or ReturnCompletion is directly returned</li>
           <li>when the result of constructing a Completion Record is directly returned</li>
         </ul>
         <p>It is an editorial error if a Completion Record is returned from such an abstract operation through any other means. For example, within these abstract operations,</p>
@@ -4177,6 +4177,19 @@
         </dl>
         <emu-alg>
           1. Return Completion Record { [[Type]]: ~throw~, [[Value]]: _value_, [[Target]]: ~empty~ }.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-returncompletion" type="abstract operation">
+        <h1>
+          ReturnCompletion (
+            _value_: an ECMAScript language value,
+          ): a return completion
+        </h1>
+        <dl class="header">
+        </dl>
+        <emu-alg>
+          1. Return Completion Record { [[Type]]: ~return~, [[Value]]: _value_, [[Target]]: ~empty~ }.
         </emu-alg>
       </emu-clause>
 
@@ -13422,7 +13435,7 @@
           1. Else,
             1. Let _rhs_ be ? Evaluation of |AssignmentExpression|.
             1. Let _value_ be ? GetValue(_rhs_).
-          1. Return Completion Record { [[Type]]: ~return~, [[Value]]: _value_, [[Target]]: ~empty~ }.
+          1. Return ReturnCompletion(_value_).
         </emu-alg>
         <emu-note>
           <p>Even though field initializers constitute a function boundary, calling FunctionDeclarationInstantiation does not have any observable effect and so is omitted.</p>
@@ -22586,14 +22599,14 @@
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>ReturnStatement : `return` `;`</emu-grammar>
       <emu-alg>
-        1. Return Completion Record { [[Type]]: ~return~, [[Value]]: *undefined*, [[Target]]: ~empty~ }.
+        1. Return ReturnCompletion(*undefined*).
       </emu-alg>
       <emu-grammar>ReturnStatement : `return` Expression `;`</emu-grammar>
       <emu-alg>
         1. Let _exprRef_ be ? Evaluation of |Expression|.
         1. Let _exprValue_ be ? GetValue(_exprRef_).
         1. If GetGeneratorKind() is ~async~, set _exprValue_ to ? Await(_exprValue_).
-        1. Return Completion Record { [[Type]]: ~return~, [[Value]]: _exprValue_, [[Target]]: ~empty~ }.
+        1. Return ReturnCompletion(_exprValue_).
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -23695,7 +23708,7 @@
       <emu-alg>
         1. Let _exprRef_ be ? Evaluation of |AssignmentExpression|.
         1. Let _exprValue_ be ? GetValue(_exprRef_).
-        1. Return Completion Record { [[Type]]: ~return~, [[Value]]: _exprValue_, [[Target]]: ~empty~ }.
+        1. Return ReturnCompletion(_exprValue_).
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -24020,7 +24033,7 @@
         1. Set _G_.[[GeneratorBrand]] to ~empty~.
         1. Set _G_.[[GeneratorState]] to ~suspended-start~.
         1. Perform GeneratorStart(_G_, |FunctionBody|).
-        1. Return Completion Record { [[Type]]: ~return~, [[Value]]: _G_, [[Target]]: ~empty~ }.
+        1. Return ReturnCompletion(_G_).
       </emu-alg>
     </emu-clause>
 
@@ -24160,14 +24173,14 @@
               1. Set _value_ to _received_.[[Value]].
               1. If _generatorKind_ is ~async~, then
                 1. Set _value_ to ? Await(_value_).
-              1. Return Completion Record { [[Type]]: ~return~, [[Value]]: _value_, [[Target]]: ~empty~ }.
+              1. Return ReturnCompletion(_value_).
             1. Let _innerReturnResult_ be ? Call(_return_, _iterator_, « _received_.[[Value]] »).
             1. If _generatorKind_ is ~async~, set _innerReturnResult_ to ? Await(_innerReturnResult_).
             1. If _innerReturnResult_ is not an Object, throw a *TypeError* exception.
             1. Let _done_ be ? IteratorComplete(_innerReturnResult_).
             1. If _done_ is *true*, then
               1. Set _value_ to ? IteratorValue(_innerReturnResult_).
-              1. Return Completion Record { [[Type]]: ~return~, [[Value]]: _value_, [[Target]]: ~empty~ }.
+              1. Return ReturnCompletion(_value_).
             1. If _generatorKind_ is ~async~, set _received_ to Completion(AsyncGeneratorYield(? IteratorValue(_innerReturnResult_))).
             1. Else, set _received_ to Completion(GeneratorYield(_innerReturnResult_)).
       </emu-alg>
@@ -24248,7 +24261,7 @@
         1. Set _generator_.[[GeneratorBrand]] to ~empty~.
         1. Set _generator_.[[AsyncGeneratorState]] to ~suspended-start~.
         1. Perform AsyncGeneratorStart(_generator_, |FunctionBody|).
-        1. Return Completion Record { [[Type]]: ~return~, [[Value]]: _generator_, [[Target]]: ~empty~ }.
+        1. Return ReturnCompletion(_generator_).
       </emu-alg>
     </emu-clause>
 
@@ -25264,7 +25277,7 @@
           1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, « _completion_.[[Value]] »).
         1. Else,
           1. Perform AsyncFunctionStart(_promiseCapability_, |FunctionBody|).
-        1. Return Completion Record { [[Type]]: ~return~, [[Value]]: _promiseCapability_.[[Promise]], [[Target]]: ~empty~ }.
+        1. Return ReturnCompletion(_promiseCapability_.[[Promise]]).
       </emu-alg>
     </emu-clause>
 
@@ -25371,7 +25384,7 @@
           1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, « _completion_.[[Value]] »).
         1. Else,
           1. Perform AsyncFunctionStart(_promiseCapability_, |ExpressionBody|).
-        1. Return Completion Record { [[Type]]: ~return~, [[Value]]: _promiseCapability_.[[Promise]], [[Target]]: ~empty~ }.
+        1. Return ReturnCompletion(_promiseCapability_.[[Promise]]).
       </emu-alg>
     </emu-clause>
 
@@ -48042,7 +48055,7 @@ THH:mm:ss.sss
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _g_ be the *this* value.
-          1. Let _C_ be Completion Record { [[Type]]: ~return~, [[Value]]: _value_, [[Target]]: ~empty~ }.
+          1. Let _C_ be ReturnCompletion(_value_).
           1. Return ? GeneratorResumeAbrupt(_g_, _C_, ~empty~).
         </emu-alg>
       </emu-clause>
@@ -48371,7 +48384,7 @@ THH:mm:ss.sss
           1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
           1. Let _result_ be Completion(AsyncGeneratorValidate(_generator_, ~empty~)).
           1. IfAbruptRejectPromise(_result_, _promiseCapability_).
-          1. Let _completion_ be Completion Record { [[Type]]: ~return~, [[Value]]: _value_, [[Target]]: ~empty~ }.
+          1. Let _completion_ be ReturnCompletion(_value_).
           1. Perform AsyncGeneratorEnqueue(_generator_, _completion_, _promiseCapability_).
           1. Let _state_ be _generator_.[[AsyncGeneratorState]].
           1. If _state_ is either ~suspended-start~ or ~completed~, then
@@ -48622,7 +48635,7 @@ THH:mm:ss.sss
           1. Let _awaited_ be Completion(Await(_resumptionValue_.[[Value]])).
           1. If _awaited_ is a throw completion, return ? _awaited_.
           1. Assert: _awaited_ is a normal completion.
-          1. Return Completion Record { [[Type]]: ~return~, [[Value]]: _awaited_.[[Value]], [[Target]]: ~empty~ }.
+          1. Return ReturnCompletion(_awaited_.[[Value]]).
         </emu-alg>
       </emu-clause>
 


### PR DESCRIPTION
There were 13 of these, so it seemed enough to justify an AO like we have for `NormalCompletion` (31) and `ThrowCompletion` (15).