### PR TITLE
Editorial: Quick fixes for CreateListFromArrayLike

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -6471,7 +6471,7 @@
       <h1>
         CreateListFromArrayLike (
           _obj_: an ECMAScript language value,
-          optional _requirePropertyKeys_: a boolean,
+          optional _validElementTypes_: ~all~ or ~property-key~,
         ): either a normal completion containing a List of ECMAScript language values or a throw completion
       </h1>
       <dl class="header">
@@ -6479,6 +6479,7 @@
         <dd>It is used to create a List value whose elements are provided by the indexed properties of _obj_. _elementTypes_ contains the names of ECMAScript Language Types that are allowed for element values of the List that is created.</dd>
       </dl>
       <emu-alg>
+        1. If _validElementTypes_ is not present, set _validElementTypes_ to ~all~.
         1. If _obj_ is not an Object, throw a *TypeError* exception.
         1. Let _len_ be ? LengthOfArrayLike(_obj_).
         1. Let _list_ be a new empty List.
@@ -6486,7 +6487,7 @@
         1. Repeat, while _index_ &lt; _len_,
           1. Let _indexName_ be ! ToString(𝔽(_index_)).
           1. Let _next_ be ? Get(_obj_, _indexName_).
-          1. If _requirePropertyKeys_ is *true* and _next_ is not a property key, throw a *TypeError* exception.
+          1. If _validElementTypes_ is ~property-key~ and _next_ is not a property key, throw a *TypeError* exception.
           1. Append _next_ to _list_.
           1. Set _index_ to _index_ + 1.
         1. Return _list_.
@@ -15884,7 +15885,7 @@
         1. If _trap_ is *undefined*, then
           1. Return ? <emu-meta effects="user-code">_target_.[[OwnPropertyKeys]]()</emu-meta>.
         1. Let _trapResultArray_ be ? Call(_trap_, _handler_, « _target_ »).
-        1. Let _trapResult_ be ? CreateListFromArrayLike(_trapResultArray_, *true*).
+        1. Let _trapResult_ be ? CreateListFromArrayLike(_trapResultArray_, ~property-key~).
         1. If _trapResult_ contains any duplicate entries, throw a *TypeError* exception.
         1. Let _extensibleTarget_ be ? IsExtensible(_target_).
         1. Let _targetKeys_ be ? <emu-meta effects="user-code">_target_.[[OwnPropertyKeys]]()</emu-meta>.


### PR DESCRIPTION
- Capital 'B' on "Boolean"

- When an operation has an optional parameter X, the op doesn't do anything with X until either:
  - it has established that a value was passed to X, or
  - it has established that a value wasn't passed to X, and has set X to some value.