### PR TITLE
Editorial: List all TypedArray internal slots

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -14756,7 +14756,7 @@
       <emu-note>
         <p>Because ToString(_n_) for any Number _n_ is a canonical numeric string, an implementation may treat Numbers as property keys for TypedArrays without actually performing the string conversion.</p>
       </emu-note>
-      <p>TypedArrays have the same internal slots as ordinary objects and additionally [[ViewedArrayBuffer]], [[ArrayLength]], [[ByteOffset]], [[ContentType]], and [[TypedArrayName]] internal slots.</p>
+      <p>TypedArrays have the same internal slots as ordinary objects and additionally [[ViewedArrayBuffer]], [[ArrayLength]], [[ByteLength]], [[ByteOffset]], [[ContentType]], and [[TypedArrayName]] internal slots.</p>
       <p>An object is a <dfn id="typedarray" oldids="integer-indexed-exotic-object" variants="TypedArrays">TypedArray</dfn> if its [[PreventExtensions]], [[GetOwnProperty]], [[HasProperty]], [[DefineOwnProperty]], [[Get]], [[Set]], [[Delete]], and [[OwnPropertyKeys]], internal methods use the definitions in this section, and its other essential internal methods use the definitions found in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>. These methods are installed by TypedArrayCreate.</p>
 
       <emu-clause id="sec-typedarray-preventextensions" type="internal method">
@@ -42986,7 +42986,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-properties-of-typedarray-instances">
       <h1>Properties of _TypedArray_ Instances</h1>
-      <p>_TypedArray_ instances are TypedArrays. Each _TypedArray_ instance inherits properties from the corresponding _TypedArray_ prototype object. Each _TypedArray_ instance has the following internal slots: [[TypedArrayName]], [[ViewedArrayBuffer]], [[ByteLength]], [[ByteOffset]], and [[ArrayLength]].</p>
+      <p>_TypedArray_ instances are TypedArrays. Each _TypedArray_ instance inherits properties from the corresponding _TypedArray_ prototype object. Each _TypedArray_ instance has the following internal slots: [[ViewedArrayBuffer]], [[TypedArrayName]], [[ContentType]], [[ByteLength]], [[ByteOffset]], and [[ArrayLength]].</p>
     </emu-clause>
   </emu-clause>
 </emu-clause>


### PR DESCRIPTION
This commit updates the list of TypedArray internal slots in `#sec-typedarray-exotic-objects` and `#sec-properties-of-typedarray-instances` to match the list of slots added by `TypedArrayCreate`.