### PR TITLE
Editorial: Fix omitted return types of functions that can return empty

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -22878,7 +22878,7 @@
       <h1>
         Runtime Semantics: LabelledEvaluation (
           _labelSet_: a List of Strings,
-        ): either a normal completion containing an ECMAScript language value or an abrupt completion
+        ): either a normal completion containing either an ECMAScript language value or ~empty~, or an abrupt completion
       </h1>
       <dl class="header">
       </dl>
@@ -23006,7 +23006,7 @@
       <h1>
         Runtime Semantics: CatchClauseEvaluation (
           _thrownValue_: an ECMAScript language value,
-        ): either a normal completion containing an ECMAScript language value or an abrupt completion
+        ): either a normal completion containing either an ECMAScript language value or ~empty~, or an abrupt completion
       </h1>
       <dl class="header">
       </dl>
@@ -23481,7 +23481,7 @@
         Runtime Semantics: EvaluateFunctionBody (
           _functionObject_: an ECMAScript function object,
           _argumentsList_: a List of ECMAScript language values,
-        ): either a normal completion containing an ECMAScript language value or an abrupt completion
+        ): either a normal completion containing either an ECMAScript language value or ~empty~, or an abrupt completion
       </h1>
       <dl class="header">
       </dl>
@@ -24870,7 +24870,7 @@
       <h1>
         Runtime Semantics: EvaluateClassStaticBlockBody (
           _functionObject_: an ECMAScript function object,
-        ): either a normal completion containing an ECMAScript language value or an abrupt completion
+        ): either a normal completion containing either an ECMAScript language value or ~empty~, or an abrupt completion
       </h1>
       <dl class="header">
       </dl>


### PR DESCRIPTION
Certain functions may return `~empty~`, though this is not always reflected in the return type. Each identified error is presented alongside specific code examples, where scenarios include the presence of `~empty~` values.

All of these errors were discovered using ESMeta, so executing the provided code in ESMeta may help obtain a detailed execution path(Also note that some of the codes only compile in the [dev](https://github.com/es-meta/esmeta/tree/dev) branch).

## Fixed functions

### [LabelledEvaluation](https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#sec-runtime-semantics-labelledevaluation)
LabelledEvaluation of LabelledItem with argument newLabelSet can return `~empty~` because of the break statement, the return value can be `~empty~`.

Scenario: 

```js
label: break label;
label: function f() {}
label: {}
label: var x;
label: ;
```

<details><summary>Details (ESMeta)</summary>
<p>

```
[ReturnTypeMismatch] Block[12989] return statement in LabelledStatement[0,0].LabelledEvaluation (step 5, 7:12-34)
- expected: Normal[ESValue] | Abrupt
- actual  : Normal[ESValue | Enum[~empty~]] | Abrupt[break, continue, throw]

[ReturnTypeMismatch] Block[12991] return statement in LabelledItem[1,0].LabelledEvaluation (step 1, 2:12-57)
- expected: Normal[ESValue] | Abrupt
- actual  : Normal[Enum[~empty~]]

[ReturnTypeMismatch] Block[12993] return statement in Statement[0,0].LabelledEvaluation (step 1, 2:12-47)
- expected: Normal[ESValue] | Abrupt
- actual  : Normal[ESValue | Enum[~empty~]] | Abrupt[break, continue, throw]

[ReturnTypeMismatch] Block[12995] return statement in Statement[1,0].LabelledEvaluation (step 1, 2:12-47)
- expected: Normal[ESValue] | Abrupt
- actual  : Normal[Enum[~empty~]] | Throw

[ReturnTypeMismatch] Block[12997] return statement in Statement[2,0].LabelledEvaluation (step 1, 2:12-47)
- expected: Normal[ESValue] | Abrupt
- actual  : Normal[Enum[~empty~]]
```

</p>
</details> 

###  [CatchClauseEvaluation](https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#sec-runtime-semantics-catchclauseevaluation)

The Completion(Evaluation of Block) could result in `~empty~`. Since it flows into B and returns immediately, the return type should account for `~empty~`.

Scenario: 

```js
try { x; } catch (e) {}
try { x; } catch {}
```

Note that each line corresponds to the bug in the details. 

<details><summary>Details (ESMeta)</summary>
<p>

```
[ReturnTypeMismatch] Block[13050] return statement in Catch[0,0].CatchClauseEvaluation (step 9, 13:12-25)
- expected: Normal[ESValue] | Abrupt
- actual  : Normal[ESValue | Enum[~empty~]] | Abrupt[break, continue, throw]

[ReturnTypeMismatch] Block[13052] return statement in Catch[1,0].CatchClauseEvaluation (step 1, 2:12-43)
- expected: Normal[ESValue] | Abrupt
- actual  : Normal[ESValue | Enum[~empty~]] | Abrupt[break, continue, throw]
```

</p>
</details> 

###  [EvaluateFunctionBody](https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-runtime-semantics-evaluatefunctionbody)

Since the evaluation of a single block is an `~empty~`, an evaluation of the FunctionStatementList can be `~empty~` too. 

Scenario: 

```js
function f() { {} } f();
```

<details><summary>Details (ESMeta)</summary>
<p>

```
[ReturnTypeMismatch] Block[13224] return statement in FunctionBody[0,0].EvaluateFunctionBody (step 2, 3:12-59)
- expected: Normal[ESValue] | Abrupt
- actual  : Normal[ESValue | Enum[~empty~]] | Abrupt[break, continue, throw]
```

</p>
</details> 

###  [EvaluateClassStaticBlockBody](https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-runtime-semantics-evaluateclassstaticblockbody)

Similar to EvaluateFunctionBody, this function can return `~empty~.`

Scenario: 

```js
class A { static { {} } }
```

<details><summary>Details (ESMeta)</summary>
<p>

```
[ReturnTypeMismatch] Block[14021] return statement in ClassStaticBlockBody[0,0].EvaluateClassStaticBlockBody (step 3, 4:12-67)
- expected: Normal[ESValue] | Abrupt
- actual  : Normal[ESValue | Enum[~empty~]] | Abrupt[break, continue, throw]
```

</p>
</details>