### PR TITLE
Editorial: Fix parameter type of the OrdinaryCreateFromConstructor

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -13045,7 +13045,7 @@
     <emu-clause id="sec-ordinarycreatefromconstructor" type="abstract operation">
       <h1>
         OrdinaryCreateFromConstructor (
-          _constructor_: a constructor,
+          _constructor_: a function object,
           _intrinsicDefaultProto_: a String,
           optional _internalSlotsList_: a List of names of internal slots,
         ): either a normal completion containing an Object or a throw completion


### PR DESCRIPTION
In [OrdinaryCreateFromConstructor](https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-ordinarycreatefromconstructor), the constructor parameter is currently expected to be a constructor.
However, the following code demonstrates that a function object can also be passed as the parameter(Specifically, the problem is from the [EvaluateGeneratorBody](https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-runtime-semantics-evaluategeneratorbody)).

```js
function *f() {} f();
async function *f() {} f();
```

<details><summary>ESMeta log</summary>
<p>

Running ESMeta in dev branch reproduces the result below. 

```
[ParamTypeMismatch] Call[13531] argument assignment to first parameter _constructor_ when Call[13508] function call from GeneratorBody[0,0].EvaluateGeneratorBody (step 2, 3:25-183) to OrdinaryCreateFromConstructor
- expected: Record[Constructor]
- actual  : Record[ECMAScriptFunctionObject]

[ParamTypeMismatch] Call[13809] argument assignment to first parameter _constructor_ when Call[13786] function call from AsyncGeneratorBody[0,0].EvaluateAsyncGeneratorBody (step 2, 3:33-231) to OrdinaryCreateFromConstructor
- expected: Record[Constructor]
- actual  : Record[ECMAScriptFunctionObject]
```

</p>
</details> 

Since changing the type from a constructor to a function object does not introduce any breaks, I propose broadening the parameter type for now. This change would also align with [GetPrototypeFromConstructor](https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-getprototypefromconstructor).

However, further discussion may needed because, given the current parameter names and descriptions, it is unclear whether these functions are intended to accept a function object rather than just a constructor.