### PR TITLE
Editorial: Narrow return type of CreateBuiltinFunction

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -13935,7 +13935,7 @@
           optional _realm_: a Realm Record,
           optional _prototype_: an Object or *null*,
           optional _prefix_: a String,
-        ): a function object
+        ): a built-in function object
       </h1>
       <dl class="header">
         <dt>description</dt>


### PR DESCRIPTION
The return type of [CreateBuiltinFunction](https://tc39.es/ecma262/#sec-createbuiltinfunction) is a function object. However, as indicated by its name, the return type should more specifically be identified as a built-in function object.

This distinction clarifies an operation in [ClassDefinitionEvaluation](https://tc39.es/ecma262/#sec-runtime-semantics-classdefinitionevaluation), where [MakeConstructor](https://tc39.es/ecma262/#sec-makeconstructor) requires either an ECMAScript function object or a built-in function object.

> 14.b. Let F be [CreateBuiltinFunction](https://github.com/tc39/ecma262/compare/main...kimjg1119:create-builtin-object?expand=1#sec-createbuiltinfunction)(defaultConstructor, 0, className, « [[ConstructorKind]], [[SourceText]] », the current Realm Record, constructorParent).
> ...
> 16. Perform [MakeConstructor](https://tc39.es/ecma262/#sec-makeconstructor)(F, false, proto).

cf. It also resolves some ESMeta errors. 

<details><summary>ESMeta logs</summary>
<p>

```
[ParamTypeMismatch] Call[14206] argument assignment to first parameter _F_ when Call[14181] function call from ClassTail[0,0].ClassDefinitionEvaluation (step 16, 59:20-58) to MakeConstructor
- expected: Record[BuiltinFunctionObject | ECMAScriptFunctionObject]
- actual  : Record[FunctionObject]

[ParamTypeMismatch] Call[14391] argument assignment to first parameter _F_ when Call[14361] function call from ClassTail[0,1].ClassDefinitionEvaluation (step 16, 59:20-58) to MakeConstructor
- expected: Record[BuiltinFunctionObject | ECMAScriptFunctionObject]
- actual  : Record[FunctionObject]

[ParamTypeMismatch] Call[14576] argument assignment to first parameter _F_ when Call[14541] function call from ClassTail[0,2].ClassDefinitionEvaluation (step 16, 59:20-58) to MakeConstructor
- expected: Record[BuiltinFunctionObject | ECMAScriptFunctionObject]
- actual  : Record[FunctionObject]

[ParamTypeMismatch] Call[14761] argument assignment to first parameter _F_ when Call[14721] function call from ClassTail[0,3].ClassDefinitionEvaluation (step 16, 59:20-58) to MakeConstructor
- expected: Record[BuiltinFunctionObject | ECMAScriptFunctionObject]
- actual  : Record[FunctionObject]
```

</p>
</details> 
