### PR TITLE
Editorial: use suspended-start instead of `undefined` in GeneratorState initialization

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -48864,7 +48864,7 @@ THH:mm:ss.sss
           1. Let _internalSlotsList_ be the list-concatenation of _extraSlots_ and « [[GeneratorState]], [[GeneratorContext]], [[GeneratorBrand]] ».
           1. Let _generator_ be OrdinaryObjectCreate(_generatorPrototype_, _internalSlotsList_).
           1. Set _generator_.[[GeneratorBrand]] to _generatorBrand_.
-          1. Set _generator_.[[GeneratorState]] to *undefined*.
+          1. Set _generator_.[[GeneratorState]] to ~suspended-start~.
           1. Let _callerContext_ be the running execution context.
           1. Let _calleeContext_ be a new execution context.
           1. Set the Function of _calleeContext_ to *null*.


### PR DESCRIPTION
In #3383, we chose to use ~suspended-start~ instead of undefined for initializing a GeneratorState, but the changes do not include [CreatorIteratorFromClosure](https://tc39.es/ecma262/#sec-createiteratorfromclosure).