### PR TITLE
Editorial: GlobalObject cannot be undefined in the GetGlobalObject 

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -11721,7 +11721,7 @@
             [[GlobalObject]]
           </td>
           <td>
-            an Object or *undefined*
+            an Object
           </td>
           <td>
             The global object for this realm
@@ -11786,7 +11786,6 @@
         1. Let _realm_ be a new Realm Record.
         1. Perform CreateIntrinsics(_realm_).
         1. Set _realm_.[[AgentSignifier]] to AgentSignifier().
-        1. Set _realm_.[[GlobalObject]] to *undefined*.
         1. Set _realm_.[[GlobalEnv]] to *undefined*.
         1. Set _realm_.[[TemplateMap]] to a new empty List.
         1. Let _newContext_ be a new execution context.


### PR DESCRIPTION
The [[GlobalObject]] of the Realm record is an Object or undefined. However, it seems that in GetGlobalObject, the slot cannot be undefined. To make this clear(and resolve some ESMeta alarms), I suggest adding an assertion. 