### PR TITLE
Normative: Remove Species check for TypedArrays ArrayBuffers and SharedArrayBuffers

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -6572,6 +6572,12 @@
         1. If IsConstructor(_S_) is *true*, return _S_.
         1. Throw a *TypeError* exception.
       </emu-alg>
+      <emu-note>
+        <p>Species constructor is only available for Array, RegExp and Promise built-in classes. It
+        will not be provided to any other built-in classes. Species are an expensive and complex
+        operation that did not end up being used by the community, resulting in the feature being
+        deprecated.</p>
+      </emu-note>
     </emu-clause>
 
     <emu-clause id="sec-enumerableownproperties" type="abstract operation" oldids="sec-enumerableownpropertynames">
@@ -40793,7 +40799,7 @@ THH:mm:ss.sss
               1. Append _kValue_ to _kept_.
               1. Set _captured_ to _captured_ + 1.
             1. Set _k_ to _k_ + 1.
-          1. Let _A_ be ? TypedArraySpeciesCreate(_O_, « 𝔽(_captured_) »).
+          1. Let _A_ be ? TypedArrayCreateSameType(_O_, « 𝔽(_captured_) »).
           1. Let _n_ be 0.
           1. For each element _e_ of _kept_, do
             1. Perform ! Set(_A_, ! ToString(𝔽(_n_)), _e_, *true*).
@@ -41019,7 +41025,7 @@ THH:mm:ss.sss
           1. Let _taRecord_ be ? ValidateTypedArray(_O_, ~seq-cst~).
           1. Let _len_ be TypedArrayLength(_taRecord_).
           1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
-          1. Let _A_ be ? TypedArraySpeciesCreate(_O_, « 𝔽(_len_) »).
+          1. Let _A_ be ? TypedArrayCreateSameType(_O_, « 𝔽(_len_) »).
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_,
             1. Let _Pk_ be ! ToString(𝔽(_k_)).
@@ -41235,7 +41241,7 @@ THH:mm:ss.sss
           1. Else if _relativeEnd_ &lt; 0, let _endIndex_ be max(_srcArrayLength_ + _relativeEnd_, 0).
           1. Else, let _endIndex_ be min(_relativeEnd_, _srcArrayLength_).
           1. Let _countBytes_ be max(_endIndex_ - _startIndex_, 0).
-          1. Let _A_ be ? TypedArraySpeciesCreate(_O_, « 𝔽(_countBytes_) »).
+          1. Let _A_ be ? TypedArrayCreateSameType(_O_, « 𝔽(_countBytes_) »).
           1. If _countBytes_ > 0, then
             1. Set _taRecord_ to MakeTypedArrayWithBufferWitnessRecord(_O_, ~seq-cst~).
             1. If IsTypedArrayOutOfBounds(_taRecord_) is *true*, throw a *TypeError* exception.
@@ -41347,7 +41353,7 @@ THH:mm:ss.sss
             1. Else, let _endIndex_ be min(_relativeEnd_, _srcLength_).
             1. Let _newLength_ be max(_endIndex_ - _startIndex_, 0).
             1. Let _argumentsList_ be « _buffer_, 𝔽(_beginByteOffset_), 𝔽(_newLength_) ».
-          1. Return ? TypedArraySpeciesCreate(_O_, _argumentsList_).
+          1. Return ? TypedArrayCreateSameType(_O_, _argumentsList_).
         </emu-alg>
         <p>This method is not generic. The *this* value must be an object with a [[TypedArrayName]] internal slot.</p>
       </emu-clause>
@@ -41465,27 +41471,6 @@ THH:mm:ss.sss
     <emu-clause id="sec-abstract-operations-for-typedarray-objects">
       <h1>Abstract Operations for TypedArray Objects</h1>
 
-      <emu-clause id="typedarray-species-create" type="abstract operation">
-        <h1>
-          TypedArraySpeciesCreate (
-            _exemplar_: a TypedArray,
-            _argumentList_: a List of ECMAScript language values,
-          ): either a normal completion containing a TypedArray or a throw completion
-        </h1>
-        <dl class="header">
-          <dt>description</dt>
-          <dd>It is used to specify the creation of a new TypedArray using a constructor function that is derived from _exemplar_. Unlike ArraySpeciesCreate, which can create non-Array objects through the use of %Symbol.species%, this operation enforces that the constructor function creates an actual TypedArray.</dd>
-        </dl>
-        <emu-alg>
-          1. Let _defaultConstructor_ be the intrinsic object associated with the constructor name _exemplar_.[[TypedArrayName]] in <emu-xref href="#table-the-typedarray-constructors"></emu-xref>.
-          1. Let _constructor_ be ? SpeciesConstructor(_exemplar_, _defaultConstructor_).
-          1. Let _result_ be ? TypedArrayCreateFromConstructor(_constructor_, _argumentList_).
-          1. Assert: _result_ has [[TypedArrayName]] and [[ContentType]] internal slots.
-          1. If _result_.[[ContentType]] is not _exemplar_.[[ContentType]], throw a *TypeError* exception.
-          1. Return _result_.
-        </emu-alg>
-      </emu-clause>
-
       <emu-clause id="sec-typedarraycreatefromconstructor" oldids="typedarray-create" type="abstract operation">
         <h1>
           TypedArrayCreateFromConstructor (
@@ -41517,7 +41502,7 @@ THH:mm:ss.sss
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It is used to specify the creation of a new TypedArray using a constructor function that is derived from _exemplar_. Unlike TypedArraySpeciesCreate, which can construct custom TypedArray subclasses through the use of %Symbol.species%, this operation always uses one of the built-in TypedArray constructors.</dd>
+          <dd>It is used to specify the creation of a new TypedArray using a constructor function that is derived from _exemplar_. This operation always uses one of the built-in TypedArray constructors.</dd>
         </dl>
         <emu-alg>
           1. Let _constructor_ be the intrinsic object associated with the constructor name _exemplar_.[[TypedArrayName]] in <emu-xref href="#table-the-typedarray-constructors"></emu-xref>.
@@ -43807,7 +43792,7 @@ THH:mm:ss.sss
           1. Else if _relativeEnd_ &lt; 0, let _final_ be max(_len_ + _relativeEnd_, 0).
           1. Else, let _final_ be min(_relativeEnd_, _len_).
           1. Let _newLen_ be max(_final_ - _first_, 0).
-          1. Let _ctor_ be ? SpeciesConstructor(_O_, %ArrayBuffer%).
+          1. Let _ctor_ be %ArrayBuffer%.
           1. Let _new_ be ? Construct(_ctor_, « 𝔽(_newLen_) »).
           1. Perform ? RequireInternalSlot(_new_, [[ArrayBufferData]]).
           1. If IsSharedArrayBuffer(_new_) is *true*, throw a *TypeError* exception.
@@ -44125,7 +44110,7 @@ THH:mm:ss.sss
           1. Else if _relativeEnd_ &lt; 0, let _final_ be max(_len_ + _relativeEnd_, 0).
           1. Else, let _final_ be min(_relativeEnd_, _len_).
           1. Let _newLen_ be max(_final_ - _first_, 0).
-          1. Let _ctor_ be ? SpeciesConstructor(_O_, %SharedArrayBuffer%).
+          1. Let _ctor_ be %SharedArrayBuffer%.
           1. Let _new_ be ? Construct(_ctor_, « 𝔽(_newLen_) »).
           1. Perform ? RequireInternalSlot(_new_, [[ArrayBufferData]]).
           1. If IsSharedArrayBuffer(_new_) is *false*, throw a *TypeError* exception.

--- a/spec.html
+++ b/spec.html
@@ -6573,10 +6573,7 @@
         1. Throw a *TypeError* exception.
       </emu-alg>
       <emu-note>
-        <p>Species constructor is only available for Array, RegExp and Promise built-in classes. It
-        will not be provided to any other built-in classes. Species are an expensive and complex
-        operation that did not end up being used by the community, resulting in the feature being
-        deprecated.</p>
+        <p>Species constructor is only available for Array, RegExp, and Promise built-in classes. </p>
       </emu-note>
     </emu-clause>
 
@@ -41493,7 +41490,7 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-typedarray-create-same-type" type="abstract operation">
+      <emu-clause id="sec-typedarray-create-same-type" oldids="typedarray-species-create" type="abstract operation">
         <h1>
           TypedArrayCreateSameType (
             _exemplar_: a TypedArray,
@@ -41502,7 +41499,7 @@ THH:mm:ss.sss
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It is used to specify the creation of a new TypedArray using a constructor function that is derived from _exemplar_. This operation always uses one of the built-in TypedArray constructors.</dd>
+          <dd>It is used to specify the creation of a new TypedArray using a constructor function that is derived from _exemplar_. This operation always uses one of the built-in TypedArray constructors. Prior to the 2025 edition of the specification some TypedArray methods made use of SpeciesCreate, but that functionality has been removed.</dd>
         </dl>
         <emu-alg>
           1. Let _constructor_ be the intrinsic object associated with the constructor name _exemplar_.[[TypedArrayName]] in <emu-xref href="#table-the-typedarray-constructors"></emu-xref>.
@@ -43792,8 +43789,7 @@ THH:mm:ss.sss
           1. Else if _relativeEnd_ &lt; 0, let _final_ be max(_len_ + _relativeEnd_, 0).
           1. Else, let _final_ be min(_relativeEnd_, _len_).
           1. Let _newLen_ be max(_final_ - _first_, 0).
-          1. Let _ctor_ be %ArrayBuffer%.
-          1. Let _new_ be ? Construct(_ctor_, « 𝔽(_newLen_) »).
+          1. Let _new_ be ? Construct(%ArrayBuffer%, « 𝔽(_newLen_) »).
           1. Perform ? RequireInternalSlot(_new_, [[ArrayBufferData]]).
           1. If IsSharedArrayBuffer(_new_) is *true*, throw a *TypeError* exception.
           1. If IsDetachedBuffer(_new_) is *true*, throw a *TypeError* exception.
@@ -44110,8 +44106,7 @@ THH:mm:ss.sss
           1. Else if _relativeEnd_ &lt; 0, let _final_ be max(_len_ + _relativeEnd_, 0).
           1. Else, let _final_ be min(_relativeEnd_, _len_).
           1. Let _newLen_ be max(_final_ - _first_, 0).
-          1. Let _ctor_ be %SharedArrayBuffer%.
-          1. Let _new_ be ? Construct(_ctor_, « 𝔽(_newLen_) »).
+          1. Let _new_ be ? Construct(%SharedArrayBuffer%, « 𝔽(_newLen_) »).
           1. Perform ? RequireInternalSlot(_new_, [[ArrayBufferData]]).
           1. If IsSharedArrayBuffer(_new_) is *false*, throw a *TypeError* exception.
           1. If _new_.[[ArrayBufferData]] is _O_.[[ArrayBufferData]], throw a *TypeError* exception.

--- a/spec.html
+++ b/spec.html
@@ -6573,7 +6573,7 @@
         1. Throw a *TypeError* exception.
       </emu-alg>
       <emu-note>
-        <p>Species constructor is only available for Array, RegExp, and Promise built-in classes. </p>
+        <p>Species constructor is only available for Array, RegExp and Promise built-in classes.</p>
       </emu-note>
     </emu-clause>
 


### PR DESCRIPTION
This is a first stab at removing the Species check for TA, ABs, and SABs, in line with our review of the webcompat of it all: https://docs.google.com/presentation/d/1J0xct8EHUC90P6QpggISxuAp_5L_qaDa3SZ9gQaB0kA/edit#slide=id.p

There is a note in there about deprecating this behavior, but I wasn't 100% sure how to do that. Comments welcome.

cc @mgaudet  
