### PR TITLE
Editorial: Allow ACs in Async{Function,Block}Start

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -49462,7 +49462,7 @@ THH:mm:ss.sss
         <h1>
           AsyncFunctionStart (
             _promiseCapability_: a PromiseCapability Record,
-            _asyncFunctionBody_: a |FunctionBody| Parse Node or an |ExpressionBody| Parse Node,
+            _asyncFunctionBody_: a |FunctionBody| Parse Node, an |ExpressionBody| Parse Node, or an Abstract Closure with no parameters,
           ): ~unused~
         </h1>
         <dl class="header">
@@ -49480,7 +49480,7 @@ THH:mm:ss.sss
         <h1>
           AsyncBlockStart (
             _promiseCapability_: a PromiseCapability Record,
-            _asyncBody_: a Parse Node,
+            _asyncBody_: a Parse Node or an Abstract Closure with no parameters,
             _asyncContext_: an execution context,
           ): ~unused~
         </h1>
@@ -49490,7 +49490,11 @@ THH:mm:ss.sss
           1. Let _runningContext_ be the running execution context.
           1. Let _closure_ be a new Abstract Closure with no parameters that captures _promiseCapability_ and _asyncBody_ and performs the following steps when called:
             1. Let _acAsyncContext_ be the running execution context.
-            1. Let _result_ be Completion(Evaluation of _asyncBody_).
+            1. If _asyncBody_ is a Parse Node, then
+              1. Let _result_ be Completion(Evaluation of _asyncBody_).
+            1. Else,
+              1. Assert: _asyncBody_ is an Abstract Closure with no parameters.
+              1. Let _result_ be _asyncBody_().
             1. Assert: If we return here, the async function either threw an exception or performed an implicit or explicit return; all awaiting is done.
             1. Remove _acAsyncContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
             1. If _result_ is a normal completion, then


### PR DESCRIPTION
There is no use of Abstract Closures as async function bodies in ecma262 itself. This PR is a prereq to allow the JSPI specification to pass in an AC.

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
