### PR TITLE
Normative: Return false in [[PreventExtensions]] for variable length TypedArrays

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -14708,7 +14708,20 @@
       <h1>TypedArray Exotic Objects</h1>
       <p>A TypedArray is an exotic object that performs special handling of integer index property keys.</p>
       <p>TypedArrays have the same internal slots as ordinary objects and additionally [[ViewedArrayBuffer]], [[ArrayLength]], [[ByteOffset]], [[ContentType]], and [[TypedArrayName]] internal slots.</p>
-      <p>An object is a <dfn id="typedarray" oldids="integer-indexed-exotic-object" variants="TypedArrays">TypedArray</dfn> if its [[GetOwnProperty]], [[HasProperty]], [[DefineOwnProperty]], [[Get]], [[Set]], [[Delete]], and [[OwnPropertyKeys]] internal methods use the definitions in this section, and its other essential internal methods use the definitions found in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>. These methods are installed by TypedArrayCreate.</p>
+      <p>An object is a <dfn id="typedarray" oldids="integer-indexed-exotic-object" variants="TypedArrays">TypedArray</dfn> if its [[PreventExtensions]], [[GetOwnProperty]], [[HasProperty]], [[DefineOwnProperty]], [[Get]], [[Set]], [[Delete]], and [[OwnPropertyKeys]], internal methods use the definitions in this section, and its other essential internal methods use the definitions found in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>. These methods are installed by TypedArrayCreate.</p>
+
+      <emu-clause id="sec-typedarray-preventextensions" type="internal method">
+        <h1>[[PreventExtensions]] ( ): a normal completion containing a Boolean</h1>
+        <dl class="header">
+          <dt>for</dt>
+          <dd>a TypedArray _O_</dd>
+        </dl>
+        <emu-alg>
+          1. NOTE: The extensibility-related invariants specified in <emu-xref href="#sec-invariants-of-the-essential-internal-methods"></emu-xref> do not allow this method to return *true* when _O_ can gain (or lose and then regain) properties, which might occur for properties with integer index names when its underlying buffer is resized.
+          1. If IsTypedArrayFixedLength(_O_) is *false*, return *false*.
+          1. Return OrdinaryPreventExtensions(_O_).
+        </emu-alg>
+      </emu-clause>
 
       <emu-clause id="sec-typedarray-getownproperty" oldids="sec-integer-indexed-exotic-objects-getownproperty-p" type="internal method">
         <h1>
@@ -14936,6 +14949,7 @@
         <emu-alg>
           1. Let _internalSlotsList_ be « [[Prototype]], [[Extensible]], [[ViewedArrayBuffer]], [[TypedArrayName]], [[ContentType]], [[ByteLength]], [[ByteOffset]], [[ArrayLength]] ».
           1. Let _A_ be MakeBasicObject(_internalSlotsList_).
+          1. Set _A_.[[PreventExtensions]] as specified in <emu-xref href="#sec-typedarray-preventextensions"></emu-xref>.
           1. Set _A_.[[GetOwnProperty]] as specified in <emu-xref href="#sec-typedarray-getownproperty"></emu-xref>.
           1. Set _A_.[[HasProperty]] as specified in <emu-xref href="#sec-typedarray-hasproperty"></emu-xref>.
           1. Set _A_.[[DefineOwnProperty]] as specified in <emu-xref href="#sec-typedarray-defineownproperty"></emu-xref>.
@@ -15012,6 +15026,22 @@
           1. If _byteOffsetStart_ > _bufferByteLength_ or _byteOffsetEnd_ > _bufferByteLength_, return *true*.
           1. NOTE: 0-length TypedArrays are not considered out-of-bounds.
           1. Return *false*.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-istypedarrayfixedlength" type="abstract operation">
+        <h1>
+          IsTypedArrayFixedLength (
+            _O_: a TypedArray,
+          ): a Boolean
+        </h1>
+        <dl class="header">
+        </dl>
+        <emu-alg>
+          1. If _O_.[[ArrayLength]] is ~auto~, return *false*.
+          1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
+          1. If IsFixedLengthArrayBuffer(_buffer_) is *false* and IsSharedArrayBuffer(_buffer_) is *false*, return *false*.
+          1. Return *true*.
         </emu-alg>
       </emu-clause>
 


### PR DESCRIPTION
Fixes #3385

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
