### PR TITLE
Editorial: fix IteratorClose call in %IteratorHelperPrototype%.return

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -46684,7 +46684,7 @@ THH:mm:ss.sss
             1. If _O_.[[GeneratorState]] is ~suspended-start~, then
               1. Set _O_.[[GeneratorState]] to ~completed~.
               1. NOTE: Once a generator enters the completed state it never leaves it and its associated execution context is never resumed. Any execution state associated with _O_ can be discarded at this point.
-              1. Perform ? IteratorClose(_O_.[[UnderlyingIterator]], ReturnCompletion(*undefined*)).
+              1. Perform ? IteratorClose(_O_.[[UnderlyingIterator]], NormalCompletion(~unused~)).
               1. Return CreateIteratorResultObject(*undefined*, *true*).
             1. Let _C_ be ReturnCompletion(*undefined*).
             1. Return ? GeneratorResumeAbrupt(_O_, _C_, *"Iterator Helper"*).


### PR DESCRIPTION
As pointed out [here](https://github.com/tc39/ecma262/pull/3395#discussion_r1807857989).

This pattern of closing an iterator _not_ because of an error or other abrupt completion hasn't come up much yet, but compare e.g. step 5.c.ii.1.a of [Set.prototype.isDisjointFrom](https://tc39.es/ecma262/multipage/keyed-collections.html#sec-set.prototype.isdisjointfrom).