### PR TITLE
Editorial: eliminate extra verbosity with %GeneratorPrototype% references

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -7274,7 +7274,7 @@
             1. Perform ? GeneratorYield(CreateIteratorResultObject(_E_, *false*)).
           1. Return NormalCompletion(*undefined*).
         1. Let _iterator_ be CreateIteratorFromClosure(_closure_, ~empty~, %Iterator.prototype%).
-        1. Return the Iterator Record { [[Iterator]]: _iterator_, [[NextMethod]]: %GeneratorFunction.prototype.prototype.next%, [[Done]]: *false* }.
+        1. Return the Iterator Record { [[Iterator]]: _iterator_, [[NextMethod]]: %GeneratorPrototype.next%, [[Done]]: *false* }.
       </emu-alg>
       <emu-note>
         <p>The list iterator object is never directly accessible to ECMAScript code.</p>
@@ -23980,7 +23980,7 @@
         1. Let _closure_ be OrdinaryFunctionCreate(%GeneratorFunction.prototype%, _sourceText_, |UniqueFormalParameters|, |GeneratorBody|, ~non-lexical-this~, _env_, _privateEnv_).
         1. Perform MakeMethod(_closure_, _object_).
         1. Perform SetFunctionName(_closure_, _propKey_).
-        1. Let _prototype_ be OrdinaryObjectCreate(%GeneratorFunction.prototype.prototype%).
+        1. Let _prototype_ be OrdinaryObjectCreate(%GeneratorPrototype%).
         1. Perform ! DefinePropertyOrThrow(_closure_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
         1. Return ? DefineMethodProperty(_object_, _propKey_, _closure_, _enumerable_).
       </emu-alg>
@@ -23995,7 +23995,7 @@
         1. Let _closure_ be OrdinaryFunctionCreate(%AsyncGeneratorFunction.prototype%, _sourceText_, |UniqueFormalParameters|, |AsyncGeneratorBody|, ~non-lexical-this~, _env_, _privateEnv_).
         1. Perform MakeMethod(_closure_, _object_).
         1. Perform SetFunctionName(_closure_, _propKey_).
-        1. Let _prototype_ be OrdinaryObjectCreate(%AsyncGeneratorFunction.prototype.prototype%).
+        1. Let _prototype_ be OrdinaryObjectCreate(%AsyncGeneratorPrototype%).
         1. Perform ! DefinePropertyOrThrow(_closure_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
         1. Return ? DefineMethodProperty(_object_, _propKey_, _closure_, _enumerable_).
       </emu-alg>
@@ -24115,7 +24115,7 @@
       <emu-grammar>GeneratorBody : FunctionBody</emu-grammar>
       <emu-alg>
         1. Perform ? FunctionDeclarationInstantiation(_functionObject_, _argumentsList_).
-        1. Let _G_ be ? OrdinaryCreateFromConstructor(_functionObject_, *"%GeneratorFunction.prototype.prototype%"*, « [[GeneratorState]], [[GeneratorContext]], [[GeneratorBrand]] »).
+        1. Let _G_ be ? OrdinaryCreateFromConstructor(_functionObject_, *"%GeneratorPrototype%"*, « [[GeneratorState]], [[GeneratorContext]], [[GeneratorBrand]] »).
         1. Set _G_.[[GeneratorBrand]] to ~empty~.
         1. Set _G_.[[GeneratorState]] to ~suspended-start~.
         1. Perform GeneratorStart(_G_, |FunctionBody|).
@@ -24138,7 +24138,7 @@
         1. Let _sourceText_ be the source text matched by |GeneratorDeclaration|.
         1. Let _F_ be OrdinaryFunctionCreate(%GeneratorFunction.prototype%, _sourceText_, |FormalParameters|, |GeneratorBody|, ~non-lexical-this~, _env_, _privateEnv_).
         1. Perform SetFunctionName(_F_, _name_).
-        1. Let _prototype_ be OrdinaryObjectCreate(%GeneratorFunction.prototype.prototype%).
+        1. Let _prototype_ be OrdinaryObjectCreate(%GeneratorPrototype%).
         1. Perform ! DefinePropertyOrThrow(_F_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
         1. Return _F_.
       </emu-alg>
@@ -24147,7 +24147,7 @@
         1. Let _sourceText_ be the source text matched by |GeneratorDeclaration|.
         1. Let _F_ be OrdinaryFunctionCreate(%GeneratorFunction.prototype%, _sourceText_, |FormalParameters|, |GeneratorBody|, ~non-lexical-this~, _env_, _privateEnv_).
         1. Perform SetFunctionName(_F_, *"default"*).
-        1. Let _prototype_ be OrdinaryObjectCreate(%GeneratorFunction.prototype.prototype%).
+        1. Let _prototype_ be OrdinaryObjectCreate(%GeneratorPrototype%).
         1. Perform ! DefinePropertyOrThrow(_F_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
         1. Return _F_.
       </emu-alg>
@@ -24172,7 +24172,7 @@
         1. Let _sourceText_ be the source text matched by |GeneratorExpression|.
         1. Let _closure_ be OrdinaryFunctionCreate(%GeneratorFunction.prototype%, _sourceText_, |FormalParameters|, |GeneratorBody|, ~non-lexical-this~, _env_, _privateEnv_).
         1. Perform SetFunctionName(_closure_, _name_).
-        1. Let _prototype_ be OrdinaryObjectCreate(%GeneratorFunction.prototype.prototype%).
+        1. Let _prototype_ be OrdinaryObjectCreate(%GeneratorPrototype%).
         1. Perform ! DefinePropertyOrThrow(_closure_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
         1. Return _closure_.
       </emu-alg>
@@ -24187,7 +24187,7 @@
         1. Let _sourceText_ be the source text matched by |GeneratorExpression|.
         1. Let _closure_ be OrdinaryFunctionCreate(%GeneratorFunction.prototype%, _sourceText_, |FormalParameters|, |GeneratorBody|, ~non-lexical-this~, _funcEnv_, _privateEnv_).
         1. Perform SetFunctionName(_closure_, _name_).
-        1. Let _prototype_ be OrdinaryObjectCreate(%GeneratorFunction.prototype.prototype%).
+        1. Let _prototype_ be OrdinaryObjectCreate(%GeneratorPrototype%).
         1. Perform ! DefinePropertyOrThrow(_closure_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
         1. Perform ! _funcEnv_.InitializeBinding(_name_, _closure_).
         1. Return _closure_.
@@ -24343,7 +24343,7 @@
       </emu-grammar>
       <emu-alg>
         1. Perform ? FunctionDeclarationInstantiation(_functionObject_, _argumentsList_).
-        1. Let _generator_ be ? OrdinaryCreateFromConstructor(_functionObject_, *"%AsyncGeneratorFunction.prototype.prototype%"*, « [[AsyncGeneratorState]], [[AsyncGeneratorContext]], [[AsyncGeneratorQueue]], [[GeneratorBrand]] »).
+        1. Let _generator_ be ? OrdinaryCreateFromConstructor(_functionObject_, *"%AsyncGeneratorPrototype%"*, « [[AsyncGeneratorState]], [[AsyncGeneratorContext]], [[AsyncGeneratorQueue]], [[GeneratorBrand]] »).
         1. Set _generator_.[[GeneratorBrand]] to ~empty~.
         1. Set _generator_.[[AsyncGeneratorState]] to ~suspended-start~.
         1. Perform AsyncGeneratorStart(_generator_, |FunctionBody|).
@@ -24368,7 +24368,7 @@
         1. Let _sourceText_ be the source text matched by |AsyncGeneratorDeclaration|.
         1. Let _F_ be OrdinaryFunctionCreate(%AsyncGeneratorFunction.prototype%, _sourceText_, |FormalParameters|, |AsyncGeneratorBody|, ~non-lexical-this~, _env_, _privateEnv_).
         1. Perform SetFunctionName(_F_, _name_).
-        1. Let _prototype_ be OrdinaryObjectCreate(%AsyncGeneratorFunction.prototype.prototype%).
+        1. Let _prototype_ be OrdinaryObjectCreate(%AsyncGeneratorPrototype%).
         1. Perform ! DefinePropertyOrThrow(_F_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
         1. Return _F_.
       </emu-alg>
@@ -24379,7 +24379,7 @@
         1. Let _sourceText_ be the source text matched by |AsyncGeneratorDeclaration|.
         1. Let _F_ be OrdinaryFunctionCreate(%AsyncGeneratorFunction.prototype%, _sourceText_, |FormalParameters|, |AsyncGeneratorBody|, ~non-lexical-this~, _env_, _privateEnv_).
         1. Perform SetFunctionName(_F_, *"default"*).
-        1. Let _prototype_ be OrdinaryObjectCreate(%AsyncGeneratorFunction.prototype.prototype%).
+        1. Let _prototype_ be OrdinaryObjectCreate(%AsyncGeneratorPrototype%).
         1. Perform ! DefinePropertyOrThrow(_F_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
         1. Return _F_.
       </emu-alg>
@@ -24406,7 +24406,7 @@
         1. Let _sourceText_ be the source text matched by |AsyncGeneratorExpression|.
         1. Let _closure_ be OrdinaryFunctionCreate(%AsyncGeneratorFunction.prototype%, _sourceText_, |FormalParameters|, |AsyncGeneratorBody|, ~non-lexical-this~, _env_, _privateEnv_).
         1. Perform SetFunctionName(_closure_, _name_).
-        1. Let _prototype_ be OrdinaryObjectCreate(%AsyncGeneratorFunction.prototype.prototype%).
+        1. Let _prototype_ be OrdinaryObjectCreate(%AsyncGeneratorPrototype%).
         1. Perform ! DefinePropertyOrThrow(_closure_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
         1. Return _closure_.
       </emu-alg>
@@ -24423,7 +24423,7 @@
         1. Let _sourceText_ be the source text matched by |AsyncGeneratorExpression|.
         1. Let _closure_ be OrdinaryFunctionCreate(%AsyncGeneratorFunction.prototype%, _sourceText_, |FormalParameters|, |AsyncGeneratorBody|, ~non-lexical-this~, _funcEnv_, _privateEnv_).
         1. Perform SetFunctionName(_closure_, _name_).
-        1. Let _prototype_ be OrdinaryObjectCreate(%AsyncGeneratorFunction.prototype.prototype%).
+        1. Let _prototype_ be OrdinaryObjectCreate(%AsyncGeneratorPrototype%).
         1. Perform ! DefinePropertyOrThrow(_closure_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
         1. Perform ! _funcEnv_.InitializeBinding(_name_, _closure_).
         1. Return _closure_.
@@ -30510,10 +30510,10 @@
             1. Let _F_ be OrdinaryFunctionCreate(_proto_, _sourceText_, _parameters_, _body_, ~non-lexical-this~, _env_, _privateEnv_).
             1. Perform SetFunctionName(_F_, *"anonymous"*).
             1. If _kind_ is ~generator~, then
-              1. Let _prototype_ be OrdinaryObjectCreate(%GeneratorFunction.prototype.prototype%).
+              1. Let _prototype_ be OrdinaryObjectCreate(%GeneratorPrototype%).
               1. Perform ! DefinePropertyOrThrow(_F_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
             1. Else if _kind_ is ~async-generator~, then
-              1. Let _prototype_ be OrdinaryObjectCreate(%AsyncGeneratorFunction.prototype.prototype%).
+              1. Let _prototype_ be OrdinaryObjectCreate(%AsyncGeneratorPrototype%).
               1. Perform ! DefinePropertyOrThrow(_F_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
             1. Else if _kind_ is ~normal~, then
               1. Perform MakeConstructor(_F_).


### PR DESCRIPTION
`%GeneratorFunction.prototype.prototype%` is just `%GeneratorPrototype%`