### PR TITLE
Editorial: Narrowing an assertion in SuperCall: super Arguments

### DIFF
--- a/esmeta-ignore.json
+++ b/esmeta-ignore.json
@@ -10,7 +10,6 @@
   "MakeMatchIndicesIndexPairArray",
   "Record[SourceTextModuleRecord].ExecuteModule",
   "Record[SourceTextModuleRecord].ResolveExport",
-  "SuperCall[0,0].Evaluation",
   "TypedArrayGetElement",
   "TypedArrayLength",
   "TypedArraySetElement",

--- a/spec.html
+++ b/spec.html
@@ -10695,7 +10695,7 @@
                 [[NewTarget]]
               </td>
               <td>
-                an Object or *undefined*
+                a constructor or *undefined*
               </td>
               <td>
                 If this Environment Record was created by the [[Construct]] internal method, [[NewTarget]] is the value of the [[Construct]] _newTarget_ parameter. Otherwise, its value is *undefined*.
@@ -19494,7 +19494,7 @@
         <emu-grammar>SuperCall : `super` Arguments</emu-grammar>
         <emu-alg>
           1. Let _newTarget_ be GetNewTarget().
-          1. Assert: _newTarget_ is an Object.
+          1. Assert: _newTarget_ is a constructor.
           1. Let _func_ be GetSuperConstructor().
           1. Let _argList_ be ? ArgumentListEvaluation of |Arguments|.
           1. If IsConstructor(_func_) is *false*, throw a *TypeError* exception.


### PR DESCRIPTION
In runtime semantics [SuperCall: super Arguments](https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-super-keyword), there is an assertion which narrows a `newTarget`'s type to Object. However, we know that this is always a constructor in this step, and fixing it to a constructor will resolve a mismatch between calling [Construct](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-construct) at step 6.

