### PR TITLE
Normative: iterator helpers close receiver on argument validation failure

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -47356,11 +47356,17 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. If _O_ is not an Object, throw a *TypeError* exception.
-          1. Let _numLimit_ be ? ToNumber(_limit_).
-          1. If _numLimit_ is *NaN*, throw a *RangeError* exception.
+          1. Let _iterated_ be the Iterator Record { [[Iterator]]: _O_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
+          1. Let _numLimit_ be Completion(ToNumber(_limit_)).
+          1. IfAbruptCloseIterator(_numLimit_, _iterated_).
+          1. If _numLimit_ is *NaN*, then
+            1. Let _error_ be ThrowCompletion(a newly created *RangeError* object).
+            1. Return ? IteratorClose(_iterated_, _error_).
           1. Let _integerLimit_ be ! ToIntegerOrInfinity(_numLimit_).
-          1. If _integerLimit_ &lt; 0, throw a *RangeError* exception.
-          1. Let _iterated_ be ? GetIteratorDirect(_O_).
+          1. If _integerLimit_ &lt; 0, then
+            1. Let _error_ be ThrowCompletion(a newly created *RangeError* object).
+            1. Return ? IteratorClose(_iterated_, _error_).
+          1. Set _iterated_ to ? GetIteratorDirect(_O_).
           1. Let _closure_ be a new Abstract Closure with no parameters that captures _iterated_ and _integerLimit_ and performs the following steps when called:
             1. Let _remaining_ be _integerLimit_.
             1. Repeat, while _remaining_ > 0,
@@ -47404,8 +47410,11 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. If _O_ is not an Object, throw a *TypeError* exception.
-          1. If IsCallable(_predicate_) is *false*, throw a *TypeError* exception.
-          1. Let _iterated_ be ? GetIteratorDirect(_O_).
+          1. Let _iterated_ be the Iterator Record { [[Iterator]]: _O_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
+          1. If IsCallable(_predicate_) is *false*, then
+            1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
+            1. Return ? IteratorClose(_iterated_, _error_).
+          1. Set _iterated_ to ? GetIteratorDirect(_O_).
           1. Let _closure_ be a new Abstract Closure with no parameters that captures _iterated_ and _predicate_ and performs the following steps when called:
             1. Let _counter_ be 0.
             1. Repeat,
@@ -47448,8 +47457,11 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. If _O_ is not an Object, throw a *TypeError* exception.
-          1. If IsCallable(_mapper_) is *false*, throw a *TypeError* exception.
-          1. Let _iterated_ be ? GetIteratorDirect(_O_).
+          1. Let _iterated_ be the Iterator Record { [[Iterator]]: _O_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
+          1. If IsCallable(_mapper_) is *false*, then
+            1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
+            1. Return ? IteratorClose(_iterated_, _error_).
+          1. Set _iterated_ to ? GetIteratorDirect(_O_).
           1. Let _closure_ be a new Abstract Closure with no parameters that captures _iterated_ and _mapper_ and performs the following steps when called:
             1. Let _counter_ be 0.
             1. Repeat,
@@ -47502,8 +47514,11 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. If _O_ is not an Object, throw a *TypeError* exception.
-          1. If IsCallable(_mapper_) is *false*, throw a *TypeError* exception.
-          1. Let _iterated_ be ? GetIteratorDirect(_O_).
+          1. Let _iterated_ be the Iterator Record { [[Iterator]]: _O_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
+          1. If IsCallable(_mapper_) is *false*, then
+            1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
+            1. Return ? IteratorClose(_iterated_, _error_).
+          1. Set _iterated_ to ? GetIteratorDirect(_O_).
           1. Let _closure_ be a new Abstract Closure with no parameters that captures _iterated_ and _mapper_ and performs the following steps when called:
             1. Let _counter_ be 0.
             1. Repeat,
@@ -47570,11 +47585,17 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. If _O_ is not an Object, throw a *TypeError* exception.
-          1. Let _numLimit_ be ? ToNumber(_limit_).
-          1. If _numLimit_ is *NaN*, throw a *RangeError* exception.
+          1. Let _iterated_ be the Iterator Record { [[Iterator]]: _O_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
+          1. Let _numLimit_ be Completion(ToNumber(_limit_)).
+          1. IfAbruptCloseIterator(_numLimit_, _iterated_).
+          1. If _numLimit_ is *NaN*, then
+            1. Let _error_ be ThrowCompletion(a newly created *RangeError* object).
+            1. Return ? IteratorClose(_iterated_, _error_).
           1. Let _integerLimit_ be ! ToIntegerOrInfinity(_numLimit_).
-          1. If _integerLimit_ &lt; 0, throw a *RangeError* exception.
-          1. Let _iterated_ be ? GetIteratorDirect(_O_).
+          1. If _integerLimit_ &lt; 0, then
+            1. Let _error_ be ThrowCompletion(a newly created *RangeError* object).
+            1. Return ? IteratorClose(_iterated_, _error_).
+          1. Set _iterated_ to ? GetIteratorDirect(_O_).
           1. Let _closure_ be a new Abstract Closure with no parameters that captures _iterated_ and _integerLimit_ and performs the following steps when called:
             1. Let _remaining_ be _integerLimit_.
             1. Repeat,

--- a/spec.html
+++ b/spec.html
@@ -47391,8 +47391,11 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. If _O_ is not an Object, throw a *TypeError* exception.
-          1. If IsCallable(_predicate_) is *false*, throw a *TypeError* exception.
-          1. Let _iterated_ be ? GetIteratorDirect(_O_).
+          1. Let _iterated_ be the Iterator Record { [[Iterator]]: _O_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
+          1. If IsCallable(_predicate_) is *false*, then
+            1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
+            1. Return ? IteratorClose(_iterated_, _error_).
+          1. Set _iterated_ to ? GetIteratorDirect(_O_).
           1. Let _counter_ be 0.
           1. Repeat,
             1. Let _value_ be ? IteratorStepValue(_iterated_).
@@ -47438,8 +47441,11 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. If _O_ is not an Object, throw a *TypeError* exception.
-          1. If IsCallable(_predicate_) is *false*, throw a *TypeError* exception.
-          1. Let _iterated_ be ? GetIteratorDirect(_O_).
+          1. Let _iterated_ be the Iterator Record { [[Iterator]]: _O_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
+          1. If IsCallable(_predicate_) is *false*, then
+            1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
+            1. Return ? IteratorClose(_iterated_, _error_).
+          1. Set _iterated_ to ? GetIteratorDirect(_O_).
           1. Let _counter_ be 0.
           1. Repeat,
             1. Let _value_ be ? IteratorStepValue(_iterated_).
@@ -47496,8 +47502,11 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. If _O_ is not an Object, throw a *TypeError* exception.
-          1. If IsCallable(_procedure_) is *false*, throw a *TypeError* exception.
-          1. Let _iterated_ be ? GetIteratorDirect(_O_).
+          1. Let _iterated_ be the Iterator Record { [[Iterator]]: _O_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
+          1. If IsCallable(_procedure_) is *false*, then
+            1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
+            1. Return ? IteratorClose(_iterated_, _error_).
+          1. Set _iterated_ to ? GetIteratorDirect(_O_).
           1. Let _counter_ be 0.
           1. Repeat,
             1. Let _value_ be ? IteratorStepValue(_iterated_).
@@ -47541,8 +47550,11 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. If _O_ is not an Object, throw a *TypeError* exception.
-          1. If IsCallable(_reducer_) is *false*, throw a *TypeError* exception.
-          1. Let _iterated_ be ? GetIteratorDirect(_O_).
+          1. Let _iterated_ be the Iterator Record { [[Iterator]]: _O_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
+          1. If IsCallable(_reducer_) is *false*, then
+            1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
+            1. Return ? IteratorClose(_iterated_, _error_).
+          1. Set _iterated_ to ? GetIteratorDirect(_O_).
           1. If _initialValue_ is not present, then
             1. Let _accumulator_ be ? IteratorStepValue(_iterated_).
             1. If _accumulator_ is ~done~, throw a *TypeError* exception.
@@ -47566,8 +47578,11 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. If _O_ is not an Object, throw a *TypeError* exception.
-          1. If IsCallable(_predicate_) is *false*, throw a *TypeError* exception.
-          1. Let _iterated_ be ? GetIteratorDirect(_O_).
+          1. Let _iterated_ be the Iterator Record { [[Iterator]]: _O_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
+          1. If IsCallable(_predicate_) is *false*, then
+            1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
+            1. Return ? IteratorClose(_iterated_, _error_).
+          1. Set _iterated_ to ? GetIteratorDirect(_O_).
           1. Let _counter_ be 0.
           1. Repeat,
             1. Let _value_ be ? IteratorStepValue(_iterated_).


### PR DESCRIPTION
The general rule when working with iterators / iterables is that once you get an iterator it is your responsibility to close it when you're done with it, unless it errors out or completes. We're consistent about this when we get the iterator from an iterable, and in some of the places where we get the iterator directly (e.g. in [`Set.prototype.isDisjointFrom`](https://tc39.es/ecma262/multipage/keyed-collections.html#sec-set.prototype.isdisjointfrom) step 5.c.ii.1.a), but as [pointed out](https://github.com/tc39/proposal-iterator-sequencing/issues/16#issuecomment-2448601515) by @zloirock, iterator helpers don't close their receiver when one of their argument is invalid. Since iterator helpers are conceptually "take ownership" of their receiver (either by consuming it fully, or by closing the receiver when the iterator helper itself is closed), and since an argument failing validation is not an error of the underlying iterator, helpers should close their receiver in this case to be consistent with the general rule above.

Unfortunately `IfAbruptCloseIterator` and `IteratorClose` both take an Iterator Record, not the iterator object itself, and we don't construct the Iterator Record until after argument validation. So we have to make a "partial" Iterator Record for use by these methods. (It's still a well-typed Iterator Record.) This is a spec fiction to simplify the spec text and doesn't need to correspond to anything in an actual implementation.