### PR TITLE
Editorial:The CreateArrayIterator abstract operation incorrectly describes the return value as "a Generator".

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -40282,7 +40282,7 @@ THH:mm:ss.sss
           CreateArrayIterator (
             _array_: an Object,
             _kind_: ~key+value~, ~key~, or ~value~,
-          ): a Generator
+          ): an Iterator
         </h1>
         <dl class="header">
           <dt>description</dt>


### PR DESCRIPTION
This is just a description change, as the title states, the error is in 23.1.5.1 CreateArrayIterator:

> The abstract operation CreateArrayIterator takes arguments array (an Object) and kind (key+value, key, or value) and returns a Generator. 

change to:

> The abstract operation CreateArrayIterator takes arguments array (an Object) and kind (key+value, key, or value) and returns an Iterator.