### PR TITLE
Editorial: Consistify capitalization re iterator wording

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -3331,7 +3331,7 @@
               <td>
               </td>
               <td>
-                The prototype of async-from-sync iterator objects (<emu-xref href="#sec-async-from-sync-iterator-objects"></emu-xref>)
+                The prototype of Async-from-Sync Iterator objects (<emu-xref href="#sec-async-from-sync-iterator-objects"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3568,7 +3568,7 @@
               <td>
               </td>
               <td>
-                The prototype of For-In iterator objects (<emu-xref href="#sec-for-in-iterator-objects"></emu-xref>)
+                The prototype of For-In Iterator objects (<emu-xref href="#sec-for-in-iterator-objects"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -22445,7 +22445,7 @@
             <emu-alg>
               1. Let _O_ be the *this* value.
               1. Assert: _O_ is an Object.
-              1. Assert: _O_ has all of the internal slots of a For-In Iterator Instance (<emu-xref href="#sec-properties-of-for-in-iterator-instances"></emu-xref>).
+              1. Assert: _O_ has all of the internal slots of a For-In Iterator instance (<emu-xref href="#sec-properties-of-for-in-iterator-instances"></emu-xref>).
               1. Let _object_ be _O_.[[Object]].
               1. Repeat,
                 1. If _O_.[[ObjectWasVisited]] is *false*, then
@@ -42308,7 +42308,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-map-iterator-objects">
       <h1>Map Iterator Objects</h1>
-      <p>A <dfn variants="Map Iterators,Map Iterator object,Map Iterator objects">Map Iterator</dfn> is an object that represents a specific iteration over some specific Map instance object. There is not a named constructor for Map Iterator objects. Instead, map iterator objects are created by calling certain methods of Map instance objects.</p>
+      <p>A <dfn variants="Map Iterators,Map Iterator object,Map Iterator objects">Map Iterator</dfn> is an object that represents a specific iteration over some specific Map instance object. There is not a named constructor for Map Iterator objects. Instead, Map Iterator objects are created by calling certain methods of Map instance objects.</p>
 
       <emu-clause id="sec-createmapiterator" type="abstract operation" oldids="sec-properties-of-map-iterator-instances,table-50,table-internal-slots-of-map-iterator-instances">
         <h1>
@@ -42940,7 +42940,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-set-iterator-objects">
       <h1>Set Iterator Objects</h1>
-      <p>A <dfn variants="Set Iterators,Set Iterator object,Set Iterator objects">Set Iterator</dfn> is an ordinary object, with the structure defined below, that represents a specific iteration over some specific Set instance object. There is not a named constructor for Set Iterator objects. Instead, set iterator objects are created by calling certain methods of Set instance objects.</p>
+      <p>A <dfn variants="Set Iterators,Set Iterator object,Set Iterator objects">Set Iterator</dfn> is an ordinary object, with the structure defined below, that represents a specific iteration over some specific Set instance object. There is not a named constructor for Set Iterator objects. Instead, Set Iterator objects are created by calling certain methods of Set instance objects.</p>
 
       <emu-clause id="sec-createsetiterator" type="abstract operation" oldids="sec-properties-of-set-iterator-instances,table-51,table-internal-slots-of-set-iterator-instances">
         <h1>
@@ -46452,7 +46452,7 @@ THH:mm:ss.sss
           </table>
         </emu-table>
         <emu-note>
-          <p>Arguments may be passed to the `next` function but their interpretation and validity is dependent upon the target iterator. The for-of statement and other common users of <em>Iterators</em> do not pass any arguments, so iterator objects that expect to be used in such a manner must be prepared to deal with being called with no arguments.</p>
+          <p>Arguments may be passed to the `next` function but their interpretation and validity is dependent upon the target iterator. The for-of statement and other common users of iterators do not pass any arguments, so iterator objects that expect to be used in such a manner must be prepared to deal with being called with no arguments.</p>
         </emu-note>
         <emu-table id="table-iterator-interface-optional-properties" caption="Iterator Interface Optional Properties" oldids="table-54">
           <table>
@@ -46543,7 +46543,7 @@ THH:mm:ss.sss
           </table>
         </emu-table>
         <emu-note>
-          <p>Arguments may be passed to the `next` function but their interpretation and validity is dependent upon the target async iterator. The `for`-`await`-`of` statement and other common users of <em>AsyncIterators</em> do not pass any arguments, so async iterator objects that expect to be used in such a manner must be prepared to deal with being called with no arguments.</p>
+          <p>Arguments may be passed to the `next` function but their interpretation and validity is dependent upon the target async iterator. The `for`-`await`-`of` statement and other common users of async iterators do not pass any arguments, so async iterator objects that expect to be used in such a manner must be prepared to deal with being called with no arguments.</p>
         </emu-note>
         <emu-table id="table-async-iterator-optional" caption="Async Iterator Interface Optional Properties">
           <table>
@@ -46605,7 +46605,7 @@ THH:mm:ss.sss
                 a Boolean
               </td>
               <td>
-                This is the result status of an <em>iterator</em> `next` method call. If the end of the iterator was reached *"done"* is *true*. If the end was not reached *"done"* is *false* and a value is available. If a *"done"* property (either own or inherited) does not exist, it is considered to have the value *false*.
+                This is the result status of an iterator `next` method call. If the end of the iterator was reached *"done"* is *true*. If the end was not reached *"done"* is *false* and a value is available. If a *"done"* property (either own or inherited) does not exist, it is considered to have the value *false*.
               </td>
             </tr>
             <tr>
@@ -46761,7 +46761,7 @@ THH:mm:ss.sss
         <li>is an ordinary object.</li>
       </ul>
       <emu-note>
-        <p>All objects defined in this specification that implement the Iterator interface also inherit from %Iterator.prototype%. ECMAScript code may also define objects that inherit from %Iterator.prototype%. The %Iterator.prototype% object provides a place where additional methods that are applicable to all iterator objects may be added.</p>
+        <p>All objects defined in this specification that implement the iterator interface also inherit from %Iterator.prototype%. ECMAScript code may also define objects that inherit from %Iterator.prototype%. The %Iterator.prototype% object provides a place where additional methods that are applicable to all iterator objects may be added.</p>
         <p>The following expression is one way that ECMAScript code can access the %Iterator.prototype% object:</p>
         <pre><code class="javascript">Object.getPrototypeOf(Object.getPrototypeOf([][Symbol.iterator]()))</code></pre>
       </emu-note>


### PR DESCRIPTION
It looks like PR #3459 missed these changes to capitalization and use of `<em>`.

----

Things I noticed but didn't change:

- "Iterator instance objects": Not sure about that "I".

- "an [Oo]bject that conforms to the IteratorResult interface": Change to "an IteratorResult object" (of which there are already many occurrences)?

The latter reminds me that the spec should perhaps have a sentence saying that an object that conforms to interface Foo can be called "a Foo object".