### PR TITLE
Editorial: added meta viewport tag to spec.html to solve #3479

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en-GB-oxendict">
 <meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="icon" href="img/favicon.ico">
 <style>
   #metadata-block {


### PR DESCRIPTION
Added <meta name="viewport" content="width=device-width, initial-scale=1"> to spec.html to stop mobile auto-adjusting inline-block element font size. 
This solves the issue #3479 small fontsize on mobile for emu-nt tags


