### PR TITLE
Editorial: Add an Assertion for Built-in Function Object

### DIFF
--- a/esmeta-ignore.json
+++ b/esmeta-ignore.json
@@ -10,7 +10,6 @@
   "GetViewByteLength",
   "INTRINSICS.Atomics.notify",
   "MakeMatchIndicesIndexPairArray",
-  "Record[BuiltinFunctionObject].Construct",
   "Record[ModuleNamespaceExoticObject].Get",
   "Record[SourceTextModuleRecord].ExecuteModule",
   "Record[SourceTextModuleRecord].InitializeEnvironment",

--- a/spec.html
+++ b/spec.html
@@ -13979,7 +13979,9 @@
         <dd>a built-in function object _F_ (when the method is present)</dd>
       </dl>
       <emu-alg>
-        1. Return ? BuiltinCallOrConstruct(_F_, ~uninitialized~, _argumentsList_, _newTarget_).
+        1. Let _result_ be ? BuiltinCallOrConstruct(_F_, ~uninitialized~, _argumentsList_, _newTarget_).
+        1. Assert: _result_ is an Object.
+        1. Return _result_.
       </emu-alg>
     </emu-clause>
 


### PR DESCRIPTION
In [Construct](https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-built-in-function-objects-construct-argumentslist-newtarget) method for built-in function object, it seems that the result must be an object. However, current ESMeta is unable to check this since [BuiltinCallOrConstruct](https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-builtincallorconstruct) handles Call and Construct together.

It will be helpful to add an assertion to resolve a false alarm. 

ESMeta alarm: 
```
[ReturnTypeMismatch] Block[6404] return statement in Record[BuiltinFunctionObject].Construct (step 1, 2:12-96)
- expected: Normal[Record[Object]] | Throw
- actual  : Normal[ESValue] | Throw
```
