### PR TITLE
Editorial: Add an assertion for PrivateEnvironment cannot be null

### DIFF
--- a/esmeta-ignore.json
+++ b/esmeta-ignore.json
@@ -19,7 +19,6 @@
   "Record[SourceTextModuleRecord].ExecuteModule",
   "Record[SourceTextModuleRecord].InitializeEnvironment",
   "Record[SourceTextModuleRecord].ResolveExport",
-  "RelationalExpression[7,0].Evaluation",
   "SuperCall[0,0].Evaluation",
   "TypedArrayGetElement",
   "TypedArrayLength",

--- a/spec.html
+++ b/spec.html
@@ -20404,6 +20404,7 @@
         1. Let _rVal_ be ? GetValue(_rRef_).
         1. If _rVal_ is not an Object, throw a *TypeError* exception.
         1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Assert: _privateEnv_ is not *null*.
         1. Let _privateName_ be ResolvePrivateIdentifier(_privateEnv_, _privateIdentifier_).
         1. If PrivateElementFind(_rVal_, _privateName_) is not ~empty~, return *true*.
         1. Return *false*.


### PR DESCRIPTION
In [RelationalExpression](https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-relational-operators-runtime-semantics-evaluation), evaluation of RelationalExpression : PrivateIdentifier in ShiftExpression makes an alarm in ESMeta since it is not trivial to know that running execution context's PrivateEnvironment never becomes null. 

It can be resolved in the same way with step 2 of [MakePrivateReference](https://tc39.es/ecma262/multipage/ecmascript-data-types-and-values.html#sec-makeprivatereference); add an assertion to annotate it. 

ESMeta alarm: 
```
[ParamTypeMismatch] Call[9993] argument assignment to first parameter _privateEnv_ when Call[9993] function call from RelationalExpression[7,0].Evaluation (step 6, 7:33-92) to ResolvePrivateIdentifier
- expected: Record[PrivateEnvironmentRecord]
- actual  : Record[PrivateEnvironmentRecord] | Null
```