### PR TITLE
Editorial: Add [[ImportName]] assertion for non-direct binding cases in ResolveExports

### DIFF
--- a/esmeta-ignore.json
+++ b/esmeta-ignore.json
@@ -9,7 +9,6 @@
   "INTRINSICS.Atomics.notify",
   "MakeMatchIndicesIndexPairArray",
   "Record[SourceTextModuleRecord].ExecuteModule",
-  "Record[SourceTextModuleRecord].ResolveExport",
   "TypedArrayGetElement",
   "TypedArrayLength",
   "TypedArraySetElement",

--- a/spec.html
+++ b/spec.html
@@ -28251,6 +28251,7 @@
                   1. Return ResolvedBinding Record { [[Module]]: _importedModule_, [[BindingName]]: ~namespace~ }.
                 1. Else,
                   1. Assert: _module_ imports a specific binding for this export.
+                  1. Assert: _e_.[[ImportName]] is a String.
                   1. Return _importedModule_.ResolveExport(_e_.[[ImportName]], _resolveSet_).
             1. If _exportName_ is *"default"*, then
               1. Assert: A `default` export was not explicitly defined by this module.


### PR DESCRIPTION
In step 6.a.iv.3 of [ResolveExport](https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-resolveexport), the case where `e.[[ImportName]]` is `ALL`, indicating that the module does not provide a direct binding, is addressed. I’m uncertain but curious whether we should also handle [other cases](https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#table-exportentry-records) such as ALL-BUT-DEFAULT and null in this context.

c.f. This is problematic because the recursive call in step 6.a.iv.4 requires exportName to be a string. Therefore, the remaining cases should be explicitly handled in some way. 