### PR TITLE
Normative: re-use IteratorResult objects in some iterator helpers

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -46804,9 +46804,9 @@ THH:mm:ss.sss
               1. Let _next_ be ? IteratorStep(_iterated_).
               1. If _next_ is ~done~, return ReturnCompletion(*undefined*).
             1. Repeat,
-              1. Let _value_ be ? IteratorStepValue(_iterated_).
-              1. If _value_ is ~done~, return ReturnCompletion(*undefined*).
-              1. Let _completion_ be Completion(Yield(_value_)).
+              1. Let _iteratorResult_ be ? IteratorStep(_iterated_).
+              1. If _iteratorResult_ is ~done~, return ReturnCompletion(*undefined*).
+              1. Let _completion_ be Completion(GeneratorYield(_iteratorResult_)).
               1. IfAbruptCloseIterator(_completion_, _iterated_).
           1. Let _result_ be CreateIteratorFromClosure(_closure_, *"Iterator Helper"*, %IteratorHelperPrototype%, « [[UnderlyingIterator]] »).
           1. Set _result_.[[UnderlyingIterator]] to _iterated_.
@@ -46844,12 +46844,16 @@ THH:mm:ss.sss
           1. Let _closure_ be a new Abstract Closure with no parameters that captures _iterated_ and _predicate_ and performs the following steps when called:
             1. Let _counter_ be 0.
             1. Repeat,
-              1. Let _value_ be ? IteratorStepValue(_iterated_).
-              1. If _value_ is ~done~, return ReturnCompletion(*undefined*).
+              1. Let _iteratorResult_ be ? IteratorStep(_iterated_).
+              1. If _iteratorResult_ is ~done~, return ReturnCompletion(*undefined*).
+              1. Let _value_ be Completion(IteratorValue(_iteratorResult_)).
+              1. If _value_ is a throw completion, then
+                1. Set _iterated_.[[Done]] to *true*.
+              1. Set _value_ to _value_.[[Value]].
               1. Let _selected_ be Completion(Call(_predicate_, *undefined*, « _value_, 𝔽(_counter_) »)).
               1. IfAbruptCloseIterator(_selected_, _iterated_).
               1. If ToBoolean(_selected_) is *true*, then
-                1. Let _completion_ be Completion(Yield(_value_)).
+                1. Let _completion_ be Completion(GeneratorYield(_iteratorResult_)).
                 1. IfAbruptCloseIterator(_completion_, _iterated_).
               1. Set _counter_ to _counter_ + 1.
           1. Let _result_ be CreateIteratorFromClosure(_closure_, *"Iterator Helper"*, %IteratorHelperPrototype%, « [[UnderlyingIterator]] »).
@@ -47017,9 +47021,9 @@ THH:mm:ss.sss
                 1. Return ? IteratorClose(_iterated_, ReturnCompletion(*undefined*)).
               1. If _remaining_ ≠ +∞, then
                 1. Set _remaining_ to _remaining_ - 1.
-              1. Let _value_ be ? IteratorStepValue(_iterated_).
-              1. If _value_ is ~done~, return ReturnCompletion(*undefined*).
-              1. Let _completion_ be Completion(Yield(_value_)).
+              1. Let _iteratorResult_ be ? IteratorStep(_iterated_).
+              1. If _iteratorResult_ is ~done~, return ReturnCompletion(*undefined*).
+              1. Let _completion_ be Completion(GeneratorYield(_iteratorResult_)).
               1. IfAbruptCloseIterator(_completion_, _iterated_).
           1. Let _result_ be CreateIteratorFromClosure(_closure_, *"Iterator Helper"*, %IteratorHelperPrototype%, « [[UnderlyingIterator]] »).
           1. Set _result_.[[UnderlyingIterator]] to _iterated_.


### PR DESCRIPTION
This re-uses IteratorResult objects when it's possible to just pass the object through. There are currently 3 cases of this: `take`/`drop`/`filter`. See related PR for the iterator sequencing proposal, which also has this opportunity: https://github.com/tc39/proposal-iterator-sequencing/pull/18

I actually don't like doing this for `filter` since `filter` observes the value, which would mean triggering a value getter both for filtering and by the eventual consumer.