### PR TITLE
Editorial: clarify that Map/Set do not literally use SameValueZero

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1757,9 +1757,8 @@
               `[x].includes(y)`
             </td>
             <td>
-              Array, Map, and Set methods,
               via <emu-xref href="#sec-samevaluezero" title></emu-xref>,
-              to test value equality, ignoring the difference between *+0*<sub>𝔽</sub> and *-0*<sub>𝔽</sub>
+              to test value equality, ignoring the difference between *+0*<sub>𝔽</sub> and *-0*<sub>𝔽</sub>, as in Array, Map, and Set methods
             </td>
             <td>
               Boolean
@@ -42049,7 +42048,7 @@ THH:mm:ss.sss
 
   <emu-clause id="sec-map-objects">
     <h1>Map Objects</h1>
-    <p>Maps are collections of key/value pairs where both the keys and values may be arbitrary ECMAScript language values. A distinct key value may only occur in one key/value pair within the Map's collection. Distinct key values are discriminated using the SameValueZero comparison algorithm.</p>
+    <p>Maps are collections of key/value pairs where both the keys and values may be arbitrary ECMAScript language values. A distinct key value may only occur in one key/value pair within the Map's collection. Distinct key values are discriminated using the semantics of the SameValueZero comparison algorithm.</p>
     <p>Maps must be implemented using either hash tables or other mechanisms that, on average, provide access times that are sublinear on the number of elements in the collection. The data structure used in this specification is only intended to describe the required observable semantics of Maps. It is not intended to be a viable implementation model.</p>
 
     <emu-clause id="sec-map-constructor">
@@ -42404,7 +42403,7 @@ THH:mm:ss.sss
 
   <emu-clause id="sec-set-objects">
     <h1>Set Objects</h1>
-    <p>Set objects are collections of ECMAScript language values. A distinct value may only occur once as an element of a Set's collection. Distinct values are discriminated using the SameValueZero comparison algorithm.</p>
+    <p>Set objects are collections of ECMAScript language values. A distinct value may only occur once as an element of a Set's collection. Distinct values are discriminated using the semantics of the SameValueZero comparison algorithm.</p>
     <p>Set objects must be implemented using either hash tables or other mechanisms that, on average, provide access times that are sublinear on the number of elements in the collection. The data structure used in this specification is only intended to describe the required observable semantics of Set objects. It is not intended to be a viable implementation model.</p>
 
     <emu-clause id="sec-abstract-operations-for-set-objects">


### PR DESCRIPTION
Fixes #3473.

Readers should still think of these algorithms as using SameValueZero, so we went with saying "the semantics of SameValueZero" to make it technically correct while still referencing SameValueZero.