### PR TITLE
Editorial: more explicit handling of [[PromiseResult]]

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -47758,6 +47758,7 @@ THH:mm:ss.sss
           1. If IsCallable(_executor_) is *false*, throw a *TypeError* exception.
           1. Let _promise_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Promise.prototype%"*, « [[PromiseState]], [[PromiseResult]], [[PromiseFulfillReactions]], [[PromiseRejectReactions]], [[PromiseIsHandled]] »).
           1. Set _promise_.[[PromiseState]] to ~pending~.
+          1. Set _promise_.[[PromiseResult]] to ~empty~.
           1. Set _promise_.[[PromiseFulfillReactions]] to a new empty List.
           1. Set _promise_.[[PromiseRejectReactions]] to a new empty List.
           1. Set _promise_.[[PromiseIsHandled]] to *false*.
@@ -48388,10 +48389,10 @@ THH:mm:ss.sss
               [[PromiseResult]]
             </td>
             <td>
-              an ECMAScript language value
+              an ECMAScript language value or ~empty~
             </td>
             <td>
-              The value with which the promise has been fulfilled or rejected, if any. Only meaningful if [[PromiseState]] is not ~pending~.
+              The value with which the promise has been fulfilled or rejected, if any. ~empty~ if and only if the [[PromiseState]] is ~pending~.
             </td>
           </tr>
           <tr>


### PR DESCRIPTION
The `[[PromiseResult]]` of a Promise is only initialized when the Promise actually settles. Generally we prefer to initialize everything explicitly. See #3482 (which also covers `[[GeneratorContext]]`).

There's various places which use this field without asserting that it's not `~empty~`, which might confuse esmeta, but those places _do_ assert that the state is not `~pending~`, so an additional assert seemed like overkill. I could add those asserts anyway if we want though.