### PR TITLE
Editorial: use suspended-start instead of undefined in AsyncGeneratorState 

### DIFF
--- a/esmeta-ignore.json
+++ b/esmeta-ignore.json
@@ -3,7 +3,6 @@
   "AsyncGeneratorYield",
   "ClassStaticBlockBody[0,0].EvaluateClassStaticBlockBody",
   "CompareTypedArrayElements",
-  "CreateAsyncIteratorFromClosure",
   "DoWait",
   "FunctionBody[0,0].EvaluateFunctionBody",
   "GetFunctionRealm",

--- a/spec.html
+++ b/spec.html
@@ -49386,7 +49386,7 @@ THH:mm:ss.sss
           1. Let _internalSlotsList_ be « [[AsyncGeneratorState]], [[AsyncGeneratorContext]], [[AsyncGeneratorQueue]], [[GeneratorBrand]] ».
           1. Let _generator_ be OrdinaryObjectCreate(_generatorPrototype_, _internalSlotsList_).
           1. Set _generator_.[[GeneratorBrand]] to _generatorBrand_.
-          1. Set _generator_.[[AsyncGeneratorState]] to *undefined*.
+          1. Set _generator_.[[AsyncGeneratorState]] to ~suspended-start~.
           1. Let _callerContext_ be the running execution context.
           1. Let _calleeContext_ be a new execution context.
           1. Set the Function of _calleeContext_ to *null*.


### PR DESCRIPTION
This is completely the same PR as #3483, but an async version.