### PR TITLE
Editorial: Allocate-and-use in MakeMatchIndicesIndexPairArray for refinement

### DIFF
--- a/esmeta-ignore.json
+++ b/esmeta-ignore.json
@@ -7,7 +7,6 @@
   "FunctionBody[0,0].EvaluateFunctionBody",
   "GetViewByteLength",
   "INTRINSICS.Atomics.notify",
-  "MakeMatchIndicesIndexPairArray",
   "Record[SourceTextModuleRecord].ExecuteModule",
   "TypedArrayGetElement",
   "TypedArrayLength",

--- a/spec.html
+++ b/spec.html
@@ -38812,11 +38812,12 @@ THH:mm:ss.sss
             1. Else,
               1. Let _matchIndexPair_ be *undefined*.
             1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_i_)), _matchIndexPair_).
-            1. If _i_ > 0 and _groupNames_[_i_ - 1] is not *undefined*, then
-              1. Assert: _groups_ is not *undefined*.
+            1. If _i_ > 0, then
               1. Let _s_ be _groupNames_[_i_ - 1].
-              1. NOTE: If there are multiple groups named _s_, _groups_ may already have an _s_ property at this point. However, because _groups_ is an ordinary object whose properties are all writable data properties, the call to CreateDataPropertyOrThrow is nevertheless guaranteed to succeed.
-              1. Perform ! CreateDataPropertyOrThrow(_groups_, _s_, _matchIndexPair_).
+              1. If _s_ is not *undefined*, then
+                1. Assert: _groups_ is not *undefined*.
+                1. NOTE: If there are multiple groups named _s_, _groups_ may already have an _s_ property at this point. However, because _groups_ is an ordinary object whose properties are all writable data properties, the call to CreateDataPropertyOrThrow is nevertheless guaranteed to succeed.
+                1. Perform ! CreateDataPropertyOrThrow(_groups_, _s_, _matchIndexPair_).
           1. Return _A_.
         </emu-alg>
       </emu-clause>


### PR DESCRIPTION
In step 9.e of [MakeMatchIndicesIndexPairArray](https://tc39.es/ecma262/multipage/text-processing.html#sec-makematchindicesindexpairarray):

> e. If i > 0 and groupNames[i - 1] is not undefined, then …

`groupNames[i - 1]` is refined to a non-undefined value. However, the current implementation of ESMeta does not support field-level refinement. To remove unsatisfactory alarms, it would helpful to first assign the value to a temporary variable before we support the feature.

c.f. Alternatively, this could be achieved by adding an identical assertion below step 9.e.ii. I'm not sure this is a better way though. 