### PR TITLE
Editorial: ProxyTarget is always a function object in GetFunctionRealm

### DIFF
--- a/esmeta-ignore.json
+++ b/esmeta-ignore.json
@@ -5,7 +5,6 @@
   "CompareTypedArrayElements",
   "DoWait",
   "FunctionBody[0,0].EvaluateFunctionBody",
-  "GetFunctionRealm",
   "GetViewByteLength",
   "INTRINSICS.Atomics.notify",
   "MakeMatchIndicesIndexPairArray",

--- a/spec.html
+++ b/spec.html
@@ -6646,6 +6646,7 @@
         1. If _obj_ is a Proxy exotic object, then
           1. Perform ? ValidateNonRevokedProxy(_obj_).
           1. Let _proxyTarget_ be _obj_.[[ProxyTarget]].
+          1. Assert: _proxyTarget_ is a function object.
           1. Return ? GetFunctionRealm(_proxyTarget_).
         1. [id="step-getfunctionrealm-default-return"] Return the current Realm Record.
       </emu-alg>


### PR DESCRIPTION
In [GetFunctionRealm](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-getfunctionrealm), step 3.c. call `GetFunctionRealm` recursively with `proxyTarget` which assumes that `proxyTarget` is a function object. 

If my investigation is correct, proxy exotic objects are generated in [ProxyCreate](https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-proxycreate) and it is callable only if the `target` is callable. Thus if a function object has a target, then it is also a function object thus it isn't a spec bug. However I think add an assertion here will be helpful. 

