### PR TITLE
Editorial: Create the realm execution context slightly later

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -11652,11 +11652,6 @@
         1. Perform CreateIntrinsics(_realm_).
         1. Set _realm_.[[AgentSignifier]] to AgentSignifier().
         1. Set _realm_.[[TemplateMap]] to a new empty List.
-        1. Let _newContext_ be a new execution context.
-        1. Set the Function of _newContext_ to *null*.
-        1. Set the Realm of _newContext_ to _realm_.
-        1. Set the ScriptOrModule of _newContext_ to *null*.
-        1. Push _newContext_ onto the execution context stack; _newContext_ is now the running execution context.
         1. If the host requires use of a specific object to serve as _realm_'s global object, then
           1. Let _global_ be such an object created in a host-defined manner.
         1. Else,
@@ -11667,6 +11662,11 @@
           1. Let _thisValue_ be _global_.
         1. Set _realm_.[[GlobalObject]] to _global_.
         1. Set _realm_.[[GlobalEnv]] to NewGlobalEnvironment(_global_, _thisValue_).
+        1. Let _newContext_ be a new execution context.
+        1. Set the Function of _newContext_ to *null*.
+        1. Set the Realm of _newContext_ to _realm_.
+        1. Set the ScriptOrModule of _newContext_ to *null*.
+        1. Push _newContext_ onto the execution context stack; _newContext_ is now the running execution context.
         1. Perform ? SetDefaultGlobalBindings(_realm_).
         1. Create any host-defined global object properties on _global_.
         1. Return ~unused~.


### PR DESCRIPTION
`InitializeHostDefinedRealm` (IHDR), in addition to creating a realm, also creates an execution context (EC) to house it, and pushes that EC onto the EC stack. In the status quo, the EC-related steps appear in the midst of the realm-creation steps, which is odd, and doesn't appear to be necessary. (You might think that the later realm-creation steps somehow assume that the realm EC exists and has been pushed on the EC stack, but as far as I can tell, they don't. I think it's just an artifact of how IHDR was introduced in ES6.)

This PR moves the EC-related steps to a point after the realm's fields have been finalized.

(This makes it easier to see that the early settings of `[[GlobalObject]]` and `[[GlobalEnv]]` to `*undefined*` are superfluous. I would have deleted those steps, but that overlaps with PR #3445.)

----

I would  have preferred to move the EC-related steps to just before the Return step. However, that would be a change in behavior. The invocation of `SetDefaultGlobalBindings` can return an abrupt completion, which is immediately returned by IHDR. In such a case, the status quo says that the EC-related things have happened, which is a side-effect that can be observed by IHDR's caller. In particular, when the HTML spec invokes IHDR, it ignores the return value; it fetches the realm EC from the EC stack regardless of whether IHDR returned an abrupt completion.

(Mind you, I think the only way that `SetDefaultGlobalBindings` could throw is if IHDR's caller provided a global object that was specifically designed to make that happen.)

----

I suggested this change in https://github.com/tc39/ecma262/pull/3445#issuecomment-2489897373

This should probably have been a quick follow-up to PR #3139.

See also PR #3274, which considers changing some of the linkage between IHDR and its caller.