### PR TITLE
Editorial: allow hosts to create ordinary global objects

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -11794,7 +11794,7 @@
         1. Set the Realm of _newContext_ to _realm_.
         1. Set the ScriptOrModule of _newContext_ to *null*.
         1. Push _newContext_ onto the execution context stack; _newContext_ is now the running execution context.
-        1. If the host requires use of an exotic object to serve as _realm_'s global object, then
+        1. If the host requires use of a specific object to serve as _realm_'s global object, then
           1. Let _global_ be such an object created in a host-defined manner.
         1. Else,
           1. Let _global_ be OrdinaryObjectCreate(_realm_.[[Intrinsics]].[[%Object.prototype%]]).


### PR DESCRIPTION
There doesn't seem to be a reason for this hook to only allow *exotic* objects.

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
