### PR TITLE
Editorial: Don't set [[GlobalEnv]] to undefined temporarily

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -11786,7 +11786,6 @@
         1. Let _realm_ be a new Realm Record.
         1. Perform CreateIntrinsics(_realm_).
         1. Set _realm_.[[AgentSignifier]] to AgentSignifier().
-        1. Set _realm_.[[GlobalEnv]] to *undefined*.
         1. Set _realm_.[[TemplateMap]] to a new empty List.
         1. Let _newContext_ be a new execution context.
         1. Set the Function of _newContext_ to *null*.


### PR DESCRIPTION
For reasons that I don't understand #3445 tightened the typing of `[[GlobalObject]]` and removed the temporary explicit assignment of undefined but left `[[GlobalEnv]]` untouched.