### PR TITLE
Editorial: Fix "property name" autolinking

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -2739,7 +2739,7 @@
           An <dfn variants="accessor properties">accessor property</dfn> associates a key value with one or two accessor functions, and a set of Boolean attributes. The accessor functions are used to store or retrieve an ECMAScript language value that is associated with the property.
         </li>
       </ul>
-      <p>The properties of an object are uniquely identified using property keys. A <dfn id="property-key" variants="property keys" oldids="sec-ispropertykey">property key</dfn> is either a String or a Symbol. All Strings and Symbols, including the empty String, are valid as property keys. A <dfn id="property-name">property name</dfn> is a property key that is a String.</p>
+      <p>The properties of an object are uniquely identified using property keys. A <dfn id="property-key" variants="property keys" oldids="sec-ispropertykey">property key</dfn> is either a String or a Symbol. All Strings and Symbols, including the empty String, are valid as property keys. A <dfn id="property-name" variants="property names">property name</dfn> is a property key that is a String.</p>
       <p>An <dfn id="integer-index" variants="integer indices,integer-indexed">integer index</dfn> is a property name _n_ such that CanonicalNumericIndexString(_n_) returns an integral Number in the inclusive interval from *+0*<sub>𝔽</sub> to 𝔽(2<sup>53</sup> - 1). An <dfn id="array-index" variants="array indices">array index</dfn> is an integer index _n_ such that CanonicalNumericIndexString(_n_) returns an integral Number in the inclusive interval from *+0*<sub>𝔽</sub> to 𝔽(2<sup>32</sup> - 2).</p>
       <emu-note>
         <p>Every non-negative safe integer has a corresponding integer index. Every 32-bit unsigned integer except <emu-eqn>2<sup>32</sup> - 1</emu-eqn> has a corresponding array index. *"-0"* is neither an integer index nor an array index.</p>
@@ -36092,7 +36092,7 @@ THH:mm:ss.sss
         <emu-grammar>UnicodePropertyValueExpression :: UnicodePropertyName `=` UnicodePropertyValue</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the source text matched by |UnicodePropertyName| is not a Unicode property name or property alias listed in the “Property name and aliases” column of <emu-xref href="#table-nonbinary-unicode-properties"></emu-xref>.
+            It is a Syntax Error if the source text matched by |UnicodePropertyName| is not a <emu-not-ref>Unicode property name</emu-not-ref> or property alias listed in the “<emu-not-ref>Property name and aliases</emu-not-ref>” column of <emu-xref href="#table-nonbinary-unicode-properties"></emu-xref>.
           </li>
           <li>
             It is a Syntax Error if the source text matched by |UnicodePropertyValue| is not a property value or property value alias for the Unicode property or property alias given by the source text matched by |UnicodePropertyName| listed in <a href="https://unicode.org/Public/UCD/latest/ucd/PropertyValueAliases.txt"><code>PropertyValueAliases.txt</code></a>.
@@ -36101,10 +36101,10 @@ THH:mm:ss.sss
         <emu-grammar>UnicodePropertyValueExpression :: LoneUnicodePropertyNameOrValue</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the source text matched by |LoneUnicodePropertyNameOrValue| is not a Unicode property value or property value alias for the General_Category (gc) property listed in <a href="https://unicode.org/Public/UCD/latest/ucd/PropertyValueAliases.txt"><code>PropertyValueAliases.txt</code></a>, nor a binary property or binary property alias listed in the “Property name and aliases” column of <emu-xref href="#table-binary-unicode-properties"></emu-xref>, nor a binary property of strings listed in the “Property name” column of <emu-xref href="#table-binary-unicode-properties-of-strings"></emu-xref>.
+            It is a Syntax Error if the source text matched by |LoneUnicodePropertyNameOrValue| is not a Unicode property value or property value alias for the General_Category (gc) property listed in <a href="https://unicode.org/Public/UCD/latest/ucd/PropertyValueAliases.txt"><code>PropertyValueAliases.txt</code></a>, nor a binary property or binary property alias listed in the “<emu-not-ref>Property name and aliases</emu-not-ref>” column of <emu-xref href="#table-binary-unicode-properties"></emu-xref>, nor a binary property of strings listed in the “<emu-not-ref>Property name</emu-not-ref>” column of <emu-xref href="#table-binary-unicode-properties-of-strings"></emu-xref>.
           </li>
           <li>
-            It is a Syntax Error if the enclosing |Pattern| does not have a <sub>[UnicodeSetsMode]</sub> parameter and the source text matched by |LoneUnicodePropertyNameOrValue| is a binary property of strings listed in the “Property name” column of <emu-xref href="#table-binary-unicode-properties-of-strings"></emu-xref>.
+            It is a Syntax Error if the enclosing |Pattern| does not have a <sub>[UnicodeSetsMode]</sub> parameter and the source text matched by |LoneUnicodePropertyNameOrValue| is a binary property of strings listed in the “<emu-not-ref>Property name</emu-not-ref>” column of <emu-xref href="#table-binary-unicode-properties-of-strings"></emu-xref>.
           </li>
         </ul>
         <emu-grammar>CharacterClassEscape :: `P{` UnicodePropertyValueExpression `}`</emu-grammar>
@@ -36474,7 +36474,7 @@ THH:mm:ss.sss
         </emu-alg>
         <emu-grammar>UnicodePropertyValueExpression :: LoneUnicodePropertyNameOrValue</emu-grammar>
         <emu-alg>
-          1. If the source text matched by |LoneUnicodePropertyNameOrValue| is a binary property of strings listed in the “Property name” column of <emu-xref href="#table-binary-unicode-properties-of-strings"></emu-xref>, return *true*.
+          1. If the source text matched by |LoneUnicodePropertyNameOrValue| is a binary property of strings listed in the “<emu-not-ref>Property name</emu-not-ref>” column of <emu-xref href="#table-binary-unicode-properties-of-strings"></emu-xref>, return *true*.
           1. Return *false*.
         </emu-alg>
         <emu-grammar>ClassUnion :: ClassSetRange ClassUnion?</emu-grammar>
@@ -37542,7 +37542,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _ps_ be the source text matched by |UnicodePropertyName|.
           1. Let _p_ be UnicodeMatchProperty(_rer_, _ps_).
-          1. Assert: _p_ is a Unicode property name or property alias listed in the “Property name and aliases” column of <emu-xref href="#table-nonbinary-unicode-properties"></emu-xref>.
+          1. Assert: _p_ is a <emu-not-ref>Unicode property name</emu-not-ref> or property alias listed in the “<emu-not-ref>Property name and aliases</emu-not-ref>” column of <emu-xref href="#table-nonbinary-unicode-properties"></emu-xref>.
           1. Let _vs_ be the source text matched by |UnicodePropertyValue|.
           1. Let _v_ be UnicodeMatchPropertyValue(_p_, _vs_).
           1. Let _A_ be the CharSet containing all Unicode code points whose character database definition includes the property _p_ with value _v_.
@@ -37554,7 +37554,7 @@ THH:mm:ss.sss
           1. If UnicodeMatchPropertyValue(`General_Category`, _s_) is a Unicode property value or property value alias for the General_Category (gc) property listed in <a href="https://unicode.org/Public/UCD/latest/ucd/PropertyValueAliases.txt"><code>PropertyValueAliases.txt</code></a>, then
             1. Return the CharSet containing all Unicode code points whose character database definition includes the property “General_Category” with value _s_.
           1. Let _p_ be UnicodeMatchProperty(_rer_, _s_).
-          1. Assert: _p_ is a binary Unicode property or binary property alias listed in the “<emu-not-ref>Property name</emu-not-ref> and aliases” column of <emu-xref href="#table-binary-unicode-properties"></emu-xref>, or a binary Unicode property of strings listed in the “<emu-not-ref>Property name</emu-not-ref>” column of <emu-xref href="#table-binary-unicode-properties-of-strings"></emu-xref>.
+          1. Assert: _p_ is a binary Unicode property or binary property alias listed in the “<emu-not-ref>Property name and aliases</emu-not-ref>” column of <emu-xref href="#table-binary-unicode-properties"></emu-xref>, or a binary Unicode property of strings listed in the “<emu-not-ref>Property name</emu-not-ref>” column of <emu-xref href="#table-binary-unicode-properties-of-strings"></emu-xref>.
           1. Let _A_ be the CharSet containing all CharSetElements whose character database definition includes the property _p_ with value “True”.
           1. Return MaybeSimpleCaseFolding(_rer_, _A_).
         </emu-alg>
@@ -37800,20 +37800,20 @@ THH:mm:ss.sss
             UnicodeMatchProperty (
               _rer_: a RegExp Record,
               _p_: ECMAScript source text,
-            ): a Unicode property name
+            ): a <emu-not-ref>Unicode property name</emu-not-ref>
           </h1>
           <dl class="header">
           </dl>
           <emu-alg>
-            1. If _rer_.[[UnicodeSets]] is *true* and _p_ is a Unicode <emu-not-ref>property name</emu-not-ref> listed in the “<emu-not-ref>Property name</emu-not-ref>” column of <emu-xref href="#table-binary-unicode-properties-of-strings"></emu-xref>, then
+            1. If _rer_.[[UnicodeSets]] is *true* and _p_ is a <emu-not-ref>Unicode property name</emu-not-ref> listed in the “<emu-not-ref>Property name</emu-not-ref>” column of <emu-xref href="#table-binary-unicode-properties-of-strings"></emu-xref>, then
               1. Return the List of Unicode code points _p_.
-            1. Assert: _p_ is a Unicode <emu-not-ref>property name</emu-not-ref> or property alias listed in the “<emu-not-ref>Property name</emu-not-ref> and aliases” column of <emu-xref href="#table-nonbinary-unicode-properties"></emu-xref> or <emu-xref href="#table-binary-unicode-properties"></emu-xref>.
-            1. Let _c_ be the canonical <emu-not-ref>property name</emu-not-ref> of _p_ as given in the “Canonical <emu-not-ref>property name</emu-not-ref>” column of the corresponding row.
+            1. Assert: _p_ is a <emu-not-ref>Unicode property name</emu-not-ref> or property alias listed in the “<emu-not-ref>Property name and aliases</emu-not-ref>” column of <emu-xref href="#table-nonbinary-unicode-properties"></emu-xref> or <emu-xref href="#table-binary-unicode-properties"></emu-xref>.
+            1. Let _c_ be the canonical <emu-not-ref>property name</emu-not-ref> of _p_ as given in the “<emu-not-ref>Canonical property name</emu-not-ref>” column of the corresponding row.
             1. Return the List of Unicode code points _c_.
           </emu-alg>
-          <p>Implementations must support the Unicode property names and aliases listed in <emu-xref href="#table-nonbinary-unicode-properties"></emu-xref>, <emu-xref href="#table-binary-unicode-properties"></emu-xref>, and <emu-xref href="#table-binary-unicode-properties-of-strings"></emu-xref>. To ensure interoperability, implementations must not support any other property names or aliases.</p>
+          <p>Implementations must support the <emu-not-ref>Unicode property names</emu-not-ref> and aliases listed in <emu-xref href="#table-nonbinary-unicode-properties"></emu-xref>, <emu-xref href="#table-binary-unicode-properties"></emu-xref>, and <emu-xref href="#table-binary-unicode-properties-of-strings"></emu-xref>. To ensure interoperability, implementations must not support any other <emu-not-ref>property names</emu-not-ref> or aliases.</p>
           <emu-note>
-            <p>For example, `Script_Extensions` (property name) and `scx` (property alias) are valid, but `script_extensions` or `Scx` aren't.</p>
+            <p>For example, `Script_Extensions` (<emu-not-ref>property name</emu-not-ref>) and `scx` (property alias) are valid, but `script_extensions` or `Scx` aren't.</p>
           </emu-note>
           <emu-note>
             <p>The listed properties form a superset of what <a href="https://unicode.org/reports/tr18/#RL1.2">UTS18 RL1.2</a> requires.</p>
@@ -37836,7 +37836,7 @@ THH:mm:ss.sss
           <dl class="header">
           </dl>
           <emu-alg>
-            1. Assert: _p_ is a canonical, unaliased Unicode property name listed in the “Canonical property name” column of <emu-xref href="#table-nonbinary-unicode-properties"></emu-xref>.
+            1. Assert: _p_ is a canonical, unaliased <emu-not-ref>Unicode property name</emu-not-ref> listed in the “<emu-not-ref>Canonical property name</emu-not-ref>” column of <emu-xref href="#table-nonbinary-unicode-properties"></emu-xref>.
             1. Assert: _v_ is a property value or property value alias for the Unicode property _p_ listed in <a href="https://unicode.org/Public/UCD/latest/ucd/PropertyValueAliases.txt"><code>PropertyValueAliases.txt</code></a>.
             1. Let _value_ be the canonical property value of _v_ as given in the “Canonical property value” column of the corresponding row.
             1. Return the List of Unicode code points _value_.

--- a/table-binary-unicode-properties-of-strings.html
+++ b/table-binary-unicode-properties-of-strings.html
@@ -3,7 +3,7 @@
   <table class="real-table unicode-property-table">
     <thead>
       <tr>
-        <th>Property name</th>
+        <th><emu-not-ref>Property name</emu-not-ref></th>
       </tr>
     </thead>
     <tr>

--- a/table-binary-unicode-properties.html
+++ b/table-binary-unicode-properties.html
@@ -1,10 +1,10 @@
 <emu-table id="table-binary-unicode-properties">
-  <emu-caption>Binary Unicode property aliases and their canonical property names</emu-caption>
+  <emu-caption>Binary Unicode property aliases and their canonical <emu-not-ref>property names</emu-not-ref></emu-caption>
   <table class="real-table unicode-property-table">
     <thead>
       <tr>
-        <th>Property name and aliases</th>
-        <th>Canonical property name</th>
+        <th><emu-not-ref>Property name and aliases</emu-not-ref></th>
+        <th><emu-not-ref>Canonical property name</emu-not-ref></th>
       </tr>
     </thead>
     <tr>

--- a/table-nonbinary-unicode-properties.html
+++ b/table-nonbinary-unicode-properties.html
@@ -1,10 +1,10 @@
 <emu-table id="table-nonbinary-unicode-properties">
-  <emu-caption>Non-binary Unicode property aliases and their canonical property names</emu-caption>
+  <emu-caption>Non-binary Unicode property aliases and their canonical <emu-not-ref>property names</emu-not-ref></emu-caption>
   <table class="real-table unicode-property-table">
     <thead>
       <tr>
-        <th>Property name and aliases</th>
-        <th>Canonical property name</th>
+        <th><emu-not-ref>Property name and aliases</emu-not-ref></th>
+        <th><emu-not-ref>Canonical property name</emu-not-ref></th>
       </tr>
     </thead>
     <tr>


### PR DESCRIPTION
* Add "property names" as an alias.
* Use \<emu-not-ref> to exempt "Unicode property name" and similar externally-defined concepts (_which are currently inappropriately linked to the ECMAScript "[property name](https://tc39.es/ecma262/multipage/ecmascript-data-types-and-values.html#property-name)" term throughout the [Regular Expression](https://tc39.es/ecma262/multipage/text-processing.html#sec-regexp-regular-expression-objects) section_).
* Adjust \<emu-not-ref>s to fully wrap such phrases (_for less disruption of searching in source text_).