### PR TITLE
fix: AsyncGeneratorComplete cannot call user code

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -49281,7 +49281,7 @@ THH:mm:ss.sss
               1. Set the running execution context's Realm to _oldRealm_.
             1. Else,
               1. Let _iteratorResult_ be CreateIteratorResultObject(_value_, _done_).
-            1. Perform ! <emu-meta effects="user-code">Call</emu-meta>(_promiseCapability_.[[Resolve]], *undefined*, « _iteratorResult_ »).
+            1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, « _iteratorResult_ »).
           1. Return ~unused~.
         </emu-alg>
       </emu-clause>


### PR DESCRIPTION
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->

It shouldn't be possible for a `Call` to both be asserted to never throw an error _and_ call user code. I believe in this case the user-code effect is the wrong one.