### PR TITLE
Editorial: Update range comparisons involving a zero

### DIFF
--- a/esmeta-ignore.json
+++ b/esmeta-ignore.json
@@ -8,8 +8,6 @@
   "GetViewByteLength",
   "INTRINSICS.Atomics.notify",
   "Record[SourceTextModuleRecord].ExecuteModule",
-  "TypedArrayGetElement",
   "TypedArrayLength",
-  "TypedArraySetElement",
   "YieldExpression[2,0].Evaluation"
 ]

--- a/spec.html
+++ b/spec.html
@@ -14432,11 +14432,11 @@
           1. Let _index_ be CanonicalNumericIndexString(_P_).
           1. If _index_ is *undefined*, return *undefined*.
           1. If _index_ is not an integral Number, return *undefined*.
-          1. If _index_ is *-0*<sub>𝔽</sub>, return *undefined*.
+          1. If _index_ is *-0*<sub>𝔽</sub> or _index_ &lt; *-0*<sub>𝔽</sub>, return *undefined*.
           1. Let _str_ be _S_.[[StringData]].
           1. Assert: _str_ is a String.
           1. Let _len_ be the length of _str_.
-          1. If ℝ(_index_) &lt; 0 or _len_ ≤ ℝ(_index_), return *undefined*.
+          1. If _len_ ≤ ℝ(_index_), return *undefined*.
           1. Let _resultStr_ be the substring of _str_ from ℝ(_index_) to ℝ(_index_) + 1.
           1. Return the PropertyDescriptor { [[Value]]: _resultStr_, [[Writable]]: *false*, [[Enumerable]]: *true*, [[Configurable]]: *false* }.
         </emu-alg>
@@ -15057,12 +15057,12 @@
         <emu-alg>
           1. If IsDetachedBuffer(_O_.[[ViewedArrayBuffer]]) is *true*, return *false*.
           1. If _index_ is not an integral Number, return *false*.
-          1. If _index_ is *-0*<sub>𝔽</sub>, return *false*.
+          1. If _index_ is *-0*<sub>𝔽</sub> or _index_ &lt; *-0*<sub>𝔽</sub>, return *false*.
           1. Let _taRecord_ be MakeTypedArrayWithBufferWitnessRecord(_O_, ~unordered~).
           1. NOTE: Bounds checking is not a synchronizing operation when _O_'s backing buffer is a growable SharedArrayBuffer.
           1. If IsTypedArrayOutOfBounds(_taRecord_) is *true*, return *false*.
           1. Let _length_ be TypedArrayLength(_taRecord_).
-          1. If ℝ(_index_) &lt; 0 or ℝ(_index_) ≥ _length_, return *false*.
+          1. If ℝ(_index_) ≥ _length_, return *false*.
           1. Return *true*.
         </emu-alg>
       </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -14430,13 +14430,12 @@
         <emu-alg>
           1. If _P_ is not a String, return *undefined*.
           1. Let _index_ be CanonicalNumericIndexString(_P_).
-          1. If _index_ is *undefined*, return *undefined*.
           1. If _index_ is not an integral Number, return *undefined*.
           1. If _index_ is *-0*<sub>𝔽</sub> or _index_ &lt; *-0*<sub>𝔽</sub>, return *undefined*.
           1. Let _str_ be _S_.[[StringData]].
           1. Assert: _str_ is a String.
           1. Let _len_ be the length of _str_.
-          1. If _len_ ≤ ℝ(_index_), return *undefined*.
+          1. If ℝ(_index_) ≥ _len_, return *undefined*.
           1. Let _resultStr_ be the substring of _str_ from ℝ(_index_) to ℝ(_index_) + 1.
           1. Return the PropertyDescriptor { [[Value]]: _resultStr_, [[Writable]]: *false*, [[Enumerable]]: *true*, [[Configurable]]: *false* }.
         </emu-alg>

--- a/spec.html
+++ b/spec.html
@@ -32517,7 +32517,7 @@
           <p>`Math.round(3.5)` returns 4, but `Math.round(-3.5)` returns -3.</p>
         </emu-note>
         <emu-note>
-          <p>The value of `Math.round(x)` is not always the same as the value of `Math.floor(x + 0.5)`. When `x` is *-0*<sub>𝔽</sub> or `x` is less than *+0*<sub>𝔽</sub> but greater than or equal to *-0.5*<sub>𝔽</sub>, `Math.round(x)` returns *-0*<sub>𝔽</sub>, but `Math.floor(x + 0.5)` returns *+0*<sub>𝔽</sub>. `Math.round(x)` may also differ from the value of `Math.floor(x + 0.5)`because of internal rounding when computing `x + 0.5`.</p>
+          <p>The value of `Math.round(x)` is not always the same as the value of `Math.floor(x + 0.5)`. When `x` is *-0*<sub>𝔽</sub> or `x` is less than *-0*<sub>𝔽</sub> but greater than or equal to *-0.5*<sub>𝔽</sub>, `Math.round(x)` returns *-0*<sub>𝔽</sub>, but `Math.floor(x + 0.5)` returns *+0*<sub>𝔽</sub>. `Math.round(x)` may also differ from the value of `Math.floor(x + 0.5)`because of internal rounding when computing `x + 0.5`.</p>
         </emu-note>
       </emu-clause>
 


### PR DESCRIPTION
* When zero bounds a Number range, always use <code>&lt; -0<sub>𝔽</sub></code> or <code>&gt; +0<sub>𝔽</sub></code> (_there was one exception_).
* Consolidate static bounds checking in [IsValidIntegerIndex](https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-isvalidintegerindex) and [StringGetOwnProperty](https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-stringgetownproperty) (_index Numbers with negative sign bit are in the same "not applicable" category as non-integers_).
* Clean up [StringGetOwnProperty](https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-stringgetownproperty) to remove a redundant check and swap comparison operands for a more conventional ordering.