### PR TITLE
Editorial: consistency around how we refer to GlobalSymbolRegistry stuff

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -30915,12 +30915,12 @@
           1. Let _stringKey_ be ? ToString(_key_).
           1. For each element _e_ of the GlobalSymbolRegistry List, do
             1. If _e_.[[Key]] is _stringKey_, return _e_.[[Symbol]].
-          1. Assert: GlobalSymbolRegistry does not currently contain an entry for _stringKey_.
+          1. Assert: The GlobalSymbolRegistry List does not currently contain an entry for _stringKey_.
           1. Let _newSymbol_ be a new Symbol whose [[Description]] is _stringKey_.
-          1. Append the Record { [[Key]]: _stringKey_, [[Symbol]]: _newSymbol_ } to the GlobalSymbolRegistry List.
+          1. Append the GlobalSymbolRegistry Record { [[Key]]: _stringKey_, [[Symbol]]: _newSymbol_ } to the GlobalSymbolRegistry List.
           1. Return _newSymbol_.
         </emu-alg>
-        <p>The GlobalSymbolRegistry is an append-only List that is globally available. It is shared by all realms. Prior to the evaluation of any ECMAScript code, it is initialized as a new empty List. Elements of the GlobalSymbolRegistry are Records with the structure defined in <emu-xref href="#table-globalsymbolregistry-record-fields"></emu-xref>.</p>
+        <p>The <dfn>GlobalSymbolRegistry List</dfn> is an append-only List that is globally available. It is shared by all realms. Prior to the evaluation of any ECMAScript code, it is initialized as a new empty List. Elements of the GlobalSymbolRegistry List are Records with the structure defined in <emu-xref href="#table-globalsymbolregistry-record-fields"></emu-xref>.</p>
         <emu-table id="table-globalsymbolregistry-record-fields" caption="GlobalSymbolRegistry Record Fields" oldids="table-44">
           <table>
             <thead>
@@ -31163,12 +31163,12 @@
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>If _sym_ is in the GlobalSymbolRegistry (see <emu-xref href="#sec-symbol.for"></emu-xref>) the String used to register _sym_ will be returned.</dd>
+          <dd>If _sym_ is in the GlobalSymbolRegistry List, the String used to register _sym_ will be returned.</dd>
         </dl>
         <emu-alg>
           1. For each element _e_ of the GlobalSymbolRegistry List, do
             1. If SameValue(_e_.[[Symbol]], _sym_) is *true*, return _e_.[[Key]].
-          1. Assert: GlobalSymbolRegistry does not currently contain an entry for _sym_.
+          1. Assert: The GlobalSymbolRegistry List does not currently contain an entry for _sym_.
           1. Return *undefined*.
         </emu-alg>
       </emu-clause>


### PR DESCRIPTION
- always refer to "the GlobalSymbolRegistry List" instead of sometimes just saying "GlobalSymbolRegistry"
- when creating a GlobalSymbolRegistry Record, do so explicitly
- dfn "GlobalSymbolRegistry List"