### PR TITLE
Editorial: Store ToString(𝔽(k)) in a variable for consistency

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -41055,9 +41055,10 @@ THH:mm:ss.sss
             1. Let _k_ be _len_ + _n_.
             1. If _k_ &lt; 0, set _k_ to 0.
           1. Repeat, while _k_ &lt; _len_,
-            1. Let _kPresent_ be ! HasProperty(_O_, ! ToString(𝔽(_k_))).
+            1. Let _Pk_ be ! ToString(𝔽(_k_)).
+            1. Let _kPresent_ be ! HasProperty(_O_, _Pk_).
             1. If _kPresent_ is *true*, then
-              1. Let _elementK_ be ! Get(_O_, ! ToString(𝔽(_k_))).
+              1. Let _elementK_ be ! Get(_O_, _Pk_).
               1. If IsStrictlyEqual(_searchElement_, _elementK_) is *true*, return 𝔽(_k_).
             1. Set _k_ to _k_ + 1.
           1. Return *-1*<sub>𝔽</sub>.
@@ -41115,9 +41116,10 @@ THH:mm:ss.sss
           1. Else,
             1. Let _k_ be _len_ + _n_.
           1. Repeat, while _k_ ≥ 0,
-            1. Let _kPresent_ be ! HasProperty(_O_, ! ToString(𝔽(_k_))).
+            1. Let _Pk_ be ! ToString(𝔽(_k_)).
+            1. Let _kPresent_ be ! HasProperty(_O_, _Pk_).
             1. If _kPresent_ is *true*, then
-              1. Let _elementK_ be ! Get(_O_, ! ToString(𝔽(_k_))).
+              1. Let _elementK_ be ! Get(_O_, _Pk_).
               1. If IsStrictlyEqual(_searchElement_, _elementK_) is *true*, return 𝔽(_k_).
             1. Set _k_ to _k_ - 1.
           1. Return *-1*<sub>𝔽</sub>.


### PR DESCRIPTION
ToString(𝔽(_k_)) was sometimes stored in let Pk and sometimes not. While this does not affect behavior, for consistency in the specification, I have standardized it to be stored in a variable.

Fixes #3530