### PR TITLE
Editorial: Document initial internal slot values at their point of creation

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -6151,6 +6151,7 @@
       <emu-alg>
         1. Set _internalSlotsList_ to the list-concatenation of _internalSlotsList_ and « [[PrivateElements]] ».
         1. Let _obj_ be a newly created object with an internal slot for each name in _internalSlotsList_.
+        1. NOTE: As described in <emu-xref href="#sec-object-internal-methods-and-internal-slots" title></emu-xref>, the initial value of each such internal slot is *undefined* unless specified otherwise.
         1. Set _obj_.[[PrivateElements]] to a new empty List.
         1. Set _obj_'s essential internal methods to the default ordinary object definitions specified in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>.
         1. Assert: If the caller will not be overriding both _obj_'s [[GetPrototypeOf]] and [[SetPrototypeOf]] essential internal methods, then _internalSlotsList_ contains [[Prototype]].


### PR DESCRIPTION
[Object Internal Methods and Internal Slots](https://tc39.es/ecma262/multipage/ecmascript-data-types-and-values.html#sec-object-internal-methods-and-internal-slots) defines the initial value of an internal slot to be **undefined**, but without a reference to that in [MakeBasicObject](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-makebasicobject), it can be difficult to track branding/externally-oriented slots such as [Error](https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-error-message) [[ErrorData]], [AllocateArrayBuffer](https://tc39.es/ecma262/multipage/structured-data.html#sec-allocatearraybuffer) [[ArrayBufferDetachKey]], and [ECMA-402](https://tc39.es/ecma402/) [[Initialized$TypeName]] slots.

This PR adds a note to make that behavior more obvious.