### PR TITLE
Editorial: Document all TypedArray instance internal slots

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -14618,7 +14618,7 @@
     <emu-clause id="sec-typedarray-exotic-objects" oldids="sec-integer-indexed-exotic-objects">
       <h1>TypedArray Exotic Objects</h1>
       <p>A TypedArray is an exotic object that performs special handling of integer index property keys.</p>
-      <p>TypedArrays have the same internal slots as ordinary objects and additionally [[ViewedArrayBuffer]], [[ArrayLength]], [[ByteOffset]], [[ContentType]], and [[TypedArrayName]] internal slots.</p>
+      <p>TypedArrays have the same internal slots as ordinary objects and additionally [[ViewedArrayBuffer]], [[TypedArrayName]], [[ContentType]], [[ByteLength]], [[ByteOffset]], and [[ArrayLength]] internal slots.</p>
       <p>An object is a <dfn id="typedarray" oldids="integer-indexed-exotic-object" variants="TypedArrays">TypedArray</dfn> if its [[PreventExtensions]], [[GetOwnProperty]], [[HasProperty]], [[DefineOwnProperty]], [[Get]], [[Set]], [[Delete]], and [[OwnPropertyKeys]], internal methods use the definitions in this section, and its other essential internal methods use the definitions found in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>. These methods are installed by TypedArrayCreate.</p>
 
       <emu-clause id="sec-typedarray-preventextensions" type="internal method">
@@ -42542,7 +42542,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-properties-of-typedarray-instances">
       <h1>Properties of _TypedArray_ Instances</h1>
-      <p>_TypedArray_ instances are TypedArrays. Each _TypedArray_ instance inherits properties from the corresponding _TypedArray_ prototype object. Each _TypedArray_ instance has the following internal slots: [[TypedArrayName]], [[ViewedArrayBuffer]], [[ByteLength]], [[ByteOffset]], and [[ArrayLength]].</p>
+      <p>_TypedArray_ instances are TypedArrays. Each _TypedArray_ instance inherits properties from the corresponding _TypedArray_ prototype object. Each _TypedArray_ instance has the following internal slots: [[ViewedArrayBuffer]], [[TypedArrayName]], [[ContentType]], [[ByteLength]], [[ByteOffset]], and [[ArrayLength]].</p>
     </emu-clause>
   </emu-clause>
 </emu-clause>


### PR DESCRIPTION
There are three locations in which the list of internal slots for a TypedArray instance appears:
* [10.4.5 TypedArray Exotic Objects](https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-typedarray-exotic-objects)
* [10.4.5.11 TypedArrayCreate](https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-typedarraycreate)
* [23.2.8 Properties of TypedArray Instances](https://tc39.es/ecma262/multipage/indexed-collections.html#sec-properties-of-typedarray-instances)

The first of those is missing [[ByteLength]], the last is missing [[ContentType]], and all three disagree on the order in which to mention them. This PR updates everything to match the current contents and ordering in TypedArrayCreate.