### PR TITLE
Editorial: Simplify the algorithms for Array and TypedArray constructors

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -39387,7 +39387,7 @@ THH:mm:ss.sss
           1. Let _numberOfArgs_ be the number of elements in _values_.
           1. If _numberOfArgs_ = 0, then
             1. Return ! ArrayCreate(0, _proto_).
-          1. Else if _numberOfArgs_ = 1, then
+          1. If _numberOfArgs_ = 1, then
             1. Let _len_ be _values_[0].
             1. Let _array_ be ! ArrayCreate(0, _proto_).
             1. If _len_ is not a Number, then
@@ -39398,17 +39398,16 @@ THH:mm:ss.sss
               1. If SameValueZero(_intLen_, _len_) is *false*, throw a *RangeError* exception.
             1. Perform ! Set(_array_, *"length"*, _intLen_, *true*).
             1. Return _array_.
-          1. Else,
-            1. Assert: _numberOfArgs_ ≥ 2.
-            1. Let _array_ be ? ArrayCreate(_numberOfArgs_, _proto_).
-            1. Let _k_ be 0.
-            1. Repeat, while _k_ &lt; _numberOfArgs_,
-              1. Let _Pk_ be ! ToString(𝔽(_k_)).
-              1. Let _itemK_ be _values_[_k_].
-              1. Perform ! CreateDataPropertyOrThrow(_array_, _Pk_, _itemK_).
-              1. Set _k_ to _k_ + 1.
-            1. Assert: The mathematical value of _array_'s *"length"* property is _numberOfArgs_.
-            1. Return _array_.
+          1. Assert: _numberOfArgs_ ≥ 2.
+          1. Let _array_ be ? ArrayCreate(_numberOfArgs_, _proto_).
+          1. Let _k_ be 0.
+          1. Repeat, while _k_ &lt; _numberOfArgs_,
+            1. Let _Pk_ be ! ToString(𝔽(_k_)).
+            1. Let _itemK_ be _values_[_k_].
+            1. Perform ! CreateDataPropertyOrThrow(_array_, _Pk_, _itemK_).
+            1. Set _k_ to _k_ + 1.
+          1. Assert: The mathematical value of _array_'s *"length"* property is _numberOfArgs_.
+          1. Return _array_.
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -42311,30 +42310,27 @@ THH:mm:ss.sss
           1. Let _numberOfArgs_ be the number of elements in _args_.
           1. If _numberOfArgs_ = 0, then
             1. Return ? AllocateTypedArray(_constructorName_, NewTarget, _proto_, 0).
-          1. Else,
-            1. Let _firstArgument_ be _args_[0].
-            1. If _firstArgument_ is an Object, then
-              1. Let _O_ be ? AllocateTypedArray(_constructorName_, NewTarget, _proto_).
-              1. If _firstArgument_ has a [[TypedArrayName]] internal slot, then
-                1. Perform ? InitializeTypedArrayFromTypedArray(_O_, _firstArgument_).
-              1. Else if _firstArgument_ has an [[ArrayBufferData]] internal slot, then
-                1. If _numberOfArgs_ > 1, let _byteOffset_ be _args_[1]; else let _byteOffset_ be *undefined*.
-                1. If _numberOfArgs_ > 2, let _length_ be _args_[2]; else let _length_ be *undefined*.
-                1. Perform ? InitializeTypedArrayFromArrayBuffer(_O_, _firstArgument_, _byteOffset_, _length_).
-              1. Else,
-                1. Assert: _firstArgument_ is an Object and _firstArgument_ does not have either a [[TypedArrayName]] or an [[ArrayBufferData]] internal slot.
-                1. Let _usingIterator_ be ? GetMethod(_firstArgument_, %Symbol.iterator%).
-                1. If _usingIterator_ is not *undefined*, then
-                  1. Let _values_ be ? IteratorToList(? GetIteratorFromMethod(_firstArgument_, _usingIterator_)).
-                  1. Perform ? InitializeTypedArrayFromList(_O_, _values_).
-                1. Else,
-                  1. NOTE: _firstArgument_ is not an iterable object, so assume it is already an array-like object.
-                  1. Perform ? InitializeTypedArrayFromArrayLike(_O_, _firstArgument_).
-              1. Return _O_.
+          1. Let _firstArgument_ be _args_[0].
+          1. If _firstArgument_ is an Object, then
+            1. Let _O_ be ? AllocateTypedArray(_constructorName_, NewTarget, _proto_).
+            1. If _firstArgument_ has a [[TypedArrayName]] internal slot, then
+              1. Perform ? InitializeTypedArrayFromTypedArray(_O_, _firstArgument_).
+            1. Else if _firstArgument_ has an [[ArrayBufferData]] internal slot, then
+              1. If _numberOfArgs_ > 1, let _byteOffset_ be _args_[1]; else let _byteOffset_ be *undefined*.
+              1. If _numberOfArgs_ > 2, let _length_ be _args_[2]; else let _length_ be *undefined*.
+              1. Perform ? InitializeTypedArrayFromArrayBuffer(_O_, _firstArgument_, _byteOffset_, _length_).
             1. Else,
-              1. Assert: _firstArgument_ is not an Object.
-              1. Let _elementLength_ be ? ToIndex(_firstArgument_).
-              1. Return ? AllocateTypedArray(_constructorName_, NewTarget, _proto_, _elementLength_).
+              1. Let _usingIterator_ be ? GetMethod(_firstArgument_, %Symbol.iterator%).
+              1. If _usingIterator_ is not *undefined*, then
+                1. Let _values_ be ? IteratorToList(? GetIteratorFromMethod(_firstArgument_, _usingIterator_)).
+                1. Perform ? InitializeTypedArrayFromList(_O_, _values_).
+              1. Else,
+                1. NOTE: _firstArgument_ is not an iterable object, so assume it is already an array-like object.
+                1. Perform ? InitializeTypedArrayFromArrayLike(_O_, _firstArgument_).
+            1. Return _O_.
+          1. Assert: _firstArgument_ is not an Object.
+          1. Let _elementLength_ be ? ToIndex(_firstArgument_).
+          1. Return ? AllocateTypedArray(_constructorName_, NewTarget, _proto_, _elementLength_).
         </emu-alg>
 
         <emu-clause id="sec-allocatetypedarray" type="abstract operation">


### PR DESCRIPTION
Remove some unnecessary condition nesting and a trivial assertion. The small scope of the changes is most obvious while [ignoring whitespace](https://github.com/tc39/ecma262/pull/3544/files?w=1).