### PR TITLE
Editorial: unify NaN phrasing, editorial followups to #3532

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -45352,8 +45352,8 @@ THH:mm:ss.sss
         <h1>DataView.prototype.getBigInt64 ( _byteOffset_ [ , _littleEndian_ ] )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _v_ be the *this* value.
-          1. Return ? GetViewValue(_v_, _byteOffset_, _littleEndian_, ~bigint64~).
+          1. Let _view_ be the *this* value.
+          1. Return ? GetViewValue(_view_, _byteOffset_, _littleEndian_, ~bigint64~).
         </emu-alg>
       </emu-clause>
 
@@ -45361,8 +45361,8 @@ THH:mm:ss.sss
         <h1>DataView.prototype.getBigUint64 ( _byteOffset_ [ , _littleEndian_ ] )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _v_ be the *this* value.
-          1. Return ? GetViewValue(_v_, _byteOffset_, _littleEndian_, ~biguint64~).
+          1. Let _view_ be the *this* value.
+          1. Return ? GetViewValue(_view_, _byteOffset_, _littleEndian_, ~biguint64~).
         </emu-alg>
       </emu-clause>
 
@@ -45370,9 +45370,9 @@ THH:mm:ss.sss
         <h1>DataView.prototype.getFloat16 ( _byteOffset_ [ , _littleEndian_ ] )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _v_ be the *this* value.
+          1. Let _view_ be the *this* value.
           1. If _littleEndian_ is not present, set _littleEndian_ to *false*.
-          1. Return ? GetViewValue(_v_, _byteOffset_, _littleEndian_, ~float16~).
+          1. Return ? GetViewValue(_view_, _byteOffset_, _littleEndian_, ~float16~).
         </emu-alg>
       </emu-clause>
 
@@ -45380,9 +45380,9 @@ THH:mm:ss.sss
         <h1>DataView.prototype.getFloat32 ( _byteOffset_ [ , _littleEndian_ ] )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _v_ be the *this* value.
+          1. Let _view_ be the *this* value.
           1. If _littleEndian_ is not present, set _littleEndian_ to *false*.
-          1. Return ? GetViewValue(_v_, _byteOffset_, _littleEndian_, ~float32~).
+          1. Return ? GetViewValue(_view_, _byteOffset_, _littleEndian_, ~float32~).
         </emu-alg>
       </emu-clause>
 
@@ -45390,9 +45390,9 @@ THH:mm:ss.sss
         <h1>DataView.prototype.getFloat64 ( _byteOffset_ [ , _littleEndian_ ] )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _v_ be the *this* value.
+          1. Let _view_ be the *this* value.
           1. If _littleEndian_ is not present, set _littleEndian_ to *false*.
-          1. Return ? GetViewValue(_v_, _byteOffset_, _littleEndian_, ~float64~).
+          1. Return ? GetViewValue(_view_, _byteOffset_, _littleEndian_, ~float64~).
         </emu-alg>
       </emu-clause>
 
@@ -45400,8 +45400,8 @@ THH:mm:ss.sss
         <h1>DataView.prototype.getInt8 ( _byteOffset_ )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _v_ be the *this* value.
-          1. Return ? GetViewValue(_v_, _byteOffset_, *true*, ~int8~).
+          1. Let _view_ be the *this* value.
+          1. Return ? GetViewValue(_view_, _byteOffset_, *true*, ~int8~).
         </emu-alg>
       </emu-clause>
 
@@ -45409,9 +45409,9 @@ THH:mm:ss.sss
         <h1>DataView.prototype.getInt16 ( _byteOffset_ [ , _littleEndian_ ] )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _v_ be the *this* value.
+          1. Let _view_ be the *this* value.
           1. If _littleEndian_ is not present, set _littleEndian_ to *false*.
-          1. Return ? GetViewValue(_v_, _byteOffset_, _littleEndian_, ~int16~).
+          1. Return ? GetViewValue(_view_, _byteOffset_, _littleEndian_, ~int16~).
         </emu-alg>
       </emu-clause>
 
@@ -45419,9 +45419,9 @@ THH:mm:ss.sss
         <h1>DataView.prototype.getInt32 ( _byteOffset_ [ , _littleEndian_ ] )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _v_ be the *this* value.
+          1. Let _view_ be the *this* value.
           1. If _littleEndian_ is not present, set _littleEndian_ to *false*.
-          1. Return ? GetViewValue(_v_, _byteOffset_, _littleEndian_, ~int32~).
+          1. Return ? GetViewValue(_view_, _byteOffset_, _littleEndian_, ~int32~).
         </emu-alg>
       </emu-clause>
 
@@ -45429,8 +45429,8 @@ THH:mm:ss.sss
         <h1>DataView.prototype.getUint8 ( _byteOffset_ )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _v_ be the *this* value.
-          1. Return ? GetViewValue(_v_, _byteOffset_, *true*, ~uint8~).
+          1. Let _view_ be the *this* value.
+          1. Return ? GetViewValue(_view_, _byteOffset_, *true*, ~uint8~).
         </emu-alg>
       </emu-clause>
 
@@ -45438,9 +45438,9 @@ THH:mm:ss.sss
         <h1>DataView.prototype.getUint16 ( _byteOffset_ [ , _littleEndian_ ] )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _v_ be the *this* value.
+          1. Let _view_ be the *this* value.
           1. If _littleEndian_ is not present, set _littleEndian_ to *false*.
-          1. Return ? GetViewValue(_v_, _byteOffset_, _littleEndian_, ~uint16~).
+          1. Return ? GetViewValue(_view_, _byteOffset_, _littleEndian_, ~uint16~).
         </emu-alg>
       </emu-clause>
 
@@ -45448,9 +45448,9 @@ THH:mm:ss.sss
         <h1>DataView.prototype.getUint32 ( _byteOffset_ [ , _littleEndian_ ] )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _v_ be the *this* value.
+          1. Let _view_ be the *this* value.
           1. If _littleEndian_ is not present, set _littleEndian_ to *false*.
-          1. Return ? GetViewValue(_v_, _byteOffset_, _littleEndian_, ~uint32~).
+          1. Return ? GetViewValue(_view_, _byteOffset_, _littleEndian_, ~uint32~).
         </emu-alg>
       </emu-clause>
 
@@ -45458,8 +45458,8 @@ THH:mm:ss.sss
         <h1>DataView.prototype.setBigInt64 ( _byteOffset_, _value_ [ , _littleEndian_ ] )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _v_ be the *this* value.
-          1. Return ? SetViewValue(_v_, _byteOffset_, _littleEndian_, ~bigint64~, _value_).
+          1. Let _view_ be the *this* value.
+          1. Return ? SetViewValue(_view_, _byteOffset_, _littleEndian_, ~bigint64~, _value_).
         </emu-alg>
       </emu-clause>
 
@@ -45467,8 +45467,8 @@ THH:mm:ss.sss
         <h1>DataView.prototype.setBigUint64 ( _byteOffset_, _value_ [ , _littleEndian_ ] )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _v_ be the *this* value.
-          1. Return ? SetViewValue(_v_, _byteOffset_, _littleEndian_, ~biguint64~, _value_).
+          1. Let _view_ be the *this* value.
+          1. Return ? SetViewValue(_view_, _byteOffset_, _littleEndian_, ~biguint64~, _value_).
         </emu-alg>
       </emu-clause>
 
@@ -45476,9 +45476,9 @@ THH:mm:ss.sss
         <h1>DataView.prototype.setFloat16 ( _byteOffset_, _value_ [ , _littleEndian_ ] )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _v_ be the *this* value.
+          1. Let _view_ be the *this* value.
           1. If _littleEndian_ is not present, set _littleEndian_ to *false*.
-          1. Return ? SetViewValue(_v_, _byteOffset_, _littleEndian_, ~float16~, _value_).
+          1. Return ? SetViewValue(_view_, _byteOffset_, _littleEndian_, ~float16~, _value_).
         </emu-alg>
       </emu-clause>
 
@@ -45486,9 +45486,9 @@ THH:mm:ss.sss
         <h1>DataView.prototype.setFloat32 ( _byteOffset_, _value_ [ , _littleEndian_ ] )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _v_ be the *this* value.
+          1. Let _view_ be the *this* value.
           1. If _littleEndian_ is not present, set _littleEndian_ to *false*.
-          1. Return ? SetViewValue(_v_, _byteOffset_, _littleEndian_, ~float32~, _value_).
+          1. Return ? SetViewValue(_view_, _byteOffset_, _littleEndian_, ~float32~, _value_).
         </emu-alg>
       </emu-clause>
 
@@ -45496,9 +45496,9 @@ THH:mm:ss.sss
         <h1>DataView.prototype.setFloat64 ( _byteOffset_, _value_ [ , _littleEndian_ ] )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _v_ be the *this* value.
+          1. Let _view_ be the *this* value.
           1. If _littleEndian_ is not present, set _littleEndian_ to *false*.
-          1. Return ? SetViewValue(_v_, _byteOffset_, _littleEndian_, ~float64~, _value_).
+          1. Return ? SetViewValue(_view_, _byteOffset_, _littleEndian_, ~float64~, _value_).
         </emu-alg>
       </emu-clause>
 
@@ -45506,8 +45506,8 @@ THH:mm:ss.sss
         <h1>DataView.prototype.setInt8 ( _byteOffset_, _value_ )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _v_ be the *this* value.
-          1. Return ? SetViewValue(_v_, _byteOffset_, *true*, ~int8~, _value_).
+          1. Let _view_ be the *this* value.
+          1. Return ? SetViewValue(_view_, _byteOffset_, *true*, ~int8~, _value_).
         </emu-alg>
       </emu-clause>
 
@@ -45515,9 +45515,9 @@ THH:mm:ss.sss
         <h1>DataView.prototype.setInt16 ( _byteOffset_, _value_ [ , _littleEndian_ ] )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _v_ be the *this* value.
+          1. Let _view_ be the *this* value.
           1. If _littleEndian_ is not present, set _littleEndian_ to *false*.
-          1. Return ? SetViewValue(_v_, _byteOffset_, _littleEndian_, ~int16~, _value_).
+          1. Return ? SetViewValue(_view_, _byteOffset_, _littleEndian_, ~int16~, _value_).
         </emu-alg>
       </emu-clause>
 
@@ -45525,9 +45525,9 @@ THH:mm:ss.sss
         <h1>DataView.prototype.setInt32 ( _byteOffset_, _value_ [ , _littleEndian_ ] )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _v_ be the *this* value.
+          1. Let _view_ be the *this* value.
           1. If _littleEndian_ is not present, set _littleEndian_ to *false*.
-          1. Return ? SetViewValue(_v_, _byteOffset_, _littleEndian_, ~int32~, _value_).
+          1. Return ? SetViewValue(_view_, _byteOffset_, _littleEndian_, ~int32~, _value_).
         </emu-alg>
       </emu-clause>
 
@@ -45535,8 +45535,8 @@ THH:mm:ss.sss
         <h1>DataView.prototype.setUint8 ( _byteOffset_, _value_ )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _v_ be the *this* value.
-          1. Return ? SetViewValue(_v_, _byteOffset_, *true*, ~uint8~, _value_).
+          1. Let _view_ be the *this* value.
+          1. Return ? SetViewValue(_view_, _byteOffset_, *true*, ~uint8~, _value_).
         </emu-alg>
       </emu-clause>
 
@@ -45544,9 +45544,9 @@ THH:mm:ss.sss
         <h1>DataView.prototype.setUint16 ( _byteOffset_, _value_ [ , _littleEndian_ ] )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _v_ be the *this* value.
+          1. Let _view_ be the *this* value.
           1. If _littleEndian_ is not present, set _littleEndian_ to *false*.
-          1. Return ? SetViewValue(_v_, _byteOffset_, _littleEndian_, ~uint16~, _value_).
+          1. Return ? SetViewValue(_view_, _byteOffset_, _littleEndian_, ~uint16~, _value_).
         </emu-alg>
       </emu-clause>
 
@@ -45554,9 +45554,9 @@ THH:mm:ss.sss
         <h1>DataView.prototype.setUint32 ( _byteOffset_, _value_ [ , _littleEndian_ ] )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _v_ be the *this* value.
+          1. Let _view_ be the *this* value.
           1. If _littleEndian_ is not present, set _littleEndian_ to *false*.
-          1. Return ? SetViewValue(_v_, _byteOffset_, _littleEndian_, ~uint32~, _value_).
+          1. Return ? SetViewValue(_view_, _byteOffset_, _littleEndian_, ~uint32~, _value_).
         </emu-alg>
       </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -521,7 +521,7 @@
 
     <emu-clause id="sec-terms-and-definitions-number-type">
       <h1>Number type</h1>
-      <p>set of all possible Number values including the special “Not-a-Number” (NaN) value, positive infinity, and negative infinity</p>
+      <p>set of all possible Number values including *NaN* (“not a number”), *+∞*<sub>𝔽</sub> (positive infinity), and *-∞*<sub>𝔽</sub> (negative infinity)</p>
     </emu-clause>
 
     <emu-clause id="sec-number-object">
@@ -539,7 +539,7 @@
 
     <emu-clause id="sec-terms-and-definitions-nan">
       <h1>NaN</h1>
-      <p>Number value that is an IEEE 754-2019 “Not-a-Number” value</p>
+      <p>Number value that is an IEEE 754-2019 NaN (“not a number”) value</p>
     </emu-clause>
 
     <emu-clause id="sec-terms-and-definitions-bigint-value">
@@ -1968,7 +1968,7 @@
 
       <emu-clause id="sec-ecmascript-language-types-number-type">
         <h1>The Number Type</h1>
-        <p>The <dfn variants="is a Number,is not a Number">Number type</dfn> has exactly 18,437,736,874,454,810,627 (that is, <emu-eqn>2<sup>64</sup> - 2<sup>53</sup> + 3</emu-eqn>) values, representing the double-precision floating point IEEE 754-2019 binary64 values as specified in the IEEE Standard for Binary Floating-Point Arithmetic, except that the 9,007,199,254,740,990 (that is, <emu-eqn>2<sup>53</sup> - 2</emu-eqn>) distinct “Not-a-Number” values of the IEEE Standard are represented in ECMAScript as a single special *NaN* value. (Note that the *NaN* value is produced by the program expression `NaN`.) In some implementations, external code might be able to detect a difference between various Not-a-Number values, but such behaviour is implementation-defined; to ECMAScript code, all *NaN* values are indistinguishable from each other.</p>
+        <p>The <dfn variants="is a Number,is not a Number">Number type</dfn> has exactly 18,437,736,874,454,810,627 (that is, <emu-eqn>2<sup>64</sup> - 2<sup>53</sup> + 3</emu-eqn>) values, representing the double-precision floating point IEEE 754-2019 binary64 values as specified in the IEEE Standard for Binary Floating-Point Arithmetic, except that the 9,007,199,254,740,990 (that is, <emu-eqn>2<sup>53</sup> - 2</emu-eqn>) distinct NaN values of the IEEE Standard are represented in ECMAScript as a single special *NaN* value. (Note that the *NaN* value is produced by the program expression `NaN`.) In some implementations, external code might be able to detect a difference between various NaN values, but such behaviour is implementation-defined; to ECMAScript code, all *NaN* values are indistinguishable from each other.</p>
         <emu-note>
           <p>The bit pattern that might be observed in an ArrayBuffer (see <emu-xref href="#sec-arraybuffer-objects"></emu-xref>) or a SharedArrayBuffer (see <emu-xref href="#sec-sharedarraybuffer-objects"></emu-xref>) after a Number value has been stored into it is not necessarily the same as the internal representation of that Number value used by the ECMAScript implementation.</p>
         </emu-note>
@@ -44346,15 +44346,15 @@ THH:mm:ss.sss
           1. If _isLittleEndian_ is *false*, reverse the order of the elements of _rawBytes_.
           1. If _type_ is ~float16~, then
             1. Let _value_ be the byte elements of _rawBytes_ concatenated and interpreted as a little-endian bit string encoding of an IEEE 754-2019 binary16 value.
-            1. If _value_ is an IEEE 754-2019 binary16 NaN value, return the *NaN* Number value.
+            1. If _value_ is a NaN, return *NaN*.
             1. Return the Number value that corresponds to _value_.
           1. If _type_ is ~float32~, then
             1. Let _value_ be the byte elements of _rawBytes_ concatenated and interpreted as a little-endian bit string encoding of an IEEE 754-2019 binary32 value.
-            1. If _value_ is an IEEE 754-2019 binary32 NaN value, return the *NaN* Number value.
+            1. If _value_ is a NaN, return *NaN*.
             1. Return the Number value that corresponds to _value_.
           1. If _type_ is ~float64~, then
             1. Let _value_ be the byte elements of _rawBytes_ concatenated and interpreted as a little-endian bit string encoding of an IEEE 754-2019 binary64 value.
-            1. If _value_ is an IEEE 754-2019 binary64 NaN value, return the *NaN* Number value.
+            1. If _value_ is a NaN, return *NaN*.
             1. Return the Number value that corresponds to _value_.
           1. If IsUnsignedElementType(_type_) is *true*, then
             1. Let _intValue_ be the byte elements of _rawBytes_ concatenated and interpreted as a bit string encoding of an unsigned little-endian binary number.
@@ -44432,11 +44432,11 @@ THH:mm:ss.sss
         </dl>
         <emu-alg>
           1. If _type_ is ~float16~, then
-            1. Let _rawBytes_ be a List whose elements are the 2 bytes that are the result of converting _value_ to IEEE 754-2019 binary16 format using roundTiesToEven mode. The bytes are arranged in little endian order. If _value_ is *NaN*, _rawBytes_ may be set to any implementation chosen IEEE 754-2019 binary16 format Not-a-Number encoding. An implementation must always choose the same encoding for each implementation distinguishable *NaN* value.
+            1. Let _rawBytes_ be a List whose elements are the 2 bytes that are the result of converting _value_ to IEEE 754-2019 binary16 format using roundTiesToEven mode. The bytes are arranged in little endian order. If _value_ is *NaN*, _rawBytes_ may be set to any implementation chosen IEEE 754-2019 binary16 format NaN encoding. An implementation must always choose the same encoding for each implementation distinguishable *NaN* value.
           1. Else if _type_ is ~float32~, then
-            1. Let _rawBytes_ be a List whose elements are the 4 bytes that are the result of converting _value_ to IEEE 754-2019 binary32 format using roundTiesToEven mode. The bytes are arranged in little endian order. If _value_ is *NaN*, _rawBytes_ may be set to any implementation chosen IEEE 754-2019 binary32 format Not-a-Number encoding. An implementation must always choose the same encoding for each implementation distinguishable *NaN* value.
+            1. Let _rawBytes_ be a List whose elements are the 4 bytes that are the result of converting _value_ to IEEE 754-2019 binary32 format using roundTiesToEven mode. The bytes are arranged in little endian order. If _value_ is *NaN*, _rawBytes_ may be set to any implementation chosen IEEE 754-2019 binary32 format NaN encoding. An implementation must always choose the same encoding for each implementation distinguishable *NaN* value.
           1. Else if _type_ is ~float64~, then
-            1. Let _rawBytes_ be a List whose elements are the 8 bytes that are the IEEE 754-2019 binary64 format encoding of _value_. The bytes are arranged in little endian order. If _value_ is *NaN*, _rawBytes_ may be set to any implementation chosen IEEE 754-2019 binary64 format Not-a-Number encoding. An implementation must always choose the same encoding for each implementation distinguishable *NaN* value.
+            1. Let _rawBytes_ be a List whose elements are the 8 bytes that are the IEEE 754-2019 binary64 format encoding of _value_. The bytes are arranged in little endian order. If _value_ is *NaN*, _rawBytes_ may be set to any implementation chosen IEEE 754-2019 binary64 format NaN encoding. An implementation must always choose the same encoding for each implementation distinguishable *NaN* value.
           1. Else,
             1. Let _n_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for Element Type _type_.
             1. Let _conversionOperation_ be the abstract operation named in the Conversion Operation column in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for Element Type _type_.


### PR DESCRIPTION
* unify phrasing in RawBytesToNumeric and NumericToRawBytes
* prefer "NaN" over "the NaN Number value"
* rename `v` alias in DataView.prototype methods to `view`