### PR TITLE
Markup: consistent spacing for method signatures in tables

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -26682,7 +26682,7 @@
             </thead>
             <tr>
               <td>
-                LoadRequestedModules( [ _hostDefined_ ] )
+                LoadRequestedModules([_hostDefined_])
               </td>
               <td>
                 <p>Prepares the module for linking by recursively loading all its dependencies, and returns a promise.</p>
@@ -26905,7 +26905,7 @@
             </tr>
             <tr>
               <td>
-                ExecuteModule( [ _promiseCapability_ ] )
+                ExecuteModule([_promiseCapability_])
               </td>
               <td>
                 Evaluate the module's code within its execution context. If this module has *true* in [[HasTLA]], then a PromiseCapability Record is passed as an argument, and the method is expected to resolve or reject the given capability. In this case, the method must not throw an exception, but instead reject the PromiseCapability Record if necessary.


### PR DESCRIPTION
All the other signatures omit these spaces, which I think also looks better.