### PR TITLE
Markup: Print styles for slashed corner cell

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -161,6 +161,34 @@
   .unicode-property-table th:first-of-type {
     width: 33%;
   }
+
+  .corner-cell {
+    background-image: url(data:image/svg+xml;base64,PHN2ZyBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGZpbGwtcnVsZT0iZXZlbm9kZCIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIiBzdHJva2UtbWl0ZXJsaW1pdD0iMS41IiB2aWV3Qm94PSIwIDAgMjQyIDQ2IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Y2xpcFBhdGggaWQ9ImEiPjxwYXRoIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0ibS03Ny43MDQtMzYuMDI3aDI0MS4wNDJ2NDUuMDQyaC0yNDEuMDQyeiIvPjwvY2xpcFBhdGg+PGcgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoNzcuNzAzOSAzNi4wMjY2KSI+PHBhdGggZD0ibS03Ny43MDQtMzYuMDI3aDI0MS4wNDJ2NDUuMDQyaC0yNDEuMDQyeiIgZmlsbD0ibm9uZSIvPjxnIGNsaXAtcGF0aD0idXJsKCNhKSI+PHBhdGggZD0ibTMxNC45MyAzOTUuOTM1IDI0MS4wNDIgNDUuMDQyIiBmaWxsPSJub25lIiBzdHJva2U9IiMyMzFmMjAiIHN0cm9rZS13aWR0aD0iMS4wNCIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoLTM5Mi42MzQgLTQzMS45NjIpIi8+PC9nPjwvZz48L3N2Zz4=);
+    background-size: cover;
+    height: 3em;
+    padding: 0;
+    vertical-align: inherit;
+    position: static;
+  }
+
+  .corner-cell .slash {
+    display: none;
+  }
+
+  .corner-cell > .column, .corner-cell > .row {
+    display: block;
+    position: relative;
+  }
+
+  .corner-cell > .row {
+    text-align: right;
+    top: -0.75em
+  }
+
+  .corner-cell > .column {
+    text-align: left;
+    bottom: -1.25em;
+  }
 </style>
 <pre class="metadata">
   title: ECMAScript<sup>&reg;</sup> 2025 Language&nbsp;Specification


### PR DESCRIPTION
The overlapping background gradient is fun in Chrome, but it ends up a blurry mess against vector table borders in the PDF. Also the CSS spec apparently doesn’t actually define behavior for non-static positioning within table cells? So implementations vary. Prince’s isn’t great. (idk, i read this somewhere, i didn’t dig in to the spec because it doesn’t really matter)

Anyway here’s a base64-encoded SVG. It’s only on Table 48, as that’s how I found it.
<img width="856" alt="2503_nydom" src="https://github.com/user-attachments/assets/2172818d-a2d2-4198-9c61-cca10464ab0b" />

IMO you should put this in ecmarkup, it could be useful for other publications. But you do you boo.