### PR TITLE
Meta: bump ecmarkup to v21.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://tc39.es/ecma262/#sec-copyright-and-software-license",
       "devDependencies": {
-        "ecmarkup": "^21.0.0",
+        "ecmarkup": "^21.2.0",
         "glob": "^7.1.6",
         "jsdom": "^15.0.0",
         "pagedjs": "^0.4.3",
@@ -1360,9 +1360,9 @@
       }
     },
     "node_modules/ecmarkup": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-21.0.0.tgz",
-      "integrity": "sha512-yzbVI6cHm+TqX+q1Bb+TotPMdA+DTR7ofOg6bUa6zuyvNceToblqWpTxRp0/MtcntDATl5WZCi36//LcwYhdEg==",
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-21.2.0.tgz",
+      "integrity": "sha512-d7FvzQiPGYVukzyd8z4a9HxjEPxi4X1u0VhETSCcLudzc5T8aGmJBw0wNGlf+sekfpFy6SJC9Nco/Fn8I09FHg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "license": "SEE LICENSE IN https://tc39.es/ecma262/#sec-copyright-and-software-license",
   "homepage": "https://tc39.es/ecma262/",
   "devDependencies": {
-    "ecmarkup": "^21.0.0",
+    "ecmarkup": "^21.2.0",
     "glob": "^7.1.6",
     "jsdom": "^15.0.0",
     "pagedjs": "^0.4.3",


### PR DESCRIPTION
Adds dark mode, thanks @arai-a!

~We need to update the SVGs to render correctly in dark mode before landing (which I think we can do with some CSS in the SVGs).~ Actually they're already fine.

~Also should land some other ecmarkup PRs first I guess.~ Done.