### PR TITLE
Editorial: Add %IteratorPrototype% for the Iterator.prototype object (#3555)

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -3832,6 +3832,16 @@
             </tr>
             <tr>
               <td>
+                %IteratorPrototype%
+              </td>
+              <td>
+              </td>
+              <td>
+                The prototype of Iterator objects (<emu-xref href="#sec-iterator.prototype"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
                 %JSON%
               </td>
               <td>
@@ -47617,16 +47627,17 @@ THH:mm:ss.sss
 
         <emu-clause id="sec-iterator.prototype">
           <h1>Iterator.prototype</h1>
-          <p>The initial value of Iterator.prototype is %Iterator.prototype%.</p>
+          <p>The initial value of Iterator.prototype is %IteratorPrototype%.</p>
           <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
         </emu-clause>
       </emu-clause>
     </emu-clause>
 
     <emu-clause oldids="sec-%iteratorprototype%-object" id="sec-%iterator.prototype%-object">
-      <h1>The %Iterator.prototype% Object</h1>
-      <p>The <dfn>%Iterator.prototype%</dfn> object:</p>
+      <h1>The %IteratorPrototype% Object</h1>
+      <p>The <dfn>%IteratorPrototype%</dfn> object:</p>
       <ul>
+        <li>is <dfn>%Iterator.prototype%</dfn>.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
         <li>is an ordinary object.</li>
       </ul>


### PR DESCRIPTION
Possible fix for #3555.

This introduces a new well-known intrinsic object name `%IteratorPrototype%`, and use it for the definition of the Iterator prototype object, and also for `Iterator.prototype` property definition, to clarify where the definition is, and make it consistent with the other parts of the document.

The properties of `Iterator.prototype`, such as `Iterator.prototype.constructor` are not touched by this PR, given Array prototypes etc are using this style, where the section header uses the prototype object's name ("Array Prototype Object" in the case), while the properties are using the `Array.prototype.*` style.

The other possible option is to use the "Iterator Prototype Object" style.