### PR TITLE
Editorial: address circular definition of Iterator.prototype

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -47616,21 +47616,22 @@ THH:mm:ss.sss
 
         <emu-clause id="sec-iterator.prototype">
           <h1>Iterator.prototype</h1>
-          <p>The initial value of Iterator.prototype is %Iterator.prototype%.</p>
+          <p>The initial value of Iterator.prototype is the Iterator prototype object.</p>
           <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
         </emu-clause>
       </emu-clause>
     </emu-clause>
 
     <emu-clause oldids="sec-%iteratorprototype%-object" id="sec-%iterator.prototype%-object">
-      <h1>The %Iterator.prototype% Object</h1>
-      <p>The <dfn>%Iterator.prototype%</dfn> object:</p>
+      <h1>Properties of the Iterator Prototype Object</h1>
+      <p>The <dfn>Iterator prototype object</dfn>:</p>
       <ul>
+        <li>is <dfn>%Iterator.prototype%</dfn>.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
         <li>is an ordinary object.</li>
       </ul>
       <emu-note>
-        <p>All objects defined in this specification that implement the iterator interface also inherit from %Iterator.prototype%. ECMAScript code may also define objects that inherit from %Iterator.prototype%. The %Iterator.prototype% object provides a place where additional methods that are applicable to all iterator objects may be added.</p>
+        <p>All objects defined in this specification that implement the iterator interface also inherit from %Iterator.prototype%. ECMAScript code may also define objects that inherit from %Iterator.prototype%. %Iterator.prototype% provides a place where additional methods that are applicable to all iterator objects may be added.</p>
         <p>The following expression is one way that ECMAScript code can access the %Iterator.prototype% object:</p>
         <pre><code class="javascript">Object.getPrototypeOf(Object.getPrototypeOf([][Symbol.iterator]()))</code></pre>
       </emu-note>


### PR DESCRIPTION
As discussed in editor call. Fixes #3555 using the first suggested approach. Closes #3556.