### PR TITLE
Editorial: Quick fixes re recent merge

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -39593,7 +39593,7 @@ THH:mm:ss.sss
           <h1>%RegExpStringIteratorPrototype%.next ( )</h1>
           <emu-alg>
             1. Let _O_ be the *this* value.
-            1. If O is not an Object, throw a *TypeError* exception.
+            1. If _O_ is not an Object, throw a *TypeError* exception.
             1. If _O_ does not have all of the internal slots of a RegExp String Iterator Object Instance (see <emu-xref href="#sec-properties-of-regexp-string-iterator-instances"></emu-xref>), throw a *TypeError* exception.
             1. If _O_.[[Done]] is *true*, then
               1. Return CreateIteratorResultObject(*undefined*, *true*).

--- a/spec.html
+++ b/spec.html
@@ -39631,27 +39631,33 @@ THH:mm:ss.sss
           <table>
             <tr>
               <th>Internal Slot</th>
+              <th>Type</th>
               <th>Description</th>
             </tr>
             <tr>
               <td>[[IteratingRegExp]]</td>
+              <td>an Object</td>
               <td>The regular expression used for iteration. IsRegExp([[IteratingRegExp]]) is initially *true*.</td>
             </tr>
             <tr>
               <td>[[IteratedString]]</td>
+              <td>a String</td>
               <td>The String value being iterated upon.</td>
             </tr>
             <tr>
               <td>[[Global]]</td>
-              <td>A Boolean value to indicate whether the [[IteratingRegExp]] is global or not.</td>
+              <td>a Boolean</td>
+              <td>Indicates whether the [[IteratingRegExp]] is global or not.</td>
             </tr>
             <tr>
               <td>[[Unicode]]</td>
-              <td>A Boolean value to indicate whether the [[IteratingRegExp]] is in Unicode mode or not.</td>
+              <td>a Boolean</td>
+              <td>Indicates whether the [[IteratingRegExp]] is in Unicode mode or not.</td>
             </tr>
             <tr>
               <td>[[Done]]</td>
-              <td>A Boolean value to indicate whether the iteration is complete or not.</td>
+              <td>a Boolean</td>
+              <td>Indicates whether the iteration is complete or not.</td>
             </tr>
           </table>
         </emu-table>
@@ -41255,12 +41261,18 @@ THH:mm:ss.sss
                 Internal Slot
               </th>
               <th>
+                Type
+              </th>
+              <th>
                 Description
               </th>
             </tr>
             <tr>
               <td>
                 [[IteratedArrayLike]]
+              </td>
+              <td>
+                an Object or *undefined*
               </td>
               <td>
                 The array-like object that is being iterated.
@@ -41271,6 +41283,9 @@ THH:mm:ss.sss
                 [[ArrayLikeNextIndex]]
               </td>
               <td>
+                a non-negative integer
+              </td>
+              <td>
                 The integer index of the next element to be examined by this iterator.
               </td>
             </tr>
@@ -41279,7 +41294,10 @@ THH:mm:ss.sss
                 [[ArrayLikeIterationKind]]
               </td>
               <td>
-                A String value that identifies what is returned for each element of the iteration. The possible values are: ~key~, ~value~, ~key+value~.
+                ~key+value~, ~key~, or ~value~
+              </td>
+              <td>
+                A value that identifies what is returned for each element of the iteration.
               </td>
             </tr>
           </table>

--- a/spec.html
+++ b/spec.html
@@ -39622,39 +39622,39 @@ THH:mm:ss.sss
           <p>The initial value of the %Symbol.toStringTag% property is the String value *"RegExp String Iterator"*.</p>
           <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
         </emu-clause>
+      </emu-clause>
 
-        <emu-clause id="sec-properties-of-regexp-string-iterator-instances">
-          <h1>Properties of RegExp String Iterator Instances</h1>
-          <p>RegExp String Iterator instances are ordinary objects that inherit properties from the %RegExpStringIteratorPrototype% intrinsic object. RegExp String Iterator instances are initially created with the internal slots listed in <emu-xref href="#table-regexp-string-iterator-instance-slots"></emu-xref>.</p>
-          <emu-table id="table-regexp-string-iterator-instance-slots" caption="Internal Slots of RegExp String Iterator Instances">
-            <table>
-              <tr>
-                <th>Internal Slot</th>
-                <th>Description</th>
-              </tr>
-              <tr>
-                <td>[[IteratingRegExp]]</td>
-                <td>The regular expression used for iteration. IsRegExp([[IteratingRegExp]]) is initially *true*.</td>
-              </tr>
-              <tr>
-                <td>[[IteratedString]]</td>
-                <td>The String value being iterated upon.</td>
-              </tr>
-              <tr>
-                <td>[[Global]]</td>
-                <td>A Boolean value to indicate whether the [[IteratingRegExp]] is global or not.</td>
-              </tr>
-              <tr>
-                <td>[[Unicode]]</td>
-                <td>A Boolean value to indicate whether the [[IteratingRegExp]] is in Unicode mode or not.</td>
-              </tr>
-              <tr>
-                <td>[[Done]]</td>
-                <td>A Boolean value to indicate whether the iteration is complete or not.</td>
-              </tr>
-            </table>
-          </emu-table>
-        </emu-clause>
+      <emu-clause id="sec-properties-of-regexp-string-iterator-instances">
+        <h1>Properties of RegExp String Iterator Instances</h1>
+        <p>RegExp String Iterator instances are ordinary objects that inherit properties from the %RegExpStringIteratorPrototype% intrinsic object. RegExp String Iterator instances are initially created with the internal slots listed in <emu-xref href="#table-regexp-string-iterator-instance-slots"></emu-xref>.</p>
+        <emu-table id="table-regexp-string-iterator-instance-slots" caption="Internal Slots of RegExp String Iterator Instances">
+          <table>
+            <tr>
+              <th>Internal Slot</th>
+              <th>Description</th>
+            </tr>
+            <tr>
+              <td>[[IteratingRegExp]]</td>
+              <td>The regular expression used for iteration. IsRegExp([[IteratingRegExp]]) is initially *true*.</td>
+            </tr>
+            <tr>
+              <td>[[IteratedString]]</td>
+              <td>The String value being iterated upon.</td>
+            </tr>
+            <tr>
+              <td>[[Global]]</td>
+              <td>A Boolean value to indicate whether the [[IteratingRegExp]] is global or not.</td>
+            </tr>
+            <tr>
+              <td>[[Unicode]]</td>
+              <td>A Boolean value to indicate whether the [[IteratingRegExp]] is in Unicode mode or not.</td>
+            </tr>
+            <tr>
+              <td>[[Done]]</td>
+              <td>A Boolean value to indicate whether the iteration is complete or not.</td>
+            </tr>
+          </table>
+        </emu-table>
       </emu-clause>
     </emu-clause>
   </emu-clause>
@@ -41243,47 +41243,47 @@ THH:mm:ss.sss
           <p>The initial value of the %Symbol.toStringTag% property is the String value *"Array Iterator"*.</p>
           <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
         </emu-clause>
+      </emu-clause>
 
-        <emu-clause id="sec-properties-of-array-iterator-instances">
-          <h1>Properties of Array Iterator Instances</h1>
-          <p>Array Iterator instances are ordinary objects that inherit properties from the %ArrayIteratorPrototype% intrinsic object. Array Iterator instances are initially created with the internal slots listed in <emu-xref href="#table-internal-slots-of-array-iterator-instances"></emu-xref>.</p>
-          <emu-table id="table-internal-slots-of-array-iterator-instances" caption="Internal Slots of Array Iterator Instances" oldids="table-48">
-            <table>
-              <tr>
-                <th>
-                  Internal Slot
-                </th>
-                <th>
-                  Description
-                </th>
-              </tr>
-              <tr>
-                <td>
-                  [[IteratedArrayLike]]
-                </td>
-                <td>
-                  The array-like object that is being iterated.
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  [[ArrayLikeNextIndex]]
-                </td>
-                <td>
-                  The integer index of the next element to be examined by this iterator.
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  [[ArrayLikeIterationKind]]
-                </td>
-                <td>
-                  A String value that identifies what is returned for each element of the iteration. The possible values are: ~key~, ~value~, ~key+value~.
-                </td>
-              </tr>
-            </table>
-          </emu-table>
-        </emu-clause>
+      <emu-clause id="sec-properties-of-array-iterator-instances">
+        <h1>Properties of Array Iterator Instances</h1>
+        <p>Array Iterator instances are ordinary objects that inherit properties from the %ArrayIteratorPrototype% intrinsic object. Array Iterator instances are initially created with the internal slots listed in <emu-xref href="#table-internal-slots-of-array-iterator-instances"></emu-xref>.</p>
+        <emu-table id="table-internal-slots-of-array-iterator-instances" caption="Internal Slots of Array Iterator Instances" oldids="table-48">
+          <table>
+            <tr>
+              <th>
+                Internal Slot
+              </th>
+              <th>
+                Description
+              </th>
+            </tr>
+            <tr>
+              <td>
+                [[IteratedArrayLike]]
+              </td>
+              <td>
+                The array-like object that is being iterated.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                [[ArrayLikeNextIndex]]
+              </td>
+              <td>
+                The integer index of the next element to be examined by this iterator.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                [[ArrayLikeIterationKind]]
+              </td>
+              <td>
+                A String value that identifies what is returned for each element of the iteration. The possible values are: ~key~, ~value~, ~key+value~.
+              </td>
+            </tr>
+          </table>
+        </emu-table>
       </emu-clause>
     </emu-clause>
   </emu-clause>


### PR DESCRIPTION
This amends some editorial inconsistencies introduced by PR #3559.

(You should probably use "Hide whitespace" if you're looking at the first commit, or at all commits together.)