### PR TITLE
Normative: Add "Runtime Errors for Function Call Assignment Targets" to Annex B

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -9980,7 +9980,7 @@
     </emu-clause>
 
     <emu-clause id="sec-static-semantics-assignmenttargettype" oldids="sec-identifiers-static-semantics-assignmenttargettype,sec-identifiers-static-semantics-isvalidsimpleassignmenttarget,sec-semantics-static-semantics-assignmenttargettype,sec-semantics-static-semantics-isvalidsimpleassignmenttarget,sec-grouping-operator-static-semantics-assignmenttargettype,sec-grouping-operator-static-semantics-isvalidsimpleassignmenttarget,sec-static-semantics-static-semantics-assignmenttargettype,sec-static-semantics-static-semantics-isvalidsimpleassignmenttarget,sec-update-expressions-static-semantics-assignmenttargettype,sec-update-expressions-static-semantics-isvalidsimpleassignmenttarget,sec-unary-operators-static-semantics-assignmenttargettype,sec-unary-operators-static-semantics-isvalidsimpleassignmenttarget,sec-exp-operator-static-semantics-assignmenttargettype,sec-exp-operator-static-semantics-isvalidsimpleassignmenttarget,sec-multiplicative-operators-static-semantics-assignmenttargettype,sec-multiplicative-operators-static-semantics-isvalidsimpleassignmenttarget,sec-additive-operators-static-semantics-assignmenttargettype,sec-additive-operators-static-semantics-isvalidsimpleassignmenttarget,sec-bitwise-shift-operators-static-semantics-assignmenttargettype,sec-bitwise-shift-operators-static-semantics-isvalidsimpleassignmenttarget,sec-relational-operators-static-semantics-assignmenttargettype,sec-relational-operators-static-semantics-isvalidsimpleassignmenttarget,sec-equality-operators-static-semantics-assignmenttargettype,sec-equality-operators-static-semantics-isvalidsimpleassignmenttarget,sec-binary-bitwise-operators-static-semantics-assignmenttargettype,sec-binary-bitwise-operators-static-semantics-isvalidsimpleassignmenttarget,sec-binary-logical-operators-static-semantics-assignmenttargettype,sec-binary-logical-operators-static-semantics-isvalidsimpleassignmenttarget,sec-conditional-operator-static-semantics-assignmenttargettype,sec-conditional-operator-static-semantics-isvalidsimpleassignmenttarget,sec-assignment-operators-static-semantics-assignmenttargettype,sec-assignment-operators-static-semantics-isvalidsimpleassignmenttarget,sec-comma-operator-static-semantics-assignmenttargettype,sec-comma-operator-static-semantics-isvalidsimpleassignmenttarget" type="sdo">
-      <h1>Static Semantics: AssignmentTargetType ( ): ~simple~ or ~invalid~</h1>
+      <h1>Static Semantics: AssignmentTargetType ( ): ~simple~, ~web-compat~, or ~invalid~</h1>
       <dl class="header">
       </dl>
       <emu-grammar>IdentifierReference : Identifier</emu-grammar>
@@ -10016,6 +10016,16 @@
         1. Return the AssignmentTargetType of _expr_.
       </emu-alg>
       <emu-grammar>
+        CallExpression :
+          CoverCallExpressionAndAsyncArrowHead
+          CallExpression Arguments
+      </emu-grammar>
+      <emu-alg>
+        1. [id="step-assignmenttargettype-web-compat", normative-optional] If the host is a web browser or otherwise supports <emu-xref href="#sec-runtime-errors-for-function-call-assignment-targets" title></emu-xref> and IsStrict(this |CallExpression|) is *false*, then
+          1. Return ~web-compat~.
+        1. Return ~invalid~.
+      </emu-alg>
+      <emu-grammar>
         PrimaryExpression :
           `this`
           Literal
@@ -10030,10 +10040,8 @@
           TemplateLiteral
 
         CallExpression :
-          CoverCallExpressionAndAsyncArrowHead
           SuperCall
           ImportCall
-          CallExpression Arguments
           CallExpression TemplateLiteral
 
         NewExpression :
@@ -19995,7 +20003,7 @@
       </emu-grammar>
       <ul>
         <li>
-          It is an early Syntax Error if the AssignmentTargetType of |LeftHandSideExpression| is not ~simple~.
+          It is an early Syntax Error if the AssignmentTargetType of |LeftHandSideExpression| is ~invalid~.
         </li>
       </ul>
 
@@ -20006,7 +20014,7 @@
       </emu-grammar>
       <ul>
         <li>
-          It is an early Syntax Error if the AssignmentTargetType of |UnaryExpression| is not ~simple~.
+          It is an early Syntax Error if the AssignmentTargetType of |UnaryExpression| is ~invalid~.
         </li>
       </ul>
     </emu-clause>
@@ -20019,6 +20027,7 @@
         <emu-grammar>UpdateExpression : LeftHandSideExpression `++`</emu-grammar>
         <emu-alg>
           1. Let _lhs_ be ? Evaluation of |LeftHandSideExpression|.
+          1. If the AssignmentTargetType of |LeftHandSideExpression| is ~web-compat~, throw a *ReferenceError* exception.
           1. Let _oldValue_ be ? ToNumeric(? GetValue(_lhs_)).
           1. If _oldValue_ is a Number, then
             1. Let _newValue_ be Number::add(_oldValue_, *1*<sub>𝔽</sub>).
@@ -20039,6 +20048,7 @@
         <emu-grammar>UpdateExpression : LeftHandSideExpression `--`</emu-grammar>
         <emu-alg>
           1. Let _lhs_ be ? Evaluation of |LeftHandSideExpression|.
+          1. If the AssignmentTargetType of |LeftHandSideExpression| is ~web-compat~, throw a *ReferenceError* exception.
           1. Let _oldValue_ be ? ToNumeric(? GetValue(_lhs_)).
           1. If _oldValue_ is a Number, then
             1. Let _newValue_ be Number::subtract(_oldValue_, *1*<sub>𝔽</sub>).
@@ -20059,6 +20069,7 @@
         <emu-grammar>UpdateExpression : `++` UnaryExpression</emu-grammar>
         <emu-alg>
           1. Let _expr_ be ? Evaluation of |UnaryExpression|.
+          1. If the AssignmentTargetType of |UnaryExpression| is ~web-compat~, throw a *ReferenceError* exception.
           1. Let _oldValue_ be ? ToNumeric(? GetValue(_expr_)).
           1. If _oldValue_ is a Number, then
             1. Let _newValue_ be Number::add(_oldValue_, *1*<sub>𝔽</sub>).
@@ -20079,6 +20090,7 @@
         <emu-grammar>UpdateExpression : `--` UnaryExpression</emu-grammar>
         <emu-alg>
           1. Let _expr_ be ? Evaluation of |UnaryExpression|.
+          1. If the AssignmentTargetType of |UnaryExpression| is ~web-compat~, throw a *ReferenceError* exception.
           1. Let _oldValue_ be ? ToNumeric(? GetValue(_expr_)).
           1. If _oldValue_ is a Number, then
             1. Let _newValue_ be Number::subtract(_oldValue_, *1*<sub>𝔽</sub>).
@@ -20781,12 +20793,20 @@
           If |LeftHandSideExpression| is either an |ObjectLiteral| or an |ArrayLiteral|, |LeftHandSideExpression| must cover an |AssignmentPattern|.
         </li>
         <li>
-          If |LeftHandSideExpression| is neither an |ObjectLiteral| nor an |ArrayLiteral|, it is a Syntax Error if the AssignmentTargetType of |LeftHandSideExpression| is not ~simple~.
+          If |LeftHandSideExpression| is neither an |ObjectLiteral| nor an |ArrayLiteral|, it is a Syntax Error if the AssignmentTargetType of |LeftHandSideExpression| is ~invalid~.
         </li>
       </ul>
       <emu-grammar>
         AssignmentExpression :
           LeftHandSideExpression AssignmentOperator AssignmentExpression
+      </emu-grammar>
+      <ul>
+        <li>
+          It is a Syntax Error if the AssignmentTargetType of |LeftHandSideExpression| is ~invalid~.
+        </li>
+      </ul>
+      <emu-grammar>
+        AssignmentExpression :
           LeftHandSideExpression `&amp;&amp;=` AssignmentExpression
           LeftHandSideExpression `||=` AssignmentExpression
           LeftHandSideExpression `??=` AssignmentExpression
@@ -20804,6 +20824,7 @@
       <emu-alg>
         1. If |LeftHandSideExpression| is neither an |ObjectLiteral| nor an |ArrayLiteral|, then
           1. Let _lRef_ be ? Evaluation of |LeftHandSideExpression|.
+          1. If the AssignmentTargetType of |LeftHandSideExpression| is ~web-compat~, throw a *ReferenceError* exception.
           1. If IsAnonymousFunctionDefinition(|AssignmentExpression|) is *true* and IsIdentifierRef of |LeftHandSideExpression| is *true*, then
             1. Let _lhs_ be the StringValue of |LeftHandSideExpression|.
             1. Let _rVal_ be ? NamedEvaluation of |AssignmentExpression| with argument _lhs_.
@@ -20821,6 +20842,7 @@
       <emu-grammar>AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression</emu-grammar>
       <emu-alg>
         1. Let _lRef_ be ? Evaluation of |LeftHandSideExpression|.
+        1. If the AssignmentTargetType of |LeftHandSideExpression| is ~web-compat~, throw a *ReferenceError* exception.
         1. [id="step-assignmentexpression-evaluation-compound-getvalue"] Let _lVal_ be ? GetValue(_lRef_).
         1. Let _rRef_ be ? Evaluation of |AssignmentExpression|.
         1. Let _rVal_ be ? GetValue(_rRef_).
@@ -22259,7 +22281,7 @@
             If |LeftHandSideExpression| is either an |ObjectLiteral| or an |ArrayLiteral|, |LeftHandSideExpression| must cover an |AssignmentPattern|.
           </li>
           <li>
-            If |LeftHandSideExpression| is neither an |ObjectLiteral| nor an |ArrayLiteral|, it is a Syntax Error if the AssignmentTargetType of |LeftHandSideExpression| is not ~simple~.
+            If |LeftHandSideExpression| is neither an |ObjectLiteral| nor an |ArrayLiteral|, it is a Syntax Error if the AssignmentTargetType of |LeftHandSideExpression| is ~invalid~.
           </li>
         </ul>
         <emu-grammar>
@@ -22503,6 +22525,7 @@
                   1. Let _status_ be Completion(BindingInitialization of _lhs_ with arguments _nextValue_ and *undefined*).
               1. Else,
                 1. Let _lhsRef_ be Completion(Evaluation of _lhs_). (It may be evaluated repeatedly.)
+                1. If _lhsKind_ is ~assignment~ and the AssignmentTargetType of _lhs_ is ~web-compat~, throw a *ReferenceError* exception.
                 1. If _lhsRef_ is an abrupt completion, then
                   1. Let _status_ be _lhsRef_.
                 1. Else,
@@ -52983,6 +53006,15 @@ THH:mm:ss.sss
     <emu-annex id="sec-web-compat-host-ensure-can-add-private-field">
       <h1>Non-default behaviour in HostEnsureCanAddPrivateElement</h1>
       <p>The HostEnsureCanAddPrivateElement abstract operation allows hosts which are web browsers to specify non-default behaviour.</p>
+    </emu-annex>
+
+    <emu-annex id="sec-runtime-errors-for-function-call-assignment-targets">
+      <h1>Runtime Errors for Function Call Assignment Targets</h1>
+      <p>When a function call (<emu-xref href="#sec-function-calls"></emu-xref>) is used as an assignment target in non-strict code, instead of producing an early error, a *ReferenceError* exception is thrown during evaluation of the assignment.</p>
+      <emu-note>
+        <p>When the assignment target is the |LeftHandSideExpression| of an |AssignmentExpression|, the assignment operator must be `=` or an |AssignmentOperator|; in particular, the allowance here does not apply to the logical assignment operators (`??=`, `&&=`, `||=`).</p>
+      </emu-note>
+      <p>See step <emu-xref href="#step-assignmenttargettype-web-compat"></emu-xref> of AssignmentTargetType for <emu-grammar>CallExpression : CoverCallExpressionAndAsyncArrowHead</emu-grammar> and <emu-grammar>CallExpression : CallExpression Arguments</emu-grammar>.</p>
     </emu-annex>
   </emu-annex>
 </emu-annex>


### PR DESCRIPTION
Replaces #2193.

This PR specifies the web reality that the following are not early errors in sloppy mode on browser-hosted engines:
```js
f() = 1;
f() *= 1;
f()++;
for (f() in [1]) {}
for (f() of [1]) {}
```

It aligns with the new Annex B editorial convention (#2952) and amounts to:
- augmenting AssignmentTargetType with a new value `~web-compat~`
- throwing a ReferenceError immediately after performing the function call in each case