### PR TITLE
feat: TypedArrayCreateSameType take length as parameter

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -21084,7 +21084,7 @@
           1. Perform ? RequireObjectCoercible(_value_).
           1. Return ~unused~.
         </emu-alg>
-        <emu-grammar>
+        <emu-grammar></emu-grammar>
           ObjectAssignmentPattern :
             `{` AssignmentPropertyList `}`
             `{` AssignmentPropertyList `,` `}`
@@ -22539,7 +22539,7 @@
 
       <emu-clause id="sec-for-in-and-for-of-statements-runtime-semantics-evaluation" type="sdo">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar>
+        <emu-grammar></emu-grammar>
           BindingIdentifier :
             Identifier
             `yield`
@@ -42423,11 +42423,11 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Let _taRecord_ be ? ValidateTypedArray(_O_, ~seq-cst~).
-          1. Let _length_ be TypedArrayLength(_taRecord_).
-          1. Let _A_ be ? TypedArrayCreateSameType(_O_, « 𝔽(_length_) »).
+          1. Let _len_ be TypedArrayLength(_taRecord_).
+          1. Let _A_ be ? TypedArrayCreateSameType(_O_, _len_).
           1. Let _k_ be 0.
-          1. Repeat, while _k_ &lt; _length_,
-            1. Let _from_ be ! ToString(𝔽(_length_ - _k_ - 1)).
+          1. Repeat, while _k_ &lt; _len_,
+            1. Let _from_ be ! ToString(𝔽(_len_ - _k_ - 1)).
             1. Let _Pk_ be ! ToString(𝔽(_k_)).
             1. Let _fromValue_ be ! Get(_O_, _from_).
             1. Perform ! Set(_A_, _Pk_, _fromValue_, *true*).
@@ -42444,7 +42444,7 @@ THH:mm:ss.sss
           1. Let _O_ be the *this* value.
           1. Let _taRecord_ be ? ValidateTypedArray(_O_, ~seq-cst~).
           1. Let _len_ be TypedArrayLength(_taRecord_).
-          1. Let _A_ be ? TypedArrayCreateSameType(_O_, « 𝔽(_len_) »).
+          1. Let _A_ be ? TypedArrayCreateSameType(_O_, _len_).
           1. NOTE: The following closure performs a numeric comparison rather than the string comparison used in <emu-xref href="#sec-array.prototype.tosorted"></emu-xref>.
           1. Let _SortCompare_ be a new Abstract Closure with parameters (_x_, _y_) that captures _comparator_ and performs the following steps when called:
             1. Return ? CompareTypedArrayElements(_x_, _y_, _comparator_).
@@ -42485,7 +42485,7 @@ THH:mm:ss.sss
           1. If _O_.[[ContentType]] is ~bigint~, let _numericValue_ be ? ToBigInt(_value_).
           1. Else, let _numericValue_ be ? ToNumber(_value_).
           1. If IsValidIntegerIndex(_O_, 𝔽(_actualIndex_)) is *false*, throw a *RangeError* exception.
-          1. Let _A_ be ? TypedArrayCreateSameType(_O_, « 𝔽(_len_) »).
+          1. Let _A_ be ? TypedArrayCreateSameType(_O_, _len_).
           1. Let _k_ be 0.
           1. Repeat, while _k_ &lt; _len_,
             1. Let _Pk_ be ! ToString(𝔽(_k_)).
@@ -42568,16 +42568,16 @@ THH:mm:ss.sss
         <h1>
           TypedArrayCreateSameType (
             _exemplar_: a TypedArray,
-            _argumentList_: a List of ECMAScript language values,
+            _length_: a non-negative integer,
           ): either a normal completion containing a TypedArray or a throw completion
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It is used to specify the creation of a new TypedArray using a constructor function that is derived from _exemplar_. Unlike TypedArraySpeciesCreate, which can construct custom TypedArray subclasses through the use of %Symbol.species%, this operation always uses one of the built-in TypedArray constructors.</dd>
+          <dd>It is used to specify the creation of a new TypedArray using a constructor function that is derived from _exemplar_, and a _length_. Unlike TypedArraySpeciesCreate, which can construct custom TypedArray subclasses through the use of %Symbol.species%, this operation always uses one of the built-in TypedArray constructors.</dd>
         </dl>
         <emu-alg>
           1. Let _constructor_ be the intrinsic object associated with the constructor name _exemplar_.[[TypedArrayName]] in <emu-xref href="#table-the-typedarray-constructors"></emu-xref>.
-          1. Let _result_ be ? TypedArrayCreateFromConstructor(_constructor_, _argumentList_).
+          1. Let _result_ be ? <emu-meta suppress-effects="user-code">TypedArrayCreateFromConstructor(_constructor_, « 𝔽(_length_) »)</emu-meta>.
           1. Assert: _result_ has [[TypedArrayName]] and [[ContentType]] internal slots.
           1. Assert: _result_.[[ContentType]] is _exemplar_.[[ContentType]].
           1. Return _result_.


### PR DESCRIPTION
This method is only called with an explicit length but because it can theoretically take any arguments list, the call to TypedArray construction could trigger user code: This is not really the case.