### PR TITLE
Meta: Upgrade ESMeta to v0.6.0

### DIFF
--- a/.github/workflows/esmeta-typecheck.yml
+++ b/.github/workflows/esmeta-typecheck.yml
@@ -26,7 +26,7 @@ jobs:
           cd "${ESMETA_HOME}"
           git init
           git remote add origin https://github.com/es-meta/esmeta.git
-          git fetch --depth 1 origin 4bc6a2ffd015a150596fde1c9dcbcb3614e7cbbb ;# v0.5.1
+          git fetch --depth 1 origin c2dd287931f8a557f730f4216e26fea3bab42524 ;# v0.6.0
           git checkout FETCH_HEAD
       - name: build esmeta
         run: |


### PR DESCRIPTION
We updated the version of [ESMeta](https://github.com/es-meta/esmeta) to [v0.6.0](https://github.com/es-meta/esmeta/releases/tag/v0.6.0).

We fixed minor bugs in the `Math` type domain (https://github.com/es-meta/esmeta/pull/272) and the stringified form for return type mismatches (https://github.com/es-meta/esmeta/pull/273).

In addition, we support the following two new features:
- [ECMA Visualizer](https://chromewebstore.google.com/detail/ecma-visualizer/nlfpedidieegejndiikebcgclhggaocd), a specification visualizer with example programs or conformance tests as a Chrome extension
- [ECMAScript Double Debugger](https://es-meta.github.io/playground/), an ECMAScript interpreter with states of both ECMAScript programs and the specification

If you're interested in how to use it, take a look at a short introduction video here: https://youtu.be/4XMjJPNmuBM.