### PR TITLE
Meta: bump ecmarkup to v21.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://tc39.es/ecma262/#sec-copyright-and-software-license",
       "devDependencies": {
-        "ecmarkup": "^21.2.0",
+        "ecmarkup": "^21.3.0",
         "glob": "^7.1.6",
         "jsdom": "^15.0.0",
         "pagedjs": "^0.4.3",
@@ -1360,9 +1360,9 @@
       }
     },
     "node_modules/ecmarkup": {
-      "version": "21.2.0",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-21.2.0.tgz",
-      "integrity": "sha512-d7FvzQiPGYVukzyd8z4a9HxjEPxi4X1u0VhETSCcLudzc5T8aGmJBw0wNGlf+sekfpFy6SJC9Nco/Fn8I09FHg==",
+      "version": "21.3.0",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-21.3.0.tgz",
+      "integrity": "sha512-vvIvGnaHq54YIXkjs1p3R9tm9YywiABDHQqMUyq45Dw45PYTe38qAIsnXZOvU61vUhLqyA0L4NNaNODoJCKhiA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "license": "SEE LICENSE IN https://tc39.es/ecma262/#sec-copyright-and-software-license",
   "homepage": "https://tc39.es/ecma262/",
   "devDependencies": {
-    "ecmarkup": "^21.2.0",
+    "ecmarkup": "^21.3.0",
     "glob": "^7.1.6",
     "jsdom": "^15.0.0",
     "pagedjs": "^0.4.3",


### PR DESCRIPTION
Fixes https://github.com/tc39/ecma262/issues/3479 via inclusion of https://github.com/tc39/ecmarkup/pull/626 (hopefully).