### PR TITLE
Fix [[AsyncEvaluationOrder]] examples for evaluated modules

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -27586,7 +27586,7 @@
               <tr>
                 <th>[[AsyncEvaluationOrder]]</th>
                 <td>3</td>
-                <td>2</td>
+                <td>~done~</td>
               </tr>
               <tr>
                 <th>[[AsyncParentModules]]</th>
@@ -27640,7 +27640,7 @@
                 <th>[[AsyncEvaluationOrder]]</th>
                 <td>1</td>
                 <td>3</td>
-                <td>0</td>
+                <td>~done~</td>
               </tr>
               <tr>
                 <th>[[AsyncParentModules]]</th>
@@ -27691,7 +27691,7 @@
               <tr>
                 <th>[[AsyncEvaluationOrder]]</th>
                 <td>4</td>
-                <td>3</td>
+                <td>~done~</td>
               </tr>
               <tr>
                 <th>[[AsyncParentModules]]</th>
@@ -27740,7 +27740,7 @@
               <tr>
                 <th>[[AsyncEvaluationOrder]]</th>
                 <td>4</td>
-                <td>1</td>
+                <td>~done~</td>
               </tr>
               <tr>
                 <th>[[AsyncParentModules]]</th>
@@ -27784,7 +27784,7 @@
               </tr>
               <tr>
                 <th>[[AsyncEvaluationOrder]]</th>
-                <td>4</td>
+                <td>~done~</td>
               </tr>
               <tr>
                 <th>[[AsyncParentModules]]</th>
@@ -27830,8 +27830,8 @@
               </tr>
               <tr>
                 <th>[[AsyncEvaluationOrder]]</th>
-                <td>4</td>
-                <td>3</td>
+                <td>~done~</td>
+                <td>~done~</td>
               </tr>
               <tr>
                 <th>[[AsyncParentModules]]</th>
@@ -27880,7 +27880,7 @@
               </tr>
               <tr>
                 <th>[[AsyncEvaluationOrder]]</th>
-                <td>4</td>
+                <td>~done~</td>
               </tr>
               <tr>
                 <th>[[AsyncParentModules]]</th>


### PR DESCRIPTION
Fixes https://github.com/tc39/ecma262/issues/3578

Once a module transitions from `~async-evaluating~` to `~evaluated~`, its [[AsyncEvaluationOrder]] field changes from an integer to `~done~`.