### PR TITLE
Ensure all evaluated modules have a [[CycleRoot]]

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -27198,7 +27198,9 @@
             <emu-alg>
               1. Assert: This call to Evaluate is not happening at the same time as another call to Evaluate within the surrounding agent.
               1. Assert: _module_.[[Status]] is one of ~linked~, ~evaluating-async~, or ~evaluated~.
-              1. If _module_.[[Status]] is either ~evaluating-async~ or ~evaluated~, set _module_ to _module_.[[CycleRoot]].
+              1. If _module_.[[Status]] is either ~evaluating-async~ or ~evaluated~, then
+                1. Assert: _module_.[[CycleRoot]] is not ~empty~.
+                1. Set _module_ to _module_.[[CycleRoot]].
               1. If _module_.[[TopLevelCapability]] is not ~empty~, then
                 1. Return _module_.[[TopLevelCapability]].[[Promise]].
               1. Let _stack_ be a new empty List.
@@ -27211,6 +27213,7 @@
                   1. Assert: _m_.[[AsyncEvaluationOrder]] is ~unset~.
                   1. Set _m_.[[Status]] to ~evaluated~.
                   1. Set _m_.[[EvaluationError]] to _result_.
+                  1. Set _m_.[[CycleRoot]] to _m_.
                 1. Assert: _module_.[[Status]] is ~evaluated~.
                 1. Assert: _module_.[[EvaluationError]] and _result_ are the same Completion Record.
                 1. Perform ! Call(_capability_.[[Reject]], *undefined*, « _result_.[[Value]] »).


### PR DESCRIPTION
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->

This PR fixes #3582 by defaulting [[CycleRoot]] to the module itself in case of error.

In case the module is effectively on a cycle, this would be lying, but in practice it doesn't matter: when a module has an error, the error is immediately propagated to all its ancestors, so the real cycle root has the same error state.

I originally tried to set [[CycleRoot]] properly, which requires more complexity. This code that sets the states of the modules in _stack_ in case of error, needs to:
- first, iterate the stack reversed, propagating setting [[DFSAncestorIndex]] of each module to min([[DFSAncestorIndex]] of module, [[DFSAncestorIndex]] of its child)
- then, when iterating in order, it needs to set [[CycleRoot]] to the module itself unless the [[DFSAncestorIndex]] is the same as the previous module, in which case it copies the [[CycleRoot]] from it.

While this complex approach is more correct, I discarded it because it's still not 100% correct. In [this graph](https://nicolo-ribaudo.github.io/es-module-evaluation/#s=IEEKQiBDCiAgRAogRSBG&c=QSAtPiBCCkEgLT4gQwpDIC0%2BIEQKRCAtPiBFCkUgLT4gQwpFIC0%2BIEY%3D&a=Cg%3D%3D&f=Rg%3D%3D), assuming that E throws, we will have not traversed F at that point so we don't know that D should actually have [[CycleRoot]] set to C.
<img src="https://github.com/user-attachments/assets/633d1ad1-3b93-4c5c-9b34-4fac09abbb26" width="300">

In https://github.com/nicolo-ribaudo/ecma262/tree/cycleroot-fix-ugly I have an alternative fix if you prefer, that instead of ensuring that [[CycleRoot]] is always set it acknowledges that in this specific case it will be `~empty~`.