### PR TITLE
Remove unreachable code in InnerModuleEvaluation

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -27267,7 +27267,7 @@
                     1. Else,
                       1. Set _requiredModule_ to _requiredModule_.[[CycleRoot]].
                       1. Assert: _requiredModule_.[[Status]] is either ~evaluating-async~ or ~evaluated~.
-                      1. If _requiredModule_.[[EvaluationError]] is not ~empty~, return ? _requiredModule_.[[EvaluationError]].
+                      1. Assert: _requiredModule_.[[EvaluationError]] is ~empty~.
                     1. If _requiredModule_.[[AsyncEvaluationOrder]] is an integer, then
                       1. Set _module_.[[PendingAsyncDependencies]] to _module_.[[PendingAsyncDependencies]] + 1.
                       1. Append _module_ to _requiredModule_.[[AsyncParentModules]].


### PR DESCRIPTION
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->

I _think_ the contents of the `If` are unreachable, so it can be removed.

My reasoning is that:
- If _requiredModule(cycle root)_.[[EvaluationError]] is not `~empty~`, then _requiredModule(cycle root)_.[[Status]] must be `~evaluated~`
- If _requiredModule(cycle root)_ is evaluated, then also _requiredModule(not the root)_ must be evaluated, because it's a descendant of it (since the cycle-breaking logic puts the cycle root as the root node of the flattened tree)
- If _requiredModule(not the root)_ is evaluated and _requiredModule(not the root)_.[[EvaluationError]] is not `~empty~`, InnerModuleEvaluation(_requiredModule(not the root)_) would have returned that throw completion, and thus we would have returned early due to the ? before the InnerModuleEvaluation call.