### PR TITLE
Editorial: Remove optional waitable parameter

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -45981,14 +45981,12 @@ THH:mm:ss.sss
           ValidateAtomicAccessOnIntegerTypedArray (
             _typedArray_: an ECMAScript language value,
             _requestIndex_: an ECMAScript language value,
-            optional _waitable_: a Boolean,
           ): either a normal completion containing an integer or a throw completion
         </h1>
         <dl class="header">
         </dl>
         <emu-alg>
-          1. If _waitable_ is not present, set _waitable_ to *false*.
-          1. Let _taRecord_ be ? ValidateIntegerTypedArray(_typedArray_, _waitable_).
+          1. Let _taRecord_ be ? ValidateIntegerTypedArray(_typedArray_, *false*).
           1. Return ? ValidateAtomicAccess(_taRecord_, _requestIndex_).
         </emu-alg>
       </emu-clause>
@@ -46568,7 +46566,8 @@ THH:mm:ss.sss
       <p>This function notifies some agents that are sleeping in the wait queue.</p>
       <p>It performs the following steps when called:</p>
       <emu-alg>
-        1. Let _byteIndexInBuffer_ be ? ValidateAtomicAccessOnIntegerTypedArray(_typedArray_, _index_, *true*).
+        1. Let _taRecord_ be ? ValidateIntegerTypedArray(_typedArray_, *true*).
+        1. Let _byteIndexInBuffer_ be ? ValidateAtomicAccess(_taRecord_, _index_).
         1. If _count_ is *undefined*, then
           1. Let _c_ be +∞.
         1. Else,


### PR DESCRIPTION
This PR removes the optional _waitable_ parameter in the ValidateAtomicAccessOnIntegerTypedArray AO. Only Atomics.notify passes true explicitly as an argument, and this inlines the steps in that caller.

See #3475.

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
