### PR TITLE
Editorial: Unify style of abrupt completion and non-LoopContinues result handling in ForIn/OfBodyEvaluation

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -22402,20 +22402,20 @@
                 1. Let _status_ be Completion(InitializeReferencedBinding(_lhsRef_, _nextValue_)).
             1. If _status_ is an abrupt completion, then
               1. Set the running execution context's LexicalEnvironment to _oldEnv_.
-              1. If _iteratorKind_ is ~async~, return ? AsyncIteratorClose(_iteratorRecord_, _status_).
               1. If _iterationKind_ is ~enumerate~, then
                 1. Return ? _status_.
               1. Else,
                 1. Assert: _iterationKind_ is ~iterate~.
+                1. If _iteratorKind_ is ~async~, return ? AsyncIteratorClose(_iteratorRecord_, _status_).
                 1. Return ? IteratorClose(_iteratorRecord_, _status_).
             1. Let _result_ be Completion(Evaluation of _stmt_).
             1. Set the running execution context's LexicalEnvironment to _oldEnv_.
             1. If LoopContinues(_result_, _labelSet_) is *false*, then
+              1. Set _status_ to Completion(UpdateEmpty(_result_, _V_)).
               1. If _iterationKind_ is ~enumerate~, then
-                1. Return ? UpdateEmpty(_result_, _V_).
+                1. Return ? _status_.
               1. Else,
                 1. Assert: _iterationKind_ is ~iterate~.
-                1. Set _status_ to Completion(UpdateEmpty(_result_, _V_)).
                 1. If _iteratorKind_ is ~async~, return ? AsyncIteratorClose(_iteratorRecord_, _status_).
                 1. Return ? IteratorClose(_iteratorRecord_, _status_).
             1. If _result_.[[Value]] is not ~empty~, set _V_ to _result_.[[Value]].


### PR DESCRIPTION
A personal favourite of mine: the order of checking/comparing `iterationKind` and `iteratorKind` is different between two otherwise nearly identical blocks handling abrupt completions (exceptions) in the loop header binding, and handling non-loop-continuing results of the body evaluation.

The difference makes the two blocks really hard to compare, even though they're 100% the same except for the `UpdateEmpty` call.