### PR TITLE
Editorial: mark a callsite of GetBindingValue as not throwing

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -14721,7 +14721,7 @@
           </dl>
           <emu-alg>
             1. Let _getterClosure_ be a new Abstract Closure with no parameters that captures _name_ and _env_ and performs the following steps when called:
-              1. Return _env_.GetBindingValue(_name_, *false*).
+              1. Return ! _env_.GetBindingValue(_name_, *false*).
             1. Let _getter_ be CreateBuiltinFunction(_getterClosure_, 0, *""*, « »).
             1. NOTE: _getter_ is never directly accessible to ECMAScript code.
             1. Return _getter_.


### PR DESCRIPTION
All other callsites are annotated properly, we just missed this one. Tooling doesn't handle concrete methods very well currently which is why it's not caught automatically.