### PR TITLE
Editorial: mark asyncBody() as a completion record in AsyncBlockStart

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -50563,7 +50563,7 @@ THH:mm:ss.sss
               1. Let _result_ be Completion(Evaluation of _asyncBody_).
             1. Else,
               1. Assert: _asyncBody_ is an Abstract Closure with no parameters.
-              1. Let _result_ be _asyncBody_().
+              1. Let _result_ be Completion(_asyncBody_()).
             1. Assert: If we return here, the async function either threw an exception or performed an implicit or explicit return; all awaiting is done.
             1. Remove _acAsyncContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
             1. If _result_ is a normal completion, then


### PR DESCRIPTION
This is the same as #3597 but for AsyncBlockStart.