### PR TITLE
Editorial: wrap AC return values in completion records where needed

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -14731,7 +14731,7 @@
           </dl>
           <emu-alg>
             1. Let _getterClosure_ be a new Abstract Closure with no parameters that captures _name_ and _env_ and performs the following steps when called:
-              1. Return ! _env_.GetBindingValue(_name_, *false*).
+              1. Return NormalCompletion(! _env_.GetBindingValue(_name_, *false*)).
             1. Let _getter_ be CreateBuiltinFunction(_getterClosure_, 0, *""*, « »).
             1. NOTE: _getter_ is never directly accessible to ECMAScript code.
             1. Return _getter_.
@@ -14751,7 +14751,7 @@
           </dl>
           <emu-alg>
             1. Let _setterClosure_ be a new Abstract Closure with parameters (_value_) that captures _name_ and _env_ and performs the following steps when called:
-              1. Return ! _env_.SetMutableBinding(_name_, _value_, *false*).
+              1. Return NormalCompletion(! _env_.SetMutableBinding(_name_, _value_, *false*)).
             1. Let _setter_ be CreateBuiltinFunction(_setterClosure_, 1, *""*, « »).
             1. NOTE: _setter_ is never directly accessible to ECMAScript code.
             1. Return _setter_.
@@ -19871,18 +19871,18 @@
           1. Let _loadPromise_ be _module_.LoadRequestedModules().
           1. Let _rejectedClosure_ be a new Abstract Closure with parameters (_reason_) that captures _promiseCapability_ and performs the following steps when called:
             1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, « _reason_ »).
-            1. Return ~unused~.
+            1. Return NormalCompletion(*undefined*).
           1. Let _onRejected_ be CreateBuiltinFunction(_rejectedClosure_, 1, *""*, « »).
           1. Let _linkAndEvaluateClosure_ be a new Abstract Closure with no parameters that captures _module_, _promiseCapability_, and _onRejected_ and performs the following steps when called:
             1. Let _link_ be Completion(_module_.Link()).
             1. If _link_ is an abrupt completion, then
               1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, « _link_.[[Value]] »).
-              1. Return ~unused~.
+              1. Return NormalCompletion(*undefined*).
             1. Let _evaluatePromise_ be _module_.Evaluate().
             1. Let _fulfilledClosure_ be a new Abstract Closure with no parameters that captures _module_ and _promiseCapability_ and performs the following steps when called:
               1. Let _namespace_ be GetModuleNamespace(_module_).
               1. Perform ! <emu-meta effects="user-code">Call</emu-meta>(_promiseCapability_.[[Resolve]], *undefined*, « _namespace_ »).
-              1. Return ~unused~.
+              1. Return NormalCompletion(*undefined*).
             1. Let _onFulfilled_ be CreateBuiltinFunction(_fulfilledClosure_, 0, *""*, « »).
             1. Perform PerformPromiseThen(_evaluatePromise_, _onFulfilled_, _onRejected_).
             1. Return ~unused~.
@@ -25240,7 +25240,7 @@
               1. NOTE: This branch behaves similarly to `constructor() {}`.
               1. Let _result_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Object.prototype%"*).
             1. Perform ? InitializeInstanceElements(_result_, _F_).
-            1. Return _result_.
+            1. Return NormalCompletion(_result_).
           1. Let _F_ be CreateBuiltinFunction(_defaultConstructor_, 0, _className_, « [[ConstructorKind]], [[SourceText]] », the current Realm Record, _constructorParent_).
         1. Else,
           1. Let _constructorInfo_ be ! DefineMethod of _constructor_ with arguments _proto_ and _constructorParent_.
@@ -27352,11 +27352,11 @@
                 1. Let _capability_ be ! NewPromiseCapability(%Promise%).
                 1. Let _fulfilledClosure_ be a new Abstract Closure with no parameters that captures _module_ and performs the following steps when called:
                   1. Perform AsyncModuleExecutionFulfilled(_module_).
-                  1. Return *undefined*.
+                  1. Return NormalCompletion(*undefined*).
                 1. Let _onFulfilled_ be CreateBuiltinFunction(_fulfilledClosure_, 0, *""*, « »).
                 1. Let _rejectedClosure_ be a new Abstract Closure with parameters (_error_) that captures _module_ and performs the following steps when called:
                   1. Perform AsyncModuleExecutionRejected(_module_, _error_).
-                  1. Return *undefined*.
+                  1. Return NormalCompletion(*undefined*).
                 1. Let _onRejected_ be CreateBuiltinFunction(_rejectedClosure_, 0, *""*, « »).
                 1. Perform PerformPromiseThen(_capability_.[[Promise]], _onFulfilled_, _onRejected_).
                 1. Perform ! <emu-meta effects="user-code">_module_.ExecuteModule</emu-meta>(_capability_).
@@ -30658,7 +30658,7 @@
           1. Let _closure_ be a new Abstract Closure with parameters (_key_, _value_) that captures _obj_ and performs the following steps when called:
             1. Let _propertyKey_ be ? ToPropertyKey(_key_).
             1. Perform ! CreateDataPropertyOrThrow(_obj_, _propertyKey_, _value_).
-            1. Return *undefined*.
+            1. Return NormalCompletion(*undefined*).
           1. Let _adder_ be CreateBuiltinFunction(_closure_, 2, *""*, « »).
           1. Return ? AddEntriesFromIterable(_obj_, _iterable_, _adder_).
         </emu-alg>
@@ -36338,7 +36338,7 @@ THH:mm:ss.sss
               1. Let _resultString_ be the substring of _s_ from _position_ to _nextIndex_.
               1. Set _position_ to _nextIndex_.
               1. Perform ? GeneratorYield(CreateIteratorResultObject(_resultString_, *false*)).
-            1. Return *undefined*.
+            1. Return NormalCompletion(~unused~).
           1. Return CreateIteratorFromClosure(_closure_, *"%StringIteratorPrototype%"*, %StringIteratorPrototype%).
         </emu-alg>
         <p>The value of the *"name"* property of this method is *"[Symbol.iterator]"*.</p>
@@ -43284,7 +43284,7 @@ THH:mm:ss.sss
                 1. Perform ? GeneratorYield(CreateIteratorResultObject(_result_, *false*)).
                 1. NOTE: The number of elements in _entries_ may have increased while execution of this abstract operation was paused by GeneratorYield.
                 1. Set _numEntries_ to the number of elements in _entries_.
-            1. Return *undefined*.
+            1. Return NormalCompletion(~unused~).
           1. Return CreateIteratorFromClosure(_closure_, *"%MapIteratorPrototype%"*, %MapIteratorPrototype%).
         </emu-alg>
       </emu-clause>
@@ -43914,7 +43914,7 @@ THH:mm:ss.sss
                   1. Perform ? GeneratorYield(CreateIteratorResultObject(_e_, *false*)).
                 1. NOTE: The number of elements in _entries_ may have increased while execution of this abstract operation was paused by GeneratorYield.
                 1. Set _numEntries_ to the number of elements in _entries_.
-            1. Return *undefined*.
+            1. Return NormalCompletion(~unused~).
           1. Return CreateIteratorFromClosure(_closure_, *"%SetIteratorPrototype%"*, %SetIteratorPrototype%).
         </emu-alg>
       </emu-clause>
@@ -48574,7 +48574,7 @@ THH:mm:ss.sss
             1. If _resolvingFunctions_.[[Reject]] is not *undefined*, throw a *TypeError* exception.
             1. Set _resolvingFunctions_.[[Resolve]] to _resolve_.
             1. Set _resolvingFunctions_.[[Reject]] to _reject_.
-            1. Return *undefined*.
+            1. Return NormalCompletion(*undefined*).
           1. Let _executor_ be CreateBuiltinFunction(_executorClosure_, 2, *""*, « »).
           1. Let _promise_ be ? Construct(_C_, « _executor_ »).
           1. If IsCallable(_resolvingFunctions_.[[Resolve]]) is *false*, throw a *TypeError* exception.
@@ -49281,7 +49281,7 @@ THH:mm:ss.sss
               1. Let _result_ be ? Call(_onFinally_, *undefined*).
               1. Let _p_ be ? PromiseResolve(_C_, _result_).
               1. Let _returnValue_ be a new Abstract Closure with no parameters that captures _value_ and performs the following steps when called:
-                1. Return _value_.
+                1. Return NormalCompletion(_value_).
               1. Let _valueThunk_ be CreateBuiltinFunction(_returnValue_, 0, *""*, « »).
               1. Return ? Invoke(_p_, *"then"*, « _valueThunk_ »).
             1. Let _thenFinally_ be CreateBuiltinFunction(_thenFinallyClosure_, 1, *""*, « »).
@@ -49796,7 +49796,7 @@ THH:mm:ss.sss
             1. Else,
               1. Assert: _result_ is a throw completion.
               1. Return ? _result_.
-            1. Return CreateIteratorResultObject(_resultValue_, *true*).
+            1. Return NormalCompletion(CreateIteratorResultObject(_resultValue_, *true*)).
           1. Set the code evaluation state of _genContext_ such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
           1. Set _generator_.[[GeneratorContext]] to _genContext_.
           1. Return ~unused~.
@@ -50156,7 +50156,7 @@ THH:mm:ss.sss
             1. If _result_ is a return completion, set _result_ to NormalCompletion(_result_.[[Value]]).
             1. Perform AsyncGeneratorCompleteStep(_acGenerator_, _result_, *true*).
             1. Perform AsyncGeneratorDrainQueue(_acGenerator_).
-            1. Return *undefined*.
+            1. Return NormalCompletion(*undefined*).
           1. Set the code evaluation state of _genContext_ such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
           1. Set _generator_.[[AsyncGeneratorContext]] to _genContext_.
           1. Set _generator_.[[AsyncGeneratorQueue]] to a new empty List.
@@ -50333,14 +50333,14 @@ THH:mm:ss.sss
             1. Let _result_ be NormalCompletion(_value_).
             1. Perform AsyncGeneratorCompleteStep(_generator_, _result_, *true*).
             1. Perform AsyncGeneratorDrainQueue(_generator_).
-            1. Return *undefined*.
+            1. Return NormalCompletion(*undefined*).
           1. Let _onFulfilled_ be CreateBuiltinFunction(_fulfilledClosure_, 1, *""*, « »).
           1. Let _rejectedClosure_ be a new Abstract Closure with parameters (_reason_) that captures _generator_ and performs the following steps when called:
             1. Assert: _generator_.[[AsyncGeneratorState]] is ~draining-queue~.
             1. Let _result_ be ThrowCompletion(_reason_).
             1. Perform AsyncGeneratorCompleteStep(_generator_, _result_, *true*).
             1. Perform AsyncGeneratorDrainQueue(_generator_).
-            1. Return *undefined*.
+            1. Return NormalCompletion(*undefined*).
           1. Let _onRejected_ be CreateBuiltinFunction(_rejectedClosure_, 1, *""*, « »).
           1. Perform PerformPromiseThen(_promise_, _onFulfilled_, _onRejected_).
           1. Return ~unused~.
@@ -50549,7 +50549,7 @@ THH:mm:ss.sss
             1. Else,
               1. Assert: _result_ is a throw completion.
               1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, « _result_.[[Value]] »).
-            1. [id="step-asyncblockstart-return-undefined"] Return ~unused~.
+            1. [id="step-asyncblockstart-return-undefined"] Return NormalCompletion(~unused~).
           1. Set the code evaluation state of _asyncContext_ such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
           1. Push _asyncContext_ onto the execution context stack; _asyncContext_ is now the running execution context.
           1. <emu-meta effects="user-code">Resume the suspended evaluation of _asyncContext_</emu-meta>. Let _result_ be the value returned by the resumed computation.
@@ -50576,7 +50576,7 @@ THH:mm:ss.sss
             1. Push _asyncContext_ onto the execution context stack; _asyncContext_ is now the running execution context.
             1. <emu-meta effects="user-code">Resume the suspended evaluation of _asyncContext_</emu-meta> using NormalCompletion(_v_) as the result of the operation that suspended it.
             1. Assert: When we reach this step, _asyncContext_ has already been removed from the execution context stack and _prevContext_ is the currently running execution context.
-            1. Return *undefined*.
+            1. Return NormalCompletion(*undefined*).
           1. Let _onFulfilled_ be CreateBuiltinFunction(_fulfilledClosure_, 1, *""*, « »).
           1. Let _rejectedClosure_ be a new Abstract Closure with parameters (_reason_) that captures _asyncContext_ and performs the following steps when called:
             1. Let _prevContext_ be the running execution context.
@@ -50584,7 +50584,7 @@ THH:mm:ss.sss
             1. Push _asyncContext_ onto the execution context stack; _asyncContext_ is now the running execution context.
             1. <emu-meta effects="user-code">Resume the suspended evaluation of _asyncContext_</emu-meta> using ThrowCompletion(_reason_) as the result of the operation that suspended it.
             1. Assert: When we reach this step, _asyncContext_ has already been removed from the execution context stack and _prevContext_ is the currently running execution context.
-            1. Return *undefined*.
+            1. Return NormalCompletion(*undefined*).
           1. Let _onRejected_ be CreateBuiltinFunction(_rejectedClosure_, 1, *""*, « »).
           1. Perform PerformPromiseThen(_promise_, _onFulfilled_, _onRejected_).
           1. Remove _asyncContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
@@ -50798,12 +50798,12 @@ THH:mm:ss.sss
           1. Let _revokerClosure_ be a new Abstract Closure with no parameters that captures nothing and performs the following steps when called:
             1. Let _F_ be the active function object.
             1. Let _p_ be _F_.[[RevocableProxy]].
-            1. If _p_ is *null*, return *undefined*.
+            1. If _p_ is *null*, return NormalCompletion(*undefined*).
             1. Set _F_.[[RevocableProxy]] to *null*.
             1. Assert: _p_ is a Proxy exotic object.
             1. Set _p_.[[ProxyTarget]] to *null*.
             1. Set _p_.[[ProxyHandler]] to *null*.
-            1. Return *undefined*.
+            1. Return NormalCompletion(*undefined*).
           1. Let _revoker_ be CreateBuiltinFunction(_revokerClosure_, 0, *""*, « [[RevocableProxy]] »).
           1. Set _revoker_.[[RevocableProxy]] to _proxy_.
           1. Let _result_ be OrdinaryObjectCreate(%Object.prototype%).


### PR DESCRIPTION
Turns out there were 23. As discussed in editor call. Layered on top of https://github.com/tc39/ecma262/pull/3599.