### PR TITLE
use normal completions in ACs passed to CreateIteratorFromClosure when possible

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -48606,7 +48606,7 @@ THH:mm:ss.sss
                     1. Let _completion_ be Completion(Yield(_innerValue_)).
                     1. If _completion_ is an abrupt completion, then
                       1. Return ? IteratorClose(_iteratorRecord_, _completion_).
-              1. Return ReturnCompletion(*undefined*).
+              1. Return NormalCompletion(~unused~).
             1. Let _gen_ be CreateIteratorFromClosure(_closure_, *"Iterator Helper"*, %IteratorHelperPrototype%, « [[UnderlyingIterators]] »).
             1. Set _gen_.[[UnderlyingIterators]] to a new empty List.
             1. Return _gen_.
@@ -48729,10 +48729,10 @@ THH:mm:ss.sss
                 1. If _remaining_ ≠ +∞, then
                   1. Set _remaining_ to _remaining_ - 1.
                 1. Let _next_ be ? IteratorStep(_iterated_).
-                1. If _next_ is ~done~, return ReturnCompletion(*undefined*).
+                1. If _next_ is ~done~, return NormalCompletion(~unused~).
               1. Repeat,
                 1. Let _value_ be ? IteratorStepValue(_iterated_).
-                1. If _value_ is ~done~, return ReturnCompletion(*undefined*).
+                1. If _value_ is ~done~, return NormalCompletion(~unused~).
                 1. Let _completion_ be Completion(Yield(_value_)).
                 1. IfAbruptCloseIterator(_completion_, _iterated_).
             1. Let _result_ be CreateIteratorFromClosure(_closure_, *"Iterator Helper"*, %IteratorHelperPrototype%, « [[UnderlyingIterators]] »).
@@ -48778,7 +48778,7 @@ THH:mm:ss.sss
               1. Let _counter_ be 0.
               1. Repeat,
                 1. Let _value_ be ? IteratorStepValue(_iterated_).
-                1. If _value_ is ~done~, return ReturnCompletion(*undefined*).
+                1. If _value_ is ~done~, return NormalCompletion(~unused~).
                 1. Let _selected_ be Completion(Call(_predicate_, *undefined*, « _value_, 𝔽(_counter_) »)).
                 1. IfAbruptCloseIterator(_selected_, _iterated_).
                 1. If ToBoolean(_selected_) is *true*, then
@@ -48828,7 +48828,7 @@ THH:mm:ss.sss
               1. Let _counter_ be 0.
               1. Repeat,
                 1. Let _value_ be ? IteratorStepValue(_iterated_).
-                1. If _value_ is ~done~, return ReturnCompletion(*undefined*).
+                1. If _value_ is ~done~, return NormalCompletion(~unused~).
                 1. Let _mapped_ be Completion(Call(_mapper_, *undefined*, « _value_, 𝔽(_counter_) »)).
                 1. IfAbruptCloseIterator(_mapped_, _iterated_).
                 1. Let _innerIterator_ be Completion(GetIteratorFlattenable(_mapped_, ~reject-primitives~)).
@@ -48888,7 +48888,7 @@ THH:mm:ss.sss
               1. Let _counter_ be 0.
               1. Repeat,
                 1. Let _value_ be ? IteratorStepValue(_iterated_).
-                1. If _value_ is ~done~, return ReturnCompletion(*undefined*).
+                1. If _value_ is ~done~, return NormalCompletion(~unused~).
                 1. Let _mapped_ be Completion(Call(_mapper_, *undefined*, « _value_, 𝔽(_counter_) »)).
                 1. IfAbruptCloseIterator(_mapped_, _iterated_).
                 1. Let _completion_ be Completion(Yield(_mapped_)).
@@ -48971,11 +48971,11 @@ THH:mm:ss.sss
               1. Let _remaining_ be _integerLimit_.
               1. Repeat,
                 1. If _remaining_ = 0, then
-                  1. Return ? IteratorClose(_iterated_, ReturnCompletion(*undefined*)).
+                  1. Return ? IteratorClose(_iterated_, NormalCompletion(~unused~)).
                 1. If _remaining_ ≠ +∞, then
                   1. Set _remaining_ to _remaining_ - 1.
                 1. Let _value_ be ? IteratorStepValue(_iterated_).
-                1. If _value_ is ~done~, return ReturnCompletion(*undefined*).
+                1. If _value_ is ~done~, return NormalCompletion(~unused~).
                 1. Let _completion_ be Completion(Yield(_value_)).
                 1. IfAbruptCloseIterator(_completion_, _iterated_).
             1. Let _result_ be CreateIteratorFromClosure(_closure_, *"Iterator Helper"*, %IteratorHelperPrototype%, « [[UnderlyingIterators]] »).


### PR DESCRIPTION
CreateIteratorFromClosure passes the AC to GeneratorStart which treats any normal completion return value the same as a `ReturnCompletion(*undefined*)`. It seems better to me to use `NormalCompletion(~unused~)` in these locations and only return a return completion if we want to use a value other than `*undefined*`.