### PR TITLE
mark the conversion operation in NumericToRawBytes as infallible

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -44664,7 +44664,7 @@ THH:mm:ss.sss
           1. Else,
             1. Let _n_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for Element Type _type_.
             1. Let _conversionOperation_ be the abstract operation named in the Conversion Operation column in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for Element Type _type_.
-            1. Let _intValue_ be ℝ(_conversionOperation_(_value_)).
+            1. Let _intValue_ be ℝ(! _conversionOperation_(_value_)).
             1. If _intValue_ ≥ 0, then
               1. Let _rawBytes_ be a List whose elements are the _n_-byte binary encoding of _intValue_. The bytes are ordered in little endian order.
             1. Else,


### PR DESCRIPTION
I haven't actually checked yet that there's no path that can throw here. But each of these AOs that are indirectly referenced through the table return completion records (which are sometimes abrupt!). So we better hope that they can't be made to throw.