### PR TITLE
Editorial: fix note in AsyncBlockStart to not assume its argument is a function

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -50564,7 +50564,7 @@ THH:mm:ss.sss
             1. Else,
               1. Assert: _asyncBody_ is an Abstract Closure with no parameters.
               1. Let _result_ be _asyncBody_().
-            1. Assert: If we return here, the async function either threw an exception or performed an implicit or explicit return; all awaiting is done.
+            1. Assert: If we return here, evaluation has finished either by throwing, by an explicit return, or by reaching the end of the Parse Node; all awaiting is done.
             1. Remove _acAsyncContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
             1. If _result_ is a normal completion, then
               1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, « *undefined* »).


### PR DESCRIPTION
AsyncBlockStart is also used for modules which have top-level awaits.