### PR TITLE
Editorial: non-syntactic async/generator functions use ReturnCompletion

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -49806,16 +49806,18 @@ THH:mm:ss.sss
             1. Let _acGenerator_ be the Generator component of _acGenContext_.
             1. If _generatorBody_ is a Parse Node, then
               1. Let _result_ be Completion(Evaluation of _generatorBody_).
+              1. If _result_ is a normal completion, then
+                1. NOTE: This implies that evaluation finished without reaching an explicit |ReturnStatement|.
+                1. Set _result_ to ReturnCompletion(*undefined*).
             1. Else,
               1. Assert: _generatorBody_ is an Abstract Closure with no parameters.
               1. Let _result_ be Completion(_generatorBody_()).
+              1. Assert: _result_ is a return completion or a throw completion.
             1. Assert: If we return here, the generator either threw an exception or performed either an implicit or explicit return.
             1. Remove _acGenContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
             1. Set _acGenerator_.[[GeneratorState]] to ~completed~.
             1. NOTE: Once a generator enters the ~completed~ state it never leaves it and its associated execution context is never resumed. Any execution state associated with _acGenerator_ can be discarded at this point.
-            1. If _result_ is a normal completion, then
-              1. Let _resultValue_ be *undefined*.
-            1. Else if _result_ is a return completion, then
+            1. If _result_ is a return completion, then
               1. Let _resultValue_ be _result_.[[Value]].
             1. Else,
               1. Assert: _result_ is a throw completion.
@@ -50170,14 +50172,20 @@ THH:mm:ss.sss
             1. Let _acGenerator_ be the Generator component of _acGenContext_.
             1. If _generatorBody_ is a Parse Node, then
               1. Let _result_ be Completion(Evaluation of _generatorBody_).
+              1. If _result_ is a normal completion, then
+                1. NOTE: This implies that evaluation finished without reaching an explicit |ReturnStatement|.
+                1. Set _result_ to ReturnCompletion(*undefined*).
             1. Else,
               1. Assert: _generatorBody_ is an Abstract Closure with no parameters.
               1. Let _result_ be Completion(_generatorBody_()).
+              1. Assert: _result_ is a return completion or a throw completion.
             1. Assert: If we return here, the async generator either threw an exception or performed either an implicit or explicit return.
             1. Remove _acGenContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
             1. Set _acGenerator_.[[AsyncGeneratorState]] to ~draining-queue~.
-            1. If _result_ is a normal completion, set _result_ to NormalCompletion(*undefined*).
-            1. If _result_ is a return completion, set _result_ to NormalCompletion(_result_.[[Value]]).
+            1. If _result_ is a return completion, then
+              1. Set _result_ to NormalCompletion(_result_.[[Value]]).
+            1. Else,
+              1. Assert: _result_ is a throw completion.
             1. Perform AsyncGeneratorCompleteStep(_acGenerator_, _result_, *true*).
             1. Perform AsyncGeneratorDrainQueue(_acGenerator_).
             1. Return *undefined*.
@@ -50561,14 +50569,16 @@ THH:mm:ss.sss
             1. Let _acAsyncContext_ be the running execution context.
             1. If _asyncBody_ is a Parse Node, then
               1. Let _result_ be Completion(Evaluation of _asyncBody_).
+              1. If _result_ is a normal completion, then
+                1. NOTE: This implies that evaluation finished without reaching an explicit |ReturnStatement|.
+                1. Set _result_ to ReturnCompletion(*undefined*).
             1. Else,
               1. Assert: _asyncBody_ is an Abstract Closure with no parameters.
-              1. Let _result_ be _asyncBody_().
+              1. Let _result_ be Completion(_asyncBody_()).
+              1. Assert: _result_ is a return completion or a throw completion.
             1. Assert: If we return here, the async function either threw an exception or performed an implicit or explicit return; all awaiting is done.
             1. Remove _acAsyncContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
-            1. If _result_ is a normal completion, then
-              1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, « *undefined* »).
-            1. Else if _result_ is a return completion, then
+            1. If _result_ is a return completion, then
               1. Perform ! <emu-meta effects="user-code">Call</emu-meta>(_promiseCapability_.[[Resolve]], *undefined*, « _result_.[[Value]] »).
             1. Else,
               1. Assert: _result_ is a throw completion.


### PR DESCRIPTION
This moves the machinery for handling implicit returns in syntactic async/generator functions into the branches for evaluating parse nodes, instead of also using that logic for evaluating Abstract Closures.

It assumes that non-syntactic async/generator functions always internally return ThrowCompletions or ReturnCompletions. Right now they can use both ReturnCompletions or NormalCompletions, which [provides an unnecessary degree of freedom](https://github.com/tc39/ecma262/pull/3602). The alternative is to enforce that non-syntactic async/generator functions return ThrowCompletions or NormalCompletions, for which see https://github.com/tc39/ecma262/pull/3606.

This makes non-syntactic async/generator functions _unlike_ non-syntactic ordinary functions, which never use ReturnCompletion (and the [machinery](https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-builtincallorconstruct) isn't set up to handle them). For that reason, I prefer #3606 over this PR.

You'll note a certain awkwardness in AsyncGeneratorStart: later in the algorithm ReturnCompletions are translated to NormalCompletions, for use as an argument to AsyncGeneratorCompleteStep. This accomplishes the same thing as the current `If _result_ is a normal completion, set _result_ to NormalCompletion(*undefined*)`, but in a more roundabout way, and is necessary to avoid refactoring AsyncGeneratorCompleteStep.

(This PR would also require changing the existing built-in generators/async functions to never return NormalCompletions. I'll push up a commit doing that if we go this route.)