### PR TITLE
Editorial: FunctionDeclarationInstantiation cannot return ReturnCompletion

### DIFF
--- a/esmeta-ignore.json
+++ b/esmeta-ignore.json
@@ -6,6 +6,7 @@
   "DoWait",
   "EvaluateImportCall",
   "FinishLoadingImportedModule",
+  "FunctionDeclarationInstantiation",
   "FunctionBody[0,0].EvaluateFunctionBody",
   "GetViewByteLength",
   "INTRINSICS.Atomics.notify",

--- a/spec.html
+++ b/spec.html
@@ -13848,7 +13848,7 @@
         FunctionDeclarationInstantiation (
           _func_: an ECMAScript function object,
           _argumentsList_: a List of ECMAScript language values,
-        ): either a normal completion containing ~unused~ or an abrupt completion
+        ): either a normal completion containing ~unused~ or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -13927,9 +13927,11 @@
           1. Let _parameterBindings_ be _parameterNames_.
         1. Let _iteratorRecord_ be CreateListIteratorRecord(_argumentsList_).
         1. If _hasDuplicates_ is *true*, then
-          1. Perform ? IteratorBindingInitialization of _formals_ with arguments _iteratorRecord_ and *undefined*.
+          1. Let _usedEnv_ be *undefined*.
         1. Else,
-          1. Perform ? IteratorBindingInitialization of _formals_ with arguments _iteratorRecord_ and _env_.
+          1. Let _usedEnv_ be _env_.
+        1. NOTE: The following step cannot return a ReturnCompletion because the only way such a completion can arise in expression position is by use of |YieldExpression|, which is forbidden in parameter lists by Early Error rules in <emu-xref href="#sec-generator-function-definitions-static-semantics-early-errors"></emu-xref> and <emu-xref href="#sec-async-generator-function-definitions-static-semantics-early-errors"></emu-xref>.
+        1. Perform ? IteratorBindingInitialization of _formals_ with arguments _iteratorRecord_ and _usedEnv_.
         1. If _hasParameterExpressions_ is *false*, then
           1. NOTE: Only a single Environment Record is needed for the parameters and top-level vars.
           1. Let _instantiatedVarNames_ be a copy of the List _parameterBindings_.


### PR DESCRIPTION
This is because the only way to get a return completion in expression position is with a `yield`, and `yield` is [statically forbidden](https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-generator-function-definitions-static-semantics-early-errors) in generator formal parameters.

I suspect esmeta will complain about this, because [FunctionDeclarationInstantiation](https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-functiondeclarationinstantiation) calls [IteratorBindingInitialization](https://tc39.es/ecma262/multipage/syntax-directed-operations.html#sec-runtime-semantics-iteratorbindinginitialization) to do the initialization, and that AO is also used for `let [foo] = bar` declarations, which _can_ contain `yield` expressions and therefore can produce return completions. I didn't think it was worth adding an assert in FunctionDeclarationInstantiation which says that IteratorBindingInitialization cannot produce a return completion in this specific case, but I'm open to doing so if we can do it without making the algorithm too awkward.

This imprecision is exposed by https://github.com/tc39/ecma262/pull/3606 failing esmeta's typechecks. It should pass if rebased on this (I think).