### PR TITLE
Editorial: replace "is at least" with ≥ in parseInt

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -29976,7 +29976,7 @@
         1. Else,
           1. Set _R_ to 10.
         1. If _stripPrefix_ is *true*, then
-          1. If the length of _S_ is at least 2 and the first two code units of _S_ are either *"0x"* or *"0X"*, then
+          1. If the length of _S_ ≥ 2 and the first two code units of _S_ are either *"0x"* or *"0X"*, then
             1. Set _S_ to the substring of _S_ from index 2.
             1. Set _R_ to 16.
         1. If _S_ contains a code unit that is not a radix-_R_ digit, let _end_ be the index within _S_ of the first such code unit; otherwise let _end_ be the length of _S_.


### PR DESCRIPTION
Convention is to use `≥` for mathematical value comparisons.