### PR TITLE
Editorial: Unify _obj_ to _O_ within indexed-collections

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -40758,21 +40758,21 @@ THH:mm:ss.sss
         <p>It performs the following steps when called:</p>
         <emu-alg>
           1. [id="step-array-sort-comparefn"] If _comparator_ is not *undefined* and IsCallable(_comparator_) is *false*, throw a *TypeError* exception.
-          1. Let _obj_ be ? ToObject(*this* value).
-          1. [id="step-array-sort-len"] Let _len_ be ? LengthOfArrayLike(_obj_).
+          1. Let _O_ be ? ToObject(*this* value).
+          1. [id="step-array-sort-len"] Let _len_ be ? LengthOfArrayLike(_O_).
           1. Let _SortCompare_ be a new Abstract Closure with parameters (_x_, _y_) that captures _comparator_ and performs the following steps when called:
             1. Return ? CompareArrayElements(_x_, _y_, _comparator_).
-          1. [id="step-array-sortindexedproperties"] Let _sortedList_ be ? SortIndexedProperties(_obj_, _len_, _SortCompare_, ~skip-holes~).
+          1. [id="step-array-sortindexedproperties"] Let _sortedList_ be ? SortIndexedProperties(_O_, _len_, _SortCompare_, ~skip-holes~).
           1. Let _itemCount_ be the number of elements in _sortedList_.
           1. Let _j_ be 0.
           1. Repeat, while _j_ &lt; _itemCount_,
-            1. Perform ? Set(_obj_, ! ToString(𝔽(_j_)), _sortedList_[_j_], *true*).
+            1. Perform ? Set(_O_, ! ToString(𝔽(_j_)), _sortedList_[_j_], *true*).
             1. Set _j_ to _j_ + 1.
           1. NOTE: The call to SortIndexedProperties in step <emu-xref href="#step-array-sortindexedproperties"></emu-xref> uses ~skip-holes~. The remaining indices are deleted to preserve the number of holes that were detected and excluded from the sort.
           1. Repeat, while _j_ &lt; _len_,
-            1. Perform ? DeletePropertyOrThrow(_obj_, ! ToString(𝔽(_j_))).
+            1. Perform ? DeletePropertyOrThrow(_O_, ! ToString(𝔽(_j_))).
             1. Set _j_ to _j_ + 1.
-          1. Return _obj_.
+          1. Return _O_.
         </emu-alg>
         <emu-note>
           <p>Because non-existent property values always compare greater than *undefined* property values, and *undefined* always compares greater than any other value (see CompareArrayElements), *undefined* property values always sort to the end of the result, followed by non-existent property values.</p>
@@ -42396,18 +42396,18 @@ THH:mm:ss.sss
         <p>It performs the following steps when called:</p>
         <emu-alg>
           1. If _comparator_ is not *undefined* and IsCallable(_comparator_) is *false*, throw a *TypeError* exception.
-          1. Let _obj_ be the *this* value.
-          1. Let _taRecord_ be ? ValidateTypedArray(_obj_, ~seq-cst~).
+          1. Let _O_ be the *this* value.
+          1. Let _taRecord_ be ? ValidateTypedArray(_O_, ~seq-cst~).
           1. Let _len_ be TypedArrayLength(_taRecord_).
           1. NOTE: The following closure performs a numeric comparison rather than the string comparison used in <emu-xref href="#sec-array.prototype.sort"></emu-xref>.
           1. Let _SortCompare_ be a new Abstract Closure with parameters (_x_, _y_) that captures _comparator_ and performs the following steps when called:
             1. Return ? CompareTypedArrayElements(_x_, _y_, _comparator_).
-          1. Let _sortedList_ be ? SortIndexedProperties(_obj_, _len_, _SortCompare_, ~read-through-holes~).
+          1. Let _sortedList_ be ? SortIndexedProperties(_O_, _len_, _SortCompare_, ~read-through-holes~).
           1. Let _j_ be 0.
           1. Repeat, while _j_ &lt; _len_,
-            1. Perform ! Set(_obj_, ! ToString(𝔽(_j_)), _sortedList_[_j_], *true*).
+            1. Perform ! Set(_O_, ! ToString(𝔽(_j_)), _sortedList_[_j_], *true*).
             1. Set _j_ to _j_ + 1.
-          1. Return _obj_.
+          1. Return _O_.
         </emu-alg>
         <emu-note>
           <p>Because *NaN* always compares greater than any other value (see CompareTypedArrayElements), *NaN* property values always sort to the end of the result when _comparator_ is not provided.</p>
@@ -42761,18 +42761,18 @@ THH:mm:ss.sss
           </dl>
           <emu-alg>
             1. Let _proto_ be ? GetPrototypeFromConstructor(_newTarget_, _defaultProto_).
-            1. Let _obj_ be TypedArrayCreate(_proto_).
-            1. Assert: _obj_.[[ViewedArrayBuffer]] is *undefined*.
-            1. Set _obj_.[[TypedArrayName]] to _constructorName_.
-            1. If _constructorName_ is either *"BigInt64Array"* or *"BigUint64Array"*, set _obj_.[[ContentType]] to ~bigint~.
-            1. Otherwise, set _obj_.[[ContentType]] to ~number~.
+            1. Let _O_ be TypedArrayCreate(_proto_).
+            1. Assert: _O_.[[ViewedArrayBuffer]] is *undefined*.
+            1. Set _O_.[[TypedArrayName]] to _constructorName_.
+            1. If _constructorName_ is either *"BigInt64Array"* or *"BigUint64Array"*, set _O_.[[ContentType]] to ~bigint~.
+            1. Otherwise, set _O_.[[ContentType]] to ~number~.
             1. If _length_ is not present, then
-              1. Set _obj_.[[ByteLength]] to 0.
-              1. Set _obj_.[[ByteOffset]] to 0.
-              1. Set _obj_.[[ArrayLength]] to 0.
+              1. Set _O_.[[ByteLength]] to 0.
+              1. Set _O_.[[ByteOffset]] to 0.
+              1. Set _O_.[[ArrayLength]] to 0.
             1. Else,
-              1. Perform ? AllocateTypedArrayBuffer(_obj_, _length_).
-            1. Return _obj_.
+              1. Perform ? AllocateTypedArrayBuffer(_O_, _length_).
+            1. Return _O_.
           </emu-alg>
         </emu-clause>
 


### PR DESCRIPTION
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->

In this PR, I replaced all instances of `_obj_` with `_O_` within the [indexed-collections](https://tc39.es/ecma262/multipage/indexed-collections.html) section.

While there are still many occurrences of `_obj_` elsewhere in the spec, it seemed that within indexed-collections, `_O_` is consistently used. In particular, since [toSorted](https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.tosorted) uses `_O_`, the use of `_obj_` in [sort](https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.sort) felt a bit inconsistent.