### PR TITLE
Editorial: module namespace exotic objects are immutable prototype exotic objects

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -15183,8 +15183,8 @@
 
     <emu-clause id="sec-module-namespace-exotic-objects">
       <h1>Module Namespace Exotic Objects</h1>
-      <p>A module namespace exotic object is an exotic object that exposes the bindings exported from an ECMAScript |Module| (See <emu-xref href="#sec-exports"></emu-xref>). There is a one-to-one correspondence between the String-keyed own properties of a module namespace exotic object and the binding names exported by the |Module|. The exported bindings include any bindings that are indirectly exported using `export *` export items. Each String-valued own property key is the StringValue of the corresponding exported binding name. These are the only String-keyed properties of a module namespace exotic object. Each such property has the attributes { [[Writable]]: *true*, [[Enumerable]]: *true*, [[Configurable]]: *false* }. Module namespace exotic objects are not extensible.</p>
-      <p>An object is a <dfn id="module-namespace-exotic-object" variants="module namespace exotic objects">module namespace exotic object</dfn> if its [[GetPrototypeOf]], [[SetPrototypeOf]], [[IsExtensible]], [[PreventExtensions]], [[GetOwnProperty]], [[DefineOwnProperty]], [[HasProperty]], [[Get]], [[Set]], [[Delete]], and [[OwnPropertyKeys]] internal methods use the definitions in this section, and its other essential internal methods use the definitions found in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>. These methods are installed by ModuleNamespaceCreate.</p>
+      <p>A module namespace exotic object is an immutable prototype exotic object that exposes the bindings exported from an ECMAScript |Module| (See <emu-xref href="#sec-exports"></emu-xref>). There is a one-to-one correspondence between the String-keyed own properties of a module namespace exotic object and the binding names exported by the |Module|. The exported bindings include any bindings that are indirectly exported using `export *` export items. Each String-valued own property key is the StringValue of the corresponding exported binding name. These are the only String-keyed properties of a module namespace exotic object. Each such property has the attributes { [[Writable]]: *true*, [[Enumerable]]: *true*, [[Configurable]]: *false* }. Module namespace exotic objects are not extensible.</p>
+      <p>An object is a <dfn id="module-namespace-exotic-object" variants="module namespace exotic objects">module namespace exotic object</dfn> if its [[GetPrototypeOf]], [[IsExtensible]], [[PreventExtensions]], [[GetOwnProperty]], [[DefineOwnProperty]], [[HasProperty]], [[Get]], [[Set]], [[Delete]], and [[OwnPropertyKeys]] internal methods use the definitions in this section, its [[SetPrototypeOf]] internal method uses the definition in <emu-xref href="#sec-immutable-prototype-exotic-objects-setprototypeof-v"></emu-xref> (thus, it is an immutable prototype exotic object), and its other essential internal methods use the definitions found in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>. These methods are installed by ModuleNamespaceCreate.</p>
       <p>Module namespace exotic objects have the internal slots defined in <emu-xref href="#table-internal-slots-of-module-namespace-exotic-objects"></emu-xref>.</p>
       <emu-table id="table-internal-slots-of-module-namespace-exotic-objects" caption="Internal Slots of Module Namespace Exotic Objects" oldids="table-29">
         <table>
@@ -15234,21 +15234,6 @@
         </dl>
         <emu-alg>
           1. Return *null*.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-module-namespace-exotic-objects-setprototypeof-v" type="internal method">
-        <h1>
-          [[SetPrototypeOf]] (
-            _V_: an Object or *null*,
-          ): a normal completion containing a Boolean
-        </h1>
-        <dl class="header">
-          <dt>for</dt>
-          <dd>a module namespace exotic object _O_</dd>
-        </dl>
-        <emu-alg>
-          1. Return ! SetImmutablePrototype(_O_, _V_).
         </emu-alg>
       </emu-clause>
 
@@ -15449,10 +15434,10 @@
       <p>An object is an <dfn id="immutable-prototype-exotic-object" variants="immutable prototype exotic objects">immutable prototype exotic object</dfn> if its [[SetPrototypeOf]] internal method uses the following implementation. (Its other essential internal methods may use any implementation, depending on the specific immutable prototype exotic object in question.)</p>
 
       <emu-note>
-        <p>Unlike other exotic objects, there is not a dedicated creation abstract operation provided for immutable prototype exotic objects. This is because they are only used by %Object.prototype% and by host environments, and in host environments, the relevant objects are potentially exotic in other ways and thus need their own dedicated creation operation.</p>
+        <p>Unlike other exotic objects, there is not a dedicated creation abstract operation provided for immutable prototype exotic objects. This is because they are only used by %Object.prototype%, module namespace exotic objects, and by host environments, and in host environments, the relevant objects are potentially exotic in other ways and thus need their own dedicated creation operation.</p>
       </emu-note>
 
-      <emu-clause id="sec-immutable-prototype-exotic-objects-setprototypeof-v" type="internal method">
+      <emu-clause id="sec-immutable-prototype-exotic-objects-setprototypeof-v" oldids="sec-set-immutable-prototype,sec-module-namespace-exotic-objects-setprototypeof-v" type="internal method">
         <h1>
           [[SetPrototypeOf]] (
             _V_: an Object or *null*,
@@ -15461,20 +15446,6 @@
         <dl class="header">
           <dt>for</dt>
           <dd>an immutable prototype exotic object _O_</dd>
-        </dl>
-        <emu-alg>
-          1. Return ? SetImmutablePrototype(_O_, _V_).
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-set-immutable-prototype" type="abstract operation">
-        <h1>
-          SetImmutablePrototype (
-            _O_: an Object,
-            _V_: an Object or *null*,
-          ): either a normal completion containing a Boolean or a throw completion
-        </h1>
-        <dl class="header">
         </dl>
         <emu-alg>
           1. Let _current_ be ? <emu-meta effects="user-code">_O_.[[GetPrototypeOf]]</emu-meta>().

--- a/spec.html
+++ b/spec.html
@@ -15431,7 +15431,7 @@
       <h1>Immutable Prototype Exotic Objects</h1>
       <p>An immutable prototype exotic object is an exotic object that has a [[Prototype]] internal slot that will not change once it is initialized.</p>
 
-      <p>An object is an <dfn id="immutable-prototype-exotic-object" variants="immutable prototype exotic objects">immutable prototype exotic object</dfn> if its [[SetPrototypeOf]] internal method uses the following implementation. (Its other essential internal methods may use any implementation, depending on the specific immutable prototype exotic object in question.)</p>
+      <p>An object is an <dfn id="immutable-prototype-exotic-object" variants="immutable prototype exotic objects">immutable prototype exotic object</dfn> if its [[SetPrototypeOf]] internal method uses the following implementation. Its other essential internal methods may use any implementation, depending on the specific immutable prototype exotic object in question.</p>
 
       <emu-note>
         <p>Unlike other exotic objects, there is not a dedicated creation abstract operation provided for immutable prototype exotic objects. This is because they are only used by %Object.prototype%, module namespace exotic objects, and by host environments, and in host environments, the relevant objects are potentially exotic in other ways and thus need their own dedicated creation operation.</p>


### PR DESCRIPTION
This removes the definition of `[[SetPrototypeOf]]` for module namespace exotic objects (which was identical to that of immutable prototype exotic objects), making them actually fit the definition of immutable prototype exotic objects.