### PR TITLE
Adjust invalid assertion about [[AsyncEvaluationOrder]]

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -27244,8 +27244,7 @@
                 1. Assert: _module_.[[Status]] is either ~evaluating-async~ or ~evaluated~.
                 1. Assert: _module_.[[EvaluationError]] is ~empty~.
                 1. If _module_.[[Status]] is ~evaluated~, then
-                  1. NOTE: This implies that evaluation of _module_ completed synchronously.
-                  1. Assert: _module_.[[AsyncEvaluationOrder]] is ~unset~.
+                  1. Assert: _module_.[[AsyncEvaluationOrder]] is not an integer.
                   1. Perform ! Call(_capability_.[[Resolve]], *undefined*, « *undefined* »).
                 1. Assert: _stack_ is empty.
               1. Return _capability_.[[Promise]].


### PR DESCRIPTION
Silly mistake by me in https://github.com/tc39/ecma262/pull/3353, where I translated "[[AsyncEvaluation]] is false" to "[[AsyncEvaluationOrder]] is unset".

That's not true even in trivial cases. If you have module A that depends on module B, and B is async:
- you first import A, which imports B. Once everything is done, B has [[AsyncEvaluationOrder]] set to done
- then with a dynamic import you import B, which obviously even the re-Evaluation of it completes synchronously (because it's already evaluated) does not have [[AsyncEvaluationOrder]] set to unset.

This is different from the error case, where we can indeed assert that [[AsyncEvaluationOrder]] is unset. That's because in the error case we assert it on what's in the `stack`, but we push modules to it only _after_ checking that they are not already evaluated.