### PR TITLE
Meta: Upgrade ESMeta to v0.6.1

### DIFF
--- a/.github/workflows/esmeta-typecheck.yml
+++ b/.github/workflows/esmeta-typecheck.yml
@@ -26,7 +26,7 @@ jobs:
           cd "${ESMETA_HOME}"
           git init
           git remote add origin https://github.com/es-meta/esmeta.git
-          git fetch --depth 1 origin c2dd287931f8a557f730f4216e26fea3bab42524 ;# v0.6.0
+          git fetch --depth 1 origin 49ac09ee597701b421208398ca3ea69c2af62693 ;# v0.6.1
           git checkout FETCH_HEAD
       - name: build esmeta
         run: |


### PR DESCRIPTION
We updated the version of [ESMeta](https://github.com/es-meta/esmeta) to [v0.6.1](https://github.com/es-meta/esmeta/releases/tag/v0.6.1).

In this update, we added support for the shorthand `IfAbruptCloseAsyncIterator`, which is introduced in the **Array.fromAsync** proposal ([proposal-array-from-async](https://github.com/tc39/proposal-array-from-async), [ecma262/pull/3581](https://github.com/tc39/ecma262/pull/3581)). The proposal is currently at Stage 3 and may be approved for Stage 4 at the upcoming TC39 plenary. This shorthand is expected to be used in other proposals such as [proposal-async-iterator-helpers](https://github.com/tc39/proposal-async-iterator-helpers), as per [esmeta/284#comment](https://github.com/es-meta/esmeta/issues/284#issue-3091434500).

While not yet part of the official spec, this addition improves type-checking support for proposals at advanced stages.