### PR TITLE
Editorial: Make "Properties of the Iterator Prototype Object" a subclause of "Iterator Objects"

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -48091,374 +48091,374 @@ THH:mm:ss.sss
           <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
         </emu-clause>
       </emu-clause>
-    </emu-clause>
 
-    <emu-clause oldids="sec-%iteratorprototype%-object" id="sec-%iterator.prototype%-object">
-      <h1>Properties of the Iterator Prototype Object</h1>
-      <p>The <dfn>Iterator prototype object</dfn>:</p>
-      <ul>
-        <li>is <dfn>%Iterator.prototype%</dfn>.</li>
-        <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
-        <li>is an ordinary object.</li>
-      </ul>
-      <emu-note>
-        <p>All objects defined in this specification that implement the iterator interface also inherit from %Iterator.prototype%. ECMAScript code may also define objects that inherit from %Iterator.prototype%. %Iterator.prototype% provides a place where additional methods that are applicable to all iterator objects may be added.</p>
-        <p>The following expression is one way that ECMAScript code can access the %Iterator.prototype% object:</p>
-        <pre><code class="javascript">Object.getPrototypeOf(Object.getPrototypeOf([][Symbol.iterator]()))</code></pre>
-      </emu-note>
-
-      <emu-clause id="sec-iterator.prototype.constructor">
-        <h1>Iterator.prototype.constructor</h1>
-        <p>`Iterator.prototype.constructor` is an accessor property with attributes { [[Enumerable]]: *false*, [[Configurable]]: *true* }. The [[Get]] and [[Set]] attributes are defined as follows:</p>
-
-        <emu-clause id="sec-get-iterator.prototype.constructor">
-          <h1>get Iterator.prototype.constructor</h1>
-          <p>The value of the [[Get]] attribute is a built-in function that requires no arguments. It performs the following steps when called:</p>
-          <emu-alg>
-            1. Return %Iterator%.
-          </emu-alg>
-        </emu-clause>
-
-        <emu-clause id="sec-set-iterator.prototype.constructor">
-          <h1>set Iterator.prototype.constructor</h1>
-          <p>The value of the [[Set]] attribute is a built-in function that takes an argument _v_. It performs the following steps when called:</p>
-          <emu-alg>
-            1. Perform ? SetterThatIgnoresPrototypeProperties(*this* value, %Iterator.prototype%, *"constructor"*, _v_).
-            1. Return *undefined*.
-          </emu-alg>
-        </emu-clause>
-
+      <emu-clause oldids="sec-%iteratorprototype%-object" id="sec-%iterator.prototype%-object">
+        <h1>Properties of the Iterator Prototype Object</h1>
+        <p>The <dfn>Iterator prototype object</dfn>:</p>
+        <ul>
+          <li>is <dfn>%Iterator.prototype%</dfn>.</li>
+          <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
+          <li>is an ordinary object.</li>
+        </ul>
         <emu-note>
-          <p>Unlike the *"constructor"* property on most built-in prototypes, for web-compatibility reasons this property must be an accessor.</p>
+          <p>All objects defined in this specification that implement the iterator interface also inherit from %Iterator.prototype%. ECMAScript code may also define objects that inherit from %Iterator.prototype%. %Iterator.prototype% provides a place where additional methods that are applicable to all iterator objects may be added.</p>
+          <p>The following expression is one way that ECMAScript code can access the %Iterator.prototype% object:</p>
+          <pre><code class="javascript">Object.getPrototypeOf(Object.getPrototypeOf([][Symbol.iterator]()))</code></pre>
         </emu-note>
-      </emu-clause>
 
-      <emu-clause id="sec-iterator.prototype.drop">
-        <h1>Iterator.prototype.drop ( _limit_ )</h1>
-        <p>This method performs the following steps when called:</p>
-        <emu-alg>
-          1. Let _O_ be the *this* value.
-          1. If _O_ is not an Object, throw a *TypeError* exception.
-          1. Let _iterated_ be the Iterator Record { [[Iterator]]: _O_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
-          1. Let _numLimit_ be Completion(ToNumber(_limit_)).
-          1. IfAbruptCloseIterator(_numLimit_, _iterated_).
-          1. If _numLimit_ is *NaN*, then
-            1. Let _error_ be ThrowCompletion(a newly created *RangeError* object).
-            1. Return ? IteratorClose(_iterated_, _error_).
-          1. Let _integerLimit_ be ! ToIntegerOrInfinity(_numLimit_).
-          1. If _integerLimit_ &lt; 0, then
-            1. Let _error_ be ThrowCompletion(a newly created *RangeError* object).
-            1. Return ? IteratorClose(_iterated_, _error_).
-          1. Set _iterated_ to ? GetIteratorDirect(_O_).
-          1. Let _closure_ be a new Abstract Closure with no parameters that captures _iterated_ and _integerLimit_ and performs the following steps when called:
-            1. Let _remaining_ be _integerLimit_.
-            1. Repeat, while _remaining_ > 0,
-              1. If _remaining_ ≠ +∞, then
-                1. Set _remaining_ to _remaining_ - 1.
-              1. Let _next_ be ? IteratorStep(_iterated_).
-              1. If _next_ is ~done~, return ReturnCompletion(*undefined*).
-            1. Repeat,
-              1. Let _value_ be ? IteratorStepValue(_iterated_).
-              1. If _value_ is ~done~, return ReturnCompletion(*undefined*).
-              1. Let _completion_ be Completion(Yield(_value_)).
-              1. IfAbruptCloseIterator(_completion_, _iterated_).
-          1. Let _result_ be CreateIteratorFromClosure(_closure_, *"Iterator Helper"*, %IteratorHelperPrototype%, « [[UnderlyingIterator]] »).
-          1. Set _result_.[[UnderlyingIterator]] to _iterated_.
-          1. Return _result_.
-        </emu-alg>
-      </emu-clause>
+        <emu-clause id="sec-iterator.prototype.constructor">
+          <h1>Iterator.prototype.constructor</h1>
+          <p>`Iterator.prototype.constructor` is an accessor property with attributes { [[Enumerable]]: *false*, [[Configurable]]: *true* }. The [[Get]] and [[Set]] attributes are defined as follows:</p>
 
-      <emu-clause id="sec-iterator.prototype.every">
-        <h1>Iterator.prototype.every ( _predicate_ )</h1>
-        <p>This method performs the following steps when called:</p>
-        <emu-alg>
-          1. Let _O_ be the *this* value.
-          1. If _O_ is not an Object, throw a *TypeError* exception.
-          1. Let _iterated_ be the Iterator Record { [[Iterator]]: _O_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
-          1. If IsCallable(_predicate_) is *false*, then
-            1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
-            1. Return ? IteratorClose(_iterated_, _error_).
-          1. Set _iterated_ to ? GetIteratorDirect(_O_).
-          1. Let _counter_ be 0.
-          1. Repeat,
-            1. Let _value_ be ? IteratorStepValue(_iterated_).
-            1. If _value_ is ~done~, return *true*.
-            1. Let _result_ be Completion(Call(_predicate_, *undefined*, « _value_, 𝔽(_counter_) »)).
-            1. IfAbruptCloseIterator(_result_, _iterated_).
-            1. If ToBoolean(_result_) is *false*, return ? IteratorClose(_iterated_, NormalCompletion(*false*)).
-            1. Set _counter_ to _counter_ + 1.
-        </emu-alg>
-      </emu-clause>
+          <emu-clause id="sec-get-iterator.prototype.constructor">
+            <h1>get Iterator.prototype.constructor</h1>
+            <p>The value of the [[Get]] attribute is a built-in function that requires no arguments. It performs the following steps when called:</p>
+            <emu-alg>
+              1. Return %Iterator%.
+            </emu-alg>
+          </emu-clause>
 
-      <emu-clause id="sec-iterator.prototype.filter">
-        <h1>Iterator.prototype.filter ( _predicate_ )</h1>
-        <p>This method performs the following steps when called:</p>
-        <emu-alg>
-          1. Let _O_ be the *this* value.
-          1. If _O_ is not an Object, throw a *TypeError* exception.
-          1. Let _iterated_ be the Iterator Record { [[Iterator]]: _O_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
-          1. If IsCallable(_predicate_) is *false*, then
-            1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
-            1. Return ? IteratorClose(_iterated_, _error_).
-          1. Set _iterated_ to ? GetIteratorDirect(_O_).
-          1. Let _closure_ be a new Abstract Closure with no parameters that captures _iterated_ and _predicate_ and performs the following steps when called:
-            1. Let _counter_ be 0.
-            1. Repeat,
-              1. Let _value_ be ? IteratorStepValue(_iterated_).
-              1. If _value_ is ~done~, return ReturnCompletion(*undefined*).
-              1. Let _selected_ be Completion(Call(_predicate_, *undefined*, « _value_, 𝔽(_counter_) »)).
-              1. IfAbruptCloseIterator(_selected_, _iterated_).
-              1. If ToBoolean(_selected_) is *true*, then
+          <emu-clause id="sec-set-iterator.prototype.constructor">
+            <h1>set Iterator.prototype.constructor</h1>
+            <p>The value of the [[Set]] attribute is a built-in function that takes an argument _v_. It performs the following steps when called:</p>
+            <emu-alg>
+              1. Perform ? SetterThatIgnoresPrototypeProperties(*this* value, %Iterator.prototype%, *"constructor"*, _v_).
+              1. Return *undefined*.
+            </emu-alg>
+          </emu-clause>
+
+          <emu-note>
+            <p>Unlike the *"constructor"* property on most built-in prototypes, for web-compatibility reasons this property must be an accessor.</p>
+          </emu-note>
+        </emu-clause>
+
+        <emu-clause id="sec-iterator.prototype.drop">
+          <h1>Iterator.prototype.drop ( _limit_ )</h1>
+          <p>This method performs the following steps when called:</p>
+          <emu-alg>
+            1. Let _O_ be the *this* value.
+            1. If _O_ is not an Object, throw a *TypeError* exception.
+            1. Let _iterated_ be the Iterator Record { [[Iterator]]: _O_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
+            1. Let _numLimit_ be Completion(ToNumber(_limit_)).
+            1. IfAbruptCloseIterator(_numLimit_, _iterated_).
+            1. If _numLimit_ is *NaN*, then
+              1. Let _error_ be ThrowCompletion(a newly created *RangeError* object).
+              1. Return ? IteratorClose(_iterated_, _error_).
+            1. Let _integerLimit_ be ! ToIntegerOrInfinity(_numLimit_).
+            1. If _integerLimit_ &lt; 0, then
+              1. Let _error_ be ThrowCompletion(a newly created *RangeError* object).
+              1. Return ? IteratorClose(_iterated_, _error_).
+            1. Set _iterated_ to ? GetIteratorDirect(_O_).
+            1. Let _closure_ be a new Abstract Closure with no parameters that captures _iterated_ and _integerLimit_ and performs the following steps when called:
+              1. Let _remaining_ be _integerLimit_.
+              1. Repeat, while _remaining_ > 0,
+                1. If _remaining_ ≠ +∞, then
+                  1. Set _remaining_ to _remaining_ - 1.
+                1. Let _next_ be ? IteratorStep(_iterated_).
+                1. If _next_ is ~done~, return ReturnCompletion(*undefined*).
+              1. Repeat,
+                1. Let _value_ be ? IteratorStepValue(_iterated_).
+                1. If _value_ is ~done~, return ReturnCompletion(*undefined*).
                 1. Let _completion_ be Completion(Yield(_value_)).
                 1. IfAbruptCloseIterator(_completion_, _iterated_).
-              1. Set _counter_ to _counter_ + 1.
-          1. Let _result_ be CreateIteratorFromClosure(_closure_, *"Iterator Helper"*, %IteratorHelperPrototype%, « [[UnderlyingIterator]] »).
-          1. Set _result_.[[UnderlyingIterator]] to _iterated_.
-          1. Return _result_.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-iterator.prototype.find">
-        <h1>Iterator.prototype.find ( _predicate_ )</h1>
-        <p>This method performs the following steps when called:</p>
-        <emu-alg>
-          1. Let _O_ be the *this* value.
-          1. If _O_ is not an Object, throw a *TypeError* exception.
-          1. Let _iterated_ be the Iterator Record { [[Iterator]]: _O_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
-          1. If IsCallable(_predicate_) is *false*, then
-            1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
-            1. Return ? IteratorClose(_iterated_, _error_).
-          1. Set _iterated_ to ? GetIteratorDirect(_O_).
-          1. Let _counter_ be 0.
-          1. Repeat,
-            1. Let _value_ be ? IteratorStepValue(_iterated_).
-            1. If _value_ is ~done~, return *undefined*.
-            1. Let _result_ be Completion(Call(_predicate_, *undefined*, « _value_, 𝔽(_counter_) »)).
-            1. IfAbruptCloseIterator(_result_, _iterated_).
-            1. If ToBoolean(_result_) is *true*, return ? IteratorClose(_iterated_, NormalCompletion(_value_)).
-            1. Set _counter_ to _counter_ + 1.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-iterator.prototype.flatmap">
-        <h1>Iterator.prototype.flatMap ( _mapper_ )</h1>
-        <p>This method performs the following steps when called:</p>
-        <emu-alg>
-          1. Let _O_ be the *this* value.
-          1. If _O_ is not an Object, throw a *TypeError* exception.
-          1. Let _iterated_ be the Iterator Record { [[Iterator]]: _O_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
-          1. If IsCallable(_mapper_) is *false*, then
-            1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
-            1. Return ? IteratorClose(_iterated_, _error_).
-          1. Set _iterated_ to ? GetIteratorDirect(_O_).
-          1. Let _closure_ be a new Abstract Closure with no parameters that captures _iterated_ and _mapper_ and performs the following steps when called:
-            1. Let _counter_ be 0.
-            1. Repeat,
-              1. Let _value_ be ? IteratorStepValue(_iterated_).
-              1. If _value_ is ~done~, return ReturnCompletion(*undefined*).
-              1. Let _mapped_ be Completion(Call(_mapper_, *undefined*, « _value_, 𝔽(_counter_) »)).
-              1. IfAbruptCloseIterator(_mapped_, _iterated_).
-              1. Let _innerIterator_ be Completion(GetIteratorFlattenable(_mapped_, ~reject-primitives~)).
-              1. IfAbruptCloseIterator(_innerIterator_, _iterated_).
-              1. Let _innerAlive_ be *true*.
-              1. Repeat, while _innerAlive_ is *true*,
-                1. Let _innerValue_ be Completion(IteratorStepValue(_innerIterator_)).
-                1. IfAbruptCloseIterator(_innerValue_, _iterated_).
-                1. If _innerValue_ is ~done~, then
-                  1. Set _innerAlive_ to *false*.
-                1. Else,
-                  1. Let _completion_ be Completion(Yield(_innerValue_)).
-                  1. If _completion_ is an abrupt completion, then
-                    1. Let _backupCompletion_ be Completion(IteratorClose(_innerIterator_, _completion_)).
-                    1. IfAbruptCloseIterator(_backupCompletion_, _iterated_).
-                    1. Return ? IteratorClose(_iterated_, _completion_).
-              1. Set _counter_ to _counter_ + 1.
-          1. Let _result_ be CreateIteratorFromClosure(_closure_, *"Iterator Helper"*, %IteratorHelperPrototype%, « [[UnderlyingIterator]] »).
-          1. Set _result_.[[UnderlyingIterator]] to _iterated_.
-          1. Return _result_.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-iterator.prototype.foreach">
-        <h1>Iterator.prototype.forEach ( _procedure_ )</h1>
-        <p>This method performs the following steps when called:</p>
-        <emu-alg>
-          1. Let _O_ be the *this* value.
-          1. If _O_ is not an Object, throw a *TypeError* exception.
-          1. Let _iterated_ be the Iterator Record { [[Iterator]]: _O_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
-          1. If IsCallable(_procedure_) is *false*, then
-            1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
-            1. Return ? IteratorClose(_iterated_, _error_).
-          1. Set _iterated_ to ? GetIteratorDirect(_O_).
-          1. Let _counter_ be 0.
-          1. Repeat,
-            1. Let _value_ be ? IteratorStepValue(_iterated_).
-            1. If _value_ is ~done~, return *undefined*.
-            1. Let _result_ be Completion(Call(_procedure_, *undefined*, « _value_, 𝔽(_counter_) »)).
-            1. IfAbruptCloseIterator(_result_, _iterated_).
-            1. Set _counter_ to _counter_ + 1.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-iterator.prototype.map">
-        <h1>Iterator.prototype.map ( _mapper_ )</h1>
-        <p>This method performs the following steps when called:</p>
-        <emu-alg>
-          1. Let _O_ be the *this* value.
-          1. If _O_ is not an Object, throw a *TypeError* exception.
-          1. Let _iterated_ be the Iterator Record { [[Iterator]]: _O_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
-          1. If IsCallable(_mapper_) is *false*, then
-            1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
-            1. Return ? IteratorClose(_iterated_, _error_).
-          1. Set _iterated_ to ? GetIteratorDirect(_O_).
-          1. Let _closure_ be a new Abstract Closure with no parameters that captures _iterated_ and _mapper_ and performs the following steps when called:
-            1. Let _counter_ be 0.
-            1. Repeat,
-              1. Let _value_ be ? IteratorStepValue(_iterated_).
-              1. If _value_ is ~done~, return ReturnCompletion(*undefined*).
-              1. Let _mapped_ be Completion(Call(_mapper_, *undefined*, « _value_, 𝔽(_counter_) »)).
-              1. IfAbruptCloseIterator(_mapped_, _iterated_).
-              1. Let _completion_ be Completion(Yield(_mapped_)).
-              1. IfAbruptCloseIterator(_completion_, _iterated_).
-              1. Set _counter_ to _counter_ + 1.
-          1. Let _result_ be CreateIteratorFromClosure(_closure_, *"Iterator Helper"*, %IteratorHelperPrototype%, « [[UnderlyingIterator]] »).
-          1. Set _result_.[[UnderlyingIterator]] to _iterated_.
-          1. Return _result_.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-iterator.prototype.reduce">
-        <h1>Iterator.prototype.reduce ( _reducer_ [ , _initialValue_ ] )</h1>
-        <p>This method performs the following steps when called:</p>
-        <emu-alg>
-          1. Let _O_ be the *this* value.
-          1. If _O_ is not an Object, throw a *TypeError* exception.
-          1. Let _iterated_ be the Iterator Record { [[Iterator]]: _O_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
-          1. If IsCallable(_reducer_) is *false*, then
-            1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
-            1. Return ? IteratorClose(_iterated_, _error_).
-          1. Set _iterated_ to ? GetIteratorDirect(_O_).
-          1. If _initialValue_ is not present, then
-            1. Let _accumulator_ be ? IteratorStepValue(_iterated_).
-            1. If _accumulator_ is ~done~, throw a *TypeError* exception.
-            1. Let _counter_ be 1.
-          1. Else,
-            1. Let _accumulator_ be _initialValue_.
-            1. Let _counter_ be 0.
-          1. Repeat,
-            1. Let _value_ be ? IteratorStepValue(_iterated_).
-            1. If _value_ is ~done~, return _accumulator_.
-            1. Let _result_ be Completion(Call(_reducer_, *undefined*, « _accumulator_, _value_, 𝔽(_counter_) »)).
-            1. IfAbruptCloseIterator(_result_, _iterated_).
-            1. Set _accumulator_ to _result_.
-            1. Set _counter_ to _counter_ + 1.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-iterator.prototype.some">
-        <h1>Iterator.prototype.some ( _predicate_ )</h1>
-        <p>This method performs the following steps when called:</p>
-        <emu-alg>
-          1. Let _O_ be the *this* value.
-          1. If _O_ is not an Object, throw a *TypeError* exception.
-          1. Let _iterated_ be the Iterator Record { [[Iterator]]: _O_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
-          1. If IsCallable(_predicate_) is *false*, then
-            1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
-            1. Return ? IteratorClose(_iterated_, _error_).
-          1. Set _iterated_ to ? GetIteratorDirect(_O_).
-          1. Let _counter_ be 0.
-          1. Repeat,
-            1. Let _value_ be ? IteratorStepValue(_iterated_).
-            1. If _value_ is ~done~, return *false*.
-            1. Let _result_ be Completion(Call(_predicate_, *undefined*, « _value_, 𝔽(_counter_) »)).
-            1. IfAbruptCloseIterator(_result_, _iterated_).
-            1. If ToBoolean(_result_) is *true*, return ? IteratorClose(_iterated_, NormalCompletion(*true*)).
-            1. Set _counter_ to _counter_ + 1.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-iterator.prototype.take">
-        <h1>Iterator.prototype.take ( _limit_ )</h1>
-        <p>This method performs the following steps when called:</p>
-        <emu-alg>
-          1. Let _O_ be the *this* value.
-          1. If _O_ is not an Object, throw a *TypeError* exception.
-          1. Let _iterated_ be the Iterator Record { [[Iterator]]: _O_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
-          1. Let _numLimit_ be Completion(ToNumber(_limit_)).
-          1. IfAbruptCloseIterator(_numLimit_, _iterated_).
-          1. If _numLimit_ is *NaN*, then
-            1. Let _error_ be ThrowCompletion(a newly created *RangeError* object).
-            1. Return ? IteratorClose(_iterated_, _error_).
-          1. Let _integerLimit_ be ! ToIntegerOrInfinity(_numLimit_).
-          1. If _integerLimit_ &lt; 0, then
-            1. Let _error_ be ThrowCompletion(a newly created *RangeError* object).
-            1. Return ? IteratorClose(_iterated_, _error_).
-          1. Set _iterated_ to ? GetIteratorDirect(_O_).
-          1. Let _closure_ be a new Abstract Closure with no parameters that captures _iterated_ and _integerLimit_ and performs the following steps when called:
-            1. Let _remaining_ be _integerLimit_.
-            1. Repeat,
-              1. If _remaining_ = 0, then
-                1. Return ? IteratorClose(_iterated_, ReturnCompletion(*undefined*)).
-              1. If _remaining_ ≠ +∞, then
-                1. Set _remaining_ to _remaining_ - 1.
-              1. Let _value_ be ? IteratorStepValue(_iterated_).
-              1. If _value_ is ~done~, return ReturnCompletion(*undefined*).
-              1. Let _completion_ be Completion(Yield(_value_)).
-              1. IfAbruptCloseIterator(_completion_, _iterated_).
-          1. Let _result_ be CreateIteratorFromClosure(_closure_, *"Iterator Helper"*, %IteratorHelperPrototype%, « [[UnderlyingIterator]] »).
-          1. Set _result_.[[UnderlyingIterator]] to _iterated_.
-          1. Return _result_.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-iterator.prototype.toarray">
-        <h1>Iterator.prototype.toArray ( )</h1>
-        <p>This method performs the following steps when called:</p>
-        <emu-alg>
-          1. Let _O_ be the *this* value.
-          1. If _O_ is not an Object, throw a *TypeError* exception.
-          1. Let _iterated_ be ? GetIteratorDirect(_O_).
-          1. Let _items_ be a new empty List.
-          1. Repeat,
-            1. Let _value_ be ? IteratorStepValue(_iterated_).
-            1. If _value_ is ~done~, return CreateArrayFromList(_items_).
-            1. Append _value_ to _items_.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause oldids="sec-%iteratorprototype%-@@iterator,sec-%iteratorprototype%-%symbol.iterator%" id="sec-iterator.prototype-%symbol.iterator%">
-        <h1>Iterator.prototype [ %Symbol.iterator% ] ( )</h1>
-        <p>This function performs the following steps when called:</p>
-        <emu-alg>
-          1. Return the *this* value.
-        </emu-alg>
-        <p>The value of the *"name"* property of this function is *"[Symbol.iterator]"*.</p>
-      </emu-clause>
-
-      <emu-clause id="sec-iterator.prototype-%symbol.tostringtag%">
-        <h1>Iterator.prototype [ %Symbol.toStringTag% ]</h1>
-        <p>`Iterator.prototype[%Symbol.toStringTag%]` is an accessor property with attributes { [[Enumerable]]: *false*, [[Configurable]]: *true* }. The [[Get]] and [[Set]] attributes are defined as follows:</p>
-
-        <emu-clause id="sec-get-iterator.prototype-%symbol.tostringtag%">
-          <h1>get Iterator.prototype [ %Symbol.toStringTag% ]</h1>
-          <p>The value of the [[Get]] attribute is a built-in function that requires no arguments. It performs the following steps when called:</p>
-          <emu-alg>
-            1. Return *"Iterator"*.
+            1. Let _result_ be CreateIteratorFromClosure(_closure_, *"Iterator Helper"*, %IteratorHelperPrototype%, « [[UnderlyingIterator]] »).
+            1. Set _result_.[[UnderlyingIterator]] to _iterated_.
+            1. Return _result_.
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-set-iterator.prototype-%symbol.tostringtag%">
-          <h1>set Iterator.prototype [ %Symbol.toStringTag% ]</h1>
-          <p>The value of the [[Set]] attribute is a built-in function that takes an argument _v_. It performs the following steps when called:</p>
+        <emu-clause id="sec-iterator.prototype.every">
+          <h1>Iterator.prototype.every ( _predicate_ )</h1>
+          <p>This method performs the following steps when called:</p>
           <emu-alg>
-            1. Perform ? SetterThatIgnoresPrototypeProperties(*this* value, %Iterator.prototype%, %Symbol.toStringTag%, _v_).
-            1. Return *undefined*.
+            1. Let _O_ be the *this* value.
+            1. If _O_ is not an Object, throw a *TypeError* exception.
+            1. Let _iterated_ be the Iterator Record { [[Iterator]]: _O_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
+            1. If IsCallable(_predicate_) is *false*, then
+              1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
+              1. Return ? IteratorClose(_iterated_, _error_).
+            1. Set _iterated_ to ? GetIteratorDirect(_O_).
+            1. Let _counter_ be 0.
+            1. Repeat,
+              1. Let _value_ be ? IteratorStepValue(_iterated_).
+              1. If _value_ is ~done~, return *true*.
+              1. Let _result_ be Completion(Call(_predicate_, *undefined*, « _value_, 𝔽(_counter_) »)).
+              1. IfAbruptCloseIterator(_result_, _iterated_).
+              1. If ToBoolean(_result_) is *false*, return ? IteratorClose(_iterated_, NormalCompletion(*false*)).
+              1. Set _counter_ to _counter_ + 1.
           </emu-alg>
         </emu-clause>
 
-        <emu-note>
-          <p>Unlike the %Symbol.toStringTag% property on most built-in prototypes, for web-compatibility reasons this property must be an accessor.</p>
-        </emu-note>
+        <emu-clause id="sec-iterator.prototype.filter">
+          <h1>Iterator.prototype.filter ( _predicate_ )</h1>
+          <p>This method performs the following steps when called:</p>
+          <emu-alg>
+            1. Let _O_ be the *this* value.
+            1. If _O_ is not an Object, throw a *TypeError* exception.
+            1. Let _iterated_ be the Iterator Record { [[Iterator]]: _O_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
+            1. If IsCallable(_predicate_) is *false*, then
+              1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
+              1. Return ? IteratorClose(_iterated_, _error_).
+            1. Set _iterated_ to ? GetIteratorDirect(_O_).
+            1. Let _closure_ be a new Abstract Closure with no parameters that captures _iterated_ and _predicate_ and performs the following steps when called:
+              1. Let _counter_ be 0.
+              1. Repeat,
+                1. Let _value_ be ? IteratorStepValue(_iterated_).
+                1. If _value_ is ~done~, return ReturnCompletion(*undefined*).
+                1. Let _selected_ be Completion(Call(_predicate_, *undefined*, « _value_, 𝔽(_counter_) »)).
+                1. IfAbruptCloseIterator(_selected_, _iterated_).
+                1. If ToBoolean(_selected_) is *true*, then
+                  1. Let _completion_ be Completion(Yield(_value_)).
+                  1. IfAbruptCloseIterator(_completion_, _iterated_).
+                1. Set _counter_ to _counter_ + 1.
+            1. Let _result_ be CreateIteratorFromClosure(_closure_, *"Iterator Helper"*, %IteratorHelperPrototype%, « [[UnderlyingIterator]] »).
+            1. Set _result_.[[UnderlyingIterator]] to _iterated_.
+            1. Return _result_.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-iterator.prototype.find">
+          <h1>Iterator.prototype.find ( _predicate_ )</h1>
+          <p>This method performs the following steps when called:</p>
+          <emu-alg>
+            1. Let _O_ be the *this* value.
+            1. If _O_ is not an Object, throw a *TypeError* exception.
+            1. Let _iterated_ be the Iterator Record { [[Iterator]]: _O_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
+            1. If IsCallable(_predicate_) is *false*, then
+              1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
+              1. Return ? IteratorClose(_iterated_, _error_).
+            1. Set _iterated_ to ? GetIteratorDirect(_O_).
+            1. Let _counter_ be 0.
+            1. Repeat,
+              1. Let _value_ be ? IteratorStepValue(_iterated_).
+              1. If _value_ is ~done~, return *undefined*.
+              1. Let _result_ be Completion(Call(_predicate_, *undefined*, « _value_, 𝔽(_counter_) »)).
+              1. IfAbruptCloseIterator(_result_, _iterated_).
+              1. If ToBoolean(_result_) is *true*, return ? IteratorClose(_iterated_, NormalCompletion(_value_)).
+              1. Set _counter_ to _counter_ + 1.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-iterator.prototype.flatmap">
+          <h1>Iterator.prototype.flatMap ( _mapper_ )</h1>
+          <p>This method performs the following steps when called:</p>
+          <emu-alg>
+            1. Let _O_ be the *this* value.
+            1. If _O_ is not an Object, throw a *TypeError* exception.
+            1. Let _iterated_ be the Iterator Record { [[Iterator]]: _O_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
+            1. If IsCallable(_mapper_) is *false*, then
+              1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
+              1. Return ? IteratorClose(_iterated_, _error_).
+            1. Set _iterated_ to ? GetIteratorDirect(_O_).
+            1. Let _closure_ be a new Abstract Closure with no parameters that captures _iterated_ and _mapper_ and performs the following steps when called:
+              1. Let _counter_ be 0.
+              1. Repeat,
+                1. Let _value_ be ? IteratorStepValue(_iterated_).
+                1. If _value_ is ~done~, return ReturnCompletion(*undefined*).
+                1. Let _mapped_ be Completion(Call(_mapper_, *undefined*, « _value_, 𝔽(_counter_) »)).
+                1. IfAbruptCloseIterator(_mapped_, _iterated_).
+                1. Let _innerIterator_ be Completion(GetIteratorFlattenable(_mapped_, ~reject-primitives~)).
+                1. IfAbruptCloseIterator(_innerIterator_, _iterated_).
+                1. Let _innerAlive_ be *true*.
+                1. Repeat, while _innerAlive_ is *true*,
+                  1. Let _innerValue_ be Completion(IteratorStepValue(_innerIterator_)).
+                  1. IfAbruptCloseIterator(_innerValue_, _iterated_).
+                  1. If _innerValue_ is ~done~, then
+                    1. Set _innerAlive_ to *false*.
+                  1. Else,
+                    1. Let _completion_ be Completion(Yield(_innerValue_)).
+                    1. If _completion_ is an abrupt completion, then
+                      1. Let _backupCompletion_ be Completion(IteratorClose(_innerIterator_, _completion_)).
+                      1. IfAbruptCloseIterator(_backupCompletion_, _iterated_).
+                      1. Return ? IteratorClose(_iterated_, _completion_).
+                1. Set _counter_ to _counter_ + 1.
+            1. Let _result_ be CreateIteratorFromClosure(_closure_, *"Iterator Helper"*, %IteratorHelperPrototype%, « [[UnderlyingIterator]] »).
+            1. Set _result_.[[UnderlyingIterator]] to _iterated_.
+            1. Return _result_.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-iterator.prototype.foreach">
+          <h1>Iterator.prototype.forEach ( _procedure_ )</h1>
+          <p>This method performs the following steps when called:</p>
+          <emu-alg>
+            1. Let _O_ be the *this* value.
+            1. If _O_ is not an Object, throw a *TypeError* exception.
+            1. Let _iterated_ be the Iterator Record { [[Iterator]]: _O_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
+            1. If IsCallable(_procedure_) is *false*, then
+              1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
+              1. Return ? IteratorClose(_iterated_, _error_).
+            1. Set _iterated_ to ? GetIteratorDirect(_O_).
+            1. Let _counter_ be 0.
+            1. Repeat,
+              1. Let _value_ be ? IteratorStepValue(_iterated_).
+              1. If _value_ is ~done~, return *undefined*.
+              1. Let _result_ be Completion(Call(_procedure_, *undefined*, « _value_, 𝔽(_counter_) »)).
+              1. IfAbruptCloseIterator(_result_, _iterated_).
+              1. Set _counter_ to _counter_ + 1.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-iterator.prototype.map">
+          <h1>Iterator.prototype.map ( _mapper_ )</h1>
+          <p>This method performs the following steps when called:</p>
+          <emu-alg>
+            1. Let _O_ be the *this* value.
+            1. If _O_ is not an Object, throw a *TypeError* exception.
+            1. Let _iterated_ be the Iterator Record { [[Iterator]]: _O_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
+            1. If IsCallable(_mapper_) is *false*, then
+              1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
+              1. Return ? IteratorClose(_iterated_, _error_).
+            1. Set _iterated_ to ? GetIteratorDirect(_O_).
+            1. Let _closure_ be a new Abstract Closure with no parameters that captures _iterated_ and _mapper_ and performs the following steps when called:
+              1. Let _counter_ be 0.
+              1. Repeat,
+                1. Let _value_ be ? IteratorStepValue(_iterated_).
+                1. If _value_ is ~done~, return ReturnCompletion(*undefined*).
+                1. Let _mapped_ be Completion(Call(_mapper_, *undefined*, « _value_, 𝔽(_counter_) »)).
+                1. IfAbruptCloseIterator(_mapped_, _iterated_).
+                1. Let _completion_ be Completion(Yield(_mapped_)).
+                1. IfAbruptCloseIterator(_completion_, _iterated_).
+                1. Set _counter_ to _counter_ + 1.
+            1. Let _result_ be CreateIteratorFromClosure(_closure_, *"Iterator Helper"*, %IteratorHelperPrototype%, « [[UnderlyingIterator]] »).
+            1. Set _result_.[[UnderlyingIterator]] to _iterated_.
+            1. Return _result_.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-iterator.prototype.reduce">
+          <h1>Iterator.prototype.reduce ( _reducer_ [ , _initialValue_ ] )</h1>
+          <p>This method performs the following steps when called:</p>
+          <emu-alg>
+            1. Let _O_ be the *this* value.
+            1. If _O_ is not an Object, throw a *TypeError* exception.
+            1. Let _iterated_ be the Iterator Record { [[Iterator]]: _O_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
+            1. If IsCallable(_reducer_) is *false*, then
+              1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
+              1. Return ? IteratorClose(_iterated_, _error_).
+            1. Set _iterated_ to ? GetIteratorDirect(_O_).
+            1. If _initialValue_ is not present, then
+              1. Let _accumulator_ be ? IteratorStepValue(_iterated_).
+              1. If _accumulator_ is ~done~, throw a *TypeError* exception.
+              1. Let _counter_ be 1.
+            1. Else,
+              1. Let _accumulator_ be _initialValue_.
+              1. Let _counter_ be 0.
+            1. Repeat,
+              1. Let _value_ be ? IteratorStepValue(_iterated_).
+              1. If _value_ is ~done~, return _accumulator_.
+              1. Let _result_ be Completion(Call(_reducer_, *undefined*, « _accumulator_, _value_, 𝔽(_counter_) »)).
+              1. IfAbruptCloseIterator(_result_, _iterated_).
+              1. Set _accumulator_ to _result_.
+              1. Set _counter_ to _counter_ + 1.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-iterator.prototype.some">
+          <h1>Iterator.prototype.some ( _predicate_ )</h1>
+          <p>This method performs the following steps when called:</p>
+          <emu-alg>
+            1. Let _O_ be the *this* value.
+            1. If _O_ is not an Object, throw a *TypeError* exception.
+            1. Let _iterated_ be the Iterator Record { [[Iterator]]: _O_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
+            1. If IsCallable(_predicate_) is *false*, then
+              1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
+              1. Return ? IteratorClose(_iterated_, _error_).
+            1. Set _iterated_ to ? GetIteratorDirect(_O_).
+            1. Let _counter_ be 0.
+            1. Repeat,
+              1. Let _value_ be ? IteratorStepValue(_iterated_).
+              1. If _value_ is ~done~, return *false*.
+              1. Let _result_ be Completion(Call(_predicate_, *undefined*, « _value_, 𝔽(_counter_) »)).
+              1. IfAbruptCloseIterator(_result_, _iterated_).
+              1. If ToBoolean(_result_) is *true*, return ? IteratorClose(_iterated_, NormalCompletion(*true*)).
+              1. Set _counter_ to _counter_ + 1.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-iterator.prototype.take">
+          <h1>Iterator.prototype.take ( _limit_ )</h1>
+          <p>This method performs the following steps when called:</p>
+          <emu-alg>
+            1. Let _O_ be the *this* value.
+            1. If _O_ is not an Object, throw a *TypeError* exception.
+            1. Let _iterated_ be the Iterator Record { [[Iterator]]: _O_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
+            1. Let _numLimit_ be Completion(ToNumber(_limit_)).
+            1. IfAbruptCloseIterator(_numLimit_, _iterated_).
+            1. If _numLimit_ is *NaN*, then
+              1. Let _error_ be ThrowCompletion(a newly created *RangeError* object).
+              1. Return ? IteratorClose(_iterated_, _error_).
+            1. Let _integerLimit_ be ! ToIntegerOrInfinity(_numLimit_).
+            1. If _integerLimit_ &lt; 0, then
+              1. Let _error_ be ThrowCompletion(a newly created *RangeError* object).
+              1. Return ? IteratorClose(_iterated_, _error_).
+            1. Set _iterated_ to ? GetIteratorDirect(_O_).
+            1. Let _closure_ be a new Abstract Closure with no parameters that captures _iterated_ and _integerLimit_ and performs the following steps when called:
+              1. Let _remaining_ be _integerLimit_.
+              1. Repeat,
+                1. If _remaining_ = 0, then
+                  1. Return ? IteratorClose(_iterated_, ReturnCompletion(*undefined*)).
+                1. If _remaining_ ≠ +∞, then
+                  1. Set _remaining_ to _remaining_ - 1.
+                1. Let _value_ be ? IteratorStepValue(_iterated_).
+                1. If _value_ is ~done~, return ReturnCompletion(*undefined*).
+                1. Let _completion_ be Completion(Yield(_value_)).
+                1. IfAbruptCloseIterator(_completion_, _iterated_).
+            1. Let _result_ be CreateIteratorFromClosure(_closure_, *"Iterator Helper"*, %IteratorHelperPrototype%, « [[UnderlyingIterator]] »).
+            1. Set _result_.[[UnderlyingIterator]] to _iterated_.
+            1. Return _result_.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-iterator.prototype.toarray">
+          <h1>Iterator.prototype.toArray ( )</h1>
+          <p>This method performs the following steps when called:</p>
+          <emu-alg>
+            1. Let _O_ be the *this* value.
+            1. If _O_ is not an Object, throw a *TypeError* exception.
+            1. Let _iterated_ be ? GetIteratorDirect(_O_).
+            1. Let _items_ be a new empty List.
+            1. Repeat,
+              1. Let _value_ be ? IteratorStepValue(_iterated_).
+              1. If _value_ is ~done~, return CreateArrayFromList(_items_).
+              1. Append _value_ to _items_.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause oldids="sec-%iteratorprototype%-@@iterator,sec-%iteratorprototype%-%symbol.iterator%" id="sec-iterator.prototype-%symbol.iterator%">
+          <h1>Iterator.prototype [ %Symbol.iterator% ] ( )</h1>
+          <p>This function performs the following steps when called:</p>
+          <emu-alg>
+            1. Return the *this* value.
+          </emu-alg>
+          <p>The value of the *"name"* property of this function is *"[Symbol.iterator]"*.</p>
+        </emu-clause>
+
+        <emu-clause id="sec-iterator.prototype-%symbol.tostringtag%">
+          <h1>Iterator.prototype [ %Symbol.toStringTag% ]</h1>
+          <p>`Iterator.prototype[%Symbol.toStringTag%]` is an accessor property with attributes { [[Enumerable]]: *false*, [[Configurable]]: *true* }. The [[Get]] and [[Set]] attributes are defined as follows:</p>
+
+          <emu-clause id="sec-get-iterator.prototype-%symbol.tostringtag%">
+            <h1>get Iterator.prototype [ %Symbol.toStringTag% ]</h1>
+            <p>The value of the [[Get]] attribute is a built-in function that requires no arguments. It performs the following steps when called:</p>
+            <emu-alg>
+              1. Return *"Iterator"*.
+            </emu-alg>
+          </emu-clause>
+
+          <emu-clause id="sec-set-iterator.prototype-%symbol.tostringtag%">
+            <h1>set Iterator.prototype [ %Symbol.toStringTag% ]</h1>
+            <p>The value of the [[Set]] attribute is a built-in function that takes an argument _v_. It performs the following steps when called:</p>
+            <emu-alg>
+              1. Perform ? SetterThatIgnoresPrototypeProperties(*this* value, %Iterator.prototype%, %Symbol.toStringTag%, _v_).
+              1. Return *undefined*.
+            </emu-alg>
+          </emu-clause>
+
+          <emu-note>
+            <p>Unlike the %Symbol.toStringTag% property on most built-in prototypes, for web-compatibility reasons this property must be an accessor.</p>
+          </emu-note>
+        </emu-clause>
       </emu-clause>
     </emu-clause>
 


### PR DESCRIPTION
This matches the structure used for other built-in objects.


The first commit moves the clause and the second commit reformats the spec.