### PR TITLE
Normative: Add missing function name for Iterator.prototype[Symbol.toStringTag] accessors

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -48121,6 +48121,7 @@ THH:mm:ss.sss
           <emu-alg>
             1. Return *"Iterator"*.
           </emu-alg>
+          <p>The value of the *"name"* property of this function is *"get [Symbol.toStringTag]"*.</p>
         </emu-clause>
 
         <emu-clause id="sec-set-iterator.prototype-%symbol.tostringtag%">
@@ -48130,6 +48131,7 @@ THH:mm:ss.sss
             1. Perform ? SetterThatIgnoresPrototypeProperties(*this* value, %Iterator.prototype%, %Symbol.toStringTag%, _v_).
             1. Return *undefined*.
           </emu-alg>
+          <p>The value of the *"name"* property of this function is *"set [Symbol.toStringTag]"*.</p>
         </emu-clause>
 
         <emu-note>


### PR DESCRIPTION
The function name must be explicitly specified for methods whose property key is a Symbol value.
