### PR TITLE
Markup: rendering edits for 2025 edition & beyond

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -54,16 +54,22 @@
   /**
   * ECMA-262-specific hacks. Shouldn't require a ton of maintenance; audit if
   * visual inspection results in unexpected page breaks.
+  *
+  * For print version, the table captioned "Module fields after the initial Evaluate() call" _may_ need to set the row
+  * EVALUATING-ASYNC to one cell with a colspan of 5. It typically does not fit on the page, but the cell merging is
+  * not a perfectly accurate solution and will not be merged back in to the specification.
+  * See https://github.com/tc39/ecma262/pull/3623#issuecomment-3029366960
   */
+
+  /* Make sure tables are wide enough for their captions */
+  table {
+    min-width: 135mm;
+  }
+
   /* 2.2 Examples of legacy/normative-optional are small enough to be aggressive against breaks */
   #sec-conformance [example],
-
-  /* 8.3.3 avoid breaking in small alg lists */
-  #sec-static-semantics-containsundefinedcontinuetarget li,
-
-  /* 16.2.1.5.4 many tables */
-  #table-module-graph-cycle-async-fields-1 table,
-  #table-module-graph-cycle-async-fields-9 table {
+  /* 16.2.1.xxx many tables */
+  #sec-example-cyclic-module-record-graphs table {
     break-inside: avoid-page;
   }
 
@@ -73,7 +79,7 @@
     break-inside: initial;
   }
 
-  /* 12.10.2, 12.10.3, 12.10.3.2 Sections start with an <em> not inside a <p> */
+  /* 12.10.X Sections start with an <em> not inside a <p> */
   #sec-examples-of-automatic-semicolon-insertion > em,
   #sec-interesting-cases-of-automatic-semicolon-insertion > em,
   #sec-asi-cases-with-no-lineterminator-here > em {
@@ -81,7 +87,7 @@
     margin-top: 1.25ex;
   }
 
-  /* 15.1.2 bad spacing between intro and first emu-grammar */
+  /* 15.1.X missing spacing between intro and first emu-grammar */
   #sec-static-semantics-containsexpression > emu-grammar:first-of-type {
     margin-top: 2ex;
   }
@@ -91,63 +97,18 @@
     text-align: left;
   }
 
-  /* 16.2.1.5.4 squish margins on graphics so table 46 fits on one page */
-  #sec-example-cyclic-module-record-graphs figure:has(> img),
-  #sec-example-cyclic-module-record-graphs figure > img {
-    margin: 0;
-  }
-  #sec-example-cyclic-module-record-graphs figure:has(> img) > figcaption {
-    margin-bottom: 1ex;
-  }
-  #sec-example-cyclic-module-record-graphs emu-figure:has(> figure > img) + p {
-    margin-top: 1ex;
-  }
-
-  /* 16.2.1.5.4 table 51 & 54 are too narrow for caption */
-  #table-module-graph-cycle-async-fields-6 table {
-    width: 110mm;
-  }
-  #table-module-graph-cycle-async-fields-9 table {
-    width: 135mm;
-  }
-
-  /* 20.1.3.7 legacy title */
+  /* 20.X legacy title */
   #sec-object\.prototype\.__proto__ > .attributes-tag {
     break-before: avoid-page;
     break-after: avoid-page;
   }
 
-  /* 21.4.1.22 Table 61 middle column is too narrow */
+  /* 21.X table middle column is too narrow */
   #table-time-zone-identifier-record-fields > figure > table th:nth-of-type(2) {
-    width: 15%;
+    min-width: 19mm;
   }
 
-  /* 21.4.4.41.2 These tables are way too narrow for their captions */
-  #sec-todatestring-day-names table,
-  #sec-todatestring-month-names table {
-    width: 100mm;
-  }
-
-  /* 27.2.6 squeeze to make more room for figure-2.svg */
-  #table-internal-slots-of-promise-instances > figure {
-    margin-bottom: 0;
-  }
-
-  /* 27.3 fit generator objects relationships diagram */
-  #sec-generatorfunction-objects,
-  #sec-generatorfunction-objects h1 {
-    margin-top: 1.5ex;
-  }
-
-  /* 27.3 `figure-2.svg` is just a tiny bit too big to fit on the page, results in weird white space */
-  #figure-2 figure {
-    margin: 1ex 0;
-  }
-  #figure-2 > figure > img {
-    width: 97%;
-  }
-
-  /* 29.11 extremely long note */
+  /* 29.X extremely long note */
   #sec-shared-memory-guidelines > emu-note {
     break-inside: auto;
   }
@@ -163,8 +124,9 @@
   }
 
   .corner-cell {
-    background-image: url(data:image/svg+xml;base64,PHN2ZyBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGZpbGwtcnVsZT0iZXZlbm9kZCIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIiBzdHJva2UtbWl0ZXJsaW1pdD0iMS41IiB2aWV3Qm94PSIwIDAgMjQyIDQ2IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Y2xpcFBhdGggaWQ9ImEiPjxwYXRoIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0ibS03Ny43MDQtMzYuMDI3aDI0MS4wNDJ2NDUuMDQyaC0yNDEuMDQyeiIvPjwvY2xpcFBhdGg+PGcgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoNzcuNzAzOSAzNi4wMjY2KSI+PHBhdGggZD0ibS03Ny43MDQtMzYuMDI3aDI0MS4wNDJ2NDUuMDQyaC0yNDEuMDQyeiIgZmlsbD0ibm9uZSIvPjxnIGNsaXAtcGF0aD0idXJsKCNhKSI+PHBhdGggZD0ibTMxNC45MyAzOTUuOTM1IDI0MS4wNDIgNDUuMDQyIiBmaWxsPSJub25lIiBzdHJva2U9IiMyMzFmMjAiIHN0cm9rZS13aWR0aD0iMS4wNCIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoLTM5Mi42MzQgLTQzMS45NjIpIi8+PC9nPjwvZz48L3N2Zz4=);
-    background-size: cover;
+    background-image: url(data:image/svg+xml;base64,PHN2ZyBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGZpbGwtcnVsZT0iZXZlbm9kZCIgaGVpZ2h0PSI0NiIgc3Ryb2tlLWxpbmVjYXA9InNxdWFyZSIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgc3Ryb2tlLW1pdGVybGltaXQ9IjEuNSIgd2lkdGg9IjI0MiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cGF0aCBkPSJtMzE1LjI2NiAzOTYuMzQzIDI0MS4zOTQgNDUuMTU1IiBmaWxsPSJub25lIiBzdHJva2U9IiMwMDAiIHN0cm9rZS13aWR0aD0iMS4wNCIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoLTMxNC45MyAtMzk1LjkzNSkiLz48L3N2Zz4=);
+    background-repeat: no-repeat;
+    background-size: 100% 3em;
     height: 3em;
     padding: 0;
     vertical-align: inherit;
@@ -53044,6 +53006,6 @@ THH:mm:ss.sss
 
 <emu-annex id="sec-colophon" back-matter>
   <h1>Colophon</h1>
-  <p>This specification is authored on <a href="https://github.com/tc39/ecma262">GitHub</a> in a plaintext source format called <a href="https://github.com/bterlson/ecmarkup">Ecmarkup</a>. Ecmarkup is an HTML and Markdown dialect that provides a framework and toolset for authoring ECMAScript specifications in plaintext and processing the specification into a full-featured HTML rendering that follows the editorial conventions for this document. Ecmarkup builds on and integrates a number of other formats and technologies including <a href="https://github.com/rbuckton/grammarkdown">Grammarkdown</a> for defining syntax and <a href="https://github.com/domenic/ecmarkdown">Ecmarkdown</a> for authoring algorithm steps. PDF renderings of this specification are produced using a print stylesheet which takes advantage of the CSS Paged Media specification and is converted using <a href="https://www.princexml.com/">PrinceXML</a>.</p>
+  <p>This specification is authored on <a href="https://github.com/tc39/ecma262">GitHub</a> in a plaintext source format called <a href="https://github.com/bterlson/ecmarkup">Ecmarkup</a>. Ecmarkup is an HTML and Markdown dialect that provides a framework and toolset for authoring Ecma specifications in plaintext and processing the specification into a full-featured HTML rendering that follows the editorial conventions for this document. Ecmarkup builds on and integrates a number of other formats and technologies including <a href="https://github.com/rbuckton/grammarkdown">Grammarkdown</a> for defining syntax and <a href="https://github.com/domenic/ecmarkdown">Ecmarkdown</a> for authoring algorithm steps. PDF renderings of this specification are produced using a print stylesheet which takes advantage of the CSS Paged Media specification and is converted using <a href="https://www.princexml.com/">PrinceXML</a>.</p>
   <p>Prior editions of this specification were authored using Word—the Ecmarkup source text that formed the basis of this edition was produced by converting the ECMAScript 2015 Word document to Ecmarkup using an automated conversion tool.</p>
 </emu-annex>


### PR DESCRIPTION
This PR

- Cleans up and improves comments on ECMA-262-specific print styles
- Restores the (mandatory? i thought?) version line to metadata
- Transforms 5 identical cells into one cell with rowspan 5 in table "Module fields after the initial Evaluate() call"
  - we made this change last year as well, I must have failed to push those changes back to main
- Clarifies in the colophon that ecmarkup is used for Ecma specifications, not _just_ ECMAScript specifications