### PR TITLE
Editorial: remove unused AO CreateAsyncIteratorFromClosure

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -50741,35 +50741,6 @@ THH:mm:ss.sss
           1. Return ~unused~.
         </emu-alg>
       </emu-clause>
-
-      <emu-clause id="sec-createasynciteratorfromclosure" type="abstract operation">
-        <h1>
-          CreateAsyncIteratorFromClosure (
-            _closure_: an Abstract Closure with no parameters,
-            _generatorBrand_: a String or ~empty~,
-            _generatorPrototype_: an Object,
-          ): an AsyncGenerator
-        </h1>
-        <dl class="header">
-        </dl>
-        <emu-alg>
-          1. NOTE: _closure_ can contain uses of the Await operation and uses of the Yield operation to yield an IteratorResult object.
-          1. Let _internalSlotsList_ be « [[AsyncGeneratorState]], [[AsyncGeneratorContext]], [[AsyncGeneratorQueue]], [[GeneratorBrand]] ».
-          1. Let _generator_ be OrdinaryObjectCreate(_generatorPrototype_, _internalSlotsList_).
-          1. Set _generator_.[[GeneratorBrand]] to _generatorBrand_.
-          1. Set _generator_.[[AsyncGeneratorState]] to ~suspended-start~.
-          1. Let _callerContext_ be the running execution context.
-          1. Let _calleeContext_ be a new execution context.
-          1. Set the Function of _calleeContext_ to *null*.
-          1. Set the Realm of _calleeContext_ to the current Realm Record.
-          1. Set the ScriptOrModule of _calleeContext_ to _callerContext_'s ScriptOrModule.
-          1. If _callerContext_ is not already suspended, suspend _callerContext_.
-          1. Push _calleeContext_ onto the execution context stack; _calleeContext_ is now the running execution context.
-          1. Perform AsyncGeneratorStart(_generator_, _closure_).
-          1. Remove _calleeContext_ from the execution context stack and restore _callerContext_ as the running execution context.
-          1. Return _generator_.
-        </emu-alg>
-      </emu-clause>
     </emu-clause>
   </emu-clause>
 


### PR DESCRIPTION
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)
* [WebAssembly](https://webassembly.github.io/spec/) - [file an issue](https://github.com/WebAssembly/spec/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
fixes #3509
