### PR TITLE
Editorial: Cleanup some ArrayBuffer/TypedArray/DataView/Atomics text

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -42222,37 +42222,31 @@ THH:mm:ss.sss
             1. Let _srcLength_ be TypedArrayLength(_srcRecord_).
             1. If _srcLength_ + _targetOffset_ > TypedArrayLength(_targetRecord_), throw a *RangeError* exception.
             1. If _target_.[[ContentType]] is not _source_.[[ContentType]], throw a *TypeError* exception.
-            1. Let _targetBuffer_ be _target_.[[ViewedArrayBuffer]].
-            1. Let _targetByteOffset_ be _target_.[[ByteOffset]].
-            1. Let _srcBuffer_ be _source_.[[ViewedArrayBuffer]].
-            1. Let _srcByteOffset_ be _source_.[[ByteOffset]].
-            1. If IsSharedArrayBuffer(_srcBuffer_) is *true*, IsSharedArrayBuffer(_targetBuffer_) is *true*, and _srcBuffer_.[[ArrayBufferData]] is _targetBuffer_.[[ArrayBufferData]], let _sameSharedArrayBuffer_ be *true*; otherwise, let _sameSharedArrayBuffer_ be *false*.
-            1. If SameValue(_srcBuffer_, _targetBuffer_) is *true* or _sameSharedArrayBuffer_ is *true*, then
-              1. NOTE: Later steps require the original source data, even if it is being overwritten. But since their effects are not observable until this operation completes, implementations may perform them in-place rather than allocating a new ArrayBuffer.
-              1. Let _srcByteLength_ be TypedArrayByteLength(_srcRecord_).
-              1. Set _srcBuffer_ to ? CloneArrayBuffer(_srcBuffer_, _srcByteOffset_, _srcByteLength_).
-              1. Let _srcByteIndex_ be 0.
-            1. Else,
-              1. Let _srcByteIndex_ be _srcByteOffset_.
-            1. Let _targetType_ be TypedArrayElementType(_target_).
             1. Let _targetElementSize_ be TypedArrayElementSize(_target_).
-            1. Let _srcType_ be TypedArrayElementType(_source_).
             1. Let _srcElementSize_ be TypedArrayElementSize(_source_).
-            1. Let _targetByteIndex_ be _targetByteOffset_ + (_targetElementSize_ × _targetOffset_).
-            1. Let _limit_ be _targetByteIndex_ + (_targetElementSize_ × _srcLength_).
+            1. Let _targetType_ be TypedArrayElementType(_target_).
+            1. Let _srcType_ be TypedArrayElementType(_source_).
+            1. NOTE: When _srcType_ matches _targetType_, bit-level encoding of the source data must be preserved. Operating on byte-sized units ensures that guarantee, but an implementation that can satisfy it with larger chunks may do so.
             1. If _srcType_ is _targetType_, then
-              1. NOTE: The transfer must be performed in a manner that preserves the bit-level encoding of the source data.
-              1. Repeat, while _targetByteIndex_ &lt; _limit_,
-                1. Let _value_ be GetValueFromBuffer(_srcBuffer_, _srcByteIndex_, ~uint8~, *true*, ~unordered~).
-                1. Perform SetValueInBuffer(_targetBuffer_, _targetByteIndex_, ~uint8~, _value_, *true*, ~unordered~).
-                1. Set _srcByteIndex_ to _srcByteIndex_ + 1.
-                1. Set _targetByteIndex_ to _targetByteIndex_ + 1.
-            1. Else,
-              1. Repeat, while _targetByteIndex_ &lt; _limit_,
-                1. Let _value_ be GetValueFromBuffer(_srcBuffer_, _srcByteIndex_, _srcType_, *true*, ~unordered~).
-                1. Perform SetValueInBuffer(_targetBuffer_, _targetByteIndex_, _targetType_, _value_, *true*, ~unordered~).
-                1. Set _srcByteIndex_ to _srcByteIndex_ + _srcElementSize_.
-                1. Set _targetByteIndex_ to _targetByteIndex_ + _targetElementSize_.
+              1. Set _targetType_ to ~uint8~.
+              1. Set _targetElementSize_ to 1.
+              1. Set _srcType_ to ~uint8~.
+              1. Set _srcElementSize_ to 1.
+            1. Let _targetBuffer_ be _target_.[[ViewedArrayBuffer]].
+            1. Let _srcBuffer_ be _source_.[[ViewedArrayBuffer]].
+            1. Let _srcByteIndex_ be _source_.[[ByteOffset]].
+            1. If IsSameBuffer(_srcBuffer_, _targetBuffer_) is *true*, then
+              1. NOTE: This operation must behave as if copying data into an overlapping range within the same Data Block is a single atomic step. But because the results of copying are not observable until it completes, implementations unable to perform such copying atomically may still avoid allocating a new ArrayBuffer by copying chunks in-place if they alter the direction of iteration as appropriate to avoid overwriting source data that has not yet been read.
+              1. Let _srcByteLength_ be TypedArrayByteLength(_srcRecord_).
+              1. Set _srcBuffer_ to ? CloneArrayBuffer(_srcBuffer_, _srcByteIndex_, _srcByteLength_).
+              1. Set _srcByteIndex_ to 0.
+            1. Let _targetByteIndex_ be _target_.[[ByteOffset]] + (_targetElementSize_ × _targetOffset_).
+            1. Let _limit_ be _targetByteIndex_ + (_targetElementSize_ × _srcLength_).
+            1. Repeat, while _targetByteIndex_ &lt; _limit_,
+              1. Let _value_ be GetValueFromBuffer(_srcBuffer_, _srcByteIndex_, _srcType_, *true*, ~unordered~).
+              1. Perform SetValueInBuffer(_targetBuffer_, _targetByteIndex_, _targetType_, _value_, *true*, ~unordered~).
+              1. Set _srcByteIndex_ to _srcByteIndex_ + _srcElementSize_.
+              1. Set _targetByteIndex_ to _targetByteIndex_ + _targetElementSize_.
             1. Return ~unused~.
           </emu-alg>
         </emu-clause>
@@ -44376,6 +44370,22 @@ THH:mm:ss.sss
           1. Let _targetBlock_ be _targetBuffer_.[[ArrayBufferData]].
           1. Perform CopyDataBlockBytes(_targetBlock_, 0, _srcBlock_, _srcByteOffset_, _srcLength_).
           1. Return _targetBuffer_.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-issamebuffer" type="abstract operation">
+        <h1>
+          IsSameBuffer (
+            _a_: an ArrayBuffer or a SharedArrayBuffer,
+            _b_: an ArrayBuffer or a SharedArrayBuffer,
+          ): a Boolean
+        </h1>
+        <dl class="header">
+        </dl>
+        <emu-alg>
+          1. If SameValue(_a_, _b_) is *true*, return *true*.
+          1. If IsSharedArrayBuffer(_a_) is *true*, IsSharedArrayBuffer(_b_) is *true*, and _b_.[[ArrayBufferData]] is _a_.[[ArrayBufferData]], return *true*.
+          1. Return *false*.
         </emu-alg>
       </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -45897,13 +45897,12 @@ THH:mm:ss.sss
         <dl class="header">
         </dl>
         <emu-alg>
-          1. Let _taRecord_ be ? ValidateTypedArray(_typedArray_, ~unordered~).
           1. NOTE: Bounds checking is not a synchronizing operation when _typedArray_'s backing buffer is a growable SharedArrayBuffer.
+          1. Let _taRecord_ be ? ValidateTypedArray(_typedArray_, ~unordered~).
           1. If _waitable_ is *true*, then
             1. If _typedArray_.[[TypedArrayName]] is neither *"Int32Array"* nor *"BigInt64Array"*, throw a *TypeError* exception.
-          1. Else,
-            1. Let _type_ be TypedArrayElementType(_typedArray_).
-            1. If IsUnclampedIntegerElementType(_type_) is *false* and IsBigIntElementType(_type_) is *false*, throw a *TypeError* exception.
+          1. Let _type_ be TypedArrayElementType(_typedArray_).
+          1. If IsNoTearConfiguration(_type_, ~seq-cst~) is *false*, throw a *TypeError* exception.
           1. Return _taRecord_.
         </emu-alg>
       </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -42190,11 +42190,9 @@ THH:mm:ss.sss
           </dl>
           <emu-alg>
             1. Let _targetRecord_ be ? ValidateTypedArray(_target_, ~seq-cst~).
-            1. Let _targetLength_ be TypedArrayLength(_targetRecord_).
             1. Let _src_ be ? ToObject(_source_).
             1. Let _srcLength_ be ? LengthOfArrayLike(_src_).
-            1. If _targetOffset_ = +∞, throw a *RangeError* exception.
-            1. If _srcLength_ + _targetOffset_ > _targetLength_, throw a *RangeError* exception.
+            1. If _srcLength_ + _targetOffset_ > TypedArrayLength(_targetRecord_), throw a *RangeError* exception.
             1. Let _k_ be 0.
             1. Repeat, while _k_ &lt; _srcLength_,
               1. Let _Pk_ be ! ToString(𝔽(_k_)).
@@ -42219,29 +42217,28 @@ THH:mm:ss.sss
             <dd>It sets multiple values in _target_, starting at index _targetOffset_, reading the values from _source_.</dd>
           </dl>
           <emu-alg>
-            1. Let _targetBuffer_ be _target_.[[ViewedArrayBuffer]].
             1. Let _targetRecord_ be ? ValidateTypedArray(_target_, ~seq-cst~).
-            1. Let _targetLength_ be TypedArrayLength(_targetRecord_).
-            1. Let _srcBuffer_ be _source_.[[ViewedArrayBuffer]].
             1. Let _srcRecord_ be ? ValidateTypedArray(_source_, ~seq-cst~).
             1. Let _srcLength_ be TypedArrayLength(_srcRecord_).
-            1. Let _targetType_ be TypedArrayElementType(_target_).
-            1. Let _targetElementSize_ be TypedArrayElementSize(_target_).
-            1. Let _targetByteOffset_ be _target_.[[ByteOffset]].
-            1. Let _srcType_ be TypedArrayElementType(_source_).
-            1. Let _srcElementSize_ be TypedArrayElementSize(_source_).
-            1. Let _srcByteOffset_ be _source_.[[ByteOffset]].
-            1. If _targetOffset_ = +∞, throw a *RangeError* exception.
-            1. If _srcLength_ + _targetOffset_ > _targetLength_, throw a *RangeError* exception.
+            1. If _srcLength_ + _targetOffset_ > TypedArrayLength(_targetRecord_), throw a *RangeError* exception.
             1. If _target_.[[ContentType]] is not _source_.[[ContentType]], throw a *TypeError* exception.
+            1. Let _targetBuffer_ be _target_.[[ViewedArrayBuffer]].
+            1. Let _targetByteOffset_ be _target_.[[ByteOffset]].
+            1. Let _srcBuffer_ be _source_.[[ViewedArrayBuffer]].
+            1. Let _srcByteOffset_ be _source_.[[ByteOffset]].
             1. If IsSharedArrayBuffer(_srcBuffer_) is *true*, IsSharedArrayBuffer(_targetBuffer_) is *true*, and _srcBuffer_.[[ArrayBufferData]] is _targetBuffer_.[[ArrayBufferData]], let _sameSharedArrayBuffer_ be *true*; otherwise, let _sameSharedArrayBuffer_ be *false*.
             1. If SameValue(_srcBuffer_, _targetBuffer_) is *true* or _sameSharedArrayBuffer_ is *true*, then
+              1. NOTE: Later steps require the original source data, even if it is being overwritten. But since their effects are not observable until this operation completes, implementations may perform them in-place rather than allocating a new ArrayBuffer.
               1. Let _srcByteLength_ be TypedArrayByteLength(_srcRecord_).
               1. Set _srcBuffer_ to ? CloneArrayBuffer(_srcBuffer_, _srcByteOffset_, _srcByteLength_).
               1. Let _srcByteIndex_ be 0.
             1. Else,
               1. Let _srcByteIndex_ be _srcByteOffset_.
-            1. Let _targetByteIndex_ be (_targetOffset_ × _targetElementSize_) + _targetByteOffset_.
+            1. Let _targetType_ be TypedArrayElementType(_target_).
+            1. Let _targetElementSize_ be TypedArrayElementSize(_target_).
+            1. Let _srcType_ be TypedArrayElementType(_source_).
+            1. Let _srcElementSize_ be TypedArrayElementSize(_source_).
+            1. Let _targetByteIndex_ be _targetByteOffset_ + (_targetElementSize_ × _targetOffset_).
             1. Let _limit_ be _targetByteIndex_ + (_targetElementSize_ × _srcLength_).
             1. If _srcType_ is _targetType_, then
               1. NOTE: The transfer must be performed in a manner that preserves the bit-level encoding of the source data.

--- a/spec.html
+++ b/spec.html
@@ -42235,7 +42235,7 @@ THH:mm:ss.sss
             1. Let _targetBuffer_ be _target_.[[ViewedArrayBuffer]].
             1. Let _srcBuffer_ be _source_.[[ViewedArrayBuffer]].
             1. Let _srcByteIndex_ be _source_.[[ByteOffset]].
-            1. If IsSameBuffer(_srcBuffer_, _targetBuffer_) is *true*, then
+            1. If _targetBuffer_.[[ArrayBufferData]] is _srcBuffer_.[[ArrayBufferData]], then
               1. NOTE: This operation must behave as if copying data into an overlapping range within the same Data Block is a single atomic step. But because the results of copying are not observable until it completes, implementations unable to perform such copying atomically may still avoid allocating a new ArrayBuffer by copying chunks in-place if they alter the direction of iteration as appropriate to avoid overwriting source data that has not yet been read.
               1. Let _srcByteLength_ be TypedArrayByteLength(_srcRecord_).
               1. Set _srcBuffer_ to ? CloneArrayBuffer(_srcBuffer_, _srcByteIndex_, _srcByteLength_).
@@ -44379,22 +44379,6 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-issamebuffer" type="abstract operation">
-        <h1>
-          IsSameBuffer (
-            _a_: an ArrayBuffer or a SharedArrayBuffer,
-            _b_: an ArrayBuffer or a SharedArrayBuffer,
-          ): a Boolean
-        </h1>
-        <dl class="header">
-        </dl>
-        <emu-alg>
-          1. If SameValue(_a_, _b_) is *true*, return *true*.
-          1. If IsSharedArrayBuffer(_a_) is *true*, IsSharedArrayBuffer(_b_) is *true*, and _b_.[[ArrayBufferData]] is _a_.[[ArrayBufferData]], return *true*.
-          1. Return *false*.
-        </emu-alg>
-      </emu-clause>
-
       <emu-clause id="sec-getarraybuffermaxbytelengthoption" type="abstract operation">
         <h1>
           GetArrayBufferMaxByteLengthOption (
@@ -44886,7 +44870,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_new_, [[ArrayBufferData]]).
           1. If IsSharedArrayBuffer(_new_) is *true*, throw a *TypeError* exception.
           1. If IsDetachedBuffer(_new_) is *true*, throw a *TypeError* exception.
-          1. If IsSameBuffer(_new_, _O_) is *true*, throw a *TypeError* exception.
+          1. If _new_.[[ArrayBufferData]] is _O_.[[ArrayBufferData]], throw a *TypeError* exception.
           1. If _new_.[[ArrayBufferByteLength]] &lt; _newLen_, throw a *TypeError* exception.
           1. NOTE: Side-effects of the above steps may have detached or resized _O_.
           1. If IsDetachedBuffer(_O_) is *true*, throw a *TypeError* exception.
@@ -45203,7 +45187,7 @@ THH:mm:ss.sss
           1. Let _new_ be ? Construct(_ctor_, « 𝔽(_newLen_) »).
           1. Perform ? RequireInternalSlot(_new_, [[ArrayBufferData]]).
           1. If IsSharedArrayBuffer(_new_) is *false*, throw a *TypeError* exception.
-          1. If IsSameBuffer(_new_, _O_) is *true*, throw a *TypeError* exception.
+          1. If _new_.[[ArrayBufferData]] is _O_.[[ArrayBufferData]], throw a *TypeError* exception.
           1. If ArrayBufferByteLength(_new_, ~seq-cst~) &lt; _newLen_, throw a *TypeError* exception.
           1. Let _fromBuf_ be _O_.[[ArrayBufferData]].
           1. Let _toBuf_ be _new_.[[ArrayBufferData]].

--- a/spec.html
+++ b/spec.html
@@ -46164,9 +46164,8 @@ THH:mm:ss.sss
           1. Let _buffer_ be _taRecord_.[[Object]].[[ViewedArrayBuffer]].
           1. If IsSharedArrayBuffer(_buffer_) is *false*, throw a *TypeError* exception.
           1. Let _i_ be ? ValidateAtomicAccess(_taRecord_, _index_).
-          1. Let _arrayTypeName_ be _typedArray_.[[TypedArrayName]].
-          1. If _arrayTypeName_ is *"BigInt64Array"*, let _v_ be ? ToBigInt64(_value_).
-          1. Else, let _v_ be ? ToInt32(_value_).
+          1. Let _conversionOperation_ be the abstract operation named in the Conversion Operation column in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for Constructor Name _typedArray_.[[TypedArrayName]].
+          1. Let _v_ be ? _conversionOperation_(_value_).
           1. Let _q_ be ? ToNumber(_timeout_).
           1. If _q_ is either *NaN* or *+∞*<sub>𝔽</sub>, let _t_ be +∞; else if _q_ is *-∞*<sub>𝔽</sub>, let _t_ be 0; else let _t_ be max(ℝ(_q_), 0).
           1. If _mode_ is ~sync~ and AgentCanSuspend() is *false*, throw a *TypeError* exception.
@@ -46289,11 +46288,10 @@ THH:mm:ss.sss
         </dl>
         <emu-alg>
           1. Let _byteIndexInBuffer_ be ? ValidateAtomicAccessOnIntegerTypedArray(_typedArray_, _index_).
-          1. If _typedArray_.[[ContentType]] is ~bigint~, let _v_ be ? ToBigInt(_value_).
-          1. Otherwise, let _v_ be 𝔽(? ToIntegerOrInfinity(_value_)).
+          1. Let _elementType_ be TypedArrayElementType(_typedArray_).
+          1. Let _v_ be ? ToElementCategory(_value_, _elementType_).
           1. Perform ? RevalidateAtomicAccess(_typedArray_, _byteIndexInBuffer_).
           1. Let _buffer_ be _typedArray_.[[ViewedArrayBuffer]].
-          1. Let _elementType_ be TypedArrayElementType(_typedArray_).
           1. Return GetModifySetValueInBuffer(_buffer_, _byteIndexInBuffer_, _elementType_, _v_, _op_).
         </emu-alg>
       </emu-clause>
@@ -46388,18 +46386,14 @@ THH:mm:ss.sss
         1. Let _byteIndexInBuffer_ be ? ValidateAtomicAccessOnIntegerTypedArray(_typedArray_, _index_).
         1. Let _buffer_ be _typedArray_.[[ViewedArrayBuffer]].
         1. Let _block_ be _buffer_.[[ArrayBufferData]].
-        1. If _typedArray_.[[ContentType]] is ~bigint~, then
-          1. Let _expected_ be ? ToBigInt(_expectedValue_).
-          1. Let _replacement_ be ? ToBigInt(_replacementValue_).
-        1. Else,
-          1. Let _expected_ be 𝔽(? ToIntegerOrInfinity(_expectedValue_)).
-          1. Let _replacement_ be 𝔽(? ToIntegerOrInfinity(_replacementValue_)).
-        1. Perform ? RevalidateAtomicAccess(_typedArray_, _byteIndexInBuffer_).
         1. Let _elementType_ be TypedArrayElementType(_typedArray_).
-        1. Let _elementSize_ be TypedArrayElementSize(_typedArray_).
+        1. Let _expected_ be ? ToElementCategory(_expectedValue_, _elementType_).
+        1. Let _replacement_ be ? ToElementCategory(_replacementValue_, _elementType_).
+        1. Perform ? RevalidateAtomicAccess(_typedArray_, _byteIndexInBuffer_).
         1. Let _isLittleEndian_ be the value of the [[LittleEndian]] field of the surrounding agent's Agent Record.
         1. Let _expectedBytes_ be NumericToRawBytes(_elementType_, _expected_, _isLittleEndian_).
         1. Let _replacementBytes_ be NumericToRawBytes(_elementType_, _replacement_, _isLittleEndian_).
+        1. Let _elementSize_ be TypedArrayElementSize(_typedArray_).
         1. If IsSharedArrayBuffer(_buffer_) is *true*, then
           1. Let _rawBytesRead_ be AtomicCompareExchangeInSharedBlock(_block_, _byteIndexInBuffer_, _elementSize_, _expectedBytes_, _replacementBytes_).
         1. Else,
@@ -46466,12 +46460,12 @@ THH:mm:ss.sss
       <p>This function performs the following steps when called:</p>
       <emu-alg>
         1. Let _byteIndexInBuffer_ be ? ValidateAtomicAccessOnIntegerTypedArray(_typedArray_, _index_).
-        1. If _typedArray_.[[ContentType]] is ~bigint~, let _v_ be ? ToBigInt(_value_).
-        1. Otherwise, let _v_ be 𝔽(? ToIntegerOrInfinity(_value_)).
+        1. Let _elementType_ be TypedArrayElementType(_typedArray_).
+        1. Let _v_ be ? ToElementCategory(_value_, _elementType_).
         1. Perform ? RevalidateAtomicAccess(_typedArray_, _byteIndexInBuffer_).
         1. Let _buffer_ be _typedArray_.[[ViewedArrayBuffer]].
-        1. Let _elementType_ be TypedArrayElementType(_typedArray_).
         1. Perform SetValueInBuffer(_buffer_, _byteIndexInBuffer_, _elementType_, _v_, *true*, ~seq-cst~).
+        1. If _v_ is a Number, return 𝔽(! ToIntegerOrInfinity(_v_)).
         1. Return _v_.
       </emu-alg>
     </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -42654,30 +42654,28 @@ THH:mm:ss.sss
           1. Let _numberOfArgs_ be the number of elements in _args_.
           1. If _numberOfArgs_ = 0, then
             1. Return ? AllocateTypedArray(_constructorName_, NewTarget, _proto_, 0).
+          1. Else if _args_[0] is not an Object, then
+            1. Let _elementLength_ be ? ToIndex(_args_[0]).
+            1. Return ? AllocateTypedArray(_constructorName_, NewTarget, _proto_, _elementLength_).
+          1. Let _firstArgument_ be _args_[0].
+          1. Assert: _firstArgument_ is an Object.
+          1. Let _O_ be ? AllocateTypedArray(_constructorName_, NewTarget, _proto_).
+          1. If _firstArgument_ has a [[TypedArrayName]] internal slot, then
+            1. Perform ? InitializeTypedArrayFromTypedArray(_O_, _firstArgument_).
+          1. Else if _firstArgument_ has an [[ArrayBufferData]] internal slot, then
+            1. If _numberOfArgs_ > 1, let _byteOffset_ be _args_[1]; else let _byteOffset_ be *undefined*.
+            1. If _numberOfArgs_ > 2, let _length_ be _args_[2]; else let _length_ be *undefined*.
+            1. Perform ? InitializeTypedArrayFromArrayBuffer(_O_, _firstArgument_, _byteOffset_, _length_).
           1. Else,
-            1. Let _firstArgument_ be _args_[0].
-            1. If _firstArgument_ is an Object, then
-              1. Let _O_ be ? AllocateTypedArray(_constructorName_, NewTarget, _proto_).
-              1. If _firstArgument_ has a [[TypedArrayName]] internal slot, then
-                1. Perform ? InitializeTypedArrayFromTypedArray(_O_, _firstArgument_).
-              1. Else if _firstArgument_ has an [[ArrayBufferData]] internal slot, then
-                1. If _numberOfArgs_ > 1, let _byteOffset_ be _args_[1]; else let _byteOffset_ be *undefined*.
-                1. If _numberOfArgs_ > 2, let _length_ be _args_[2]; else let _length_ be *undefined*.
-                1. Perform ? InitializeTypedArrayFromArrayBuffer(_O_, _firstArgument_, _byteOffset_, _length_).
-              1. Else,
-                1. Assert: _firstArgument_ is an Object and _firstArgument_ does not have either a [[TypedArrayName]] or an [[ArrayBufferData]] internal slot.
-                1. Let _usingIterator_ be ? GetMethod(_firstArgument_, %Symbol.iterator%).
-                1. If _usingIterator_ is not *undefined*, then
-                  1. Let _values_ be ? IteratorToList(? GetIteratorFromMethod(_firstArgument_, _usingIterator_)).
-                  1. Perform ? InitializeTypedArrayFromList(_O_, _values_).
-                1. Else,
-                  1. NOTE: _firstArgument_ is not an iterable object, so assume it is already an array-like object.
-                  1. Perform ? InitializeTypedArrayFromArrayLike(_O_, _firstArgument_).
-              1. Return _O_.
+            1. Assert: _firstArgument_ is an Object and _firstArgument_ does not have either a [[TypedArrayName]] or an [[ArrayBufferData]] internal slot.
+            1. Let _usingIterator_ be ? GetMethod(_firstArgument_, %Symbol.iterator%).
+            1. If _usingIterator_ is not *undefined*, then
+              1. Let _values_ be ? IteratorToList(? GetIteratorFromMethod(_firstArgument_, _usingIterator_)).
+              1. Perform ? InitializeTypedArrayFromList(_O_, _values_).
             1. Else,
-              1. Assert: _firstArgument_ is not an Object.
-              1. Let _elementLength_ be ? ToIndex(_firstArgument_).
-              1. Return ? AllocateTypedArray(_constructorName_, NewTarget, _proto_, _elementLength_).
+              1. NOTE: _firstArgument_ is not an iterable object, so assume it is already an array-like object.
+              1. Perform ? InitializeTypedArrayFromArrayLike(_O_, _firstArgument_).
+          1. Return _O_.
         </emu-alg>
 
         <emu-clause id="sec-allocatetypedarray" type="abstract operation">
@@ -42720,30 +42718,27 @@ THH:mm:ss.sss
           <dl class="header">
           </dl>
           <emu-alg>
-            1. Let _srcData_ be _srcArray_.[[ViewedArrayBuffer]].
-            1. Let _elementType_ be TypedArrayElementType(_O_).
-            1. Let _elementSize_ be TypedArrayElementSize(_O_).
-            1. Let _srcType_ be TypedArrayElementType(_srcArray_).
-            1. Let _srcElementSize_ be TypedArrayElementSize(_srcArray_).
-            1. Let _srcByteOffset_ be _srcArray_.[[ByteOffset]].
             1. Let _srcRecord_ be ? ValidateTypedArray(_srcArray_, ~seq-cst~).
+            1. Let _srcBuffer_ be _srcArray_.[[ViewedArrayBuffer]].
+            1. Let _srcByteIndex_ be _srcArray_.[[ByteOffset]].
             1. Let _elementLength_ be TypedArrayLength(_srcRecord_).
-            1. Let _byteLength_ be _elementSize_ × _elementLength_.
-            1. If _elementType_ is _srcType_, then
-              1. Let _data_ be ? CloneArrayBuffer(_srcData_, _srcByteOffset_, _byteLength_).
+            1. Let _targetElementSize_ be TypedArrayElementSize(_O_).
+            1. Let _byteLength_ be _targetElementSize_ × _elementLength_.
+            1. Let _targetType_ be TypedArrayElementType(_O_).
+            1. Let _srcType_ be TypedArrayElementType(_srcArray_).
+            1. If _srcType_ is _targetType_, then
+              1. Let _targetBuffer_ be ? CloneArrayBuffer(_srcBuffer_, _srcByteIndex_, _byteLength_).
             1. Else,
-              1. Let _data_ be ? <emu-meta suppress-effects="user-code">AllocateArrayBuffer(%ArrayBuffer%, _byteLength_)</emu-meta>.
+              1. Let _targetBuffer_ be ? <emu-meta suppress-effects="user-code">AllocateArrayBuffer(%ArrayBuffer%, _byteLength_)</emu-meta>.
               1. If _srcArray_.[[ContentType]] is not _O_.[[ContentType]], throw a *TypeError* exception.
-              1. Let _srcByteIndex_ be _srcByteOffset_.
               1. Let _targetByteIndex_ be 0.
-              1. Let _count_ be _elementLength_.
-              1. Repeat, while _count_ > 0,
-                1. Let _value_ be GetValueFromBuffer(_srcData_, _srcByteIndex_, _srcType_, *true*, ~unordered~).
-                1. Perform SetValueInBuffer(_data_, _targetByteIndex_, _elementType_, _value_, *true*, ~unordered~).
+              1. Let _srcElementSize_ be TypedArrayElementSize(_srcArray_).
+              1. Repeat, while _targetByteIndex_ &lt; _byteLength_,
+                1. Let _value_ be GetValueFromBuffer(_srcBuffer_, _srcByteIndex_, _srcType_, *true*, ~unordered~).
+                1. Perform SetValueInBuffer(_targetBuffer_, _targetByteIndex_, _targetType_, _value_, *true*, ~unordered~).
                 1. Set _srcByteIndex_ to _srcByteIndex_ + _srcElementSize_.
-                1. Set _targetByteIndex_ to _targetByteIndex_ + _elementSize_.
-                1. Set _count_ to _count_ - 1.
-            1. Set _O_.[[ViewedArrayBuffer]] to _data_.
+                1. Set _targetByteIndex_ to _targetByteIndex_ + _targetElementSize_.
+            1. Set _O_.[[ViewedArrayBuffer]] to _targetBuffer_.
             1. Set _O_.[[ByteLength]] to _byteLength_.
             1. Set _O_.[[ByteOffset]] to 0.
             1. Set _O_.[[ArrayLength]] to _elementLength_.
@@ -42764,29 +42759,26 @@ THH:mm:ss.sss
           </dl>
           <emu-alg>
             1. Let _elementSize_ be TypedArrayElementSize(_O_).
-            1. Let _offset_ be ? ToIndex(_byteOffset_).
-            1. If _offset_ modulo _elementSize_ ≠ 0, throw a *RangeError* exception.
-            1. Let _bufferIsFixedLength_ be IsFixedLengthArrayBuffer(_buffer_).
-            1. If _length_ is not *undefined*, then
-              1. Let _newLength_ be ? ToIndex(_length_).
+            1. Set _byteOffset_ to ? ToIndex(_byteOffset_).
+            1. If _byteOffset_ modulo _elementSize_ ≠ 0, throw a *RangeError* exception.
+            1. If _length_ is not *undefined*, set _length_ to ? ToIndex(_length_).
             1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
             1. Let _bufferByteLength_ be ArrayBufferByteLength(_buffer_, ~seq-cst~).
-            1. If _length_ is *undefined* and _bufferIsFixedLength_ is *false*, then
-              1. If _offset_ > _bufferByteLength_, throw a *RangeError* exception.
+            1. If _byteOffset_ > _bufferByteLength_, throw a *RangeError* exception.
+            1. If _length_ is *undefined* and IsFixedLengthArrayBuffer(_buffer_) is *false*, then
               1. Set _O_.[[ByteLength]] to ~auto~.
               1. Set _O_.[[ArrayLength]] to ~auto~.
             1. Else,
               1. If _length_ is *undefined*, then
-                1. If _bufferByteLength_ modulo _elementSize_ ≠ 0, throw a *RangeError* exception.
-                1. Let _newByteLength_ be _bufferByteLength_ - _offset_.
-                1. If _newByteLength_ &lt; 0, throw a *RangeError* exception.
+                1. Let _byteLength_ be _bufferByteLength_ - _byteOffset_.
+                1. If _byteLength_ modulo _elementSize_ ≠ 0, throw a *RangeError* exception.
               1. Else,
-                1. Let _newByteLength_ be _newLength_ × _elementSize_.
-                1. If _offset_ + _newByteLength_ > _bufferByteLength_, throw a *RangeError* exception.
-              1. Set _O_.[[ByteLength]] to _newByteLength_.
-              1. Set _O_.[[ArrayLength]] to _newByteLength_ / _elementSize_.
+                1. Let _byteLength_ be _length_ × _elementSize_.
+                1. If _byteOffset_ + _byteLength_ > _bufferByteLength_, throw a *RangeError* exception.
+              1. Set _O_.[[ByteLength]] to _byteLength_.
+              1. Set _O_.[[ArrayLength]] to _byteLength_ / _elementSize_.
             1. Set _O_.[[ViewedArrayBuffer]] to _buffer_.
-            1. Set _O_.[[ByteOffset]] to _offset_.
+            1. Set _O_.[[ByteOffset]] to _byteOffset_.
             1. Return ~unused~.
           </emu-alg>
         </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -44503,7 +44503,7 @@ THH:mm:ss.sss
         </dl>
         <emu-alg>
           1. If IsUnclampedIntegerElementType(_type_) is *true*, return *true*.
-          1. If IsBigIntElementType(_type_) is *true* and _order_ is neither ~init~ nor ~unordered~, return *true*.
+          1. If IsBigIntElementType(_type_) is *true* and _order_ is ~seq-cst~, return *true*.
           1. Return *false*.
         </emu-alg>
       </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -42660,20 +42660,19 @@ THH:mm:ss.sss
           1. Let _firstArgument_ be _args_[0].
           1. Assert: _firstArgument_ is an Object.
           1. Let _O_ be ? AllocateTypedArray(_constructorName_, NewTarget, _proto_).
-          1. If _firstArgument_ has a [[TypedArrayName]] internal slot, then
-            1. Perform ? InitializeTypedArrayFromTypedArray(_O_, _firstArgument_).
-          1. Else if _firstArgument_ has an [[ArrayBufferData]] internal slot, then
+          1. If _firstArgument_ has an [[ArrayBufferData]] internal slot, then
             1. If _numberOfArgs_ > 1, let _byteOffset_ be _args_[1]; else let _byteOffset_ be *undefined*.
             1. If _numberOfArgs_ > 2, let _length_ be _args_[2]; else let _length_ be *undefined*.
             1. Perform ? InitializeTypedArrayFromArrayBuffer(_O_, _firstArgument_, _byteOffset_, _length_).
+          1. Else if _firstArgument_ has a [[TypedArrayName]] internal slot, then
+            1. Perform ? InitializeTypedArrayFromTypedArray(_O_, _firstArgument_).
           1. Else,
-            1. Assert: _firstArgument_ is an Object and _firstArgument_ does not have either a [[TypedArrayName]] or an [[ArrayBufferData]] internal slot.
+            1. Assert: _firstArgument_ does not have either an [[ArrayBufferData]] or a [[TypedArrayName]] internal slot.
             1. Let _usingIterator_ be ? GetMethod(_firstArgument_, %Symbol.iterator%).
             1. If _usingIterator_ is not *undefined*, then
               1. Let _values_ be ? IteratorToList(? GetIteratorFromMethod(_firstArgument_, _usingIterator_)).
               1. Perform ? InitializeTypedArrayFromList(_O_, _values_).
             1. Else,
-              1. NOTE: _firstArgument_ is not an iterable object, so assume it is already an array-like object.
               1. Perform ? InitializeTypedArrayFromArrayLike(_O_, _firstArgument_).
           1. Return _O_.
         </emu-alg>
@@ -42705,6 +42704,43 @@ THH:mm:ss.sss
             1. Else,
               1. Perform ? AllocateTypedArrayBuffer(_obj_, _length_).
             1. Return _obj_.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-initializetypedarrayfromarraybuffer" type="abstract operation" oldids="sec-typedarray-buffer-byteoffset-length">
+          <h1>
+            InitializeTypedArrayFromArrayBuffer (
+              _O_: a TypedArray,
+              _buffer_: an ArrayBuffer or a SharedArrayBuffer,
+              _byteOffset_: an ECMAScript language value,
+              _length_: an ECMAScript language value,
+            ): either a normal completion containing ~unused~ or a throw completion
+          </h1>
+          <dl class="header">
+          </dl>
+          <emu-alg>
+            1. Let _elementSize_ be TypedArrayElementSize(_O_).
+            1. Set _byteOffset_ to ? ToIndex(_byteOffset_).
+            1. If _byteOffset_ modulo _elementSize_ ≠ 0, throw a *RangeError* exception.
+            1. If _length_ is not *undefined*, set _length_ to ? ToIndex(_length_).
+            1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
+            1. Let _bufferByteLength_ be ArrayBufferByteLength(_buffer_, ~seq-cst~).
+            1. If _byteOffset_ > _bufferByteLength_, throw a *RangeError* exception.
+            1. If _length_ is *undefined* and IsFixedLengthArrayBuffer(_buffer_) is *false*, then
+              1. Set _O_.[[ByteLength]] to ~auto~.
+              1. Set _O_.[[ArrayLength]] to ~auto~.
+            1. Else,
+              1. If _length_ is *undefined*, then
+                1. Let _byteLength_ be _bufferByteLength_ - _byteOffset_.
+                1. If _byteLength_ modulo _elementSize_ ≠ 0, throw a *RangeError* exception.
+              1. Else,
+                1. Let _byteLength_ be _length_ × _elementSize_.
+                1. If _byteOffset_ + _byteLength_ > _bufferByteLength_, throw a *RangeError* exception.
+              1. Set _O_.[[ByteLength]] to _byteLength_.
+              1. Set _O_.[[ArrayLength]] to _byteLength_ / _elementSize_.
+            1. Set _O_.[[ViewedArrayBuffer]] to _buffer_.
+            1. Set _O_.[[ByteOffset]] to _byteOffset_.
+            1. Return ~unused~.
           </emu-alg>
         </emu-clause>
 
@@ -42742,43 +42778,6 @@ THH:mm:ss.sss
             1. Set _O_.[[ByteLength]] to _byteLength_.
             1. Set _O_.[[ByteOffset]] to 0.
             1. Set _O_.[[ArrayLength]] to _elementLength_.
-            1. Return ~unused~.
-          </emu-alg>
-        </emu-clause>
-
-        <emu-clause id="sec-initializetypedarrayfromarraybuffer" type="abstract operation" oldids="sec-typedarray-buffer-byteoffset-length">
-          <h1>
-            InitializeTypedArrayFromArrayBuffer (
-              _O_: a TypedArray,
-              _buffer_: an ArrayBuffer or a SharedArrayBuffer,
-              _byteOffset_: an ECMAScript language value,
-              _length_: an ECMAScript language value,
-            ): either a normal completion containing ~unused~ or a throw completion
-          </h1>
-          <dl class="header">
-          </dl>
-          <emu-alg>
-            1. Let _elementSize_ be TypedArrayElementSize(_O_).
-            1. Set _byteOffset_ to ? ToIndex(_byteOffset_).
-            1. If _byteOffset_ modulo _elementSize_ ≠ 0, throw a *RangeError* exception.
-            1. If _length_ is not *undefined*, set _length_ to ? ToIndex(_length_).
-            1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
-            1. Let _bufferByteLength_ be ArrayBufferByteLength(_buffer_, ~seq-cst~).
-            1. If _byteOffset_ > _bufferByteLength_, throw a *RangeError* exception.
-            1. If _length_ is *undefined* and IsFixedLengthArrayBuffer(_buffer_) is *false*, then
-              1. Set _O_.[[ByteLength]] to ~auto~.
-              1. Set _O_.[[ArrayLength]] to ~auto~.
-            1. Else,
-              1. If _length_ is *undefined*, then
-                1. Let _byteLength_ be _bufferByteLength_ - _byteOffset_.
-                1. If _byteLength_ modulo _elementSize_ ≠ 0, throw a *RangeError* exception.
-              1. Else,
-                1. Let _byteLength_ be _length_ × _elementSize_.
-                1. If _byteOffset_ + _byteLength_ > _bufferByteLength_, throw a *RangeError* exception.
-              1. Set _O_.[[ByteLength]] to _byteLength_.
-              1. Set _O_.[[ArrayLength]] to _byteLength_ / _elementSize_.
-            1. Set _O_.[[ViewedArrayBuffer]] to _buffer_.
-            1. Set _O_.[[ByteOffset]] to _byteOffset_.
             1. Return ~unused~.
           </emu-alg>
         </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -44880,7 +44880,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_new_, [[ArrayBufferData]]).
           1. If IsSharedArrayBuffer(_new_) is *true*, throw a *TypeError* exception.
           1. If IsDetachedBuffer(_new_) is *true*, throw a *TypeError* exception.
-          1. If SameValue(_new_, _O_) is *true*, throw a *TypeError* exception.
+          1. If IsSameBuffer(_new_, _O_) is *true*, throw a *TypeError* exception.
           1. If _new_.[[ArrayBufferByteLength]] &lt; _newLen_, throw a *TypeError* exception.
           1. NOTE: Side-effects of the above steps may have detached or resized _O_.
           1. If IsDetachedBuffer(_O_) is *true*, throw a *TypeError* exception.
@@ -45197,7 +45197,7 @@ THH:mm:ss.sss
           1. Let _new_ be ? Construct(_ctor_, « 𝔽(_newLen_) »).
           1. Perform ? RequireInternalSlot(_new_, [[ArrayBufferData]]).
           1. If IsSharedArrayBuffer(_new_) is *false*, throw a *TypeError* exception.
-          1. If _new_.[[ArrayBufferData]] is _O_.[[ArrayBufferData]], throw a *TypeError* exception.
+          1. If IsSameBuffer(_new_, _O_) is *true*, throw a *TypeError* exception.
           1. If ArrayBufferByteLength(_new_, ~seq-cst~) &lt; _newLen_, throw a *TypeError* exception.
           1. Let _fromBuf_ be _O_.[[ArrayBufferData]].
           1. Let _toBuf_ be _new_.[[ArrayBufferData]].

--- a/spec.html
+++ b/spec.html
@@ -42655,15 +42655,15 @@ THH:mm:ss.sss
           1. If _numberOfArgs_ = 0, then
             1. Return ? AllocateTypedArray(_constructorName_, NewTarget, _proto_, 0).
           1. Else if _args_[0] is not an Object, then
-            1. Let _elementLength_ be ? ToIndex(_args_[0]).
-            1. Return ? AllocateTypedArray(_constructorName_, NewTarget, _proto_, _elementLength_).
+            1. Let _elementCount_ be ? ToIndex(_args_[0]).
+            1. Return ? AllocateTypedArray(_constructorName_, NewTarget, _proto_, _elementCount_).
           1. Let _firstArgument_ be _args_[0].
           1. Assert: _firstArgument_ is an Object.
           1. Let _O_ be ? AllocateTypedArray(_constructorName_, NewTarget, _proto_).
           1. If _firstArgument_ has an [[ArrayBufferData]] internal slot, then
             1. If _numberOfArgs_ > 1, let _byteOffset_ be _args_[1]; else let _byteOffset_ be *undefined*.
-            1. If _numberOfArgs_ > 2, let _length_ be _args_[2]; else let _length_ be *undefined*.
-            1. Perform ? InitializeTypedArrayFromArrayBuffer(_O_, _firstArgument_, _byteOffset_, _length_).
+            1. If _numberOfArgs_ > 2, let _elementCount_ be _args_[2]; else let _elementCount_ be *undefined*.
+            1. Perform ? InitializeTypedArrayFromArrayBuffer(_O_, _firstArgument_, _byteOffset_, _elementCount_).
           1. Else if _firstArgument_ has a [[TypedArrayName]] internal slot, then
             1. Perform ? InitializeTypedArrayFromTypedArray(_O_, _firstArgument_).
           1. Else,
@@ -42683,12 +42683,12 @@ THH:mm:ss.sss
               _constructorName_: a String which is the name of a TypedArray constructor in <emu-xref href="#table-the-typedarray-constructors"></emu-xref>,
               _newTarget_: a constructor,
               _defaultProto_: a String,
-              optional _length_: a non-negative integer,
+              optional _elementCount_: a non-negative integer,
             ): either a normal completion containing a TypedArray or a throw completion
           </h1>
           <dl class="header">
             <dt>description</dt>
-            <dd>It is used to validate and create an instance of a TypedArray constructor. If the _length_ argument is passed, an ArrayBuffer of that length is also allocated and associated with the new TypedArray instance. AllocateTypedArray provides common semantics that is used by _TypedArray_.</dd>
+            <dd>It is used to validate and create an instance of a TypedArray constructor. If the _elementCount_ argument is passed, an ArrayBuffer of that length is also allocated and associated with the new TypedArray instance. AllocateTypedArray provides common semantics that is used by _TypedArray_.</dd>
           </dl>
           <emu-alg>
             1. Let _proto_ be ? GetPrototypeFromConstructor(_newTarget_, _defaultProto_).
@@ -42697,12 +42697,12 @@ THH:mm:ss.sss
             1. Set _obj_.[[TypedArrayName]] to _constructorName_.
             1. If _constructorName_ is either *"BigInt64Array"* or *"BigUint64Array"*, set _obj_.[[ContentType]] to ~bigint~.
             1. Otherwise, set _obj_.[[ContentType]] to ~number~.
-            1. If _length_ is not present, then
+            1. If _elementCount_ is not present, then
               1. Set _obj_.[[ByteLength]] to 0.
               1. Set _obj_.[[ByteOffset]] to 0.
               1. Set _obj_.[[ArrayLength]] to 0.
             1. Else,
-              1. Perform ? AllocateTypedArrayBuffer(_obj_, _length_).
+              1. Perform ? AllocateTypedArrayBuffer(_obj_, _elementCount_).
             1. Return _obj_.
           </emu-alg>
         </emu-clause>
@@ -42713,7 +42713,7 @@ THH:mm:ss.sss
               _O_: a TypedArray,
               _buffer_: an ArrayBuffer or a SharedArrayBuffer,
               _byteOffset_: an ECMAScript language value,
-              _length_: an ECMAScript language value,
+              _elementCount_: an ECMAScript language value,
             ): either a normal completion containing ~unused~ or a throw completion
           </h1>
           <dl class="header">
@@ -42722,19 +42722,19 @@ THH:mm:ss.sss
             1. Let _elementSize_ be TypedArrayElementSize(_O_).
             1. Set _byteOffset_ to ? ToIndex(_byteOffset_).
             1. If _byteOffset_ modulo _elementSize_ ≠ 0, throw a *RangeError* exception.
-            1. If _length_ is not *undefined*, set _length_ to ? ToIndex(_length_).
+            1. If _elementCount_ is not *undefined*, set _elementCount_ to ? ToIndex(_elementCount_).
             1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
             1. Let _bufferByteLength_ be ArrayBufferByteLength(_buffer_, ~seq-cst~).
             1. If _byteOffset_ > _bufferByteLength_, throw a *RangeError* exception.
-            1. If _length_ is *undefined* and IsFixedLengthArrayBuffer(_buffer_) is *false*, then
+            1. If _elementCount_ is *undefined* and IsFixedLengthArrayBuffer(_buffer_) is *false*, then
               1. Set _O_.[[ByteLength]] to ~auto~.
               1. Set _O_.[[ArrayLength]] to ~auto~.
             1. Else,
-              1. If _length_ is *undefined*, then
+              1. If _elementCount_ is *undefined*, then
                 1. Let _byteLength_ be _bufferByteLength_ - _byteOffset_.
                 1. If _byteLength_ modulo _elementSize_ ≠ 0, throw a *RangeError* exception.
               1. Else,
-                1. Let _byteLength_ be _length_ × _elementSize_.
+                1. Let _byteLength_ be _elementSize_ × _elementCount_.
                 1. If _byteOffset_ + _byteLength_ > _bufferByteLength_, throw a *RangeError* exception.
               1. Set _O_.[[ByteLength]] to _byteLength_.
               1. Set _O_.[[ArrayLength]] to _byteLength_ / _elementSize_.
@@ -42757,9 +42757,9 @@ THH:mm:ss.sss
             1. Let _srcRecord_ be ? ValidateTypedArray(_srcArray_, ~seq-cst~).
             1. Let _srcBuffer_ be _srcArray_.[[ViewedArrayBuffer]].
             1. Let _srcByteIndex_ be _srcArray_.[[ByteOffset]].
-            1. Let _elementLength_ be TypedArrayLength(_srcRecord_).
+            1. Let _elementCount_ be TypedArrayLength(_srcRecord_).
             1. Let _targetElementSize_ be TypedArrayElementSize(_O_).
-            1. Let _byteLength_ be _targetElementSize_ × _elementLength_.
+            1. Let _byteLength_ be _targetElementSize_ × _elementCount_.
             1. Let _targetType_ be TypedArrayElementType(_O_).
             1. Let _srcType_ be TypedArrayElementType(_srcArray_).
             1. If _srcType_ is _targetType_, then
@@ -42777,7 +42777,7 @@ THH:mm:ss.sss
             1. Set _O_.[[ViewedArrayBuffer]] to _targetBuffer_.
             1. Set _O_.[[ByteLength]] to _byteLength_.
             1. Set _O_.[[ByteOffset]] to 0.
-            1. Set _O_.[[ArrayLength]] to _elementLength_.
+            1. Set _O_.[[ArrayLength]] to _elementCount_.
             1. Return ~unused~.
           </emu-alg>
         </emu-clause>
@@ -42832,7 +42832,7 @@ THH:mm:ss.sss
           <h1>
             AllocateTypedArrayBuffer (
               _O_: a TypedArray,
-              _length_: a non-negative integer,
+              _elementCount_: a non-negative integer,
             ): either a normal completion containing ~unused~ or a throw completion
           </h1>
           <dl class="header">
@@ -42842,12 +42842,12 @@ THH:mm:ss.sss
           <emu-alg>
             1. Assert: _O_.[[ViewedArrayBuffer]] is *undefined*.
             1. Let _elementSize_ be TypedArrayElementSize(_O_).
-            1. Let _byteLength_ be _elementSize_ × _length_.
+            1. Let _byteLength_ be _elementSize_ × _elementCount_.
             1. Let _data_ be ? <emu-meta suppress-effects="user-code">AllocateArrayBuffer(%ArrayBuffer%, _byteLength_)</emu-meta>.
             1. Set _O_.[[ViewedArrayBuffer]] to _data_.
             1. Set _O_.[[ByteLength]] to _byteLength_.
             1. Set _O_.[[ByteOffset]] to 0.
-            1. Set _O_.[[ArrayLength]] to _length_.
+            1. Set _O_.[[ArrayLength]] to _elementCount_.
             1. Return ~unused~.
           </emu-alg>
         </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -42221,7 +42221,7 @@ THH:mm:ss.sss
             1. Let _srcRecord_ be ? ValidateTypedArray(_source_, ~seq-cst~).
             1. Let _srcLength_ be TypedArrayLength(_srcRecord_).
             1. If _srcLength_ + _targetOffset_ > TypedArrayLength(_targetRecord_), throw a *RangeError* exception.
-            1. If _target_.[[ContentType]] is not _source_.[[ContentType]], throw a *TypeError* exception.
+            1. Perform ? ValidateTypedArrayCompatibility(_target_, _source_).
             1. Let _targetElementSize_ be TypedArrayElementSize(_target_).
             1. Let _srcElementSize_ be TypedArrayElementSize(_source_).
             1. Let _targetType_ be TypedArrayElementType(_target_).
@@ -42554,7 +42554,7 @@ THH:mm:ss.sss
           1. Let _defaultConstructor_ be the intrinsic object associated with the constructor name _exemplar_.[[TypedArrayName]] in <emu-xref href="#table-the-typedarray-constructors"></emu-xref>.
           1. Let _constructor_ be ? SpeciesConstructor(_exemplar_, _defaultConstructor_).
           1. Let _result_ be ? TypedArrayCreateFromConstructor(_constructor_, _argumentList_).
-          1. If _result_.[[ContentType]] is not _exemplar_.[[ContentType]], throw a *TypeError* exception.
+          1. Perform ? ValidateTypedArrayCompatibility(_result_, _exemplar_).
           1. Return _result_.
         </emu-alg>
       </emu-clause>
@@ -42574,6 +42574,21 @@ THH:mm:ss.sss
           1. Let _taRecord_ be MakeTypedArrayWithBufferWitnessRecord(_O_, _order_).
           1. If IsTypedArrayOutOfBounds(_taRecord_) is *true*, throw a *TypeError* exception.
           1. Return _taRecord_.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-validatetypedarraycompatibility" type="abstract operation">
+        <h1>
+          ValidateTypedArrayCompatibility (
+            _a_: a TypedArray,
+            _b_: a TypedArray,
+          ): either a normal completion containing ~unused~ or a throw completion
+        </h1>
+        <dl class="header">
+        </dl>
+        <emu-alg>
+          1. If _a_.[[ContentType]] is not _b_.[[ContentType]], throw a *TypeError* exception.
+          1. Return ~unused~.
         </emu-alg>
       </emu-clause>
 
@@ -42766,7 +42781,7 @@ THH:mm:ss.sss
               1. Let _targetBuffer_ be ? CloneArrayBuffer(_srcBuffer_, _srcByteIndex_, _byteLength_).
             1. Else,
               1. Let _targetBuffer_ be ? <emu-meta suppress-effects="user-code">AllocateArrayBuffer(%ArrayBuffer%, _byteLength_)</emu-meta>.
-              1. If _srcArray_.[[ContentType]] is not _O_.[[ContentType]], throw a *TypeError* exception.
+              1. Perform ? ValidateTypedArrayCompatibility(_O_, _srcArray_).
               1. Let _targetByteIndex_ be 0.
               1. Let _srcElementSize_ be TypedArrayElementSize(_srcArray_).
               1. Repeat, while _targetByteIndex_ &lt; _byteLength_,

--- a/spec.html
+++ b/spec.html
@@ -15148,7 +15148,7 @@
         <dl class="header">
         </dl>
         <emu-alg>
-          1. Let _numValue_ be ? ToElementCategory(_value_, TypedArrayElementType(_O_)).
+          1. Let _numValue_ be ? ToNumericForTypedArray(_value_, TypedArrayElementType(_O_)).
           1. If IsValidIntegerIndex(_O_, _index_) is *true*, then
             1. Let _offset_ be _O_.[[ByteOffset]].
             1. Let _elementSize_ be TypedArrayElementSize(_O_).
@@ -41796,7 +41796,7 @@ THH:mm:ss.sss
           1. Let _O_ be the *this* value.
           1. Let _taRecord_ be ? ValidateTypedArray(_O_, ~seq-cst~).
           1. Let _len_ be TypedArrayLength(_taRecord_).
-          1. Set _value_ to ? ToElementCategory(_value_, TypedArrayElementType(_O_)).
+          1. Set _value_ to ? ToNumericForTypedArray(_value_, TypedArrayElementType(_O_)).
           1. Let _relativeStart_ be ? ToIntegerOrInfinity(_start_).
           1. If _relativeStart_ = -∞, let _startIndex_ be 0.
           1. Else if _relativeStart_ &lt; 0, let _startIndex_ be max(_len_ + _relativeStart_, 0).
@@ -42459,7 +42459,7 @@ THH:mm:ss.sss
           1. Let _relativeIndex_ be ? ToIntegerOrInfinity(_index_).
           1. If _relativeIndex_ ≥ 0, let _actualIndex_ be _relativeIndex_.
           1. Else, let _actualIndex_ be _len_ + _relativeIndex_.
-          1. Let _numericValue_ be ? ToElementCategory(_value_, TypedArrayElementType(_O_)).
+          1. Let _numericValue_ be ? ToNumericForTypedArray(_value_, TypedArrayElementType(_O_)).
           1. If IsValidIntegerIndex(_O_, 𝔽(_actualIndex_)) is *false*, throw a *RangeError* exception.
           1. Let _A_ be ? TypedArrayCreateSameType(_O_, « 𝔽(_len_) »).
           1. Let _k_ be 0.
@@ -44698,9 +44698,9 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-toelementcategory" type="abstract operation">
+      <emu-clause id="sec-tonumericfortypedarray" type="abstract operation">
         <h1>
-          ToElementCategory (
+          ToNumericForTypedArray (
             _value_: an ECMAScript language value,
             _type_: a TypedArray element type,
           ): either a normal completion containing either a Number or a BigInt, or a throw completion
@@ -45411,7 +45411,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_view_, [[DataView]]).
           1. Assert: _view_ has a [[ViewedArrayBuffer]] internal slot.
           1. Let _getIndex_ be ? ToIndex(_requestIndex_).
-          1. Let _numberValue_ be ? ToElementCategory(_value_, _type_).
+          1. Let _numberValue_ be ? ToNumericForTypedArray(_value_, _type_).
           1. Set _isLittleEndian_ to ToBoolean(_isLittleEndian_).
           1. Let _viewOffset_ be _view_.[[ByteOffset]].
           1. Let _viewRecord_ be MakeDataViewWithBufferWitnessRecord(_view_, ~unordered~).
@@ -46302,7 +46302,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _byteIndexInBuffer_ be ? ValidateAtomicAccessOnIntegerTypedArray(_typedArray_, _index_).
           1. Let _elementType_ be TypedArrayElementType(_typedArray_).
-          1. Let _v_ be ? ToElementCategory(_value_, _elementType_).
+          1. Let _v_ be ? ToNumericForTypedArray(_value_, _elementType_).
           1. Perform ? RevalidateAtomicAccess(_typedArray_, _byteIndexInBuffer_).
           1. Let _buffer_ be _typedArray_.[[ViewedArrayBuffer]].
           1. Return GetModifySetValueInBuffer(_buffer_, _byteIndexInBuffer_, _elementType_, _v_, _op_).
@@ -46400,8 +46400,8 @@ THH:mm:ss.sss
         1. Let _buffer_ be _typedArray_.[[ViewedArrayBuffer]].
         1. Let _block_ be _buffer_.[[ArrayBufferData]].
         1. Let _elementType_ be TypedArrayElementType(_typedArray_).
-        1. Let _expected_ be ? ToElementCategory(_expectedValue_, _elementType_).
-        1. Let _replacement_ be ? ToElementCategory(_replacementValue_, _elementType_).
+        1. Let _expected_ be ? ToNumericForTypedArray(_expectedValue_, _elementType_).
+        1. Let _replacement_ be ? ToNumericForTypedArray(_replacementValue_, _elementType_).
         1. Perform ? RevalidateAtomicAccess(_typedArray_, _byteIndexInBuffer_).
         1. Let _isLittleEndian_ be the value of the [[LittleEndian]] field of the surrounding agent's Agent Record.
         1. Let _expectedBytes_ be NumericToRawBytes(_elementType_, _expected_, _isLittleEndian_).
@@ -46474,7 +46474,7 @@ THH:mm:ss.sss
       <emu-alg>
         1. Let _byteIndexInBuffer_ be ? ValidateAtomicAccessOnIntegerTypedArray(_typedArray_, _index_).
         1. Let _elementType_ be TypedArrayElementType(_typedArray_).
-        1. Let _v_ be ? ToElementCategory(_value_, _elementType_).
+        1. Let _v_ be ? ToNumericForTypedArray(_value_, _elementType_).
         1. Perform ? RevalidateAtomicAccess(_typedArray_, _byteIndexInBuffer_).
         1. Let _buffer_ be _typedArray_.[[ViewedArrayBuffer]].
         1. Perform SetValueInBuffer(_buffer_, _byteIndexInBuffer_, _elementType_, _v_, *true*, ~seq-cst~).

--- a/spec.html
+++ b/spec.html
@@ -42553,7 +42553,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _constructor_ be the intrinsic object associated with the constructor name _exemplar_.[[TypedArrayName]] in <emu-xref href="#table-the-typedarray-constructors"></emu-xref>.
           1. Let _result_ be ? TypedArrayCreateFromConstructor(_constructor_, _argumentList_).
-          1. Assert: _result_.[[ContentType]] is _exemplar_.[[ContentType]].
+          1. Assert: _result_.[[TypedArrayName]] is _exemplar_.[[TypedArrayName]].
           1. Return _result_.
         </emu-alg>
       </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -41197,8 +41197,7 @@ THH:mm:ss.sss
             1. Let _index_ be _O_.[[ArrayLikeNextIndex]].
             1. Let _kind_ be _O_.[[ArrayLikeIterationKind]].
             1. If _array_ has a [[TypedArrayName]] internal slot, then
-              1. Let _taRecord_ be MakeTypedArrayWithBufferWitnessRecord(_array_, ~seq-cst~).
-              1. If IsTypedArrayOutOfBounds(_taRecord_) is *true*, throw a *TypeError* exception.
+              1. Let _taRecord_ be ? ValidateTypedArray(_array_, ~seq-cst~).
               1. Let _len_ be TypedArrayLength(_taRecord_).
             1. Else,
               1. Let _len_ be ? LengthOfArrayLike(_array_).
@@ -41732,8 +41731,7 @@ THH:mm:ss.sss
           1. If _count_ > 0, then
             1. NOTE: The copying must be performed in a manner that preserves the bit-level encoding of the source data.
             1. Let _buffer_ be _O_.[[ViewedArrayBuffer]].
-            1. Set _taRecord_ to MakeTypedArrayWithBufferWitnessRecord(_O_, ~seq-cst~).
-            1. If IsTypedArrayOutOfBounds(_taRecord_) is *true*, throw a *TypeError* exception.
+            1. Set _taRecord_ to ? ValidateTypedArray(_O_, ~seq-cst~).
             1. Set _len_ to TypedArrayLength(_taRecord_).
             1. Let _elementSize_ be TypedArrayElementSize(_O_).
             1. Let _byteOffset_ be _O_.[[ByteOffset]].
@@ -41809,8 +41807,7 @@ THH:mm:ss.sss
           1. If _relativeEnd_ = -∞, let _endIndex_ be 0.
           1. Else if _relativeEnd_ &lt; 0, let _endIndex_ be max(_len_ + _relativeEnd_, 0).
           1. Else, let _endIndex_ be min(_relativeEnd_, _len_).
-          1. Set _taRecord_ to MakeTypedArrayWithBufferWitnessRecord(_O_, ~seq-cst~).
-          1. If IsTypedArrayOutOfBounds(_taRecord_) is *true*, throw a *TypeError* exception.
+          1. Set _taRecord_ to ? ValidateTypedArray(_O_, ~seq-cst~).
           1. Set _len_ to TypedArrayLength(_taRecord_).
           1. Set _endIndex_ to min(_endIndex_, _len_).
           1. Let _k_ be _startIndex_.
@@ -42194,8 +42191,7 @@ THH:mm:ss.sss
             <dd>It sets multiple values in _target_, starting at index _targetOffset_, reading the values from _source_.</dd>
           </dl>
           <emu-alg>
-            1. Let _targetRecord_ be MakeTypedArrayWithBufferWitnessRecord(_target_, ~seq-cst~).
-            1. If IsTypedArrayOutOfBounds(_targetRecord_) is *true*, throw a *TypeError* exception.
+            1. Let _targetRecord_ be ? ValidateTypedArray(_target_, ~seq-cst~).
             1. Let _targetLength_ be TypedArrayLength(_targetRecord_).
             1. Let _src_ be ? ToObject(_source_).
             1. Let _srcLength_ be ? LengthOfArrayLike(_src_).
@@ -42226,12 +42222,10 @@ THH:mm:ss.sss
           </dl>
           <emu-alg>
             1. Let _targetBuffer_ be _target_.[[ViewedArrayBuffer]].
-            1. Let _targetRecord_ be MakeTypedArrayWithBufferWitnessRecord(_target_, ~seq-cst~).
-            1. If IsTypedArrayOutOfBounds(_targetRecord_) is *true*, throw a *TypeError* exception.
+            1. Let _targetRecord_ be ? ValidateTypedArray(_target_, ~seq-cst~).
             1. Let _targetLength_ be TypedArrayLength(_targetRecord_).
             1. Let _srcBuffer_ be _source_.[[ViewedArrayBuffer]].
-            1. Let _srcRecord_ be MakeTypedArrayWithBufferWitnessRecord(_source_, ~seq-cst~).
-            1. If IsTypedArrayOutOfBounds(_srcRecord_) is *true*, throw a *TypeError* exception.
+            1. Let _srcRecord_ be ? ValidateTypedArray(_source_, ~seq-cst~).
             1. Let _srcLength_ be TypedArrayLength(_srcRecord_).
             1. Let _targetType_ be TypedArrayElementType(_target_).
             1. Let _targetElementSize_ be TypedArrayElementSize(_target_).
@@ -42288,8 +42282,7 @@ THH:mm:ss.sss
           1. Let _countBytes_ be max(_endIndex_ - _startIndex_, 0).
           1. Let _A_ be ? TypedArraySpeciesCreate(_O_, « 𝔽(_countBytes_) »).
           1. If _countBytes_ > 0, then
-            1. Set _taRecord_ to MakeTypedArrayWithBufferWitnessRecord(_O_, ~seq-cst~).
-            1. If IsTypedArrayOutOfBounds(_taRecord_) is *true*, throw a *TypeError* exception.
+            1. Set _taRecord_ to ? ValidateTypedArray(_O_, ~seq-cst~).
             1. Set _endIndex_ to min(_endIndex_, TypedArrayLength(_taRecord_)).
             1. Set _countBytes_ to max(_endIndex_ - _startIndex_, 0).
             1. Let _srcType_ be TypedArrayElementType(_O_).
@@ -42745,8 +42738,7 @@ THH:mm:ss.sss
             1. Let _srcType_ be TypedArrayElementType(_srcArray_).
             1. Let _srcElementSize_ be TypedArrayElementSize(_srcArray_).
             1. Let _srcByteOffset_ be _srcArray_.[[ByteOffset]].
-            1. Let _srcRecord_ be MakeTypedArrayWithBufferWitnessRecord(_srcArray_, ~seq-cst~).
-            1. If IsTypedArrayOutOfBounds(_srcRecord_) is *true*, throw a *TypeError* exception.
+            1. Let _srcRecord_ be ? ValidateTypedArray(_srcArray_, ~seq-cst~).
             1. Let _elementLength_ be TypedArrayLength(_srcRecord_).
             1. Let _byteLength_ be _elementSize_ × _elementLength_.
             1. If _elementType_ is _srcType_, then
@@ -45955,9 +45947,8 @@ THH:mm:ss.sss
           <dd>This operation revalidates the index within the backing buffer for atomic operations after all argument coercions are performed in Atomics methods, as argument coercions can have arbitrary side effects, which could cause the buffer to become out of bounds. This operation does not throw when _typedArray_'s backing buffer is a SharedArrayBuffer.</dd>
         </dl>
         <emu-alg>
-          1. Let _taRecord_ be MakeTypedArrayWithBufferWitnessRecord(_typedArray_, ~unordered~).
           1. NOTE: Bounds checking is not a synchronizing operation when _typedArray_'s backing buffer is a growable SharedArrayBuffer.
-          1. If IsTypedArrayOutOfBounds(_taRecord_) is *true*, throw a *TypeError* exception.
+          1. Let _taRecord_ be ? ValidateTypedArray(_typedArray_, ~unordered~).
           1. Assert: _byteIndexInBuffer_ ≥ _typedArray_.[[ByteOffset]].
           1. If _byteIndexInBuffer_ ≥ _taRecord_.[[CachedBufferByteLength]], throw a *RangeError* exception.
           1. Return ~unused~.

--- a/spec.html
+++ b/spec.html
@@ -15148,8 +15148,7 @@
         <dl class="header">
         </dl>
         <emu-alg>
-          1. If _O_.[[ContentType]] is ~bigint~, let _numValue_ be ? ToBigInt(_value_).
-          1. Otherwise, let _numValue_ be ? ToNumber(_value_).
+          1. Let _numValue_ be ? ToElementCategory(_value_, TypedArrayElementType(_O_)).
           1. If IsValidIntegerIndex(_O_, _index_) is *true*, then
             1. Let _offset_ be _O_.[[ByteOffset]].
             1. Let _elementSize_ be TypedArrayElementSize(_O_).
@@ -41797,8 +41796,7 @@ THH:mm:ss.sss
           1. Let _O_ be the *this* value.
           1. Let _taRecord_ be ? ValidateTypedArray(_O_, ~seq-cst~).
           1. Let _len_ be TypedArrayLength(_taRecord_).
-          1. If _O_.[[ContentType]] is ~bigint~, set _value_ to ? ToBigInt(_value_).
-          1. Otherwise, set _value_ to ? ToNumber(_value_).
+          1. Set _value_ to ? ToElementCategory(_value_, TypedArrayElementType(_O_)).
           1. Let _relativeStart_ be ? ToIntegerOrInfinity(_start_).
           1. If _relativeStart_ = -∞, let _startIndex_ be 0.
           1. Else if _relativeStart_ &lt; 0, let _startIndex_ be max(_len_ + _relativeStart_, 0).
@@ -42470,8 +42468,7 @@ THH:mm:ss.sss
           1. Let _relativeIndex_ be ? ToIntegerOrInfinity(_index_).
           1. If _relativeIndex_ ≥ 0, let _actualIndex_ be _relativeIndex_.
           1. Else, let _actualIndex_ be _len_ + _relativeIndex_.
-          1. If _O_.[[ContentType]] is ~bigint~, let _numericValue_ be ? ToBigInt(_value_).
-          1. Else, let _numericValue_ be ? ToNumber(_value_).
+          1. Let _numericValue_ be ? ToElementCategory(_value_, TypedArrayElementType(_O_)).
           1. If IsValidIntegerIndex(_O_, 𝔽(_actualIndex_)) is *false*, throw a *RangeError* exception.
           1. Let _A_ be ? TypedArrayCreateSameType(_O_, « 𝔽(_len_) »).
           1. Let _k_ be 0.
@@ -44687,6 +44684,21 @@ THH:mm:ss.sss
           1. Return RawBytesToNumeric(_type_, _rawBytesRead_, _isLittleEndian_).
         </emu-alg>
       </emu-clause>
+
+      <emu-clause id="sec-toelementcategory" type="abstract operation">
+        <h1>
+          ToElementCategory (
+            _value_: an ECMAScript language value,
+            _type_: a TypedArray element type,
+          ): either a normal completion containing either a Number or a BigInt, or a throw completion
+        </h1>
+        <dl class="header">
+        </dl>
+        <emu-alg>
+          1. If _type_ is either ~bigint64~ or ~biguint64~, return ? ToBigInt(_value_).
+          1. Return ? ToNumber(_value_).
+        </emu-alg>
+      </emu-clause>
     </emu-clause>
 
     <emu-clause id="sec-arraybuffer-constructor">
@@ -45386,8 +45398,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_view_, [[DataView]]).
           1. Assert: _view_ has a [[ViewedArrayBuffer]] internal slot.
           1. Let _getIndex_ be ? ToIndex(_requestIndex_).
-          1. If IsBigIntElementType(_type_) is *true*, let _numberValue_ be ? ToBigInt(_value_).
-          1. Otherwise, let _numberValue_ be ? ToNumber(_value_).
+          1. Let _numberValue_ be ? ToElementCategory(_value_, _type_).
           1. Set _isLittleEndian_ to ToBoolean(_isLittleEndian_).
           1. Let _viewOffset_ be _view_.[[ByteOffset]].
           1. Let _viewRecord_ be MakeDataViewWithBufferWitnessRecord(_view_, ~unordered~).

--- a/spec.html
+++ b/spec.html
@@ -43338,7 +43338,7 @@ THH:mm:ss.sss
           1. Let _ctor_ be the intrinsic object associated with the constructor name _exemplar_.[[TypedArrayName]] in <emu-xref href="#table-the-typedarray-constructors"></emu-xref>.
           1. Let _result_ be ? <emu-meta suppress-effects="user-code">TypedArrayCreateFromConstructor(_ctor_, « 𝔽(_length_) »)</emu-meta>.
           1. Assert: _result_ has [[TypedArrayName]] and [[ContentType]] internal slots.
-          1. Assert: _result_.[[ContentType]] is _exemplar_.[[ContentType]].
+          1. Assert: _result_.[[TypedArrayName]] is _exemplar_.[[TypedArrayName]].
           1. Return _result_.
         </emu-alg>
       </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -43466,20 +43466,18 @@ THH:mm:ss.sss
             1. Let _elementLength_ be ? ToIndex(_firstArg_).
             1. Return ? AllocateTypedArray(_ctorName_, NewTarget, _proto_, _elementLength_).
           1. Let _obj_ be ? AllocateTypedArray(_ctorName_, NewTarget, _proto_).
-          1. If _firstArg_ has a [[TypedArrayName]] internal slot, then
-            1. Perform ? InitializeTypedArrayFromTypedArray(_obj_, _firstArg_).
-          1. Else if _firstArg_ has an [[ArrayBufferData]] internal slot, then
+          1. If _firstArg_ has an [[ArrayBufferData]] internal slot, then
             1. If _numberOfArgs_ > 1, let _byteOffset_ be _args_[1]; else let _byteOffset_ be *undefined*.
             1. If _numberOfArgs_ > 2, let _length_ be _args_[2]; else let _length_ be *undefined*.
             1. Perform ? InitializeTypedArrayFromArrayBuffer(_obj_, _firstArg_, _byteOffset_, _length_).
+          1. Else if _firstArg_ has a [[TypedArrayName]] internal slot, then
+            1. Perform ? InitializeTypedArrayFromTypedArray(_obj_, _firstArg_).
           1. Else,
-            1. Assert: _firstArg_ is an Object and _firstArg_ does not have either a [[TypedArrayName]] or an [[ArrayBufferData]] internal slot.
             1. Let _usingIterator_ be ? GetMethod(_firstArg_, %Symbol.iterator%).
             1. If _usingIterator_ is not *undefined*, then
               1. Let _values_ be ? IteratorToList(? GetIteratorFromMethod(_firstArg_, _usingIterator_)).
               1. Perform ? InitializeTypedArrayFromList(_obj_, _values_).
             1. Else,
-              1. NOTE: _firstArg_ is not an iterable object, so assume it is already an array-like object.
               1. Perform ? InitializeTypedArrayFromArrayLike(_obj_, _firstArg_).
           1. Return _obj_.
         </emu-alg>
@@ -43511,6 +43509,43 @@ THH:mm:ss.sss
             1. Else,
               1. Perform ? AllocateTypedArrayBuffer(_obj_, _length_).
             1. Return _obj_.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-initializetypedarrayfromarraybuffer" type="abstract operation" oldids="sec-typedarray-buffer-byteoffset-length">
+          <h1>
+            InitializeTypedArrayFromArrayBuffer (
+              _obj_: a TypedArray,
+              _buffer_: an ArrayBuffer or a SharedArrayBuffer,
+              _byteOffset_: an ECMAScript language value,
+              _length_: an ECMAScript language value,
+            ): either a normal completion containing ~unused~ or a throw completion
+          </h1>
+          <dl class="header">
+          </dl>
+          <emu-alg>
+            1. Let _elementSize_ be TypedArrayElementSize(_obj_).
+            1. Set _byteOffset_ to ? ToIndex(_byteOffset_).
+            1. If _byteOffset_ modulo _elementSize_ ≠ 0, throw a *RangeError* exception.
+            1. If _length_ is not *undefined*, set _length_ to ? ToIndex(_length_).
+            1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
+            1. Let _bufferByteLength_ be ArrayBufferByteLength(_buffer_, ~seq-cst~).
+            1. If _byteOffset_ > _bufferByteLength_, throw a *RangeError* exception.
+            1. If _length_ is *undefined* and IsFixedLengthArrayBuffer(_buffer_) is *false*, then
+              1. Set _obj_.[[ByteLength]] to ~auto~.
+              1. Set _obj_.[[ArrayLength]] to ~auto~.
+            1. Else,
+              1. If _length_ is *undefined*, then
+                1. Let _byteLength_ be _bufferByteLength_ - _byteOffset_.
+                1. If _byteLength_ modulo _elementSize_ ≠ 0, throw a *RangeError* exception.
+              1. Else,
+                1. Let _byteLength_ be _length_ × _elementSize_.
+                1. If _byteOffset_ + _byteLength_ > _bufferByteLength_, throw a *RangeError* exception.
+              1. Set _obj_.[[ByteLength]] to _byteLength_.
+              1. Set _obj_.[[ArrayLength]] to _byteLength_ / _elementSize_.
+            1. Set _obj_.[[ViewedArrayBuffer]] to _buffer_.
+            1. Set _obj_.[[ByteOffset]] to _byteOffset_.
+            1. Return ~unused~.
           </emu-alg>
         </emu-clause>
 
@@ -43548,43 +43583,6 @@ THH:mm:ss.sss
             1. Set _obj_.[[ByteLength]] to _targetByteLength_.
             1. Set _obj_.[[ByteOffset]] to 0.
             1. Set _obj_.[[ArrayLength]] to _elementLength_.
-            1. Return ~unused~.
-          </emu-alg>
-        </emu-clause>
-
-        <emu-clause id="sec-initializetypedarrayfromarraybuffer" type="abstract operation" oldids="sec-typedarray-buffer-byteoffset-length">
-          <h1>
-            InitializeTypedArrayFromArrayBuffer (
-              _obj_: a TypedArray,
-              _buffer_: an ArrayBuffer or a SharedArrayBuffer,
-              _byteOffset_: an ECMAScript language value,
-              _length_: an ECMAScript language value,
-            ): either a normal completion containing ~unused~ or a throw completion
-          </h1>
-          <dl class="header">
-          </dl>
-          <emu-alg>
-            1. Let _elementSize_ be TypedArrayElementSize(_obj_).
-            1. Set _byteOffset_ to ? ToIndex(_byteOffset_).
-            1. If _byteOffset_ modulo _elementSize_ ≠ 0, throw a *RangeError* exception.
-            1. If _length_ is not *undefined*, set _length_ to ? ToIndex(_length_).
-            1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
-            1. Let _bufferByteLength_ be ArrayBufferByteLength(_buffer_, ~seq-cst~).
-            1. If _byteOffset_ > _bufferByteLength_, throw a *RangeError* exception.
-            1. If _length_ is *undefined* and IsFixedLengthArrayBuffer(_buffer_) is *false*, then
-              1. Set _obj_.[[ByteLength]] to ~auto~.
-              1. Set _obj_.[[ArrayLength]] to ~auto~.
-            1. Else,
-              1. If _length_ is *undefined*, then
-                1. Let _byteLength_ be _bufferByteLength_ - _byteOffset_.
-                1. If _byteLength_ modulo _elementSize_ ≠ 0, throw a *RangeError* exception.
-              1. Else,
-                1. Let _byteLength_ be _length_ × _elementSize_.
-                1. If _byteOffset_ + _byteLength_ > _bufferByteLength_, throw a *RangeError* exception.
-              1. Set _obj_.[[ByteLength]] to _byteLength_.
-              1. Set _obj_.[[ArrayLength]] to _byteLength_ / _elementSize_.
-            1. Set _obj_.[[ViewedArrayBuffer]] to _buffer_.
-            1. Set _obj_.[[ByteOffset]] to _byteOffset_.
             1. Return ~unused~.
           </emu-alg>
         </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -43462,27 +43462,26 @@ THH:mm:ss.sss
           1. Let _numberOfArgs_ be the number of elements in _args_.
           1. If _numberOfArgs_ = 0, return ? AllocateTypedArray(_ctorName_, NewTarget, _proto_, 0).
           1. Let _firstArg_ be _args_[0].
-          1. If _firstArg_ is an Object, then
-            1. Let _obj_ be ? AllocateTypedArray(_ctorName_, NewTarget, _proto_).
-            1. If _firstArg_ has a [[TypedArrayName]] internal slot, then
-              1. Perform ? InitializeTypedArrayFromTypedArray(_obj_, _firstArg_).
-            1. Else if _firstArg_ has an [[ArrayBufferData]] internal slot, then
-              1. If _numberOfArgs_ > 1, let _byteOffset_ be _args_[1]; else let _byteOffset_ be *undefined*.
-              1. If _numberOfArgs_ > 2, let _length_ be _args_[2]; else let _length_ be *undefined*.
-              1. Perform ? InitializeTypedArrayFromArrayBuffer(_obj_, _firstArg_, _byteOffset_, _length_).
+          1. If _firstArg_ is not an Object, then
+            1. Let _elementLength_ be ? ToIndex(_firstArg_).
+            1. Return ? AllocateTypedArray(_ctorName_, NewTarget, _proto_, _elementLength_).
+          1. Let _obj_ be ? AllocateTypedArray(_ctorName_, NewTarget, _proto_).
+          1. If _firstArg_ has a [[TypedArrayName]] internal slot, then
+            1. Perform ? InitializeTypedArrayFromTypedArray(_obj_, _firstArg_).
+          1. Else if _firstArg_ has an [[ArrayBufferData]] internal slot, then
+            1. If _numberOfArgs_ > 1, let _byteOffset_ be _args_[1]; else let _byteOffset_ be *undefined*.
+            1. If _numberOfArgs_ > 2, let _length_ be _args_[2]; else let _length_ be *undefined*.
+            1. Perform ? InitializeTypedArrayFromArrayBuffer(_obj_, _firstArg_, _byteOffset_, _length_).
+          1. Else,
+            1. Assert: _firstArg_ is an Object and _firstArg_ does not have either a [[TypedArrayName]] or an [[ArrayBufferData]] internal slot.
+            1. Let _usingIterator_ be ? GetMethod(_firstArg_, %Symbol.iterator%).
+            1. If _usingIterator_ is not *undefined*, then
+              1. Let _values_ be ? IteratorToList(? GetIteratorFromMethod(_firstArg_, _usingIterator_)).
+              1. Perform ? InitializeTypedArrayFromList(_obj_, _values_).
             1. Else,
-              1. Assert: _firstArg_ is an Object and _firstArg_ does not have either a [[TypedArrayName]] or an [[ArrayBufferData]] internal slot.
-              1. Let _usingIterator_ be ? GetMethod(_firstArg_, %Symbol.iterator%).
-              1. If _usingIterator_ is not *undefined*, then
-                1. Let _values_ be ? IteratorToList(? GetIteratorFromMethod(_firstArg_, _usingIterator_)).
-                1. Perform ? InitializeTypedArrayFromList(_obj_, _values_).
-              1. Else,
-                1. NOTE: _firstArg_ is not an iterable object, so assume it is already an array-like object.
-                1. Perform ? InitializeTypedArrayFromArrayLike(_obj_, _firstArg_).
-            1. Return _obj_.
-          1. Assert: _firstArg_ is not an Object.
-          1. Let _elementLength_ be ? ToIndex(_firstArg_).
-          1. Return ? AllocateTypedArray(_ctorName_, NewTarget, _proto_, _elementLength_).
+              1. NOTE: _firstArg_ is not an iterable object, so assume it is already an array-like object.
+              1. Perform ? InitializeTypedArrayFromArrayLike(_obj_, _firstArg_).
+          1. Return _obj_.
         </emu-alg>
 
         <emu-clause id="sec-allocatetypedarray" type="abstract operation">
@@ -43525,31 +43524,28 @@ THH:mm:ss.sss
           <dl class="header">
           </dl>
           <emu-alg>
-            1. Let _sourceData_ be _sourceArray_.[[ViewedArrayBuffer]].
-            1. Let _elementType_ be TypedArrayElementType(_obj_).
-            1. Let _elementSize_ be TypedArrayElementSize(_obj_).
-            1. Let _sourceType_ be TypedArrayElementType(_sourceArray_).
-            1. Let _sourceElementSize_ be TypedArrayElementSize(_sourceArray_).
-            1. Let _sourceByteOffset_ be _sourceArray_.[[ByteOffset]].
             1. Let _sourceRecord_ be ? ValidateTypedArrayBounds(_sourceArray_, ~seq-cst~).
+            1. Let _sourceBuffer_ be _sourceArray_.[[ViewedArrayBuffer]].
+            1. Let _sourceByteIndex_ be _sourceArray_.[[ByteOffset]].
             1. Let _elementLength_ be TypedArrayLength(_sourceRecord_).
-            1. Let _byteLength_ be _elementSize_ × _elementLength_.
-            1. If _elementType_ is _sourceType_, then
-              1. Let _data_ be ? CloneArrayBuffer(_sourceData_, _sourceByteOffset_, _byteLength_).
+            1. Let _targetElementSize_ be TypedArrayElementSize(_obj_).
+            1. Let _targetByteLength_ be _targetElementSize_ × _elementLength_.
+            1. Let _targetType_ be TypedArrayElementType(_obj_).
+            1. Let _sourceType_ be TypedArrayElementType(_sourceArray_).
+            1. If _targetType_ is _sourceType_, then
+              1. Let _targetBuffer_ be ? CloneArrayBuffer(_sourceBuffer_, _sourceByteIndex_, _targetByteLength_).
             1. Else,
-              1. Let _data_ be ? <emu-meta suppress-effects="user-code">AllocateArrayBuffer(%ArrayBuffer%, _byteLength_)</emu-meta>.
-              1. If _sourceArray_.[[ContentType]] is not _obj_.[[ContentType]], throw a *TypeError* exception.
-              1. Let _sourceByteIndex_ be _sourceByteOffset_.
+              1. Let _targetBuffer_ be ? <emu-meta suppress-effects="user-code">AllocateArrayBuffer(%ArrayBuffer%, _targetByteLength_)</emu-meta>.
+              1. If _obj_.[[ContentType]] is not _sourceArray_.[[ContentType]], throw a *TypeError* exception.
+              1. Let _sourceElementSize_ be TypedArrayElementSize(_sourceArray_).
               1. Let _targetByteIndex_ be 0.
-              1. Let _count_ be _elementLength_.
-              1. Repeat, while _count_ > 0,
-                1. Let _value_ be GetValueFromBuffer(_sourceData_, _sourceByteIndex_, _sourceType_, *true*, ~unordered~).
-                1. Perform SetValueInBuffer(_data_, _targetByteIndex_, _elementType_, _value_, *true*, ~unordered~).
+              1. Repeat, while _targetByteIndex_ &lt; _targetByteLength_,
+                1. Let _value_ be GetValueFromBuffer(_sourceBuffer_, _sourceByteIndex_, _sourceType_, *true*, ~unordered~).
+                1. Perform SetValueInBuffer(_targetBuffer_, _targetByteIndex_, _targetType_, _value_, *true*, ~unordered~).
                 1. Set _sourceByteIndex_ to _sourceByteIndex_ + _sourceElementSize_.
-                1. Set _targetByteIndex_ to _targetByteIndex_ + _elementSize_.
-                1. Set _count_ to _count_ - 1.
-            1. Set _obj_.[[ViewedArrayBuffer]] to _data_.
-            1. Set _obj_.[[ByteLength]] to _byteLength_.
+                1. Set _targetByteIndex_ to _targetByteIndex_ + _targetElementSize_.
+            1. Set _obj_.[[ViewedArrayBuffer]] to _targetBuffer_.
+            1. Set _obj_.[[ByteLength]] to _targetByteLength_.
             1. Set _obj_.[[ByteOffset]] to 0.
             1. Set _obj_.[[ArrayLength]] to _elementLength_.
             1. Return ~unused~.
@@ -43569,29 +43565,26 @@ THH:mm:ss.sss
           </dl>
           <emu-alg>
             1. Let _elementSize_ be TypedArrayElementSize(_obj_).
-            1. Let _offset_ be ? ToIndex(_byteOffset_).
-            1. If _offset_ modulo _elementSize_ ≠ 0, throw a *RangeError* exception.
-            1. Let _bufferIsFixedLength_ be IsFixedLengthArrayBuffer(_buffer_).
-            1. If _length_ is not *undefined*, then
-              1. Let _newLength_ be ? ToIndex(_length_).
+            1. Set _byteOffset_ to ? ToIndex(_byteOffset_).
+            1. If _byteOffset_ modulo _elementSize_ ≠ 0, throw a *RangeError* exception.
+            1. If _length_ is not *undefined*, set _length_ to ? ToIndex(_length_).
             1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
             1. Let _bufferByteLength_ be ArrayBufferByteLength(_buffer_, ~seq-cst~).
-            1. If _length_ is *undefined* and _bufferIsFixedLength_ is *false*, then
-              1. If _offset_ > _bufferByteLength_, throw a *RangeError* exception.
+            1. If _byteOffset_ > _bufferByteLength_, throw a *RangeError* exception.
+            1. If _length_ is *undefined* and IsFixedLengthArrayBuffer(_buffer_) is *false*, then
               1. Set _obj_.[[ByteLength]] to ~auto~.
               1. Set _obj_.[[ArrayLength]] to ~auto~.
             1. Else,
               1. If _length_ is *undefined*, then
-                1. If _bufferByteLength_ modulo _elementSize_ ≠ 0, throw a *RangeError* exception.
-                1. Let _newByteLength_ be _bufferByteLength_ - _offset_.
-                1. If _newByteLength_ &lt; 0, throw a *RangeError* exception.
+                1. Let _byteLength_ be _bufferByteLength_ - _byteOffset_.
+                1. If _byteLength_ modulo _elementSize_ ≠ 0, throw a *RangeError* exception.
               1. Else,
-                1. Let _newByteLength_ be _newLength_ × _elementSize_.
-                1. If _offset_ + _newByteLength_ > _bufferByteLength_, throw a *RangeError* exception.
-              1. Set _obj_.[[ByteLength]] to _newByteLength_.
-              1. Set _obj_.[[ArrayLength]] to _newByteLength_ / _elementSize_.
+                1. Let _byteLength_ be _length_ × _elementSize_.
+                1. If _byteOffset_ + _byteLength_ > _bufferByteLength_, throw a *RangeError* exception.
+              1. Set _obj_.[[ByteLength]] to _byteLength_.
+              1. Set _obj_.[[ArrayLength]] to _byteLength_ / _elementSize_.
             1. Set _obj_.[[ViewedArrayBuffer]] to _buffer_.
-            1. Set _obj_.[[ByteOffset]] to _offset_.
+            1. Set _obj_.[[ByteOffset]] to _byteOffset_.
             1. Return ~unused~.
           </emu-alg>
         </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -43463,13 +43463,13 @@ THH:mm:ss.sss
           1. If _numberOfArgs_ = 0, return ? AllocateTypedArray(_ctorName_, NewTarget, _proto_, 0).
           1. Let _firstArg_ be _args_[0].
           1. If _firstArg_ is not an Object, then
-            1. Let _elementLength_ be ? ToIndex(_firstArg_).
-            1. Return ? AllocateTypedArray(_ctorName_, NewTarget, _proto_, _elementLength_).
+            1. Let _elementCount_ be ? ToIndex(_firstArg_).
+            1. Return ? AllocateTypedArray(_ctorName_, NewTarget, _proto_, _elementCount_).
           1. Let _obj_ be ? AllocateTypedArray(_ctorName_, NewTarget, _proto_).
           1. If _firstArg_ has an [[ArrayBufferData]] internal slot, then
             1. If _numberOfArgs_ > 1, let _byteOffset_ be _args_[1]; else let _byteOffset_ be *undefined*.
-            1. If _numberOfArgs_ > 2, let _length_ be _args_[2]; else let _length_ be *undefined*.
-            1. Perform ? InitializeTypedArrayFromArrayBuffer(_obj_, _firstArg_, _byteOffset_, _length_).
+            1. If _numberOfArgs_ > 2, let _elementCount_ be _args_[2]; else let _elementCount_ be *undefined*.
+            1. Perform ? InitializeTypedArrayFromArrayBuffer(_obj_, _firstArg_, _byteOffset_, _elementCount_).
           1. Else if _firstArg_ has a [[TypedArrayName]] internal slot, then
             1. Perform ? InitializeTypedArrayFromTypedArray(_obj_, _firstArg_).
           1. Else,
@@ -43488,12 +43488,12 @@ THH:mm:ss.sss
               _ctorName_: a String which is the name of a TypedArray constructor in <emu-xref href="#table-the-typedarray-constructors"></emu-xref>,
               _newTarget_: a constructor,
               _defaultProto_: a String,
-              optional _length_: a non-negative integer,
+              optional _elementCount_: a non-negative integer,
             ): either a normal completion containing a TypedArray or a throw completion
           </h1>
           <dl class="header">
             <dt>description</dt>
-            <dd>It is used to validate and create an instance of a TypedArray constructor. If the _length_ argument is passed, an ArrayBuffer of that length is also allocated and associated with the new TypedArray instance. AllocateTypedArray provides common semantics that is used by _TypedArray_.</dd>
+            <dd>It is used to validate and create an instance of a TypedArray constructor. If the _elementCount_ argument is passed, an ArrayBuffer of that length is also allocated and associated with the new TypedArray instance. AllocateTypedArray provides common semantics that is used by _TypedArray_.</dd>
           </dl>
           <emu-alg>
             1. Let _proto_ be ? GetPrototypeFromConstructor(_newTarget_, _defaultProto_).
@@ -43502,12 +43502,12 @@ THH:mm:ss.sss
             1. Set _obj_.[[TypedArrayName]] to _ctorName_.
             1. If _ctorName_ is either *"BigInt64Array"* or *"BigUint64Array"*, set _obj_.[[ContentType]] to ~bigint~.
             1. Else, set _obj_.[[ContentType]] to ~number~.
-            1. If _length_ is not present, then
+            1. If _elementCount_ is not present, then
               1. Set _obj_.[[ByteLength]] to 0.
               1. Set _obj_.[[ByteOffset]] to 0.
               1. Set _obj_.[[ArrayLength]] to 0.
             1. Else,
-              1. Perform ? AllocateTypedArrayBuffer(_obj_, _length_).
+              1. Perform ? AllocateTypedArrayBuffer(_obj_, _elementCount_).
             1. Return _obj_.
           </emu-alg>
         </emu-clause>
@@ -43518,7 +43518,7 @@ THH:mm:ss.sss
               _obj_: a TypedArray,
               _buffer_: an ArrayBuffer or a SharedArrayBuffer,
               _byteOffset_: an ECMAScript language value,
-              _length_: an ECMAScript language value,
+              _elementCount_: an ECMAScript language value,
             ): either a normal completion containing ~unused~ or a throw completion
           </h1>
           <dl class="header">
@@ -43527,19 +43527,19 @@ THH:mm:ss.sss
             1. Let _elementSize_ be TypedArrayElementSize(_obj_).
             1. Set _byteOffset_ to ? ToIndex(_byteOffset_).
             1. If _byteOffset_ modulo _elementSize_ ≠ 0, throw a *RangeError* exception.
-            1. If _length_ is not *undefined*, set _length_ to ? ToIndex(_length_).
+            1. If _elementCount_ is not *undefined*, set _elementCount_ to ? ToIndex(_elementCount_).
             1. If IsDetachedBuffer(_buffer_) is *true*, throw a *TypeError* exception.
             1. Let _bufferByteLength_ be ArrayBufferByteLength(_buffer_, ~seq-cst~).
             1. If _byteOffset_ > _bufferByteLength_, throw a *RangeError* exception.
-            1. If _length_ is *undefined* and IsFixedLengthArrayBuffer(_buffer_) is *false*, then
+            1. If _elementCount_ is *undefined* and IsFixedLengthArrayBuffer(_buffer_) is *false*, then
               1. Set _obj_.[[ByteLength]] to ~auto~.
               1. Set _obj_.[[ArrayLength]] to ~auto~.
             1. Else,
-              1. If _length_ is *undefined*, then
+              1. If _elementCount_ is *undefined*, then
                 1. Let _byteLength_ be _bufferByteLength_ - _byteOffset_.
                 1. If _byteLength_ modulo _elementSize_ ≠ 0, throw a *RangeError* exception.
               1. Else,
-                1. Let _byteLength_ be _length_ × _elementSize_.
+                1. Let _byteLength_ be _elementSize_ × _elementCount_.
                 1. If _byteOffset_ + _byteLength_ > _bufferByteLength_, throw a *RangeError* exception.
               1. Set _obj_.[[ByteLength]] to _byteLength_.
               1. Set _obj_.[[ArrayLength]] to _byteLength_ / _elementSize_.
@@ -43562,9 +43562,9 @@ THH:mm:ss.sss
             1. Let _sourceRecord_ be ? ValidateTypedArrayBounds(_sourceArray_, ~seq-cst~).
             1. Let _sourceBuffer_ be _sourceArray_.[[ViewedArrayBuffer]].
             1. Let _sourceByteIndex_ be _sourceArray_.[[ByteOffset]].
-            1. Let _elementLength_ be TypedArrayLength(_sourceRecord_).
+            1. Let _elementCount_ be TypedArrayLength(_sourceRecord_).
             1. Let _targetElementSize_ be TypedArrayElementSize(_obj_).
-            1. Let _targetByteLength_ be _targetElementSize_ × _elementLength_.
+            1. Let _targetByteLength_ be _targetElementSize_ × _elementCount_.
             1. Let _targetType_ be TypedArrayElementType(_obj_).
             1. Let _sourceType_ be TypedArrayElementType(_sourceArray_).
             1. If _targetType_ is _sourceType_, then
@@ -43582,7 +43582,7 @@ THH:mm:ss.sss
             1. Set _obj_.[[ViewedArrayBuffer]] to _targetBuffer_.
             1. Set _obj_.[[ByteLength]] to _targetByteLength_.
             1. Set _obj_.[[ByteOffset]] to 0.
-            1. Set _obj_.[[ArrayLength]] to _elementLength_.
+            1. Set _obj_.[[ArrayLength]] to _elementCount_.
             1. Return ~unused~.
           </emu-alg>
         </emu-clause>
@@ -43637,7 +43637,7 @@ THH:mm:ss.sss
           <h1>
             AllocateTypedArrayBuffer (
               _obj_: a TypedArray,
-              _length_: a non-negative integer,
+              _elementCount_: a non-negative integer,
             ): either a normal completion containing ~unused~ or a throw completion
           </h1>
           <dl class="header">
@@ -43647,12 +43647,12 @@ THH:mm:ss.sss
           <emu-alg>
             1. Assert: _obj_.[[ViewedArrayBuffer]] is *undefined*.
             1. Let _elementSize_ be TypedArrayElementSize(_obj_).
-            1. Let _byteLength_ be _elementSize_ × _length_.
+            1. Let _byteLength_ be _elementSize_ × _elementCount_.
             1. Let _data_ be ? <emu-meta suppress-effects="user-code">AllocateArrayBuffer(%ArrayBuffer%, _byteLength_)</emu-meta>.
             1. Set _obj_.[[ViewedArrayBuffer]] to _data_.
             1. Set _obj_.[[ByteLength]] to _byteLength_.
             1. Set _obj_.[[ByteOffset]] to 0.
-            1. Set _obj_.[[ArrayLength]] to _length_.
+            1. Set _obj_.[[ArrayLength]] to _elementCount_.
             1. Return ~unused~.
           </emu-alg>
         </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -43028,7 +43028,7 @@ THH:mm:ss.sss
             1. Let _sourceRecord_ be ? ValidateTypedArrayBounds(_source_, ~seq-cst~).
             1. Let _sourceLength_ be TypedArrayLength(_sourceRecord_).
             1. If _sourceLength_ + _targetOffset_ > TypedArrayLength(_targetRecord_), throw a *RangeError* exception.
-            1. If _target_.[[ContentType]] is not _source_.[[ContentType]], throw a *TypeError* exception.
+            1. Perform ? ValidateTypedArrayCompatibility(_target_, _source_).
             1. Let _targetElementSize_ be TypedArrayElementSize(_target_).
             1. Let _sourceElementSize_ be TypedArrayElementSize(_source_).
             1. Let _targetType_ be TypedArrayElementType(_target_).
@@ -43346,7 +43346,7 @@ THH:mm:ss.sss
           1. Let _defaultCtor_ be the intrinsic object associated with the constructor name _exemplar_.[[TypedArrayName]] in <emu-xref href="#table-the-typedarray-constructors"></emu-xref>.
           1. Let _ctor_ be ? SpeciesConstructor(_exemplar_, _defaultCtor_).
           1. Let _result_ be ? TypedArrayCreateFromConstructor(_ctor_, _argList_).
-          1. If _result_.[[ContentType]] is not _exemplar_.[[ContentType]], throw a *TypeError* exception.
+          1. Perform ? ValidateTypedArrayCompatibility(_result_, _exemplar_).
           1. Return _result_.
         </emu-alg>
       </emu-clause>
@@ -43382,6 +43382,21 @@ THH:mm:ss.sss
           1. Let _taRecord_ be MakeTypedArrayWithBufferWitnessRecord(_ta_, _order_).
           1. If IsTypedArrayOutOfBounds(_taRecord_) is *true*, throw a *TypeError* exception.
           1. Return _taRecord_.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-validatetypedarraycompatibility" type="abstract operation">
+        <h1>
+          ValidateTypedArrayCompatibility (
+            _a_: a TypedArray,
+            _b_: a TypedArray,
+          ): either a normal completion containing ~unused~ or a throw completion
+        </h1>
+        <dl class="header">
+        </dl>
+        <emu-alg>
+          1. If _a_.[[ContentType]] is not _b_.[[ContentType]], throw a *TypeError* exception.
+          1. Return ~unused~.
         </emu-alg>
       </emu-clause>
 
@@ -43571,7 +43586,7 @@ THH:mm:ss.sss
               1. Let _targetBuffer_ be ? CloneArrayBuffer(_sourceBuffer_, _sourceByteIndex_, _targetByteLength_).
             1. Else,
               1. Let _targetBuffer_ be ? <emu-meta suppress-effects="user-code">AllocateArrayBuffer(%ArrayBuffer%, _targetByteLength_)</emu-meta>.
-              1. If _obj_.[[ContentType]] is not _sourceArray_.[[ContentType]], throw a *TypeError* exception.
+              1. Perform ? ValidateTypedArrayCompatibility(_obj_, _sourceArray_).
               1. Let _sourceElementSize_ be TypedArrayElementSize(_sourceArray_).
               1. Let _targetByteIndex_ be 0.
               1. Repeat, while _targetByteIndex_ &lt; _targetByteLength_,

--- a/spec.html
+++ b/spec.html
@@ -43029,37 +43029,31 @@ THH:mm:ss.sss
             1. Let _sourceLength_ be TypedArrayLength(_sourceRecord_).
             1. If _sourceLength_ + _targetOffset_ > TypedArrayLength(_targetRecord_), throw a *RangeError* exception.
             1. If _target_.[[ContentType]] is not _source_.[[ContentType]], throw a *TypeError* exception.
-            1. Let _targetBuffer_ be _target_.[[ViewedArrayBuffer]].
-            1. Let _targetByteOffset_ be _target_.[[ByteOffset]].
-            1. Let _sourceBuffer_ be _source_.[[ViewedArrayBuffer]].
-            1. Let _sourceByteOffset_ be _source_.[[ByteOffset]].
-            1. If IsSharedArrayBuffer(_sourceBuffer_) is *true*, IsSharedArrayBuffer(_targetBuffer_) is *true*, and _sourceBuffer_.[[ArrayBufferData]] is _targetBuffer_.[[ArrayBufferData]], let _sameSharedArrayBuffer_ be *true*; else let _sameSharedArrayBuffer_ be *false*.
-            1. If SameValue(_sourceBuffer_, _targetBuffer_) is *true* or _sameSharedArrayBuffer_ is *true*, then
-              1. NOTE: Later steps require the original source data, even if it is being overwritten. But since their effects are not observable until this operation completes, implementations may perform them in-place rather than allocating a new ArrayBuffer.
-              1. Let _sourceByteLength_ be TypedArrayByteLength(_sourceRecord_).
-              1. Set _sourceBuffer_ to ? CloneArrayBuffer(_sourceBuffer_, _sourceByteOffset_, _sourceByteLength_).
-              1. Let _sourceByteIndex_ be 0.
-            1. Else,
-              1. Let _sourceByteIndex_ be _sourceByteOffset_.
-            1. Let _targetType_ be TypedArrayElementType(_target_).
             1. Let _targetElementSize_ be TypedArrayElementSize(_target_).
-            1. Let _sourceType_ be TypedArrayElementType(_source_).
             1. Let _sourceElementSize_ be TypedArrayElementSize(_source_).
-            1. Let _targetByteIndex_ be _targetByteOffset_ + (_targetElementSize_ × _targetOffset_).
-            1. Let _limit_ be _targetByteIndex_ + (_targetElementSize_ × _sourceLength_).
+            1. Let _targetType_ be TypedArrayElementType(_target_).
+            1. Let _sourceType_ be TypedArrayElementType(_source_).
+            1. NOTE: When _sourceType_ matches _targetType_, bit-level encoding of the source data must be preserved. Operating on byte-sized units ensures that guarantee, but an implementation that can satisfy it with larger chunks may do so.
             1. If _sourceType_ is _targetType_, then
-              1. NOTE: The transfer must be performed in a manner that preserves the bit-level encoding of the source data.
-              1. Repeat, while _targetByteIndex_ &lt; _limit_,
-                1. Let _value_ be GetValueFromBuffer(_sourceBuffer_, _sourceByteIndex_, ~uint8~, *true*, ~unordered~).
-                1. Perform SetValueInBuffer(_targetBuffer_, _targetByteIndex_, ~uint8~, _value_, *true*, ~unordered~).
-                1. Set _sourceByteIndex_ to _sourceByteIndex_ + 1.
-                1. Set _targetByteIndex_ to _targetByteIndex_ + 1.
-            1. Else,
-              1. Repeat, while _targetByteIndex_ &lt; _limit_,
-                1. Let _value_ be GetValueFromBuffer(_sourceBuffer_, _sourceByteIndex_, _sourceType_, *true*, ~unordered~).
-                1. Perform SetValueInBuffer(_targetBuffer_, _targetByteIndex_, _targetType_, _value_, *true*, ~unordered~).
-                1. Set _sourceByteIndex_ to _sourceByteIndex_ + _sourceElementSize_.
-                1. Set _targetByteIndex_ to _targetByteIndex_ + _targetElementSize_.
+              1. Set _targetType_ to ~uint8~.
+              1. Set _targetElementSize_ to 1.
+              1. Set _sourceType_ to ~uint8~.
+              1. Set _sourceElementSize_ to 1.
+            1. Let _targetBuffer_ be _target_.[[ViewedArrayBuffer]].
+            1. Let _sourceBuffer_ be _source_.[[ViewedArrayBuffer]].
+            1. Let _sourceByteIndex_ be _source_.[[ByteOffset]].
+            1. If _targetBuffer_.[[ArrayBufferData]] is _sourceBuffer_.[[ArrayBufferData]], then
+              1. NOTE: This operation must behave as if copying data into an overlapping range within the same Data Block is a single atomic step. But because the results of copying are not observable until it completes, implementations unable to perform such copying atomically may still avoid allocating a new ArrayBuffer by copying chunks in-place if they alter the direction of iteration as appropriate to avoid overwriting source data that has not yet been read.
+              1. Let _sourceByteLength_ be TypedArrayByteLength(_sourceRecord_).
+              1. Set _sourceBuffer_ to ? CloneArrayBuffer(_sourceBuffer_, _sourceByteIndex_, _sourceByteLength_).
+              1. Set _sourceByteIndex_ to 0.
+            1. Let _targetByteIndex_ be _target_.[[ByteOffset]] + (_targetElementSize_ × _targetOffset_).
+            1. Let _limit_ be _targetByteIndex_ + (_targetElementSize_ × _sourceLength_).
+            1. Repeat, while _targetByteIndex_ &lt; _limit_,
+              1. Let _value_ be GetValueFromBuffer(_sourceBuffer_, _sourceByteIndex_, _sourceType_, *true*, ~unordered~).
+              1. Perform SetValueInBuffer(_targetBuffer_, _targetByteIndex_, _targetType_, _value_, *true*, ~unordered~).
+              1. Set _sourceByteIndex_ to _sourceByteIndex_ + _sourceElementSize_.
+              1. Set _targetByteIndex_ to _targetByteIndex_ + _targetElementSize_.
             1. Return ~unused~.
           </emu-alg>
         </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -15538,8 +15538,7 @@
         <dl class="header">
         </dl>
         <emu-alg>
-          1. If _obj_.[[ContentType]] is ~bigint~, let _number_ be ? ToBigInt(_value_).
-          1. Else, let _number_ be ? ToNumber(_value_).
+          1. Let _number_ be ? ToNumericForTypedArray(_value_, TypedArrayElementType(_obj_)).
           1. If IsValidIntegerIndex(_obj_, _index_) is *true*, then
             1. Let _offset_ be _obj_.[[ByteOffset]].
             1. Let _elementSize_ be TypedArrayElementSize(_obj_).
@@ -42631,8 +42630,7 @@ THH:mm:ss.sss
           1. Let _obj_ be the *this* value.
           1. Let _taRecord_ be ? ValidateTypedArray(_obj_, ~seq-cst~).
           1. Let _length_ be TypedArrayLength(_taRecord_).
-          1. If _obj_.[[ContentType]] is ~bigint~, set _value_ to ? ToBigInt(_value_).
-          1. Else, set _value_ to ? ToNumber(_value_).
+          1. Set _value_ to ? ToNumericForTypedArray(_value_, TypedArrayElementType(_obj_)).
           1. Let _startIndex_ be ? ToClampedIndex(_start_, _length_).
           1. If _end_ is *undefined*, let _endIndex_ be _length_; else let _endIndex_ be ? ToClampedIndex(_end_, _length_).
           1. Set _taRecord_ to ? ValidateTypedArrayBounds(_obj_, ~seq-cst~).
@@ -43261,8 +43259,7 @@ THH:mm:ss.sss
           1. Let _taRecord_ be ? ValidateTypedArray(_obj_, ~seq-cst~).
           1. Let _length_ be TypedArrayLength(_taRecord_).
           1. Let _actualIndex_ be ? ToAbsoluteIndex(_index_, _length_).
-          1. If _obj_.[[ContentType]] is ~bigint~, let _numericValue_ be ? ToBigInt(_value_).
-          1. Else, let _numericValue_ be ? ToNumber(_value_).
+          1. Let _numericValue_ be ? ToNumericForTypedArray(_value_, TypedArrayElementType(_obj_)).
           1. If IsValidIntegerIndex(_obj_, 𝔽(_actualIndex_)) is *false*, throw a *RangeError* exception.
           1. Let _resultArray_ be ? TypedArrayCreateSameType(_obj_, _length_).
           1. Let _k_ be 0.
@@ -45954,6 +45951,21 @@ THH:mm:ss.sss
           1. Return RawBytesToNumeric(_type_, _rawBytesRead_, _isLittleEndian_).
         </emu-alg>
       </emu-clause>
+
+      <emu-clause id="sec-tonumericfortypedarray" type="abstract operation">
+        <h1>
+          ToNumericForTypedArray (
+            _value_: an ECMAScript language value,
+            _type_: a TypedArray element type,
+          ): either a normal completion containing either a Number or a BigInt, or a throw completion
+        </h1>
+        <dl class="header">
+        </dl>
+        <emu-alg>
+          1. If _type_ is either ~bigint64~ or ~biguint64~, return ? ToBigInt(_value_).
+          1. Return ? ToNumber(_value_).
+        </emu-alg>
+      </emu-clause>
     </emu-clause>
 
     <emu-clause id="sec-arraybuffer-constructor">
@@ -46660,8 +46672,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_view_, [[DataView]]).
           1. Assert: _view_ has a [[ViewedArrayBuffer]] internal slot.
           1. Let _getIndex_ be ? ToIndex(_requestIndex_).
-          1. If IsBigIntElementType(_type_) is *true*, let _number_ be ? ToBigInt(_value_).
-          1. Else, let _number_ be ? ToNumber(_value_).
+          1. Let _number_ be ? ToNumericForTypedArray(_value_, _type_).
           1. Set _isLittleEndian_ to ToBoolean(_isLittleEndian_).
           1. Let _viewOffset_ be _view_.[[ByteOffset]].
           1. Let _viewRecord_ be MakeDataViewWithBufferWitnessRecord(_view_, ~unordered~).

--- a/spec.html
+++ b/spec.html
@@ -46126,7 +46126,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_new_, [[ArrayBufferData]]).
           1. If IsSharedArrayBuffer(_new_) is *true*, throw a *TypeError* exception.
           1. If IsDetachedBuffer(_new_) is *true*, throw a *TypeError* exception.
-          1. If SameValue(_new_, _obj_) is *true*, throw a *TypeError* exception.
+          1. If _new_.[[ArrayBufferData]] is _obj_.[[ArrayBufferData]], throw a *TypeError* exception.
           1. If _new_.[[ArrayBufferByteLength]] &lt; _newLength_, throw a *TypeError* exception.
           1. NOTE: Side-effects of the above steps may have detached or resized _obj_.
           1. If IsDetachedBuffer(_obj_) is *true*, throw a *TypeError* exception.

--- a/spec.html
+++ b/spec.html
@@ -42997,11 +42997,9 @@ THH:mm:ss.sss
           </dl>
           <emu-alg>
             1. Let _targetRecord_ be ? ValidateTypedArrayBounds(_target_, ~seq-cst~).
-            1. Let _targetLength_ be TypedArrayLength(_targetRecord_).
             1. Set _source_ to ? ToObject(_source_).
             1. Let _sourceLength_ be ? LengthOfArrayLike(_source_).
-            1. If _targetOffset_ = +∞, throw a *RangeError* exception.
-            1. If _sourceLength_ + _targetOffset_ > _targetLength_, throw a *RangeError* exception.
+            1. If _sourceLength_ + _targetOffset_ > TypedArrayLength(_targetRecord_), throw a *RangeError* exception.
             1. Let _k_ be 0.
             1. Repeat, while _k_ &lt; _sourceLength_,
               1. Let _propertyKey_ be ! ToString(𝔽(_k_)).
@@ -43026,29 +43024,28 @@ THH:mm:ss.sss
             <dd>It sets multiple values in _target_, starting at index _targetOffset_, reading the values from _source_.</dd>
           </dl>
           <emu-alg>
-            1. Let _targetBuffer_ be _target_.[[ViewedArrayBuffer]].
             1. Let _targetRecord_ be ? ValidateTypedArrayBounds(_target_, ~seq-cst~).
-            1. Let _targetLength_ be TypedArrayLength(_targetRecord_).
-            1. Let _sourceBuffer_ be _source_.[[ViewedArrayBuffer]].
             1. Let _sourceRecord_ be ? ValidateTypedArrayBounds(_source_, ~seq-cst~).
             1. Let _sourceLength_ be TypedArrayLength(_sourceRecord_).
-            1. Let _targetType_ be TypedArrayElementType(_target_).
-            1. Let _targetElementSize_ be TypedArrayElementSize(_target_).
-            1. Let _targetByteOffset_ be _target_.[[ByteOffset]].
-            1. Let _sourceType_ be TypedArrayElementType(_source_).
-            1. Let _sourceElementSize_ be TypedArrayElementSize(_source_).
-            1. Let _sourceByteOffset_ be _source_.[[ByteOffset]].
-            1. If _targetOffset_ = +∞, throw a *RangeError* exception.
-            1. If _sourceLength_ + _targetOffset_ > _targetLength_, throw a *RangeError* exception.
+            1. If _sourceLength_ + _targetOffset_ > TypedArrayLength(_targetRecord_), throw a *RangeError* exception.
             1. If _target_.[[ContentType]] is not _source_.[[ContentType]], throw a *TypeError* exception.
+            1. Let _targetBuffer_ be _target_.[[ViewedArrayBuffer]].
+            1. Let _targetByteOffset_ be _target_.[[ByteOffset]].
+            1. Let _sourceBuffer_ be _source_.[[ViewedArrayBuffer]].
+            1. Let _sourceByteOffset_ be _source_.[[ByteOffset]].
             1. If IsSharedArrayBuffer(_sourceBuffer_) is *true*, IsSharedArrayBuffer(_targetBuffer_) is *true*, and _sourceBuffer_.[[ArrayBufferData]] is _targetBuffer_.[[ArrayBufferData]], let _sameSharedArrayBuffer_ be *true*; else let _sameSharedArrayBuffer_ be *false*.
             1. If SameValue(_sourceBuffer_, _targetBuffer_) is *true* or _sameSharedArrayBuffer_ is *true*, then
+              1. NOTE: Later steps require the original source data, even if it is being overwritten. But since their effects are not observable until this operation completes, implementations may perform them in-place rather than allocating a new ArrayBuffer.
               1. Let _sourceByteLength_ be TypedArrayByteLength(_sourceRecord_).
               1. Set _sourceBuffer_ to ? CloneArrayBuffer(_sourceBuffer_, _sourceByteOffset_, _sourceByteLength_).
               1. Let _sourceByteIndex_ be 0.
             1. Else,
               1. Let _sourceByteIndex_ be _sourceByteOffset_.
-            1. Let _targetByteIndex_ be (_targetOffset_ × _targetElementSize_) + _targetByteOffset_.
+            1. Let _targetType_ be TypedArrayElementType(_target_).
+            1. Let _targetElementSize_ be TypedArrayElementSize(_target_).
+            1. Let _sourceType_ be TypedArrayElementType(_source_).
+            1. Let _sourceElementSize_ be TypedArrayElementSize(_source_).
+            1. Let _targetByteIndex_ be _targetByteOffset_ + (_targetElementSize_ × _targetOffset_).
             1. Let _limit_ be _targetByteIndex_ + (_targetElementSize_ × _sourceLength_).
             1. If _sourceType_ is _targetType_, then
               1. NOTE: The transfer must be performed in a manner that preserves the bit-level encoding of the source data.

--- a/spec.html
+++ b/spec.html
@@ -47566,11 +47566,10 @@ THH:mm:ss.sss
         </dl>
         <emu-alg>
           1. Let _byteIndexInBuffer_ be ? ValidateAtomicAccessOnIntegerTypedArray(_ta_, _index_).
-          1. If _ta_.[[ContentType]] is ~bigint~, let _coerced_ be ? ToBigInt(_value_).
-          1. Else, let _coerced_ be 𝔽(? ToIntegerOrInfinity(_value_)).
+          1. Let _elementType_ be TypedArrayElementType(_ta_).
+          1. Let _coerced_ be ? ToNumericForTypedArray(_value_, _elementType_).
           1. Perform ? RevalidateAtomicAccess(_ta_, _byteIndexInBuffer_).
           1. Let _buffer_ be _ta_.[[ViewedArrayBuffer]].
-          1. Let _elementType_ be TypedArrayElementType(_ta_).
           1. Return GetModifySetValueInBuffer(_buffer_, _byteIndexInBuffer_, _elementType_, _coerced_, _op_).
         </emu-alg>
       </emu-clause>
@@ -47666,19 +47665,15 @@ THH:mm:ss.sss
         1. Let _byteIndexInBuffer_ be ? ValidateAtomicAccessOnIntegerTypedArray(_ta_, _index_).
         1. Let _buffer_ be _ta_.[[ViewedArrayBuffer]].
         1. Let _block_ be _buffer_.[[ArrayBufferData]].
-        1. If _ta_.[[ContentType]] is ~bigint~, then
-          1. Let _expected_ be ? ToBigInt(_expectedValue_).
-          1. Let _replacement_ be ? ToBigInt(_replacementValue_).
-        1. Else,
-          1. Let _expected_ be 𝔽(? ToIntegerOrInfinity(_expectedValue_)).
-          1. Let _replacement_ be 𝔽(? ToIntegerOrInfinity(_replacementValue_)).
-        1. Perform ? RevalidateAtomicAccess(_ta_, _byteIndexInBuffer_).
         1. Let _elementType_ be TypedArrayElementType(_ta_).
-        1. Let _elementSize_ be TypedArrayElementSize(_ta_).
+        1. Let _expected_ be ? ToNumericForTypedArray(_expectedValue_, _elementType_).
+        1. Let _replacement_ be ? ToNumericForTypedArray(_replacementValue_, _elementType_).
+        1. Perform ? RevalidateAtomicAccess(_ta_, _byteIndexInBuffer_).
         1. Let _agentRecord_ be the Agent Record of the surrounding agent.
         1. Let _isLittleEndian_ be _agentRecord_.[[LittleEndian]].
         1. Let _expectedBytes_ be NumericToRawBytes(_elementType_, _expected_, _isLittleEndian_).
         1. Let _replacementBytes_ be NumericToRawBytes(_elementType_, _replacement_, _isLittleEndian_).
+        1. Let _elementSize_ be TypedArrayElementSize(_ta_).
         1. If IsSharedArrayBuffer(_buffer_) is *true*, then
           1. Let _rawBytesRead_ be AtomicCompareExchangeInSharedBlock(_block_, _byteIndexInBuffer_, _elementSize_, _expectedBytes_, _replacementBytes_).
         1. Else,
@@ -47789,11 +47784,11 @@ THH:mm:ss.sss
       <p>This function performs the following steps when called:</p>
       <emu-alg>
         1. Let _byteIndexInBuffer_ be ? ValidateAtomicAccessOnIntegerTypedArray(_ta_, _index_).
-        1. If _ta_.[[ContentType]] is ~bigint~, let _coerced_ be ? ToBigInt(_value_).
-        1. Else, let _coerced_ be 𝔽(? ToIntegerOrInfinity(_value_)).
+        1. Let _elementType_ be TypedArrayElementType(_ta_).
+        1. Let _coerced_ be ? ToNumericForTypedArray(_value_, _elementType_).
+        1. If _coerced_ is a Number, set _coerced_ to 𝔽(! ToIntegerOrInfinity(_coerced_)).
         1. Perform ? RevalidateAtomicAccess(_ta_, _byteIndexInBuffer_).
         1. Let _buffer_ be _ta_.[[ViewedArrayBuffer]].
-        1. Let _elementType_ be TypedArrayElementType(_ta_).
         1. Perform SetValueInBuffer(_buffer_, _byteIndexInBuffer_, _elementType_, _coerced_, *true*, ~seq-cst~).
         1. Return _coerced_.
       </emu-alg>


### PR DESCRIPTION
This is a series of editorial commits that strive to improve the consistency and comprehensibility of spec text relating to ArrayBuffers and APIs that build on top of them.