### PR TITLE
editorial: Get/Set 'lastIndex' on RegExp object cannot trigger user-code

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -39289,7 +39289,7 @@ THH:mm:ss.sss
         </dl>
         <emu-alg>
           1. Let _length_ be the length of _S_.
-          1. Let _lastIndex_ be ℝ(? ToLength(? Get(_R_, *"lastIndex"*))).
+          1. Let _lastIndex_ be ℝ(? ToLength(! Get(_R_, *"lastIndex"*))).
           1. Let _flags_ be _R_.[[OriginalFlags]].
           1. If _flags_ contains *"g"*, let _global_ be *true*; else let _global_ be *false*.
           1. If _flags_ contains *"y"*, let _sticky_ be *true*; else let _sticky_ be *false*.
@@ -39303,13 +39303,13 @@ THH:mm:ss.sss
           1. Repeat, while _matchSucceeded_ is *false*,
             1. If _lastIndex_ > _length_, then
               1. If _global_ is *true* or _sticky_ is *true*, then
-                1. Perform ? Set(_R_, *"lastIndex"*, *+0*<sub>𝔽</sub>, *true*).
+                1. Perform ? <emu-meta suppress-effects="user-code">Set(_R_, *"lastIndex"*, *+0*<sub>𝔽</sub>, *true*)</emu-meta>.
               1. Return *null*.
             1. Let _inputIndex_ be the index into _input_ of the character that was obtained from element _lastIndex_ of _S_.
             1. Let _r_ be _matcher_(_input_, _inputIndex_).
             1. If _r_ is ~failure~, then
               1. If _sticky_ is *true*, then
-                1. Perform ? Set(_R_, *"lastIndex"*, *+0*<sub>𝔽</sub>, *true*).
+                1. Perform ? <emu-meta suppress-effects="user-code">Set(_R_, *"lastIndex"*, *+0*<sub>𝔽</sub>, *true*)</emu-meta>.
                 1. Return *null*.
               1. Set _lastIndex_ to AdvanceStringIndex(_S_, _lastIndex_, _fullUnicode_).
             1. Else,
@@ -39318,7 +39318,7 @@ THH:mm:ss.sss
           1. Let _e_ be _r_.[[EndIndex]].
           1. If _fullUnicode_ is *true*, set _e_ to GetStringIndex(_S_, _e_).
           1. If _global_ is *true* or _sticky_ is *true*, then
-            1. Perform ? Set(_R_, *"lastIndex"*, 𝔽(_e_), *true*).
+            1. Perform ? <emu-meta suppress-effects="user-code">Set(_R_, *"lastIndex"*, 𝔽(_e_), *true*)</emu-meta>.
           1. Let _n_ be the number of elements in _r_.[[Captures]].
           1. Assert: _n_ = _R_.[[RegExpRecord]].[[CapturingGroupsCount]].
           1. Assert: _n_ &lt; 2<sup>32</sup> - 1.


### PR DESCRIPTION
Purely an editorial change, this implies no change in the implementation: The `Get` and `Set` calls on "lastIndex" property of a builtin RegExp object cannot trigger user-code, as the property is installed as an unconfigurable own data property of the object with a set value: the property cannot be turned into an accessor property, and the value cannot be unset to make the Get/Set operations enter the prototype chain.

The `Get` call on `"lastIndex"` is thus fully infallible: it will always find a valid property value and can never throw any errors.
The `Set` call on `"lastIndex"` can still throw errors, as the property can be made unwritable in which case trying to change its value will throw an error.