### PR TITLE
Editorial: Use the dfs stack instead of [[DFSAncestorIndex]] 

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -27048,6 +27048,7 @@
                 1. Assert: _module_.[[Status]] is ~unlinked~.
                 1. Set _module_.[[Status]] to ~linking~.
                 1. Let _moduleIndex_ be the length of _stack_.
+                1. Let _sccAncestorIndex_ be _moduleIndex_.
                 1. Set _module_.[[DFSAncestorIndex]] to _moduleIndex_.
                 1. Append _module_ to _stack_.
                 1. For each ModuleRequest Record _request_ of _module_.[[RequestedModules]], do
@@ -27057,11 +27058,11 @@
                     1. Assert: _requiredModule_.[[Status]] is one of ~linking~, ~linked~, ~evaluating-async~, or ~evaluated~.
                     1. Assert: _requiredModule_.[[Status]] is ~linking~ if and only if _stack_ contains _requiredModule_.
                     1. If _requiredModule_.[[Status]] is ~linking~, then
-                      1. Set _module_.[[DFSAncestorIndex]] to min(_module_.[[DFSAncestorIndex]], _requiredModule_.[[DFSAncestorIndex]]).
+                      1. Set _sccAncestorIndex_ to min(_sccAncestorIndex_, _requiredModule_.[[DFSAncestorIndex]]).
                 1. Perform ? _module_.InitializeEnvironment().
                 1. Assert: _module_ occurs exactly once in _stack_.
-                1. Assert: _module_.[[DFSAncestorIndex]] ≤ _moduleIndex_.
-                1. If _module_.[[DFSAncestorIndex]] = _moduleIndex_, then
+                1. Assert: _sccAncestorIndex_ ≤ _moduleIndex_.
+                1. If _sccAncestorIndex_ = _moduleIndex_, then
                   1. Let _done_ be *false*.
                   1. Repeat, while _done_ is *false*,
                     1. Let _requiredModule_ be the last element of _stack_.
@@ -27069,6 +27070,8 @@
                     1. Assert: _requiredModule_ is a Cyclic Module Record.
                     1. Set _requiredModule_.[[Status]] to ~linked~.
                     1. If _requiredModule_ and _module_ are the same Module Record, set _done_ to *true*.
+                1. Else,
+                  1. Set _module_.[[DFSAncestorIndex]] to _sccAncestorIndex_.
                 1. Return ~unused~.
               </emu-alg>
             </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -27095,7 +27095,7 @@
               1. Let _stack_ be a new empty List.
               1. Let _capability_ be ! NewPromiseCapability(%Promise%).
               1. Set _module_.[[TopLevelCapability]] to _capability_.
-              1. Let _result_ be Completion(InnerModuleEvaluation(_module_, _stack_, 0)).
+              1. Let _result_ be Completion(InnerModuleEvaluation(_module_, _stack_)).
               1. If _result_ is an abrupt completion, then
                 1. For each Cyclic Module Record _m_ of _stack_, do
                   1. Assert: _m_.[[Status]] is ~evaluating~.
@@ -27121,38 +27121,38 @@
                 InnerModuleEvaluation (
                   _module_: a Module Record,
                   _stack_: a List of Cyclic Module Records,
-                  _index_: a non-negative integer,
                 ): either a normal completion containing a non-negative integer or a throw completion
               </h1>
               <dl class="header">
                 <dt>description</dt>
-                <dd>It is used by Evaluate to perform the actual evaluation process for _module_, as well as recursively on all other modules in the dependency graph. The _stack_ and _index_ parameters, as well as _module_'s [[DFSAncestorIndex]] field, are used the same way as in InnerModuleLinking.</dd>
+                <dd>It is used by Evaluate to perform the actual evaluation process for _module_, as well as recursively on all other modules in the dependency graph. The _stack_ parameter and the return value are used the same way as in InnerModuleLinking.</dd>
               </dl>
 
               <emu-alg>
+                1. Let _moduleIndex_ be the length of _stack_.
                 1. If _module_ is not a Cyclic Module Record, then
                   1. Perform ? EvaluateModuleSync(_module_).
-                  1. Return _index_.
+                  1. Return _moduleIndex_.
                 1. If _module_.[[Status]] is either ~evaluating-async~ or ~evaluated~, then
-                  1. If _module_.[[EvaluationError]] is ~empty~, return _index_.
+                  1. If _module_.[[EvaluationError]] is ~empty~, return _moduleIndex_.
                   1. Otherwise, return ? _module_.[[EvaluationError]].
-                1. If _module_.[[Status]] is ~evaluating~, return _index_.
+                1. If _module_.[[Status]] is ~evaluating~, then
+                  1. Assert: _module_ occurs exactly once in _stack_.
+                  1. NOTE: Once a _module_ is added to _stack_, its index never changes. Implementations may thus cache _module_'s index when it's first inserted, rather than computing it here.
+                  1. Return the integer _i_ such that _stack_[_i_] = _module_.
                 1. Assert: _module_.[[Status]] is ~linked~.
                 1. Set _module_.[[Status]] to ~evaluating~.
-                1. Let _moduleIndex_ be _index_.
-                1. Set _module_.[[DFSAncestorIndex]] to _index_.
                 1. Set _module_.[[PendingAsyncDependencies]] to 0.
-                1. Set _index_ to _index_ + 1.
+                1. Let _sccAncestorIndex_ be _moduleIndex_.
                 1. Append _module_ to _stack_.
                 1. For each ModuleRequest Record _request_ of _module_.[[RequestedModules]], do
                   1. Let _requiredModule_ be GetImportedModule(_module_, _request_).
-                  1. Set _index_ to ? InnerModuleEvaluation(_requiredModule_, _stack_, _index_).
+                  1. Let _childSccAncestorIndex_ be ? InnerModuleEvaluation(_requiredModule_, _stack_).
+                  1. Set _sccAncestorIndex_ to min(_sccAncestorIndex_, _childSccAncestorIndex_).
                   1. If _requiredModule_ is a Cyclic Module Record, then
                     1. Assert: _requiredModule_.[[Status]] is one of ~evaluating~, ~evaluating-async~, or ~evaluated~.
                     1. Assert: _requiredModule_.[[Status]] is ~evaluating~ if and only if _stack_ contains _requiredModule_.
-                    1. If _requiredModule_.[[Status]] is ~evaluating~, then
-                      1. Set _module_.[[DFSAncestorIndex]] to min(_module_.[[DFSAncestorIndex]], _requiredModule_.[[DFSAncestorIndex]]).
-                    1. Else,
+                    1. If _requiredModule_.[[Status]] is not ~evaluating~, then
                       1. Set _requiredModule_ to _requiredModule_.[[CycleRoot]].
                       1. Assert: _requiredModule_.[[Status]] is either ~evaluating-async~ or ~evaluated~.
                       1. If _requiredModule_.[[EvaluationError]] is not ~empty~, return ? _requiredModule_.[[EvaluationError]].
@@ -27166,8 +27166,8 @@
                 1. Else,
                   1. Perform ? <emu-meta effects="user-code">_module_.ExecuteModule()</emu-meta>.
                 1. Assert: _module_ occurs exactly once in _stack_.
-                1. Assert: _module_.[[DFSAncestorIndex]] ≤ _moduleIndex_.
-                1. If _module_.[[DFSAncestorIndex]] = _moduleIndex_, then
+                1. Assert: _sccAncestorIndex_ ≤ _moduleIndex_.
+                1. If _sccAncestorIndex_ = _moduleIndex_, then
                   1. Let _done_ be *false*.
                   1. Repeat, while _done_ is *false*,
                     1. Let _requiredModule_ be the last element of _stack_.
@@ -27178,7 +27178,7 @@
                     1. Otherwise, set _requiredModule_.[[Status]] to ~evaluating-async~.
                     1. If _requiredModule_ and _module_ are the same Module Record, set _done_ to *true*.
                     1. Set _requiredModule_.[[CycleRoot]] to _module_.
-                1. Return _index_.
+                1. Return _sccAncestorIndex_.
               </emu-alg>
               <emu-note>
                 <p>A module is ~evaluating~ while it is being traversed by InnerModuleEvaluation. A module is ~evaluated~ on execution completion or ~evaluating-async~ during execution if its [[HasTLA]] field is *true* or if it has asynchronous dependencies.</p>

--- a/spec.html
+++ b/spec.html
@@ -27015,7 +27015,7 @@
             <emu-alg>
               1. Assert: _module_.[[Status]] is one of ~unlinked~, ~linked~, ~evaluating-async~, or ~evaluated~.
               1. Let _stack_ be a new empty List.
-              1. Let _result_ be Completion(InnerModuleLinking(_module_, _stack_, 0)).
+              1. Let _result_ be Completion(InnerModuleLinking(_module_, _stack_)).
               1. If _result_ is an abrupt completion, then
                 1. For each Cyclic Module Record _m_ of _stack_, do
                   1. Assert: _m_.[[Status]] is ~linking~.
@@ -27032,29 +27032,27 @@
                 InnerModuleLinking (
                   _module_: a Module Record,
                   _stack_: a List of Cyclic Module Records,
-                  _index_: a non-negative integer,
-                ): either a normal completion containing a non-negative integer or a throw completion
+                ): either a normal completion containing ~unused~, or a throw completion
               </h1>
               <dl class="header">
                 <dt>description</dt>
-                <dd>It is used by Link to perform the actual linking process for _module_, as well as recursively on all other modules in the dependency graph. The _stack_ and _index_ parameters, as well as a module's [[DFSAncestorIndex]] field, keep track of the depth-first search (DFS) traversal. In particular, [[DFSAncestorIndex]] is used to discover strongly connected components (SCCs), such that all modules in an SCC transition to ~linked~ together.</dd>
+                <dd>It is used by Link to perform the actual linking process for _module_, as well as recursively on all other modules in the dependency graph. The _stack_ parameter, as well as a module's [[DFSAncestorIndex]] field, keep track of the depth-first search (DFS) traversal. In particular, [[DFSAncestorIndex]] is used to discover strongly connected components (SCCs), such that all modules in an SCC transition to ~linked~ together.</dd>
               </dl>
 
               <emu-alg>
                 1. If _module_ is not a Cyclic Module Record, then
                   1. Perform ? _module_.Link().
-                  1. Return _index_.
+                  1. Return ~unused~.
                 1. If _module_.[[Status]] is one of ~linking~, ~linked~, ~evaluating-async~, or ~evaluated~, then
-                  1. Return _index_.
+                  1. Return ~unused~.
                 1. Assert: _module_.[[Status]] is ~unlinked~.
                 1. Set _module_.[[Status]] to ~linking~.
-                1. Let _moduleIndex_ be _index_.
-                1. Set _module_.[[DFSAncestorIndex]] to _index_.
-                1. Set _index_ to _index_ + 1.
+                1. Let _moduleIndex_ be the length of _stack_.
+                1. Set _module_.[[DFSAncestorIndex]] to _moduleIndex_.
                 1. Append _module_ to _stack_.
                 1. For each ModuleRequest Record _request_ of _module_.[[RequestedModules]], do
                   1. Let _requiredModule_ be GetImportedModule(_module_, _request_).
-                  1. Set _index_ to ? InnerModuleLinking(_requiredModule_, _stack_, _index_).
+                  1. Perform ? InnerModuleLinking(_requiredModule_, _stack_).
                   1. If _requiredModule_ is a Cyclic Module Record, then
                     1. Assert: _requiredModule_.[[Status]] is one of ~linking~, ~linked~, ~evaluating-async~, or ~evaluated~.
                     1. Assert: _requiredModule_.[[Status]] is ~linking~ if and only if _stack_ contains _requiredModule_.
@@ -27071,7 +27069,7 @@
                     1. Assert: _requiredModule_ is a Cyclic Module Record.
                     1. Set _requiredModule_.[[Status]] to ~linked~.
                     1. If _requiredModule_ and _module_ are the same Module Record, set _done_ to *true*.
-                1. Return _index_.
+                1. Return ~unused~.
               </emu-alg>
             </emu-clause>
           </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -27072,8 +27072,6 @@
                     1. Assert: _requiredModule_ is a Cyclic Module Record.
                     1. Set _requiredModule_.[[Status]] to ~linked~.
                     1. If _requiredModule_ and _module_ are the same Module Record, set _done_ to *true*.
-                1. Else,
-                  1. Set _module_.[[DFSAncestorIndex]] to _sccAncestorIndex_.
                 1. Return _sccAncestorIndex_.
               </emu-alg>
             </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -26702,17 +26702,6 @@
             </tr>
             <tr>
               <td>
-                [[DFSAncestorIndex]]
-              </td>
-              <td>
-                an integer or ~empty~
-              </td>
-              <td>
-                Auxiliary field used during Link and Evaluate only. If [[Status]] is either ~linking~ or ~evaluating~, this is either the module's depth-first traversal index or that of an "earlier" module in the same strongly connected component.
-              </td>
-            </tr>
-            <tr>
-              <td>
                 [[RequestedModules]]
               </td>
               <td>
@@ -26741,7 +26730,7 @@
                 a Cyclic Module Record or ~empty~
               </td>
               <td>
-                The first visited module of the cycle, the root DFS ancestor of the strongly connected component. For a module not in a cycle, this would be the module itself. Once Evaluate has completed, a module's [[DFSAncestorIndex]] is the depth-first traversal index of its [[CycleRoot]].
+                The first visited module of the cycle, the root DFS ancestor of the strongly connected component. For a module not in a cycle, this would be the module itself.
               </td>
             </tr>
             <tr>
@@ -27390,14 +27379,6 @@
                 </tr>
               </thead>
               <tr>
-                <th>[[DFSAncestorIndex]]</th>
-                <td>0</td>
-                <td>0</td>
-                <td>0</td>
-                <td>0</td>
-                <td>4</td>
-              </tr>
-              <tr>
                 <th>[[Status]]</th>
                 <td>~evaluating-async~</td>
                 <td>~evaluating-async~</td>
@@ -27449,11 +27430,6 @@
                 </tr>
               </thead>
               <tr>
-                <th>[[DFSAncestorIndex]]</th>
-                <td>0</td>
-                <td>4</td>
-              </tr>
-              <tr>
                 <th>[[Status]]</th>
                 <td>~evaluating-async~</td>
                 <td>~evaluated~</td>
@@ -27493,12 +27469,6 @@
                   <th>_D_</th>
                 </tr>
               </thead>
-              <tr>
-                <th>[[DFSAncestorIndex]]</th>
-                <td>0</td>
-                <td>0</td>
-                <td>0</td>
-              </tr>
               <tr>
                 <th>[[Status]]</th>
                 <td>~evaluating-async~</td>
@@ -27543,11 +27513,6 @@
                 </tr>
               </thead>
               <tr>
-                <th>[[DFSAncestorIndex]]</th>
-                <td>0</td>
-                <td>0</td>
-              </tr>
-              <tr>
                 <th>[[Status]]</th>
                 <td>~evaluating-async~</td>
                 <td>~evaluated~</td>
@@ -27587,11 +27552,6 @@
                 </tr>
               </thead>
               <tr>
-                <th>[[DFSAncestorIndex]]</th>
-                <td>0</td>
-                <td>0</td>
-              </tr>
-              <tr>
                 <th>[[Status]]</th>
                 <td>~evaluating-async~</td>
                 <td>~evaluated~</td>
@@ -27630,10 +27590,6 @@
                 </tr>
               </thead>
               <tr>
-                <th>[[DFSAncestorIndex]]</th>
-                <td>0</td>
-              </tr>
-              <tr>
                 <th>[[Status]]</th>
                 <td>~evaluated~</td>
               </tr>
@@ -27668,11 +27624,6 @@
                   <th>_C_</th>
                 </tr>
               </thead>
-              <tr>
-                <th>[[DFSAncestorIndex]]</th>
-                <td>0</td>
-                <td>0</td>
-              </tr>
               <tr>
                 <th>[[Status]]</th>
                 <td>~evaluated~</td>
@@ -27717,10 +27668,6 @@
                 </tr>
               </thead>
               <tr>
-                <th>[[DFSAncestorIndex]]</th>
-                <td>0</td>
-              </tr>
-              <tr>
                 <th>[[Status]]</th>
                 <td>~evaluated~</td>
               </tr>
@@ -27760,11 +27707,6 @@
                   <th>_B_</th>
                 </tr>
               </thead>
-              <tr>
-                <th>[[DFSAncestorIndex]]</th>
-                <td>0</td>
-                <td>0</td>
-              </tr>
               <tr>
                 <th>[[Status]]</th>
                 <td>~evaluated~</td>
@@ -28335,7 +28277,7 @@
               1. Else,
                 1. Append _ee_ to _indirectExportEntries_.
             1. Let _async_ be _body_ Contains `await`.
-            1. Return Source Text Module Record { [[Realm]]: _realm_, [[Environment]]: ~empty~, [[Namespace]]: ~empty~, [[CycleRoot]]: ~empty~, [[HasTLA]]: _async_, [[AsyncEvaluationOrder]]: ~unset~, [[TopLevelCapability]]: ~empty~, [[AsyncParentModules]]: « », [[PendingAsyncDependencies]]: ~empty~, [[Status]]: ~new~, [[EvaluationError]]: ~empty~, [[HostDefined]]: _hostDefined_, [[ECMAScriptCode]]: _body_, [[Context]]: ~empty~, [[ImportMeta]]: ~empty~, [[RequestedModules]]: _requestedModules_, [[LoadedModules]]: « », [[ImportEntries]]: _importEntries_, [[LocalExportEntries]]: _localExportEntries_, [[IndirectExportEntries]]: _indirectExportEntries_, [[StarExportEntries]]: _starExportEntries_, [[DFSAncestorIndex]]: ~empty~ }.
+            1. Return Source Text Module Record { [[Realm]]: _realm_, [[Environment]]: ~empty~, [[Namespace]]: ~empty~, [[CycleRoot]]: ~empty~, [[HasTLA]]: _async_, [[AsyncEvaluationOrder]]: ~unset~, [[TopLevelCapability]]: ~empty~, [[AsyncParentModules]]: « », [[PendingAsyncDependencies]]: ~empty~, [[Status]]: ~new~, [[EvaluationError]]: ~empty~, [[HostDefined]]: _hostDefined_, [[ECMAScriptCode]]: _body_, [[Context]]: ~empty~, [[ImportMeta]]: ~empty~, [[RequestedModules]]: _requestedModules_, [[LoadedModules]]: « », [[ImportEntries]]: _importEntries_, [[LocalExportEntries]]: _localExportEntries_, [[IndirectExportEntries]]: _indirectExportEntries_, [[StarExportEntries]]: _starExportEntries_ }.
           </emu-alg>
           <emu-note>
             <p>An implementation may parse module source text and analyse it for Early Error conditions prior to the evaluation of ParseModule for that module source text. However, the reporting of any errors must be deferred until the point where this specification actually performs ParseModule upon that source text.</p>

--- a/spec.html
+++ b/spec.html
@@ -27046,6 +27046,7 @@
                 1. For each ModuleRequest Record _request_ of _module_.[[RequestedModules]], do
                   1. Let _requiredModule_ be GetImportedModule(_module_, _request_).
                   1. Let _childSccAncestorIndex_ be ? InnerModuleLinking(_requiredModule_, _stack_).
+                  1. Assert: Assert: If _requiredModule_ is not a Cyclic Module Record or _requiredModule_.[[Status]] is not ~linking~, then _sccAncestorIndex_ &lt; _childSccAncestorIndex_.
                   1. Set _sccAncestorIndex_ to min(_sccAncestorIndex_, _childSccAncestorIndex_).
                   1. Assert: If _requiredModule_ is a Cyclic Module Record, _requiredModule_.[[Status]] is one of ~linking~, ~linked~, ~evaluating-async~, or ~evaluated~.
                   1. Assert: If _requiredModule_ is a Cyclic Module Record, _requiredModule_.[[Status]] is ~linking~ if and only if _stack_ contains _requiredModule_.
@@ -27137,6 +27138,7 @@
                 1. For each ModuleRequest Record _request_ of _module_.[[RequestedModules]], do
                   1. Let _requiredModule_ be GetImportedModule(_module_, _request_).
                   1. Let _childSccAncestorIndex_ be ? InnerModuleEvaluation(_requiredModule_, _stack_).
+                  1. Assert: If _requiredModule_ is not a Cyclic Module Record or _requiredModule_.[[Status]] is not ~evaluating~, then _sccAncestorIndex_ &lt; _childSccAncestorIndex_.
                   1. Set _sccAncestorIndex_ to min(_sccAncestorIndex_, _childSccAncestorIndex_).
                   1. If _requiredModule_ is a Cyclic Module Record, then
                     1. Assert: _requiredModule_.[[Status]] is one of ~evaluating~, ~evaluating-async~, or ~evaluated~.

--- a/spec.html
+++ b/spec.html
@@ -27032,7 +27032,7 @@
                 InnerModuleLinking (
                   _module_: a Module Record,
                   _stack_: a List of Cyclic Module Records,
-                ): either a normal completion containing ~unused~, or a throw completion
+                ): either a normal completion containing a non-negative integer or a throw completion
               </h1>
               <dl class="header">
                 <dt>description</dt>
@@ -27040,25 +27040,27 @@
               </dl>
 
               <emu-alg>
+                1. Let _moduleIndex_ be the length of _stack_.
                 1. If _module_ is not a Cyclic Module Record, then
                   1. Perform ? _module_.Link().
-                  1. Return ~unused~.
-                1. If _module_.[[Status]] is one of ~linking~, ~linked~, ~evaluating-async~, or ~evaluated~, then
-                  1. Return ~unused~.
+                  1. Return _moduleIndex_.
+                1. If _module_.[[Status]] is one of ~linked~, ~evaluating-async~, or ~evaluated~, then
+                  1. Return _moduleIndex_.
+                1. If _module_.[[Status]] is ~linking~, then
+                  1. Assert: _module_ occurs exactly once in _stack_.
+                  1. Assert: _module_.[[DFSAncestorIndex]] is not ~empty~.
+                  1. Return _module_.[[DFSAncestorIndex]].
                 1. Assert: _module_.[[Status]] is ~unlinked~.
                 1. Set _module_.[[Status]] to ~linking~.
-                1. Let _moduleIndex_ be the length of _stack_.
                 1. Let _sccAncestorIndex_ be _moduleIndex_.
-                1. Set _module_.[[DFSAncestorIndex]] to _moduleIndex_.
+                1. Set _module_.[[DFSAncestorIndex]] to _sccAncestorIndex_.
                 1. Append _module_ to _stack_.
                 1. For each ModuleRequest Record _request_ of _module_.[[RequestedModules]], do
                   1. Let _requiredModule_ be GetImportedModule(_module_, _request_).
-                  1. Perform ? InnerModuleLinking(_requiredModule_, _stack_).
-                  1. If _requiredModule_ is a Cyclic Module Record, then
-                    1. Assert: _requiredModule_.[[Status]] is one of ~linking~, ~linked~, ~evaluating-async~, or ~evaluated~.
-                    1. Assert: _requiredModule_.[[Status]] is ~linking~ if and only if _stack_ contains _requiredModule_.
-                    1. If _requiredModule_.[[Status]] is ~linking~, then
-                      1. Set _sccAncestorIndex_ to min(_sccAncestorIndex_, _requiredModule_.[[DFSAncestorIndex]]).
+                  1. Let _childSccAncestorIndex_ be ? InnerModuleLinking(_requiredModule_, _stack_).
+                  1. Set _sccAncestorIndex_ to min(_sccAncestorIndex_, _childSccAncestorIndex_).
+                  1. Assert: If _requiredModule_ is a Cyclic Module Record, _requiredModule_.[[Status]] is one of ~linking~, ~linked~, ~evaluating-async~, or ~evaluated~.
+                  1. Assert: If _requiredModule_ is a Cyclic Module Record, _requiredModule_.[[Status]] is ~linking~ if and only if _stack_ contains _requiredModule_.
                 1. Perform ? _module_.InitializeEnvironment().
                 1. Assert: _module_ occurs exactly once in _stack_.
                 1. Assert: _sccAncestorIndex_ ≤ _moduleIndex_.
@@ -27072,7 +27074,7 @@
                     1. If _requiredModule_ and _module_ are the same Module Record, set _done_ to *true*.
                 1. Else,
                   1. Set _module_.[[DFSAncestorIndex]] to _sccAncestorIndex_.
-                1. Return ~unused~.
+                1. Return _sccAncestorIndex_.
               </emu-alg>
             </emu-clause>
           </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -27036,7 +27036,7 @@
               </h1>
               <dl class="header">
                 <dt>description</dt>
-                <dd>It is used by Link to perform the actual linking process for _module_, as well as recursively on all other modules in the dependency graph. The _stack_ parameter, as well as a module's [[DFSAncestorIndex]] field, keep track of the depth-first search (DFS) traversal. In particular, [[DFSAncestorIndex]] is used to discover strongly connected components (SCCs), such that all modules in an SCC transition to ~linked~ together.</dd>
+                <dd>It is used by Link to perform the actual linking process for _module_, as well as recursively on all other modules in the dependency graph. The _stack_ parameter keeps track of the depth-first search (DFS) traversal and, together with the return value, it is used to discover strongly connected components (SCCs), such that all modules in an SCC transition to ~linked~ together.</dd>
               </dl>
 
               <emu-alg>
@@ -27048,12 +27048,11 @@
                   1. Return _moduleIndex_.
                 1. If _module_.[[Status]] is ~linking~, then
                   1. Assert: _module_ occurs exactly once in _stack_.
-                  1. Assert: _module_.[[DFSAncestorIndex]] is not ~empty~.
-                  1. Return _module_.[[DFSAncestorIndex]].
+                  1. NOTE: Once a _module_ is added to _stack_, its index never changes. Implementations may thus cache _module_'s index when it's first inserted, rather than computing it here.
+                  1. Return the integer _i_ such that _stack_[_i_] = _module_.
                 1. Assert: _module_.[[Status]] is ~unlinked~.
                 1. Set _module_.[[Status]] to ~linking~.
                 1. Let _sccAncestorIndex_ be _moduleIndex_.
-                1. Set _module_.[[DFSAncestorIndex]] to _sccAncestorIndex_.
                 1. Append _module_ to _stack_.
                 1. For each ModuleRequest Record _request_ of _module_.[[RequestedModules]], do
                   1. Let _requiredModule_ be GetImportedModule(_module_, _request_).


### PR DESCRIPTION
This is an attempt at removing [[DFSAncestorIndex]], similarly to how https://github.com/tc39/ecma262/pull/3625 removed [[DFSIndex]], by slightly modifying Tarjan's algorithm to use the stack depth instead of the module discovery index.

Even though they do not represent how I came up with this different approach, I tried to split the changes in 5 separate commits that can be reviewed one-by-one for correctness. The rest of the commits to the same change for InnerModuleEvaluation.

This changes the editorial aspects but does not simplify implementations: they'd still need to keep track of a per-traversal number (just now it's the stack length rather than the discovery length) and a per-module number (unless they prefer to do an `O(number of nodes in a SCC)` loop for each cycle detected while traversing the graph, to find an index in a list).

Again, like for https://github.com/tc39/ecma262/pull/3635, this change is not _objectively_ good and I'm curious to se what editors think about it.

You can find a demo of the updated algorithm at https://nicolo-ribaudo.github.io/es-module-evaluation/#s=ICBBCiBCIEMKICBECiBFIEkKRiAgSgpIIEc%3D&c=QSAtPiBCCkIgLT4gQwpCIC0%2BIEQKQyAtPiBBCkMgLT4gRApEIC0%2BIEUKRSAtPiBGCkYgLT4gRwpHIC0%2BIEgKRyAtPiBFCkggLT4gRgpEIC0%2BIEkKSSAtPiBKCkogLT4gSQ%3D%3D&a=&f=

> **Editorial: Use stack index instead of traverse index for SCC detection**
> 
> To detect strongly connected components in module graphs, we need to
> use a number that increases as we go further away from the graph root
> on any branch of the DFS tree. This is so that when a node has a child
> that (1) is still not finalized yet, and (2) has a lower number than
> the node itself, we know that the child is an ancestor of the node
> and thus we are in a strongly connected component. Strongly connected
> components roots are thus nodes from which it is not possible to reach
> a non-finalized node with a lower number.
> 
> For this Tarjan's algorithm uses the discovery index of each node, but
> other indexes that have the same property are:
> - the depth of the node in the DFS tree
> - the index of the node in the stack that contains yet-to-be-finalized
>   nodes.
> 
> This commit updates the SCC discovery logic to use this last option,
> rather than carrying around the discovery index.

(Note: this first commit is the most complex one. A proof of its correctness is in https://github.com/tc39/ecma262/pull/3637#issuecomment-3051853852)

> **Editorial: Do not constantly update [[DFSAncestorIndex]] as we find lower values**
> 
> Instead, only update it at the end of InnerModuleLinking if the current
> module is a non-root node of a SCC. We do not need to update its value
> in the loop through a module's dependencies because, even if there
> was a loop leading back to the node currently being processed, the
> [[DFSAncestorIndex]] value propagated back across the loop would not
> cause the module's [[DFSAncestorIndex]] to decrease.

> **Editorial: return the SCC ancestor index from InnerModuleLinking**
> 
> Rather than returning ~unused~ and then reading it from the
> [[DFSAncestorIndex]] slot. Also return the index for modules that
> are not participating in cycles (returning the module index itself),
> to avoid having a separate path in the InnerModuleLinking loop.

> **Editorial: Do not update [[DFSAncestorIndex]] with the final low index**
> 
> The lowest possible [[DFSAncestorIndex]] will already be propagated back
> to the SCC root through _one_ of the SCC branches. InnerModuleLinking
> does not need modules to have their actually lowest possible
> [[DFSAncestorIndex]] set to know that they are a non-root node of a SCC:
> it's enough to know that from that node it's possible to reach _one_
> other node with a lower index, and that's signaled by the return value.

> **Editorial: Do not use [[DFSAncestorIndex]] in InnerModuleLinking**
> 
> [[DFSAncestorIndex]] index is only set once per module during a given
> traversal process, and it represents the module's index in _stack_.
> Instead explicitly storing it, we can compute it given _stack_ when
> needed (i.e. when we process an edge that "closes" a loop).