### PR TITLE
Normative: WeakRef.prototype.constructor should be writable

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -47165,8 +47165,6 @@ THH:mm:ss.sss
         <h1>WeakRef.prototype.constructor</h1>
 
         <p>The initial value of `WeakRef.prototype.constructor` is %WeakRef%.</p>
-
-        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
 
       <emu-clause id="sec-weak-ref.prototype.deref">


### PR DESCRIPTION
This matches how all other `constructor` properties are defined and implementations also implement the property as writable.