### PR TITLE
Editorial: add a note about synchronicity of SyntheticModule Evaluate

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -26779,6 +26779,7 @@
               <td>
                 <p>Returns a promise for the evaluation of this module and its dependencies, resolving on successful evaluation or if it has already been evaluated successfully, and rejecting for an evaluation error or if it has already been evaluated unsuccessfully. If the promise is rejected, hosts are expected to handle the promise rejection and rethrow the evaluation error.</p>
                 <p>Link must have completed successfully prior to invoking this method.</p>
+                <p>A non Cyclic Module Record must always returns a settled promise. This is asserted in InnerModuleEvaluation, and a non Cyclic Module Record is evaluated with EvaluateModuleSync.</p>
               </td>
             </tr>
           </table>
@@ -28738,7 +28739,7 @@
             <tr>
               <td>[[EvaluationSteps]]</td>
               <td>an Abstract Closure</td>
-              <td>The initialization logic to perform upon evaluation of the module, taking the Synthetic Module Record as its sole argument. It must not modify [[ExportNames]]. It may return an abrupt completion.</td>
+              <td>The initialization logic to perform upon evaluation of the module, taking the Synthetic Module Record as its sole argument. It must not modify [[ExportNames]]. It returns either normal completion containing ~unused~, or a throw completion.</td>
             </tr>
           </table>
         </emu-table>


### PR DESCRIPTION
It is not clear if a Synthetic Module's `[[EvaluationSteps]]` should be sync or not by reading the steps in Synthetic Module's `Evaluate` algorithm solely.

The synchronicity of a Synthetic Module's Evaluate steps is asserted in `EvaluateModuleSync`.

Add a note at Synthetic Module Evaluate abstract operation about the synchronicity.