### PR TITLE
Editorial: Refer to [[Call]] as an internal method

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -20212,7 +20212,7 @@
           1. If _val_ is a BigInt, return *"bigint"*.
           1. Assert: _val_ is an Object.
           1. [id="step-typeof-web-compat-insertion-point"] NOTE: This step is replaced in section <emu-xref href="#sec-IsHTMLDDA-internal-slot-typeof"></emu-xref>.
-          1. If _val_ has a [[Call]] internal slot, return *"function"*.
+          1. If _val_ has a [[Call]] internal method, return *"function"*.
           1. Return *"object"*.
         </emu-alg>
       </emu-clause>


### PR DESCRIPTION
This is the only place where `[[Call]]` is referred to as an "internal slot". Change it to "internal method" for consistency.


