### PR TITLE
Editorial: Include "object" in dfn for WeakRef and FinalizationRegistry prototype object

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -43246,7 +43246,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-properties-of-map-instances">
       <h1>Properties of Map Instances</h1>
-      <p>Map instances are ordinary objects that inherit properties from the Map prototype. Map instances also have a [[MapData]] internal slot.</p>
+      <p>Map instances are ordinary objects that inherit properties from the Map prototype object. Map instances also have a [[MapData]] internal slot.</p>
     </emu-clause>
 
     <emu-clause id="sec-map-iterator-objects">
@@ -43878,7 +43878,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-properties-of-set-instances">
       <h1>Properties of Set Instances</h1>
-      <p>Set instances are ordinary objects that inherit properties from the Set prototype. Set instances also have a [[SetData]] internal slot.</p>
+      <p>Set instances are ordinary objects that inherit properties from the Set prototype object. Set instances also have a [[SetData]] internal slot.</p>
     </emu-clause>
 
     <emu-clause id="sec-set-iterator-objects">
@@ -44086,7 +44086,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-properties-of-weakmap-instances">
       <h1>Properties of WeakMap Instances</h1>
-      <p>WeakMap instances are ordinary objects that inherit properties from the WeakMap prototype. WeakMap instances also have a [[WeakMapData]] internal slot.</p>
+      <p>WeakMap instances are ordinary objects that inherit properties from the WeakMap prototype object. WeakMap instances also have a [[WeakMapData]] internal slot.</p>
     </emu-clause>
   </emu-clause>
 
@@ -44215,7 +44215,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-properties-of-weakset-instances">
       <h1>Properties of WeakSet Instances</h1>
-      <p>WeakSet instances are ordinary objects that inherit properties from the WeakSet prototype. WeakSet instances also have a [[WeakSetData]] internal slot.</p>
+      <p>WeakSet instances are ordinary objects that inherit properties from the WeakSet prototype object. WeakSet instances also have a [[WeakSetData]] internal slot.</p>
     </emu-clause>
   </emu-clause>
 
@@ -47227,7 +47227,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-properties-of-weak-ref-instances">
       <h1>Properties of WeakRef Instances</h1>
-      <p>WeakRef instances are ordinary objects that inherit properties from the WeakRef prototype. WeakRef instances also have a [[WeakRefTarget]] internal slot.</p>
+      <p>WeakRef instances are ordinary objects that inherit properties from the WeakRef prototype object. WeakRef instances also have a [[WeakRefTarget]] internal slot.</p>
     </emu-clause>
   </emu-clause>
 
@@ -47352,7 +47352,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-properties-of-finalization-registry-instances">
       <h1>Properties of FinalizationRegistry Instances</h1>
-      <p>FinalizationRegistry instances are ordinary objects that inherit properties from the FinalizationRegistry prototype. FinalizationRegistry instances also have [[Cells]] and [[CleanupCallback]] internal slots.</p>
+      <p>FinalizationRegistry instances are ordinary objects that inherit properties from the FinalizationRegistry prototype object. FinalizationRegistry instances also have [[Cells]] and [[CleanupCallback]] internal slots.</p>
     </emu-clause>
   </emu-clause>
 </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -47151,7 +47151,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-properties-of-the-weak-ref-prototype-object">
       <h1>Properties of the WeakRef Prototype Object</h1>
-      <p>The <dfn>WeakRef prototype</dfn> object:</p>
+      <p>The <dfn>WeakRef prototype object</dfn>:</p>
       <ul>
         <li>is <dfn>%WeakRef.prototype%</dfn>.</li>
         <li>
@@ -47289,7 +47289,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-properties-of-the-finalization-registry-prototype-object">
       <h1>Properties of the FinalizationRegistry Prototype Object</h1>
-      <p>The <dfn>FinalizationRegistry prototype</dfn> object:</p>
+      <p>The <dfn>FinalizationRegistry prototype object</dfn>:</p>
       <ul>
         <li>is <dfn>%FinalizationRegistry.prototype%</dfn>.</li>
         <li>


### PR DESCRIPTION
Include "object" to match dfn of other built-in prototype objects.
