### PR TITLE
Editorial: allow Symbols and Private Names to have internals slots and use slot notation as appropriate

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -13817,7 +13817,7 @@
       <emu-alg>
         1. Assert: _F_ is an extensible object that does not have a *"name"* own property.
         1. If _name_ is a Symbol, then
-          1. Let _description_ be _name_'s [[Description]] value.
+          1. Let _description_ be _name_.[[Description]].
           1. If _description_ is *undefined*, set _name_ to the empty String.
           1. Else, set _name_ to the string-concatenation of *"["*, _description_, and *"]"*.
         1. Else if _name_ is a Private Name, then
@@ -31719,7 +31719,7 @@
           <dl class="header">
           </dl>
           <emu-alg>
-            1. Let _desc_ be _sym_'s [[Description]] value.
+            1. Let _desc_ be _sym_.[[Description]].
             1. If _desc_ is *undefined*, set _desc_ to the empty String.
             1. Assert: _desc_ is a String.
             1. Return the string-concatenation of *"Symbol("*, _desc_, and *")"*.

--- a/spec.html
+++ b/spec.html
@@ -1366,8 +1366,8 @@
     <emu-clause id="sec-ecmascript-language-types-symbol-type">
       <h1>The Symbol Type</h1>
       <p>The <dfn variants="is a Symbol,is not a Symbol">Symbol type</dfn> is the set of all non-String values that may be used as the key of an Object property (<emu-xref href="#sec-object-type"></emu-xref>).</p>
-      <p>Each possible Symbol value is unique and immutable.</p>
-      <p>Each Symbol value immutably holds an associated value called [[Description]] that is either *undefined* or a String value.</p>
+      <p>Each Symbol is unique and immutable.</p>
+      <p>Each Symbol has an immutable [[Description]] internal slot whose value is either a String or *undefined*.</p>
 
       <emu-clause id="sec-well-known-symbols">
         <h1>Well-Known Symbols</h1>
@@ -3012,7 +3012,7 @@
         <h1>Object Internal Methods and Internal Slots</h1>
         <p>The actual semantics of objects, in ECMAScript, are specified via algorithms called <em>internal methods</em>. Each object in an ECMAScript engine is associated with a set of internal methods that defines its runtime behaviour. These internal methods are not part of the ECMAScript language. They are defined by this specification purely for expository purposes. However, each object within an implementation of ECMAScript must behave as specified by the internal methods associated with it. The exact manner in which this is accomplished is determined by the implementation.</p>
         <p>Internal method names are polymorphic. This means that different object values may perform different algorithms when a common internal method name is invoked upon them. That actual object upon which an internal method is invoked is the “target” of the invocation. If, at runtime, the implementation of an algorithm attempts to use an internal method of an object that the object does not support, a *TypeError* exception is thrown.</p>
-        <p>Internal slots correspond to internal state that is associated with objects and used by various ECMAScript specification algorithms. Internal slots are not object properties and they are not inherited. Depending upon the specific internal slot specification, such state may consist of values of any ECMAScript language type or of specific ECMAScript specification type values. Unless explicitly specified otherwise, internal slots are allocated as part of the process of creating an object and may not be dynamically added to an object. Unless specified otherwise, the initial value of an internal slot is the value *undefined*. Various algorithms within this specification create objects that have internal slots. However, the ECMAScript language provides no direct way to associate internal slots with an object.</p>
+        <p>Internal slots correspond to internal state that is associated with objects, Symbols, or Private Names and used by various ECMAScript specification algorithms. Internal slots are not object properties and they are not inherited. Depending upon the specific internal slot specification, such state may consist of values of any ECMAScript language type or of specific ECMAScript specification type values. Unless explicitly specified otherwise, internal slots are allocated as part of the process of creating an object, Symbol, or Private Name and may not be dynamically added. Unless specified otherwise, the initial value of an internal slot is the value *undefined*. Various algorithms within this specification create values that have internal slots. However, the ECMAScript language provides no direct way to manipulate internal slots.</p>
         <p>All objects have an internal slot named [[PrivateElements]], which is a List of PrivateElements. This List represents the values of the private fields, methods, and accessors for the object. Initially, it is an empty List.</p>
         <p>Internal methods and internal slots are identified within this specification using names enclosed in double square brackets [[ ]].</p>
         <p><emu-xref href="#table-essential-internal-methods"></emu-xref> summarizes the <em>essential internal methods</em> used by this specification that are applicable to all objects created or manipulated by ECMAScript code. Every object must have algorithms for all of the essential internal methods. However, all objects do not necessarily use the same algorithms for those methods.</p>
@@ -4984,7 +4984,7 @@
 
     <emu-clause id="sec-private-names">
       <h1>Private Names</h1>
-      <p>The <dfn variants="Private Names">Private Name</dfn> specification type is used to describe a globally unique value (one which differs from any other Private Name, even if they are otherwise indistinguishable) which represents the key of a private class element (field, method, or accessor). Each Private Name has an associated immutable [[Description]] which is a String value. A Private Name may be installed on any ECMAScript object with PrivateFieldAdd or PrivateMethodOrAccessorAdd, and then read or written using PrivateGet and PrivateSet.</p>
+      <p>The <dfn variants="Private Names">Private Name</dfn> specification type is used to describe a globally unique value (one which differs from any other Private Name, even if they are otherwise indistinguishable) which represents the key of a private class element (field, method, or accessor). Each Private Name has an immutable [[Description]] internal slot which is a String. A Private Name may be installed on any ECMAScript object with PrivateFieldAdd or PrivateMethodOrAccessorAdd, and then read or written using PrivateGet and PrivateSet.</p>
     </emu-clause>
 
     <emu-clause id="sec-classstaticblockdefinition-record-specification-type">


### PR DESCRIPTION
As previously discussed with @michaelficarra, I replaced the occurrences of `ref's property value` with the conventional `ref.property`.
A more detailed report is available [here](https://github.com/tontonialberto/ecma262-spec-inconsistencies?tab=readme-ov-file#object-field-references).
