### PR TITLE
Editorial: consistently order undefined before null in comparisons

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -6135,7 +6135,7 @@
       </dl>
       <emu-alg>
         1. Assert: SameType(_x_, _y_) is *true*.
-        1. If _x_ is either *null* or *undefined*, return *true*.
+        1. If _x_ is either *undefined* or *null*, return *true*.
         1. If _x_ is a BigInt, then
           1. Return BigInt::equal(_x_, _y_).
         1. If _x_ is a String, then


### PR DESCRIPTION
There are 17 occurrences of `is either *undefined* or *null*` and only 1 occurrence of `is either *null* or *undefined*`.