### PR TITLE
meta: make esmeta log files available for download after CI run

### DIFF
--- a/.github/workflows/esmeta-typecheck.yml
+++ b/.github/workflows/esmeta-typecheck.yml
@@ -37,5 +37,11 @@ jobs:
           rmdir "${ESMETA_HOME}"/ecma262 \
             && ln -s "$(pwd)" "${ESMETA_HOME}"/ecma262
       - name: typecheck
-        run: '"${ESMETA_HOME}"/bin/esmeta tycheck -status -tycheck:log -tycheck:ignore=esmeta-ignore.json'
-
+        run: '"${ESMETA_HOME}"/bin/esmeta tycheck -status -extract:log -tycheck:log -tycheck:ignore=esmeta-ignore.json'
+      - name: create logs archive
+        run: 'tar --verbose --verbose --create --gzip --file esmeta-logs.tar.gz --directory="${ESMETA_HOME}" logs/'
+      - name: upload logs archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: esmeta-logs
+          path: esmeta-logs.tar.gz


### PR DESCRIPTION
The esmeta log files contain a bunch of additional information that's not available in the stdout output and which may be useful for debugging.