### PR TITLE
Editorial: unify various forms of if-otherwise in single-line conditionals

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -2065,19 +2065,19 @@
             1. If _exponent_ is either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, return *1*<sub>𝔽</sub>.
             1. If _base_ is *NaN*, return *NaN*.
             1. If _base_ is *+∞*<sub>𝔽</sub>, then
-              1. If _exponent_ > *+0*<sub>𝔽</sub>, return *+∞*<sub>𝔽</sub>. Otherwise, return *+0*<sub>𝔽</sub>.
+              1. If _exponent_ > *+0*<sub>𝔽</sub>, return *+∞*<sub>𝔽</sub>; otherwise return *+0*<sub>𝔽</sub>.
             1. If _base_ is *-∞*<sub>𝔽</sub>, then
               1. If _exponent_ > *+0*<sub>𝔽</sub>, then
-                1. If _exponent_ is an odd integral Number, return *-∞*<sub>𝔽</sub>. Otherwise, return *+∞*<sub>𝔽</sub>.
+                1. If _exponent_ is an odd integral Number, return *-∞*<sub>𝔽</sub>; otherwise return *+∞*<sub>𝔽</sub>.
               1. Else,
-                1. If _exponent_ is an odd integral Number, return *-0*<sub>𝔽</sub>. Otherwise, return *+0*<sub>𝔽</sub>.
+                1. If _exponent_ is an odd integral Number, return *-0*<sub>𝔽</sub>; otherwise return *+0*<sub>𝔽</sub>.
             1. If _base_ is *+0*<sub>𝔽</sub>, then
-              1. If _exponent_ > *+0*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>. Otherwise, return *+∞*<sub>𝔽</sub>.
+              1. If _exponent_ > *+0*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>; otherwise return *+∞*<sub>𝔽</sub>.
             1. If _base_ is *-0*<sub>𝔽</sub>, then
               1. If _exponent_ > *+0*<sub>𝔽</sub>, then
-                1. If _exponent_ is an odd integral Number, return *-0*<sub>𝔽</sub>. Otherwise, return *+0*<sub>𝔽</sub>.
+                1. If _exponent_ is an odd integral Number, return *-0*<sub>𝔽</sub>; otherwise return *+0*<sub>𝔽</sub>.
               1. Else,
-                1. If _exponent_ is an odd integral Number, return *-∞*<sub>𝔽</sub>. Otherwise, return *+∞*<sub>𝔽</sub>.
+                1. If _exponent_ is an odd integral Number, return *-∞*<sub>𝔽</sub>; otherwise return *+∞*<sub>𝔽</sub>.
             1. Assert: _base_ is finite and is neither *+0*<sub>𝔽</sub> nor *-0*<sub>𝔽</sub>.
             1. If _exponent_ is *+∞*<sub>𝔽</sub>, then
               1. If abs(ℝ(_base_)) > 1, return *+∞*<sub>𝔽</sub>.
@@ -2148,17 +2148,17 @@
               1. If _y_ is *+0*<sub>𝔽</sub> or _y_ > *+0*<sub>𝔽</sub>, return _x_.
               1. Return -_x_.
             1. If _y_ is *+∞*<sub>𝔽</sub>, then
-              1. If _x_ is *+0*<sub>𝔽</sub> or _x_ > *+0*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>. Otherwise, return *-0*<sub>𝔽</sub>.
+              1. If _x_ is *+0*<sub>𝔽</sub> or _x_ > *+0*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>; otherwise return *-0*<sub>𝔽</sub>.
             1. If _y_ is *-∞*<sub>𝔽</sub>, then
-              1. If _x_ is *+0*<sub>𝔽</sub> or _x_ > *+0*<sub>𝔽</sub>, return *-0*<sub>𝔽</sub>. Otherwise, return *+0*<sub>𝔽</sub>.
+              1. If _x_ is *+0*<sub>𝔽</sub> or _x_ > *+0*<sub>𝔽</sub>, return *-0*<sub>𝔽</sub>; otherwise return *+0*<sub>𝔽</sub>.
             1. If _x_ is either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, then
               1. If _y_ is either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, return *NaN*.
               1. If _y_ > *+0*<sub>𝔽</sub>, return _x_.
               1. Return -_x_.
             1. If _y_ is *+0*<sub>𝔽</sub>, then
-              1. If _x_ > *+0*<sub>𝔽</sub>, return *+∞*<sub>𝔽</sub>. Otherwise, return *-∞*<sub>𝔽</sub>.
+              1. If _x_ > *+0*<sub>𝔽</sub>, return *+∞*<sub>𝔽</sub>; otherwise return *-∞*<sub>𝔽</sub>.
             1. If _y_ is *-0*<sub>𝔽</sub>, then
-              1. If _x_ > *+0*<sub>𝔽</sub>, return *-∞*<sub>𝔽</sub>. Otherwise, return *+∞*<sub>𝔽</sub>.
+              1. If _x_ > *+0*<sub>𝔽</sub>, return *-∞*<sub>𝔽</sub>; otherwise return *+∞*<sub>𝔽</sub>.
             1. Return 𝔽(ℝ(_x_) / ℝ(_y_)).
           </emu-alg>
         </emu-clause>
@@ -2309,7 +2309,7 @@
             1. If _y_ is *-∞*<sub>𝔽</sub>, return *false*.
             1. If _x_ is *-∞*<sub>𝔽</sub>, return *true*.
             1. Assert: _x_ and _y_ are finite.
-            1. If ℝ(_x_) &lt; ℝ(_y_), return *true*. Otherwise, return *false*.
+            1. If ℝ(_x_) &lt; ℝ(_y_), return *true*; otherwise return *false*.
           </emu-alg>
         </emu-clause>
 
@@ -5259,20 +5259,20 @@
             1. Else,
               1. Let _b_ be 0.
               1. Let _n_ be 0.
-            1. If |ExponentPart| is present, let _e_ be the MV of |ExponentPart|. Otherwise, let _e_ be 0.
+            1. If |ExponentPart| is present, let _e_ be the MV of |ExponentPart|; otherwise let _e_ be 0.
             1. Return RoundMVResult((_a_ + (_b_ × 10<sup>-_n_</sup>)) × 10<sup>_e_</sup>).
           </emu-alg>
           <emu-grammar>StrUnsignedDecimalLiteral ::: `.` DecimalDigits ExponentPart?</emu-grammar>
           <emu-alg>
             1. Let _b_ be the MV of |DecimalDigits|.
-            1. If |ExponentPart| is present, let _e_ be the MV of |ExponentPart|. Otherwise, let _e_ be 0.
+            1. If |ExponentPart| is present, let _e_ be the MV of |ExponentPart|; otherwise let _e_ be 0.
             1. Let _n_ be the number of code points in |DecimalDigits|.
             1. Return RoundMVResult(_b_ × 10<sup>_e_ - _n_</sup>).
           </emu-alg>
           <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits ExponentPart?</emu-grammar>
           <emu-alg>
             1. Let _a_ be the MV of |DecimalDigits|.
-            1. If |ExponentPart| is present, let _e_ be the MV of |ExponentPart|. Otherwise, let _e_ be 0.
+            1. If |ExponentPart| is present, let _e_ be the MV of |ExponentPart|; otherwise let _e_ be 0.
             1. Return RoundMVResult(_a_ × 10<sup>_e_</sup>).
           </emu-alg>
         </emu-clause>
@@ -5494,7 +5494,7 @@
         1. Let _f_ be floor(_clamped_).
         1. If _clamped_ &lt; _f_ + 0.5, return 𝔽(_f_).
         1. If _clamped_ > _f_ + 0.5, return 𝔽(_f_ + 1).
-        1. If _f_ is even, return 𝔽(_f_). Otherwise, return 𝔽(_f_ + 1).
+        1. If _f_ is even, return 𝔽(_f_); otherwise return 𝔽(_f_ + 1).
       </emu-alg>
       <emu-note>
         <p>Unlike most other ECMAScript integer conversion operations, ToUint8Clamp rounds rather than truncates non-integral values. It also uses “round half to even” tie-breaking, which differs from the “round half up” tie-breaking of <emu-xref href="#sec-math.round">`Math.round`</emu-xref>.</p>
@@ -6139,11 +6139,11 @@
         1. If _x_ is a BigInt, then
           1. Return BigInt::equal(_x_, _y_).
         1. If _x_ is a String, then
-          1. If _x_ and _y_ have the same length and the same code units in the same positions, return *true*; otherwise, return *false*.
+          1. If _x_ and _y_ have the same length and the same code units in the same positions, return *true*; otherwise return *false*.
         1. If _x_ is a Boolean, then
-          1. If _x_ and _y_ are both *true* or both *false*, return *true*; otherwise, return *false*.
+          1. If _x_ and _y_ are both *true* or both *false*, return *true*; otherwise return *false*.
         1. NOTE: All other ECMAScript language values are compared by identity.
-        1. If _x_ is _y_, return *true*; otherwise, return *false*.
+        1. If _x_ is _y_, return *true*; otherwise return *false*.
       </emu-alg>
       <emu-note>
         For expository purposes, some cases are handled separately within this algorithm even if it is unnecessary to do so.
@@ -6181,7 +6181,7 @@
             1. Let _cy_ be the numeric value of the code unit at index _i_ within _py_.
             1. If _cx_ &lt; _cy_, return *true*.
             1. If _cx_ > _cy_, return *false*.
-          1. If _lx_ &lt; _ly_, return *true*. Otherwise, return *false*.
+          1. If _lx_ &lt; _ly_, return *true*; otherwise return *false*.
         1. Else,
           1. If _px_ is a BigInt and _py_ is a String, then
             1. Let _ny_ be StringToBigInt(_py_).
@@ -10918,7 +10918,7 @@
             <dd>a Function Environment Record _envRec_</dd>
           </dl>
           <emu-alg>
-            1. If _envRec_.[[ThisBindingStatus]] is ~lexical~, return *false*; otherwise, return *true*.
+            1. If _envRec_.[[ThisBindingStatus]] is ~lexical~, return *false*; otherwise return *true*.
           </emu-alg>
         </emu-clause>
 
@@ -10930,7 +10930,7 @@
           </dl>
           <emu-alg>
             1. If _envRec_.[[ThisBindingStatus]] is ~lexical~, return *false*.
-            1. If _envRec_.[[FunctionObject]].[[HomeObject]] is *undefined*, return *false*; otherwise, return *true*.
+            1. If _envRec_.[[FunctionObject]].[[HomeObject]] is *undefined*, return *false*; otherwise return *true*.
           </emu-alg>
         </emu-clause>
 
@@ -12005,7 +12005,7 @@
       <emu-alg>
         1. If the execution context stack is empty, return *null*.
         1. Let _ec_ be the topmost execution context on the execution context stack whose ScriptOrModule component is not *null*.
-        1. If no such execution context exists, return *null*. Otherwise, return _ec_'s ScriptOrModule.
+        1. If no such execution context exists, return *null*; otherwise return _ec_'s ScriptOrModule.
       </emu-alg>
     </emu-clause>
 
@@ -13877,7 +13877,7 @@
         1. Let _strict_ be _func_.[[Strict]].
         1. Let _formals_ be _func_.[[FormalParameters]].
         1. Let _parameterNames_ be the BoundNames of _formals_.
-        1. If _parameterNames_ has any duplicate entries, let _hasDuplicates_ be *true*. Otherwise, let _hasDuplicates_ be *false*.
+        1. If _parameterNames_ has any duplicate entries, let _hasDuplicates_ be *true*; otherwise let _hasDuplicates_ be *false*.
         1. Let _simpleParameterList_ be IsSimpleParameterList of _formals_.
         1. Let _hasParameterExpressions_ be ContainsExpression of _formals_.
         1. Let _varNames_ be the VarDeclaredNames of _code_.
@@ -14060,7 +14060,7 @@
         1. Set the ScriptOrModule of _calleeContext_ to *null*.
         1. Perform any necessary implementation-defined initialization of _calleeContext_.
         1. Push _calleeContext_ onto the execution context stack; _calleeContext_ is now the running execution context.
-        1. [id="step-call-builtin-function-result"] Let _result_ be the Completion Record that is <emu-meta effects="user-code">the result of evaluating</emu-meta> _F_ in a manner that conforms to the specification of _F_. If _thisArgument_ is ~uninitialized~, the *this* value is uninitialized; otherwise, _thisArgument_ provides the *this* value. _argumentsList_ provides the named parameters. _newTarget_ provides the NewTarget value.
+        1. [id="step-call-builtin-function-result"] Let _result_ be the Completion Record that is <emu-meta effects="user-code">the result of evaluating</emu-meta> _F_ in a manner that conforms to the specification of _F_. If _thisArgument_ is ~uninitialized~, the *this* value is uninitialized; otherwise _thisArgument_ provides the *this* value. _argumentsList_ provides the named parameters. _newTarget_ provides the NewTarget value.
         1. NOTE: If _F_ is defined in this document, “the specification of _F_” is the behaviour specified for it via algorithm steps or other means.
         1. Remove _calleeContext_ from the execution context stack and restore _callerContext_ as the running execution context.
         1. Return ? _result_.
@@ -20467,7 +20467,7 @@
         1. Let _rRef_ be ? Evaluation of |ShiftExpression|.
         1. Let _rVal_ be ? GetValue(_rRef_).
         1. Let _r_ be ? IsLessThan(_lVal_, _rVal_, *true*).
-        1. If _r_ is *undefined*, return *false*. Otherwise, return _r_.
+        1. If _r_ is *undefined*, return *false*; otherwise return _r_.
       </emu-alg>
       <emu-grammar>RelationalExpression : RelationalExpression `&gt;` ShiftExpression</emu-grammar>
       <emu-alg>
@@ -20476,7 +20476,7 @@
         1. Let _rRef_ be ? Evaluation of |ShiftExpression|.
         1. Let _rVal_ be ? GetValue(_rRef_).
         1. Let _r_ be ? IsLessThan(_rVal_, _lVal_, *false*).
-        1. If _r_ is *undefined*, return *false*. Otherwise, return _r_.
+        1. If _r_ is *undefined*, return *false*; otherwise return _r_.
       </emu-alg>
       <emu-grammar>RelationalExpression : RelationalExpression `&lt;=` ShiftExpression</emu-grammar>
       <emu-alg>
@@ -20485,7 +20485,7 @@
         1. Let _rRef_ be ? Evaluation of |ShiftExpression|.
         1. Let _rVal_ be ? GetValue(_rRef_).
         1. Let _r_ be ? IsLessThan(_rVal_, _lVal_, *false*).
-        1. If _r_ is either *true* or *undefined*, return *false*. Otherwise, return *true*.
+        1. If _r_ is either *true* or *undefined*, return *false*; otherwise return *true*.
       </emu-alg>
       <emu-grammar>RelationalExpression : RelationalExpression `&gt;=` ShiftExpression</emu-grammar>
       <emu-alg>
@@ -20494,7 +20494,7 @@
         1. Let _rRef_ be ? Evaluation of |ShiftExpression|.
         1. Let _rVal_ be ? GetValue(_rRef_).
         1. Let _r_ be ? IsLessThan(_lVal_, _rVal_, *true*).
-        1. If _r_ is either *true* or *undefined*, return *false*. Otherwise, return *true*.
+        1. If _r_ is either *true* or *undefined*, return *false*; otherwise return *true*.
       </emu-alg>
       <emu-grammar>RelationalExpression : RelationalExpression `instanceof` ShiftExpression</emu-grammar>
       <emu-alg>
@@ -20584,7 +20584,7 @@
         1. Let _rRef_ be ? Evaluation of |RelationalExpression|.
         1. Let _rVal_ be ? GetValue(_rRef_).
         1. Let _r_ be ? IsLooselyEqual(_rVal_, _lVal_).
-        1. If _r_ is *true*, return *false*. Otherwise, return *true*.
+        1. If _r_ is *true*, return *false*; otherwise return *true*.
       </emu-alg>
       <emu-grammar>EqualityExpression : EqualityExpression `===` RelationalExpression</emu-grammar>
       <emu-alg>
@@ -20601,7 +20601,7 @@
         1. Let _rRef_ be ? Evaluation of |RelationalExpression|.
         1. Let _rVal_ be ? GetValue(_rRef_).
         1. Let _r_ be IsStrictlyEqual(_rVal_, _lVal_).
-        1. If _r_ is *true*, return *false*. Otherwise, return *true*.
+        1. If _r_ is *true*, return *false*; otherwise return *true*.
       </emu-alg>
       <emu-note>
         <p>Given the above definition of equality:</p>
@@ -22132,15 +22132,15 @@
           1. If the first |Expression| is present, then
             1. Let _exprRef_ be ? Evaluation of the first |Expression|.
             1. Perform ? GetValue(_exprRef_).
-          1. If the second |Expression| is present, let _test_ be the second |Expression|; otherwise, let _test_ be ~empty~.
-          1. If the third |Expression| is present, let _increment_ be the third |Expression|; otherwise, let _increment_ be ~empty~.
+          1. If the second |Expression| is present, let _test_ be the second |Expression|; otherwise let _test_ be ~empty~.
+          1. If the third |Expression| is present, let _increment_ be the third |Expression|; otherwise let _increment_ be ~empty~.
           1. Return ? ForBodyEvaluation(_test_, _increment_, |Statement|, « », _labelSet_).
         </emu-alg>
         <emu-grammar>ForStatement : `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement</emu-grammar>
         <emu-alg>
           1. Perform ? Evaluation of |VariableDeclarationList|.
-          1. If the first |Expression| is present, let _test_ be the first |Expression|; otherwise, let _test_ be ~empty~.
-          1. If the second |Expression| is present, let _increment_ be the second |Expression|; otherwise, let _increment_ be ~empty~.
+          1. If the first |Expression| is present, let _test_ be the first |Expression|; otherwise let _test_ be ~empty~.
+          1. If the second |Expression| is present, let _increment_ be the second |Expression|; otherwise let _increment_ be ~empty~.
           1. Return ? ForBodyEvaluation(_test_, _increment_, |Statement|, « », _labelSet_).
         </emu-alg>
         <emu-grammar>ForStatement : `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement</emu-grammar>
@@ -22160,8 +22160,8 @@
             1. Set the running execution context's LexicalEnvironment to _oldEnv_.
             1. Return ? _forDcl_.
           1. If _isConst_ is *false*, let _perIterationLets_ be _boundNames_; otherwise let _perIterationLets_ be a new empty List.
-          1. If the first |Expression| is present, let _test_ be the first |Expression|; otherwise, let _test_ be ~empty~.
-          1. If the second |Expression| is present, let _increment_ be the second |Expression|; otherwise, let _increment_ be ~empty~.
+          1. If the first |Expression| is present, let _test_ be the first |Expression|; otherwise let _test_ be ~empty~.
+          1. If the second |Expression| is present, let _increment_ be the second |Expression|; otherwise let _increment_ be ~empty~.
           1. Let _bodyResult_ be Completion(ForBodyEvaluation(_test_, _increment_, |Statement|, _perIterationLets_, _labelSet_)).
           1. Set the running execution context's LexicalEnvironment to _oldEnv_.
           1. Return ? _bodyResult_.
@@ -23720,7 +23720,7 @@
       </dl>
       <emu-grammar>FunctionBody : FunctionStatementList</emu-grammar>
       <emu-alg>
-        1. If the Directive Prologue of |FunctionBody| contains a Use Strict Directive, return *true*; otherwise, return *false*.
+        1. If the Directive Prologue of |FunctionBody| contains a Use Strict Directive, return *true*; otherwise return *false*.
       </emu-alg>
     </emu-clause>
 
@@ -26122,7 +26122,7 @@
       </dl>
       <emu-grammar>Script : ScriptBody?</emu-grammar>
       <emu-alg>
-        1. If |ScriptBody| is present and the Directive Prologue of |ScriptBody| contains a Use Strict Directive, return *true*; otherwise, return *false*.
+        1. If |ScriptBody| is present and the Directive Prologue of |ScriptBody| contains a Use Strict Directive, return *true*; otherwise return *false*.
       </emu-alg>
     </emu-clause>
 
@@ -30080,7 +30080,7 @@
           1. If the length of _S_ is at least 2 and the first two code units of _S_ are either *"0x"* or *"0X"*, then
             1. Set _S_ to the substring of _S_ from index 2.
             1. Set _R_ to 16.
-        1. If _S_ contains a code unit that is not a radix-_R_ digit, let _end_ be the index within _S_ of the first such code unit; otherwise, let _end_ be the length of _S_.
+        1. If _S_ contains a code unit that is not a radix-_R_ digit, let _end_ be the index within _S_ of the first such code unit; otherwise let _end_ be the length of _S_.
         1. Let _Z_ be the substring of _S_ from 0 to _end_.
         1. If _Z_ is empty, return *NaN*.
         1. Let _mathInt_ be the integer value that is represented by _Z_ in radix-_R_ notation, using the letters <b>A</b> through <b>Z</b> and <b>a</b> through <b>z</b> for digits with values 10 through 35. (However, if _R_ = 10 and _Z_ contains more than 20 significant digits, every significant digit after the 20th may be replaced by a 0 digit, at the option of the implementation; and if _R_ is not one of 2, 4, 8, 10, 16, or 32, then _mathInt_ may be an implementation-approximated integer representing the integer value denoted by _Z_ in radix-_R_ notation.)
@@ -30216,7 +30216,7 @@
               1. Let _n_ be the number of leading 1 bits in _B_.
               1. If _n_ = 0, then
                 1. Let _asciiChar_ be the code unit whose numeric value is _B_.
-                1. If _preserveEscapeSet_ contains _asciiChar_, set _S_ to _escape_. Otherwise, set _S_ to _asciiChar_.
+                1. If _preserveEscapeSet_ contains _asciiChar_, set _S_ to _escape_; otherwise set _S_ to _asciiChar_.
               1. Else,
                 1. If _n_ = 1 or _n_ > 4, throw a *URIError* exception.
                 1. Let _Octets_ be « _B_ ».
@@ -32373,7 +32373,7 @@
             1. Let _m_ be ! ToString(𝔽(_x_)).
           1. Else,
             1. Let _n_ be an integer for which _n_ / 10<sup>_f_</sup> - _x_ is as close to zero as possible. If there are two such _n_, pick the larger _n_.
-            1. If _n_ = 0, let _m_ be *"0"*. Otherwise, let _m_ be the String value consisting of the digits of the decimal representation of _n_ (in order, with no leading zeroes).
+            1. If _n_ = 0, let _m_ be *"0"*; otherwise let _m_ be the String value consisting of the digits of the decimal representation of _n_ (in order, with no leading zeroes).
             1. If _f_ ≠ 0, then
               1. Let _k_ be the length of _m_.
               1. If _k_ ≤ _f_, then
@@ -32548,7 +32548,7 @@
           1. Set _bits_ to ? ToIndex(_bits_).
           1. Set _bigint_ to ? ToBigInt(_bigint_).
           1. Let _mod_ be ℝ(_bigint_) modulo 2<sup>_bits_</sup>.
-          1. If _mod_ ≥ 2<sup>_bits_ - 1</sup>, return ℤ(_mod_ - 2<sup>_bits_</sup>); otherwise, return ℤ(_mod_).
+          1. If _mod_ ≥ 2<sup>_bits_ - 1</sup>, return ℤ(_mod_ - 2<sup>_bits_</sup>); otherwise return ℤ(_mod_).
         </emu-alg>
       </emu-clause>
 
@@ -34603,9 +34603,9 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
           1. Let _t_ be _dateObject_.[[DateValue]].
           1. Let _y_ be ? ToNumber(_year_).
-          1. If _t_ is *NaN*, set _t_ to *+0*<sub>𝔽</sub>; otherwise, set _t_ to LocalTime(_t_).
-          1. If _month_ is not present, let _m_ be MonthFromTime(_t_); otherwise, let _m_ be ? ToNumber(_month_).
-          1. If _date_ is not present, let _dt_ be DateFromTime(_t_); otherwise, let _dt_ be ? ToNumber(_date_).
+          1. If _t_ is *NaN*, set _t_ to *+0*<sub>𝔽</sub>; otherwise set _t_ to LocalTime(_t_).
+          1. If _month_ is not present, let _m_ be MonthFromTime(_t_); otherwise let _m_ be ? ToNumber(_month_).
+          1. If _date_ is not present, let _dt_ be DateFromTime(_t_); otherwise let _dt_ be ? ToNumber(_date_).
           1. Let _newDate_ be MakeDate(MakeDay(_y_, _m_, _dt_), TimeWithinDay(_t_)).
           1. Let _u_ be TimeClip(UTC(_newDate_)).
           1. Set _dateObject_.[[DateValue]] to _u_.
@@ -34770,8 +34770,8 @@ THH:mm:ss.sss
           1. Let _t_ be _dateObject_.[[DateValue]].
           1. If _t_ is *NaN*, set _t_ to *+0*<sub>𝔽</sub>.
           1. Let _y_ be ? ToNumber(_year_).
-          1. If _month_ is not present, let _m_ be MonthFromTime(_t_); otherwise, let _m_ be ? ToNumber(_month_).
-          1. If _date_ is not present, let _dt_ be DateFromTime(_t_); otherwise, let _dt_ be ? ToNumber(_date_).
+          1. If _month_ is not present, let _m_ be MonthFromTime(_t_); otherwise let _m_ be ? ToNumber(_month_).
+          1. If _date_ is not present, let _dt_ be DateFromTime(_t_); otherwise let _dt_ be ? ToNumber(_date_).
           1. Let _newDate_ be MakeDate(MakeDay(_y_, _m_, _dt_), TimeWithinDay(_t_)).
           1. Let _v_ be TimeClip(_newDate_).
           1. Set _dateObject_.[[DateValue]] to _v_.
@@ -35004,7 +35004,7 @@ THH:mm:ss.sss
             1. Let _month_ be the Name of the entry in <emu-xref href="#sec-todatestring-month-names"></emu-xref> with the Number MonthFromTime(_tv_).
             1. Let _day_ be ToZeroPaddedDecimalString(ℝ(DateFromTime(_tv_)), 2).
             1. Let _yv_ be YearFromTime(_tv_).
-            1. If _yv_ is *+0*<sub>𝔽</sub> or _yv_ > *+0*<sub>𝔽</sub>, let _yearSign_ be the empty String; otherwise, let _yearSign_ be *"-"*.
+            1. If _yv_ is *+0*<sub>𝔽</sub> or _yv_ > *+0*<sub>𝔽</sub>, let _yearSign_ be the empty String; otherwise let _yearSign_ be *"-"*.
             1. Let _paddedYear_ be ToZeroPaddedDecimalString(abs(ℝ(_yv_)), 4).
             1. Return the string-concatenation of _weekday_, the code unit 0x0020 (SPACE), _month_, the code unit 0x0020 (SPACE), _day_, the code unit 0x0020 (SPACE), _yearSign_, and _paddedYear_.
           </emu-alg>
@@ -35260,7 +35260,7 @@ THH:mm:ss.sss
           1. Let _month_ be the Name of the entry in <emu-xref href="#sec-todatestring-month-names"></emu-xref> with the Number MonthFromTime(_tv_).
           1. Let _day_ be ToZeroPaddedDecimalString(ℝ(DateFromTime(_tv_)), 2).
           1. Let _yv_ be YearFromTime(_tv_).
-          1. If _yv_ is *+0*<sub>𝔽</sub> or _yv_ > *+0*<sub>𝔽</sub>, let _yearSign_ be the empty String; otherwise, let _yearSign_ be *"-"*.
+          1. If _yv_ is *+0*<sub>𝔽</sub> or _yv_ > *+0*<sub>𝔽</sub>, let _yearSign_ be the empty String; otherwise let _yearSign_ be *"-"*.
           1. Let _paddedYear_ be ToZeroPaddedDecimalString(abs(ℝ(_yv_)), 4).
           1. Return the string-concatenation of _weekday_, *","*, the code unit 0x0020 (SPACE), _day_, the code unit 0x0020 (SPACE), _month_, the code unit 0x0020 (SPACE), _yearSign_, _paddedYear_, the code unit 0x0020 (SPACE), and TimeString(_tv_).
         </emu-alg>
@@ -35626,7 +35626,7 @@ THH:mm:ss.sss
           1. Let _searchStr_ be ? ToString(_searchString_).
           1. Let _numPos_ be ? ToNumber(_position_).
           1. Assert: If _position_ is *undefined*, then _numPos_ is *NaN*.
-          1. If _numPos_ is *NaN*, let _pos_ be +∞; otherwise, let _pos_ be ! ToIntegerOrInfinity(_numPos_).
+          1. If _numPos_ is *NaN*, let _pos_ be +∞; otherwise let _pos_ be ! ToIntegerOrInfinity(_numPos_).
           1. Let _len_ be the length of _S_.
           1. Let _searchLen_ be the length of _searchStr_.
           1. Let _start_ be the result of clamping _pos_ between 0 and _len_ - _searchLen_.
@@ -35915,7 +35915,7 @@ THH:mm:ss.sss
                 1. Let _refReplacement_ be the substring of _str_ from min(_tailPos_, _stringLength_).
                 1. NOTE: _tailPos_ can exceed _stringLength_ only if this abstract operation was invoked by a call to the intrinsic %Symbol.replace% method of %RegExp.prototype% on an object whose *"exec"* property is not the intrinsic %RegExp.prototype.exec%.
               1. Else if _templateRemainder_ starts with *"$"* followed by 1 or more decimal digits, then
-                1. If _templateRemainder_ starts with *"$"* followed by 2 or more decimal digits, let _digitCount_ be 2. Otherwise, let _digitCount_ be 1.
+                1. If _templateRemainder_ starts with *"$"* followed by 2 or more decimal digits, let _digitCount_ be 2; otherwise let _digitCount_ be 1.
                 1. Let _digits_ be the substring of _templateRemainder_ from 1 to 1 + _digitCount_.
                 1. Let _index_ be ℝ(StringToNumber(_digits_)).
                 1. Assert: 0 ≤ _index_ ≤ 99.
@@ -38004,7 +38004,7 @@ THH:mm:ss.sss
               1. Let _index_ be min(_e_, _f_).
               1. Let _ch_ be the character _Input_[_index_].
               1. Let _cc_ be Canonicalize(_rer_, _ch_).
-              1. If there exists a CharSetElement in _A_ containing exactly one character _a_ such that Canonicalize(_rer_, _a_) is _cc_, let _found_ be *true*. Otherwise, let _found_ be *false*.
+              1. If there exists a CharSetElement in _A_ containing exactly one character _a_ such that Canonicalize(_rer_, _a_) is _cc_, let _found_ be *true*; otherwise let _found_ be *false*.
               1. If _invert_ is *false* and _found_ is *false*, return ~failure~.
               1. If _invert_ is *true* and _found_ is *true*, return ~failure~.
               1. Let _cap_ be _x_.[[Captures]].
@@ -38954,7 +38954,7 @@ THH:mm:ss.sss
           1. If _flags_ does not contain *"g"*, then
             1. Return ? RegExpExec(_rx_, _S_).
           1. Else,
-            1. If _flags_ contains *"u"* or _flags_ contains *"v"*, let _fullUnicode_ be *true*. Otherwise, let _fullUnicode_ be *false*.
+            1. If _flags_ contains *"u"* or _flags_ contains *"v"*, let _fullUnicode_ be *true*; otherwise let _fullUnicode_ be *false*.
             1. Perform ? Set(_rx_, *"lastIndex"*, *+0*<sub>𝔽</sub>, *true*).
             1. Let _A_ be ! ArrayCreate(0).
             1. Let _n_ be 0.
@@ -39021,7 +39021,7 @@ THH:mm:ss.sss
           1. If _functionalReplace_ is *false*, then
             1. Set _replaceValue_ to ? ToString(_replaceValue_).
           1. Let _flags_ be ? ToString(? Get(_rx_, *"flags"*)).
-          1. If _flags_ contains *"g"*, let _global_ be *true*. Otherwise, let _global_ be *false*.
+          1. If _flags_ contains *"g"*, let _global_ be *true*; otherwise let _global_ be *false*.
           1. If _global_ is *true*, then
             1. Perform ? Set(_rx_, *"lastIndex"*, *+0*<sub>𝔽</sub>, *true*).
           1. Let _results_ be a new empty List.
@@ -39038,7 +39038,7 @@ THH:mm:ss.sss
                 1. Let _matchStr_ be ? ToString(? Get(_result_, *"0"*)).
                 1. If _matchStr_ is the empty String, then
                   1. Let _thisIndex_ be ℝ(? ToLength(? Get(_rx_, *"lastIndex"*))).
-                  1. If _flags_ contains *"u"* or _flags_ contains *"v"*, let _fullUnicode_ be *true*. Otherwise, let _fullUnicode_ be *false*.
+                  1. If _flags_ contains *"u"* or _flags_ contains *"v"*, let _fullUnicode_ be *true*; otherwise let _fullUnicode_ be *false*.
                   1. Let _nextIndex_ be AdvanceStringIndex(_S_, _thisIndex_, _fullUnicode_).
                   1. Perform ? Set(_rx_, *"lastIndex"*, 𝔽(_nextIndex_), *true*).
           1. Let _accumulatedResult_ be the empty String.
@@ -39321,7 +39321,7 @@ THH:mm:ss.sss
           1. Let _matcher_ be _R_.[[RegExpMatcher]].
           1. If _flags_ contains *"u"* or _flags_ contains *"v"*, let _fullUnicode_ be *true*; else let _fullUnicode_ be *false*.
           1. Let _matchSucceeded_ be *false*.
-          1. If _fullUnicode_ is *true*, let _input_ be StringToCodePoints(_S_). Otherwise, let _input_ be a List whose elements are the code units that are the elements of _S_.
+          1. If _fullUnicode_ is *true*, let _input_ be StringToCodePoints(_S_); otherwise let _input_ be a List whose elements are the code units that are the elements of _S_.
           1. NOTE: Each element of _input_ is considered to be a character.
           1. Repeat, while _matchSucceeded_ is *false*,
             1. If _lastIndex_ > _length_, then
@@ -42265,7 +42265,7 @@ THH:mm:ss.sss
             1. If _targetOffset_ = +∞, throw a *RangeError* exception.
             1. If _srcLength_ + _targetOffset_ > _targetLength_, throw a *RangeError* exception.
             1. If _target_.[[ContentType]] is not _source_.[[ContentType]], throw a *TypeError* exception.
-            1. If IsSharedArrayBuffer(_srcBuffer_) is *true*, IsSharedArrayBuffer(_targetBuffer_) is *true*, and _srcBuffer_.[[ArrayBufferData]] is _targetBuffer_.[[ArrayBufferData]], let _sameSharedArrayBuffer_ be *true*; otherwise, let _sameSharedArrayBuffer_ be *false*.
+            1. If IsSharedArrayBuffer(_srcBuffer_) is *true*, IsSharedArrayBuffer(_targetBuffer_) is *true*, and _srcBuffer_.[[ArrayBufferData]] is _targetBuffer_.[[ArrayBufferData]], let _sameSharedArrayBuffer_ be *true*; otherwise let _sameSharedArrayBuffer_ be *false*.
             1. If SameValue(_srcBuffer_, _targetBuffer_) is *true* or _sameSharedArrayBuffer_ is *true*, then
               1. Let _srcByteLength_ be TypedArrayByteLength(_srcRecord_).
               1. Set _srcBuffer_ to ? CloneArrayBuffer(_srcBuffer_, _srcByteOffset_, _srcByteLength_).
@@ -52597,7 +52597,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
           1. Let _t_ be _dateObject_.[[DateValue]].
           1. Let _y_ be ? ToNumber(_year_).
-          1. If _t_ is *NaN*, set _t_ to *+0*<sub>𝔽</sub>; otherwise, set _t_ to LocalTime(_t_).
+          1. If _t_ is *NaN*, set _t_ to *+0*<sub>𝔽</sub>; otherwise set _t_ to LocalTime(_t_).
           1. Let _yyyy_ be MakeFullYear(_y_).
           1. Let _d_ be MakeDay(_yyyy_, MonthFromTime(_t_), DateFromTime(_t_)).
           1. Let _date_ be MakeDate(_d_, TimeWithinDay(_t_)).

--- a/spec.html
+++ b/spec.html
@@ -19481,7 +19481,7 @@
               1. Let _argList_ be ? ArgumentListEvaluation of _arguments_.
               1. If _argList_ has no elements, return *undefined*.
               1. Let _evalArg_ be the first element of _argList_.
-              1. If IsStrict(this |CallExpression|) is *true*, let _strictCaller_ be *true*. Otherwise let _strictCaller_ be *false*.
+              1. If IsStrict(this |CallExpression|) is *true*, let _strictCaller_ be *true*; otherwise let _strictCaller_ be *false*.
               1. [id="step-callexpression-evaluation-direct-eval"] Return ? PerformEval(_evalArg_, _strictCaller_, *true*).
           1. Let _thisCall_ be this |CallExpression|.
           1. Let _tailCall_ be IsInTailPosition(_thisCall_).
@@ -43822,7 +43822,7 @@ THH:mm:ss.sss
             1. If _next_ is not ~done~, then
               1. Set _next_ to CanonicalizeKeyedCollectionKey(_next_).
               1. Let _resultIndex_ be SetDataIndex(_resultSetData_, _next_).
-              1. If _resultIndex_ is ~not-found~, let _alreadyInResult_ be *false*. Otherwise let _alreadyInResult_ be *true*.
+              1. If _resultIndex_ is ~not-found~, let _alreadyInResult_ be *false*; otherwise let _alreadyInResult_ be *true*.
               1. If SetDataHas(_O_.[[SetData]], _next_) is *true*, then
                 1. If _alreadyInResult_ is *true*, set _resultSetData_[_resultIndex_] to ~empty~.
               1. Else,


### PR DESCRIPTION
Partially fixes #3648.

The following occurrences
- `If cond, s1. Otherwise s2`
- `If cond, s1. Otherwise, s2`
- `If cond, s1; otherwise, s2`

have been replaced with `If cond, s1; otherwise s2`.