### PR TITLE
Meta: Upgrade ESMeta to v0.6.4

### DIFF
--- a/.github/workflows/esmeta-typecheck.yml
+++ b/.github/workflows/esmeta-typecheck.yml
@@ -26,7 +26,7 @@ jobs:
           cd "${ESMETA_HOME}"
           git init
           git remote add origin https://github.com/es-meta/esmeta.git
-          git fetch --depth 1 origin 2c53ff64f4d34fd4ff9ac6d4d90dfe09e2fe604e ;# v0.6.2
+          git fetch --depth 1 origin 154cd346cfad4bfb485de1c34fc9715748e2d517 ;# v0.6.4
           git checkout FETCH_HEAD
       - name: build esmeta
         run: |


### PR DESCRIPTION
I directly updated [v0.6.4](https://github.com/es-meta/esmeta/releases/tag/v0.6.4) instead of [v0.6.3](https://github.com/es-meta/esmeta/releases/tag/v0.6.3).

It resolves the [CI failure](https://github.com/tc39/ecma262/actions/runs/16358715380/job/46222498674) that appears in https://github.com/tc39/ecma262/pull/3653 by fixing bugs related to handling the `function object` and `constructor` types by revising the intersection and normalization of record types (https://github.com/es-meta/esmeta/pull/300).

It supports more detailed reporting with the number of occurrences of each unique phrase (https://github.com/es-meta/esmeta/issues/287).

It adds type modeling for each separate case of `TypedArray` (e.g. `Uint8Array`) to resolve the type check error in https://github.com/tc39/ecma262/pull/3655 (https://github.com/es-meta/esmeta/pull/304)