### PR TITLE
Normative: handle len < seachLen in String.prototype.lastIndexOf

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -35629,6 +35629,7 @@ THH:mm:ss.sss
           1. If _numPos_ is *NaN*, let _pos_ be +∞; otherwise, let _pos_ be ! ToIntegerOrInfinity(_numPos_).
           1. Let _len_ be the length of _S_.
           1. Let _searchLen_ be the length of _searchStr_.
+          1. If _len_ &lt; _searchLen_, return *-1*<sub>𝔽</sub>.
           1. Let _start_ be the result of clamping _pos_ between 0 and _len_ - _searchLen_.
           1. Let _result_ be StringLastIndexOf(_S_, _searchStr_, _start_).
           1. If _result_ is ~not-found~, return *-1*<sub>𝔽</sub>.


### PR DESCRIPTION
In Step 9 of [String.prototype.lastIndexOf](https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.lastindexof), it tries to clamp _pos_ between 0 and _len - searchLen_ and according to [clamping](https://tc39.es/ecma262/multipage/notational-conventions.html#clamping), `len - searchLen >= 0`. So it cannot be defined when `len - searchLen < 0`.

For example:
```javascript
"x".lastIndexOf("xy")
```

Even if _clamping_ were defined to allow cases where the lower bound is greater than the upper bound (i.e., `len - searchLen < 0`), Step 10 would result in an invalid state. In Step 10, [StringLastIndexOf(S, searchStr, start)](https://tc39.es/ecma262/multipage/ecmascript-data-types-and-values.html#sec-stringlastindexof) is invoked with _start_, which is required to be a non-negative integer. When `len < searchLen`, the computed _start_ could become negative, which is invalid.

Therefore, this PR adds a step that returns -1 when `len < searchLen` before Step 9, since it is impossible to find _searchString_ within _string_ when `len < searchLen`.