### PR TITLE
Editorial: Fix type mismatch for class without constructor

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -6989,7 +6989,7 @@
       <h1>
         InitializeInstanceElements (
           _O_: an Object,
-          _constructor_: an ECMAScript function object,
+          _constructor_: an ECMAScript function object or a built-in function object,
         ): either a normal completion containing ~unused~ or a throw completion
       </h1>
       <dl class="header">
@@ -25241,7 +25241,7 @@
               1. Let _result_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Object.prototype%"*).
             1. Perform ? InitializeInstanceElements(_result_, _F_).
             1. Return NormalCompletion(_result_).
-          1. Let _F_ be CreateBuiltinFunction(_defaultConstructor_, 0, _className_, « [[ConstructorKind]], [[SourceText]] », the current Realm Record, _constructorParent_).
+          1. Let _F_ be CreateBuiltinFunction(_defaultConstructor_, 0, _className_, « [[ConstructorKind]], [[SourceText]], [[PrivateMethods]], [[Fields]] », the current Realm Record, _constructorParent_).
         1. Else,
           1. Let _constructorInfo_ be ! DefineMethod of _constructor_ with arguments _proto_ and _constructorParent_.
           1. Let _F_ be _constructorInfo_.[[Closure]].


### PR DESCRIPTION
When a class has no explicit constructor, [ClassDefinitionEvaluation](https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-runtime-semantics-classdefinitionevaluation) step 14.b creates the default constructor via **CreateBuiltinFunction**.
Later, step 14.a.vi calls **InitializeInstanceElements(result, F)**, which expects its second parameter _constructor_ to be an ECMAScript Function Object. However, actual _F_'s type is a Built-in Function Object and this causes type mismatch.

For example:

```javascript
class A {}
var x = new A();
```

This PR fixes the inconsistency in two parts

- Add `built-in function object` type to [InitializeInstanceElements](https://tc39.es/ecma262/2025/multipage/abstract-operations.html#sec-initializeinstanceelements)' second parameter(`constructor`)
  In step 16, [MakeConstructor](https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-makeconstructor) already allows a Built-in Function Object type, so this brings the earlier step into line.
- Add `[[PrivateMethods]]` and `[[Fields]]` to _additionalInternalSlotList_ when calling **CreateBuiltinFunction** in step 14.b
  Without these slots a built-in constructor produced for a class would not have the properties that InitializeInstanceElements step 1 and 3 and ClassDefinitionEvaluation steps 27 and 28 immediately access, causing an invalid operation (see #3204).

Fixes #3204.
