### PR TITLE
Editorial: the Object constructor's parameter is expected to be present

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -30447,7 +30447,7 @@
       </ul>
 
       <emu-clause id="sec-object-value">
-        <h1>Object ( [ _value_ ] )</h1>
+        <h1>Object ( _value_ )</h1>
         <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. If NewTarget is neither *undefined* nor the active function object, then
@@ -30460,12 +30460,7 @@
 
     <emu-clause id="sec-properties-of-the-object-constructor">
       <h1>Properties of the Object Constructor</h1>
-      <p>The Object constructor:</p>
-      <ul>
-        <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
-        <li>has a *"length"* property whose value is *1*<sub>𝔽</sub>.</li>
-        <li>has the following additional properties:</li>
-      </ul>
+      <p>The Object constructor has a [[Prototype]] internal slot whose value is %Function.prototype%. It also has the following properties:</p>
 
       <emu-clause id="sec-object.assign">
         <h1>Object.assign ( _target_, ..._sources_ )</h1>


### PR DESCRIPTION
Fixes #3627 according to the conclusion from last week's editor call.