### PR TITLE
Editorial: remove unnecessarily verbose description in TypedArrayCreateSameType

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -42545,7 +42545,7 @@ THH:mm:ss.sss
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It is used to specify the creation of a new TypedArray using a constructor function that is derived from _exemplar_, and a _length_. Unlike TypedArraySpeciesCreate, which can construct custom TypedArray subclasses through the use of %Symbol.species%, this operation always uses one of the built-in TypedArray constructors.</dd>
+          <dd>It is used to specify the creation of a new TypedArray using a constructor function that is derived from _exemplar_. Unlike TypedArraySpeciesCreate, which can construct custom TypedArray subclasses through the use of %Symbol.species%, this operation always uses one of the built-in TypedArray constructors.</dd>
         </dl>
         <emu-alg>
           1. Let _constructor_ be the intrinsic object associated with the constructor name _exemplar_.[[TypedArrayName]] in <emu-xref href="#table-the-typedarray-constructors"></emu-xref>.


### PR DESCRIPTION
This was supposed to happen in https://github.com/tc39/ecma262/pull/3570#discussion_r2059382976 but got dropped somehow.