### PR TITLE
Editorial: _ff_ is not defined in the alternative version of #step-number-proto-toexponential-intermediate-values

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -32246,7 +32246,7 @@
         <emu-note>
           <p>For implementations that provide more accurate conversions than required by the rules above, it is recommended that the following alternative version of step <emu-xref href="#step-number-proto-toexponential-intermediate-values"></emu-xref> be used as a guideline:</p>
           <emu-alg replaces-step="step-number-proto-toexponential-intermediate-values">
-            1. Let _e_, _n_, and _f_ be integers such that _f_ ≥ 0, 10<sup>_f_</sup> ≤ _n_ &lt; 10<sup>_f_ + 1</sup>, 𝔽(_n_ × 10<sup>_e_ - _f_</sup>) is 𝔽(_x_), and _f_ is as small as possible. If there are multiple possibilities for _n_, choose the value of _n_ for which 𝔽(_n_ × 10<sup>_e_ - _f_</sup>) is closest in value to 𝔽(_x_). If there are two such possible values of _n_, choose the one that is even.
+            1. Let _e_, _n_, and _ff_ be integers such that _ff_ ≥ 0, 10<sup>_ff_</sup> ≤ _n_ &lt; 10<sup>_ff_ + 1</sup>, 𝔽(_n_ × 10<sup>_e_ - _ff_</sup>) is 𝔽(_x_), and _ff_ is as small as possible. If there are multiple possibilities for _n_, choose the value of _n_ for which 𝔽(_n_ × 10<sup>_e_ - _ff_</sup>) is closest in value to 𝔽(_x_). If there are two such possible values of _n_, choose the one that is even.
           </emu-alg>
         </emu-note>
       </emu-clause>


### PR DESCRIPTION
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)
* [WebAssembly](https://webassembly.github.io/spec/) - [file an issue](https://github.com/WebAssembly/spec/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->

Fix the inconsistency that while the original `10.b.i` uses `ff` as one of the intermediate variables, the alternative `10.b.i` uses `f`.

# Before this change

<img width="1144" height="1678" alt="image" src="https://github.com/user-attachments/assets/b89f6980-2746-49c5-ab64-7c87c088b297" />

# After this change

<img width="1123" height="1660" alt="image" src="https://github.com/user-attachments/assets/e894e16d-6bc9-4a9f-b213-6311e1c3eb3d" />
