### PR TITLE
Normative: Align async modules rejection order with fulfillment order

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -27340,11 +27340,11 @@
                 1. Set _module_.[[Status]] to ~evaluated~.
                 1. Set _module_.[[AsyncEvaluationOrder]] to ~done~.
                 1. NOTE: _module_.[[AsyncEvaluationOrder]] is set to ~done~ for symmetry with AsyncModuleExecutionFulfilled. In InnerModuleEvaluation, the value of a module's [[AsyncEvaluationOrder]] internal slot is unused when its [[EvaluationError]] internal slot is not ~empty~.
-                1. For each Cyclic Module Record _m_ of _module_.[[AsyncParentModules]], do
-                  1. Perform AsyncModuleExecutionRejected(_m_, _error_).
                 1. If _module_.[[TopLevelCapability]] is not ~empty~, then
                   1. Assert: _module_.[[CycleRoot]] and _module_ are the same Module Record.
                   1. Perform ! Call(_module_.[[TopLevelCapability]].[[Reject]], *undefined*, « _error_ »).
+                1. For each Cyclic Module Record _m_ of _module_.[[AsyncParentModules]], do
+                  1. Perform AsyncModuleExecutionRejected(_m_, _error_).
                 1. Return ~unused~.
               </emu-alg>
             </emu-clause>


### PR DESCRIPTION
This PR implements the normative change that reached consensus in July 2025 ([slides](https://docs.google.com/presentation/d/1g3JGIazNuA1Tuk35t_M4qxJD8ajNsYiTcWpTrXQnEns/edit), [notes](https://github.com/tc39/notes/blob/main/meetings/2025-07/july-28.md#specimplementations-divergence-on-module-evaluation-promises-settlement-order))

This is what the exact consensus request was, that this PR matches:
<img width="2747" height="526" alt="image" src="https://github.com/user-attachments/assets/dc81de62-143c-44fd-a99b-c51ae39d6318" />