### PR TITLE
Meta: Update metadata to use correct copyright

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build-only": "ecmarkup --verbose spec.html --multipage out",
     "build": "npm run build-head",
     "build-for-pdf": "npm run prebuild-only && ecmarkup --verbose spec.html out/index.html --assets external --assets-dir out --printable --lint-spec --strict",
-    "pdf": "npm run build-for-pdf && prince --script ./node_modules/ecmarkup/js/print.js out/index.html -o out/ECMA-262.pdf",
+    "pdf": "npm run build-for-pdf && prince-books --script ./node_modules/ecmarkup/js/print.js out/index.html -o out/ECMA-262.pdf",
     "prebuild-snapshot": "npm run clean",
     "build-snapshot": "npm run build-head && node scripts/insert-snapshot-warning.js",
     "clean": "rm -rf out",

--- a/spec.html
+++ b/spec.html
@@ -158,6 +158,8 @@
   status: draft
   location: https://tc39.es/ecma262/
   markEffects: true
+  boilerplate:
+    copyright: alternative
 </pre>
 <p><img src="img/ecma-logo.svg" id="ecma-logo" alt="Ecma International logo"></p>
 <div id="metadata-block">


### PR DESCRIPTION
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)
* [WebAssembly](https://webassembly.github.io/spec/) - [file an issue](https://github.com/WebAssembly/spec/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->


The only copyright that TC39 Standards (draft or otherwise) should ever have is the Ecma alternative copyright.