### PR TITLE
Editorial: use typical phrasing for Agent Record field access

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -4743,7 +4743,8 @@
         </dl>
         <emu-alg>
           1. Let _db_ be a new Shared Data Block value consisting of _size_ bytes. If it is impossible to create such a Shared Data Block, throw a *RangeError* exception.
-          1. Let _execution_ be the [[CandidateExecution]] field of the surrounding agent's Agent Record.
+          1. Let _AR_ be the Agent Record of the surrounding agent.
+          1. Let _execution_ be _AR_.[[CandidateExecution]].
           1. Let _eventsRecord_ be the Agent Events Record of _execution_.[[EventsRecords]] whose [[AgentSignifier]] is AgentSignifier().
           1. Let _zero_ be « 0 ».
           1. For each index _i_ of _db_, do
@@ -4772,7 +4773,8 @@
           1. Assert: _toIndex_ + _count_ ≤ _toSize_.
           1. Repeat, while _count_ > 0,
             1. If _fromBlock_ is a Shared Data Block, then
-              1. Let _execution_ be the [[CandidateExecution]] field of the surrounding agent's Agent Record.
+              1. Let _AR_ be the Agent Record of the surrounding agent.
+              1. Let _execution_ be _AR_.[[CandidateExecution]].
               1. Let _eventsRecord_ be the Agent Events Record of _execution_.[[EventsRecords]] whose [[AgentSignifier]] is AgentSignifier().
               1. Let _bytes_ be a List whose sole element is a nondeterministically chosen byte value.
               1. NOTE: In implementations, _bytes_ is the result of a non-atomic read instruction on the underlying hardware. The nondeterminism is a semantic prescription of the memory model to describe observable behaviour of hardware with weak consistency.
@@ -44669,7 +44671,8 @@ THH:mm:ss.sss
           1. If IsGrowableSharedArrayBuffer(_arrayBuffer_) is *true*, then
             1. Let _bufferByteLengthBlock_ be _arrayBuffer_.[[ArrayBufferByteLengthData]].
             1. Let _rawLength_ be GetRawBytesFromSharedBlock(_bufferByteLengthBlock_, 0, ~biguint64~, *true*, _order_).
-            1. Let _isLittleEndian_ be the value of the [[LittleEndian]] field of the surrounding agent's Agent Record.
+            1. Let _AR_ be the Agent Record of the surrounding agent.
+            1. Let _isLittleEndian_ be _AR_.[[LittleEndian]].
             1. Return ℝ(RawBytesToNumeric(~biguint64~, _rawLength_, _isLittleEndian_)).
           1. Assert: IsDetachedBuffer(_arrayBuffer_) is *false*.
           1. Return _arrayBuffer_.[[ArrayBufferByteLength]].
@@ -44933,7 +44936,8 @@ THH:mm:ss.sss
         </dl>
         <emu-alg>
           1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for Element Type _type_.
-          1. Let _execution_ be the [[CandidateExecution]] field of the surrounding agent's Agent Record.
+          1. Let _AR_ be the Agent Record of the surrounding agent.
+          1. Let _execution_ be _AR_.[[CandidateExecution]].
           1. Let _eventsRecord_ be the Agent Events Record of _execution_.[[EventsRecords]] whose [[AgentSignifier]] is AgentSignifier().
           1. If _isTypedArray_ is *true* and IsNoTearConfiguration(_type_, _order_) is *true*, let _noTear_ be *true*; otherwise let _noTear_ be *false*.
           1. Let _rawValue_ be a List of length _elementSize_ whose elements are nondeterministically chosen byte values.
@@ -44969,7 +44973,9 @@ THH:mm:ss.sss
           1. Else,
             1. Let _rawValue_ be a List whose elements are bytes from _block_ at indices in the interval from _byteIndex_ (inclusive) to _byteIndex_ + _elementSize_ (exclusive).
           1. Assert: The number of elements in _rawValue_ is _elementSize_.
-          1. If _isLittleEndian_ is not present, set _isLittleEndian_ to the value of the [[LittleEndian]] field of the surrounding agent's Agent Record.
+          1. If _isLittleEndian_ is not present, then
+            1. Let _AR_ be the Agent Record of the surrounding agent.
+            1. Set _isLittleEndian_ to _AR_.[[LittleEndian]].
           1. Return RawBytesToNumeric(_type_, _rawValue_, _isLittleEndian_).
         </emu-alg>
       </emu-clause>
@@ -45024,10 +45030,12 @@ THH:mm:ss.sss
           1. Assert: _value_ is a BigInt if IsBigIntElementType(_type_) is *true*; otherwise, _value_ is a Number.
           1. Let _block_ be _arrayBuffer_.[[ArrayBufferData]].
           1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for Element Type _type_.
-          1. If _isLittleEndian_ is not present, set _isLittleEndian_ to the value of the [[LittleEndian]] field of the surrounding agent's Agent Record.
+          1. Let _AR_ be the Agent Record of the surrounding agent.
+          1. If _isLittleEndian_ is not present, then
+            1. Set _isLittleEndian_ to _AR_.[[LittleEndian]].
           1. Let _rawBytes_ be NumericToRawBytes(_type_, _value_, _isLittleEndian_).
           1. If IsSharedArrayBuffer(_arrayBuffer_) is *true*, then
-            1. Let _execution_ be the [[CandidateExecution]] field of the surrounding agent's Agent Record.
+            1. Let _execution_ be _AR_.[[CandidateExecution]].
             1. Let _eventsRecord_ be the Agent Events Record of _execution_.[[EventsRecords]] whose [[AgentSignifier]] is AgentSignifier().
             1. If _isTypedArray_ is *true* and IsNoTearConfiguration(_type_, _order_) is *true*, let _noTear_ be *true*; otherwise let _noTear_ be *false*.
             1. Append WriteSharedMemory { [[Order]]: _order_, [[NoTear]]: _noTear_, [[Block]]: _block_, [[ByteIndex]]: _byteIndex_, [[ElementSize]]: _elementSize_, [[Payload]]: _rawBytes_ } to _eventsRecord_.[[EventList]].
@@ -45055,10 +45063,11 @@ THH:mm:ss.sss
           1. Assert: _value_ is a BigInt if IsBigIntElementType(_type_) is *true*; otherwise, _value_ is a Number.
           1. Let _block_ be _arrayBuffer_.[[ArrayBufferData]].
           1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for Element Type _type_.
-          1. Let _isLittleEndian_ be the value of the [[LittleEndian]] field of the surrounding agent's Agent Record.
+          1. Let _AR_ be the Agent Record of the surrounding agent.
+          1. Let _isLittleEndian_ be _AR_.[[LittleEndian]].
           1. Let _rawBytes_ be NumericToRawBytes(_type_, _value_, _isLittleEndian_).
           1. If IsSharedArrayBuffer(_arrayBuffer_) is *true*, then
-            1. Let _execution_ be the [[CandidateExecution]] field of the surrounding agent's Agent Record.
+            1. Let _execution_ be _AR_.[[CandidateExecution]].
             1. Let _eventsRecord_ be the Agent Events Record of _execution_.[[EventsRecords]] whose [[AgentSignifier]] is AgentSignifier().
             1. Let _rawBytesRead_ be a List of length _elementSize_ whose elements are nondeterministically chosen byte values.
             1. NOTE: In implementations, _rawBytesRead_ is the result of a load-link, of a load-exclusive, or of an operand of a read-modify-write instruction on the underlying hardware. The nondeterminism is a semantic prescription of the memory model to describe observable behaviour of hardware with weak consistency.
@@ -45405,7 +45414,7 @@ THH:mm:ss.sss
         <p>The implementation of HostGrowSharedArrayBuffer must conform to the following requirements:</p>
         <ul>
           <li>If the abstract operation does not complete normally with ~unhandled~, and _newByteLength_ &lt; the current byte length of the _buffer_ or _newByteLength_ > _buffer_.[[ArrayBufferMaxByteLength]], throw a *RangeError* exception.</li>
-          <li>Let _isLittleEndian_ be the value of the [[LittleEndian]] field of the surrounding agent's Agent Record. If the abstract operation completes normally with ~handled~, a WriteSharedMemory or ReadModifyWriteSharedMemory event whose [[Order]] is ~seq-cst~, [[Payload]] is NumericToRawBytes(~biguint64~, _newByteLength_, _isLittleEndian_), [[Block]] is _buffer_.[[ArrayBufferByteLengthData]], [[ByteIndex]] is 0, and [[ElementSize]] is 8 is added to the surrounding agent's candidate execution such that racing calls to <emu-xref href="#sec-sharedarraybuffer.prototype.grow" title></emu-xref> are not "lost", i.e. silently do nothing.</li>
+          <li>Let _AR_ be the Agent Record of the surrounding agent. Let _isLittleEndian_ be _AR_.[[LittleEndian]]. If the abstract operation completes normally with ~handled~, a WriteSharedMemory or ReadModifyWriteSharedMemory event whose [[Order]] is ~seq-cst~, [[Payload]] is NumericToRawBytes(~biguint64~, _newByteLength_, _isLittleEndian_), [[Block]] is _buffer_.[[ArrayBufferByteLengthData]], [[ByteIndex]] is 0, and [[ElementSize]] is 8 is added to the surrounding agent's candidate execution such that racing calls to <emu-xref href="#sec-sharedarraybuffer.prototype.grow" title></emu-xref> are not "lost", i.e. silently do nothing.</li>
         </ul>
 
         <emu-note>
@@ -45507,7 +45516,8 @@ THH:mm:ss.sss
           1. Let _newByteLength_ be ? ToIndex(_newLength_).
           1. Let _hostHandled_ be ? HostGrowSharedArrayBuffer(_O_, _newByteLength_).
           1. If _hostHandled_ is ~handled~, return *undefined*.
-          1. Let _isLittleEndian_ be the value of the [[LittleEndian]] field of the surrounding agent's Agent Record.
+          1. Let _AR_ be the Agent Record of the surrounding agent.
+          1. Let _isLittleEndian_ be _AR_.[[LittleEndian]].
           1. Let _byteLengthBlock_ be _O_.[[ArrayBufferByteLengthData]].
           1. Let _currentByteLengthRawBytes_ be GetRawBytesFromSharedBlock(_byteLengthBlock_, 0, ~biguint64~, *true*, ~seq-cst~).
           1. Let _newByteLengthRawBytes_ be NumericToRawBytes(~biguint64~, ℤ(_newByteLength_), _isLittleEndian_).
@@ -46385,7 +46395,8 @@ THH:mm:ss.sss
           1. Wait until no agent is in the critical section for _WL_, then enter the critical section for _WL_ (without allowing any other agent to enter).
           1. If _WL_.[[MostRecentLeaveEvent]] is not ~empty~, then
             1. NOTE: A _WL_ whose critical section has been entered at least once has a Synchronize event set by LeaveCriticalSection.
-            1. Let _execution_ be the [[CandidateExecution]] field of the surrounding agent's Agent Record.
+            1. Let _AR_ be the Agent Record of the surrounding agent.
+            1. Let _execution_ be _AR_.[[CandidateExecution]].
             1. Let _eventsRecord_ be the Agent Events Record of _execution_.[[EventsRecords]] whose [[AgentSignifier]] is AgentSignifier().
             1. Let _enterEvent_ be a new Synchronize event.
             1. Append _enterEvent_ to _eventsRecord_.[[EventList]].
@@ -46405,7 +46416,8 @@ THH:mm:ss.sss
         </dl>
         <emu-alg>
           1. Assert: The surrounding agent is in the critical section for _WL_.
-          1. Let _execution_ be the [[CandidateExecution]] field of the surrounding agent's Agent Record.
+          1. Let _AR_ be the Agent Record of the surrounding agent.
+          1. Let _execution_ be _AR_.[[CandidateExecution]].
           1. Let _eventsRecord_ be the Agent Events Record of _execution_.[[EventsRecords]] whose [[AgentSignifier]] is AgentSignifier().
           1. Let _leaveEvent_ be a new Synchronize event.
           1. Append _leaveEvent_ to _eventsRecord_.[[EventList]].
@@ -46648,7 +46660,8 @@ THH:mm:ss.sss
         <dl class="header">
         </dl>
         <emu-alg>
-          1. Let _execution_ be the [[CandidateExecution]] field of the surrounding agent's Agent Record.
+          1. Let _AR_ be the Agent Record of the surrounding agent.
+          1. Let _execution_ be _AR_.[[CandidateExecution]].
           1. Let _eventsRecord_ be the Agent Events Record of _execution_.[[EventsRecords]] whose [[AgentSignifier]] is AgentSignifier().
           1. Let _rawBytesRead_ be a List of length _elementSize_ whose elements are nondeterministically chosen byte values.
           1. NOTE: In implementations, _rawBytesRead_ is the result of a load-link, of a load-exclusive, or of an operand of a read-modify-write instruction on the underlying hardware. The nondeterminism is a semantic prescription of the memory model to describe observable behaviour of hardware with weak consistency.
@@ -46747,7 +46760,8 @@ THH:mm:ss.sss
       <emu-alg>
         1. Let _add_ be a new read-modify-write modification function with parameters (_xBytes_, _yBytes_) that captures _typedArray_ and performs the following steps atomically when called:
           1. Let _type_ be TypedArrayElementType(_typedArray_).
-          1. Let _isLittleEndian_ be the value of the [[LittleEndian]] field of the surrounding agent's Agent Record.
+          1. Let _AR_ be the Agent Record of the surrounding agent.
+          1. Let _isLittleEndian_ be _AR_.[[LittleEndian]].
           1. Let _x_ be RawBytesToNumeric(_type_, _xBytes_, _isLittleEndian_).
           1. Let _y_ be RawBytesToNumeric(_type_, _yBytes_, _isLittleEndian_).
           1. If _x_ is a Number, then
@@ -46788,7 +46802,8 @@ THH:mm:ss.sss
         1. Perform ? RevalidateAtomicAccess(_typedArray_, _byteIndexInBuffer_).
         1. Let _elementType_ be TypedArrayElementType(_typedArray_).
         1. Let _elementSize_ be TypedArrayElementSize(_typedArray_).
-        1. Let _isLittleEndian_ be the value of the [[LittleEndian]] field of the surrounding agent's Agent Record.
+        1. Let _AR_ be the Agent Record of the surrounding agent.
+        1. Let _isLittleEndian_ be _AR_.[[LittleEndian]].
         1. Let _expectedBytes_ be NumericToRawBytes(_elementType_, _expected_, _isLittleEndian_).
         1. Let _replacementBytes_ be NumericToRawBytes(_elementType_, _replacement_, _isLittleEndian_).
         1. If IsSharedArrayBuffer(_buffer_) is *true*, then
@@ -46873,7 +46888,8 @@ THH:mm:ss.sss
       <emu-alg>
         1. Let _subtract_ be a new read-modify-write modification function with parameters (_xBytes_, _yBytes_) that captures _typedArray_ and performs the following steps atomically when called:
           1. Let _type_ be TypedArrayElementType(_typedArray_).
-          1. Let _isLittleEndian_ be the value of the [[LittleEndian]] field of the surrounding agent's Agent Record.
+          1. Let _AR_ be the Agent Record of the surrounding agent.
+          1. Let _isLittleEndian_ be _AR_.[[LittleEndian]].
           1. Let _x_ be RawBytesToNumeric(_type_, _xBytes_, _isLittleEndian_).
           1. Let _y_ be RawBytesToNumeric(_type_, _yBytes_, _isLittleEndian_).
           1. If _x_ is a Number, then


### PR DESCRIPTION
Fixes #3702

Replaced all occurrences of 'the [[...]] field of the surrounding agent's Agent Record' with the more typical phrasing pattern used in AgentSignifier(), which first assigns the Agent Record to a variable AR and then accesses its fields.

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)
* [WebAssembly](https://webassembly.github.io/spec/) - [file an issue](https://github.com/WebAssembly/spec/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
