### PR TITLE
Editorial: remove ReturnIfAbrupt and specify ! and ? directly

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1079,74 +1079,44 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-returnifabrupt" aoid="ReturnIfAbrupt">
-        <h1>ReturnIfAbrupt</h1>
-        <p>Algorithms steps that say or are otherwise equivalent to:</p>
+      <emu-clause id="sec-shorthands-for-unwrapping-completion-records" oldids="sec-returnifabrupt">
+        <h1>Shorthands for Unwrapping Completion Records</h1>
+        <p>Prefix `?` and `!` are used as shorthands which unwrap Completion Records. `?` is used to propagate an abrupt completion to the caller, or otherwise to unwrap a normal completion. `!` is used to assert that a Completion Record is normal and unwrap it. Formally, the step</p>
         <emu-alg example>
-          1. ReturnIfAbrupt(_argument_).
+          1. Let _result_ be ? _record_.
         </emu-alg>
-        <p>mean the same thing as:</p>
+        <p>is equivalent to</p>
         <emu-alg example>
-          1. Assert: _argument_ is a Completion Record.
-          1. If _argument_ is an abrupt completion, return Completion(_argument_).
-          1. Else, set _argument_ to _argument_.[[Value]].
+          1. Assert: _record_ is a Completion Record.
+          1. If _record_ is an abrupt completion, return _record_.
+          1. Let _result_ be _record_.[[Value]].
         </emu-alg>
-        <p>Algorithms steps that say or are otherwise equivalent to:</p>
+        <p>Likewise, the step</p>
         <emu-alg example>
-          1. ReturnIfAbrupt(AbstractOperation()).
+          1. Let _result_ be ! _record_.
         </emu-alg>
-        <p>mean the same thing as:</p>
+        <p>is equivalent to</p>
         <emu-alg example>
-          1. Let _hygienicTemp_ be AbstractOperation().
-          1. Assert: _hygienicTemp_ is a Completion Record.
-          1. If _hygienicTemp_ is an abrupt completion, return Completion(_hygienicTemp_).
-          1. Else, set _hygienicTemp_ to _hygienicTemp_.[[Value]].
+          1. Assert: _record_ is a normal completion.
+          1. Let _result_ be _record_.[[Value]].
         </emu-alg>
-        <p>Where _hygienicTemp_ is ephemeral and visible only in the steps pertaining to ReturnIfAbrupt.</p>
-        <p>Algorithms steps that say or are otherwise equivalent to:</p>
+        <p>When `?` or `!` is used in any other context, first apply the rewrite given in <emu-xref href="#sec-evaluation-order" title></emu-xref> until this rule can be applied, then apply this rule. For example, the step</p>
         <emu-alg example>
-          1. Let _result_ be AbstractOperation(ReturnIfAbrupt(_argument_)).
+          1. Perform AO(? Other()).
         </emu-alg>
-        <p>mean the same thing as:</p>
+        <p>can be rewritten to</p>
         <emu-alg example>
-          1. Assert: _argument_ is a Completion Record.
-          1. If _argument_ is an abrupt completion, return Completion(_argument_).
-          1. Else, set _argument_ to _argument_.[[Value]].
-          1. Let _result_ be AbstractOperation(_argument_).
+          1. Let _tmp1_ be Other().
+          1. Let _tmp2_ be ? _tmp1_.
+          1. Perform AO(_tmp2_).
         </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-returnifabrupt-shorthands">
-        <h1>ReturnIfAbrupt Shorthands</h1>
-        <p>Invocations of abstract operations and syntax-directed operations that are prefixed by `?` indicate that ReturnIfAbrupt should be applied to the resulting Completion Record. For example, the step:</p>
+        <p>which in turn expands to</p>
         <emu-alg example>
-          1. ? OperationName().
-        </emu-alg>
-        <p>is equivalent to the following step:</p>
-        <emu-alg example>
-          1. ReturnIfAbrupt(OperationName()).
-        </emu-alg>
-        <p>Similarly, for method application style, the step:</p>
-        <emu-alg example>
-          1. ? _someValue_.OperationName().
-        </emu-alg>
-        <p>is equivalent to:</p>
-        <emu-alg example>
-          1. ReturnIfAbrupt(_someValue_.OperationName()).
-        </emu-alg>
-        <p>Similarly, prefix `!` is used to indicate that the following invocation of an abstract or syntax-directed operation will never return an abrupt completion and that the resulting Completion Record's [[Value]] field should be used in place of the return value of the operation. For example, the step:</p>
-        <emu-alg example>
-          1. Let _val_ be ! OperationName().
-        </emu-alg>
-        <p>is equivalent to the following steps:</p>
-        <emu-alg example>
-          1. Let _val_ be OperationName().
-          1. Assert: _val_ is a normal completion.
-          1. Set _val_ to _val_.[[Value]].
-        </emu-alg>
-        <p>Syntax-directed operations for runtime semantics make use of this shorthand by placing `!` or `?` before the invocation of the operation:</p>
-        <emu-alg example>
-          1. Perform ! SyntaxDirectedOperation of |NonTerminal|.
+          1. Let _tmp1_ be Other().
+          1. Assert: _tmp1_ is a Completion Record.
+          1. If _tmp1_ is an abrupt completion, return _tmp1_.
+          1. Let _tmp2_ be _tmp1_.[[Value]].
+          1. Perform AO(_tmp2_).
         </emu-alg>
       </emu-clause>
 


### PR DESCRIPTION
The `?` and `!` shorthands have long been under-specified, as discussed in https://github.com/tc39/ecma262/pull/1570, [this thread](https://es.discourse.group/t/returnifabrupt-macro/2446), etc. Also, as of recent efforts (#1571, #2744, #2924, #3268, etc) there are no longer any uses of `ReturnIfAbrupt` except to define `?`. So remove `ReturnIfAbrupt`. Instead, as proposed [in this comment](https://github.com/tc39/ecma262/pull/1573#issuecomment-3084926665), specify evaluation order as a (handwavy, but hopefully clear) rewrite rule, and then define `?` and `!` directly, with nontrivial cases handled by first applying the rewrite rule.

I checked ECMA-402, HTML, streams, and Wasm, and found no uses of `ReturnIfAbrupt`. There are still some uses in proposals, but whatever.

Closes #1570 and #1573. 