### PR TITLE
[editorial] Simplify Source Text Module Record's ResolveExport

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -28457,8 +28457,7 @@
                   1. Else,
                     1. Assert: There is more than one `*` import that includes the requested name.
                     1. If _resolution_.[[Module]] and _starResolution_.[[Module]] are not the same Module Record, return ~ambiguous~.
-                    1. If _resolution_.[[BindingName]] is not _starResolution_.[[BindingName]] and either _resolution_.[[BindingName]] or _starResolution_.[[BindingName]] is ~namespace~, return ~ambiguous~.
-                    1. If _resolution_.[[BindingName]] is a String, _starResolution_.[[BindingName]] is a String, and _resolution_.[[BindingName]] is not _starResolution_.[[BindingName]], return ~ambiguous~.
+                    1. If _resolution_.[[BindingName]] is not _starResolution_.[[BindingName]], return ~ambiguous~.
               1. Return _starResolution_.
             </emu-alg>
           </emu-clause>


### PR DESCRIPTION
[[BindingName]] can either be a String or NAMESPACE (source: https://tc39.es/ecma262/#resolvedbinding-record).

These two checks are basically doing
```js
if (resolution.BindingName === NAMESPACE || starResolution.BindingName === NAMESPACE) {
  if (resolution.BindingName !== starResolution.BindingName) return AMBIGUOUS;
}
if (resolution.BindingName !== NAMESPACE && starResolution.BindingName !== NAMESPACE) {
  if (resolution.BindingName !== starResolution.BindingName) return AMBIGUOUS;
}
```
Which is just
```js
if (resolution.BindingName !== starResolution.BindingName) return AMBIGUOUS;
```
Because the two conditions are the complement of each other.