### PR TITLE
Normative: Extend JSON.parse and JSON.stringify for interaction with the source text of primitive values

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -47423,16 +47423,16 @@ THH:mm:ss.sss
             1. If _isArray_ is *true*, then
               1. Let _elementRecordsLen_ be the number of elements in _elementRecords_.
               1. Let _len_ be ? LengthOfArrayLike(_val_).
-              1. Let _I_ be 0.
-              1. Repeat, while _I_ &lt; _len_,
-                1. Let _prop_ be ! ToString(𝔽(_I_)).
-                1. If _I_ &lt; _elementRecordsLen_, let _elementRecord_ be _elementRecords_[_I_]; else let _elementRecord_ be ~empty~.
+              1. Let _index_ be 0.
+              1. Repeat, while _index_ &lt; _len_,
+                1. Let _prop_ be ! ToString(𝔽(_index_)).
+                1. If _index_ &lt; _elementRecordsLen_, let _elementRecord_ be _elementRecords_[_index_]; else let _elementRecord_ be ~empty~.
                 1. Let _newElement_ be ? InternalizeJSONProperty(_val_, _prop_, _reviver_, _elementRecord_).
                 1. If _newElement_ is *undefined*, then
                   1. Perform ? <emu-meta effects="user-code">_val_.[[Delete]](_prop_)</emu-meta>.
                 1. Else,
                   1. Perform ? CreateDataProperty(_val_, _prop_, _newElement_).
-                1. Set _I_ to _I_ + 1.
+                1. Set _index_ to _index_ + 1.
             1. Else,
               1. Let _keys_ be ? EnumerableOwnProperties(_val_, ~key~).
               1. For each String _P_ of _keys_, do


### PR DESCRIPTION
This implements [JSON.parse source text access](https://github.com/tc39/proposal-json-parse-with-source), currently at stage 3. Tests have already been merged, but are being further extended by https://github.com/tc39/test262/pull/4682 .