### PR TITLE
Normative: make re-exporting a namespace object in 2 steps behave like 1 step

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -28419,10 +28419,11 @@
                 1. If _importedBoundNames_ does not contain _ee_.[[LocalName]], then
                   1. Append _ee_ to _localExportEntries_.
                 1. Else,
+                  1. NOTE: When exporting a binding or namespace object which was originally imported from another module, the ExportEntry Record is rewritten to match the form it would have if the binding or namespace object had been re-exported directly from the original module rather than imported then exported. This allows conflicts which arise from exporting the same binding or namespace twice under the same name through `export * from` to be ignored rather than being treated as ambiguous in step <emu-xref href="#step-resolveexport-conflict"></emu-xref> of <emu-xref href="#sec-resolveexport">the ResolveExport concrete method of Source Text Module Records</emu-xref>.
                   1. Let _ie_ be the element of _importEntries_ whose [[LocalName]] is _ee_.[[LocalName]].
                   1. If _ie_.[[ImportName]] is ~namespace-object~, then
                     1. NOTE: This is a re-export of an imported module namespace object.
-                    1. Append _ee_ to _localExportEntries_.
+                    1. Append the ExportEntry Record { [[ModuleRequest]]: _ie_.[[ModuleRequest]], [[ImportName]]: ~all~, [[LocalName]]: *null*, [[ExportName]]: _ee_.[[ExportName]] } to _indirectExportEntries_.
                   1. Else,
                     1. NOTE: This is a re-export of a single name.
                     1. Append the ExportEntry Record { [[ModuleRequest]]: _ie_.[[ModuleRequest]], [[ImportName]]: _ie_.[[ImportName]], [[LocalName]]: *null*, [[ExportName]]: _ee_.[[ExportName]] } to _indirectExportEntries_.
@@ -28540,7 +28541,7 @@
                   1. Assert: _resolution_ is a ResolvedBinding Record.
                   1. If _starResolution_ is *null*, then
                     1. Set _starResolution_ to _resolution_.
-                  1. Else,
+                  1. [id="step-resolveexport-conflict"] Else,
                     1. Assert: There is more than one `*` export that includes the requested name.
                     1. If _resolution_.[[Module]] and _starResolution_.[[Module]] are not the same Module Record, return ~ambiguous~.
                     1. If _resolution_.[[BindingName]] is not _starResolution_.[[BindingName]], return ~ambiguous~.


### PR DESCRIPTION
Fixes https://github.com/tc39/ecma262/issues/3710. Specifically, this makes it so that the example under "this throws" in [this comment](https://github.com/tc39/ecma262/issues/3710#issuecomment-3443845451) no longer throws, matching the behavior for re-exporting bindings rather than full namespaces.

I also added an explanatory comment about why we're doing this rewriting.

cc @nicolo-ribaudo @guybedford 