### PR TITLE
Editorial: Fix article typo in [[Enumerable]]

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -12760,11 +12760,11 @@
           1. If _O_ is not *undefined*, then
             1. If IsDataDescriptor(_current_) is *true* and IsAccessorDescriptor(_Desc_) is *true*, then
               1. If _Desc_ has a [[Configurable]] field, let _configurable_ be _Desc_.[[Configurable]]; else let _configurable_ be _current_.[[Configurable]].
-              1. If _Desc_ has a [[Enumerable]] field, let _enumerable_ be _Desc_.[[Enumerable]]; else let _enumerable_ be _current_.[[Enumerable]].
+              1. If _Desc_ has an [[Enumerable]] field, let _enumerable_ be _Desc_.[[Enumerable]]; else let _enumerable_ be _current_.[[Enumerable]].
               1. Replace the property named _P_ of object _O_ with an accessor property whose [[Configurable]] and [[Enumerable]] attributes are set to _configurable_ and _enumerable_, respectively, and whose [[Get]] and [[Set]] attributes are set to the value of the corresponding field in _Desc_ if _Desc_ has that field, or to the attribute's <emu-xref href="#table-object-property-attributes">default value</emu-xref> otherwise.
             1. Else if IsAccessorDescriptor(_current_) is *true* and IsDataDescriptor(_Desc_) is *true*, then
               1. If _Desc_ has a [[Configurable]] field, let _configurable_ be _Desc_.[[Configurable]]; else let _configurable_ be _current_.[[Configurable]].
-              1. If _Desc_ has a [[Enumerable]] field, let _enumerable_ be _Desc_.[[Enumerable]]; else let _enumerable_ be _current_.[[Enumerable]].
+              1. If _Desc_ has an [[Enumerable]] field, let _enumerable_ be _Desc_.[[Enumerable]]; else let _enumerable_ be _current_.[[Enumerable]].
               1. Replace the property named _P_ of object _O_ with a data property whose [[Configurable]] and [[Enumerable]] attributes are set to _configurable_ and _enumerable_, respectively, and whose [[Value]] and [[Writable]] attributes are set to the value of the corresponding field in _Desc_ if _Desc_ has that field, or to the attribute's <emu-xref href="#table-object-property-attributes">default value</emu-xref> otherwise.
             1. Else,
               1. For each field of _Desc_, set the corresponding attribute of the property named _P_ of object _O_ to the value of the field.


### PR DESCRIPTION
This PR fixes an article typo (a/an) in [[Enumerable]]. 

`an [[Enumerable]]` appears 5 times in spec.html, while `a [[Enumerable]]` appears twice. (see below for reference)

Considering English grammar, `a` should be replaced with `an`.

```bash
~/ecma262$ grep " a \[\[Enumer" spec.html -n
12763:              1. If _Desc_ has a [[Enumerable]] field, let _enumerable_ be _Desc_.[[Enumerable]]; else let _enumerable_ be _current_.[[Enumerable]].
12767:              1. If _Desc_ has a [[Enumerable]] field, let _enumerable_ be _Desc_.[[Enumerable]]; else let _enumerable_ be _current_.[[Enumerable]].
~/ecma262$ grep " an \[\[Enumer" spec.html -n
4617:          1. If _Desc_ has an [[Enumerable]] field, then
4684:          1. If _Desc_ does not have an [[Enumerable]] field, set _Desc_.[[Enumerable]] to _like_.[[Enumerable]].
12751:            1. If _Desc_ has an [[Enumerable]] field and _Desc_.[[Enumerable]] is not _current_.[[Enumerable]], return *false*.
14680:              1. If _Desc_ has an [[Enumerable]] field and _Desc_.[[Enumerable]] is *false*, return *false*.
15164:          1. If _Desc_ has an [[Enumerable]] field and _Desc_.[[Enumerable]] is *false*, return *false*.
```