### PR TITLE
Meta: Upgrade ESMeta to v0.7.1

### DIFF
--- a/.github/workflows/esmeta-typecheck.yml
+++ b/.github/workflows/esmeta-typecheck.yml
@@ -26,7 +26,7 @@ jobs:
           cd "${ESMETA_HOME}"
           git init
           git remote add origin https://github.com/es-meta/esmeta.git
-          git fetch --depth 1 origin 154cd346cfad4bfb485de1c34fc9715748e2d517 ;# v0.6.4
+          git fetch --depth 1 origin bd58590ef6badabbe71afdefa02dc32274902621 ;# v0.7.1
           git checkout FETCH_HEAD
       - name: build esmeta
         run: |

--- a/esmeta-ignore.json
+++ b/esmeta-ignore.json
@@ -5,14 +5,9 @@
   "CompareTypedArrayElements",
   "DoWait",
   "EvaluateImportCall",
-  "FinishLoadingImportedModule",
-  "FunctionDeclarationInstantiation",
   "FunctionBody[0,0].EvaluateFunctionBody",
+  "FunctionDeclarationInstantiation",
   "GetViewByteLength",
-  "INTRINSICS.Atomics.notify",
   "Record[SourceTextModuleRecord].ExecuteModule",
-  "Record[SourceTextModuleRecord].GetExportedNames",
-  "Record[SourceTextModuleRecord].InitializeEnvironment",
-  "Record[SourceTextModuleRecord].ResolveExport",
   "TypedArrayLength"
 ]


### PR DESCRIPTION
This PR updates the version of ESMeta to [v0.7.1](https://github.com/es-meta/esmeta/releases/tag/v0.7.1) (including updates in [v0.7.0](https://github.com/es-meta/esmeta/releases/tag/v0.7.0)) with the following key updates:

* https://github.com/es-meta/esmeta/pull/320
* https://github.com/es-meta/esmeta/pull/302
* https://github.com/es-meta/esmeta/pull/310
* https://github.com/es-meta/esmeta/pull/318

Especially, the updated type checker removes false alarms related to five algorithms:
* `FinishLoadingImportedModule`
* `INTRINSICS.Atomics.notify`
* `Record[SourceTextModuleRecord].GetExportedNames`
* `Record[SourceTextModuleRecord].InitializeEnvironment`
* `Record[SourceTextModuleRecord].ResolveExport`