### PR TITLE
Meta: Add maximum clause depth to build commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "prebuild-only": "npm run clean && mkdir out && cp -R img out",
     "build-only": "ecmarkup --verbose spec.html --multipage out",
     "build": "npm run build-head",
-    "build-for-pdf": "npm run prebuild-only && ecmarkup --verbose spec.html out/index.html --assets external --assets-dir out --printable --lint-spec --max-clause-depth 7",
+    "build-for-pdf": "npm run prebuild-only && ecmarkup --verbose spec.html out/index.html --assets external --assets-dir out --printable --lint-spec --strict --max-clause-depth 7",
     "pdf": "npm run build-for-pdf && prince-books --script ./node_modules/ecmarkup/js/print.js out/index.html -o out/ECMA-262.pdf",
     "prebuild-snapshot": "npm run clean",
     "build-snapshot": "npm run build-head && node scripts/insert-snapshot-warning.js",


### PR DESCRIPTION
ECMA-262's deepest clause level is 7, `16.2.1.6.1.1.1 InnerModuleLoading`. Ideally, no clause would go deeper than five total levels (1.2.3.4.5), but due to the complexity and history of the specification I do not believe the reader or the editor would benefit from reducing those clause levels at this time.

This PR adds the ecmarkup CLI option to allow for a clause depth of 7 when `--strict` is included.