### PR TITLE
Normative: DoWait byteIndexInBuffer is miscalculated

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -46588,7 +46588,7 @@ THH:mm:ss.sss
           1. Let _taRecord_ be ? ValidateIntegerTypedArray(_typedArray_, *true*).
           1. Let _buffer_ be _taRecord_.[[Object]].[[ViewedArrayBuffer]].
           1. If IsSharedArrayBuffer(_buffer_) is *false*, throw a *TypeError* exception.
-          1. Let _i_ be ? ValidateAtomicAccess(_taRecord_, _index_).
+          1. Let _byteIndexInBuffer_ be ? ValidateAtomicAccess(_taRecord_, _index_).
           1. Let _arrayTypeName_ be _typedArray_.[[TypedArrayName]].
           1. If _arrayTypeName_ is *"BigInt64Array"*, let _v_ be ? ToBigInt64(_value_).
           1. Else, let _v_ be ? ToInt32(_value_).
@@ -46596,8 +46596,6 @@ THH:mm:ss.sss
           1. If _q_ is either *NaN* or *+∞*<sub>𝔽</sub>, let _t_ be +∞; else if _q_ is *-∞*<sub>𝔽</sub>, let _t_ be 0; else let _t_ be max(ℝ(_q_), 0).
           1. If _mode_ is ~sync~ and AgentCanSuspend() is *false*, throw a *TypeError* exception.
           1. Let _block_ be _buffer_.[[ArrayBufferData]].
-          1. Let _offset_ be _typedArray_.[[ByteOffset]].
-          1. Let _byteIndexInBuffer_ be (_i_ × 4) + _offset_.
           1. Let _WL_ be GetWaiterList(_block_, _byteIndexInBuffer_).
           1. If _mode_ is ~sync~, then
             1. Let _promiseCapability_ be ~blocking~.


### PR DESCRIPTION
A bug has slipped into the `DoWait` method of Atomics: the `ValidateAtomicAccess` already returns the "byte index in buffer" value (see for instance the [Atomics.notify](https://tc39.es/ecma262/#sec-atomics.notify) method step 2). In `DoWait` we instead assume that it returns an index into an `Int32Array` and later perform the byte multiplication and offsetting manually on top of the value. This is of course entirely wrong and would only work if the original index and offsets are both 0.