### PR TITLE
Editorial: Reduce redundant expressions in spec

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -4448,11 +4448,11 @@
               1. Return ? PrivateGet(_baseObj_, _V_.[[ReferencedName]]).
             1. If _V_.[[ReferencedName]] is not a property key, then
               1. Set _V_.[[ReferencedName]] to ? ToPropertyKey(_V_.[[ReferencedName]]).
-            1. Return ? <emu-meta effects="user-code">_baseObj_.[[Get]]</emu-meta>(_V_.[[ReferencedName]], GetThisValue(_V_)).
+            1. Return ? <emu-meta effects="user-code">_baseObj_.[[Get]](_V_.[[ReferencedName]], GetThisValue(_V_))</emu-meta>.
           1. Else,
             1. Let _base_ be _V_.[[Base]].
             1. Assert: _base_ is an Environment Record.
-            1. Return ? <emu-meta effects="user-code">_base_.GetBindingValue</emu-meta>(_V_.[[ReferencedName]], _V_.[[Strict]]) (see <emu-xref href="#sec-environment-records"></emu-xref>).
+            1. Return ? <emu-meta effects="user-code">_base_.GetBindingValue(_V_.[[ReferencedName]], _V_.[[Strict]])</emu-meta> (see <emu-xref href="#sec-environment-records"></emu-xref>).
         </emu-alg>
         <emu-note>
           <p>The object that may be created in step <emu-xref href="#step-getvalue-toobject"></emu-xref> is not accessible outside of the above abstract operation and the ordinary object [[Get]] internal method. An implementation might choose to avoid the actual creation of the object.</p>
@@ -4481,13 +4481,13 @@
               1. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
             1. If _V_.[[ReferencedName]] is not a property key, then
               1. Set _V_.[[ReferencedName]] to ? ToPropertyKey(_V_.[[ReferencedName]]).
-            1. Let _succeeded_ be ? <emu-meta effects="user-code">_baseObj_.[[Set]]</emu-meta>(_V_.[[ReferencedName]], _W_, GetThisValue(_V_)).
+            1. Let _succeeded_ be ? <emu-meta effects="user-code">_baseObj_.[[Set]](_V_.[[ReferencedName]], _W_, GetThisValue(_V_))</emu-meta>.
             1. If _succeeded_ is *false* and _V_.[[Strict]] is *true*, throw a *TypeError* exception.
             1. Return ~unused~.
           1. Else,
             1. Let _base_ be _V_.[[Base]].
             1. Assert: _base_ is an Environment Record.
-            1. Return ? <emu-meta effects="user-code">_base_.SetMutableBinding</emu-meta>(_V_.[[ReferencedName]], _W_, _V_.[[Strict]]) (see <emu-xref href="#sec-environment-records"></emu-xref>).
+            1. Return ? <emu-meta effects="user-code">_base_.SetMutableBinding(_V_.[[ReferencedName]], _W_, _V_.[[Strict]])</emu-meta> (see <emu-xref href="#sec-environment-records"></emu-xref>).
         </emu-alg>
         <emu-note>
           <p>The object that may be created in step <emu-xref href="#step-putvalue-toobject"></emu-xref> is not accessible outside of the above abstract operation and the ordinary object [[Set]] internal method. An implementation might choose to avoid the actual creation of that object.</p>
@@ -5076,7 +5076,7 @@
       <emu-alg>
         1. Let _primValue_ be ? ToPrimitive(_value_, ~number~).
         1. If _primValue_ is a BigInt, return _primValue_.
-        1. Return ? <emu-meta suppress-effects="user-code">ToNumber</emu-meta>(_primValue_).
+        1. Return ? <emu-meta suppress-effects="user-code">ToNumber(_primValue_)</emu-meta>.
       </emu-alg>
     </emu-clause>
 
@@ -5828,7 +5828,7 @@
         <dd>It is used to determine whether additional properties can be added to _O_.</dd>
       </dl>
       <emu-alg>
-        1. Return ? <emu-meta effects="user-code">_O_.[[IsExtensible]]</emu-meta>().
+        1. Return ? <emu-meta effects="user-code">_O_.[[IsExtensible]]()</emu-meta>.
       </emu-alg>
     </emu-clause>
 
@@ -6006,8 +6006,8 @@
             1. If _nx_ is *undefined*, return *undefined*.
             1. Return BigInt::lessThan(_nx_, _py_).
           1. NOTE: Because _px_ and _py_ are primitive values, evaluation order is not important.
-          1. Let _nx_ be ? <emu-meta suppress-effects="user-code">ToNumeric</emu-meta>(_px_).
-          1. Let _ny_ be ? <emu-meta suppress-effects="user-code">ToNumeric</emu-meta>(_py_).
+          1. Let _nx_ be ? <emu-meta suppress-effects="user-code">ToNumeric(_px_)</emu-meta>.
+          1. Let _ny_ be ? <emu-meta suppress-effects="user-code">ToNumeric(_py_)</emu-meta>.
           1. If SameType(_nx_, _ny_) is *true*, then
             1. If _nx_ is a Number, then
               1. Return Number::lessThan(_nx_, _ny_).
@@ -6131,7 +6131,7 @@
         <dd>It is used to retrieve the value of a specific property of an object.</dd>
       </dl>
       <emu-alg>
-        1. Return ? <emu-meta effects="user-code">_O_.[[Get]]</emu-meta>(_P_, _O_).
+        1. Return ? <emu-meta effects="user-code">_O_.[[Get]](_P_, _O_)</emu-meta>.
       </emu-alg>
     </emu-clause>
 
@@ -6148,7 +6148,7 @@
       </dl>
       <emu-alg>
         1. Let _O_ be ? ToObject(_V_).
-        1. Return ? <emu-meta effects="user-code">_O_.[[Get]]</emu-meta>(_P_, _V_).
+        1. Return ? <emu-meta effects="user-code">_O_.[[Get]](_P_, _V_)</emu-meta>.
       </emu-alg>
     </emu-clause>
 
@@ -6166,7 +6166,7 @@
         <dd>It is used to set the value of a specific property of an object. _V_ is the new value for the property.</dd>
       </dl>
       <emu-alg>
-        1. Let _success_ be ? <emu-meta effects="user-code">_O_.[[Set]]</emu-meta>(_P_, _V_, _O_).
+        1. Let _success_ be ? <emu-meta effects="user-code">_O_.[[Set]](_P_, _V_, _O_)</emu-meta>.
         1. If _success_ is *false* and _Throw_ is *true*, throw a *TypeError* exception.
         1. Return ~unused~.
       </emu-alg>
@@ -6186,7 +6186,7 @@
       </dl>
       <emu-alg>
         1. Let _newDesc_ be the PropertyDescriptor { [[Value]]: _V_, [[Writable]]: *true*, [[Enumerable]]: *true*, [[Configurable]]: *true* }.
-        1. Return ? <emu-meta effects="user-code">_O_.[[DefineOwnProperty]]</emu-meta>(_P_, _newDesc_).
+        1. Return ? <emu-meta effects="user-code">_O_.[[DefineOwnProperty]](_P_, _newDesc_)</emu-meta>.
       </emu-alg>
       <emu-note>
         <p>This abstract operation creates a property whose attributes are set to the same defaults used for properties created by the ECMAScript language assignment operator. Normally, the property will not already exist. If it does exist and is not configurable or if _O_ is not extensible, [[DefineOwnProperty]] will return *false*.</p>
@@ -6251,7 +6251,7 @@
         <dd>It is used to call the [[DefineOwnProperty]] internal method of an object in a manner that will throw a *TypeError* exception if the requested property update cannot be performed.</dd>
       </dl>
       <emu-alg>
-        1. Let _success_ be ? <emu-meta effects="user-code">_O_.[[DefineOwnProperty]]</emu-meta>(_P_, _desc_).
+        1. Let _success_ be ? <emu-meta effects="user-code">_O_.[[DefineOwnProperty]](_P_, _desc_)</emu-meta>.
         1. If _success_ is *false*, throw a *TypeError* exception.
         1. Return ~unused~.
       </emu-alg>
@@ -6269,7 +6269,7 @@
         <dd>It is used to remove a specific own property of an object. It throws an exception if the property is not configurable.</dd>
       </dl>
       <emu-alg>
-        1. Let _success_ be ? <emu-meta effects="user-code">_O_.[[Delete]]</emu-meta>(_P_).
+        1. Let _success_ be ? <emu-meta effects="user-code">_O_.[[Delete]](_P_)</emu-meta>.
         1. If _success_ is *false*, throw a *TypeError* exception.
         1. Return ~unused~.
       </emu-alg>
@@ -6306,7 +6306,7 @@
         <dd>It is used to determine whether an object has a property with the specified property key. The property may be either own or inherited.</dd>
       </dl>
       <emu-alg>
-        1. Return ? <emu-meta effects="user-code">_O_.[[HasProperty]]</emu-meta>(_P_).
+        1. Return ? <emu-meta effects="user-code">_O_.[[HasProperty]](_P_)</emu-meta>.
       </emu-alg>
     </emu-clause>
 
@@ -6322,7 +6322,7 @@
         <dd>It is used to determine whether an object has an own property with the specified property key.</dd>
       </dl>
       <emu-alg>
-        1. Let _desc_ be ? <emu-meta effects="user-code">_O_.[[GetOwnProperty]]</emu-meta>(_P_).
+        1. Let _desc_ be ? <emu-meta effects="user-code">_O_.[[GetOwnProperty]](_P_)</emu-meta>.
         1. If _desc_ is *undefined*, return *false*.
         1. Return *true*.
       </emu-alg>
@@ -6343,7 +6343,7 @@
       <emu-alg>
         1. If _argumentsList_ is not present, set _argumentsList_ to a new empty List.
         1. If IsCallable(_F_) is *false*, throw a *TypeError* exception.
-        1. Return ? <emu-meta effects="user-code">_F_.[[Call]]</emu-meta>(_V_, _argumentsList_).
+        1. Return ? <emu-meta effects="user-code">_F_.[[Call]](_V_, _argumentsList_)</emu-meta>.
       </emu-alg>
     </emu-clause>
 
@@ -6362,7 +6362,7 @@
       <emu-alg>
         1. If _newTarget_ is not present, set _newTarget_ to _F_.
         1. If _argumentsList_ is not present, set _argumentsList_ to a new empty List.
-        1. Return ? <emu-meta effects="user-code">_F_.[[Construct]]</emu-meta>(_argumentsList_, _newTarget_).
+        1. Return ? <emu-meta effects="user-code">_F_.[[Construct]](_argumentsList_, _newTarget_)</emu-meta>.
       </emu-alg>
       <emu-note>
         <p>If _newTarget_ is not present, this operation is equivalent to: `new F(...argumentsList)`</p>
@@ -6390,7 +6390,7 @@
         1. Else,
           1. Assert: _level_ is ~frozen~.
           1. For each element _k_ of _keys_, do
-            1. Let _currentDesc_ be ? <emu-meta effects="user-code">_O_.[[GetOwnProperty]]</emu-meta>(_k_).
+            1. Let _currentDesc_ be ? <emu-meta effects="user-code">_O_.[[GetOwnProperty]](_k_)</emu-meta>.
             1. If _currentDesc_ is not *undefined*, then
               1. If IsAccessorDescriptor(_currentDesc_) is *true*, then
                 1. Let _desc_ be the PropertyDescriptor { [[Configurable]]: *false* }.
@@ -6418,7 +6418,7 @@
         1. NOTE: If the object is extensible, none of its properties are examined.
         1. Let _keys_ be ? _O_.[[OwnPropertyKeys]]().
         1. For each element _k_ of _keys_, do
-          1. Let _currentDesc_ be ? <emu-meta effects="user-code">_O_.[[GetOwnProperty]]</emu-meta>(_k_).
+          1. Let _currentDesc_ be ? <emu-meta effects="user-code">_O_.[[GetOwnProperty]](_k_)</emu-meta>.
           1. If _currentDesc_ is not *undefined*, then
             1. If _currentDesc_.[[Configurable]] is *true*, return *false*.
             1. If _level_ is ~frozen~ and IsDataDescriptor(_currentDesc_) is *true*, then
@@ -6536,7 +6536,7 @@
         1. Let _P_ be ? Get(_C_, *"prototype"*).
         1. If _P_ is not an Object, throw a *TypeError* exception.
         1. Repeat,
-          1. Set _O_ to ? <emu-meta effects="user-code">_O_.[[GetPrototypeOf]]</emu-meta>().
+          1. Set _O_ to ? <emu-meta effects="user-code">_O_.[[GetPrototypeOf]]()</emu-meta>.
           1. If _O_ is *null*, return *false*.
           1. If SameValue(_P_, _O_) is *true*, return *true*.
       </emu-alg>
@@ -6574,11 +6574,11 @@
       <dl class="header">
       </dl>
       <emu-alg>
-        1. Let _ownKeys_ be ? <emu-meta effects="user-code">_O_.[[OwnPropertyKeys]]</emu-meta>().
+        1. Let _ownKeys_ be ? <emu-meta effects="user-code">_O_.[[OwnPropertyKeys]]()</emu-meta>.
         1. Let _results_ be a new empty List.
         1. For each element _key_ of _ownKeys_, do
           1. If _key_ is a String, then
-            1. Let _desc_ be ? <emu-meta effects="user-code">_O_.[[GetOwnProperty]]</emu-meta>(_key_).
+            1. Let _desc_ be ? <emu-meta effects="user-code">_O_.[[GetOwnProperty]](_key_)</emu-meta>.
             1. If _desc_ is not *undefined* and _desc_.[[Enumerable]] is *true*, then
               1. If _kind_ is ~key~, then
                 1. Append _key_ to _results_.
@@ -6633,14 +6633,14 @@
       <emu-alg>
         1. If _source_ is either *undefined* or *null*, return ~unused~.
         1. Let _from_ be ! ToObject(_source_).
-        1. Let _keys_ be ? <emu-meta effects="user-code">_from_.[[OwnPropertyKeys]]</emu-meta>().
+        1. Let _keys_ be ? <emu-meta effects="user-code">_from_.[[OwnPropertyKeys]]()</emu-meta>.
         1. For each element _nextKey_ of _keys_, do
           1. Let _excluded_ be *false*.
           1. For each element _e_ of _excludedItems_, do
             1. If SameValue(_e_, _nextKey_) is *true*, then
               1. Set _excluded_ to *true*.
           1. If _excluded_ is *false*, then
-            1. Let _desc_ be ? <emu-meta effects="user-code">_from_.[[GetOwnProperty]]</emu-meta>(_nextKey_).
+            1. Let _desc_ be ? <emu-meta effects="user-code">_from_.[[GetOwnProperty]](_nextKey_)</emu-meta>.
             1. If _desc_ is not *undefined* and _desc_.[[Enumerable]] is *true*, then
               1. Let _propValue_ be ? Get(_from_, _nextKey_).
               1. Perform ! CreateDataPropertyOrThrow(_target_, _nextKey_, _propValue_).
@@ -10537,7 +10537,7 @@
             <dd>It is used to set the bound value of the current binding of the identifier whose name is _N_ to the value _V_.</dd>
           </dl>
           <emu-alg>
-            1. Perform ? <emu-meta effects="user-code">_envRec_.SetMutableBinding</emu-meta>(_N_, _V_, *false*).
+            1. Perform ? <emu-meta effects="user-code">_envRec_.SetMutableBinding(_N_, _V_, *false*)</emu-meta>.
             1. Return ~unused~.
           </emu-alg>
           <emu-note>
@@ -10607,7 +10607,7 @@
           </dl>
           <emu-alg>
             1. Let _bindingObject_ be _envRec_.[[BindingObject]].
-            1. Return ? <emu-meta effects="user-code">_bindingObject_.[[Delete]]</emu-meta>(_N_).
+            1. Return ? <emu-meta effects="user-code">_bindingObject_.[[Delete]](_N_)</emu-meta>.
           </emu-alg>
         </emu-clause>
 
@@ -10912,7 +10912,7 @@
             1. Let _DclRec_ be _envRec_.[[DeclarativeRecord]].
             1. If ! _DclRec_.HasBinding(_N_) is *true*, return *true*.
             1. Let _ObjRec_ be _envRec_.[[ObjectRecord]].
-            1. Return ? <emu-meta effects="user-code">_ObjRec_.HasBinding</emu-meta>(_N_).
+            1. Return ? <emu-meta effects="user-code">_ObjRec_.HasBinding(_N_)</emu-meta>.
           </emu-alg>
         </emu-clause>
 
@@ -10978,7 +10978,7 @@
               1. Return ! _DclRec_.InitializeBinding(_N_, _V_).
             1. Assert: If the binding exists, it must be in the Object Environment Record.
             1. Let _ObjRec_ be _envRec_.[[ObjectRecord]].
-            1. Return ? <emu-meta effects="user-code">_ObjRec_.InitializeBinding</emu-meta>(_N_, _V_).
+            1. Return ? <emu-meta effects="user-code">_ObjRec_.InitializeBinding(_N_, _V_)</emu-meta>.
           </emu-alg>
         </emu-clause>
 
@@ -11002,7 +11002,7 @@
             1. If ! _DclRec_.HasBinding(_N_) is *true*, then
               1. Return ? _DclRec_.SetMutableBinding(_N_, _V_, _S_).
             1. Let _ObjRec_ be _envRec_.[[ObjectRecord]].
-            1. Return ? <emu-meta effects="user-code">_ObjRec_.SetMutableBinding</emu-meta>(_N_, _V_, _S_).
+            1. Return ? <emu-meta effects="user-code">_ObjRec_.SetMutableBinding(_N_, _V_, _S_)</emu-meta>.
           </emu-alg>
         </emu-clause>
 
@@ -11025,7 +11025,7 @@
             1. If ! _DclRec_.HasBinding(_N_) is *true*, then
               1. Return ? _DclRec_.GetBindingValue(_N_, _S_).
             1. Let _ObjRec_ be _envRec_.[[ObjectRecord]].
-            1. Return ? <emu-meta effects="user-code">_ObjRec_.GetBindingValue</emu-meta>(_N_, _S_).
+            1. Return ? <emu-meta effects="user-code">_ObjRec_.GetBindingValue(_N_, _S_)</emu-meta>.
           </emu-alg>
         </emu-clause>
 
@@ -11050,7 +11050,7 @@
             1. Let _globalObject_ be _ObjRec_.[[BindingObject]].
             1. Let _existingProp_ be ? HasOwnProperty(_globalObject_, _N_).
             1. If _existingProp_ is *true*, then
-              1. Return ? <emu-meta effects="user-code">_ObjRec_.DeleteBinding</emu-meta>(_N_).
+              1. Return ? <emu-meta effects="user-code">_ObjRec_.DeleteBinding(_N_)</emu-meta>.
             1. Return *true*.
           </emu-alg>
         </emu-clause>
@@ -11136,7 +11136,7 @@
           <emu-alg>
             1. Let _ObjRec_ be _envRec_.[[ObjectRecord]].
             1. Let _globalObject_ be _ObjRec_.[[BindingObject]].
-            1. Let _existingProp_ be ? <emu-meta effects="user-code">_globalObject_.[[GetOwnProperty]]</emu-meta>(_N_).
+            1. Let _existingProp_ be ? <emu-meta effects="user-code">_globalObject_.[[GetOwnProperty]](_N_)</emu-meta>.
             1. If _existingProp_ is *undefined*, return *false*.
             1. If _existingProp_.[[Configurable]] is *true*, return *false*.
             1. Return *true*.
@@ -11180,7 +11180,7 @@
           <emu-alg>
             1. Let _ObjRec_ be _envRec_.[[ObjectRecord]].
             1. Let _globalObject_ be _ObjRec_.[[BindingObject]].
-            1. Let _existingProp_ be ? <emu-meta effects="user-code">_globalObject_.[[GetOwnProperty]]</emu-meta>(_N_).
+            1. Let _existingProp_ be ? <emu-meta effects="user-code">_globalObject_.[[GetOwnProperty]](_N_)</emu-meta>.
             1. If _existingProp_ is *undefined*, return ? IsExtensible(_globalObject_).
             1. If _existingProp_.[[Configurable]] is *true*, return *true*.
             1. If IsDataDescriptor(_existingProp_) is *true* and _existingProp_ has attribute values { [[Writable]]: *true*, [[Enumerable]]: *true* }, return *true*.
@@ -11206,8 +11206,8 @@
             1. Let _hasProperty_ be ? HasOwnProperty(_globalObject_, _N_).
             1. Let _extensible_ be ? IsExtensible(_globalObject_).
             1. If _hasProperty_ is *false* and _extensible_ is *true*, then
-              1. Perform ? <emu-meta effects="user-code">_ObjRec_.CreateMutableBinding</emu-meta>(_N_, _D_).
-              1. Perform ? <emu-meta effects="user-code">_ObjRec_.InitializeBinding</emu-meta>(_N_, *undefined*).
+              1. Perform ? <emu-meta effects="user-code">_ObjRec_.CreateMutableBinding(_N_, _D_)</emu-meta>.
+              1. Perform ? <emu-meta effects="user-code">_ObjRec_.InitializeBinding(_N_, *undefined*)</emu-meta>.
             1. Return ~unused~.
           </emu-alg>
         </emu-clause>
@@ -11228,7 +11228,7 @@
           <emu-alg>
             1. Let _ObjRec_ be _envRec_.[[ObjectRecord]].
             1. Let _globalObject_ be _ObjRec_.[[BindingObject]].
-            1. Let _existingProp_ be ? <emu-meta effects="user-code">_globalObject_.[[GetOwnProperty]]</emu-meta>(_N_).
+            1. Let _existingProp_ be ? <emu-meta effects="user-code">_globalObject_.[[GetOwnProperty]](_N_)</emu-meta>.
             1. If _existingProp_ is *undefined* or _existingProp_.[[Configurable]] is *true*, then
               1. Let _desc_ be the PropertyDescriptor { [[Value]]: _V_, [[Writable]]: *true*, [[Enumerable]]: *true*, [[Configurable]]: _D_ }.
             1. Else,
@@ -11291,7 +11291,7 @@
               1. Let _M_ and _N2_ be the indirection values provided when this binding for _N_ was created.
               1. Let _targetEnv_ be _M_.[[Environment]].
               1. If _targetEnv_ is ~empty~, throw a *ReferenceError* exception.
-              1. Return ? <emu-meta effects="user-code">_targetEnv_.GetBindingValue</emu-meta>(_N2_, *true*).
+              1. Return ? <emu-meta effects="user-code">_targetEnv_.GetBindingValue(_N2_, *true*)</emu-meta>.
             1. If the binding for _N_ in _envRec_ is an uninitialized binding, throw a *ReferenceError* exception.
             1. Return the value currently bound to _N_ in _envRec_.
           </emu-alg>
@@ -11373,7 +11373,7 @@
         <emu-alg>
           1. If _env_ is *null*, then
             1. Return the Reference Record { [[Base]]: ~unresolvable~, [[ReferencedName]]: _name_, [[Strict]]: _strict_, [[ThisValue]]: ~empty~ }.
-          1. Let _exists_ be ? <emu-meta effects="user-code">_env_.HasBinding</emu-meta>(_name_).
+          1. Let _exists_ be ? <emu-meta effects="user-code">_env_.HasBinding(_name_)</emu-meta>.
           1. If _exists_ is *true*, then
             1. Return the Reference Record { [[Base]]: _env_, [[ReferencedName]]: _name_, [[Strict]]: _strict_, [[ThisValue]]: ~empty~ }.
           1. Else,
@@ -12717,7 +12717,7 @@
         <dl class="header">
         </dl>
         <emu-alg>
-          1. Let _current_ be ? <emu-meta effects="user-code">_O_.[[GetOwnProperty]]</emu-meta>(_P_).
+          1. Let _current_ be ? <emu-meta effects="user-code">_O_.[[GetOwnProperty]](_P_)</emu-meta>.
           1. Let _extensible_ be ? IsExtensible(_O_).
           1. Return ValidateAndApplyPropertyDescriptor(_O_, _P_, _extensible_, _Desc_, _current_).
         </emu-alg>
@@ -12815,11 +12815,11 @@
         <dl class="header">
         </dl>
         <emu-alg>
-          1. Let _hasOwn_ be ? <emu-meta effects="user-code">_O_.[[GetOwnProperty]]</emu-meta>(_P_).
+          1. Let _hasOwn_ be ? <emu-meta effects="user-code">_O_.[[GetOwnProperty]](_P_)</emu-meta>.
           1. If _hasOwn_ is not *undefined*, return *true*.
-          1. Let _parent_ be ? <emu-meta effects="user-code">_O_.[[GetPrototypeOf]]</emu-meta>().
+          1. Let _parent_ be ? <emu-meta effects="user-code">_O_.[[GetPrototypeOf]]()</emu-meta>.
           1. If _parent_ is not *null*, then
-            1. Return ? <emu-meta effects="user-code">_parent_.[[HasProperty]]</emu-meta>(_P_).
+            1. Return ? <emu-meta effects="user-code">_parent_.[[HasProperty]](_P_)</emu-meta>.
           1. Return *false*.
         </emu-alg>
       </emu-clause>
@@ -12853,11 +12853,11 @@
         </dl>
 
         <emu-alg>
-          1. Let _desc_ be ? <emu-meta effects="user-code">_O_.[[GetOwnProperty]]</emu-meta>(_P_).
+          1. Let _desc_ be ? <emu-meta effects="user-code">_O_.[[GetOwnProperty]](_P_)</emu-meta>.
           1. If _desc_ is *undefined*, then
-            1. Let _parent_ be ? <emu-meta effects="user-code">_O_.[[GetPrototypeOf]]</emu-meta>().
+            1. Let _parent_ be ? <emu-meta effects="user-code">_O_.[[GetPrototypeOf]]()</emu-meta>.
             1. If _parent_ is *null*, return *undefined*.
-            1. Return ? <emu-meta effects="user-code">_parent_.[[Get]]</emu-meta>(_P_, _Receiver_).
+            1. Return ? <emu-meta effects="user-code">_parent_.[[Get]](_P_, _Receiver_)</emu-meta>.
           1. If IsDataDescriptor(_desc_) is *true*, return _desc_.[[Value]].
           1. Assert: IsAccessorDescriptor(_desc_) is *true*.
           1. Let _getter_ be _desc_.[[Get]].
@@ -12896,7 +12896,7 @@
         </dl>
 
         <emu-alg>
-          1. Let _ownDesc_ be ? <emu-meta effects="user-code">_O_.[[GetOwnProperty]]</emu-meta>(_P_).
+          1. Let _ownDesc_ be ? <emu-meta effects="user-code">_O_.[[GetOwnProperty]](_P_)</emu-meta>.
           1. Return ? OrdinarySetWithOwnDescriptor(_O_, _P_, _V_, _Receiver_, _ownDesc_).
         </emu-alg>
       </emu-clause>
@@ -12916,20 +12916,20 @@
 
         <emu-alg>
           1. If _ownDesc_ is *undefined*, then
-            1. Let _parent_ be ? <emu-meta effects="user-code">_O_.[[GetPrototypeOf]]</emu-meta>().
+            1. Let _parent_ be ? <emu-meta effects="user-code">_O_.[[GetPrototypeOf]]()</emu-meta>.
             1. If _parent_ is not *null*, then
-              1. Return ? <emu-meta effects="user-code">_parent_.[[Set]]</emu-meta>(_P_, _V_, _Receiver_).
+              1. Return ? <emu-meta effects="user-code">_parent_.[[Set]](_P_, _V_, _Receiver_)</emu-meta>.
             1. Else,
               1. Set _ownDesc_ to the PropertyDescriptor { [[Value]]: *undefined*, [[Writable]]: *true*, [[Enumerable]]: *true*, [[Configurable]]: *true* }.
           1. If IsDataDescriptor(_ownDesc_) is *true*, then
             1. If _ownDesc_.[[Writable]] is *false*, return *false*.
             1. If _Receiver_ is not an Object, return *false*.
-            1. Let _existingDescriptor_ be ? <emu-meta effects="user-code">_Receiver_.[[GetOwnProperty]]</emu-meta>(_P_).
+            1. Let _existingDescriptor_ be ? <emu-meta effects="user-code">_Receiver_.[[GetOwnProperty]](_P_)</emu-meta>.
             1. If _existingDescriptor_ is not *undefined*, then
               1. If IsAccessorDescriptor(_existingDescriptor_) is *true*, return *false*.
               1. If _existingDescriptor_.[[Writable]] is *false*, return *false*.
               1. Let _valueDesc_ be the PropertyDescriptor { [[Value]]: _V_ }.
-              1. Return ? <emu-meta effects="user-code">_Receiver_.[[DefineOwnProperty]]</emu-meta>(_P_, _valueDesc_).
+              1. Return ? <emu-meta effects="user-code">_Receiver_.[[DefineOwnProperty]](_P_, _valueDesc_)</emu-meta>.
             1. Else,
               1. Assert: _Receiver_ does not currently have a property _P_.
               1. Return ? CreateDataProperty(_Receiver_, _P_, _V_).
@@ -12966,7 +12966,7 @@
         <dl class="header">
         </dl>
         <emu-alg>
-          1. Let _desc_ be ? <emu-meta effects="user-code">_O_.[[GetOwnProperty]]</emu-meta>(_P_).
+          1. Let _desc_ be ? <emu-meta effects="user-code">_O_.[[GetOwnProperty]](_P_)</emu-meta>.
           1. If _desc_ is *undefined*, return *true*.
           1. If _desc_.[[Configurable]] is *true*, then
             1. Remove the own property with name _P_ from _O_.
@@ -14094,7 +14094,7 @@
           <dd>It is used to specify the creation of new bound function exotic objects.</dd>
         </dl>
         <emu-alg>
-          1. Let _proto_ be ? <emu-meta effects="user-code">_targetFunction_.[[GetPrototypeOf]]</emu-meta>().
+          1. Let _proto_ be ? <emu-meta effects="user-code">_targetFunction_.[[GetPrototypeOf]]()</emu-meta>.
           1. Let _internalSlotsList_ be the list-concatenation of « [[Prototype]], [[Extensible]] » and the internal slots listed in <emu-xref href="#table-internal-slots-of-bound-function-exotic-objects"></emu-xref>.
           1. Let _obj_ be MakeBasicObject(_internalSlotsList_).
           1. Set _obj_.[[Prototype]] to _proto_.
@@ -15361,7 +15361,7 @@
         <dl class="header">
         </dl>
         <emu-alg>
-          1. Let _current_ be ? <emu-meta effects="user-code">_O_.[[GetPrototypeOf]]</emu-meta>().
+          1. Let _current_ be ? <emu-meta effects="user-code">_O_.[[GetPrototypeOf]]()</emu-meta>.
           1. If SameValue(_V_, _current_) is *true*, return *true*.
           1. Return *false*.
         </emu-alg>
@@ -15511,12 +15511,12 @@
         1. Assert: _handler_ is an Object.
         1. Let _trap_ be ? GetMethod(_handler_, *"getPrototypeOf"*).
         1. If _trap_ is *undefined*, then
-          1. Return ? <emu-meta effects="user-code">_target_.[[GetPrototypeOf]]</emu-meta>().
+          1. Return ? <emu-meta effects="user-code">_target_.[[GetPrototypeOf]]()</emu-meta>.
         1. Let _handlerProto_ be ? Call(_trap_, _handler_, « _target_ »).
         1. If _handlerProto_ is not an Object and _handlerProto_ is not *null*, throw a *TypeError* exception.
         1. Let _extensibleTarget_ be ? IsExtensible(_target_).
         1. If _extensibleTarget_ is *true*, return _handlerProto_.
-        1. Let _targetProto_ be ? <emu-meta effects="user-code">_target_.[[GetPrototypeOf]]</emu-meta>().
+        1. Let _targetProto_ be ? <emu-meta effects="user-code">_target_.[[GetPrototypeOf]]()</emu-meta>.
         1. If SameValue(_handlerProto_, _targetProto_) is *false*, throw a *TypeError* exception.
         1. Return _handlerProto_.
       </emu-alg>
@@ -15550,12 +15550,12 @@
         1. Assert: _handler_ is an Object.
         1. Let _trap_ be ? GetMethod(_handler_, *"setPrototypeOf"*).
         1. If _trap_ is *undefined*, then
-          1. Return ? <emu-meta effects="user-code">_target_.[[SetPrototypeOf]]</emu-meta>(_V_).
+          1. Return ? <emu-meta effects="user-code">_target_.[[SetPrototypeOf]](_V_)</emu-meta>.
         1. Let _booleanTrapResult_ be ToBoolean(? Call(_trap_, _handler_, « _target_, _V_ »)).
         1. If _booleanTrapResult_ is *false*, return *false*.
         1. Let _extensibleTarget_ be ? IsExtensible(_target_).
         1. If _extensibleTarget_ is *true*, return *true*.
-        1. Let _targetProto_ be ? <emu-meta effects="user-code">_target_.[[GetPrototypeOf]]</emu-meta>().
+        1. Let _targetProto_ be ? <emu-meta effects="user-code">_target_.[[GetPrototypeOf]]()</emu-meta>.
         1. If SameValue(_V_, _targetProto_) is *false*, throw a *TypeError* exception.
         1. Return *true*.
       </emu-alg>
@@ -15617,7 +15617,7 @@
         1. Assert: _handler_ is an Object.
         1. Let _trap_ be ? GetMethod(_handler_, *"preventExtensions"*).
         1. If _trap_ is *undefined*, then
-          1. Return ? <emu-meta effects="user-code">_target_.[[PreventExtensions]]</emu-meta>().
+          1. Return ? <emu-meta effects="user-code">_target_.[[PreventExtensions]]()</emu-meta>.
         1. Let _booleanTrapResult_ be ToBoolean(? Call(_trap_, _handler_, « _target_ »)).
         1. If _booleanTrapResult_ is *true*, then
           1. Let _extensibleTarget_ be ? IsExtensible(_target_).
@@ -15654,10 +15654,10 @@
         1. Assert: _handler_ is an Object.
         1. Let _trap_ be ? GetMethod(_handler_, *"getOwnPropertyDescriptor"*).
         1. If _trap_ is *undefined*, then
-          1. Return ? <emu-meta effects="user-code">_target_.[[GetOwnProperty]]</emu-meta>(_P_).
+          1. Return ? <emu-meta effects="user-code">_target_.[[GetOwnProperty]](_P_)</emu-meta>.
         1. Let _trapResultObj_ be ? Call(_trap_, _handler_, « _target_, _P_ »).
         1. If _trapResultObj_ is not an Object and _trapResultObj_ is not *undefined*, throw a *TypeError* exception.
-        1. Let _targetDesc_ be ? <emu-meta effects="user-code">_target_.[[GetOwnProperty]]</emu-meta>(_P_).
+        1. Let _targetDesc_ be ? <emu-meta effects="user-code">_target_.[[GetOwnProperty]](_P_)</emu-meta>.
         1. If _trapResultObj_ is *undefined*, then
           1. If _targetDesc_ is *undefined*, return *undefined*.
           1. If _targetDesc_.[[Configurable]] is *false*, throw a *TypeError* exception.
@@ -15720,11 +15720,11 @@
         1. Assert: _handler_ is an Object.
         1. Let _trap_ be ? GetMethod(_handler_, *"defineProperty"*).
         1. If _trap_ is *undefined*, then
-          1. Return ? <emu-meta effects="user-code">_target_.[[DefineOwnProperty]]</emu-meta>(_P_, _Desc_).
+          1. Return ? <emu-meta effects="user-code">_target_.[[DefineOwnProperty]](_P_, _Desc_)</emu-meta>.
         1. Let _descObj_ be FromPropertyDescriptor(_Desc_).
         1. Let _booleanTrapResult_ be ToBoolean(? Call(_trap_, _handler_, « _target_, _P_, _descObj_ »)).
         1. If _booleanTrapResult_ is *false*, return *false*.
-        1. Let _targetDesc_ be ? <emu-meta effects="user-code">_target_.[[GetOwnProperty]]</emu-meta>(_P_).
+        1. Let _targetDesc_ be ? <emu-meta effects="user-code">_target_.[[GetOwnProperty]](_P_)</emu-meta>.
         1. Let _extensibleTarget_ be ? IsExtensible(_target_).
         1. If _Desc_ has a [[Configurable]] field and _Desc_.[[Configurable]] is *false*, then
           1. Let _settingConfigFalse_ be *true*.
@@ -15779,10 +15779,10 @@
         1. Assert: _handler_ is an Object.
         1. Let _trap_ be ? GetMethod(_handler_, *"has"*).
         1. If _trap_ is *undefined*, then
-          1. Return ? <emu-meta effects="user-code">_target_.[[HasProperty]]</emu-meta>(_P_).
+          1. Return ? <emu-meta effects="user-code">_target_.[[HasProperty]](_P_)</emu-meta>.
         1. Let _booleanTrapResult_ be ToBoolean(? Call(_trap_, _handler_, « _target_, _P_ »)).
         1. If _booleanTrapResult_ is *false*, then
-          1. Let _targetDesc_ be ? <emu-meta effects="user-code">_target_.[[GetOwnProperty]]</emu-meta>(_P_).
+          1. Let _targetDesc_ be ? <emu-meta effects="user-code">_target_.[[GetOwnProperty]](_P_)</emu-meta>.
           1. If _targetDesc_ is not *undefined*, then
             1. If _targetDesc_.[[Configurable]] is *false*, throw a *TypeError* exception.
             1. Let _extensibleTarget_ be ? IsExtensible(_target_).
@@ -15823,9 +15823,9 @@
         1. Assert: _handler_ is an Object.
         1. Let _trap_ be ? GetMethod(_handler_, *"get"*).
         1. If _trap_ is *undefined*, then
-          1. Return ? <emu-meta effects="user-code">_target_.[[Get]]</emu-meta>(_P_, _Receiver_).
+          1. Return ? <emu-meta effects="user-code">_target_.[[Get]](_P_, _Receiver_)</emu-meta>.
         1. Let _trapResult_ be ? Call(_trap_, _handler_, « _target_, _P_, _Receiver_ »).
-        1. Let _targetDesc_ be ? <emu-meta effects="user-code">_target_.[[GetOwnProperty]]</emu-meta>(_P_).
+        1. Let _targetDesc_ be ? <emu-meta effects="user-code">_target_.[[GetOwnProperty]](_P_)</emu-meta>.
         1. If _targetDesc_ is not *undefined* and _targetDesc_.[[Configurable]] is *false*, then
           1. If IsDataDescriptor(_targetDesc_) is *true* and _targetDesc_.[[Writable]] is *false*, then
             1. If SameValue(_trapResult_, _targetDesc_.[[Value]]) is *false*, throw a *TypeError* exception.
@@ -15865,10 +15865,10 @@
         1. Assert: _handler_ is an Object.
         1. Let _trap_ be ? GetMethod(_handler_, *"set"*).
         1. If _trap_ is *undefined*, then
-          1. Return ? <emu-meta effects="user-code">_target_.[[Set]]</emu-meta>(_P_, _V_, _Receiver_).
+          1. Return ? <emu-meta effects="user-code">_target_.[[Set]](_P_, _V_, _Receiver_)</emu-meta>.
         1. Let _booleanTrapResult_ be ToBoolean(? Call(_trap_, _handler_, « _target_, _P_, _V_, _Receiver_ »)).
         1. If _booleanTrapResult_ is *false*, return *false*.
-        1. Let _targetDesc_ be ? <emu-meta effects="user-code">_target_.[[GetOwnProperty]]</emu-meta>(_P_).
+        1. Let _targetDesc_ be ? <emu-meta effects="user-code">_target_.[[GetOwnProperty]](_P_)</emu-meta>.
         1. If _targetDesc_ is not *undefined* and _targetDesc_.[[Configurable]] is *false*, then
           1. If IsDataDescriptor(_targetDesc_) is *true* and _targetDesc_.[[Writable]] is *false*, then
             1. If SameValue(_V_, _targetDesc_.[[Value]]) is *false*, throw a *TypeError* exception.
@@ -15909,10 +15909,10 @@
         1. Assert: _handler_ is an Object.
         1. Let _trap_ be ? GetMethod(_handler_, *"deleteProperty"*).
         1. If _trap_ is *undefined*, then
-          1. Return ? <emu-meta effects="user-code">_target_.[[Delete]]</emu-meta>(_P_).
+          1. Return ? <emu-meta effects="user-code">_target_.[[Delete]](_P_)</emu-meta>.
         1. Let _booleanTrapResult_ be ToBoolean(? Call(_trap_, _handler_, « _target_, _P_ »)).
         1. If _booleanTrapResult_ is *false*, return *false*.
-        1. Let _targetDesc_ be ? <emu-meta effects="user-code">_target_.[[GetOwnProperty]]</emu-meta>(_P_).
+        1. Let _targetDesc_ be ? <emu-meta effects="user-code">_target_.[[GetOwnProperty]](_P_)</emu-meta>.
         1. If _targetDesc_ is *undefined*, return *true*.
         1. If _targetDesc_.[[Configurable]] is *false*, throw a *TypeError* exception.
         1. Let _extensibleTarget_ be ? IsExtensible(_target_).
@@ -15948,18 +15948,18 @@
         1. Assert: _handler_ is an Object.
         1. Let _trap_ be ? GetMethod(_handler_, *"ownKeys"*).
         1. If _trap_ is *undefined*, then
-          1. Return ? <emu-meta effects="user-code">_target_.[[OwnPropertyKeys]]</emu-meta>().
+          1. Return ? <emu-meta effects="user-code">_target_.[[OwnPropertyKeys]]()</emu-meta>.
         1. Let _trapResultArray_ be ? Call(_trap_, _handler_, « _target_ »).
         1. Let _trapResult_ be ? CreateListFromArrayLike(_trapResultArray_, ~property-key~).
         1. If _trapResult_ contains any duplicate entries, throw a *TypeError* exception.
         1. Let _extensibleTarget_ be ? IsExtensible(_target_).
-        1. Let _targetKeys_ be ? <emu-meta effects="user-code">_target_.[[OwnPropertyKeys]]</emu-meta>().
+        1. Let _targetKeys_ be ? <emu-meta effects="user-code">_target_.[[OwnPropertyKeys]]()</emu-meta>.
         1. Assert: _targetKeys_ is a List of property keys.
         1. Assert: _targetKeys_ contains no duplicate entries.
         1. Let _targetConfigurableKeys_ be a new empty List.
         1. Let _targetNonconfigurableKeys_ be a new empty List.
         1. For each element _key_ of _targetKeys_, do
-          1. Let _desc_ be ? <emu-meta effects="user-code">_target_.[[GetOwnProperty]]</emu-meta>(_key_).
+          1. Let _desc_ be ? <emu-meta effects="user-code">_target_.[[GetOwnProperty]](_key_)</emu-meta>.
           1. If _desc_ is not *undefined* and _desc_.[[Configurable]] is *false*, then
             1. Append _key_ to _targetNonconfigurableKeys_.
           1. Else,
@@ -18692,7 +18692,7 @@
             1. Let _propValue_ be ? GetValue(_exprValueRef_).
           1. If _isProtoSetter_ is *true*, then
             1. If _propValue_ is an Object or _propValue_ is *null*, then
-              1. Perform ! <emu-meta effects="user-code">_object_.[[SetPrototypeOf]]</emu-meta>(_propValue_).
+              1. Perform ! <emu-meta effects="user-code">_object_.[[SetPrototypeOf]](_propValue_)</emu-meta>.
             1. Return ~unused~.
           1. Assert: _object_ is an ordinary, extensible object with no non-configurable properties.
           1. Perform ! CreateDataPropertyOrThrow(_object_, _propKey_, _propValue_).
@@ -19755,7 +19755,7 @@
             1. Let _evaluatePromise_ be _module_.Evaluate().
             1. Let _fulfilledClosure_ be a new Abstract Closure with no parameters that captures _module_ and _promiseCapability_ and performs the following steps when called:
               1. Let _namespace_ be GetModuleNamespace(_module_).
-              1. Perform ! <emu-meta effects="user-code">Call</emu-meta>(_promiseCapability_.[[Resolve]], *undefined*, « _namespace_ »).
+              1. Perform ! <emu-meta effects="user-code">Call(_promiseCapability_.[[Resolve]], *undefined*, « _namespace_ »)</emu-meta>.
               1. Return NormalCompletion(*undefined*).
             1. Let _onFulfilled_ be CreateBuiltinFunction(_fulfilledClosure_, 0, *""*, « »).
             1. Perform PerformPromiseThen(_evaluatePromise_, _onFulfilled_, _onRejected_).
@@ -20032,13 +20032,13 @@
             1. [id="step-delete-operator-toobject"] Let _baseObj_ be ? ToObject(_ref_.[[Base]]).
             1. If _ref_.[[ReferencedName]] is not a property key, then
               1. Set _ref_.[[ReferencedName]] to ? ToPropertyKey(_ref_.[[ReferencedName]]).
-            1. Let _deleteStatus_ be ? <emu-meta effects="user-code">_baseObj_.[[Delete]]</emu-meta>(_ref_.[[ReferencedName]]).
+            1. Let _deleteStatus_ be ? <emu-meta effects="user-code">_baseObj_.[[Delete]](_ref_.[[ReferencedName]])</emu-meta>.
             1. If _deleteStatus_ is *false* and _ref_.[[Strict]] is *true*, throw a *TypeError* exception.
             1. Return _deleteStatus_.
           1. Else,
             1. Let _base_ be _ref_.[[Base]].
             1. Assert: _base_ is an Environment Record.
-            1. Return ? <emu-meta effects="user-code">_base_.DeleteBinding</emu-meta>(_ref_.[[ReferencedName]]).
+            1. Return ? <emu-meta effects="user-code">_base_.DeleteBinding(_ref_.[[ReferencedName]])</emu-meta>.
         </emu-alg>
         <emu-note>
           <p>When a `delete` operator occurs within strict mode code, a *SyntaxError* exception is thrown if its |UnaryExpression| is a direct reference to a variable, function argument, or function name. In addition, if a `delete` operator occurs within strict mode code and the property to be deleted has the attribute { [[Configurable]]: *false* } (or otherwise cannot be deleted), a *TypeError* exception is thrown.</p>
@@ -22556,7 +22556,7 @@
               1. Let _object_ be _O_.[[Object]].
               1. Repeat,
                 1. If _O_.[[ObjectWasVisited]] is *false*, then
-                  1. Let _keys_ be ? <emu-meta effects="user-code">_object_.[[OwnPropertyKeys]]</emu-meta>().
+                  1. Let _keys_ be ? <emu-meta effects="user-code">_object_.[[OwnPropertyKeys]]()</emu-meta>.
                   1. For each element _key_ of _keys_, do
                     1. If _key_ is a String, then
                       1. Append _key_ to _O_.[[RemainingKeys]].
@@ -22565,11 +22565,11 @@
                   1. Let _r_ be the first element of _O_.[[RemainingKeys]].
                   1. Remove the first element from _O_.[[RemainingKeys]].
                   1. If _O_.[[VisitedKeys]] does not contain _r_, then
-                    1. Let _desc_ be ? <emu-meta effects="user-code">_object_.[[GetOwnProperty]]</emu-meta>(_r_).
+                    1. Let _desc_ be ? <emu-meta effects="user-code">_object_.[[GetOwnProperty]](_r_)</emu-meta>.
                     1. If _desc_ is not *undefined*, then
                       1. Append _r_ to _O_.[[VisitedKeys]].
                       1. If _desc_.[[Enumerable]] is *true*, return CreateIteratorResultObject(_r_, *false*).
-                1. Set _object_ to ? <emu-meta effects="user-code">_object_.[[GetPrototypeOf]]</emu-meta>().
+                1. Set _object_ to ? <emu-meta effects="user-code">_object_.[[GetPrototypeOf]]()</emu-meta>.
                 1. Set _O_.[[Object]] to _object_.
                 1. Set _O_.[[ObjectWasVisited]] to *false*.
                 1. If _object_ is *null*, return CreateIteratorResultObject(*undefined*, *true*).
@@ -26206,7 +26206,7 @@
                       1. Let _gEnv_ be the running execution context's VariableEnvironment.
                       1. Let _bEnv_ be the running execution context's LexicalEnvironment.
                       1. Let _fObj_ be ! _bEnv_.GetBindingValue(_F_, *false*).
-                      1. Perform ? <emu-meta effects="user-code">_gEnv_.SetMutableBinding</emu-meta>(_F_, _fObj_, *false*).
+                      1. Perform ? <emu-meta effects="user-code">_gEnv_.SetMutableBinding(_F_, _fObj_, *false*)</emu-meta>.
                       1. Return ~unused~.
         1. Let _lexDeclarations_ be the LexicallyScopedDeclarations of _script_.
         1. Let _privateEnv_ be *null*.
@@ -26214,15 +26214,15 @@
           1. NOTE: Lexically declared names are only instantiated here but not initialized.
           1. For each element _dn_ of the BoundNames of _d_, do
             1. If IsConstantDeclaration of _d_ is *true*, then
-              1. Perform ? <emu-meta effects="user-code">_env_.CreateImmutableBinding</emu-meta>(_dn_, *true*).
+              1. Perform ? <emu-meta effects="user-code">_env_.CreateImmutableBinding(_dn_, *true*)</emu-meta>.
             1. Else,
-              1. Perform ? <emu-meta effects="user-code">_env_.CreateMutableBinding</emu-meta>(_dn_, *false*).
+              1. Perform ? <emu-meta effects="user-code">_env_.CreateMutableBinding(_dn_, *false*)</emu-meta>.
         1. For each Parse Node _f_ of _functionsToInitialize_, do
           1. Let _fn_ be the sole element of the BoundNames of _f_.
           1. Let _fo_ be InstantiateFunctionObject of _f_ with arguments _env_ and _privateEnv_.
-          1. Perform ? <emu-meta effects="user-code">CreateGlobalFunctionBinding</emu-meta>(_env_, _fn_, _fo_, *false*).
+          1. Perform ? <emu-meta effects="user-code">CreateGlobalFunctionBinding(_env_, _fn_, _fo_, *false*)</emu-meta>.
         1. For each String _vn_ of _declaredVarNames_, do
-          1. Perform ? <emu-meta effects="user-code">CreateGlobalVarBinding</emu-meta>(_env_, _vn_, *false*).
+          1. Perform ? <emu-meta effects="user-code">CreateGlobalVarBinding(_env_, _vn_, *false*)</emu-meta>.
         1. Return ~unused~.
       </emu-alg>
       <emu-note>
@@ -27213,7 +27213,7 @@
                   1. Set _module_.[[AsyncEvaluationOrder]] to IncrementModuleAsyncEvaluationCount().
                   1. If _module_.[[PendingAsyncDependencies]] = 0, perform ExecuteAsyncModule(_module_).
                 1. Else,
-                  1. Perform ? <emu-meta effects="user-code">_module_.ExecuteModule</emu-meta>().
+                  1. Perform ? <emu-meta effects="user-code">_module_.ExecuteModule()</emu-meta>.
                 1. Assert: _module_ occurs exactly once in _stack_.
                 1. Assert: _module_.[[DFSAncestorIndex]] ≤ _moduleIndex_.
                 1. If _module_.[[DFSAncestorIndex]] = _moduleIndex_, then
@@ -27259,7 +27259,7 @@
                   1. Return NormalCompletion(*undefined*).
                 1. Let _onRejected_ be CreateBuiltinFunction(_rejectedClosure_, 0, *""*, « »).
                 1. Perform PerformPromiseThen(_capability_.[[Promise]], _onFulfilled_, _onRejected_).
-                1. Perform ! <emu-meta effects="user-code">_module_.ExecuteModule</emu-meta>(_capability_).
+                1. Perform ! <emu-meta effects="user-code">_module_.ExecuteModule(_capability_)</emu-meta>.
                 1. Return ~unused~.
               </emu-alg>
             </emu-clause>
@@ -27321,7 +27321,7 @@
                   1. Else if _m_.[[HasTLA]] is *true*, then
                     1. Perform ExecuteAsyncModule(_m_).
                   1. Else,
-                    1. Let _result_ be <emu-meta effects="user-code">_m_.ExecuteModule</emu-meta>().
+                    1. Let _result_ be <emu-meta effects="user-code">_m_.ExecuteModule()</emu-meta>.
                     1. If _result_ is an abrupt completion, then
                       1. Perform AsyncModuleExecutionRejected(_m_, _result_.[[Value]]).
                     1. Else,
@@ -29906,7 +29906,7 @@
                     1. Let _gEnv_ be the running execution context's VariableEnvironment.
                     1. Let _bEnv_ be the running execution context's LexicalEnvironment.
                     1. Let _fObj_ be ! _bEnv_.GetBindingValue(_F_, *false*).
-                    1. Perform ? <emu-meta effects="user-code">_gEnv_.SetMutableBinding</emu-meta>(_F_, _fObj_, *false*).
+                    1. Perform ? <emu-meta effects="user-code">_gEnv_.SetMutableBinding(_F_, _fObj_, *false*)</emu-meta>.
                     1. Return ~unused~.
           1. [id="step-evaldeclarationinstantiation-post-validation"] NOTE: No abnormal terminations occur after this algorithm step unless _varEnv_ is a Global Environment Record and the global object is a Proxy exotic object.
           1. Let _lexDeclarations_ be the LexicallyScopedDeclarations of _body_.
@@ -30484,9 +30484,9 @@
           1. For each element _nextSource_ of _sources_, do
             1. If _nextSource_ is neither *undefined* nor *null*, then
               1. Let _from_ be ! ToObject(_nextSource_).
-              1. Let _keys_ be ? <emu-meta effects="user-code">_from_.[[OwnPropertyKeys]]</emu-meta>().
+              1. Let _keys_ be ? <emu-meta effects="user-code">_from_.[[OwnPropertyKeys]]()</emu-meta>.
               1. For each element _nextKey_ of _keys_, do
-                1. Let _desc_ be ? <emu-meta effects="user-code">_from_.[[GetOwnProperty]]</emu-meta>(_nextKey_).
+                1. Let _desc_ be ? <emu-meta effects="user-code">_from_.[[GetOwnProperty]](_nextKey_)</emu-meta>.
                 1. If _desc_ is not *undefined* and _desc_.[[Enumerable]] is *true*, then
                   1. Let _propValue_ be ? Get(_from_, _nextKey_).
                   1. Perform ? Set(_to_, _nextKey_, _propValue_, *true*).
@@ -30528,10 +30528,10 @@
           </dl>
           <emu-alg>
             1. Let _props_ be ? ToObject(_Properties_).
-            1. Let _keys_ be ? <emu-meta effects="user-code">_props_.[[OwnPropertyKeys]]</emu-meta>().
+            1. Let _keys_ be ? <emu-meta effects="user-code">_props_.[[OwnPropertyKeys]]()</emu-meta>.
             1. Let _descriptors_ be a new empty List.
             1. For each element _nextKey_ of _keys_, do
-              1. Let _propDesc_ be ? <emu-meta effects="user-code">_props_.[[GetOwnProperty]]</emu-meta>(_nextKey_).
+              1. Let _propDesc_ be ? <emu-meta effects="user-code">_props_.[[GetOwnProperty]](_nextKey_)</emu-meta>.
               1. If _propDesc_ is not *undefined* and _propDesc_.[[Enumerable]] is *true*, then
                 1. Let _descObj_ be ? Get(_props_, _nextKey_).
                 1. Let _desc_ be ? ToPropertyDescriptor(_descObj_).
@@ -30602,7 +30602,7 @@
         <emu-alg>
           1. Let _obj_ be ? ToObject(_O_).
           1. Let _key_ be ? ToPropertyKey(_P_).
-          1. Let _desc_ be ? <emu-meta effects="user-code">_obj_.[[GetOwnProperty]]</emu-meta>(_key_).
+          1. Let _desc_ be ? <emu-meta effects="user-code">_obj_.[[GetOwnProperty]](_key_)</emu-meta>.
           1. Return FromPropertyDescriptor(_desc_).
         </emu-alg>
       </emu-clause>
@@ -30612,10 +30612,10 @@
         <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. Let _obj_ be ? ToObject(_O_).
-          1. Let _ownKeys_ be ? <emu-meta effects="user-code">_obj_.[[OwnPropertyKeys]]</emu-meta>().
+          1. Let _ownKeys_ be ? <emu-meta effects="user-code">_obj_.[[OwnPropertyKeys]]()</emu-meta>.
           1. Let _descriptors_ be OrdinaryObjectCreate(%Object.prototype%).
           1. For each element _key_ of _ownKeys_, do
-            1. Let _desc_ be ? <emu-meta effects="user-code">_obj_.[[GetOwnProperty]]</emu-meta>(_key_).
+            1. Let _desc_ be ? <emu-meta effects="user-code">_obj_.[[GetOwnProperty]](_key_)</emu-meta>.
             1. Let _descriptor_ be FromPropertyDescriptor(_desc_).
             1. If _descriptor_ is not *undefined*, perform ! CreateDataPropertyOrThrow(_descriptors_, _key_, _descriptor_).
           1. Return _descriptors_.
@@ -30648,7 +30648,7 @@
           </dl>
           <emu-alg>
             1. Let _obj_ be ? ToObject(_O_).
-            1. Let _keys_ be ? <emu-meta effects="user-code">_obj_.[[OwnPropertyKeys]]</emu-meta>().
+            1. Let _keys_ be ? <emu-meta effects="user-code">_obj_.[[OwnPropertyKeys]]()</emu-meta>.
             1. Let _nameList_ be a new empty List.
             1. For each element _nextKey_ of _keys_, do
               1. If _nextKey_ is a Symbol and _type_ is ~symbol~, or if _nextKey_ is a String and _type_ is ~string~, then
@@ -30663,7 +30663,7 @@
         <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. Let _obj_ be ? ToObject(_O_).
-          1. Return ? <emu-meta effects="user-code">_obj_.[[GetPrototypeOf]]</emu-meta>().
+          1. Return ? <emu-meta effects="user-code">_obj_.[[GetPrototypeOf]]()</emu-meta>.
         </emu-alg>
       </emu-clause>
 
@@ -30745,7 +30745,7 @@
         <p>This function performs the following steps when called:</p>
         <emu-alg>
           1. If _O_ is not an Object, return _O_.
-          1. Let _status_ be ? <emu-meta effects="user-code">_O_.[[PreventExtensions]]</emu-meta>().
+          1. Let _status_ be ? <emu-meta effects="user-code">_O_.[[PreventExtensions]]()</emu-meta>.
           1. If _status_ is *false*, throw a *TypeError* exception.
           1. Return _O_.
         </emu-alg>
@@ -30775,7 +30775,7 @@
           1. Perform ? RequireObjectCoercible(_O_).
           1. If _proto_ is not an Object and _proto_ is not *null*, throw a *TypeError* exception.
           1. If _O_ is not an Object, return _O_.
-          1. Let _status_ be ? <emu-meta effects="user-code">_O_.[[SetPrototypeOf]]</emu-meta>(_proto_).
+          1. Let _status_ be ? <emu-meta effects="user-code">_O_.[[SetPrototypeOf]](_proto_)</emu-meta>.
           1. If _status_ is *false*, throw a *TypeError* exception.
           1. Return _O_.
         </emu-alg>
@@ -30827,7 +30827,7 @@
           1. [id="step-isprototypeof-check-object"] If _V_ is not an Object, return *false*.
           1. [id="step-isprototypeof-toobject"] Let _O_ be ? ToObject(*this* value).
           1. Repeat,
-            1. Set _V_ to ? <emu-meta effects="user-code">_V_.[[GetPrototypeOf]]</emu-meta>().
+            1. Set _V_ to ? <emu-meta effects="user-code">_V_.[[GetPrototypeOf]]()</emu-meta>.
             1. If _V_ is *null*, return *false*.
             1. If SameValue(_O_, _V_) is *true*, return *true*.
         </emu-alg>
@@ -30842,7 +30842,7 @@
         <emu-alg>
           1. [id="step-propertyisenumerable-topropertykey"] Let _P_ be ? ToPropertyKey(_V_).
           1. [id="step-propertyisenumerable-toobject"] Let _O_ be ? ToObject(*this* value).
-          1. Let _desc_ be ? <emu-meta effects="user-code">_O_.[[GetOwnProperty]]</emu-meta>(_P_).
+          1. Let _desc_ be ? <emu-meta effects="user-code">_O_.[[GetOwnProperty]](_P_)</emu-meta>.
           1. If _desc_ is *undefined*, return *false*.
           1. Return _desc_.[[Enumerable]].
         </emu-alg>
@@ -30914,7 +30914,7 @@
           <p>The value of the [[Get]] attribute is a built-in function that requires no arguments. It performs the following steps when called:</p>
           <emu-alg>
             1. Let _O_ be ? ToObject(*this* value).
-            1. Return ? <emu-meta effects="user-code">_O_.[[GetPrototypeOf]]</emu-meta>().
+            1. Return ? <emu-meta effects="user-code">_O_.[[GetPrototypeOf]]()</emu-meta>.
           </emu-alg>
         </emu-clause>
 
@@ -30926,7 +30926,7 @@
             1. Perform ? RequireObjectCoercible(_O_).
             1. If _proto_ is not an Object and _proto_ is not *null*, return *undefined*.
             1. If _O_ is not an Object, return *undefined*.
-            1. Let _status_ be ? <emu-meta effects="user-code">_O_.[[SetPrototypeOf]]</emu-meta>(_proto_).
+            1. Let _status_ be ? <emu-meta effects="user-code">_O_.[[SetPrototypeOf]](_proto_)</emu-meta>.
             1. If _status_ is *false*, throw a *TypeError* exception.
             1. Return *undefined*.
           </emu-alg>
@@ -30969,11 +30969,11 @@
             1. Let _O_ be ? ToObject(*this* value).
             1. Let _key_ be ? ToPropertyKey(_P_).
             1. Repeat,
-              1. Let _desc_ be ? <emu-meta effects="user-code">_O_.[[GetOwnProperty]]</emu-meta>(_key_).
+              1. Let _desc_ be ? <emu-meta effects="user-code">_O_.[[GetOwnProperty]](_key_)</emu-meta>.
               1. If _desc_ is not *undefined*, then
                 1. If IsAccessorDescriptor(_desc_) is *true*, return _desc_.[[Get]].
                 1. Return *undefined*.
-              1. Set _O_ to ? <emu-meta effects="user-code">_O_.[[GetPrototypeOf]]</emu-meta>().
+              1. Set _O_ to ? <emu-meta effects="user-code">_O_.[[GetPrototypeOf]]()</emu-meta>.
               1. If _O_ is *null*, return *undefined*.
           </emu-alg>
         </emu-clause>
@@ -30985,11 +30985,11 @@
             1. Let _O_ be ? ToObject(*this* value).
             1. Let _key_ be ? ToPropertyKey(_P_).
             1. Repeat,
-              1. Let _desc_ be ? <emu-meta effects="user-code">_O_.[[GetOwnProperty]]</emu-meta>(_key_).
+              1. Let _desc_ be ? <emu-meta effects="user-code">_O_.[[GetOwnProperty]](_key_)</emu-meta>.
               1. If _desc_ is not *undefined*, then
                 1. If IsAccessorDescriptor(_desc_) is *true*, return _desc_.[[Set]].
                 1. Return *undefined*.
-              1. Set _O_ to ? <emu-meta effects="user-code">_O_.[[GetPrototypeOf]]</emu-meta>().
+              1. Set _O_ to ? <emu-meta effects="user-code">_O_.[[GetPrototypeOf]]()</emu-meta>.
               1. If _O_ is *null*, return *undefined*.
           </emu-alg>
         </emu-clause>
@@ -32444,7 +32444,7 @@
           1. If NewTarget is not *undefined*, throw a *TypeError* exception.
           1. Let _prim_ be ? ToPrimitive(_value_, ~number~).
           1. If _prim_ is a Number, return ? NumberToBigInt(_prim_).
-          1. Otherwise, return ? <emu-meta suppress-effects="user-code">ToBigInt</emu-meta>(_prim_).
+          1. Otherwise, return ? <emu-meta suppress-effects="user-code">ToBigInt(_prim_)</emu-meta>.
         </emu-alg>
 
         <emu-clause id="sec-numbertobigint" type="abstract operation">
@@ -36378,7 +36378,7 @@ THH:mm:ss.sss
         <emu-clause id="sec-%stringiteratorprototype%.next">
           <h1>%StringIteratorPrototype%.next ( )</h1>
           <emu-alg>
-            1. Return ? <emu-meta suppress-effects="user-code">GeneratorResume</emu-meta>(*this* value, ~empty~, *"%StringIteratorPrototype%"*).
+            1. Return ? <emu-meta suppress-effects="user-code">GeneratorResume(*this* value, ~empty~, *"%StringIteratorPrototype%"*)</emu-meta>.
           </emu-alg>
         </emu-clause>
 
@@ -38668,7 +38668,7 @@ THH:mm:ss.sss
           1. Let _rer_ be the RegExp Record { [[IgnoreCase]]: _i_, [[Multiline]]: _m_, [[DotAll]]: _s_, [[Unicode]]: _u_, [[UnicodeSets]]: _v_, [[CapturingGroupsCount]]: _capturingGroupsCount_ }.
           1. Set _obj_.[[RegExpRecord]] to _rer_.
           1. Set _obj_.[[RegExpMatcher]] to CompilePattern of _parseResult_ with argument _rer_.
-          1. Perform ? <emu-meta suppress-effects="user-code">Set</emu-meta>(_obj_, *"lastIndex"*, *+0*<sub>𝔽</sub>, *true*).
+          1. Perform ? <emu-meta suppress-effects="user-code">Set(_obj_, *"lastIndex"*, *+0*<sub>𝔽</sub>, *true*)</emu-meta>.
           1. Return _obj_.
         </emu-alg>
       </emu-clause>
@@ -39330,13 +39330,13 @@ THH:mm:ss.sss
           1. Repeat, while _matchSucceeded_ is *false*,
             1. If _lastIndex_ > _length_, then
               1. If _global_ is *true* or _sticky_ is *true*, then
-                1. Perform ? <emu-meta suppress-effects="user-code">Set</emu-meta>(_R_, *"lastIndex"*, *+0*<sub>𝔽</sub>, *true*).
+                1. Perform ? <emu-meta suppress-effects="user-code">Set(_R_, *"lastIndex"*, *+0*<sub>𝔽</sub>, *true*)</emu-meta>.
               1. Return *null*.
             1. Let _inputIndex_ be the index into _input_ of the character that was obtained from element _lastIndex_ of _S_.
             1. Let _r_ be _matcher_(_input_, _inputIndex_).
             1. If _r_ is ~failure~, then
               1. If _sticky_ is *true*, then
-                1. Perform ? <emu-meta suppress-effects="user-code">Set</emu-meta>(_R_, *"lastIndex"*, *+0*<sub>𝔽</sub>, *true*).
+                1. Perform ? <emu-meta suppress-effects="user-code">Set(_R_, *"lastIndex"*, *+0*<sub>𝔽</sub>, *true*)</emu-meta>.
                 1. Return *null*.
               1. Set _lastIndex_ to AdvanceStringIndex(_S_, _lastIndex_, _fullUnicode_).
             1. Else,
@@ -39345,7 +39345,7 @@ THH:mm:ss.sss
           1. Let _e_ be _r_.[[EndIndex]].
           1. If _fullUnicode_ is *true*, set _e_ to GetStringIndex(_S_, _e_).
           1. If _global_ is *true* or _sticky_ is *true*, then
-            1. Perform ? <emu-meta suppress-effects="user-code">Set</emu-meta>(_R_, *"lastIndex"*, 𝔽(_e_), *true*).
+            1. Perform ? <emu-meta suppress-effects="user-code">Set(_R_, *"lastIndex"*, 𝔽(_e_), *true*)</emu-meta>.
           1. Let _n_ be the number of elements in _r_.[[Captures]].
           1. Assert: _n_ = _R_.[[RegExpRecord]].[[CapturingGroupsCount]].
           1. Assert: _n_ &lt; 2<sup>32</sup> - 1.
@@ -42578,7 +42578,7 @@ THH:mm:ss.sss
         </dl>
         <emu-alg>
           1. Let _constructor_ be the intrinsic object associated with the constructor name _exemplar_.[[TypedArrayName]] in <emu-xref href="#table-the-typedarray-constructors"></emu-xref>.
-          1. Let _result_ be ? <emu-meta suppress-effects="user-code">TypedArrayCreateFromConstructor</emu-meta>(_constructor_, « 𝔽(_length_) »).
+          1. Let _result_ be ? <emu-meta suppress-effects="user-code">TypedArrayCreateFromConstructor(_constructor_, « 𝔽(_length_) »)</emu-meta>.
           1. Assert: _result_ has [[TypedArrayName]] and [[ContentType]] internal slots.
           1. Assert: _result_.[[ContentType]] is _exemplar_.[[ContentType]].
           1. Return _result_.
@@ -42779,7 +42779,7 @@ THH:mm:ss.sss
             1. If _elementType_ is _srcType_, then
               1. Let _data_ be ? CloneArrayBuffer(_srcData_, _srcByteOffset_, _byteLength_).
             1. Else,
-              1. Let _data_ be ? <emu-meta suppress-effects="user-code">AllocateArrayBuffer</emu-meta>(%ArrayBuffer%, _byteLength_).
+              1. Let _data_ be ? <emu-meta suppress-effects="user-code">AllocateArrayBuffer(%ArrayBuffer%, _byteLength_)</emu-meta>.
               1. If _srcArray_.[[ContentType]] is not _O_.[[ContentType]], throw a *TypeError* exception.
               1. Let _srcByteIndex_ be _srcByteOffset_.
               1. Let _targetByteIndex_ be 0.
@@ -42899,7 +42899,7 @@ THH:mm:ss.sss
             1. Assert: _O_.[[ViewedArrayBuffer]] is *undefined*.
             1. Let _elementSize_ be TypedArrayElementSize(_O_).
             1. Let _byteLength_ be _elementSize_ × _length_.
-            1. Let _data_ be ? <emu-meta suppress-effects="user-code">AllocateArrayBuffer</emu-meta>(%ArrayBuffer%, _byteLength_).
+            1. Let _data_ be ? <emu-meta suppress-effects="user-code">AllocateArrayBuffer(%ArrayBuffer%, _byteLength_)</emu-meta>.
             1. Set _O_.[[ViewedArrayBuffer]] to _data_.
             1. Set _O_.[[ByteLength]] to _byteLength_.
             1. Set _O_.[[ByteOffset]] to 0.
@@ -42982,7 +42982,7 @@ THH:mm:ss.sss
           1. If _result_.[[Error]] is not ~none~, then
             1. Return ThrowCompletion(_result_.[[Error]]).
           1. Let _resultLength_ be the number of elements in _result_.[[Bytes]].
-          1. Let _ta_ be ? <emu-meta suppress-effects="user-code">AllocateTypedArray</emu-meta>(*"Uint8Array"*, %Uint8Array%, *"%Uint8Array.prototype%"*, _resultLength_).
+          1. Let _ta_ be ? <emu-meta suppress-effects="user-code">AllocateTypedArray(*"Uint8Array"*, %Uint8Array%, *"%Uint8Array.prototype%"*, _resultLength_)</emu-meta>.
           1. Assert: _ta_.[[ViewedArrayBuffer]].[[ArrayBufferByteLength]] is the number of elements in _result_.[[Bytes]].
           1. Set the value at each index of _ta_.[[ViewedArrayBuffer]].[[ArrayBufferData]] to the value at the corresponding index of _result_.[[Bytes]].
           1. Return _ta_.
@@ -42997,7 +42997,7 @@ THH:mm:ss.sss
           1. If _result_.[[Error]] is not ~none~, then
             1. Return ThrowCompletion(_result_.[[Error]]).
           1. Let _resultLength_ be the number of elements in _result_.[[Bytes]].
-          1. Let _ta_ be ? <emu-meta suppress-effects="user-code">AllocateTypedArray</emu-meta>(*"Uint8Array"*, %Uint8Array%, *"%Uint8Array.prototype%"*, _resultLength_).
+          1. Let _ta_ be ? <emu-meta suppress-effects="user-code">AllocateTypedArray(*"Uint8Array"*, %Uint8Array%, *"%Uint8Array.prototype%"*, _resultLength_)</emu-meta>.
           1. Assert: _ta_.[[ViewedArrayBuffer]].[[ArrayBufferByteLength]] is the number of elements in _result_.[[Bytes]].
           1. Set the value at each index of _ta_.[[ViewedArrayBuffer]].[[ArrayBufferData]] to the value at the corresponding index of _result_.[[Bytes]].
           1. Return _ta_.
@@ -43693,7 +43693,7 @@ THH:mm:ss.sss
         <emu-clause id="sec-%mapiteratorprototype%.next">
           <h1>%MapIteratorPrototype%.next ( )</h1>
           <emu-alg>
-            1. Return ? <emu-meta suppress-effects="user-code">GeneratorResume</emu-meta>(*this* value, ~empty~, *"%MapIteratorPrototype%"*).
+            1. Return ? <emu-meta suppress-effects="user-code">GeneratorResume(*this* value, ~empty~, *"%MapIteratorPrototype%"*)</emu-meta>.
           </emu-alg>
         </emu-clause>
 
@@ -44323,7 +44323,7 @@ THH:mm:ss.sss
         <emu-clause id="sec-%setiteratorprototype%.next">
           <h1>%SetIteratorPrototype%.next ( )</h1>
           <emu-alg>
-            1. Return ? <emu-meta suppress-effects="user-code">GeneratorResume</emu-meta>(*this* value, ~empty~, *"%SetIteratorPrototype%"*).
+            1. Return ? <emu-meta suppress-effects="user-code">GeneratorResume(*this* value, ~empty~, *"%SetIteratorPrototype%"*)</emu-meta>.
           </emu-alg>
         </emu-clause>
 
@@ -44737,7 +44737,7 @@ THH:mm:ss.sss
           1. Else,
             1. Let _newMaxByteLength_ be ~empty~.
           1. If _arrayBuffer_.[[ArrayBufferDetachKey]] is not *undefined*, throw a *TypeError* exception.
-          1. Let _newBuffer_ be ? <emu-meta suppress-effects="user-code">AllocateArrayBuffer</emu-meta>(%ArrayBuffer%, _newByteLength_, _newMaxByteLength_).
+          1. Let _newBuffer_ be ? <emu-meta suppress-effects="user-code">AllocateArrayBuffer(%ArrayBuffer%, _newByteLength_, _newMaxByteLength_)</emu-meta>.
           1. Let _copyLength_ be min(_newByteLength_, _arrayBuffer_.[[ArrayBufferByteLength]]).
           1. Let _fromBlock_ be _arrayBuffer_.[[ArrayBufferData]].
           1. Let _toBlock_ be _newBuffer_.[[ArrayBufferData]].
@@ -44800,7 +44800,7 @@ THH:mm:ss.sss
         </dl>
         <emu-alg>
           1. Assert: IsDetachedBuffer(_srcBuffer_) is *false*.
-          1. Let _targetBuffer_ be ? <emu-meta suppress-effects="user-code">AllocateArrayBuffer</emu-meta>(%ArrayBuffer%, _srcLength_).
+          1. Let _targetBuffer_ be ? <emu-meta suppress-effects="user-code">AllocateArrayBuffer(%ArrayBuffer%, _srcLength_)</emu-meta>.
           1. Let _srcBlock_ be _srcBuffer_.[[ArrayBufferData]].
           1. Let _targetBlock_ be _targetBuffer_.[[ArrayBufferData]].
           1. Perform CopyDataBlockBytes(_targetBlock_, 0, _srcBlock_, _srcByteOffset_, _srcLength_).
@@ -47083,7 +47083,7 @@ THH:mm:ss.sss
                 1. Let _prop_ be ! ToString(𝔽(_I_)).
                 1. Let _newElement_ be ? InternalizeJSONProperty(_val_, _prop_, _reviver_).
                 1. If _newElement_ is *undefined*, then
-                  1. Perform ? <emu-meta effects="user-code">_val_.[[Delete]]</emu-meta>(_prop_).
+                  1. Perform ? <emu-meta effects="user-code">_val_.[[Delete]](_prop_)</emu-meta>.
                 1. Else,
                   1. Perform ? CreateDataProperty(_val_, _prop_, _newElement_).
                 1. Set _I_ to _I_ + 1.
@@ -47092,7 +47092,7 @@ THH:mm:ss.sss
               1. For each String _P_ of _keys_, do
                 1. Let _newElement_ be ? InternalizeJSONProperty(_val_, _P_, _reviver_).
                 1. If _newElement_ is *undefined*, then
-                  1. Perform ? <emu-meta effects="user-code">_val_.[[Delete]]</emu-meta>(_P_).
+                  1. Perform ? <emu-meta effects="user-code">_val_.[[Delete]](_P_)</emu-meta>.
                 1. Else,
                   1. Perform ? CreateDataProperty(_val_, _P_, _newElement_).
           1. Return ? Call(_reviver_, _holder_, « _name_, _val_ »).
@@ -48634,7 +48634,7 @@ THH:mm:ss.sss
             1. IfAbruptRejectPromise(_return_, _promiseCapability_).
             1. If _return_ is *undefined*, then
               1. Let _iteratorResult_ be CreateIteratorResultObject(_value_, *true*).
-              1. Perform ! <emu-meta effects="user-code">Call</emu-meta>(_promiseCapability_.[[Resolve]], *undefined*, « _iteratorResult_ »).
+              1. Perform ! <emu-meta effects="user-code">Call(_promiseCapability_.[[Resolve]], *undefined*, « _iteratorResult_ »)</emu-meta>.
               1. Return _promiseCapability_.[[Promise]].
             1. If _value_ is present, then
               1. Let _result_ be Completion(Call(_return_, _syncIterator_, « _value_ »)).
@@ -50381,7 +50381,7 @@ THH:mm:ss.sss
           1. Let _state_ be _generator_.[[AsyncGeneratorState]].
           1. If _state_ is ~completed~, then
             1. Let _iteratorResult_ be CreateIteratorResultObject(*undefined*, *true*).
-            1. Perform ! <emu-meta effects="user-code">Call</emu-meta>(_promiseCapability_.[[Resolve]], *undefined*, « _iteratorResult_ »).
+            1. Perform ! <emu-meta effects="user-code">Call(_promiseCapability_.[[Resolve]], *undefined*, « _iteratorResult_ »)</emu-meta>.
             1. Return _promiseCapability_.[[Promise]].
           1. Let _completion_ be NormalCompletion(_value_).
           1. Perform AsyncGeneratorEnqueue(_generator_, _completion_, _promiseCapability_).
@@ -50610,7 +50610,7 @@ THH:mm:ss.sss
               1. Set the running execution context's Realm to _oldRealm_.
             1. Else,
               1. Let _iteratorResult_ be CreateIteratorResultObject(_value_, _done_).
-            1. Perform ! <emu-meta effects="user-code">Call</emu-meta>(_promiseCapability_.[[Resolve]], *undefined*, « _iteratorResult_ »).
+            1. Perform ! <emu-meta effects="user-code">Call(_promiseCapability_.[[Resolve]], *undefined*, « _iteratorResult_ »)</emu-meta>.
           1. Return ~unused~.
         </emu-alg>
       </emu-clause>
@@ -50899,7 +50899,7 @@ THH:mm:ss.sss
             1. If _result_ is a normal completion, then
               1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, « *undefined* »).
             1. Else if _result_ is a return completion, then
-              1. Perform ! <emu-meta effects="user-code">Call</emu-meta>(_promiseCapability_.[[Resolve]], *undefined*, « _result_.[[Value]] »).
+              1. Perform ! <emu-meta effects="user-code">Call(_promiseCapability_.[[Resolve]], *undefined*, « _result_.[[Value]] »)</emu-meta>.
             1. Else,
               1. Assert: _result_ is a throw completion.
               1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, « _result_.[[Value]] »).
@@ -50998,7 +50998,7 @@ THH:mm:ss.sss
         1. If _target_ is not an Object, throw a *TypeError* exception.
         1. Let _key_ be ? ToPropertyKey(_propertyKey_).
         1. Let _desc_ be ? ToPropertyDescriptor(_attributes_).
-        1. Return ? <emu-meta effects="user-code">_target_.[[DefineOwnProperty]]</emu-meta>(_key_, _desc_).
+        1. Return ? <emu-meta effects="user-code">_target_.[[DefineOwnProperty]](_key_, _desc_)</emu-meta>.
       </emu-alg>
     </emu-clause>
 
@@ -51008,7 +51008,7 @@ THH:mm:ss.sss
       <emu-alg>
         1. If _target_ is not an Object, throw a *TypeError* exception.
         1. Let _key_ be ? ToPropertyKey(_propertyKey_).
-        1. Return ? <emu-meta effects="user-code">_target_.[[Delete]]</emu-meta>(_key_).
+        1. Return ? <emu-meta effects="user-code">_target_.[[Delete]](_key_)</emu-meta>.
       </emu-alg>
     </emu-clause>
 
@@ -51020,7 +51020,7 @@ THH:mm:ss.sss
         1. Let _key_ be ? ToPropertyKey(_propertyKey_).
         1. If _receiver_ is not present, then
           1. Set _receiver_ to _target_.
-        1. Return ? <emu-meta effects="user-code">_target_.[[Get]]</emu-meta>(_key_, _receiver_).
+        1. Return ? <emu-meta effects="user-code">_target_.[[Get]](_key_, _receiver_)</emu-meta>.
       </emu-alg>
     </emu-clause>
 
@@ -51030,7 +51030,7 @@ THH:mm:ss.sss
       <emu-alg>
         1. If _target_ is not an Object, throw a *TypeError* exception.
         1. Let _key_ be ? ToPropertyKey(_propertyKey_).
-        1. Let _desc_ be ? <emu-meta effects="user-code">_target_.[[GetOwnProperty]]</emu-meta>(_key_).
+        1. Let _desc_ be ? <emu-meta effects="user-code">_target_.[[GetOwnProperty]](_key_)</emu-meta>.
         1. Return FromPropertyDescriptor(_desc_).
       </emu-alg>
     </emu-clause>
@@ -51040,7 +51040,7 @@ THH:mm:ss.sss
       <p>This function performs the following steps when called:</p>
       <emu-alg>
         1. If _target_ is not an Object, throw a *TypeError* exception.
-        1. Return ? <emu-meta effects="user-code">_target_.[[GetPrototypeOf]]</emu-meta>().
+        1. Return ? <emu-meta effects="user-code">_target_.[[GetPrototypeOf]]()</emu-meta>.
       </emu-alg>
     </emu-clause>
 
@@ -51050,7 +51050,7 @@ THH:mm:ss.sss
       <emu-alg>
         1. If _target_ is not an Object, throw a *TypeError* exception.
         1. Let _key_ be ? ToPropertyKey(_propertyKey_).
-        1. Return ? <emu-meta effects="user-code">_target_.[[HasProperty]]</emu-meta>(_key_).
+        1. Return ? <emu-meta effects="user-code">_target_.[[HasProperty]](_key_)</emu-meta>.
       </emu-alg>
     </emu-clause>
 
@@ -51059,7 +51059,7 @@ THH:mm:ss.sss
       <p>This function performs the following steps when called:</p>
       <emu-alg>
         1. If _target_ is not an Object, throw a *TypeError* exception.
-        1. Return ? <emu-meta effects="user-code">_target_.[[IsExtensible]]</emu-meta>().
+        1. Return ? <emu-meta effects="user-code">_target_.[[IsExtensible]]()</emu-meta>.
       </emu-alg>
     </emu-clause>
 
@@ -51068,7 +51068,7 @@ THH:mm:ss.sss
       <p>This function performs the following steps when called:</p>
       <emu-alg>
         1. If _target_ is not an Object, throw a *TypeError* exception.
-        1. Let _keys_ be ? <emu-meta effects="user-code">_target_.[[OwnPropertyKeys]]</emu-meta>().
+        1. Let _keys_ be ? <emu-meta effects="user-code">_target_.[[OwnPropertyKeys]]()</emu-meta>.
         1. Return CreateArrayFromList(_keys_).
       </emu-alg>
     </emu-clause>
@@ -51078,7 +51078,7 @@ THH:mm:ss.sss
       <p>This function performs the following steps when called:</p>
       <emu-alg>
         1. If _target_ is not an Object, throw a *TypeError* exception.
-        1. Return ? <emu-meta effects="user-code">_target_.[[PreventExtensions]]</emu-meta>().
+        1. Return ? <emu-meta effects="user-code">_target_.[[PreventExtensions]]()</emu-meta>.
       </emu-alg>
     </emu-clause>
 
@@ -51090,7 +51090,7 @@ THH:mm:ss.sss
         1. Let _key_ be ? ToPropertyKey(_propertyKey_).
         1. If _receiver_ is not present, then
           1. Set _receiver_ to _target_.
-        1. Return ? <emu-meta effects="user-code">_target_.[[Set]]</emu-meta>(_key_, _V_, _receiver_).
+        1. Return ? <emu-meta effects="user-code">_target_.[[Set]](_key_, _V_, _receiver_)</emu-meta>.
       </emu-alg>
     </emu-clause>
 
@@ -51100,7 +51100,7 @@ THH:mm:ss.sss
       <emu-alg>
         1. If _target_ is not an Object, throw a *TypeError* exception.
         1. If _proto_ is not an Object and _proto_ is not *null*, throw a *TypeError* exception.
-        1. Return ? <emu-meta effects="user-code">_target_.[[SetPrototypeOf]]</emu-meta>(_proto_).
+        1. Return ? <emu-meta effects="user-code">_target_.[[SetPrototypeOf]](_proto_)</emu-meta>.
       </emu-alg>
     </emu-clause>
 


### PR DESCRIPTION
This PR reduces the following redundant expressions in spec.

For each cases, the line below is merged with above one.

```
# 1. `emu-meta` tag
<emu-meta *>{{ name }}</emu-meta>({{ args }})
<emu-meta *>{{ name }}({{ args }})</emu-meta>


# 2. Replace redundant verbs
as specified in <emu-xref href="*"></emu-xref>
as described in <emu-xref href="*"></emu-xref>


# 3. Remove redundant adverbs
{{ expr }} has a {{ field }}
{{ expr }} also has a {{ field }}

{{ expr }} does not have a {{ field }}
{{ expr }} does not already have a {{ field }}

1. Append {{ expr }} to {{ expr }}.
1. Append {{ expr }} to the end of {{ expr }}.
```

The merging is based on the number of each cases. Smaller cases are merged to larger ones.

```bash
$ grep '1\. .*</emu-meta>(' spec.html -c
102
$ grep '1\. .*)</emu-meta>' spec.html -c
39
$ grep '1\. .* as specified in <emu-xref' spec.html -c
19
$ grep '1\. .* as described in <emu-xref' spec.html -c
2
$ grep '1\. .* has a \[\[.*\.' spec.html -c
57
$ grep '1\. .* also has a \[\[.*\.' spec.html -c
1
$ grep '1\. .* does not have a .*\.' spec.html -c
17
$ grep '1\. .* does not already have a .*\.' spec.html -c
3
$ grep '1\. Append .* to .*\.' spec.html -c
138
$ grep '1\. Append .* to the end of .*\.' spec.html
1
```

For reference, the number of line diff is 46 = 39 + 2 + 1 + 3 + 1.