### PR TITLE
Layering: Revamp InitializeHostDefinedRealm

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -11665,7 +11665,7 @@
       <h1>
         InitializeHostDefinedRealm (
           _customizations_: an Abstract Closure that takes a Realm Record and returns a List of 2 elements, each of which is either an Object or *undefined*,
-        ): ~unused~
+        ): an execution context
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -11712,8 +11712,7 @@
         1. Set the Function of _newContext_ to *null*.
         1. Set the Realm of _newContext_ to _realm_.
         1. Set the ScriptOrModule of _newContext_ to *null*.
-        1. Push _newContext_ onto the execution context stack; _newContext_ is now the running execution context.
-        1. Return ~unused~.
+        1. Return _newContext_.
       </emu-alg>
     </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -53289,7 +53289,6 @@ THH:mm:ss.sss
     <p><b>HostMakeJobCallback(...)</b></p>
     <p><b>HostPromiseRejectionTracker(...)</b></p>
     <p><b>HostResizeArrayBuffer(...)</b></p>
-    <p><b>MakeRealm(...)</b></p>
   </emu-annex>
 
   <emu-annex id="sec-host-defined-fields-summary">

--- a/spec.html
+++ b/spec.html
@@ -11662,8 +11662,32 @@
     </emu-table>
 
     <emu-clause id="sec-initializehostdefinedrealm" type="abstract operation" oldids="sec-createrealm,sec-setrealmglobalobject">
-      <h1>InitializeHostDefinedRealm ( ): either a normal completion containing ~unused~ or a throw completion</h1>
+      <h1>
+        InitializeHostDefinedRealm (
+          _customizations_: an Abstract Closure that takes a Realm Record and returns a List of 2 elements, each of which is either an Object or *undefined*,
+        ): either a normal completion containing ~unused~ or a throw completion
+      </h1>
       <dl class="header">
+        <dt>description</dt>
+        <dd>
+          <p>This operation invokes _customizations_, passing it the Realm Record that is being initialized. It must return a List of 2 elements:</p>
+          <ul>
+            <li>
+              <p>The first element is either:</p>
+              <ul>
+                <li>the object that is to serve as the Realm's global object, created in a host-defined manner, or</li>
+                <li>*undefined*, indicating that an ordinary object should be created as the global object.</li>
+              </ul>
+            </li>
+            <li>
+              <p>The second element is either:</p>
+              <ul>
+                <li>the object that is to serve as the `this` binding in the Realm's global scope, created in a host-defined manner, or</li>
+                <li>*undefined*, indicating that the global object should be used.</li>
+              </ul>
+            </li>
+          </ul>
+        </dd>
       </dl>
       <emu-alg>
         1. Let _realm_ be a new Realm Record.
@@ -11675,14 +11699,15 @@
         1. Set the Realm of _newContext_ to _realm_.
         1. Set the ScriptOrModule of _newContext_ to *null*.
         1. Push _newContext_ onto the execution context stack; _newContext_ is now the running execution context.
-        1. If the host requires use of a specific object to serve as _realm_'s global object, then
-          1. Let _global_ be such an object created in a host-defined manner.
+        1. Let _global_ and _thisValue_ be the elements of _customizations_(_realm_).
+        1. If _global_ is *undefined*, then
+          1. Set _global_ to OrdinaryObjectCreate(_realm_.[[Intrinsics]].[[%Object.prototype%]]).
         1. Else,
-          1. Let _global_ be OrdinaryObjectCreate(_realm_.[[Intrinsics]].[[%Object.prototype%]]).
-        1. If the host requires that the `this` binding in _realm_'s global scope return an object other than the global object, then
-          1. Let _thisValue_ be such an object created in a host-defined manner.
+          1. Assert: _global_ is an Object.
+        1. If _thisValue_ is *undefined*, then
+          1. Set _thisValue_ to _global_.
         1. Else,
-          1. Let _thisValue_ be _global_.
+          1. Assert: _thisValue_ is an Object.
         1. Set _realm_.[[GlobalObject]] to _global_.
         1. Set _realm_.[[GlobalEnv]] to NewGlobalEnvironment(_global_, _thisValue_).
         1. Perform ? SetDefaultGlobalBindings(_realm_).

--- a/spec.html
+++ b/spec.html
@@ -11695,11 +11695,6 @@
         1. Perform CreateIntrinsics(_realm_).
         1. Set _realm_.[[AgentSignifier]] to AgentSignifier().
         1. Set _realm_.[[TemplateMap]] to a new empty List.
-        1. Let _newContext_ be a new execution context.
-        1. Set the Function of _newContext_ to *null*.
-        1. Set the Realm of _newContext_ to _realm_.
-        1. Set the ScriptOrModule of _newContext_ to *null*.
-        1. Push _newContext_ onto the execution context stack; _newContext_ is now the running execution context.
         1. Let _global_ and _thisValue_ be the elements of _customizations_(_realm_).
         1. If _global_ is *undefined*, then
           1. Set _global_ to OrdinaryObjectCreate(_realm_.[[Intrinsics]].[[%Object.prototype%]]).
@@ -11713,6 +11708,11 @@
         1. Set _realm_.[[GlobalEnv]] to NewGlobalEnvironment(_global_, _thisValue_).
         1. Perform SetDefaultGlobalBindings(_realm_).
         1. Create any host-defined global object properties on _global_.
+        1. Let _newContext_ be a new execution context.
+        1. Set the Function of _newContext_ to *null*.
+        1. Set the Realm of _newContext_ to _realm_.
+        1. Set the ScriptOrModule of _newContext_ to *null*.
+        1. Push _newContext_ onto the execution context stack; _newContext_ is now the running execution context.
         1. Return ~unused~.
       </emu-alg>
     </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -11661,9 +11661,9 @@
       </table>
     </emu-table>
 
-    <emu-clause id="sec-initializehostdefinedrealm" type="abstract operation" oldids="sec-createrealm,sec-setrealmglobalobject">
+    <emu-clause id="sec-makerealm" type="abstract operation" oldids="sec-initializehostdefinedrealm,sec-createrealm,sec-setrealmglobalobject">
       <h1>
-        InitializeHostDefinedRealm (
+        MakeRealm (
           _customizations_: an Abstract Closure that takes a Realm Record and returns a List of 2 elements, each of which is either an Object or *undefined*,
         ): an execution context
       </h1>
@@ -11799,7 +11799,7 @@
             ScriptOrModule
           </td>
           <td>
-            The Module Record or Script Record from which associated code originates. If there is no originating script or module, as is the case for the original execution context created in InitializeHostDefinedRealm, the value is *null*.
+            The Module Record or Script Record from which associated code originates. If there is no originating script or module, as is the case for the original execution context created in MakeRealm, the value is *null*.
           </td>
         </tr>
       </table>
@@ -53289,7 +53289,7 @@ THH:mm:ss.sss
     <p><b>HostMakeJobCallback(...)</b></p>
     <p><b>HostPromiseRejectionTracker(...)</b></p>
     <p><b>HostResizeArrayBuffer(...)</b></p>
-    <p><b>InitializeHostDefinedRealm(...)</b></p>
+    <p><b>MakeRealm(...)</b></p>
   </emu-annex>
 
   <emu-annex id="sec-host-defined-fields-summary">

--- a/spec.html
+++ b/spec.html
@@ -11665,7 +11665,7 @@
       <h1>
         InitializeHostDefinedRealm (
           _customizations_: an Abstract Closure that takes a Realm Record and returns a List of 2 elements, each of which is either an Object or *undefined*,
-        ): either a normal completion containing ~unused~ or a throw completion
+        ): ~unused~
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -11678,6 +11678,7 @@
                 <li>the object that is to serve as the Realm's global object, created in a host-defined manner, or</li>
                 <li>*undefined*, indicating that an ordinary object should be created as the global object.</li>
               </ul>
+              <p>If the former, then the supplied object must satisfy SetDefaultGlobalBindings' constraint.</p>
             </li>
             <li>
               <p>The second element is either:</p>
@@ -11710,7 +11711,7 @@
           1. Assert: _thisValue_ is an Object.
         1. Set _realm_.[[GlobalObject]] to _global_.
         1. Set _realm_.[[GlobalEnv]] to NewGlobalEnvironment(_global_, _thisValue_).
-        1. Perform ? SetDefaultGlobalBindings(_realm_).
+        1. Perform SetDefaultGlobalBindings(_realm_).
         1. Create any host-defined global object properties on _global_.
         1. Return ~unused~.
       </emu-alg>
@@ -11736,16 +11737,18 @@
       <h1>
         SetDefaultGlobalBindings (
           _realmRec_: a Realm Record,
-        ): either a normal completion containing ~unused~ or a throw completion
+        ): ~unused~
       </h1>
       <dl class="header">
+        <dt>description</dt>
+        <dd>_realmRec_.[[GlobalObject]] must be an object such that all of this operation's invocations of DefinePropertyOrThrow return a normal completion.</dd>
       </dl>
       <emu-alg>
         1. Let _global_ be _realmRec_.[[GlobalObject]].
         1. For each property of the Global Object specified in clause <emu-xref href="#sec-global-object"></emu-xref>, do
           1. Let _name_ be the String value of the property name.
           1. Let _desc_ be the fully populated data Property Descriptor for the property, containing the specified attributes for the property. For properties listed in <emu-xref href="#sec-function-properties-of-the-global-object"></emu-xref>, <emu-xref href="#sec-constructor-properties-of-the-global-object"></emu-xref>, or <emu-xref href="#sec-other-properties-of-the-global-object"></emu-xref> the value of the [[Value]] attribute is the corresponding intrinsic object from _realmRec_.
-          1. Perform ? DefinePropertyOrThrow(_global_, _name_, _desc_).
+          1. Perform ! DefinePropertyOrThrow(_global_, _name_, _desc_).
         1. Return ~unused~.
       </emu-alg>
     </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -53875,7 +53875,6 @@ THH:mm:ss.sss
     <p><b>HostMakeJobCallback(...)</b></p>
     <p><b>HostPromiseRejectionTracker(...)</b></p>
     <p><b>HostResizeArrayBuffer(...)</b></p>
-    <p><b>MakeRealm(...)</b></p>
   </emu-annex>
 
   <emu-annex id="sec-host-defined-fields-summary">

--- a/spec.html
+++ b/spec.html
@@ -11743,11 +11743,6 @@
         1. Perform CreateIntrinsics(_realm_).
         1. Set _realm_.[[AgentSignifier]] to AgentSignifier().
         1. Set _realm_.[[TemplateMap]] to a new empty List.
-        1. Let _newContext_ be a new execution context.
-        1. Set the Function of _newContext_ to *null*.
-        1. Set the Realm of _newContext_ to _realm_.
-        1. Set the ScriptOrModule of _newContext_ to *null*.
-        1. Push _newContext_ onto the execution context stack; _newContext_ is now the running execution context.
         1. Let _global_ and _thisValue_ be the elements of _customizations_(_realm_).
         1. If _global_ is *undefined*, then
           1. Set _global_ to OrdinaryObjectCreate(_realm_.[[Intrinsics]].[[%Object.prototype%]]).
@@ -11761,6 +11756,11 @@
         1. Set _realm_.[[GlobalEnv]] to NewGlobalEnvironment(_global_, _thisValue_).
         1. Perform SetDefaultGlobalBindings(_realm_).
         1. Create any host-defined global object properties on _global_.
+        1. Let _newContext_ be a new execution context.
+        1. Set the Function of _newContext_ to *null*.
+        1. Set the Realm of _newContext_ to _realm_.
+        1. Set the ScriptOrModule of _newContext_ to *null*.
+        1. Push _newContext_ onto the execution context stack; _newContext_ is now the running execution context.
         1. Return ~unused~.
       </emu-alg>
     </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -11709,9 +11709,9 @@
       </table>
     </emu-table>
 
-    <emu-clause id="sec-initializehostdefinedrealm" type="abstract operation" oldids="sec-createrealm,sec-setrealmglobalobject">
+    <emu-clause id="sec-makerealm" type="abstract operation" oldids="sec-initializehostdefinedrealm,sec-createrealm,sec-setrealmglobalobject">
       <h1>
-        InitializeHostDefinedRealm (
+        MakeRealm (
           _customizations_: an Abstract Closure that takes a Realm Record and returns a List of 2 elements, each of which is either an Object or *undefined*,
         ): an execution context
       </h1>
@@ -11847,7 +11847,7 @@
             ScriptOrModule
           </td>
           <td>
-            The Module Record or Script Record from which associated code originates. If there is no originating script or module, as is the case for the original execution context created in InitializeHostDefinedRealm, the value is *null*.
+            The Module Record or Script Record from which associated code originates. If there is no originating script or module, as is the case for the original execution context created in MakeRealm, the value is *null*.
           </td>
         </tr>
       </table>
@@ -53875,7 +53875,7 @@ THH:mm:ss.sss
     <p><b>HostMakeJobCallback(...)</b></p>
     <p><b>HostPromiseRejectionTracker(...)</b></p>
     <p><b>HostResizeArrayBuffer(...)</b></p>
-    <p><b>InitializeHostDefinedRealm(...)</b></p>
+    <p><b>MakeRealm(...)</b></p>
   </emu-annex>
 
   <emu-annex id="sec-host-defined-fields-summary">

--- a/spec.html
+++ b/spec.html
@@ -11710,8 +11710,32 @@
     </emu-table>
 
     <emu-clause id="sec-initializehostdefinedrealm" type="abstract operation" oldids="sec-createrealm,sec-setrealmglobalobject">
-      <h1>InitializeHostDefinedRealm ( ): either a normal completion containing ~unused~ or a throw completion</h1>
+      <h1>
+        InitializeHostDefinedRealm (
+          _customizations_: an Abstract Closure that takes a Realm Record and returns a List of 2 elements, each of which is either an Object or *undefined*,
+        ): either a normal completion containing ~unused~ or a throw completion
+      </h1>
       <dl class="header">
+        <dt>description</dt>
+        <dd>
+          <p>This operation invokes _customizations_, passing it the Realm Record that is being initialized. It must return a List of 2 elements:</p>
+          <ul>
+            <li>
+              <p>The first element is either:</p>
+              <ul>
+                <li>the object that is to serve as the Realm's global object, created in a host-defined manner, or</li>
+                <li>*undefined*, indicating that an ordinary object should be created as the global object.</li>
+              </ul>
+            </li>
+            <li>
+              <p>The second element is either:</p>
+              <ul>
+                <li>the object that is to serve as the `this` binding in the Realm's global scope, created in a host-defined manner, or</li>
+                <li>*undefined*, indicating that the global object should be used.</li>
+              </ul>
+            </li>
+          </ul>
+        </dd>
       </dl>
       <emu-alg>
         1. Let _realm_ be a new Realm Record.
@@ -11723,14 +11747,15 @@
         1. Set the Realm of _newContext_ to _realm_.
         1. Set the ScriptOrModule of _newContext_ to *null*.
         1. Push _newContext_ onto the execution context stack; _newContext_ is now the running execution context.
-        1. If the host requires use of a specific object to serve as _realm_'s global object, then
-          1. Let _global_ be such an object created in a host-defined manner.
+        1. Let _global_ and _thisValue_ be the elements of _customizations_(_realm_).
+        1. If _global_ is *undefined*, then
+          1. Set _global_ to OrdinaryObjectCreate(_realm_.[[Intrinsics]].[[%Object.prototype%]]).
         1. Else,
-          1. Let _global_ be OrdinaryObjectCreate(_realm_.[[Intrinsics]].[[%Object.prototype%]]).
-        1. If the host requires that the `this` binding in _realm_'s global scope return an object other than the global object, then
-          1. Let _thisValue_ be such an object created in a host-defined manner.
+          1. Assert: _global_ is an Object.
+        1. If _thisValue_ is *undefined*, then
+          1. Set _thisValue_ to _global_.
         1. Else,
-          1. Let _thisValue_ be _global_.
+          1. Assert: _thisValue_ is an Object.
         1. Set _realm_.[[GlobalObject]] to _global_.
         1. Set _realm_.[[GlobalEnv]] to NewGlobalEnvironment(_global_, _thisValue_).
         1. Perform ? SetDefaultGlobalBindings(_realm_).

--- a/spec.html
+++ b/spec.html
@@ -11713,7 +11713,7 @@
       <h1>
         InitializeHostDefinedRealm (
           _customizations_: an Abstract Closure that takes a Realm Record and returns a List of 2 elements, each of which is either an Object or *undefined*,
-        ): ~unused~
+        ): an execution context
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -11760,8 +11760,7 @@
         1. Set the Function of _newContext_ to *null*.
         1. Set the Realm of _newContext_ to _realm_.
         1. Set the ScriptOrModule of _newContext_ to *null*.
-        1. Push _newContext_ onto the execution context stack; _newContext_ is now the running execution context.
-        1. Return ~unused~.
+        1. Return _newContext_.
       </emu-alg>
     </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -11713,7 +11713,7 @@
       <h1>
         InitializeHostDefinedRealm (
           _customizations_: an Abstract Closure that takes a Realm Record and returns a List of 2 elements, each of which is either an Object or *undefined*,
-        ): either a normal completion containing ~unused~ or a throw completion
+        ): ~unused~
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -11726,6 +11726,7 @@
                 <li>the object that is to serve as the Realm's global object, created in a host-defined manner, or</li>
                 <li>*undefined*, indicating that an ordinary object should be created as the global object.</li>
               </ul>
+              <p>If the former, then the supplied object must satisfy SetDefaultGlobalBindings' constraint.</p>
             </li>
             <li>
               <p>The second element is either:</p>
@@ -11758,7 +11759,7 @@
           1. Assert: _thisValue_ is an Object.
         1. Set _realm_.[[GlobalObject]] to _global_.
         1. Set _realm_.[[GlobalEnv]] to NewGlobalEnvironment(_global_, _thisValue_).
-        1. Perform ? SetDefaultGlobalBindings(_realm_).
+        1. Perform SetDefaultGlobalBindings(_realm_).
         1. Create any host-defined global object properties on _global_.
         1. Return ~unused~.
       </emu-alg>
@@ -11784,16 +11785,18 @@
       <h1>
         SetDefaultGlobalBindings (
           _realmRecord_: a Realm Record,
-        ): either a normal completion containing ~unused~ or a throw completion
+        ): ~unused~
       </h1>
       <dl class="header">
+        <dt>description</dt>
+        <dd>_realmRecord_.[[GlobalObject]] must be an object such that all of this operation's invocations of DefinePropertyOrThrow return a normal completion.</dd>
       </dl>
       <emu-alg>
         1. Let _global_ be _realmRecord_.[[GlobalObject]].
         1. For each property of the Global Object specified in clause <emu-xref href="#sec-global-object"></emu-xref>, do
           1. Let _name_ be the String value of the property name.
           1. Let _propertyDesc_ be the fully populated data Property Descriptor for the property, containing the specified attributes for the property. For properties listed in <emu-xref href="#sec-function-properties-of-the-global-object"></emu-xref>, <emu-xref href="#sec-constructor-properties-of-the-global-object"></emu-xref>, or <emu-xref href="#sec-other-properties-of-the-global-object"></emu-xref> the value of the [[Value]] attribute is the corresponding intrinsic object from _realmRecord_.
-          1. Perform ? DefinePropertyOrThrow(_global_, _name_, _propertyDesc_).
+          1. Perform ! DefinePropertyOrThrow(_global_, _name_, _propertyDesc_).
         1. Return ~unused~.
       </emu-alg>
     </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -11712,7 +11712,7 @@
     <emu-clause id="sec-makerealm" type="abstract operation" oldids="sec-initializehostdefinedrealm,sec-createrealm,sec-setrealmglobalobject">
       <h1>
         MakeRealm (
-          _customizations_: an Abstract Closure that takes an execution context and returns a List of 2 elements, each of which is either an Object or *undefined*,
+          _customizations_: an Abstract Closure that takes an execution context and returns a List of 2 elements, each of which is either an Object or *null*,
         ): an execution context
       </h1>
       <dl class="header">
@@ -11724,7 +11724,7 @@
               <p>The first element is either:</p>
               <ul>
                 <li>the object that is to serve as the Realm's global object, created in a host-defined manner, or</li>
-                <li>*undefined*, indicating that an ordinary object should be created as the global object.</li>
+                <li>*null*, indicating that an ordinary object should be created as the global object.</li>
               </ul>
               <p>If the former, then the supplied object must satisfy SetDefaultGlobalBindings' constraint.</p>
             </li>
@@ -11732,7 +11732,7 @@
               <p>The second element is either:</p>
               <ul>
                 <li>the object that is to serve as the `this` binding in the Realm's global scope, created in a host-defined manner, or</li>
-                <li>*undefined*, indicating that the global object should be used.</li>
+                <li>*null*, indicating that the global object should be used.</li>
               </ul>
             </li>
           </ul>
@@ -11748,11 +11748,11 @@
         1. Set the Realm of _newContext_ to _realm_.
         1. Set the ScriptOrModule of _newContext_ to *null*.
         1. Let _global_ and _thisValue_ be the elements of _customizations_(_newContext_).
-        1. If _global_ is *undefined*, then
+        1. If _global_ is *null*, then
           1. Set _global_ to OrdinaryObjectCreate(_realm_.[[Intrinsics]].[[%Object.prototype%]]).
         1. Else,
           1. Assert: _global_ is an Object.
-        1. If _thisValue_ is *undefined*, then
+        1. If _thisValue_ is *null*, then
           1. Set _thisValue_ to _global_.
         1. Else,
           1. Assert: _thisValue_ is an Object.

--- a/spec.html
+++ b/spec.html
@@ -11712,7 +11712,7 @@
     <emu-clause id="sec-makerealm" type="abstract operation" oldids="sec-initializehostdefinedrealm,sec-createrealm,sec-setrealmglobalobject">
       <h1>
         MakeRealm (
-          _customizations_: an Abstract Closure that takes a Realm Record and returns a List of 2 elements, each of which is either an Object or *undefined*,
+          _customizations_: an Abstract Closure that takes an execution context and returns a List of 2 elements, each of which is either an Object or *undefined*,
         ): an execution context
       </h1>
       <dl class="header">
@@ -11743,7 +11743,11 @@
         1. Perform CreateIntrinsics(_realm_).
         1. Set _realm_.[[AgentSignifier]] to AgentSignifier().
         1. Set _realm_.[[TemplateMap]] to a new empty List.
-        1. Let _global_ and _thisValue_ be the elements of _customizations_(_realm_).
+        1. Let _newContext_ be a new execution context.
+        1. Set the Function of _newContext_ to *null*.
+        1. Set the Realm of _newContext_ to _realm_.
+        1. Set the ScriptOrModule of _newContext_ to *null*.
+        1. Let _global_ and _thisValue_ be the elements of _customizations_(_newContext_).
         1. If _global_ is *undefined*, then
           1. Set _global_ to OrdinaryObjectCreate(_realm_.[[Intrinsics]].[[%Object.prototype%]]).
         1. Else,
@@ -11756,10 +11760,6 @@
         1. Set _realm_.[[GlobalEnv]] to NewGlobalEnvironment(_global_, _thisValue_).
         1. Perform SetDefaultGlobalBindings(_realm_).
         1. Create any host-defined global object properties on _global_.
-        1. Let _newContext_ be a new execution context.
-        1. Set the Function of _newContext_ to *null*.
-        1. Set the Realm of _newContext_ to _realm_.
-        1. Set the ScriptOrModule of _newContext_ to *null*.
         1. Return _newContext_.
       </emu-alg>
     </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -11759,7 +11759,6 @@
         1. Set _realm_.[[GlobalObject]] to _global_.
         1. Set _realm_.[[GlobalEnv]] to NewGlobalEnvironment(_global_, _thisValue_).
         1. Perform SetDefaultGlobalBindings(_realm_).
-        1. Create any host-defined global object properties on _global_.
         1. Return _newContext_.
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
> ### Normative change to ask consensus for at the July 2026 meeting
>
> Before this patch, ECMA-262 would allow hosts to provide a custom global object for which defining the ECMA-262-provided built-ins would thrown an error (for example, a global object that would prevent ECMA-262 from defining the `globalThis.Array` property).
>
> This patch restricts what hosts can do, requiring that the newly created global objects allows defining all those properties that ECMA-262 needs to define on it.
>
> In practice, this means that hosts will not be able to expose the global object to user code until when it's fully initialized, unless they exotically prevent tampering (e.g. they prevent users from doing `Object.defineProperty(globalThis, "Array", { configurable: false, writable: false })` until after the built-in `globalThis.Array` is defined).
>
> This change does not impact the web.
>
> Summary by @nicolo-ribaudo

---

This PR comprises a bunch of changes to InitializeHostDefinedRealm (IHDR).  They're mostly independent, but I'm putting them into one PR to reduce churn for IHDR's callers (i.e., HTML and the ShadowRealm proposal, AFAIK).

@annevk: If/when the time comes, I can create a PR to update the HTML spec accordingly.

----

commit 1: Add _customizations_ parameter

Currently, IHDR has no parameters.  However, steps 10 and 12 say "If the host requires ..." so there's implicitly a need for the host to communicate what it requires.  In the HTML spec, the algorithm to 'create a new realm' has that spec's only call to IHDR, and says to perform it with "customizations for creating the global object and the global **this** binding".

This commit makes explicit the communication of these customizations to IHDR.  Specifically, it adds a _customizations_ parameter to IHDR.  The caller passes it an abstract closure that receives the realm record being initialized, and returns two objects to serve as the global object and the global `this` binding. (Or it can return *undefined* in either spot, to take the default.)

For example, where the HTML spec might currently say (very roughly):
```
1. Perform IHDR given the following customizations:
   - For the global object, create a new Window object.
   - For the global this binding, using _browsingContext_'s WindowProxy object.
```
it would instead say:
```
1. Let _customizations_ be the following steps, given a Realm Record _realm_:
   1. Let _global_ be a new Window object.
   1. Let _globalThisBinding_ be _browsingContext_'s WindowProxy object.
   1. Return « _global_, _globalThisBinding_ ».
1. Perform IHDR given _customizations_.
```
(The abstract closure doesnt appear to make use of the _realm_ passed to it, but the new Window object is presumably somehow created in _realm_.)

(This commit is basically the same as what I described here: https://github.com/tc39/ecma262/pull/3274#issuecomment-2495512097)

----

commit 2: Layering: Make IHDR non-throwing

Currently, IHDR is declared to return either a normal completion containing `~unused~` or a throw completion. 

The only way that IHDR can throw is if
- its call to SetDefaultGlobalBindings throws, i.e.
- one of SetDefaultGlobalBindings' calls to DefinePropertyOrThrow throws, i.e.
- the new realm's global object's [[DefineOwnProperty]] internal method throws or returns false.

I think this can't happen if the global object is the IHDR-default, so it can only happen if the host provides the global object.

So, looking at IHDR's callers:

(1)
The proposed ShadowRealm function invokes IHDR with no customizations, so the global object is the IHDR-default, so this invocation IHDR can't throw. (So even without this commit, ShadowRealm should invoke IHDR with the '!' prefix instead of '?'.)

(2)
The HTML spec invokes IHDR with customizations, so IHDR could (theoretically) throw depending on what HTML supplies as the global object. Looking at the things it does supply, I haven't been able to prove to myself that they cannot possibly cause IHDR to throw, but it's clear that the HTML spec ignores the possibility that IHDR might throw, which suggests that no-one expects it to throw.

In any event, it seems like it would be self-sabotage for a host to supply a global object that could cause IHDR to throw.

So it seems reasonable for IHDR to become non-throwing, requiring that if the host provides the global object, it must be such that no abrupt completions occur.

It seemed cleanest to me to also make SetDefaultGlobalBindings non-throwing.

(@michaelficarra suggested this idea in https://github.com/tc39/ecma262/pull/3497#discussion_r1852610577)

----

commit 3: Editorial: Create the realm execution context slightly later

Currently, IHDR creates+initializes the realm execution context in the middle of initializing the realm. Instead, do all the realm stuff, then do all the execution context stuff, just as a separation of concerns.

This is the same idea as in PR #3497, but here the context stuff can be right at the end of IHDR, because SetDefaultGlobalBindings is now non-throwing (assuming the previous commit).

[This change is reverted by a later fixup commit.]

----

commit 4: Layering: Return the realm EC from IHDR

Currently, IHDR creates an execution context (EC) for the new realm and pushes it onto the EC stack. Then IHDR's caller does (roughly):
```
1. Perform IHDR...
1. Let /realm execution context/ be the running execution context.
1. Remove /realm execution context/ from the execution context stack.
```
It's unnecessary to involve the EC stack (and the concept of the running EC). Just have IHDR return the realm EC. So then IHDR's caller would do:
```
1. Let /realm execution context/ be IHDR...
```

This is the same idea as PR #3274, but somewhat simpler given the above commits.

(It was the closure of that PR that prompted me to create this PR.)

----

commit 5: Layering: Rename IHDR as MakeRealm

To me, the name "InitializeHostDefinedRealm" suggests "the host has defined a realm, now this operation must initialize it", which is not very accurate.

Instead, "MakeRealm" seems appropriate.

The name CreateRealm would also work, except there used to be (before PR #3139 was merged) a CreateRealm operation that covered what's now the first 4 steps of IHDR, so that could possibly cause confusion (for very few people).

Renaming IHDR isn't necessary, of course, but given the changes of the preceding commits, it's a minor additional tweak.
