### PR TITLE
Editorial: use a fresh alias for `_F_.[[Index]]`

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -49292,8 +49292,8 @@ THH:mm:ss.sss
                 1. Let _F_ be the active function object.
                 1. If _F_.[[AlreadyCalled]] is *true*, return *undefined*.
                 1. Set _F_.[[AlreadyCalled]] to *true*.
-                1. Let _index_ be _F_.[[Index]].
-                1. Set _values_[_index_] to _value_.
+                1. Let _thisIndex_ be _F_.[[Index]].
+                1. Set _values_[_thisIndex_] to _value_.
                 1. Set _remainingElementsCount_.[[Value]] to _remainingElementsCount_.[[Value]] - 1.
                 1. If _remainingElementsCount_.[[Value]] = 0, then
                   1. Let _valuesArray_ be CreateArrayFromList(_values_).
@@ -49363,7 +49363,8 @@ THH:mm:ss.sss
                 1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%).
                 1. Perform ! CreateDataPropertyOrThrow(_obj_, *"status"*, *"fulfilled"*).
                 1. Perform ! CreateDataPropertyOrThrow(_obj_, *"value"*, _value_).
-                1. Set _values_[_F_.[[Index]]] to _obj_.
+                1. Let _thisIndex_ be _F_.[[Index]].
+                1. Set _values_[_thisIndex_] to _obj_.
                 1. Set _remainingElementsCount_.[[Value]] to _remainingElementsCount_.[[Value]] - 1.
                 1. If _remainingElementsCount_.[[Value]] = 0, then
                   1. Let _valuesArray_ be CreateArrayFromList(_values_).
@@ -49379,7 +49380,8 @@ THH:mm:ss.sss
                 1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%).
                 1. Perform ! CreateDataPropertyOrThrow(_obj_, *"status"*, *"rejected"*).
                 1. Perform ! CreateDataPropertyOrThrow(_obj_, *"reason"*, _error_).
-                1. Set _values_[_F_.[[Index]]] to _obj_.
+                1. Let _thisIndex_ be _F_.[[Index]].
+                1. Set _values_[_thisIndex_] to _obj_.
                 1. Set _remainingElementsCount_.[[Value]] to _remainingElementsCount_.[[Value]] - 1.
                 1. If _remainingElementsCount_.[[Value]] = 0, then
                   1. Let _valuesArray_ be CreateArrayFromList(_values_).
@@ -49446,7 +49448,8 @@ THH:mm:ss.sss
                 1. Let _F_ be the active function object.
                 1. If _F_.[[AlreadyCalled]] is *true*, return *undefined*.
                 1. Set _F_.[[AlreadyCalled]] to *true*.
-                1. Set _errors_[_F_.[[Index]]] to _error_.
+                1. Let _thisIndex_ be _F_.[[Index]].
+                1. Set _errors_[_thisIndex_] to _error_.
                 1. Set _remainingElementsCount_.[[Value]] to _remainingElementsCount_.[[Value]] - 1.
                 1. If _remainingElementsCount_.[[Value]] = 0, then
                   1. Let _aggregateError_ be a newly created *AggregateError* object.


### PR DESCRIPTION
@jmdyck pointed out that we were accidentally "shadowing" the outer `index` alias here.