### PR TITLE
Editorial: Unify 'else' and 'otherwise'

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -2018,28 +2018,32 @@
             1. If _exponent_ is either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, return *1*<sub>𝔽</sub>.
             1. If _base_ is *NaN*, return *NaN*.
             1. If _base_ is *+∞*<sub>𝔽</sub>, then
-              1. If _exponent_ > *+0*<sub>𝔽</sub>, return *+∞*<sub>𝔽</sub>; otherwise return *+0*<sub>𝔽</sub>.
+              1. If _exponent_ > *+0*<sub>𝔽</sub>, return *+∞*<sub>𝔽</sub>.
+              1. Return *+0*<sub>𝔽</sub>.
             1. If _base_ is *-∞*<sub>𝔽</sub>, then
               1. If _exponent_ > *+0*<sub>𝔽</sub>, then
-                1. If _exponent_ is an odd integral Number, return *-∞*<sub>𝔽</sub>; otherwise return *+∞*<sub>𝔽</sub>.
-              1. Else,
-                1. If _exponent_ is an odd integral Number, return *-0*<sub>𝔽</sub>; otherwise return *+0*<sub>𝔽</sub>.
+                1. If _exponent_ is an odd integral Number, return *-∞*<sub>𝔽</sub>.
+                1. Return *+∞*<sub>𝔽</sub>.
+              1. If _exponent_ is an odd integral Number, return *-0*<sub>𝔽</sub>.
+              1. Return *+0*<sub>𝔽</sub>.
             1. If _base_ is *+0*<sub>𝔽</sub>, then
-              1. If _exponent_ > *+0*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>; otherwise return *+∞*<sub>𝔽</sub>.
+              1. If _exponent_ > *+0*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
+              1. Return *+∞*<sub>𝔽</sub>.
             1. If _base_ is *-0*<sub>𝔽</sub>, then
               1. If _exponent_ > *+0*<sub>𝔽</sub>, then
-                1. If _exponent_ is an odd integral Number, return *-0*<sub>𝔽</sub>; otherwise return *+0*<sub>𝔽</sub>.
-              1. Else,
-                1. If _exponent_ is an odd integral Number, return *-∞*<sub>𝔽</sub>; otherwise return *+∞*<sub>𝔽</sub>.
+                1. If _exponent_ is an odd integral Number, return *-0*<sub>𝔽</sub>.
+                1. Return *+0*<sub>𝔽</sub>.
+              1. If _exponent_ is an odd integral Number, return *-∞*<sub>𝔽</sub>.
+              1. Return *+∞*<sub>𝔽</sub>.
             1. Assert: _base_ is finite and is neither *+0*<sub>𝔽</sub> nor *-0*<sub>𝔽</sub>.
             1. If _exponent_ is *+∞*<sub>𝔽</sub>, then
               1. If abs(ℝ(_base_)) > 1, return *+∞*<sub>𝔽</sub>.
               1. If abs(ℝ(_base_)) = 1, return *NaN*.
-              1. If abs(ℝ(_base_)) &lt; 1, return *+0*<sub>𝔽</sub>.
+              1. Return *+0*<sub>𝔽</sub>.
             1. If _exponent_ is *-∞*<sub>𝔽</sub>, then
               1. If abs(ℝ(_base_)) > 1, return *+0*<sub>𝔽</sub>.
               1. If abs(ℝ(_base_)) = 1, return *NaN*.
-              1. If abs(ℝ(_base_)) &lt; 1, return *+∞*<sub>𝔽</sub>.
+              1. Return *+∞*<sub>𝔽</sub>.
             1. Assert: _exponent_ is finite and is neither *+0*<sub>𝔽</sub> nor *-0*<sub>𝔽</sub>.
             1. If _base_ &lt; *-0*<sub>𝔽</sub> and _exponent_ is not an integral Number, return *NaN*.
             1. Return an implementation-approximated Number value representing the result of raising ℝ(_base_) to the ℝ(_exponent_) power.
@@ -2072,10 +2076,10 @@
               1. Return -_y_.
             1. If _x_ is *-0*<sub>𝔽</sub>, then
               1. If _y_ is *-0*<sub>𝔽</sub> or _y_ &lt; *-0*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
-              1. Else, return *-0*<sub>𝔽</sub>.
+              1. Return *-0*<sub>𝔽</sub>.
             1. If _y_ is *-0*<sub>𝔽</sub>, then
               1. If _x_ &lt; *-0*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
-              1. Else, return *-0*<sub>𝔽</sub>.
+              1. Return *-0*<sub>𝔽</sub>.
             1. Return 𝔽(ℝ(_x_) × ℝ(_y_)).
           </emu-alg>
           <emu-note>
@@ -2101,17 +2105,21 @@
               1. If _y_ is *+0*<sub>𝔽</sub> or _y_ > *+0*<sub>𝔽</sub>, return _x_.
               1. Return -_x_.
             1. If _y_ is *+∞*<sub>𝔽</sub>, then
-              1. If _x_ is *+0*<sub>𝔽</sub> or _x_ > *+0*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>; otherwise return *-0*<sub>𝔽</sub>.
+              1. If _x_ is *+0*<sub>𝔽</sub> or _x_ > *+0*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
+              1. Return *-0*<sub>𝔽</sub>.
             1. If _y_ is *-∞*<sub>𝔽</sub>, then
-              1. If _x_ is *+0*<sub>𝔽</sub> or _x_ > *+0*<sub>𝔽</sub>, return *-0*<sub>𝔽</sub>; otherwise return *+0*<sub>𝔽</sub>.
+              1. If _x_ is *+0*<sub>𝔽</sub> or _x_ > *+0*<sub>𝔽</sub>, return *-0*<sub>𝔽</sub>.
+              1. Return *+0*<sub>𝔽</sub>.
             1. If _x_ is either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, then
               1. If _y_ is either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, return *NaN*.
               1. If _y_ > *+0*<sub>𝔽</sub>, return _x_.
               1. Return -_x_.
             1. If _y_ is *+0*<sub>𝔽</sub>, then
-              1. If _x_ > *+0*<sub>𝔽</sub>, return *+∞*<sub>𝔽</sub>; otherwise return *-∞*<sub>𝔽</sub>.
+              1. If _x_ > *+0*<sub>𝔽</sub>, return *+∞*<sub>𝔽</sub>.
+              1. Return *-∞*<sub>𝔽</sub>.
             1. If _y_ is *-0*<sub>𝔽</sub>, then
-              1. If _x_ > *+0*<sub>𝔽</sub>, return *-∞*<sub>𝔽</sub>; otherwise return *+∞*<sub>𝔽</sub>.
+              1. If _x_ > *+0*<sub>𝔽</sub>, return *-∞*<sub>𝔽</sub>.
+              1. Return *+∞*<sub>𝔽</sub>.
             1. Return 𝔽(ℝ(_x_) / ℝ(_y_)).
           </emu-alg>
         </emu-clause>
@@ -2262,7 +2270,8 @@
             1. If _y_ is *-∞*<sub>𝔽</sub>, return *false*.
             1. If _x_ is *-∞*<sub>𝔽</sub>, return *true*.
             1. Assert: _x_ and _y_ are finite.
-            1. If ℝ(_x_) &lt; ℝ(_y_), return *true*; otherwise return *false*.
+            1. If ℝ(_x_) &lt; ℝ(_y_), return *true*.
+            1. Return *false*.
           </emu-alg>
         </emu-clause>
 
@@ -2411,18 +2420,17 @@
                 1. Return the string-concatenation of:
                   * the code units of the _k_ digits of the representation of _s_ using radix _radix_
                   * _n_ - _k_ occurrences of the code unit 0x0030 (DIGIT ZERO)
-              1. Else if _n_ > 0, then
+              1. If _n_ > 0, then
                 1. Return the string-concatenation of:
                   * the code units of the most significant _n_ digits of the representation of _s_ using radix _radix_
                   * the code unit 0x002E (FULL STOP)
                   * the code units of the remaining _k_ - _n_ digits of the representation of _s_ using radix _radix_
-              1. Else,
-                1. Assert: _n_ ≤ 0.
-                1. Return the string-concatenation of:
-                  * the code unit 0x0030 (DIGIT ZERO)
-                  * the code unit 0x002E (FULL STOP)
-                  * -_n_ occurrences of the code unit 0x0030 (DIGIT ZERO)
-                  * the code units of the _k_ digits of the representation of _s_ using radix _radix_
+              1. Assert: _n_ ≤ 0.
+              1. Return the string-concatenation of:
+                * the code unit 0x0030 (DIGIT ZERO)
+                * the code unit 0x002E (FULL STOP)
+                * -_n_ occurrences of the code unit 0x0030 (DIGIT ZERO)
+                * the code units of the _k_ digits of the representation of _s_ using radix _radix_
             1. NOTE: In this case, the input will be represented using scientific E notation, such as `1.2e+3`.
             1. Assert: _radix_ is 10.
             1. If _n_ &lt; 0, then
@@ -2654,7 +2662,8 @@
           <dl class="header">
           </dl>
           <emu-alg>
-            1. If ℝ(_x_) &lt; ℝ(_y_), return *true*; otherwise return *false*.
+            1. If ℝ(_x_) &lt; ℝ(_y_), return *true*.
+            1. Return *false*.
           </emu-alg>
         </emu-clause>
 
@@ -2668,7 +2677,8 @@
           <dl class="header">
           </dl>
           <emu-alg>
-            1. If ℝ(_x_) = ℝ(_y_), return *true*; otherwise return *false*.
+            1. If ℝ(_x_) = ℝ(_y_), return *true*.
+            1. Return *false*.
           </emu-alg>
         </emu-clause>
 
@@ -2683,7 +2693,7 @@
           </dl>
           <emu-alg>
             1. If _x_ = 1 and _y_ = 1, return 1.
-            1. Else, return 0.
+            1. Return 0.
           </emu-alg>
         </emu-clause>
 
@@ -2698,7 +2708,7 @@
           </dl>
           <emu-alg>
             1. If _x_ = 1 or _y_ = 1, return 1.
-            1. Else, return 0.
+            1. Return 0.
           </emu-alg>
         </emu-clause>
 
@@ -2713,8 +2723,8 @@
           </dl>
           <emu-alg>
             1. If _x_ = 1 and _y_ = 0, return 1.
-            1. Else if _x_ = 0 and _y_ = 1, return 1.
-            1. Else, return 0.
+            1. If _x_ = 0 and _y_ = 1, return 1.
+            1. Return 0.
           </emu-alg>
         </emu-clause>
 
@@ -4388,7 +4398,8 @@
         </dl>
         <emu-alg>
           1. If _V_.[[Base]] is ~unresolvable~, return *false*.
-          1. If _V_.[[Base]] is an Environment Record, return *false*; otherwise return *true*.
+          1. If _V_.[[Base]] is an Environment Record, return *false*.
+          1. Return *true*.
         </emu-alg>
       </emu-clause>
 
@@ -4401,7 +4412,8 @@
         <dl class="header">
         </dl>
         <emu-alg>
-          1. If _V_.[[Base]] is ~unresolvable~, return *true*; otherwise return *false*.
+          1. If _V_.[[Base]] is ~unresolvable~, return *true*.
+          1. Return *false*.
         </emu-alg>
       </emu-clause>
 
@@ -4414,7 +4426,8 @@
         <dl class="header">
         </dl>
         <emu-alg>
-          1. If _V_.[[ThisValue]] is not ~empty~, return *true*; otherwise return *false*.
+          1. If _V_.[[ThisValue]] is ~empty~, return *false*.
+          1. Return *true*.
         </emu-alg>
       </emu-clause>
 
@@ -4427,7 +4440,8 @@
         <dl class="header">
         </dl>
         <emu-alg>
-          1. If _V_.[[ReferencedName]] is a Private Name, return *true*; otherwise return *false*.
+          1. If _V_.[[ReferencedName]] is a Private Name, return *true*.
+          1. Return *false*.
         </emu-alg>
       </emu-clause>
 
@@ -4449,10 +4463,9 @@
             1. If _V_.[[ReferencedName]] is not a property key, then
               1. Set _V_.[[ReferencedName]] to ? ToPropertyKey(_V_.[[ReferencedName]]).
             1. Return ? <emu-meta effects="user-code">_baseObj_.[[Get]](_V_.[[ReferencedName]], GetThisValue(_V_))</emu-meta>.
-          1. Else,
-            1. Let _base_ be _V_.[[Base]].
-            1. Assert: _base_ is an Environment Record.
-            1. Return ? <emu-meta effects="user-code">_base_.GetBindingValue(_V_.[[ReferencedName]], _V_.[[Strict]])</emu-meta> (see <emu-xref href="#sec-environment-records"></emu-xref>).
+          1. Let _base_ be _V_.[[Base]].
+          1. Assert: _base_ is an Environment Record.
+          1. Return ? <emu-meta effects="user-code">_base_.GetBindingValue(_V_.[[ReferencedName]], _V_.[[Strict]])</emu-meta> (see <emu-xref href="#sec-environment-records"></emu-xref>).
         </emu-alg>
         <emu-note>
           <p>The object that may be created in step <emu-xref href="#step-getvalue-toobject"></emu-xref> is not accessible outside of the above abstract operation and the ordinary object [[Get]] internal method. An implementation might choose to avoid the actual creation of the object.</p>
@@ -4484,10 +4497,9 @@
             1. Let _succeeded_ be ? <emu-meta effects="user-code">_baseObj_.[[Set]](_V_.[[ReferencedName]], _W_, GetThisValue(_V_))</emu-meta>.
             1. If _succeeded_ is *false* and _V_.[[Strict]] is *true*, throw a *TypeError* exception.
             1. Return ~unused~.
-          1. Else,
-            1. Let _base_ be _V_.[[Base]].
-            1. Assert: _base_ is an Environment Record.
-            1. Return ? <emu-meta effects="user-code">_base_.SetMutableBinding(_V_.[[ReferencedName]], _W_, _V_.[[Strict]])</emu-meta> (see <emu-xref href="#sec-environment-records"></emu-xref>).
+          1. Let _base_ be _V_.[[Base]].
+          1. Assert: _base_ is an Environment Record.
+          1. Return ? <emu-meta effects="user-code">_base_.SetMutableBinding(_V_.[[ReferencedName]], _W_, _V_.[[Strict]])</emu-meta> (see <emu-xref href="#sec-environment-records"></emu-xref>).
         </emu-alg>
         <emu-note>
           <p>The object that may be created in step <emu-xref href="#step-putvalue-toobject"></emu-xref> is not accessible outside of the above abstract operation and the ordinary object [[Set]] internal method. An implementation might choose to avoid the actual creation of that object.</p>
@@ -4504,7 +4516,8 @@
         </dl>
         <emu-alg>
           1. Assert: IsPropertyReference(_V_) is *true*.
-          1. If IsSuperReference(_V_) is *true*, return _V_.[[ThisValue]]; otherwise return _V_.[[Base]].
+          1. If IsSuperReference(_V_) is *true*, return _V_.[[ThisValue]].
+          1. Return _V_.[[Base]].
         </emu-alg>
       </emu-clause>
 
@@ -5215,20 +5228,20 @@
             1. Else,
               1. Let _b_ be 0.
               1. Let _n_ be 0.
-            1. If |ExponentPart| is present, let _e_ be the MV of |ExponentPart|; otherwise let _e_ be 0.
+            1. If |ExponentPart| is present, let _e_ be the MV of |ExponentPart|; else let _e_ be 0.
             1. Return RoundMVResult((_a_ + (_b_ × 10<sup>-_n_</sup>)) × 10<sup>_e_</sup>).
           </emu-alg>
           <emu-grammar>StrUnsignedDecimalLiteral ::: `.` DecimalDigits ExponentPart?</emu-grammar>
           <emu-alg>
             1. Let _b_ be the MV of |DecimalDigits|.
-            1. If |ExponentPart| is present, let _e_ be the MV of |ExponentPart|; otherwise let _e_ be 0.
+            1. If |ExponentPart| is present, let _e_ be the MV of |ExponentPart|; else let _e_ be 0.
             1. Let _n_ be the number of code points in |DecimalDigits|.
             1. Return RoundMVResult(_b_ × 10<sup>_e_ - _n_</sup>).
           </emu-alg>
           <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits ExponentPart?</emu-grammar>
           <emu-alg>
             1. Let _a_ be the MV of |DecimalDigits|.
-            1. If |ExponentPart| is present, let _e_ be the MV of |ExponentPart|; otherwise let _e_ be 0.
+            1. If |ExponentPart| is present, let _e_ be the MV of |ExponentPart|; else let _e_ be 0.
             1. Return RoundMVResult(_a_ × 10<sup>_e_</sup>).
           </emu-alg>
         </emu-clause>
@@ -5291,7 +5304,8 @@
         1. If _number_ is not finite or _number_ is either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
         1. Let _int_ be truncate(ℝ(_number_)).
         1. Let _int32bit_ be _int_ modulo 2<sup>32</sup>.
-        1. If _int32bit_ ≥ 2<sup>31</sup>, return 𝔽(_int32bit_ - 2<sup>32</sup>); otherwise return 𝔽(_int32bit_).
+        1. If _int32bit_ ≥ 2<sup>31</sup>, return 𝔽(_int32bit_ - 2<sup>32</sup>).
+        1. Return 𝔽(_int32bit_).
       </emu-alg>
       <emu-note>
         <p>Given the above definition of ToInt32:</p>
@@ -5360,7 +5374,8 @@
         1. If _number_ is not finite or _number_ is either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
         1. Let _int_ be truncate(ℝ(_number_)).
         1. Let _int16bit_ be _int_ modulo 2<sup>16</sup>.
-        1. If _int16bit_ ≥ 2<sup>15</sup>, return 𝔽(_int16bit_ - 2<sup>16</sup>); otherwise return 𝔽(_int16bit_).
+        1. If _int16bit_ ≥ 2<sup>15</sup>, return 𝔽(_int16bit_ - 2<sup>16</sup>).
+        1. Return 𝔽(_int16bit_).
       </emu-alg>
     </emu-clause>
 
@@ -5409,7 +5424,8 @@
         1. If _number_ is not finite or _number_ is either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
         1. Let _int_ be truncate(ℝ(_number_)).
         1. Let _int8bit_ be _int_ modulo 2<sup>8</sup>.
-        1. If _int8bit_ ≥ 2<sup>7</sup>, return 𝔽(_int8bit_ - 2<sup>8</sup>); otherwise return 𝔽(_int8bit_).
+        1. If _int8bit_ ≥ 2<sup>7</sup>, return 𝔽(_int8bit_ - 2<sup>8</sup>).
+        1. Return 𝔽(_int8bit_).
       </emu-alg>
     </emu-clause>
 
@@ -5450,7 +5466,8 @@
         1. Let _f_ be floor(_clamped_).
         1. If _clamped_ &lt; _f_ + 0.5, return 𝔽(_f_).
         1. If _clamped_ > _f_ + 0.5, return 𝔽(_f_ + 1).
-        1. If _f_ is even, return 𝔽(_f_); otherwise return 𝔽(_f_ + 1).
+        1. If _f_ is even, return 𝔽(_f_).
+        1. Return 𝔽(_f_ + 1).
       </emu-alg>
       <emu-note>
         <p>Unlike most other ECMAScript integer conversion operations, ToUint8Clamp rounds rather than truncates non-integral values. It also uses “round half to even” tie-breaking, which differs from the “round half up” tie-breaking of <emu-xref href="#sec-math.round">`Math.round`</emu-xref>.</p>
@@ -5604,7 +5621,8 @@
       <emu-alg>
         1. Let _n_ be ? ToBigInt(_argument_).
         1. Let _int64bit_ be ℝ(_n_) modulo 2<sup>64</sup>.
-        1. If _int64bit_ ≥ 2<sup>63</sup>, return ℤ(_int64bit_ - 2<sup>64</sup>); otherwise return ℤ(_int64bit_).
+        1. If _int64bit_ ≥ 2<sup>63</sup>, return ℤ(_int64bit_ - 2<sup>64</sup>).
+        1. Return ℤ(_int64bit_).
       </emu-alg>
     </emu-clause>
 
@@ -5953,11 +5971,14 @@
         1. If _x_ is a BigInt, then
           1. Return BigInt::equal(_x_, _y_).
         1. If _x_ is a String, then
-          1. If _x_ and _y_ have the same length and the same code units in the same positions, return *true*; otherwise return *false*.
+          1. If _x_ and _y_ have the same length and the same code units in the same positions, return *true*.
+          1. Return *false*.
         1. If _x_ is a Boolean, then
-          1. If _x_ and _y_ are both *true* or both *false*, return *true*; otherwise return *false*.
+          1. If _x_ and _y_ are both *true* or both *false*, return *true*.
+          1. Return *false*.
         1. NOTE: All other ECMAScript language values are compared by identity.
-        1. If _x_ is _y_, return *true*; otherwise return *false*.
+        1. If _x_ is _y_, return *true*.
+        1. Return *false*.
       </emu-alg>
       <emu-note>
         For expository purposes, some cases are handled separately within this algorithm even if it is unnecessary to do so.
@@ -5995,30 +6016,29 @@
             1. Let _cy_ be the numeric value of the code unit at index _i_ within _py_.
             1. If _cx_ &lt; _cy_, return *true*.
             1. If _cx_ > _cy_, return *false*.
-          1. If _lx_ &lt; _ly_, return *true*; otherwise return *false*.
-        1. Else,
-          1. If _px_ is a BigInt and _py_ is a String, then
-            1. Let _ny_ be StringToBigInt(_py_).
-            1. If _ny_ is *undefined*, return *undefined*.
-            1. Return BigInt::lessThan(_px_, _ny_).
-          1. If _px_ is a String and _py_ is a BigInt, then
-            1. Let _nx_ be StringToBigInt(_px_).
-            1. If _nx_ is *undefined*, return *undefined*.
-            1. Return BigInt::lessThan(_nx_, _py_).
-          1. NOTE: Because _px_ and _py_ are primitive values, evaluation order is not important.
-          1. Let _nx_ be ? <emu-meta suppress-effects="user-code">ToNumeric(_px_)</emu-meta>.
-          1. Let _ny_ be ? <emu-meta suppress-effects="user-code">ToNumeric(_py_)</emu-meta>.
-          1. If SameType(_nx_, _ny_) is *true*, then
-            1. If _nx_ is a Number, then
-              1. Return Number::lessThan(_nx_, _ny_).
-            1. Else,
-              1. Assert: _nx_ is a BigInt.
-              1. Return BigInt::lessThan(_nx_, _ny_).
-          1. Assert: _nx_ is a BigInt and _ny_ is a Number, or _nx_ is a Number and _ny_ is a BigInt.
-          1. If _nx_ or _ny_ is *NaN*, return *undefined*.
-          1. If _nx_ is *-∞*<sub>𝔽</sub> or _ny_ is *+∞*<sub>𝔽</sub>, return *true*.
-          1. If _nx_ is *+∞*<sub>𝔽</sub> or _ny_ is *-∞*<sub>𝔽</sub>, return *false*.
-          1. If ℝ(_nx_) &lt; ℝ(_ny_), return *true*; otherwise return *false*.
+          1. If _lx_ &lt; _ly_, return *true*.
+          1. Return *false*.
+        1. If _px_ is a BigInt and _py_ is a String, then
+          1. Let _ny_ be StringToBigInt(_py_).
+          1. If _ny_ is *undefined*, return *undefined*.
+          1. Return BigInt::lessThan(_px_, _ny_).
+        1. If _px_ is a String and _py_ is a BigInt, then
+          1. Let _nx_ be StringToBigInt(_px_).
+          1. If _nx_ is *undefined*, return *undefined*.
+          1. Return BigInt::lessThan(_nx_, _py_).
+        1. NOTE: Because _px_ and _py_ are primitive values, evaluation order is not important.
+        1. Let _nx_ be ? <emu-meta suppress-effects="user-code">ToNumeric(_px_)</emu-meta>.
+        1. Let _ny_ be ? <emu-meta suppress-effects="user-code">ToNumeric(_py_)</emu-meta>.
+        1. If SameType(_nx_, _ny_) is *true*, then
+          1. If _nx_ is a Number, return Number::lessThan(_nx_, _ny_).
+          1. Assert: _nx_ is a BigInt.
+          1. Return BigInt::lessThan(_nx_, _ny_).
+        1. Assert: _nx_ is a BigInt and _ny_ is a Number, or _nx_ is a Number and _ny_ is a BigInt.
+        1. If _nx_ or _ny_ is *NaN*, return *undefined*.
+        1. If _nx_ is *-∞*<sub>𝔽</sub> or _ny_ is *+∞*<sub>𝔽</sub>, return *true*.
+        1. If _nx_ is *+∞*<sub>𝔽</sub> or _ny_ is *-∞*<sub>𝔽</sub>, return *false*.
+        1. If ℝ(_nx_) &lt; ℝ(_ny_), return *true*.
+        1. Return *false*.
       </emu-alg>
       <emu-note>
         <p>Step <emu-xref href="#step-arc-string-check"></emu-xref> differs from step <emu-xref href="#step-binary-op-string-check"></emu-xref> in the algorithm that handles the addition operator `+` (<emu-xref href="#sec-applystringornumericbinaryoperator"></emu-xref>) by using the logical-and operation instead of the logical-or operation.</p>
@@ -6060,7 +6080,8 @@
         1. If _x_ is an Object and _y_ is either a String, a Number, a BigInt, or a Symbol, return ! IsLooselyEqual(? ToPrimitive(_x_), _y_).
         1. If _x_ is a BigInt and _y_ is a Number, or if _x_ is a Number and _y_ is a BigInt, then
           1. If _x_ is not finite or _y_ is not finite, return *false*.
-          1. If ℝ(_x_) = ℝ(_y_), return *true*; otherwise return *false*.
+          1. If ℝ(_x_) = ℝ(_y_), return *true*.
+          1. Return *false*.
         1. Return *false*.
       </emu-alg>
     </emu-clause>
@@ -6763,10 +6784,9 @@
       <emu-alg>
         1. Let _entry_ be PrivateElementFind(_O_, _P_).
         1. If _entry_ is ~empty~, throw a *TypeError* exception.
+        1. If _entry_.[[Kind]] is ~method~, throw a *TypeError* exception.
         1. If _entry_.[[Kind]] is ~field~, then
           1. Set _entry_.[[Value]] to _value_.
-        1. Else if _entry_.[[Kind]] is ~method~, then
-          1. Throw a *TypeError* exception.
         1. Else,
           1. Assert: _entry_.[[Kind]] is ~accessor~.
           1. If _entry_.[[Set]] is *undefined*, throw a *TypeError* exception.
@@ -7213,7 +7233,7 @@
       <emu-alg>
         1. Assert: _value_ is a Completion Record.
         1. If _value_ is an abrupt completion, return ? IteratorClose(_iteratorRecord_, _value_).
-        1. Else, set _value_ to ! _value_.
+        1. Set _value_ to ! _value_.
       </emu-alg>
     </emu-clause>
 
@@ -7254,7 +7274,7 @@
       <emu-alg>
         1. Assert: _value_ is a Completion Record.
         1. If _value_ is an abrupt completion, return ? AsyncIteratorClose(_iteratorRecord_, _value_).
-        1. Else, set _value_ to ! _value_.
+        1. Set _value_ to ! _value_.
       </emu-alg>
     </emu-clause>
 
@@ -8756,8 +8776,8 @@
       </emu-alg>
       <emu-grammar>BreakStatement : `break` LabelIdentifier `;`</emu-grammar>
       <emu-alg>
-        1. If _labelSet_ does not contain the StringValue of |LabelIdentifier|, return *true*.
-        1. Return *false*.
+        1. If _labelSet_ contains the StringValue of |LabelIdentifier|, return *false*.
+        1. Return *true*.
       </emu-alg>
       <emu-grammar>WithStatement : `with` `(` Expression `)` Statement</emu-grammar>
       <emu-alg>
@@ -8945,8 +8965,8 @@
       </emu-alg>
       <emu-grammar>ContinueStatement : `continue` LabelIdentifier `;`</emu-grammar>
       <emu-alg>
-        1. If _iterationSet_ does not contain the StringValue of |LabelIdentifier|, return *true*.
-        1. Return *false*.
+        1. If _iterationSet_ contains the StringValue of |LabelIdentifier|, return *false*.
+        1. Return *true*.
       </emu-alg>
       <emu-grammar>WithStatement : `with` `(` Expression `)` Statement</emu-grammar>
       <emu-alg>
@@ -9421,7 +9441,8 @@
       <emu-alg>
         1. If _symbol_ is |ClassBody|, return *true*.
         1. If _symbol_ is |ClassHeritage|, then
-          1. If |ClassHeritage| is present, return *true*; otherwise return *false*.
+          1. If |ClassHeritage| is present, return *true*.
+          1. Return *false*.
         1. If |ClassHeritage| is present, then
           1. If |ClassHeritage| Contains _symbol_ is *true*, return *true*.
         1. Return the result of ComputedPropertyContains of |ClassBody| with argument _symbol_.
@@ -9689,9 +9710,8 @@
           1. If _environment_ is not *undefined*, then
             1. Perform ! _environment_.InitializeBinding(_name_, _value_).
             1. Return ~unused~.
-          1. Else,
-            1. Let _lhs_ be ? ResolveBinding(_name_).
-            1. Return ? PutValue(_lhs_, _value_).
+          1. Let _lhs_ be ? ResolveBinding(_name_).
+          1. Return ? PutValue(_lhs_, _value_).
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -10673,7 +10693,8 @@
             1. Let _bindingObject_ be _envRec_.[[BindingObject]].
             1. Let _value_ be ? HasProperty(_bindingObject_, _N_).
             1. If _value_ is *false*, then
-              1. If _S_ is *false*, return *undefined*; otherwise throw a *ReferenceError* exception.
+              1. If _S_ is *false*, return *undefined*.
+              1. Throw a *ReferenceError* exception.
             1. Return ? Get(_bindingObject_, _N_).
           </emu-alg>
         </emu-clause>
@@ -10738,7 +10759,7 @@
           </dl>
           <emu-alg>
             1. If _envRec_.[[IsWithEnvironment]] is *true*, return _envRec_.[[BindingObject]].
-            1. Otherwise, return *undefined*.
+            1. Return *undefined*.
           </emu-alg>
         </emu-clause>
       </emu-clause>
@@ -10837,7 +10858,8 @@
             <dd>a Function Environment Record _envRec_</dd>
           </dl>
           <emu-alg>
-            1. If _envRec_.[[ThisBindingStatus]] is ~lexical~, return *false*; otherwise return *true*.
+            1. If _envRec_.[[ThisBindingStatus]] is ~lexical~, return *false*.
+            1. Return *true*.
           </emu-alg>
         </emu-clause>
 
@@ -10862,7 +10884,8 @@
           </dl>
           <emu-alg>
             1. If _envRec_.[[ThisBindingStatus]] is ~lexical~, return *false*.
-            1. If _envRec_.[[FunctionObject]].[[HomeObject]] is *undefined*, return *false*; otherwise return *true*.
+            1. If _envRec_.[[FunctionObject]].[[HomeObject]] is *undefined*, return *false*.
+            1. Return *true*.
           </emu-alg>
         </emu-clause>
 
@@ -11401,9 +11424,8 @@
           1. Let _exists_ be ? <emu-meta effects="user-code">_env_.HasBinding(_name_)</emu-meta>.
           1. If _exists_ is *true*, then
             1. Return the Reference Record { [[Base]]: _env_, [[ReferencedName]]: _name_, [[Strict]]: _strict_, [[ThisValue]]: ~empty~ }.
-          1. Else,
-            1. Let _outer_ be _env_.[[OuterEnv]].
-            1. Return ? GetIdentifierReference(_outer_, _name_, _strict_).
+          1. Let _outer_ be _env_.[[OuterEnv]].
+          1. Return ? GetIdentifierReference(_outer_, _name_, _strict_).
         </emu-alg>
       </emu-clause>
 
@@ -11880,7 +11902,8 @@
       <emu-alg>
         1. If the execution context stack is empty, return *null*.
         1. Let _ec_ be the topmost execution context on the execution context stack whose ScriptOrModule component is not *null*.
-        1. If no such execution context exists, return *null*; otherwise return _ec_'s ScriptOrModule.
+        1. If no such execution context exists, return *null*.
+        1. Return _ec_'s ScriptOrModule.
       </emu-alg>
     </emu-clause>
 
@@ -12942,22 +12965,19 @@
         <emu-alg>
           1. If _ownDesc_ is *undefined*, then
             1. Let _parent_ be ? <emu-meta effects="user-code">_O_.[[GetPrototypeOf]]()</emu-meta>.
-            1. If _parent_ is not *null*, then
-              1. Return ? <emu-meta effects="user-code">_parent_.[[Set]](_P_, _V_, _Receiver_)</emu-meta>.
-            1. Else,
-              1. Set _ownDesc_ to the PropertyDescriptor { [[Value]]: *undefined*, [[Writable]]: *true*, [[Enumerable]]: *true*, [[Configurable]]: *true* }.
+            1. If _parent_ is not *null*, return ? <emu-meta effects="user-code">_parent_.[[Set]](_P_, _V_, _Receiver_)</emu-meta>.
+            1. Set _ownDesc_ to the PropertyDescriptor { [[Value]]: *undefined*, [[Writable]]: *true*, [[Enumerable]]: *true*, [[Configurable]]: *true* }.
           1. If IsDataDescriptor(_ownDesc_) is *true*, then
             1. If _ownDesc_.[[Writable]] is *false*, return *false*.
             1. If _Receiver_ is not an Object, return *false*.
             1. Let _existingDescriptor_ be ? <emu-meta effects="user-code">_Receiver_.[[GetOwnProperty]](_P_)</emu-meta>.
-            1. If _existingDescriptor_ is not *undefined*, then
-              1. If IsAccessorDescriptor(_existingDescriptor_) is *true*, return *false*.
-              1. If _existingDescriptor_.[[Writable]] is *false*, return *false*.
-              1. Let _valueDesc_ be the PropertyDescriptor { [[Value]]: _V_ }.
-              1. Return ? <emu-meta effects="user-code">_Receiver_.[[DefineOwnProperty]](_P_, _valueDesc_)</emu-meta>.
-            1. Else,
+            1. If _existingDescriptor_ is *undefined*, then
               1. Assert: _Receiver_ does not currently have a property _P_.
               1. Return ? CreateDataProperty(_Receiver_, _P_, _V_).
+            1. If IsAccessorDescriptor(_existingDescriptor_) is *true*, return *false*.
+            1. If _existingDescriptor_.[[Writable]] is *false*, return *false*.
+            1. Let _valueDesc_ be the PropertyDescriptor { [[Value]]: _V_ }.
+            1. Return ? <emu-meta effects="user-code">_Receiver_.[[DefineOwnProperty]](_P_, _valueDesc_)</emu-meta>.
           1. Assert: IsAccessorDescriptor(_ownDesc_) is *true*.
           1. Let _setter_ be _ownDesc_.[[Set]].
           1. If _setter_ is *undefined*, return *false*.
@@ -13667,13 +13687,11 @@
       </dl>
       <emu-alg>
         1. Assert: _homeObject_ is an ordinary, extensible object.
-        1. If _key_ is a Private Name, then
-          1. Return PrivateElement { [[Key]]: _key_, [[Kind]]: ~method~, [[Value]]: _closure_ }.
-        1. Else,
-          1. Let _desc_ be the PropertyDescriptor { [[Value]]: _closure_, [[Writable]]: *true*, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
-          1. Perform ? DefinePropertyOrThrow(_homeObject_, _key_, _desc_).
-          1. NOTE: DefinePropertyOrThrow only returns an abrupt completion when attempting to define a class static method whose _key_ is *"prototype"*.
-          1. Return ~unused~.
+        1. If _key_ is a Private Name, return PrivateElement { [[Key]]: _key_, [[Kind]]: ~method~, [[Value]]: _closure_ }.
+        1. Let _desc_ be the PropertyDescriptor { [[Value]]: _closure_, [[Writable]]: *true*, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
+        1. Perform ? DefinePropertyOrThrow(_homeObject_, _key_, _desc_).
+        1. NOTE: DefinePropertyOrThrow only returns an abrupt completion when attempting to define a class static method whose _key_ is *"prototype"*.
+        1. Return ~unused~.
       </emu-alg>
     </emu-clause>
 
@@ -13748,7 +13766,7 @@
         1. Let _strict_ be _func_.[[Strict]].
         1. Let _formals_ be _func_.[[FormalParameters]].
         1. Let _parameterNames_ be the BoundNames of _formals_.
-        1. If _parameterNames_ has any duplicate entries, let _hasDuplicates_ be *true*; otherwise let _hasDuplicates_ be *false*.
+        1. If _parameterNames_ has any duplicate entries, let _hasDuplicates_ be *true*; else let _hasDuplicates_ be *false*.
         1. Let _simpleParameterList_ be IsSimpleParameterList of _formals_.
         1. Let _hasParameterExpressions_ be ContainsExpression of _formals_.
         1. Let _varNames_ be the VarDeclaredNames of _code_.
@@ -13946,17 +13964,16 @@
         1. If _F_.[[Async]] is *true*, then
           1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
           1. Let _resultsClosure_ be a new Abstract Closure with no parameters that captures _F_, _thisArgument_, _argumentsList_, and _newTarget_ and performs the following steps when called:
-            1. Let _result_ be the Completion Record that is <emu-meta effects="user-code">the result of evaluating</emu-meta> _F_ in a manner that conforms to the specification of _F_. If _thisArgument_ is ~uninitialized~, the *this* value is uninitialized; otherwise _thisArgument_ provides the *this* value. _argumentsList_ provides the named parameters. _newTarget_ provides the NewTarget value.
+            1. Let _result_ be the Completion Record that is <emu-meta effects="user-code">the result of evaluating</emu-meta> _F_ in a manner that conforms to the specification of _F_. If _thisArgument_ is ~uninitialized~, the *this* value is uninitialized; else _thisArgument_ provides the *this* value. _argumentsList_ provides the named parameters. _newTarget_ provides the NewTarget value.
             1. NOTE: If _F_ is defined in this document, “the specification of _F_” is the behaviour specified for it via algorithm steps or other means.
             1. Return Completion(_result_).
           1. Perform AsyncFunctionStart(_promiseCapability_, _resultsClosure_).
           1. Remove _calleeContext_ from the execution context stack and restore _callerContext_ as the running execution context.
           1. Return _promiseCapability_.[[Promise]].
-        1. Else,
-          1. [id="step-call-builtin-function-result"] Let _result_ be the Completion Record that is <emu-meta effects="user-code">the result of evaluating</emu-meta> _F_ in a manner that conforms to the specification of _F_. If _thisArgument_ is ~uninitialized~, the *this* value is uninitialized; otherwise _thisArgument_ provides the *this* value. _argumentsList_ provides the named parameters. _newTarget_ provides the NewTarget value.
-          1. NOTE: If _F_ is defined in this document, “the specification of _F_” is the behaviour specified for it via algorithm steps or other means.
-          1. Remove _calleeContext_ from the execution context stack and restore _callerContext_ as the running execution context.
-          1. Return ? _result_.
+        1. [id="step-call-builtin-function-result"] Let _result_ be the Completion Record that is <emu-meta effects="user-code">the result of evaluating</emu-meta> _F_ in a manner that conforms to the specification of _F_. If _thisArgument_ is ~uninitialized~, the *this* value is uninitialized; else _thisArgument_ provides the *this* value. _argumentsList_ provides the named parameters. _newTarget_ provides the NewTarget value.
+        1. NOTE: If _F_ is defined in this document, “the specification of _F_” is the behaviour specified for it via algorithm steps or other means.
+        1. Remove _calleeContext_ from the execution context stack and restore _callerContext_ as the running execution context.
+        1. Return ? _result_.
       </emu-alg>
       <emu-note>
         <p>When _calleeContext_ is removed from the execution context stack it must not be destroyed if it has been suspended and retained by an accessible Generator for later resumption.</p>
@@ -14152,9 +14169,8 @@
           <dd>an Array exotic object _A_</dd>
         </dl>
         <emu-alg>
-          1. If _P_ is *"length"*, then
-            1. Return ? ArraySetLength(_A_, _Desc_).
-          1. Else if _P_ is an array index, then
+          1. If _P_ is *"length"*, return ? ArraySetLength(_A_, _Desc_).
+          1. If _P_ is an array index, then
             1. Let _lengthDesc_ be OrdinaryGetOwnProperty(_A_, *"length"*).
             1. Assert: _lengthDesc_ is not *undefined*.
             1. Assert: IsDataDescriptor(_lengthDesc_) is *true*.
@@ -14490,11 +14506,9 @@
         <emu-alg>
           1. Let _map_ be _args_.[[ParameterMap]].
           1. Let _isMapped_ be ! HasOwnProperty(_map_, _P_).
-          1. If _isMapped_ is *false*, then
-            1. Return ? OrdinaryGet(_args_, _P_, _Receiver_).
-          1. Else,
-            1. Assert: _map_ contains a formal parameter mapping for _P_.
-            1. Return ! Get(_map_, _P_).
+          1. If _isMapped_ is *false*, return ? OrdinaryGet(_args_, _P_, _Receiver_).
+          1. Assert: _map_ contains a formal parameter mapping for _P_.
+          1. Return ! Get(_map_, _P_).
         </emu-alg>
       </emu-clause>
 
@@ -14801,7 +14815,8 @@
           1. If _P_ is a String, then
             1. Let _numericIndex_ be CanonicalNumericIndexString(_P_).
             1. If _numericIndex_ is not *undefined*, then
-              1. If IsValidIntegerIndex(_O_, _numericIndex_) is *false*, return *true*; else return *false*.
+              1. If IsValidIntegerIndex(_O_, _numericIndex_) is *false*, return *true*.
+              1. Return *false*.
           1. Return ! OrdinaryDelete(_O_, _P_).
         </emu-alg>
       </emu-clause>
@@ -15056,7 +15071,7 @@
         </dl>
         <emu-alg>
           1. If _O_.[[ContentType]] is ~bigint~, let _numValue_ be ? ToBigInt(_value_).
-          1. Otherwise, let _numValue_ be ? ToNumber(_value_).
+          1. Else, let _numValue_ be ? ToNumber(_value_).
           1. If IsValidIntegerIndex(_O_, _index_) is *true*, then
             1. Let _offset_ be _O_.[[ByteOffset]].
             1. Let _elementSize_ be TypedArrayElementSize(_O_).
@@ -16267,7 +16282,7 @@
         1. If _sourceText_ is a String, set _sourceText_ to StringToCodePoints(_sourceText_).
         1. Attempt to parse _sourceText_ using _goalSymbol_ as the goal symbol, and analyse the parse result for any early error conditions. Parsing and early error detection may be interleaved in an implementation-defined manner.
         1. If the parse succeeded and no early errors were found, return the Parse Node (an instance of _goalSymbol_) at the root of the parse tree resulting from the parse.
-        1. Otherwise, return a List of one or more *SyntaxError* objects representing the parsing errors and/or early errors. If more than one parsing error or early error is present, the number and ordering of error objects in the list is implementation-defined, but at least one must be present.
+        1. Return a List of one or more *SyntaxError* objects representing the parsing errors and/or early errors. If more than one parsing error or early error is present, the number and ordering of error objects in the list is implementation-defined, but at least one must be present.
       </emu-alg>
       <emu-note>
         <p>Consider a text that has an early error at a particular point, and also a syntax error at a later point. An implementation that does a parse pass followed by an early errors pass might report the syntax error and not proceed to the early errors pass. An implementation that interleaves the two activities might report the early error and not proceed to find the syntax error. A third implementation might report both errors. All of these behaviours are conformant.</p>
@@ -16354,7 +16369,8 @@
         <dl class="header">
         </dl>
         <emu-alg>
-          1. If the source text matched by _node_ is strict mode code, return *true*; else return *false*.
+          1. If the source text matched by _node_ is strict mode code, return *true*.
+          1. Return *false*.
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -18775,7 +18791,8 @@
             1. Let _stringValue_ be CodePointsToString(_patternText_).
             1. Set _patternText_ to the sequence of code points resulting from interpreting each of the 16-bit elements of _stringValue_ as a Unicode BMP code point. UTF-16 decoding is not applied to the elements.
           1. Let _parseResult_ be ParsePattern(_patternText_, _u_, _v_).
-          1. If _parseResult_ is a Parse Node, return *true*; else return *false*.
+          1. If _parseResult_ is a Parse Node, return *true*.
+          1. Return *false*.
         </emu-alg>
       </emu-clause>
 
@@ -19380,7 +19397,7 @@
               1. Let _argList_ be ? ArgumentListEvaluation of _arguments_.
               1. If _argList_ has no elements, return *undefined*.
               1. Let _evalArg_ be the first element of _argList_.
-              1. If IsStrict(this |CallExpression|) is *true*, let _strictCaller_ be *true*; otherwise let _strictCaller_ be *false*.
+              1. If IsStrict(this |CallExpression|) is *true*, let _strictCaller_ be *true*; else let _strictCaller_ be *false*.
               1. [id="step-callexpression-evaluation-direct-eval"] Return ? PerformEval(_evalArg_, _strictCaller_, *true*).
           1. Let _thisCall_ be this |CallExpression|.
           1. Let _tailCall_ be IsInTailPosition(_thisCall_).
@@ -19842,9 +19859,8 @@
             1. Perform HostFinalizeImportMeta(_importMeta_, _module_).
             1. Set _module_.[[ImportMeta]] to _importMeta_.
             1. Return _importMeta_.
-          1. Else,
-            1. Assert: _importMeta_ is an Object.
-            1. Return _importMeta_.
+          1. Assert: _importMeta_ is an Object.
+          1. Return _importMeta_.
         </emu-alg>
 
         <emu-clause id="sec-hostgetimportmetaproperties" type="host-defined abstract operation">
@@ -20060,10 +20076,9 @@
             1. Let _deleteStatus_ be ? <emu-meta effects="user-code">_baseObj_.[[Delete]](_ref_.[[ReferencedName]])</emu-meta>.
             1. If _deleteStatus_ is *false* and _ref_.[[Strict]] is *true*, throw a *TypeError* exception.
             1. Return _deleteStatus_.
-          1. Else,
-            1. Let _base_ be _ref_.[[Base]].
-            1. Assert: _base_ is an Environment Record.
-            1. Return ? <emu-meta effects="user-code">_base_.DeleteBinding(_ref_.[[ReferencedName]])</emu-meta>.
+          1. Let _base_ be _ref_.[[Base]].
+          1. Assert: _base_ is an Environment Record.
+          1. Return ? <emu-meta effects="user-code">_base_.DeleteBinding(_ref_.[[ReferencedName]])</emu-meta>.
         </emu-alg>
         <emu-note>
           <p>When a `delete` operator occurs within strict mode code, a *SyntaxError* exception is thrown if its |UnaryExpression| is a direct reference to a variable, function argument, or function name. In addition, if a `delete` operator occurs within strict mode code and the property to be deleted has the attribute { [[Configurable]]: *false* } (or otherwise cannot be deleted), a *TypeError* exception is thrown.</p>
@@ -20146,11 +20161,9 @@
         <emu-alg>
           1. Let _expr_ be ? Evaluation of |UnaryExpression|.
           1. Let _oldValue_ be ? ToNumeric(? GetValue(_expr_)).
-          1. If _oldValue_ is a Number, then
-            1. Return Number::unaryMinus(_oldValue_).
-          1. Else,
-            1. Assert: _oldValue_ is a BigInt.
-            1. Return BigInt::unaryMinus(_oldValue_).
+          1. If _oldValue_ is a Number, return Number::unaryMinus(_oldValue_).
+          1. Assert: _oldValue_ is a BigInt.
+          1. Return BigInt::unaryMinus(_oldValue_).
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -20164,11 +20177,9 @@
         <emu-alg>
           1. Let _expr_ be ? Evaluation of |UnaryExpression|.
           1. Let _oldValue_ be ? ToNumeric(? GetValue(_expr_)).
-          1. If _oldValue_ is a Number, then
-            1. Return Number::bitwiseNOT(_oldValue_).
-          1. Else,
-            1. Assert: _oldValue_ is a BigInt.
-            1. Return BigInt::bitwiseNOT(_oldValue_).
+          1. If _oldValue_ is a Number, return Number::bitwiseNOT(_oldValue_).
+          1. Assert: _oldValue_ is a BigInt.
+          1. Return BigInt::bitwiseNOT(_oldValue_).
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -20367,7 +20378,8 @@
         1. Let _rRef_ be ? Evaluation of |ShiftExpression|.
         1. Let _rVal_ be ? GetValue(_rRef_).
         1. Let _r_ be ? IsLessThan(_lVal_, _rVal_, *true*).
-        1. If _r_ is *undefined*, return *false*; otherwise return _r_.
+        1. If _r_ is *undefined*, return *false*.
+        1. Return _r_.
       </emu-alg>
       <emu-grammar>RelationalExpression : RelationalExpression `&gt;` ShiftExpression</emu-grammar>
       <emu-alg>
@@ -20376,7 +20388,8 @@
         1. Let _rRef_ be ? Evaluation of |ShiftExpression|.
         1. Let _rVal_ be ? GetValue(_rRef_).
         1. Let _r_ be ? IsLessThan(_rVal_, _lVal_, *false*).
-        1. If _r_ is *undefined*, return *false*; otherwise return _r_.
+        1. If _r_ is *undefined*, return *false*.
+        1. Return _r_.
       </emu-alg>
       <emu-grammar>RelationalExpression : RelationalExpression `&lt;=` ShiftExpression</emu-grammar>
       <emu-alg>
@@ -20385,7 +20398,8 @@
         1. Let _rRef_ be ? Evaluation of |ShiftExpression|.
         1. Let _rVal_ be ? GetValue(_rRef_).
         1. Let _r_ be ? IsLessThan(_rVal_, _lVal_, *false*).
-        1. If _r_ is either *true* or *undefined*, return *false*; otherwise return *true*.
+        1. If _r_ is either *true* or *undefined*, return *false*.
+        1. Return *true*.
       </emu-alg>
       <emu-grammar>RelationalExpression : RelationalExpression `&gt;=` ShiftExpression</emu-grammar>
       <emu-alg>
@@ -20394,7 +20408,8 @@
         1. Let _rRef_ be ? Evaluation of |ShiftExpression|.
         1. Let _rVal_ be ? GetValue(_rRef_).
         1. Let _r_ be ? IsLessThan(_lVal_, _rVal_, *true*).
-        1. If _r_ is either *true* or *undefined*, return *false*; otherwise return *true*.
+        1. If _r_ is either *true* or *undefined*, return *false*.
+        1. Return *true*.
       </emu-alg>
       <emu-grammar>RelationalExpression : RelationalExpression `instanceof` ShiftExpression</emu-grammar>
       <emu-alg>
@@ -20422,8 +20437,8 @@
         1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
         1. Assert: _privateEnv_ is not *null*.
         1. Let _privateName_ be ResolvePrivateIdentifier(_privateEnv_, _privateIdentifier_).
-        1. If PrivateElementFind(_rVal_, _privateName_) is not ~empty~, return *true*.
-        1. Return *false*.
+        1. If PrivateElementFind(_rVal_, _privateName_) is ~empty~, return *false*.
+        1. Return *true*.
       </emu-alg>
     </emu-clause>
 
@@ -20484,7 +20499,8 @@
         1. Let _rRef_ be ? Evaluation of |RelationalExpression|.
         1. Let _rVal_ be ? GetValue(_rRef_).
         1. Let _r_ be ? IsLooselyEqual(_rVal_, _lVal_).
-        1. If _r_ is *true*, return *false*; otherwise return *true*.
+        1. If _r_ is *true*, return *false*.
+        1. Return *true*.
       </emu-alg>
       <emu-grammar>EqualityExpression : EqualityExpression `===` RelationalExpression</emu-grammar>
       <emu-alg>
@@ -20501,7 +20517,8 @@
         1. Let _rRef_ be ? Evaluation of |RelationalExpression|.
         1. Let _rVal_ be ? GetValue(_rRef_).
         1. Let _r_ be IsStrictlyEqual(_rVal_, _lVal_).
-        1. If _r_ is *true*, return *false*; otherwise return *true*.
+        1. If _r_ is *true*, return *false*.
+        1. Return *true*.
       </emu-alg>
       <emu-note>
         <p>The equality operators maintain the following invariants:</p>
@@ -20614,11 +20631,9 @@
       <emu-alg>
         1. Let _lRef_ be ? Evaluation of |CoalesceExpressionHead|.
         1. Let _lVal_ be ? GetValue(_lRef_).
-        1. If _lVal_ is either *undefined* or *null*, then
-          1. Let _rRef_ be ? Evaluation of |BitwiseORExpression|.
-          1. Return ? GetValue(_rRef_).
-        1. Else,
-          1. Return _lVal_.
+        1. If _lVal_ is neither *undefined* nor *null*, return _lVal_.
+        1. Let _rRef_ be ? Evaluation of |BitwiseORExpression|.
+        1. Return ? GetValue(_rRef_).
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -20644,9 +20659,8 @@
         1. If _lVal_ is *true*, then
           1. Let _trueRef_ be ? Evaluation of the first |AssignmentExpression|.
           1. Return ? GetValue(_trueRef_).
-        1. Else,
-          1. Let _falseRef_ be ? Evaluation of the second |AssignmentExpression|.
-          1. Return ? GetValue(_falseRef_).
+        1. Let _falseRef_ be ? Evaluation of the second |AssignmentExpression|.
+        1. Return ? GetValue(_falseRef_).
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -21824,11 +21838,9 @@
       <emu-alg>
         1. Let _exprRef_ be ? Evaluation of |Expression|.
         1. Let _exprValue_ be ToBoolean(? GetValue(_exprRef_)).
-        1. If _exprValue_ is *false*, then
-          1. Return *undefined*.
-        1. Else,
-          1. Let _stmtCompletion_ be Completion(Evaluation of |Statement|).
-          1. Return ? UpdateEmpty(_stmtCompletion_, *undefined*).
+        1. If _exprValue_ is *false*, return *undefined*.
+        1. Let _stmtCompletion_ be Completion(Evaluation of |Statement|).
+        1. Return ? UpdateEmpty(_stmtCompletion_, *undefined*).
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -22028,15 +22040,15 @@
           1. If the first |Expression| is present, then
             1. Let _exprRef_ be ? Evaluation of the first |Expression|.
             1. Perform ? GetValue(_exprRef_).
-          1. If the second |Expression| is present, let _test_ be the second |Expression|; otherwise let _test_ be ~empty~.
-          1. If the third |Expression| is present, let _increment_ be the third |Expression|; otherwise let _increment_ be ~empty~.
+          1. If the second |Expression| is present, let _test_ be the second |Expression|; else let _test_ be ~empty~.
+          1. If the third |Expression| is present, let _increment_ be the third |Expression|; else let _increment_ be ~empty~.
           1. Return ? ForBodyEvaluation(_test_, _increment_, |Statement|, « », _labelSet_).
         </emu-alg>
         <emu-grammar>ForStatement : `for` `(` `var` VariableDeclarationList `;` Expression? `;` Expression? `)` Statement</emu-grammar>
         <emu-alg>
           1. Perform ? Evaluation of |VariableDeclarationList|.
-          1. If the first |Expression| is present, let _test_ be the first |Expression|; otherwise let _test_ be ~empty~.
-          1. If the second |Expression| is present, let _increment_ be the second |Expression|; otherwise let _increment_ be ~empty~.
+          1. If the first |Expression| is present, let _test_ be the first |Expression|; else let _test_ be ~empty~.
+          1. If the second |Expression| is present, let _increment_ be the second |Expression|; else let _increment_ be ~empty~.
           1. Return ? ForBodyEvaluation(_test_, _increment_, |Statement|, « », _labelSet_).
         </emu-alg>
         <emu-grammar>ForStatement : `for` `(` LexicalDeclaration Expression? `;` Expression? `)` Statement</emu-grammar>
@@ -22055,9 +22067,9 @@
           1. If _forDcl_ is an abrupt completion, then
             1. Set the running execution context's LexicalEnvironment to _oldEnv_.
             1. Return ? _forDcl_.
-          1. If _isConst_ is *false*, let _perIterationLets_ be _boundNames_; otherwise let _perIterationLets_ be a new empty List.
-          1. If the first |Expression| is present, let _test_ be the first |Expression|; otherwise let _test_ be ~empty~.
-          1. If the second |Expression| is present, let _increment_ be the second |Expression|; otherwise let _increment_ be ~empty~.
+          1. If _isConst_ is *false*, let _perIterationLets_ be _boundNames_; else let _perIterationLets_ be a new empty List.
+          1. If the first |Expression| is present, let _test_ be the first |Expression|; else let _test_ be ~empty~.
+          1. If the second |Expression| is present, let _increment_ be the second |Expression|; else let _increment_ be ~empty~.
           1. Let _bodyResult_ be Completion(ForBodyEvaluation(_test_, _increment_, |Statement|, _perIterationLets_, _labelSet_)).
           1. Set the running execution context's LexicalEnvironment to _oldEnv_.
           1. Return ? _bodyResult_.
@@ -22374,11 +22386,10 @@
             1. Let _iterator_ be EnumerateObjectProperties(_obj_).
             1. Let _nextMethod_ be ! GetV(_iterator_, *"next"*).
             1. Return the Iterator Record { [[Iterator]]: _iterator_, [[NextMethod]]: _nextMethod_, [[Done]]: *false* }.
-          1. Else,
-            1. Assert: _iterationKind_ is either ~iterate~ or ~async-iterate~.
-            1. If _iterationKind_ is ~async-iterate~, let _iteratorKind_ be ~async~.
-            1. Else, let _iteratorKind_ be ~sync~.
-            1. Return ? GetIterator(_exprValue_, _iteratorKind_).
+          1. Assert: _iterationKind_ is either ~iterate~ or ~async-iterate~.
+          1. If _iterationKind_ is ~async-iterate~, let _iteratorKind_ be ~async~.
+          1. Else, let _iteratorKind_ be ~sync~.
+          1. Return ? GetIterator(_exprValue_, _iteratorKind_).
         </emu-alg>
       </emu-clause>
 
@@ -22441,22 +22452,18 @@
                 1. Let _status_ be Completion(InitializeReferencedBinding(_lhsRef_, _nextValue_)).
             1. If _status_ is an abrupt completion, then
               1. Set the running execution context's LexicalEnvironment to _oldEnv_.
-              1. If _iterationKind_ is ~enumerate~, then
-                1. Return ? _status_.
-              1. Else,
-                1. Assert: _iterationKind_ is ~iterate~.
-                1. If _iteratorKind_ is ~async~, return ? AsyncIteratorClose(_iteratorRecord_, _status_).
-                1. Return ? IteratorClose(_iteratorRecord_, _status_).
+              1. If _iterationKind_ is ~enumerate~, return ? _status_.
+              1. Assert: _iterationKind_ is ~iterate~.
+              1. If _iteratorKind_ is ~async~, return ? AsyncIteratorClose(_iteratorRecord_, _status_).
+              1. Return ? IteratorClose(_iteratorRecord_, _status_).
             1. Let _result_ be Completion(Evaluation of _stmt_).
             1. Set the running execution context's LexicalEnvironment to _oldEnv_.
             1. If LoopContinues(_result_, _labelSet_) is *false*, then
               1. Set _status_ to Completion(UpdateEmpty(_result_, _V_)).
-              1. If _iterationKind_ is ~enumerate~, then
-                1. Return ? _status_.
-              1. Else,
-                1. Assert: _iterationKind_ is ~iterate~.
-                1. If _iteratorKind_ is ~async~, return ? AsyncIteratorClose(_iteratorRecord_, _status_).
-                1. Return ? IteratorClose(_iteratorRecord_, _status_).
+              1. If _iterationKind_ is ~enumerate~, return ? _status_.
+              1. Assert: _iterationKind_ is ~iterate~.
+              1. If _iteratorKind_ is ~async~, return ? AsyncIteratorClose(_iteratorRecord_, _status_).
+              1. Return ? IteratorClose(_iteratorRecord_, _status_).
             1. If _result_.[[Value]] is not ~empty~, set _V_ to _result_.[[Value]].
         </emu-alg>
       </emu-clause>
@@ -23222,8 +23229,7 @@
         1. If an implementation-defined debugging facility is available and enabled, then
           1. Perform an implementation-defined debugging action.
           1. Return a new implementation-defined Completion Record.
-        1. Else,
-          1. Return ~empty~.
+        1. Return ~empty~.
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -23614,7 +23620,8 @@
       </dl>
       <emu-grammar>FunctionBody : FunctionStatementList</emu-grammar>
       <emu-alg>
-        1. If the Directive Prologue of |FunctionBody| contains a Use Strict Directive, return *true*; otherwise return *false*.
+        1. If the Directive Prologue of |FunctionBody| contains a Use Strict Directive, return *true*.
+        1. Return *false*.
       </emu-alg>
     </emu-clause>
 
@@ -24008,10 +24015,9 @@
         1. Perform SetFunctionName(_closure_, _propKey_, *"get"*).
         1. If _propKey_ is a Private Name, then
           1. Return PrivateElement { [[Key]]: _propKey_, [[Kind]]: ~accessor~, [[Get]]: _closure_, [[Set]]: *undefined* }.
-        1. Else,
-          1. Let _desc_ be the PropertyDescriptor { [[Get]]: _closure_, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
-          1. Perform ? DefinePropertyOrThrow(_object_, _propKey_, _desc_).
-          1. Return ~unused~.
+        1. Let _desc_ be the PropertyDescriptor { [[Get]]: _closure_, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
+        1. Perform ? DefinePropertyOrThrow(_object_, _propKey_, _desc_).
+        1. Return ~unused~.
       </emu-alg>
       <emu-grammar>MethodDefinition : `set` ClassElementName `(` PropertySetParameterList `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
@@ -24024,10 +24030,9 @@
         1. Perform SetFunctionName(_closure_, _propKey_, *"set"*).
         1. If _propKey_ is a Private Name, then
           1. Return PrivateElement { [[Key]]: _propKey_, [[Kind]]: ~accessor~, [[Get]]: *undefined*, [[Set]]: _closure_ }.
-        1. Else,
-          1. Let _desc_ be the PropertyDescriptor { [[Set]]: _closure_, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
-          1. Perform ? DefinePropertyOrThrow(_object_, _propKey_, _desc_).
-          1. Return ~unused~.
+        1. Let _desc_ be the PropertyDescriptor { [[Set]]: _closure_, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
+        1. Perform ? DefinePropertyOrThrow(_object_, _propKey_, _desc_).
+        1. Return ~unused~.
       </emu-alg>
       <emu-grammar>GeneratorMethod : `*` ClassElementName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
@@ -26015,7 +26020,8 @@
       </dl>
       <emu-grammar>Script : ScriptBody?</emu-grammar>
       <emu-alg>
-        1. If |ScriptBody| is present and the Directive Prologue of |ScriptBody| contains a Use Strict Directive, return *true*; otherwise return *false*.
+        1. If |ScriptBody| is present and the Directive Prologue of |ScriptBody| contains a Use Strict Directive, return *true*.
+        1. Return *false*.
       </emu-alg>
     </emu-clause>
 
@@ -27232,7 +27238,7 @@
                   1. Return _index_.
                 1. If _module_.[[Status]] is either ~evaluating-async~ or ~evaluated~, then
                   1. If _module_.[[EvaluationError]] is ~empty~, return _index_.
-                  1. Otherwise, return ? _module_.[[EvaluationError]].
+                  1. Return ? _module_.[[EvaluationError]].
                 1. If _module_.[[Status]] is ~evaluating~, return _index_.
                 1. Assert: _module_.[[Status]] is ~linked~.
                 1. Set _module_.[[Status]] to ~evaluating~.
@@ -27272,7 +27278,7 @@
                     1. Assert: _requiredModule_ is a Cyclic Module Record.
                     1. Assert: _requiredModule_.[[AsyncEvaluationOrder]] is either an integer or ~unset~.
                     1. If _requiredModule_.[[AsyncEvaluationOrder]] is ~unset~, set _requiredModule_.[[Status]] to ~evaluated~.
-                    1. Otherwise, set _requiredModule_.[[Status]] to ~evaluating-async~.
+                    1. Else, set _requiredModule_.[[Status]] to ~evaluating-async~.
                     1. If _requiredModule_ and _module_ are the same Module Record, set _done_ to *true*.
                     1. Set _requiredModule_.[[CycleRoot]] to _module_.
                 1. Return _index_.
@@ -28523,10 +28529,9 @@
                   1. If _e_.[[ImportName]] is ~all~, then
                     1. Assert: _module_ does not provide the direct binding for this export.
                     1. Return ResolvedBinding Record { [[Module]]: _importedModule_, [[BindingName]]: ~namespace~ }.
-                  1. Else,
-                    1. Assert: _module_ imports a specific binding for this export.
-                    1. Assert: _e_.[[ImportName]] is a String.
-                    1. Return _importedModule_.ResolveExport(_e_.[[ImportName]], _resolveSet_).
+                  1. Assert: _module_ imports a specific binding for this export.
+                  1. Assert: _e_.[[ImportName]] is a String.
+                  1. Return _importedModule_.ResolveExport(_e_.[[ImportName]], _resolveSet_).
               1. If _exportName_ is *"default"*, then
                 1. Assert: A `default` export was not explicitly defined by this module.
                 1. Return *null*.
@@ -30011,8 +30016,8 @@
       <p>It performs the following steps when called:</p>
       <emu-alg>
         1. Let _num_ be ? ToNumber(_number_).
-        1. If _num_ is not finite, return *false*.
-        1. Otherwise, return *true*.
+        1. If _num_ is finite, return *true*.
+        1. Return *false*.
       </emu-alg>
     </emu-clause>
 
@@ -30023,7 +30028,7 @@
       <emu-alg>
         1. Let _num_ be ? ToNumber(_number_).
         1. If _num_ is *NaN*, return *true*.
-        1. Otherwise, return *false*.
+        1. Return *false*.
       </emu-alg>
       <emu-note>
         <p>A reliable way for ECMAScript code to test if a value `X` is *NaN* is an expression of the form `X !== X`. The result will be *true* if and only if `X` is *NaN*.</p>
@@ -30071,7 +30076,7 @@
           1. If the length of _S_ ≥ 2 and the first two code units of _S_ are either *"0x"* or *"0X"*, then
             1. Set _S_ to the substring of _S_ from index 2.
             1. Set _R_ to 16.
-        1. If _S_ contains a code unit that is not a radix-_R_ digit, let _end_ be the index within _S_ of the first such code unit; otherwise let _end_ be the length of _S_.
+        1. If _S_ contains a code unit that is not a radix-_R_ digit, let _end_ be the index within _S_ of the first such code unit; else let _end_ be the length of _S_.
         1. Let _Z_ be the substring of _S_ from 0 to _end_.
         1. If _Z_ is empty, return *NaN*.
         1. Let _mathInt_ be the integer value that is represented by _Z_ in radix-_R_ notation, using the letters <b>A</b> through <b>Z</b> and <b>a</b> through <b>z</b> for digits with values 10 through 35. (However, if _R_ = 10 and _Z_ contains more than 20 significant digits, every significant digit after the 20th may be replaced by a 0 digit, at the option of the implementation; and if _R_ is not one of 2, 4, 8, 10, 16, or 32, then _mathInt_ may be an implementation-approximated integer representing the integer value denoted by _Z_ in radix-_R_ notation.)
@@ -30207,7 +30212,7 @@
               1. Let _n_ be the number of leading 1 bits in _B_.
               1. If _n_ = 0, then
                 1. Let _asciiChar_ be the code unit whose numeric value is _B_.
-                1. If _preserveEscapeSet_ contains _asciiChar_, set _S_ to _escape_; otherwise set _S_ to _asciiChar_.
+                1. If _preserveEscapeSet_ contains _asciiChar_, set _S_ to _escape_; else set _S_ to _asciiChar_.
               1. Else,
                 1. If _n_ = 1 or _n_ > 4, throw a *URIError* exception.
                 1. Let _Octets_ be « _B_ ».
@@ -31448,7 +31453,8 @@
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _b_ be ? ThisBooleanValue(*this* value).
-          1. If _b_ is *true*, return *"true"*; else return *"false"*.
+          1. If _b_ is *true*, return *"true"*.
+          1. Return *"false"*.
         </emu-alg>
       </emu-clause>
 
@@ -31880,9 +31886,9 @@
           1. Let _O_ be the *this* value.
           1. If _O_ is not an Object, throw a *TypeError* exception.
           1. Let _name_ be ? Get(_O_, *"name"*).
-          1. If _name_ is *undefined*, set _name_ to *"Error"*; otherwise set _name_ to ? ToString(_name_).
+          1. If _name_ is *undefined*, set _name_ to *"Error"*; else set _name_ to ? ToString(_name_).
           1. Let _msg_ be ? Get(_O_, *"message"*).
-          1. If _msg_ is *undefined*, set _msg_ to the empty String; otherwise set _msg_ to ? ToString(_msg_).
+          1. If _msg_ is *undefined*, set _msg_ to the empty String; else set _msg_ to ? ToString(_msg_).
           1. If _name_ is the empty String, return _msg_.
           1. If _msg_ is the empty String, return _name_.
           1. Return the string-concatenation of _name_, the code unit 0x003A (COLON), the code unit 0x0020 (SPACE), and _msg_.
@@ -32138,7 +32144,7 @@
           1. If _value_ is present, then
             1. Let _prim_ be ? ToNumeric(_value_).
             1. If _prim_ is a BigInt, let _n_ be 𝔽(ℝ(_prim_)).
-            1. Otherwise, let _n_ be _prim_.
+            1. Else, let _n_ be _prim_.
           1. Else,
             1. Let _n_ be *+0*<sub>𝔽</sub>.
           1. If NewTarget is *undefined*, return _n_.
@@ -32169,7 +32175,7 @@
         <emu-alg>
           1. If _number_ is not a Number, return *false*.
           1. If _number_ is not finite, return *false*.
-          1. Otherwise, return *true*.
+          1. Return *true*.
         </emu-alg>
       </emu-clause>
 
@@ -32188,7 +32194,7 @@
         <emu-alg>
           1. If _number_ is not a Number, return *false*.
           1. If _number_ is *NaN*, return *true*.
-          1. Otherwise, return *false*.
+          1. Return *false*.
         </emu-alg>
         <emu-note>
           <p>This function differs from the global isNaN function (<emu-xref href="#sec-isnan-number"></emu-xref>) in that it does not convert its argument to a Number before determining whether it is *NaN*.</p>
@@ -32364,7 +32370,7 @@
             1. Let _m_ be ! ToString(𝔽(_x_)).
           1. Else,
             1. Let _n_ be an integer for which _n_ / 10<sup>_f_</sup> - _x_ is as close to zero as possible. If there are two such _n_, pick the larger _n_.
-            1. If _n_ = 0, let _m_ be *"0"*; otherwise let _m_ be the String value consisting of the digits of the decimal representation of _n_ (in order, with no leading zeroes).
+            1. If _n_ = 0, let _m_ be *"0"*; else let _m_ be the String value consisting of the digits of the decimal representation of _n_ (in order, with no leading zeroes).
             1. If _f_ ≠ 0, then
               1. Let _k_ be the length of _m_.
               1. If _k_ ≤ _f_, then
@@ -32505,7 +32511,7 @@
           1. If NewTarget is not *undefined*, throw a *TypeError* exception.
           1. Let _prim_ be ? ToPrimitive(_value_, ~number~).
           1. If _prim_ is a Number, return ? NumberToBigInt(_prim_).
-          1. Otherwise, return ? <emu-meta suppress-effects="user-code">ToBigInt(_prim_)</emu-meta>.
+          1. Return ? <emu-meta suppress-effects="user-code">ToBigInt(_prim_)</emu-meta>.
         </emu-alg>
 
         <emu-clause id="sec-numbertobigint" type="abstract operation">
@@ -32539,7 +32545,8 @@
           1. Set _bits_ to ? ToIndex(_bits_).
           1. Set _bigint_ to ? ToBigInt(_bigint_).
           1. Let _mod_ be ℝ(_bigint_) modulo 2<sup>_bits_</sup>.
-          1. If _mod_ ≥ 2<sup>_bits_ - 1</sup>, return ℤ(_mod_ - 2<sup>_bits_</sup>); otherwise return ℤ(_mod_).
+          1. If _mod_ ≥ 2<sup>_bits_ - 1</sup>, return ℤ(_mod_ - 2<sup>_bits_</sup>).
+          1. Return ℤ(_mod_).
         </emu-alg>
       </emu-clause>
 
@@ -33028,7 +33035,8 @@
           1. Let _a_ be ℝ(? ToUint32(_x_)).
           1. Let _b_ be ℝ(? ToUint32(_y_)).
           1. Let _product_ be (_a_ × _b_) modulo 2<sup>32</sup>.
-          1. If _product_ ≥ 2<sup>31</sup>, return 𝔽(_product_ - 2<sup>32</sup>); otherwise return 𝔽(_product_).
+          1. If _product_ ≥ 2<sup>31</sup>, return 𝔽(_product_ - 2<sup>32</sup>).
+          1. Return 𝔽(_product_).
         </emu-alg>
       </emu-clause>
 
@@ -33461,7 +33469,8 @@
           <dd>It returns *1*<sub>𝔽</sub> if _t_ is within a leap year and *+0*<sub>𝔽</sub> otherwise.</dd>
         </dl>
         <emu-alg>
-          1. If DaysInYear(YearFromTime(_t_)) is *366*<sub>𝔽</sub>, return *1*<sub>𝔽</sub>; else return *+0*<sub>𝔽</sub>.
+          1. If DaysInYear(YearFromTime(_t_)) is *366*<sub>𝔽</sub>, return *1*<sub>𝔽</sub>.
+          1. Return *+0*<sub>𝔽</sub>.
         </emu-alg>
       </emu-clause>
 
@@ -34640,9 +34649,9 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
           1. Let _t_ be _dateObject_.[[DateValue]].
           1. Let _y_ be ? ToNumber(_year_).
-          1. If _t_ is *NaN*, set _t_ to *+0*<sub>𝔽</sub>; otherwise set _t_ to LocalTime(_t_).
-          1. If _month_ is not present, let _m_ be MonthFromTime(_t_); otherwise let _m_ be ? ToNumber(_month_).
-          1. If _date_ is not present, let _dt_ be DateFromTime(_t_); otherwise let _dt_ be ? ToNumber(_date_).
+          1. If _t_ is *NaN*, set _t_ to *+0*<sub>𝔽</sub>; else set _t_ to LocalTime(_t_).
+          1. If _month_ is present, let _m_ be ? ToNumber(_month_); else let _m_ be MonthFromTime(_t_).
+          1. If _date_ is present, let _dt_ be ? ToNumber(_date_); else let _dt_ be DateFromTime(_t_).
           1. Let _newDate_ be MakeDate(MakeDay(_y_, _m_, _dt_), TimeWithinDay(_t_)).
           1. Let _u_ be TimeClip(UTC(_newDate_)).
           1. Set _dateObject_.[[DateValue]] to _u_.
@@ -34807,8 +34816,8 @@ THH:mm:ss.sss
           1. Let _t_ be _dateObject_.[[DateValue]].
           1. If _t_ is *NaN*, set _t_ to *+0*<sub>𝔽</sub>.
           1. Let _y_ be ? ToNumber(_year_).
-          1. If _month_ is not present, let _m_ be MonthFromTime(_t_); otherwise let _m_ be ? ToNumber(_month_).
-          1. If _date_ is not present, let _dt_ be DateFromTime(_t_); otherwise let _dt_ be ? ToNumber(_date_).
+          1. If _month_ is present, let _m_ be ? ToNumber(_month_); else let _m_ be MonthFromTime(_t_).
+          1. If _date_ is present, let _dt_ be ? ToNumber(_date_); else let _dt_ be DateFromTime(_t_).
           1. Let _newDate_ be MakeDate(MakeDay(_y_, _m_, _dt_), TimeWithinDay(_t_)).
           1. Let _v_ be TimeClip(_newDate_).
           1. Set _dateObject_.[[DateValue]] to _v_.
@@ -35041,7 +35050,7 @@ THH:mm:ss.sss
             1. Let _month_ be the Name of the entry in <emu-xref href="#sec-todatestring-month-names"></emu-xref> with the Number MonthFromTime(_tv_).
             1. Let _day_ be ToZeroPaddedDecimalString(ℝ(DateFromTime(_tv_)), 2).
             1. Let _yv_ be YearFromTime(_tv_).
-            1. If _yv_ is *+0*<sub>𝔽</sub> or _yv_ > *+0*<sub>𝔽</sub>, let _yearSign_ be the empty String; otherwise let _yearSign_ be *"-"*.
+            1. If _yv_ is *+0*<sub>𝔽</sub> or _yv_ > *+0*<sub>𝔽</sub>, let _yearSign_ be the empty String; else let _yearSign_ be *"-"*.
             1. Let _paddedYear_ be ToZeroPaddedDecimalString(abs(ℝ(_yv_)), 4).
             1. Return the string-concatenation of _weekday_, the code unit 0x0020 (SPACE), _month_, the code unit 0x0020 (SPACE), _day_, the code unit 0x0020 (SPACE), _yearSign_, and _paddedYear_.
           </emu-alg>
@@ -35297,7 +35306,7 @@ THH:mm:ss.sss
           1. Let _month_ be the Name of the entry in <emu-xref href="#sec-todatestring-month-names"></emu-xref> with the Number MonthFromTime(_tv_).
           1. Let _day_ be ToZeroPaddedDecimalString(ℝ(DateFromTime(_tv_)), 2).
           1. Let _yv_ be YearFromTime(_tv_).
-          1. If _yv_ is *+0*<sub>𝔽</sub> or _yv_ > *+0*<sub>𝔽</sub>, let _yearSign_ be the empty String; otherwise let _yearSign_ be *"-"*.
+          1. If _yv_ is *+0*<sub>𝔽</sub> or _yv_ > *+0*<sub>𝔽</sub>, let _yearSign_ be the empty String; else let _yearSign_ be *"-"*.
           1. Let _paddedYear_ be ToZeroPaddedDecimalString(abs(ℝ(_yv_)), 4).
           1. Return the string-concatenation of _weekday_, *","*, the code unit 0x0020 (SPACE), _day_, the code unit 0x0020 (SPACE), _month_, the code unit 0x0020 (SPACE), _yearSign_, _paddedYear_, the code unit 0x0020 (SPACE), and TimeString(_tv_).
         </emu-alg>
@@ -35673,7 +35682,7 @@ THH:mm:ss.sss
           1. Let _searchStr_ be ? ToString(_searchString_).
           1. Let _numPos_ be ? ToNumber(_position_).
           1. Assert: If _position_ is *undefined*, then _numPos_ is *NaN*.
-          1. If _numPos_ is *NaN*, let _pos_ be +∞; otherwise let _pos_ be ! ToIntegerOrInfinity(_numPos_).
+          1. If _numPos_ is *NaN*, let _pos_ be +∞; else let _pos_ be ! ToIntegerOrInfinity(_numPos_).
           1. Let _len_ be the length of _S_.
           1. Let _searchLen_ be the length of _searchStr_.
           1. If _len_ &lt; _searchLen_, return *-1*<sub>𝔽</sub>.
@@ -35855,7 +35864,7 @@ THH:mm:ss.sss
             1. Let _fillLen_ be _maxLength_ - _stringLength_.
             1. Let _truncatedStringFiller_ be the String value consisting of repeated concatenations of _fillString_ truncated to length _fillLen_.
             1. If _placement_ is ~start~, return the string-concatenation of _truncatedStringFiller_ and _S_.
-            1. Else, return the string-concatenation of _S_ and _truncatedStringFiller_.
+            1. Return the string-concatenation of _S_ and _truncatedStringFiller_.
           </emu-alg>
           <emu-note>
             <p>The argument _maxLength_ will be clamped such that it can be no smaller than the length of _S_.</p>
@@ -35971,7 +35980,7 @@ THH:mm:ss.sss
                 1. Let _refReplacement_ be the substring of _str_ from min(_tailPos_, _stringLength_).
                 1. NOTE: _tailPos_ can exceed _stringLength_ only if this abstract operation was invoked by a call to the intrinsic %Symbol.replace% method of %RegExp.prototype% on an object whose *"exec"* property is not the intrinsic %RegExp.prototype.exec%.
               1. Else if _templateRemainder_ starts with *"$"* followed by 1 or more decimal digits, then
-                1. If _templateRemainder_ starts with *"$"* followed by 2 or more decimal digits, let _digitCount_ be 2; otherwise let _digitCount_ be 1.
+                1. If _templateRemainder_ starts with *"$"* followed by 2 or more decimal digits, let _digitCount_ be 2; else let _digitCount_ be 1.
                 1. Let _digits_ be the substring of _templateRemainder_ from 1 to 1 + _digitCount_.
                 1. Let _index_ be ℝ(StringToNumber(_digits_)).
                 1. Assert: 0 ≤ _index_ ≤ 99.
@@ -37566,8 +37575,8 @@ THH:mm:ss.sss
             1. Let _d_ be a new MatcherContinuation with parameters (_y_) that captures _m_, _min_, _max_, _greedy_, _x_, _c_, _parenIndex_, and _parenCount_ and performs the following steps when called:
               1. Assert: _y_ is a MatchState.
               1. [id="step-repeatmatcher-done"] If _min_ = 0 and _y_.[[EndIndex]] = _x_.[[EndIndex]], return ~failure~.
-              1. If _min_ = 0, let _min2_ be 0; otherwise let _min2_ be _min_ - 1.
-              1. If _max_ = +∞, let _max2_ be +∞; otherwise let _max2_ be _max_ - 1.
+              1. If _min_ = 0, let _min2_ be 0; else let _min2_ be _min_ - 1.
+              1. If _max_ = +∞, let _max2_ be +∞; else let _max2_ be _max_ - 1.
               1. Return RepeatMatcher(_m_, _min2_, _max2_, _greedy_, _y_, _c_, _parenIndex_, _parenCount_).
             1. Let _cap_ be a copy of _x_.[[Captures]].
             1. [id="step-repeatmatcher-clear-captures"] For each integer _k_ in the inclusive interval from _parenIndex_ + 1 to _parenIndex_ + _parenCount_, set _cap_[_k_] to *undefined*.
@@ -37675,15 +37684,14 @@ THH:mm:ss.sss
                   1. Assert: _y_ is a MatchState.
                   1. Return _m2_(_y_, _c_).
                 1. Return _m1_(_x_, _d_).
-            1. Else,
-              1. Assert: _direction_ is ~backward~.
-              1. Return a new Matcher with parameters (_x_, _c_) that captures _m1_ and _m2_ and performs the following steps when called:
-                1. Assert: _x_ is a MatchState.
-                1. Assert: _c_ is a MatcherContinuation.
-                1. Let _d_ be a new MatcherContinuation with parameters (_y_) that captures _c_ and _m1_ and performs the following steps when called:
-                  1. Assert: _y_ is a MatchState.
-                  1. Return _m1_(_y_, _c_).
-                1. Return _m2_(_x_, _d_).
+            1. Assert: _direction_ is ~backward~.
+            1. Return a new Matcher with parameters (_x_, _c_) that captures _m1_ and _m2_ and performs the following steps when called:
+              1. Assert: _x_ is a MatchState.
+              1. Assert: _c_ is a MatcherContinuation.
+              1. Let _d_ be a new MatcherContinuation with parameters (_y_) that captures _c_ and _m1_ and performs the following steps when called:
+                1. Assert: _y_ is a MatchState.
+                1. Return _m1_(_y_, _c_).
+              1. Return _m2_(_x_, _d_).
           </emu-alg>
         </emu-clause>
       </emu-clause>
@@ -38069,7 +38077,7 @@ THH:mm:ss.sss
               1. Let _index_ be min(_e_, _f_).
               1. Let _ch_ be the character _Input_[_index_].
               1. Let _cc_ be Canonicalize(_rer_, _ch_).
-              1. If there exists a CharSetElement in _A_ containing exactly one character _a_ such that Canonicalize(_rer_, _a_) is _cc_, let _found_ be *true*; otherwise let _found_ be *false*.
+              1. If there exists a CharSetElement in _A_ containing exactly one character _a_ such that Canonicalize(_rer_, _a_) is _cc_, let _found_ be *true*; else let _found_ be *false*.
               1. If _invert_ is *false* and _found_ is *false*, return ~failure~.
               1. If _invert_ is *true* and _found_ is *true*, return ~failure~.
               1. Let _cap_ be _x_.[[Captures]].
@@ -38495,8 +38503,7 @@ THH:mm:ss.sss
           <dl class="header">
           </dl>
           <emu-alg>
-            1. If _rer_.[[Unicode]] is *true* or _rer_.[[UnicodeSets]] is *true*, then
-              1. Return *true*.
+            1. If _rer_.[[Unicode]] is *true* or _rer_.[[UnicodeSets]] is *true*, return *true*.
             1. Return *false*.
           </emu-alg>
         </emu-clause>
@@ -38532,10 +38539,9 @@ THH:mm:ss.sss
           <emu-alg>
             1. If _rer_.[[UnicodeSets]] is *true* and _rer_.[[IgnoreCase]] is *true*, then
               1. [declared="c"] Return the CharSet containing all Unicode code points _c_ that do not have a <a href="https://www.unicode.org/reports/tr44/#Simple_Case_Folding">Simple Case Folding</a> mapping (that is, scf(_c_)=_c_).
-            1. Else if HasEitherUnicodeFlag(_rer_) is *true*, then
+            1. If HasEitherUnicodeFlag(_rer_) is *true*, then
               1. Return the CharSet containing all code point values.
-            1. Else,
-              1. Return the CharSet containing all code unit values.
+            1. Return the CharSet containing all code unit values.
           </emu-alg>
         </emu-clause>
 
@@ -38853,7 +38859,7 @@ THH:mm:ss.sss
           <emu-alg>
             1. If _cp_ is matched by |SyntaxCharacter| or _cp_ is U+002F (SOLIDUS), then
               1. Return the string-concatenation of 0x005C (REVERSE SOLIDUS) and UTF16EncodeCodePoint(_cp_).
-            1. Else if _cp_ is a code point listed in the “Code Point” column of <emu-xref href="#table-controlescape-code-point-values"></emu-xref>, then
+            1. If _cp_ is a code point listed in the “Code Point” column of <emu-xref href="#table-controlescape-code-point-values"></emu-xref>, then
               1. Return the string-concatenation of 0x005C (REVERSE SOLIDUS) and the string in the “ControlEscape” column of the row whose “Code Point” column contains _cp_.
             1. Let _otherPunctuators_ be the string-concatenation of *",-=&lt;>#&amp;!%:;@~'`"* and the code unit 0x0022 (QUOTATION MARK).
             1. Let _toEscape_ be StringToCodePoints(_otherPunctuators_).
@@ -38970,7 +38976,7 @@ THH:mm:ss.sss
             1. If _R_ is not an Object, throw a *TypeError* exception.
             1. If _R_ does not have an [[OriginalFlags]] internal slot, then
               1. If SameValue(_R_, %RegExp.prototype%) is *true*, return *undefined*.
-              1. Otherwise, throw a *TypeError* exception.
+              1. Throw a *TypeError* exception.
             1. Let _flags_ be _R_.[[OriginalFlags]].
             1. If _flags_ contains _codeUnit_, return *true*.
             1. Return *false*.
@@ -39016,26 +39022,23 @@ THH:mm:ss.sss
           1. If _rx_ is not an Object, throw a *TypeError* exception.
           1. Let _S_ be ? ToString(_string_).
           1. Let _flags_ be ? ToString(? Get(_rx_, *"flags"*)).
-          1. If _flags_ does not contain *"g"*, then
-            1. Return ? RegExpExec(_rx_, _S_).
-          1. Else,
-            1. If _flags_ contains *"u"* or _flags_ contains *"v"*, let _fullUnicode_ be *true*; otherwise let _fullUnicode_ be *false*.
-            1. Perform ? Set(_rx_, *"lastIndex"*, *+0*<sub>𝔽</sub>, *true*).
-            1. Let _A_ be ! ArrayCreate(0).
-            1. Let _n_ be 0.
-            1. Repeat,
-              1. Let _result_ be ? RegExpExec(_rx_, _S_).
-              1. If _result_ is *null*, then
-                1. If _n_ = 0, return *null*.
-                1. Return _A_.
-              1. Else,
-                1. Let _matchStr_ be ? ToString(? Get(_result_, *"0"*)).
-                1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_n_)), _matchStr_).
-                1. If _matchStr_ is the empty String, then
-                  1. Let _thisIndex_ be ℝ(? ToLength(? Get(_rx_, *"lastIndex"*))).
-                  1. Let _nextIndex_ be AdvanceStringIndex(_S_, _thisIndex_, _fullUnicode_).
-                  1. Perform ? Set(_rx_, *"lastIndex"*, 𝔽(_nextIndex_), *true*).
-                1. Set _n_ to _n_ + 1.
+          1. If _flags_ does not contain *"g"*, return ? RegExpExec(_rx_, _S_).
+          1. If _flags_ contains *"u"* or _flags_ contains *"v"*, let _fullUnicode_ be *true*; else let _fullUnicode_ be *false*.
+          1. Perform ? Set(_rx_, *"lastIndex"*, *+0*<sub>𝔽</sub>, *true*).
+          1. Let _A_ be ! ArrayCreate(0).
+          1. Let _n_ be 0.
+          1. Repeat,
+            1. Let _result_ be ? RegExpExec(_rx_, _S_).
+            1. If _result_ is *null*, then
+              1. If _n_ = 0, return *null*.
+              1. Return _A_.
+            1. Let _matchStr_ be ? ToString(? Get(_result_, *"0"*)).
+            1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_n_)), _matchStr_).
+            1. If _matchStr_ is the empty String, then
+              1. Let _thisIndex_ be ℝ(? ToLength(? Get(_rx_, *"lastIndex"*))).
+              1. Let _nextIndex_ be AdvanceStringIndex(_S_, _thisIndex_, _fullUnicode_).
+              1. Perform ? Set(_rx_, *"lastIndex"*, 𝔽(_nextIndex_), *true*).
+            1. Set _n_ to _n_ + 1.
         </emu-alg>
         <p>The value of the *"name"* property of this method is *"[Symbol.match]"*.</p>
         <emu-note>
@@ -39086,7 +39089,7 @@ THH:mm:ss.sss
           1. If _functionalReplace_ is *false*, then
             1. Set _replaceValue_ to ? ToString(_replaceValue_).
           1. Let _flags_ be ? ToString(? Get(_rx_, *"flags"*)).
-          1. If _flags_ contains *"g"*, let _global_ be *true*; otherwise let _global_ be *false*.
+          1. If _flags_ contains *"g"*, let _global_ be *true*; else let _global_ be *false*.
           1. If _global_ is *true*, then
             1. Perform ? Set(_rx_, *"lastIndex"*, *+0*<sub>𝔽</sub>, *true*).
           1. Let _results_ be a new empty List.
@@ -39103,7 +39106,7 @@ THH:mm:ss.sss
                 1. Let _matchStr_ be ? ToString(? Get(_result_, *"0"*)).
                 1. If _matchStr_ is the empty String, then
                   1. Let _thisIndex_ be ℝ(? ToLength(? Get(_rx_, *"lastIndex"*))).
-                  1. If _flags_ contains *"u"* or _flags_ contains *"v"*, let _fullUnicode_ be *true*; otherwise let _fullUnicode_ be *false*.
+                  1. If _flags_ contains *"u"* or _flags_ contains *"v"*, let _fullUnicode_ be *true*; else let _fullUnicode_ be *false*.
                   1. Let _nextIndex_ be AdvanceStringIndex(_S_, _thisIndex_, _fullUnicode_).
                   1. Perform ? Set(_rx_, *"lastIndex"*, 𝔽(_nextIndex_), *true*).
           1. Let _accumulatedResult_ be the empty String.
@@ -39176,7 +39179,7 @@ THH:mm:ss.sss
           1. If _R_ is not an Object, throw a *TypeError* exception.
           1. If _R_ does not have an [[OriginalSource]] internal slot, then
             1. If SameValue(_R_, %RegExp.prototype%) is *true*, return *"(?:)"*.
-            1. Otherwise, throw a *TypeError* exception.
+            1. Throw a *TypeError* exception.
           1. Assert: _R_ has an [[OriginalFlags]] internal slot.
           1. Let _src_ be _R_.[[OriginalSource]].
           1. Let _flags_ be _R_.[[OriginalFlags]].
@@ -39300,7 +39303,8 @@ THH:mm:ss.sss
           1. If _R_ is not an Object, throw a *TypeError* exception.
           1. Let _string_ be ? ToString(_S_).
           1. Let _match_ be ? RegExpExec(_R_, _string_).
-          1. If _match_ is not *null*, return *true*; else return *false*.
+          1. If _match_ is *null*, return *false*.
+          1. Return *true*.
         </emu-alg>
       </emu-clause>
 
@@ -39386,7 +39390,7 @@ THH:mm:ss.sss
           1. Let _matcher_ be _R_.[[RegExpMatcher]].
           1. If _flags_ contains *"u"* or _flags_ contains *"v"*, let _fullUnicode_ be *true*; else let _fullUnicode_ be *false*.
           1. Let _matchSucceeded_ be *false*.
-          1. If _fullUnicode_ is *true*, let _input_ be StringToCodePoints(_S_); otherwise let _input_ be a List whose elements are the code units that are the elements of _S_.
+          1. If _fullUnicode_ is *true*, let _input_ be StringToCodePoints(_S_); else let _input_ be a List whose elements are the code units that are the elements of _S_.
           1. NOTE: Each element of _input_ is considered to be a character.
           1. Repeat, while _matchSucceeded_ is *false*,
             1. If _lastIndex_ > _length_, then
@@ -39757,9 +39761,8 @@ THH:mm:ss.sss
           1. If NewTarget is *undefined*, let _newTarget_ be the active function object; else let _newTarget_ be NewTarget.
           1. Let _proto_ be ? GetPrototypeFromConstructor(_newTarget_, *"%Array.prototype%"*).
           1. Let _numberOfArgs_ be the number of elements in _values_.
-          1. If _numberOfArgs_ = 0, then
-            1. Return ! ArrayCreate(0, _proto_).
-          1. Else if _numberOfArgs_ = 1, then
+          1. If _numberOfArgs_ = 0, return ! ArrayCreate(0, _proto_).
+          1. If _numberOfArgs_ = 1, then
             1. Let _len_ be _values_[0].
             1. Let _array_ be ! ArrayCreate(0, _proto_).
             1. If _len_ is not a Number, then
@@ -39770,17 +39773,16 @@ THH:mm:ss.sss
               1. If SameValueZero(_intLen_, _len_) is *false*, throw a *RangeError* exception.
             1. Perform ! Set(_array_, *"length"*, _intLen_, *true*).
             1. Return _array_.
-          1. Else,
-            1. Assert: _numberOfArgs_ ≥ 2.
-            1. Let _array_ be ? ArrayCreate(_numberOfArgs_, _proto_).
-            1. Let _k_ be 0.
-            1. Repeat, while _k_ &lt; _numberOfArgs_,
-              1. Let _Pk_ be ! ToString(𝔽(_k_)).
-              1. Let _itemK_ be _values_[_k_].
-              1. Perform ! CreateDataPropertyOrThrow(_array_, _Pk_, _itemK_).
-              1. Set _k_ to _k_ + 1.
-            1. Assert: The mathematical value of _array_'s *"length"* property is _numberOfArgs_.
-            1. Return _array_.
+          1. Assert: _numberOfArgs_ ≥ 2.
+          1. Let _array_ be ? ArrayCreate(_numberOfArgs_, _proto_).
+          1. Let _k_ be 0.
+          1. Repeat, while _k_ &lt; _numberOfArgs_,
+            1. Let _Pk_ be ! ToString(𝔽(_k_)).
+            1. Let _itemK_ be _values_[_k_].
+            1. Perform ! CreateDataPropertyOrThrow(_array_, _Pk_, _itemK_).
+            1. Set _k_ to _k_ + 1.
+          1. Assert: The mathematical value of _array_'s *"length"* property is _numberOfArgs_.
+          1. Return _array_.
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -40448,7 +40450,7 @@ THH:mm:ss.sss
           1. Let _n_ be ? ToIntegerOrInfinity(_fromIndex_).
           1. Assert: If _fromIndex_ is *undefined*, then _n_ is 0.
           1. If _n_ = +∞, return *false*.
-          1. Else if _n_ = -∞, set _n_ to 0.
+          1. If _n_ = -∞, set _n_ to 0.
           1. If _n_ ≥ 0, then
             1. Let _k_ be _n_.
           1. Else,
@@ -40482,7 +40484,7 @@ THH:mm:ss.sss
           1. Let _n_ be ? ToIntegerOrInfinity(_fromIndex_).
           1. Assert: If _fromIndex_ is *undefined*, then _n_ is 0.
           1. If _n_ = +∞, return *-1*<sub>𝔽</sub>.
-          1. Else if _n_ = -∞, set _n_ to 0.
+          1. If _n_ = -∞, set _n_ to 0.
           1. If _n_ ≥ 0, then
             1. Let _k_ be _n_.
           1. Else,
@@ -40610,14 +40612,13 @@ THH:mm:ss.sss
           1. If _len_ = 0, then
             1. Perform ? Set(_O_, *"length"*, *+0*<sub>𝔽</sub>, *true*).
             1. Return *undefined*.
-          1. Else,
-            1. Assert: _len_ > 0.
-            1. Let _newLen_ be 𝔽(_len_ - 1).
-            1. Let _index_ be ! ToString(_newLen_).
-            1. Let _element_ be ? Get(_O_, _index_).
-            1. Perform ? DeletePropertyOrThrow(_O_, _index_).
-            1. Perform ? Set(_O_, *"length"*, _newLen_, *true*).
-            1. Return _element_.
+          1. Assert: _len_ > 0.
+          1. Let _newLen_ be 𝔽(_len_ - 1).
+          1. Let _index_ be ! ToString(_newLen_).
+          1. Let _element_ be ? Get(_O_, _index_).
+          1. Perform ? DeletePropertyOrThrow(_O_, _index_).
+          1. Perform ? Set(_O_, *"length"*, _newLen_, *true*).
+          1. Return _element_.
         </emu-alg>
         <emu-note>
           <p>This method is intentionally generic; it does not require that its *this* value be an Array. Therefore it can be transferred to other kinds of objects for use as a method.</p>
@@ -41962,7 +41963,7 @@ THH:mm:ss.sss
           1. Let _taRecord_ be ? ValidateTypedArray(_O_, ~seq-cst~).
           1. Let _len_ be TypedArrayLength(_taRecord_).
           1. If _O_.[[ContentType]] is ~bigint~, set _value_ to ? ToBigInt(_value_).
-          1. Otherwise, set _value_ to ? ToNumber(_value_).
+          1. Else, set _value_ to ? ToNumber(_value_).
           1. Let _relativeStart_ be ? ToIntegerOrInfinity(_start_).
           1. If _relativeStart_ = -∞, let _startIndex_ be 0.
           1. Else if _relativeStart_ &lt; 0, let _startIndex_ be max(_len_ + _relativeStart_, 0).
@@ -42102,7 +42103,7 @@ THH:mm:ss.sss
           1. Let _n_ be ? ToIntegerOrInfinity(_fromIndex_).
           1. Assert: If _fromIndex_ is *undefined*, then _n_ is 0.
           1. If _n_ = +∞, return *false*.
-          1. Else if _n_ = -∞, set _n_ to 0.
+          1. If _n_ = -∞, set _n_ to 0.
           1. If _n_ ≥ 0, then
             1. Let _k_ be _n_.
           1. Else,
@@ -42129,7 +42130,7 @@ THH:mm:ss.sss
           1. Let _n_ be ? ToIntegerOrInfinity(_fromIndex_).
           1. Assert: If _fromIndex_ is *undefined*, then _n_ is 0.
           1. If _n_ = +∞, return *-1*<sub>𝔽</sub>.
-          1. Else if _n_ = -∞, set _n_ to 0.
+          1. If _n_ = -∞, set _n_ to 0.
           1. If _n_ ≥ 0, then
             1. Let _k_ be _n_.
           1. Else,
@@ -42404,7 +42405,7 @@ THH:mm:ss.sss
             1. If _targetOffset_ = +∞, throw a *RangeError* exception.
             1. If _srcLength_ + _targetOffset_ > _targetLength_, throw a *RangeError* exception.
             1. If _target_.[[ContentType]] is not _source_.[[ContentType]], throw a *TypeError* exception.
-            1. If IsSharedArrayBuffer(_srcBuffer_) is *true*, IsSharedArrayBuffer(_targetBuffer_) is *true*, and _srcBuffer_.[[ArrayBufferData]] is _targetBuffer_.[[ArrayBufferData]], let _sameSharedArrayBuffer_ be *true*; otherwise let _sameSharedArrayBuffer_ be *false*.
+            1. If IsSharedArrayBuffer(_srcBuffer_) is *true*, IsSharedArrayBuffer(_targetBuffer_) is *true*, and _srcBuffer_.[[ArrayBufferData]] is _targetBuffer_.[[ArrayBufferData]], let _sameSharedArrayBuffer_ be *true*; else let _sameSharedArrayBuffer_ be *false*.
             1. If SameValue(_srcBuffer_, _targetBuffer_) is *true* or _sameSharedArrayBuffer_ is *true*, then
               1. Let _srcByteLength_ be TypedArrayByteLength(_srcRecord_).
               1. Set _srcBuffer_ to ? CloneArrayBuffer(_srcBuffer_, _srcByteOffset_, _srcByteLength_).
@@ -42834,32 +42835,29 @@ THH:mm:ss.sss
           1. Let _constructorName_ be the String value of the Constructor Name value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for this <var>TypedArray</var> constructor.
           1. Let _proto_ be <code>"%<var>TypedArray</var>.prototype%"</code>.
           1. Let _numberOfArgs_ be the number of elements in _args_.
-          1. If _numberOfArgs_ = 0, then
-            1. Return ? AllocateTypedArray(_constructorName_, NewTarget, _proto_, 0).
-          1. Else,
-            1. Let _firstArgument_ be _args_[0].
-            1. If _firstArgument_ is an Object, then
-              1. Let _O_ be ? AllocateTypedArray(_constructorName_, NewTarget, _proto_).
-              1. If _firstArgument_ has a [[TypedArrayName]] internal slot, then
-                1. Perform ? InitializeTypedArrayFromTypedArray(_O_, _firstArgument_).
-              1. Else if _firstArgument_ has an [[ArrayBufferData]] internal slot, then
-                1. If _numberOfArgs_ > 1, let _byteOffset_ be _args_[1]; else let _byteOffset_ be *undefined*.
-                1. If _numberOfArgs_ > 2, let _length_ be _args_[2]; else let _length_ be *undefined*.
-                1. Perform ? InitializeTypedArrayFromArrayBuffer(_O_, _firstArgument_, _byteOffset_, _length_).
-              1. Else,
-                1. Assert: _firstArgument_ is an Object and _firstArgument_ does not have either a [[TypedArrayName]] or an [[ArrayBufferData]] internal slot.
-                1. Let _usingIterator_ be ? GetMethod(_firstArgument_, %Symbol.iterator%).
-                1. If _usingIterator_ is not *undefined*, then
-                  1. Let _values_ be ? IteratorToList(? GetIteratorFromMethod(_firstArgument_, _usingIterator_)).
-                  1. Perform ? InitializeTypedArrayFromList(_O_, _values_).
-                1. Else,
-                  1. NOTE: _firstArgument_ is not an iterable object, so assume it is already an array-like object.
-                  1. Perform ? InitializeTypedArrayFromArrayLike(_O_, _firstArgument_).
-              1. Return _O_.
+          1. If _numberOfArgs_ = 0, return ? AllocateTypedArray(_constructorName_, NewTarget, _proto_, 0).
+          1. Let _firstArgument_ be _args_[0].
+          1. If _firstArgument_ is an Object, then
+            1. Let _O_ be ? AllocateTypedArray(_constructorName_, NewTarget, _proto_).
+            1. If _firstArgument_ has a [[TypedArrayName]] internal slot, then
+              1. Perform ? InitializeTypedArrayFromTypedArray(_O_, _firstArgument_).
+            1. Else if _firstArgument_ has an [[ArrayBufferData]] internal slot, then
+              1. If _numberOfArgs_ > 1, let _byteOffset_ be _args_[1]; else let _byteOffset_ be *undefined*.
+              1. If _numberOfArgs_ > 2, let _length_ be _args_[2]; else let _length_ be *undefined*.
+              1. Perform ? InitializeTypedArrayFromArrayBuffer(_O_, _firstArgument_, _byteOffset_, _length_).
             1. Else,
-              1. Assert: _firstArgument_ is not an Object.
-              1. Let _elementLength_ be ? ToIndex(_firstArgument_).
-              1. Return ? AllocateTypedArray(_constructorName_, NewTarget, _proto_, _elementLength_).
+              1. Assert: _firstArgument_ is an Object and _firstArgument_ does not have either a [[TypedArrayName]] or an [[ArrayBufferData]] internal slot.
+              1. Let _usingIterator_ be ? GetMethod(_firstArgument_, %Symbol.iterator%).
+              1. If _usingIterator_ is not *undefined*, then
+                1. Let _values_ be ? IteratorToList(? GetIteratorFromMethod(_firstArgument_, _usingIterator_)).
+                1. Perform ? InitializeTypedArrayFromList(_O_, _values_).
+              1. Else,
+                1. NOTE: _firstArgument_ is not an iterable object, so assume it is already an array-like object.
+                1. Perform ? InitializeTypedArrayFromArrayLike(_O_, _firstArgument_).
+            1. Return _O_.
+          1. Assert: _firstArgument_ is not an Object.
+          1. Let _elementLength_ be ? ToIndex(_firstArgument_).
+          1. Return ? AllocateTypedArray(_constructorName_, NewTarget, _proto_, _elementLength_).
         </emu-alg>
 
         <emu-clause id="sec-allocatetypedarray" type="abstract operation">
@@ -42881,7 +42879,7 @@ THH:mm:ss.sss
             1. Assert: _obj_.[[ViewedArrayBuffer]] is *undefined*.
             1. Set _obj_.[[TypedArrayName]] to _constructorName_.
             1. If _constructorName_ is either *"BigInt64Array"* or *"BigUint64Array"*, set _obj_.[[ContentType]] to ~bigint~.
-            1. Otherwise, set _obj_.[[ContentType]] to ~number~.
+            1. Else, set _obj_.[[ContentType]] to ~number~.
             1. If _length_ is not present, then
               1. Set _obj_.[[ByteLength]] to 0.
               1. Set _obj_.[[ByteOffset]] to 0.
@@ -43335,13 +43333,10 @@ THH:mm:ss.sss
             1. Set _chunk_ to the string-concatenation of _chunk_ and *"A"*.
           1. Let _bytes_ be DecodeFullLengthBase64Chunk(_chunk_).
           1. If _chunkLength_ = 2, then
-            1. If _throwOnExtraBits_ is *true* and _bytes_[1] ≠ 0, then
-              1. Throw a *SyntaxError* exception.
+            1. If _throwOnExtraBits_ is *true* and _bytes_[1] ≠ 0, throw a *SyntaxError* exception.
             1. Return « _bytes_[0] ».
-          1. Else,
-            1. If _throwOnExtraBits_ is *true* and _bytes_[2] ≠ 0, then
-              1. Throw a *SyntaxError* exception.
-            1. Return « _bytes_[0], _bytes_[1] ».
+          1. If _throwOnExtraBits_ is *true* and _bytes_[2] ≠ 0, throw a *SyntaxError* exception.
+          1. Return « _bytes_[0], _bytes_[1] ».
         </emu-alg>
       </emu-clause>
 
@@ -43390,15 +43385,14 @@ THH:mm:ss.sss
               1. If _chunkLength_ > 0, then
                 1. If _lastChunkHandling_ is *"stop-before-partial"*, then
                   1. Return the Record { [[Read]]: _read_, [[Bytes]]: _bytes_, [[Error]]: ~none~ }.
-                1. Else if _lastChunkHandling_ is *"loose"*, then
-                  1. If _chunkLength_ = 1, then
-                    1. Let _error_ be a newly created *SyntaxError* object.
-                    1. Return the Record { [[Read]]: _read_, [[Bytes]]: _bytes_, [[Error]]: _error_ }.
-                  1. Set _bytes_ to the list-concatenation of _bytes_ and ! DecodeFinalBase64Chunk(_chunk_, *false*).
-                1. Else,
-                  1. Assert: _lastChunkHandling_ is *"strict"*.
+                1. If _lastChunkHandling_ is *"strict"*, then
                   1. Let _error_ be a newly created *SyntaxError* object.
                   1. Return the Record { [[Read]]: _read_, [[Bytes]]: _bytes_, [[Error]]: _error_ }.
+                1. Assert: _lastChunkHandling_ is *"loose"*.
+                1. If _chunkLength_ = 1, then
+                  1. Let _error_ be a newly created *SyntaxError* object.
+                  1. Return the Record { [[Read]]: _read_, [[Bytes]]: _bytes_, [[Error]]: _error_ }.
+                1. Set _bytes_ to the list-concatenation of _bytes_ and ! DecodeFinalBase64Chunk(_chunk_, *false*).
               1. Return the Record { [[Read]]: _length_, [[Bytes]]: _bytes_, [[Error]]: ~none~ }.
             1. Let _char_ be the substring of _string_ from _index_ to _index_ + 1.
             1. Set _index_ to _index_ + 1.
@@ -43419,7 +43413,7 @@ THH:mm:ss.sss
               1. If _index_ &lt; _length_, then
                 1. Let _error_ be a newly created *SyntaxError* object.
                 1. Return the Record { [[Read]]: _read_, [[Bytes]]: _bytes_, [[Error]]: _error_ }.
-              1. If _lastChunkHandling_ is *"strict"*, let _throwOnExtraBits_ be *true*; otherwise let _throwOnExtraBits_ be *false*.
+              1. If _lastChunkHandling_ is *"strict"*, let _throwOnExtraBits_ be *true*; else let _throwOnExtraBits_ be *false*.
               1. Let _decodeResult_ be Completion(DecodeFinalBase64Chunk(_chunk_, _throwOnExtraBits_)).
               1. If _decodeResult_ is an abrupt completion, then
                 1. Let _error_ be _decodeResult_.[[Value]].
@@ -44386,7 +44380,7 @@ THH:mm:ss.sss
             1. If _next_ is not ~done~, then
               1. Set _next_ to CanonicalizeKeyedCollectionKey(_next_).
               1. Let _resultIndex_ be SetDataIndex(_resultSetData_, _next_).
-              1. If _resultIndex_ is ~not-found~, let _alreadyInResult_ be *false*; otherwise let _alreadyInResult_ be *true*.
+              1. If _resultIndex_ is ~not-found~, let _alreadyInResult_ be *false*; else let _alreadyInResult_ be *true*.
               1. If SetDataHas(_O_.[[SetData]], _next_) is *true*, then
                 1. If _alreadyInResult_ is *true*, set _resultSetData_[_resultIndex_] to ~empty~.
               1. Else,
@@ -44887,7 +44881,7 @@ THH:mm:ss.sss
         </dl>
         <emu-alg>
           1. Let _slots_ be « [[ArrayBufferData]], [[ArrayBufferByteLength]], [[ArrayBufferDetachKey]] ».
-          1. If _maxByteLength_ is present and _maxByteLength_ is not ~empty~, let _allocatingResizableBuffer_ be *true*; otherwise let _allocatingResizableBuffer_ be *false*.
+          1. If _maxByteLength_ is present and _maxByteLength_ is not ~empty~, let _allocatingResizableBuffer_ be *true*; else let _allocatingResizableBuffer_ be *false*.
           1. If _allocatingResizableBuffer_ is *true*, then
             1. If _byteLength_ > _maxByteLength_, throw a *RangeError* exception.
             1. Append [[ArrayBufferMaxByteLength]] to _slots_.
@@ -45163,7 +45157,7 @@ THH:mm:ss.sss
           1. Else,
             1. Let _intValue_ be the byte elements of _rawBytes_ concatenated and interpreted as a bit string encoding of a binary little-endian two's complement number of bit length _elementSize_ × 8.
           1. If IsBigIntElementType(_type_) is *true*, return the BigInt value that corresponds to _intValue_.
-          1. Otherwise, return the Number value that corresponds to _intValue_.
+          1. Return the Number value that corresponds to _intValue_.
         </emu-alg>
       </emu-clause>
 
@@ -45184,7 +45178,7 @@ THH:mm:ss.sss
           1. Let _AR_ be the Agent Record of the surrounding agent.
           1. Let _execution_ be _AR_.[[CandidateExecution]].
           1. Let _eventsRecord_ be the Agent Events Record of _execution_.[[EventsRecords]] whose [[AgentSignifier]] is AgentSignifier().
-          1. If _isTypedArray_ is *true* and IsNoTearConfiguration(_type_, _order_) is *true*, let _noTear_ be *true*; otherwise let _noTear_ be *false*.
+          1. If _isTypedArray_ is *true* and IsNoTearConfiguration(_type_, _order_) is *true*, let _noTear_ be *true*; else let _noTear_ be *false*.
           1. Let _rawValue_ be a List of length _elementSize_ whose elements are nondeterministically chosen byte values.
           1. NOTE: In implementations, _rawValue_ is the result of a non-atomic or atomic read instruction on the underlying hardware. The nondeterminism is a semantic prescription of the memory model to describe observable behaviour of hardware with weak consistency.
           1. Let _readEvent_ be ReadSharedMemory { [[Order]]: _order_, [[NoTear]]: _noTear_, [[Block]]: _block_, [[ByteIndex]]: _byteIndex_, [[ElementSize]]: _elementSize_ }.
@@ -45272,7 +45266,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Assert: IsDetachedBuffer(_arrayBuffer_) is *false*.
           1. Assert: There are sufficient bytes in _arrayBuffer_ starting at _byteIndex_ to represent a value of _type_.
-          1. Assert: _value_ is a BigInt if IsBigIntElementType(_type_) is *true*; otherwise, _value_ is a Number.
+          1. Assert: _value_ is a BigInt if IsBigIntElementType(_type_) is *true*; else, _value_ is a Number.
           1. Let _block_ be _arrayBuffer_.[[ArrayBufferData]].
           1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for Element Type _type_.
           1. Let _AR_ be the Agent Record of the surrounding agent.
@@ -45282,7 +45276,7 @@ THH:mm:ss.sss
           1. If IsSharedArrayBuffer(_arrayBuffer_) is *true*, then
             1. Let _execution_ be _AR_.[[CandidateExecution]].
             1. Let _eventsRecord_ be the Agent Events Record of _execution_.[[EventsRecords]] whose [[AgentSignifier]] is AgentSignifier().
-            1. If _isTypedArray_ is *true* and IsNoTearConfiguration(_type_, _order_) is *true*, let _noTear_ be *true*; otherwise let _noTear_ be *false*.
+            1. If _isTypedArray_ is *true* and IsNoTearConfiguration(_type_, _order_) is *true*, let _noTear_ be *true*; else let _noTear_ be *false*.
             1. Append WriteSharedMemory { [[Order]]: _order_, [[NoTear]]: _noTear_, [[Block]]: _block_, [[ByteIndex]]: _byteIndex_, [[ElementSize]]: _elementSize_, [[Payload]]: _rawBytes_ } to _eventsRecord_.[[EventList]].
           1. Else,
             1. Store the individual bytes of _rawBytes_ into _block_, starting at _block_[_byteIndex_].
@@ -45305,7 +45299,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Assert: IsDetachedBuffer(_arrayBuffer_) is *false*.
           1. Assert: There are sufficient bytes in _arrayBuffer_ starting at _byteIndex_ to represent a value of _type_.
-          1. Assert: _value_ is a BigInt if IsBigIntElementType(_type_) is *true*; otherwise, _value_ is a Number.
+          1. Assert: _value_ is a BigInt if IsBigIntElementType(_type_) is *true*; else, _value_ is a Number.
           1. Let _block_ be _arrayBuffer_.[[ArrayBufferData]].
           1. Let _elementSize_ be the Element Size value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for Element Type _type_.
           1. Let _AR_ be the Agent Record of the surrounding agent.
@@ -45450,7 +45444,8 @@ THH:mm:ss.sss
           1. Let _O_ be the *this* value.
           1. Perform ? RequireInternalSlot(_O_, [[ArrayBufferData]]).
           1. If IsSharedArrayBuffer(_O_) is *true*, throw a *TypeError* exception.
-          1. If IsFixedLengthArrayBuffer(_O_) is *false*, return *true*; otherwise return *false*.
+          1. If IsFixedLengthArrayBuffer(_O_) is *false*, return *true*.
+          1. Return *false*.
         </emu-alg>
       </emu-clause>
 
@@ -45591,14 +45586,14 @@ THH:mm:ss.sss
         </dl>
         <emu-alg>
           1. Let _slots_ be « [[ArrayBufferData]] ».
-          1. If _maxByteLength_ is present and _maxByteLength_ is not ~empty~, let _allocatingGrowableBuffer_ be *true*; otherwise let _allocatingGrowableBuffer_ be *false*.
+          1. If _maxByteLength_ is present and _maxByteLength_ is not ~empty~, let _allocatingGrowableBuffer_ be *true*; else let _allocatingGrowableBuffer_ be *false*.
           1. If _allocatingGrowableBuffer_ is *true*, then
             1. If _byteLength_ > _maxByteLength_, throw a *RangeError* exception.
             1. Append [[ArrayBufferByteLengthData]] and [[ArrayBufferMaxByteLength]] to _slots_.
           1. Else,
             1. Append [[ArrayBufferByteLength]] to _slots_.
           1. Let _obj_ be ? OrdinaryCreateFromConstructor(_constructor_, *"%SharedArrayBuffer.prototype%"*, _slots_).
-          1. If _allocatingGrowableBuffer_ is *true*, let _allocLength_ be _maxByteLength_; otherwise let _allocLength_ be _byteLength_.
+          1. If _allocatingGrowableBuffer_ is *true*, let _allocLength_ be _maxByteLength_; else let _allocLength_ be _byteLength_.
           1. Let _block_ be ? CreateSharedByteDataBlock(_allocLength_).
           1. Set _obj_.[[ArrayBufferData]] to _block_.
           1. If _allocatingGrowableBuffer_ is *true*, then
@@ -45791,7 +45786,8 @@ THH:mm:ss.sss
           1. Let _O_ be the *this* value.
           1. Perform ? RequireInternalSlot(_O_, [[ArrayBufferData]]).
           1. If IsSharedArrayBuffer(_O_) is *false*, throw a *TypeError* exception.
-          1. If IsFixedLengthArrayBuffer(_O_) is *false*, return *true*; otherwise return *false*.
+          1. If IsFixedLengthArrayBuffer(_O_) is *false*, return *true*.
+          1. Return *false*.
         </emu-alg>
       </emu-clause>
 
@@ -46042,7 +46038,7 @@ THH:mm:ss.sss
           1. Assert: _view_ has a [[ViewedArrayBuffer]] internal slot.
           1. Let _getIndex_ be ? ToIndex(_requestIndex_).
           1. If IsBigIntElementType(_type_) is *true*, let _numberValue_ be ? ToBigInt(_value_).
-          1. Otherwise, let _numberValue_ be ? ToNumber(_value_).
+          1. Else, let _numberValue_ be ? ToNumber(_value_).
           1. Set _isLittleEndian_ to ToBoolean(_isLittleEndian_).
           1. Let _viewOffset_ be _view_.[[ByteOffset]].
           1. Let _viewRecord_ be MakeDataViewWithBufferWitnessRecord(_view_, ~unordered~).
@@ -46816,7 +46812,9 @@ THH:mm:ss.sss
           1. If _arrayTypeName_ is *"BigInt64Array"*, let _v_ be ? ToBigInt64(_value_).
           1. Else, let _v_ be ? ToInt32(_value_).
           1. Let _q_ be ? ToNumber(_timeout_).
-          1. If _q_ is either *NaN* or *+∞*<sub>𝔽</sub>, let _t_ be +∞; else if _q_ is *-∞*<sub>𝔽</sub>, let _t_ be 0; else let _t_ be max(ℝ(_q_), 0).
+          1. If _q_ is either *NaN* or *+∞*<sub>𝔽</sub>, let _t_ be +∞.
+          1. Else if _q_ is *-∞*<sub>𝔽</sub>, let _t_ be 0.
+          1. Else, let _t_ be max(ℝ(_q_), 0).
           1. If _mode_ is ~sync~ and AgentCanSuspend() is *false*, throw a *TypeError* exception.
           1. Let _block_ be _buffer_.[[ArrayBufferData]].
           1. Let _WL_ be GetWaiterList(_block_, _byteIndexInBuffer_).
@@ -46937,7 +46935,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _byteIndexInBuffer_ be ? ValidateAtomicAccessOnIntegerTypedArray(_typedArray_, _index_).
           1. If _typedArray_.[[ContentType]] is ~bigint~, let _v_ be ? ToBigInt(_value_).
-          1. Otherwise, let _v_ be 𝔽(? ToIntegerOrInfinity(_value_)).
+          1. Else, let _v_ be 𝔽(? ToIntegerOrInfinity(_value_)).
           1. Perform ? RevalidateAtomicAccess(_typedArray_, _byteIndexInBuffer_).
           1. Let _buffer_ be _typedArray_.[[ViewedArrayBuffer]].
           1. Let _elementType_ be TypedArrayElementType(_typedArray_).
@@ -47116,7 +47114,7 @@ THH:mm:ss.sss
       <emu-alg>
         1. Let _byteIndexInBuffer_ be ? ValidateAtomicAccessOnIntegerTypedArray(_typedArray_, _index_).
         1. If _typedArray_.[[ContentType]] is ~bigint~, let _v_ be ? ToBigInt(_value_).
-        1. Otherwise, let _v_ be 𝔽(? ToIntegerOrInfinity(_value_)).
+        1. Else, let _v_ be 𝔽(? ToIntegerOrInfinity(_value_)).
         1. Perform ? RevalidateAtomicAccess(_typedArray_, _byteIndexInBuffer_).
         1. Let _buffer_ be _typedArray_.[[ViewedArrayBuffer]].
         1. Let _elementType_ be TypedArrayElementType(_typedArray_).
@@ -47229,13 +47227,11 @@ THH:mm:ss.sss
       <emu-alg>
         1. Let _jsonString_ be ? ToString(_text_).
         1. Let _unfiltered_ be ? ParseJSON(_jsonString_).
-        1. If IsCallable(_reviver_) is *true*, then
-          1. Let _root_ be OrdinaryObjectCreate(%Object.prototype%).
-          1. Let _rootName_ be the empty String.
-          1. Perform ! CreateDataPropertyOrThrow(_root_, _rootName_, _unfiltered_).
-          1. Return ? InternalizeJSONProperty(_root_, _rootName_, _reviver_).
-        1. Else,
-          1. Return _unfiltered_.
+        1. If IsCallable(_reviver_) is *false*, return _unfiltered_.
+        1. Let _root_ be OrdinaryObjectCreate(%Object.prototype%).
+        1. Let _rootName_ be the empty String.
+        1. Perform ! CreateDataPropertyOrThrow(_root_, _rootName_, _unfiltered_).
+        1. Return ? InternalizeJSONProperty(_root_, _rootName_, _reviver_).
       </emu-alg>
       <p>The *"length"* property of this function is *2*<sub>𝔽</sub>.</p>
 
@@ -47349,9 +47345,9 @@ THH:mm:ss.sss
         1. If _space_ is a Number, then
           1. Let _spaceMV_ be ! ToIntegerOrInfinity(_space_).
           1. Set _spaceMV_ to min(10, _spaceMV_).
-          1. If _spaceMV_ &lt; 1, let _gap_ be the empty String; otherwise let _gap_ be the String value containing _spaceMV_ occurrences of the code unit 0x0020 (SPACE).
+          1. If _spaceMV_ &lt; 1, let _gap_ be the empty String; else let _gap_ be the String value containing _spaceMV_ occurrences of the code unit 0x0020 (SPACE).
         1. Else if _space_ is a String, then
-          1. If the length of _space_ ≤ 10, let _gap_ be _space_; otherwise let _gap_ be the substring of _space_ from 0 to 10.
+          1. If the length of _space_ ≤ 10, let _gap_ be _space_; else let _gap_ be the substring of _space_ from 0 to 10.
         1. Else,
           1. Let _gap_ be the empty String.
         1. Let _wrapper_ be OrdinaryObjectCreate(%Object.prototype%).
@@ -49053,8 +49049,7 @@ THH:mm:ss.sss
             1. If _value_ is an abrupt completion, then
               1. Perform ? Call(_capability_.[[Reject]], *undefined*, « _value_.[[Value]] »).
               1. Return _capability_.[[Promise]].
-            1. Else,
-              1. Set _value_ to ! _value_.
+            1. Set _value_ to ! _value_.
           </emu-alg>
         </emu-clause>
       </emu-clause>
@@ -49331,8 +49326,7 @@ THH:mm:ss.sss
             1. Assert: _promiseCapability_ is a PromiseCapability Record.
             1. If _handlerResult_ is an abrupt completion, then
               1. Return ? Call(_promiseCapability_.[[Reject]], *undefined*, « _handlerResult_.[[Value]] »).
-            1. Else,
-              1. Return ? Call(_promiseCapability_.[[Resolve]], *undefined*, « _handlerResult_.[[Value]] »).
+            1. Return ? Call(_promiseCapability_.[[Resolve]], *undefined*, « _handlerResult_.[[Value]] »).
           1. Let _handlerRealm_ be *null*.
           1. If _reaction_.[[Handler]] is not ~empty~, then
             1. Let _getHandlerRealmResult_ be Completion(GetFunctionRealm(_reaction_.[[Handler]].[[Callback]])).
@@ -49910,10 +49904,8 @@ THH:mm:ss.sss
               1. Let _rejectJob_ be NewPromiseReactionJob(_rejectReaction_, _reason_).
               1. Perform HostEnqueuePromiseJob(_rejectJob_.[[Job]], _rejectJob_.[[Realm]]).
             1. Set _promise_.[[PromiseIsHandled]] to *true*.
-            1. If _resultCapability_ is *undefined*, then
-              1. Return *undefined*.
-            1. Else,
-              1. Return _resultCapability_.[[Promise]].
+            1. If _resultCapability_ is *undefined*, return *undefined*.
+            1. Return _resultCapability_.[[Promise]].
           </emu-alg>
         </emu-clause>
       </emu-clause>
@@ -50450,7 +50442,7 @@ THH:mm:ss.sss
           1. If _genContext_ does not have a Generator component, return ~non-generator~.
           1. Let _generator_ be the Generator component of _genContext_.
           1. If _generator_ has an [[AsyncGeneratorState]] internal slot, return ~async~.
-          1. Else, return ~sync~.
+          1. Return ~sync~.
         </emu-alg>
       </emu-clause>
 
@@ -50489,7 +50481,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _generatorKind_ be GetGeneratorKind().
           1. If _generatorKind_ is ~async~, return ? AsyncGeneratorYield(? Await(_value_)).
-          1. Otherwise, return ? GeneratorYield(CreateIteratorResultObject(_value_, *false*)).
+          1. Return ? GeneratorYield(CreateIteratorResultObject(_value_, *false*)).
         </emu-alg>
       </emu-clause>
 
@@ -50857,13 +50849,12 @@ THH:mm:ss.sss
             1. Let _toYield_ be the first element of _queue_.
             1. Let _resumptionValue_ be Completion(_toYield_.[[Completion]]).
             1. Return ? AsyncGeneratorUnwrapYieldResumption(_resumptionValue_).
-          1. Else,
-            1. Set _generator_.[[AsyncGeneratorState]] to ~suspended-yield~.
-            1. Remove _genContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
-            1. Let _callerContext_ be the running execution context.
-            1. Resume _callerContext_ passing *undefined*. If _genContext_ is ever resumed again, let _resumptionValue_ be the Completion Record with which it is resumed.
-            1. Assert: If control reaches here, then _genContext_ is the running execution context again.
-            1. Return ? AsyncGeneratorUnwrapYieldResumption(_resumptionValue_).
+          1. Set _generator_.[[AsyncGeneratorState]] to ~suspended-yield~.
+          1. Remove _genContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
+          1. Let _callerContext_ be the running execution context.
+          1. Resume _callerContext_ passing *undefined*. If _genContext_ is ever resumed again, let _resumptionValue_ be the Completion Record with which it is resumed.
+          1. Assert: If control reaches here, then _genContext_ is the running execution context again.
+          1. Return ? AsyncGeneratorUnwrapYieldResumption(_resumptionValue_).
         </emu-alg>
       </emu-clause>
 
@@ -50927,10 +50918,9 @@ THH:mm:ss.sss
             1. If _completion_ is a return completion, then
               1. Perform AsyncGeneratorAwaitReturn(_generator_).
               1. Return ~unused~.
-            1. Else,
-              1. If _completion_ is a normal completion, then
-                1. Set _completion_ to NormalCompletion(*undefined*).
-              1. Perform AsyncGeneratorCompleteStep(_generator_, _completion_, *true*).
+            1. If _completion_ is a normal completion, then
+              1. Set _completion_ to NormalCompletion(*undefined*).
+            1. Perform AsyncGeneratorCompleteStep(_generator_, _completion_, *true*).
           1. Set _generator_.[[AsyncGeneratorState]] to ~completed~.
           1. Return ~unused~.
         </emu-alg>
@@ -52923,7 +52913,7 @@ THH:mm:ss.sss
           1. If _intStart_ = -∞, set _intStart_ to 0.
           1. Else if _intStart_ &lt; 0, set _intStart_ to max(_size_ + _intStart_, 0).
           1. Else, set _intStart_ to min(_intStart_, _size_).
-          1. If _length_ is *undefined*, let _intLength_ be _size_; otherwise let _intLength_ be ? ToIntegerOrInfinity(_length_).
+          1. If _length_ is *undefined*, let _intLength_ be _size_; else let _intLength_ be ? ToIntegerOrInfinity(_length_).
           1. Set _intLength_ to the result of clamping _intLength_ between 0 and _size_.
           1. Let _intEnd_ be min(_intStart_ + _intLength_, _size_).
           1. Return the substring of _S_ from _intStart_ to _intEnd_.
@@ -53129,7 +53119,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObject_, [[DateValue]]).
           1. Let _t_ be _dateObject_.[[DateValue]].
           1. Let _y_ be ? ToNumber(_year_).
-          1. If _t_ is *NaN*, set _t_ to *+0*<sub>𝔽</sub>; otherwise set _t_ to LocalTime(_t_).
+          1. If _t_ is *NaN*, set _t_ to *+0*<sub>𝔽</sub>; else set _t_ to LocalTime(_t_).
           1. Let _yyyy_ be MakeFullYear(_y_).
           1. Let _d_ be MakeDay(_yyyy_, MonthFromTime(_t_), DateFromTime(_t_)).
           1. Let _date_ be MakeDate(_d_, TimeWithinDay(_t_)).


### PR DESCRIPTION
This PR implements points discussed in issue #3648 

Although I've tried to replace every occurrence of 'otherwise' with 'else' in the algorithm steps, there were 16 cases where simply replacing with 'else' lead to awkward sentence. I listed them below.

```
$ grep "1\. .* otherwise" spec.html -n
(...) the host is a web browser or otherwise supports <emu-xref> # 11 cases
(...) if _Desc_ has that field, or to the attribute's <emu-xref>default value</emu-xref> otherwise. # 4 cases
NOTE: (...) unless specified otherwise. # 1 case
```

Fixes #3648.