### PR TITLE
Editorial: convert single-item lists to prose

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -315,10 +315,7 @@
     <p>An <dfn id="implementation-defined">implementation-defined</dfn> facility is one that defers its definition to an external source without further qualification. This specification does not make any recommendations for particular behaviours, and conforming implementations are free to choose any behaviour within the constraints put forth by this specification.</p>
     <p>An <dfn id="implementation-approximated">implementation-approximated</dfn> facility is one that defers its definition to an external source while recommending an ideal behaviour. While conforming implementations are free to choose any behaviour within the constraints put forth by this specification, they are encouraged to strive to approximate the ideal. Some mathematical operations, such as <emu-xref href="#sec-math.exp"><code>Math.exp</code></emu-xref>, are implementation-approximated.</p>
     <p>A <dfn id="host" variants="hosts">host</dfn> is an external source that further defines facilities listed in Annex <emu-xref href="#sec-host-layering-points"></emu-xref> but does not further define other implementation-defined or implementation-approximated facilities. In informal use, a host refers to the set of all implementations, such as the set of all web browsers, that interface with this specification in the same way via Annex <emu-xref href="#sec-host-layering-points"></emu-xref>. A host is often an external specification, such as WHATWG HTML (<a href="https://html.spec.whatwg.org/">https://html.spec.whatwg.org/</a>). In other words, facilities that are host-defined are often further defined in external specifications.</p>
-    <p>A <dfn id="host-hook" variants="host hooks">host hook</dfn> is an abstract operation that is defined in whole or in part by an external source. All host hooks must be listed in Annex <emu-xref href="#sec-host-layering-points"></emu-xref>. A host hook must conform to at least the following requirements:</p>
-    <ul>
-      <li>It must return either a normal completion or a throw completion.</li>
-    </ul>
+    <p>A <dfn id="host-hook" variants="host hooks">host hook</dfn> is an abstract operation that is defined in whole or in part by an external source. All host hooks must be listed in Annex <emu-xref href="#sec-host-layering-points"></emu-xref>. A host hook must return either a normal completion or a throw completion.</p>
     <p>A <dfn id="host-defined">host-defined</dfn> facility is one that defers its definition to an external source without further qualification and is listed in Annex <emu-xref href="#sec-host-layering-points"></emu-xref>. Implementations that are not hosts may also provide definitions for host-defined facilities.</p>
     <p>A <dfn id="host-environment" variants="host environments">host environment</dfn> is a particular choice of definition for all host-defined facilities. A host environment typically includes objects or functions which allow obtaining input and providing output as host-defined properties of the global object.</p>
     <p>This specification follows the editorial convention of always using the most specific term. For example, if a facility is host-defined, it should not be referred to as implementation-defined.</p>
@@ -5381,15 +5378,7 @@
         1. Return 𝔽(_int16bit_).
       </emu-alg>
       <emu-note>
-        <p>Given the above definition of ToUint16:</p>
-        <ul>
-          <li>
-            The substitution of 2<sup>16</sup> for 2<sup>32</sup> in step <emu-xref href="#step-touint16-mod"></emu-xref> is the only difference between ToUint32 and ToUint16.
-          </li>
-          <li>
-            ToUint16 maps *-0*<sub>𝔽</sub> to *+0*<sub>𝔽</sub>.
-          </li>
-        </ul>
+        <p>Given the above definition of ToUint16, the substitution of 2<sup>16</sup> for 2<sup>32</sup> in step <emu-xref href="#step-touint16-mod"></emu-xref> is the only difference between ToUint32 and ToUint16. ToUint16 maps *-0*<sub>𝔽</sub> to *+0*<sub>𝔽</sub>.</p>
       </emu-note>
     </emu-clause>
 
@@ -12036,10 +12025,7 @@
       </h1>
       <dl class="header">
       </dl>
-      <p>An implementation of HostMakeJobCallback must conform to the following requirements:</p>
-      <ul>
-        <li>It must return a JobCallback Record whose [[Callback]] field is _callback_.</li>
-      </ul>
+      <p>An implementation of HostMakeJobCallback must return a JobCallback Record whose [[Callback]] field is _callback_.</p>
       <p>The default implementation of HostMakeJobCallback performs the following steps when called:</p>
       <emu-alg>
         1. Return the JobCallback Record { [[Callback]]: _callback_, [[HostDefined]]: ~empty~ }.
@@ -12060,10 +12046,7 @@
       </h1>
       <dl class="header">
       </dl>
-      <p>An implementation of HostCallJobCallback must conform to the following requirements:</p>
-      <ul>
-        <li>It must perform and return the result of Call(_jobCallback_.[[Callback]], _V_, _argumentsList_).</li>
-      </ul>
+      <p>An implementation of HostCallJobCallback must perform and return the result of Call(_jobCallback_.[[Callback]], _V_, _argumentsList_).</p>
       <emu-note>
         <p>This requirement means that hosts cannot change the [[Call]] behaviour of function objects defined in this specification.</p>
       </emu-note>
@@ -16054,12 +16037,7 @@
         <p>A Proxy exotic object only has a [[Construct]] internal method if the initial value of its [[ProxyTarget]] internal slot is an object that has a [[Construct]] internal method.</p>
       </emu-note>
       <emu-note>
-        <p>[[Construct]] for Proxy objects enforces the following invariants:</p>
-        <ul>
-          <li>
-            The result of [[Construct]] must be an Object.
-          </li>
-        </ul>
+        <p>[[Construct]] for Proxy objects enforces the invariant that the result of [[Construct]] must be an Object.</p>
       </emu-note>
     </emu-clause>
 


### PR DESCRIPTION
This PR addresses part of #3684 by converting several 1-2 item bulleted lists to prose where they read more naturally as inline text.

## Changes

Converted the following lists to prose:

1. **Host hook requirements** (line 318) - Single requirement about returning normal/throw completion
2. **ToUint16 notes** (line 5381) - Two related observations that flow naturally as prose
3. **HostMakeJobCallback requirements** (line 12028) - Single requirement about return value
4. **HostCallJobCallback requirements** (line 12049) - Single requirement about Call behavior
5. **Proxy [[Construct]] invariant** (line 16040) - Single invariant about Object result

## Rationale

Single-item lists and lists with non-parallel items often read better as prose. These changes improve readability while preserving the technical content.

Lists with parallel structure (e.g., "either X or Y" introductions, multiple invariants) were intentionally kept as lists.

Ref #3684