### PR TITLE
Meta: Update Yet Phrase Checking with ESMeta v0.7.3

### DIFF
--- a/.github/workflows/esmeta-installer/action.yml
+++ b/.github/workflows/esmeta-installer/action.yml
@@ -13,8 +13,8 @@ runs:
     - name: set esmeta version and path
       shell: bash
       run: |
-        # v0.7.1
-        echo "ESMETA_VERSION=bd58590ef6badabbe71afdefa02dc32274902621" >> $GITHUB_ENV
+        # v0.7.3
+        echo "ESMETA_VERSION=9066adf1edefd5d7e8dbc6eaa878242bb591cc2b" >> $GITHUB_ENV
         echo "ESMETA_HOME=vendor/esmeta" >> $GITHUB_ENV
     - name: clone esmeta
       shell: bash

--- a/.github/workflows/esmeta-yetcheck.yml
+++ b/.github/workflows/esmeta-yetcheck.yml
@@ -13,37 +13,13 @@ jobs:
           fetch-depth: 0
       - name: install esmeta
         uses: ./.github/workflows/esmeta-installer
-      - name: list added line numbers
-        id: collect
-        shell: bash
+      - name: check for newly-introduced phrases
         env:
           FILE_PATH: spec.html
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.sha }}
         run: |
-          # zero-context diff, limited to the file we care about
-          added_lines=$(git diff -U0 --no-color "${BASE_SHA}" "${HEAD_SHA}" -- "${FILE_PATH}" |
-          # keep only the hunk headers (the @@ lines)
-          awk '
-            # Example header: @@ -158,0 +159,2 @@
-            /^@@/ {
-              # Extract “+<start>[,<count>]” part
-              match($0, /\+([0-9]+)(,([0-9]+))?/, a)
-              start = a[1]
-              count = (a[3] == "" ? 1 : a[3])
-              # Print every line number in the added range
-              for (i = 0; i < count; i++) print start + i
-            }
-          ')
-
-          # Join line numbers with comma or space (whichever format you need)
-          added_joined=$(echo "$added_lines" | paste -sd "," -)
-          added_lines_json="[$added_joined]"
-
-          # Set it as an output value
-          echo "added_lines=$added_lines_json" >> "$GITHUB_OUTPUT"
-      - name: check for newly-introduced phrases
-        run: |
-          "${ESMETA_HOME}"/bin/esmeta extract \
-            -status \
-            -extract:warn-action <<< ${{ steps.collect.outputs.added_lines }}
+          "${ESMETA_HOME}"/bin/esmeta yet-check \
+            -status -yet-check:github-alert -yet-check:log \
+            "${BASE_SHA}" "${HEAD_SHA}"
+          cat "${ESMETA_HOME}"/logs/yet-check/summary.md >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
This PR updates the version of ESMeta to [v0.7.3](https://github.com/es-meta/esmeta/releases/tag/v0.7.3) and supports a more precise yet-phrase checking to resolve the [problem](https://github.com/tc39/ecma262/pull/3733#issuecomment-3687305206) mentioned in https://github.com/tc39/ecma262/pull/3733.

Now, the yet-phrase checker detects diff pairs of removed and added lines in the `spec.html` file and filters out pairs whose removed lines already contain yet-phrases or yet-types. Then, it shows alert messages only for the yet-phrases or yet-types in the added lines of the remaining pairs.

For example, among 147 commits from [dd4300d](https://github.com/tc39/ecma262/commit/dd4300da71023f729654a747d1a3f38682cd37fd) to [8febdac](https://github.com/tc39/ecma262/commit/8febdacb384c2661df5a00c0e77dcb69896496e2), the following 13 commits have at least one yet-phrase or yet-type alert:

| #  | Commit | Link | Summary | # of Yet-Phrase | # of Yet-Type |
|----|--------|------|---------|-----------------|---------------|
| 1  | [de62e8d](https://github.com/tc39/ecma262/commit/de62e8d) | [link](https://github.com/ku-plrg/ecma262/pull/32/changes) | [link](https://github.com/ku-plrg/ecma262/actions/runs/20705193450) | 3  | 0  |
| 2  | [ca045a0](https://github.com/tc39/ecma262/commit/ca045a0) | [link](https://github.com/ku-plrg/ecma262/pull/33/changes) | [link](https://github.com/ku-plrg/ecma262/actions/runs/20705221972) | 1  | 0  |
| 3  | [427ef8a](https://github.com/tc39/ecma262/commit/427ef8a) | [link](https://github.com/ku-plrg/ecma262/pull/34/changes) | [link](https://github.com/ku-plrg/ecma262/actions/runs/20705222743) | 1  | 0  |
| 4  | [60c4df0](https://github.com/tc39/ecma262/commit/60c4df0) | [link](https://github.com/ku-plrg/ecma262/pull/35/changes) | [link](https://github.com/ku-plrg/ecma262/actions/runs/20705222740) | 0  | 1  |
| 5  | [9b6a4a4](https://github.com/tc39/ecma262/commit/9b6a4a4) | [link](https://github.com/ku-plrg/ecma262/pull/36/changes) | [link](https://github.com/ku-plrg/ecma262/actions/runs/20705222858) | 1  | 0  |
| 6  | [1439803](https://github.com/tc39/ecma262/commit/1439803) | [link](https://github.com/ku-plrg/ecma262/pull/37/changes) | [link](https://github.com/ku-plrg/ecma262/actions/runs/20705223115) | 5  | 0  |
| 7  | [0411357](https://github.com/tc39/ecma262/commit/0411357) | [link](https://github.com/ku-plrg/ecma262/pull/38/changes) | [link](https://github.com/ku-plrg/ecma262/actions/runs/20705223209) | 18 | 0  |
| 8  | [9815f3a](https://github.com/tc39/ecma262/commit/9815f3a) | [link](https://github.com/ku-plrg/ecma262/pull/39/changes) | [link](https://github.com/ku-plrg/ecma262/actions/runs/20705223211) | 6  | 0  |
| 9  | [f6017b2](https://github.com/tc39/ecma262/commit/f6017b2) | [link](https://github.com/ku-plrg/ecma262/pull/40/changes) | [link](https://github.com/ku-plrg/ecma262/actions/runs/20705223633) | 3  | 0  |
| 10 | [858b1df](https://github.com/tc39/ecma262/commit/858b1df) | [link](https://github.com/ku-plrg/ecma262/pull/41/changes) | [link](https://github.com/ku-plrg/ecma262/actions/runs/20705224011) | 0  | 1  |
| 11 | [3dfa316](https://github.com/tc39/ecma262/commit/3dfa316) | [link](https://github.com/ku-plrg/ecma262/pull/42/changes) | [link](https://github.com/ku-plrg/ecma262/actions/runs/20705223993) | 11 | 1  |
| 12 | [ab6f2d5](https://github.com/tc39/ecma262/commit/ab6f2d5) | [link](https://github.com/ku-plrg/ecma262/pull/43/changes) | [link](https://github.com/ku-plrg/ecma262/actions/runs/20705224262) | 1  | 0  |
| 13 | [a51b9e9](https://github.com/tc39/ecma262/commit/a51b9e9) | [link](https://github.com/ku-plrg/ecma262/pull/44/changes) | [link](https://github.com/ku-plrg/ecma262/actions/runs/20705224533) | 2  | 0  |

However, since only maximum 10 alerts are allowed to be shown in the `Files changed` tab, we also show a summary of the detected yet-phrases and yet-types in the Actions log (`$GITHUB_STEP_SUMMARY`).

For example, the commit [3dfa316](https://github.com/tc39/ecma262/commit/3dfa316) has 11 yet-phrase alerts and 10 yet-type alerts, but only 10 alerts are shown in the `Files changed` tab (see [here](https://github.com/ku-plrg/ecma262/pull/42/changes)). The full list of alerts is available in the summary of the Actions log (see [here](https://github.com/ku-plrg/ecma262/actions/runs/20705223993)).