### PR TITLE
Editorial: Move module TopLevelCapability check inside if

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -27152,10 +27152,11 @@
                   1. Set _module_ to _module_.[[CycleRoot]].
                 1. Else,
                   1. Assert: _module_.[[Status]] is ~evaluated~ and _module_.[[EvaluationError]] is a throw completion.
-              1. If _module_.[[TopLevelCapability]] is not ~empty~, then
-                1. Return _module_.[[TopLevelCapability]].[[Promise]].
+                1. If _module_.[[TopLevelCapability]] is not ~empty~, then
+                  1. Return _module_.[[TopLevelCapability]].[[Promise]].
               1. Let _stack_ be a new empty List.
               1. Let _capability_ be ! NewPromiseCapability(%Promise%).
+              1. Assert: _module_.[[TopLevelCapability]] is ~empty~.
               1. Set _module_.[[TopLevelCapability]] to _capability_.
               1. Let _result_ be Completion(InnerModuleEvaluation(_module_, _stack_, 0)).
               1. If _result_ is an abrupt completion, then


### PR DESCRIPTION
**Current spec**:
<img width="808" height="177" alt="image" src="https://github.com/user-attachments/assets/783c75f0-f4a8-4464-a6ad-f9651add3faf" />

**Proposed spec**:
<img width="880" height="192" alt="image" src="https://github.com/user-attachments/assets/1bb39f21-fc31-4353-aecf-4e0b0b7543a7" />

---

In the current spec, the condition in step 4 can only be true if the condition in step 3 was true. Moving step 4 as a sub-step of step 3 makes it clearer, without the next reader having to wonder how we can hit the control flow path with 3 false and 4 true.

**Proof**:

For convenience, I'm going to call _module_ the value that the _module_ variable has starting from step 3.a.i/4, and _originalModule_ the "this value" of the Evaluate() concrete method. _module_ is either _originalModule_ or its [[CycleRoot]].

If 4 is true, it's because _module_ already went through step 7 of Evaluate(), since that's the only place where [[TopLevelCapability]] is set. This means that _module_.[[Status]] is either already `~evaluated~` (asserted in steps 9.b and 10.a) or (`~evaluating-async~`).

_originalModule_ was in that previous call either _module_ itself, or part of a cycle containing both. A cycle transitions to `~evaluated~`/`~evaluating-async~` atomically (steps 16.b.v and 16.b.vi of InnerModuleEvaluation), which means that _originalModule_ is also either ~evaluated~ or ~evaluating-async~.

Thus if 4 is true, 3 must have been true.