### PR TITLE
Editorial: Introduce mathematical logarithm functions

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1178,6 +1178,7 @@
       <p>Numeric operators such as +, ×, =, and ≥ refer to those operations as determined by the type of the operands. When applied to mathematical values, the operators refer to the usual mathematical operations. When applied to extended mathematical values, the operators refer to the usual mathematical operations over the extended real numbers; indeterminate forms are not defined and their use in this specification should be considered an editorial error. When applied to Numbers, the operators refer to the relevant operations within IEEE 754-2019. When applied to BigInts, the operators refer to the usual mathematical operations applied to the mathematical value of the BigInt. Numeric operators applied to mixed-type operands (such as a Number and a mathematical value) are not defined and should be considered an editorial error in this specification.</p>
       <p>Conversions between mathematical values and Numbers or BigInts are always explicit in this document. A conversion from a mathematical value or extended mathematical value _x_ to a Number is denoted as "the Number value for _x_" or <emu-eqn id="𝔽" aoid="𝔽">𝔽(_x_)</emu-eqn>, and is defined in <emu-xref href="#sec-ecmascript-language-types-number-type"></emu-xref>. A conversion from an integer _x_ to a BigInt is denoted as "the <dfn id="bigint-value-for">BigInt value for</dfn> _x_" or <emu-eqn id="ℤ" aoid="ℤ">ℤ(_x_)</emu-eqn>. A conversion from a Number or BigInt _x_ to a mathematical value is denoted as "the <dfn id="mathematical-value-of">mathematical value of</dfn> _x_", or <emu-eqn id="ℝ" aoid="ℝ">ℝ(_x_)</emu-eqn>. The mathematical value of *+0*<sub>𝔽</sub> and *-0*<sub>𝔽</sub> is the mathematical value 0. The mathematical value of non-finite values is not defined. The <dfn id="extended-mathematical-value-of">extended mathematical value of</dfn> _x_ is the mathematical value of _x_ for finite values, and is +∞ and -∞ for *+∞*<sub>𝔽</sub> and *-∞*<sub>𝔽</sub> respectively; it is not defined for *NaN*.</p>
       <p>The mathematical function <emu-eqn id="eqn-abs" aoid="abs">abs(_x_)</emu-eqn> produces the absolute value of _x_, which is <emu-eqn>-_x_</emu-eqn> if _x_ &lt; 0 and otherwise is _x_ itself.</p>
+      <p>The mathematical function <emu-eqn id="eqn-ln" aoid="ln">ln(_x_)</emu-eqn> produces the natural logarithm of _x_. The mathematical function <emu-eqn id="eqn-log10" aoid="log10">log10(_x_)</emu-eqn> produces the base 10 logarithm of _x_. The mathematical function <emu-eqn id="eqn-log2" aoid="log2">log2(_x_)</emu-eqn> produces the base 2 logarithm of _x_.</p>
       <p>The mathematical function <emu-eqn id="eqn-min" aoid="min">min(_x1_, _x2_, … , _xN_)</emu-eqn> produces the mathematically smallest of <emu-eqn>_x1_</emu-eqn> through <emu-eqn>_xN_</emu-eqn>. The mathematical function <emu-eqn id="eqn-max" aoid="max">max(_x1_, _x2_, ..., _xN_)</emu-eqn> produces the mathematically largest of <emu-eqn>_x1_</emu-eqn> through <emu-eqn>_xN_</emu-eqn>. The domain and range of these mathematical functions are the extended mathematical values.</p>
       <p>The notation “<emu-eqn id="eqn-modulo" aoid="modulo">_x_ modulo _y_</emu-eqn>” (_y_ must be finite and non-zero) computes a value _k_ of the same sign as _y_ (or zero) such that <emu-eqn>abs(_k_) &lt; abs(_y_) and _x_ - _k_ = _q_ × _y_</emu-eqn> for some integer _q_.</p>
       <p>The phrase "the result of <dfn id="clamping">clamping</dfn> _x_ between _lower_ and _upper_" (where _x_ is an extended mathematical value and _lower_ and _upper_ are mathematical values such that _lower_ ≤ _upper_) produces _lower_ if _x_ &lt; _lower_, produces _upper_ if _x_ > _upper_, and otherwise produces _x_.</p>
@@ -32994,7 +32995,7 @@
           1. If _n_ is *1*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
           1. If _n_ is either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, return *-∞*<sub>𝔽</sub>.
           1. If _n_ &lt; *-0*<sub>𝔽</sub>, return *NaN*.
-          1. Return an implementation-approximated Number value representing the natural logarithm of ℝ(_n_).
+          1. Return an implementation-approximated Number value representing ln(ℝ(_n_)).
         </emu-alg>
       </emu-clause>
 
@@ -33007,7 +33008,7 @@
           1. If _n_ is one of *NaN*, *+0*<sub>𝔽</sub>, *-0*<sub>𝔽</sub>, or *+∞*<sub>𝔽</sub>, return _n_.
           1. If _n_ is *-1*<sub>𝔽</sub>, return *-∞*<sub>𝔽</sub>.
           1. If _n_ &lt; *-1*<sub>𝔽</sub>, return *NaN*.
-          1. Return an implementation-approximated Number value representing the natural logarithm of 1 + ℝ(_n_).
+          1. Return an implementation-approximated Number value representing ln(1 + ℝ(_n_)).
         </emu-alg>
       </emu-clause>
 
@@ -33021,7 +33022,7 @@
           1. If _n_ is *1*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
           1. If _n_ is either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, return *-∞*<sub>𝔽</sub>.
           1. If _n_ &lt; *-0*<sub>𝔽</sub>, return *NaN*.
-          1. Return an implementation-approximated Number value representing the base 10 logarithm of ℝ(_n_).
+          1. Return an implementation-approximated Number value representing log10(ℝ(_n_)).
         </emu-alg>
       </emu-clause>
 
@@ -33035,7 +33036,7 @@
           1. If _n_ is *1*<sub>𝔽</sub>, return *+0*<sub>𝔽</sub>.
           1. If _n_ is either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, return *-∞*<sub>𝔽</sub>.
           1. If _n_ &lt; *-0*<sub>𝔽</sub>, return *NaN*.
-          1. Return an implementation-approximated Number value representing the base 2 logarithm of ℝ(_n_).
+          1. Return an implementation-approximated Number value representing log2(ℝ(_n_)).
         </emu-alg>
       </emu-clause>
 


### PR DESCRIPTION
ECMA-402 [ComputeExponent](https://tc39.es/ecma402/#sec-computeexponent) has some text like "the base 10 logarithm of _x_ rounded down to the nearest integer" which really should be "floor(log10(_x_))" and would be awkward to split across steps because [keep-trailing-zeros](https://github.com/tc39/proposal-intl-keep-trailing-zeros) will be making such declarations conditional.

But it would also be awkward to define log10 in ECMA-402, so I'm instead proposing it here, along with ln and log2.