### PR TITLE
Meta: Link to both single- and multi-page PR previews

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -109,5 +109,8 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMMENT_IDENTIFIER: tc39_pr_preview_comment
-          message: |
-            The rendered spec for this PR is available at ${{ steps.get-preview-url.outputs.url }}/pr/${{ github.event.number }}.
+          message: >
+            The rendered spec for this PR is available as a single page at
+            ${{ steps.get-preview-url.outputs.url }}/pr/${{ github.event.number }}
+            and as multiple pages at
+            ${{ steps.get-preview-url.outputs.url }}/pr/${{ github.event.number }}/multipage .


### PR DESCRIPTION
We're generating multi-page previews, so might as well link to them.