### PR TITLE
Proposal: quantum entangled declarations (const[a, b])

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -21291,6 +21291,7 @@
       HoistableDeclaration[?Yield, ?Await, ~Default]
       ClassDeclaration[?Yield, ?Await, ~Default]
       LexicalDeclaration[+In, ?Yield, ?Await]
+      QuantumDeclaration[?Yield, ?Await]
 
     HoistableDeclaration[Yield, Await, Default] :
       FunctionDeclaration[?Yield, ?Await, ?Default]
@@ -21535,6 +21536,50 @@
           1. Let _env_ be the running execution context's LexicalEnvironment.
           1. Return ? BindingInitialization of |BindingPattern| with arguments _value_ and _env_.
         </emu-alg>
+      </emu-clause>
+    </emu-clause>
+
+    <emu-clause id="sec-quantum-entangled-declarations">
+      <h1>Quantum Entangled Declarations</h1>
+      <emu-note>
+        <p>A `const[a, b]` declaration creates a pair of <em>quantum-entangled</em> bindings. The two bindings are assigned complementary bit values—one is *+0𝔽* and the other is *1𝔽*—determined non-deterministically at the moment of evaluation. Neither binding may be reassigned. The bindings are always complementary: `a + b` is always *1𝔽* and `a !== b` is always *true*. This mirrors quantum entanglement, where measuring one particle instantly determines the state of its partner.</p>
+      </emu-note>
+      <h2>Syntax</h2>
+      <emu-grammar type="definition">
+        QuantumDeclaration[Yield, Await] :
+          `const` `[` QuantumBinding[?Yield, ?Await] `,` QuantumBinding[?Yield, ?Await] `]` `;`
+
+        QuantumBinding[Yield, Await] :
+          BindingIdentifier[?Yield, ?Await]
+      </emu-grammar>
+
+      <emu-clause id="sec-quantum-entangled-declarations-static-semantics-early-errors">
+        <h1>Static Semantics: Early Errors</h1>
+        <emu-grammar>QuantumDeclaration : `const` `[` QuantumBinding `,` QuantumBinding `]` `;`</emu-grammar>
+        <ul>
+          <li>
+            It is a Syntax Error if the StringValue of the first |QuantumBinding|'s |BindingIdentifier| is the same as the StringValue of the second |QuantumBinding|'s |BindingIdentifier|.
+          </li>
+        </ul>
+      </emu-clause>
+
+      <emu-clause id="sec-quantum-entangled-declarations-runtime-semantics-evaluation" type="sdo">
+        <h1>Runtime Semantics: Evaluation</h1>
+        <emu-grammar>QuantumDeclaration : `const` `[` QuantumBinding `,` QuantumBinding `]` `;`</emu-grammar>
+        <emu-alg>
+          1. Let _name1_ be the StringValue of the first |QuantumBinding|'s |BindingIdentifier|.
+          1. Let _name2_ be the StringValue of the second |QuantumBinding|'s |BindingIdentifier|.
+          1. Let _lhs1_ be ! ResolveBinding(_name1_).
+          1. Let _lhs2_ be ! ResolveBinding(_name2_).
+          1. Let _bit_ be an implementation-defined Number value that is either *+0𝔽* or *1𝔽*, chosen non-deterministically.
+          1. Let _complement_ be if _bit_ is *+0𝔽* then *1𝔽* else *+0𝔽*.
+          1. Perform ! InitializeReferencedBinding(_lhs1_, _bit_).
+          1. Perform ! InitializeReferencedBinding(_lhs2_, _complement_).
+          1. Return ~empty~.
+        </emu-alg>
+        <emu-note>
+          <p>Both bindings are initialized as constant. Assignments to either binding after initialization will throw a *TypeError* at runtime, consistent with the behaviour of `const` bindings.</p>
+        </emu-note>
       </emu-clause>
     </emu-clause>
 

--- a/test/quantum-const.js
+++ b/test/quantum-const.js
@@ -1,0 +1,75 @@
+// Tests for Quantum Entangled Declarations (const[a, b])
+// Mirrors test262 style: each assertion throws if violated.
+
+function assert(condition, message) {
+  if (!condition) throw new Error("FAIL: " + message);
+}
+
+// 1. Complementary values: one is 0, the other is 1
+{
+  const[a, b];
+  assert(a + b === 1, "a + b must equal 1");
+  assert(a !== b,     "a must not equal b");
+}
+
+// 2. Values are 0 or 1 (bit values)
+{
+  const[x, y];
+  assert(x === 0 || x === 1, "x must be 0 or 1");
+  assert(y === 0 || y === 1, "y must be 0 or 1");
+}
+
+// 3. Stable after collapse: repeated reads return the same value
+{
+  const[p, q];
+  assert(p === p, "p must be stable");
+  assert(q === q, "q must be stable");
+  assert(p + q === 1, "stability must preserve entanglement");
+}
+
+// 4. Duplicate binding names are a syntax error (verified statically)
+//    The following would be a Syntax Error at parse time:
+//      const[z, z];
+
+// 5. Assignment to either binding throws TypeError (const semantics)
+{
+  const[m, n];
+  assert(typeof m === "number", "m must be a number");
+  let threw = false;
+  try { (function() { "use strict"; m = 99; })(); } catch (e) { threw = true; }
+  assert(threw, "assignment to quantum binding must throw");
+}
+
+// 6. Tiebreaker: a tied vote is always resolved to a strict majority
+//    Four votes split 2-2; the quantum casting vote guarantees a winner.
+{
+  const tally = [1, 0, 1, 0]; // tied
+  const[castingVote, abstain];
+  const result = tally.reduce((sum, v) => sum + v, castingVote);
+  assert(result === 2 || result === 3, "result must be 2 or 3");
+  assert(result !== 2 || castingVote === 0, "nays win iff castingVote is 0");
+  assert(result !== 3 || castingVote === 1, "ayes win iff castingVote is 1");
+  void abstain; // entangled but unused; its value is determined, not observed
+}
+
+// 7. Mutual exclusion: exactly one of two branches ever executes
+//    Useful wherever only one side-effect must fire across two handlers.
+{
+  let fired = 0;
+  const[send, drop];
+  if (send) fired++;
+  if (drop) fired++;
+  assert(fired === 1, "exactly one branch must fire");
+}
+
+// 8. Random byte from 8 independent entangled pairs
+//    Composes the primary bit from each pair into an 8-bit unsigned integer.
+{
+  const[b0,_0]; const[b1,_1]; const[b2,_2]; const[b3,_3];
+  const[b4,_4]; const[b5,_5]; const[b6,_6]; const[b7,_7];
+  const byte = (b0<<7)|(b1<<6)|(b2<<5)|(b3<<4)|(b4<<3)|(b5<<2)|(b6<<1)|b7;
+  assert(byte >= 0 && byte <= 255, "quantum byte must be in range [0, 255]");
+  assert(Number.isInteger(byte),   "quantum byte must be an integer");
+}
+
+console.log("All quantum-const tests passed.");


### PR DESCRIPTION
Adds QuantumDeclaration to the Declaration grammar. A const[a, b] declaration creates two complementary const bindings initialized to non-deterministic complementary bit values (0 and 1). Includes early error for duplicate binding names, runtime evaluation semantics, and test262-style tests.

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)
* [WebAssembly](https://webassembly.github.io/spec/) - [file an issue](https://github.com/WebAssembly/spec/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
