### PR TITLE
Editorial: make it clearer that resolvers for already-resolved Promises need not keep the Promise alive

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -49113,16 +49113,17 @@ THH:mm:ss.sss
       <emu-clause id="sec-createresolvingfunctions" oldids="sec-promise-reject-functions,sec-promise-resolve-functions" type="abstract operation">
         <h1>
           CreateResolvingFunctions (
-            _promise_: a Promise,
+            _toResolve_: a Promise,
           ): a Record with fields [[Resolve]] (a function object) and [[Reject]] (a function object)
         </h1>
         <dl class="header">
         </dl>
         <emu-alg>
-          1. Let _alreadyResolved_ be the Record { [[Value]]: *false* }.
-          1. Let _resolveSteps_ be a new Abstract Closure with parameters (_resolution_) that captures _promise_ and _alreadyResolved_ and performs the following steps when called:
-            1. If _alreadyResolved_.[[Value]] is *true*, return *undefined*.
-            1. Set _alreadyResolved_.[[Value]] to *true*.
+          1. Let _promiseOrEmpty_ be the Record { [[Value]]: _toResolve_ }.
+          1. Let _resolveSteps_ be a new Abstract Closure with parameters (_resolution_) that captures _promiseOrEmpty_ and performs the following steps when called:
+            1. If _promiseOrEmpty_.[[Value]] is ~empty~, return *undefined*.
+            1. Let _promise_ be _promiseOrEmpty_.[[Value]].
+            1. Set _promiseOrEmpty_.[[Value]] to ~empty~.
             1. If SameValue(_resolution_, _promise_) is *true*, then
               1. Let _selfResolutionError_ be a newly created *TypeError* object.
               1. Perform RejectPromise(_promise_, _selfResolutionError_).
@@ -49143,9 +49144,10 @@ THH:mm:ss.sss
             1. Perform HostEnqueuePromiseJob(_job_.[[Job]], _job_.[[Realm]]).
             1. Return *undefined*.
           1. Let _resolve_ be CreateBuiltinFunction(_resolveSteps_, 1, *""*, « »).
-          1. Let _rejectSteps_ be a new Abstract Closure with parameters (_reason_) that captures _promise_ and _alreadyResolved_ and performs the following steps when called:
-            1. If _alreadyResolved_.[[Value]] is *true*, return *undefined*.
-            1. Set _alreadyResolved_.[[Value]] to *true*.
+          1. Let _rejectSteps_ be a new Abstract Closure with parameters (_reason_) that captures _promiseOrEmpty_ and performs the following steps when called:
+            1. If _promiseOrEmpty_.[[Value]] is ~empty~, return *undefined*.
+            1. Let _promise_ be _promiseOrEmpty_.[[Value]].
+            1. Set _promiseOrEmpty_.[[Value]] to ~empty~.
             1. Perform RejectPromise(_promise_, _reason_).
             1. Return *undefined*.
           1. Let _reject_ be CreateBuiltinFunction(_rejectSteps_, 1, *""*, « »).


### PR DESCRIPTION
There's a [longstanding issue in V8](https://github.com/nodejs/node/issues/17469#issuecomment-685216777) where doing `Promise.race(large, slow)` will keep `large` alive until `slow` settles (at least as long as `slow` is not GC'd). It is not obvious why this should be so.

The reason is that [V8's implementation](https://source.chromium.org/chromium/chromium/src/+/main:v8/src/builtins/promise-abstract-operations.tq;l=287-288;drc=37239f6e1148c0e738d826d4d04b404a26da1970) follows [the spec](https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-createresolvingfunctions) literally: the `(resolve, reject)` resolvers created when creating a Promise each unconditionally hold a (strong) pointer to their underlying Promise plus an "already resolved" bit tracked in a separate shared boolean. This means that the Promise is kept alive for as long as either of its resolvers is alive, even if the Promise has already settled and is otherwise unreachable.

In the case of `Promise.race`, both resolvers are passed to the `.then()` of each of the arguments to `Promise.race`, so as long as any of those arguments remain unsettled the resolvers are kept alive in the arguments' `[[PromiseFulfillReactions]]`/`[[PromiseRejectReactions]]` slots. Because the resolvers hold a strong pointer to their Promise, that means they keep the Promise returned by `Promise.race` alive, including the value it holds.

An equivalent implementation is to hold a `Maybe<Promise>`, which is emptied (on both resolvers) when the Promise settles. This implementation would avoid the leak above. Implementations could do this today; indeed that is [what SpiderMonkey already does](https://searchfox.org/firefox-main/rev/0bbf19a9ffa4881cfae875c7af917f064bf2be52/js/src/builtin/Promise.cpp#63-87) (and [possibly JSC](https://github.com/WebKit/WebKit/blob/574fccad44f052870183b8d89b7f2f7df2ecfcb9/Source/JavaScriptCore/runtime/JSPromise.cpp#L401-L405), but I can't entirely tell).

Normally we don't go out of our way to specify optimizations, but in this case I think this way of writing the specification is at least as good on its own merits.