### PR TITLE
Editorial: fix wrong id for HostEnqueueFinalizationRegistryCleanupJob

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -12478,7 +12478,7 @@
     <emu-clause id="sec-weakref-host-hooks">
       <h1>Host Hooks</h1>
 
-      <emu-clause id="sec-host-cleanup-finalization-registry" type="host-defined abstract operation">
+      <emu-clause id="sec-host-enqueue-finalization-registry-cleanup-job" type="host-defined abstract operation">
         <h1>
           HostEnqueueFinalizationRegistryCleanupJob (
             _finalizationRegistry_: a FinalizationRegistry,


### PR DESCRIPTION
This PR fixes a typo on the id for the `HostEnqueueFinalizationRegistryCleanupJob` AO, which before this change pointed to `HostCleanupFinalizationRegistry`, a completely different AO.

For the "correct" id it intentionally adds hyphens instead of going with the pattern of the rest of "enqueue jobs" operations (`sec-enqueuegenericjob`, `sec-enqueuepromisejob`, etc.), because `sec-hostenqueuefinalizationregistrycleanupjob` is kind of unreadable