### PR TITLE
Editorial: Unify 'replace' step into single format

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -12457,7 +12457,7 @@
             1. Set _r_.[[Key]] to ~empty~.
             1. Set _r_.[[Value]] to ~empty~.
           1. For each WeakSet _set_ such that _set_.[[WeakSetData]] contains _value_, do
-            1. Replace the element of _set_.[[WeakSetData]] whose value is _value_ with an element whose value is ~empty~.
+            1. Replace _value_ in _set_.[[WeakSetData]] with ~empty~.
       </emu-alg>
 
       <emu-note>
@@ -44114,7 +44114,7 @@ THH:mm:ss.sss
           1. Let _S_ be the *this* value.
           1. Perform ? RequireInternalSlot(_S_, [[SetData]]).
           1. For each element _e_ of _S_.[[SetData]], do
-            1. Replace the element of _S_.[[SetData]] whose value is _e_ with an element whose value is ~empty~.
+            1. Replace _e_ in _S_.[[SetData]] with ~empty~.
           1. Return *undefined*.
         </emu-alg>
         <emu-note>
@@ -44136,7 +44136,7 @@ THH:mm:ss.sss
           1. Set _value_ to CanonicalizeKeyedCollectionKey(_value_).
           1. For each element _e_ of _S_.[[SetData]], do
             1. If _e_ is not ~empty~ and SameValue(_e_, _value_) is *true*, then
-              1. Replace the element of _S_.[[SetData]] whose value is _e_ with an element whose value is ~empty~.
+              1. Replace _e_ in _S_.[[SetData]] with ~empty~.
               1. Return *true*.
           1. Return *false*.
         </emu-alg>
@@ -44779,7 +44779,7 @@ THH:mm:ss.sss
           1. If CanBeHeldWeakly(_value_) is *false*, return *false*.
           1. For each element _e_ of _S_.[[WeakSetData]], do
             1. If _e_ is not ~empty~ and SameValue(_e_, _value_) is *true*, then
-              1. Replace the element of _S_.[[WeakSetData]] whose value is _e_ with an element whose value is ~empty~.
+              1. Replace _e_ in _S_.[[WeakSetData]] with ~empty~.
               1. Return *true*.
           1. Return *false*.
         </emu-alg>


### PR DESCRIPTION
This PR unifies 'replace' step into a consistent form.

Currently there are two forms of 'replace element of a List' step in spec.

```
# Form 1 (4 times)
# grep "1\. Replace the element of .*" spec.html
1. Replace the element of {{ container }} whose value is {{ oldElement }} with an element whose value is {{ newElement }}.

# Form 2 (1 time)
# grep "1\. Replace .* in .* with .*\." spec.html
1. Replace {{ oldElement }} in {{ container }} with {{ newElement }}.
```

**Form 1** is merged into **Form 2**, as **Form 2** expresses same meaning with brevity.

For your reference, the 'replace element of an Object' is left as a separate form. (appears 2 times in spec)

```
1. Replace the property named _P_ of object _O_ with ...
```