### PR TITLE
Editorial: don't attempt to redeclare a param alias that is not present

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -5025,7 +5025,7 @@
             1. Let _result_ be ? Call(_exoticToPrim_, _input_, « _hint_ »).
             1. If _result_ is not an Object, return _result_.
             1. Throw a *TypeError* exception.
-          1. If _preferredType_ is not present, let _preferredType_ be ~number~.
+          1. If _preferredType_ is not present, set _preferredType_ to ~number~.
           1. Return ? OrdinaryToPrimitive(_input_, _preferredType_).
         1. Return _input_.
       </emu-alg>
@@ -27026,7 +27026,7 @@
             </dl>
 
             <emu-alg>
-              1. If _hostDefined_ is not present, let _hostDefined_ be ~empty~.
+              1. If _hostDefined_ is not present, set _hostDefined_ to ~empty~.
               1. Let _pc_ be ! NewPromiseCapability(%Promise%).
               1. Let _state_ be the GraphLoadingState Record { [[IsLoading]]: *true*, [[PendingModulesCount]]: 1, [[Visited]]: « », [[PromiseCapability]]: _pc_, [[HostDefined]]: _hostDefined_ }.
               1. Perform InnerModuleLoading(_state_, _module_).


### PR DESCRIPTION
This is consistent with the phrasing we use elsewhere. There are other occurrences of "is not present, let", but they are declaring a previously-undeclared alias, not the parameter alias whose presence is being tested.