### PR TITLE
Normative: Do not read from empty [[CycleRoot]] in GatherAvailableAncestors

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -26829,7 +26829,9 @@
                 a Cyclic Module Record or ~empty~
               </td>
               <td>
-                The first visited module of the cycle, the root DFS ancestor of the strongly connected component. For a module not in a cycle, this would be the module itself. Once Evaluate has completed, a module's [[DFSAncestorIndex]] is the depth-first traversal index of its [[CycleRoot]].
+                <p>This field is initially ~empty~. Once InnerModuleEvaluation runs on a module's strongly connected component withuot returning a throw completion, it's updated to be the first visited module of the SCC (the root DFS ancestor). For a module not in a cycle, this would be the module itself.</p>
+
+                <p>Once this field is set, a module's [[DFSAncestorIndex]] is the depth-first traversal index of its [[CycleRoot]].</p>
               </td>
             </tr>
             <tr>
@@ -27256,6 +27258,7 @@
                     1. If _requiredModule_.[[Status]] is ~evaluating~, then
                       1. Set _module_.[[DFSAncestorIndex]] to min(_module_.[[DFSAncestorIndex]], _requiredModule_.[[DFSAncestorIndex]]).
                     1. Else,
+                      1. Assert: _requiredModule_.[[CycleRoot]] is not ~empty~.
                       1. Set _requiredModule_ to _requiredModule_.[[CycleRoot]].
                       1. Assert: _requiredModule_.[[Status]] is either ~evaluating-async~ or ~evaluated~.
                       1. If _requiredModule_.[[EvaluationError]] is not ~empty~, return ? _requiredModule_.[[EvaluationError]].
@@ -27280,6 +27283,7 @@
                     1. If _requiredModule_.[[AsyncEvaluationOrder]] is ~unset~, set _requiredModule_.[[Status]] to ~evaluated~.
                     1. Else, set _requiredModule_.[[Status]] to ~evaluating-async~.
                     1. If _requiredModule_ and _module_ are the same Module Record, set _done_ to *true*.
+                    1. Assert: _requiredModule_.[[CycleRoot]] is ~empty~.
                     1. Set _requiredModule_.[[CycleRoot]] to _module_.
                 1. Return _index_.
               </emu-alg>
@@ -27329,15 +27333,16 @@
               </dl>
               <emu-alg>
                 1. For each Cyclic Module Record _m_ of _module_.[[AsyncParentModules]], do
-                  1. If _execList_ does not contain _m_ and _m_.[[CycleRoot]].[[EvaluationError]] is ~empty~, then
+                  1. If _execList_ does not contain _m_ and _m_.[[EvaluationError]] is ~empty~, then
                     1. Assert: _m_.[[Status]] is ~evaluating-async~.
-                    1. Assert: _m_.[[EvaluationError]] is ~empty~.
-                    1. Assert: _m_.[[AsyncEvaluationOrder]] is an integer.
-                    1. Assert: _m_.[[PendingAsyncDependencies]] > 0.
-                    1. Set _m_.[[PendingAsyncDependencies]] to _m_.[[PendingAsyncDependencies]] - 1.
-                    1. If _m_.[[PendingAsyncDependencies]] = 0, then
-                      1. Append _m_ to _execList_.
-                      1. If _m_.[[HasTLA]] is *false*, perform GatherAvailableAncestors(_m_, _execList_).
+                    1. Assert: _m_.[[CycleRoot]] is not ~empty~.
+                    1. If _m_.[[CycleRoot]].[[EvaluationError]] is ~empty~, then
+                      1. Assert: _m_.[[AsyncEvaluationOrder]] is an integer.
+                      1. Assert: _m_.[[PendingAsyncDependencies]] > 0.
+                      1. Set _m_.[[PendingAsyncDependencies]] to _m_.[[PendingAsyncDependencies]] - 1.
+                      1. If _m_.[[PendingAsyncDependencies]] = 0, then
+                        1. Append _m_ to _execList_.
+                        1. If _m_.[[HasTLA]] is *false*, perform GatherAvailableAncestors(_m_, _execList_).
                 1. Return ~unused~.
               </emu-alg>
               <emu-note>

--- a/spec.html
+++ b/spec.html
@@ -26829,7 +26829,7 @@
                 a Cyclic Module Record or ~empty~
               </td>
               <td>
-                <p>This field is initially ~empty~. Once InnerModuleEvaluation runs on a module's strongly connected component withuot returning a throw completion, it's updated to be the first visited module of the SCC (the root DFS ancestor). For a module not in a cycle, this would be the module itself.</p>
+                <p>This field is initially ~empty~. Once InnerModuleEvaluation runs on a module's strongly connected component without returning a throw completion, it's updated to be the first visited module of the SCC (the root DFS ancestor). For a module not in a cycle, this would be the module itself.</p>
 
                 <p>Once this field is set, a module's [[DFSAncestorIndex]] is the depth-first traversal index of its [[CycleRoot]].</p>
               </td>


### PR DESCRIPTION
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)
* [WebAssembly](https://webassembly.github.io/spec/) - [file an issue](https://github.com/WebAssembly/spec/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->

Fixes https://github.com/tc39/ecma262/issues/3766. See https://github.com/tc39/ecma262/issues/3766#issuecomment-4083063686 for a more detailed analysis.

Marking this as normative as we did for https://github.com/tc39/ecma262/pull/3583, but (same as for that PR) this is aligning the spec with the commitee's desired behavior and thus does not need explicit consensus.

I checked V8's ans SM's implementations after writing this patch, and it seems like SM does exactly what this spec change does. V8 has a different but equivalent approach (it checks that the [[CycleRoot]] is not empty, and asserts that it being empty implies that the module errored, cc @o-).

cc @heimskr for your WebKit module loader rewrite.