### PR TITLE
Editorial: Define length of built-in accessor functions

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -29719,7 +29719,7 @@
   <p>Built-in function objects that are not identified as constructors do not implement the [[Construct]] internal method unless otherwise specified in the description of a particular function.</p>
   <p>Built-in function objects that are not constructors do not have a *"prototype"* property unless otherwise specified in the description of a particular function.</p>
   <p>Each built-in function defined in this specification is created by calling the CreateBuiltinFunction abstract operation (<emu-xref href="#sec-createbuiltinfunction"></emu-xref>). The values of the _length_ and _name_ parameters are the initial values of the *"length"* and *"name"* properties as discussed below. The values of the _prefix_ parameter are similarly discussed below.</p>
-  <p>Every built-in function object, including constructors, has a *"length"* property whose value is a non-negative integral Number. Unless otherwise specified, this value is the number of required parameters shown in the subclause heading for the function description. Optional parameters and rest parameters are not included in the parameter count.</p>
+  <p>Every built-in function object, including constructors, has a *"length"* property whose value is a non-negative integral Number. Unless otherwise specified, this value is the number of required parameters shown in the subclause heading for the function description. Optional parameters and rest parameters are not included in the parameter count. For built-in get accessor functions the value is always *+0*<sub>𝔽</sub>. For built-in set accessor functions the value is always *1*<sub>𝔽</sub>.</p>
   <emu-note>
     <p>For example, the function object that is the initial value of the *"map"* property of the Array prototype object is described under the subclause heading «Array.prototype.map (callback [ , thisArg])» which shows the two named arguments callback and thisArg, the latter being optional; therefore the value of the *"length"* property of that function object is *1*<sub>𝔽</sub>.</p>
   </emu-note>
@@ -30976,8 +30976,8 @@
         <p>`Object.prototype.__proto__` is an accessor property with attributes { [[Enumerable]]: *false*, [[Configurable]]: *true* }. The [[Get]] and [[Set]] attributes are defined as follows:</p>
 
         <emu-clause id="sec-get-object.prototype.__proto__">
-          <h1>get Object.prototype.__proto__</h1>
-          <p>The value of the [[Get]] attribute is a built-in function that requires no arguments. It performs the following steps when called:</p>
+          <h1>get Object.prototype.__proto__ ( )</h1>
+          <p>The value of the [[Get]] attribute is a built-in function that performs the following steps when called:</p>
           <emu-alg>
             1. Let _O_ be ? ToObject(*this* value).
             1. Return ? <emu-meta effects="user-code">_O_.[[GetPrototypeOf]]()</emu-meta>.
@@ -30985,8 +30985,8 @@
         </emu-clause>
 
         <emu-clause id="sec-set-object.prototype.__proto__">
-          <h1>set Object.prototype.__proto__</h1>
-          <p>The value of the [[Set]] attribute is a built-in function that takes an argument _proto_. It performs the following steps when called:</p>
+          <h1>set Object.prototype.__proto__ ( _proto_ )</h1>
+          <p>The value of the [[Set]] attribute is a built-in function that performs the following steps when called:</p>
           <emu-alg>
             1. Let _O_ be the *this* value.
             1. Perform ? RequireObjectCoercible(_O_).
@@ -31690,7 +31690,7 @@
       </emu-clause>
 
       <emu-clause id="sec-symbol.prototype.description">
-        <h1>get Symbol.prototype.description</h1>
+        <h1>get Symbol.prototype.description ( )</h1>
         <p>`Symbol.prototype.description` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _s_ be the *this* value.
@@ -38885,7 +38885,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause oldids="sec-get-regexp-@@species" id="sec-get-regexp-%symbol.species%">
-        <h1>get RegExp [ %Symbol.species% ]</h1>
+        <h1>get RegExp [ %Symbol.species% ] ( )</h1>
         <p>`RegExp[%Symbol.species%]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Return the *this* value.
@@ -38928,7 +38928,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-get-regexp.prototype.dotAll">
-        <h1>get RegExp.prototype.dotAll</h1>
+        <h1>get RegExp.prototype.dotAll ( )</h1>
         <p>`RegExp.prototype.dotAll` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _R_ be the *this* value.
@@ -38938,7 +38938,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-get-regexp.prototype.flags">
-        <h1>get RegExp.prototype.flags</h1>
+        <h1>get RegExp.prototype.flags ( )</h1>
         <p>`RegExp.prototype.flags` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _R_ be the *this* value.
@@ -38985,7 +38985,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-get-regexp.prototype.global">
-        <h1>get RegExp.prototype.global</h1>
+        <h1>get RegExp.prototype.global ( )</h1>
         <p>`RegExp.prototype.global` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _R_ be the *this* value.
@@ -38995,7 +38995,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-get-regexp.prototype.hasIndices">
-        <h1>get RegExp.prototype.hasIndices</h1>
+        <h1>get RegExp.prototype.hasIndices ( )</h1>
         <p>`RegExp.prototype.hasIndices` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _R_ be the *this* value.
@@ -39005,7 +39005,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-get-regexp.prototype.ignorecase">
-        <h1>get RegExp.prototype.ignoreCase</h1>
+        <h1>get RegExp.prototype.ignoreCase ( )</h1>
         <p>`RegExp.prototype.ignoreCase` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _R_ be the *this* value.
@@ -39068,7 +39068,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-get-regexp.prototype.multiline">
-        <h1>get RegExp.prototype.multiline</h1>
+        <h1>get RegExp.prototype.multiline ( )</h1>
         <p>`RegExp.prototype.multiline` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _R_ be the *this* value.
@@ -39172,7 +39172,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-get-regexp.prototype.source">
-        <h1>get RegExp.prototype.source</h1>
+        <h1>get RegExp.prototype.source ( )</h1>
         <p>`RegExp.prototype.source` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _R_ be the *this* value.
@@ -39286,7 +39286,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-get-regexp.prototype.sticky">
-        <h1>get RegExp.prototype.sticky</h1>
+        <h1>get RegExp.prototype.sticky ( )</h1>
         <p>`RegExp.prototype.sticky` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _R_ be the *this* value.
@@ -39324,7 +39324,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-get-regexp.prototype.unicode">
-        <h1>get RegExp.prototype.unicode</h1>
+        <h1>get RegExp.prototype.unicode ( )</h1>
         <p>`RegExp.prototype.unicode` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _R_ be the *this* value.
@@ -39334,7 +39334,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-get-regexp.prototype.unicodesets">
-        <h1>get RegExp.prototype.unicodeSets</h1>
+        <h1>get RegExp.prototype.unicodeSets ( )</h1>
         <p>`RegExp.prototype.unicodeSets` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _R_ be the *this* value.
@@ -39971,7 +39971,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause oldids="sec-get-array-@@species" id="sec-get-array-%symbol.species%">
-        <h1>get Array [ %Symbol.species% ]</h1>
+        <h1>get Array [ %Symbol.species% ] ( )</h1>
         <p>`Array[%Symbol.species%]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Return the *this* value.
@@ -41790,7 +41790,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause oldids="sec-get-%typedarray%-@@species" id="sec-get-%typedarray%-%symbol.species%">
-        <h1>get %TypedArray% [ %Symbol.species% ]</h1>
+        <h1>get %TypedArray% [ %Symbol.species% ] ( )</h1>
         <p>%TypedArray%`[%Symbol.species%]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Return the *this* value.
@@ -41829,7 +41829,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-get-%typedarray%.prototype.buffer">
-        <h1>get %TypedArray%.prototype.buffer</h1>
+        <h1>get %TypedArray%.prototype.buffer ( )</h1>
         <p>%TypedArray%`.prototype.buffer` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
@@ -41841,7 +41841,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-get-%typedarray%.prototype.bytelength">
-        <h1>get %TypedArray%.prototype.byteLength</h1>
+        <h1>get %TypedArray%.prototype.byteLength ( )</h1>
         <p>%TypedArray%`.prototype.byteLength` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
@@ -41855,7 +41855,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-get-%typedarray%.prototype.byteoffset">
-        <h1>get %TypedArray%.prototype.byteOffset</h1>
+        <h1>get %TypedArray%.prototype.byteOffset ( )</h1>
         <p>%TypedArray%`.prototype.byteOffset` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
@@ -42210,7 +42210,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-get-%typedarray%.prototype.length">
-        <h1>get %TypedArray%.prototype.length</h1>
+        <h1>get %TypedArray%.prototype.length ( )</h1>
         <p>%TypedArray%`.prototype.length` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
@@ -42661,7 +42661,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause oldids="sec-get-%typedarray%.prototype-@@tostringtag" id="sec-get-%typedarray%.prototype-%symbol.tostringtag%">
-        <h1>get %TypedArray%.prototype [ %Symbol.toStringTag% ]</h1>
+        <h1>get %TypedArray%.prototype [ %Symbol.toStringTag% ] ( )</h1>
         <p>%TypedArray%`.prototype[%Symbol.toStringTag%]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
@@ -43581,7 +43581,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause oldids="sec-get-map-@@species" id="sec-get-map-%symbol.species%">
-        <h1>get Map [ %Symbol.species% ]</h1>
+        <h1>get Map [ %Symbol.species% ] ( )</h1>
         <p>`Map[%Symbol.species%]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Return the *this* value.
@@ -43769,7 +43769,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-get-map.prototype.size">
-        <h1>get Map.prototype.size</h1>
+        <h1>get Map.prototype.size ( )</h1>
         <p>`Map.prototype.size` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _M_ be the *this* value.
@@ -44070,7 +44070,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause oldids="sec-get-set-@@species" id="sec-get-set-%symbol.species%">
-        <h1>get Set [ %Symbol.species% ]</h1>
+        <h1>get Set [ %Symbol.species% ] ( )</h1>
         <p>`Set[%Symbol.species%]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Return the *this* value.
@@ -44355,7 +44355,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-get-set.prototype.size">
-        <h1>get Set.prototype.size</h1>
+        <h1>get Set.prototype.size ( )</h1>
         <p>`Set.prototype.size` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _S_ be the *this* value.
@@ -45370,7 +45370,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause oldids="sec-get-arraybuffer-@@species" id="sec-get-arraybuffer-%symbol.species%">
-        <h1>get ArrayBuffer [ %Symbol.species% ]</h1>
+        <h1>get ArrayBuffer [ %Symbol.species% ] ( )</h1>
         <p>`ArrayBuffer[%Symbol.species%]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Return the *this* value.
@@ -45393,7 +45393,7 @@ THH:mm:ss.sss
       </ul>
 
       <emu-clause id="sec-get-arraybuffer.prototype.bytelength">
-        <h1>get ArrayBuffer.prototype.byteLength</h1>
+        <h1>get ArrayBuffer.prototype.byteLength ( )</h1>
         <p>`ArrayBuffer.prototype.byteLength` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
@@ -45411,7 +45411,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-get-arraybuffer.prototype.detached">
-        <h1>get ArrayBuffer.prototype.detached</h1>
+        <h1>get ArrayBuffer.prototype.detached ( )</h1>
         <p>`ArrayBuffer.prototype.detached` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
@@ -45422,7 +45422,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-get-arraybuffer.prototype.maxbytelength">
-        <h1>get ArrayBuffer.prototype.maxByteLength</h1>
+        <h1>get ArrayBuffer.prototype.maxByteLength ( )</h1>
         <p>`ArrayBuffer.prototype.maxByteLength` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
@@ -45438,7 +45438,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-get-arraybuffer.prototype.resizable">
-        <h1>get ArrayBuffer.prototype.resizable</h1>
+        <h1>get ArrayBuffer.prototype.resizable ( )</h1>
         <p>`ArrayBuffer.prototype.resizable` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
@@ -45710,7 +45710,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause oldids="sec-sharedarraybuffer-@@species" id="sec-sharedarraybuffer-%symbol.species%">
-        <h1>get SharedArrayBuffer [ %Symbol.species% ]</h1>
+        <h1>get SharedArrayBuffer [ %Symbol.species% ] ( )</h1>
         <p>`SharedArrayBuffer[%Symbol.species%]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Return the *this* value.
@@ -45730,7 +45730,7 @@ THH:mm:ss.sss
       </ul>
 
       <emu-clause id="sec-get-sharedarraybuffer.prototype.bytelength">
-        <h1>get SharedArrayBuffer.prototype.byteLength</h1>
+        <h1>get SharedArrayBuffer.prototype.byteLength ( )</h1>
         <p>`SharedArrayBuffer.prototype.byteLength` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
@@ -45780,7 +45780,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-get-sharedarraybuffer.prototype.growable">
-        <h1>get SharedArrayBuffer.prototype.growable</h1>
+        <h1>get SharedArrayBuffer.prototype.growable ( )</h1>
         <p>`SharedArrayBuffer.prototype.growable` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
@@ -45792,7 +45792,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-get-sharedarraybuffer.prototype.maxbytelength">
-        <h1>get SharedArrayBuffer.prototype.maxByteLength</h1>
+        <h1>get SharedArrayBuffer.prototype.maxByteLength ( )</h1>
         <p>`SharedArrayBuffer.prototype.maxByteLength` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
@@ -46124,7 +46124,7 @@ THH:mm:ss.sss
       </ul>
 
       <emu-clause id="sec-get-dataview.prototype.buffer">
-        <h1>get DataView.prototype.buffer</h1>
+        <h1>get DataView.prototype.buffer ( )</h1>
         <p>`DataView.prototype.buffer` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
@@ -46136,7 +46136,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-get-dataview.prototype.bytelength">
-        <h1>get DataView.prototype.byteLength</h1>
+        <h1>get DataView.prototype.byteLength ( )</h1>
         <p>`DataView.prototype.byteLength` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
@@ -46150,7 +46150,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-get-dataview.prototype.byteoffset">
-        <h1>get DataView.prototype.byteOffset</h1>
+        <h1>get DataView.prototype.byteOffset ( )</h1>
         <p>`DataView.prototype.byteOffset` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.
@@ -48405,16 +48405,16 @@ THH:mm:ss.sss
           <p>`Iterator.prototype.constructor` is an accessor property with attributes { [[Enumerable]]: *false*, [[Configurable]]: *true* }. The [[Get]] and [[Set]] attributes are defined as follows:</p>
 
           <emu-clause id="sec-get-iterator.prototype.constructor">
-            <h1>get Iterator.prototype.constructor</h1>
-            <p>The value of the [[Get]] attribute is a built-in function that requires no arguments. It performs the following steps when called:</p>
+            <h1>get Iterator.prototype.constructor ( )</h1>
+            <p>The value of the [[Get]] attribute is a built-in function that performs the following steps when called:</p>
             <emu-alg>
               1. Return %Iterator%.
             </emu-alg>
           </emu-clause>
 
           <emu-clause id="sec-set-iterator.prototype.constructor">
-            <h1>set Iterator.prototype.constructor</h1>
-            <p>The value of the [[Set]] attribute is a built-in function that takes an argument _v_. It performs the following steps when called:</p>
+            <h1>set Iterator.prototype.constructor ( _v_ )</h1>
+            <p>The value of the [[Set]] attribute is a built-in function that performs the following steps when called:</p>
             <emu-alg>
               1. Perform ? SetterThatIgnoresPrototypeProperties(*this* value, %Iterator.prototype%, *"constructor"*, _v_).
               1. Return *undefined*.
@@ -48733,16 +48733,16 @@ THH:mm:ss.sss
           <p>`Iterator.prototype[%Symbol.toStringTag%]` is an accessor property with attributes { [[Enumerable]]: *false*, [[Configurable]]: *true* }. The [[Get]] and [[Set]] attributes are defined as follows:</p>
 
           <emu-clause id="sec-get-iterator.prototype-%symbol.tostringtag%">
-            <h1>get Iterator.prototype [ %Symbol.toStringTag% ]</h1>
-            <p>The value of the [[Get]] attribute is a built-in function that requires no arguments. It performs the following steps when called:</p>
+            <h1>get Iterator.prototype [ %Symbol.toStringTag% ] ( )</h1>
+            <p>The value of the [[Get]] attribute is a built-in function that performs the following steps when called:</p>
             <emu-alg>
               1. Return *"Iterator"*.
             </emu-alg>
           </emu-clause>
 
           <emu-clause id="sec-set-iterator.prototype-%symbol.tostringtag%">
-            <h1>set Iterator.prototype [ %Symbol.toStringTag% ]</h1>
-            <p>The value of the [[Set]] attribute is a built-in function that takes an argument _v_. It performs the following steps when called:</p>
+            <h1>set Iterator.prototype [ %Symbol.toStringTag% ] ( _v_ )</h1>
+            <p>The value of the [[Set]] attribute is a built-in function that performs the following steps when called:</p>
             <emu-alg>
               1. Perform ? SetterThatIgnoresPrototypeProperties(*this* value, %Iterator.prototype%, %Symbol.toStringTag%, _v_).
               1. Return *undefined*.
@@ -49784,7 +49784,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause oldids="sec-get-promise-@@species" id="sec-get-promise-%symbol.species%">
-        <h1>get Promise [ %Symbol.species% ]</h1>
+        <h1>get Promise [ %Symbol.species% ] ( )</h1>
         <p>`Promise[%Symbol.species%]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Return the *this* value.


### PR DESCRIPTION
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)
* [WebAssembly](https://webassembly.github.io/spec/) - [file an issue](https://github.com/WebAssembly/spec/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->

Fixes https://github.com/tc39/ecma262/issues/3762. Marking as "normative" because it specifies something that was not previously specified.

Marking as draft because Ecmarkup does not recognize this syntax.

At some point we might want to `<dfn>` "accessor function", since it's used in a bunch of place.