### PR TITLE
Editorial: Reword loop in ValidateAndApplyPropertyDescriptor

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -12833,7 +12833,7 @@
               1. If _Desc_ has an [[Enumerable]] field, let _enumerable_ be _Desc_.[[Enumerable]]; else let _enumerable_ be _current_.[[Enumerable]].
               1. Replace the property named _P_ of object _O_ with a data property whose [[Configurable]] and [[Enumerable]] attributes are set to _configurable_ and _enumerable_, respectively, and whose [[Value]] and [[Writable]] attributes are set to the value of the corresponding field in _Desc_ if _Desc_ has that field, or to the attribute's <emu-xref href="#table-object-property-attributes">default value</emu-xref> otherwise.
             1. Else,
-              1. For each field of _Desc_, set the corresponding attribute of the property named _P_ of object _O_ to the value of the field.
+              1. For each field name _F_ of _Desc_, set the attribute named _F_ of the property named _P_ of object _O_ to the value of _Desc_'s _F_ field.
           1. Return *true*.
         </emu-alg>
       </emu-clause>


### PR DESCRIPTION
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)
* [WebAssembly](https://webassembly.github.io/spec/) - [file an issue](https://github.com/WebAssembly/spec/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->

Minor tweak to avoid a false positive when linting for re-declared parameters (ref https://github.com/tc39/ecmarkup/pull/679, https://github.com/tc39/ecma262/pull/3768)