### PR TITLE
Normative: use Numbers instead of reals as counters in Iterator builtins

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -49384,16 +49384,18 @@ THH:mm:ss.sss
             1. If _numberLimit_ is *NaN*, then
               1. Let _error_ be ThrowCompletion(a newly created *RangeError* object).
               1. Return ? IteratorClose(_iterated_, _error_).
+            1. If _numberLimit_ is finite and _numberLimit_ > 𝔽(2<sup>53</sup> - 1), then
+              1. Let _error_ be ThrowCompletion(a newly created *RangeError* object).
+              1. Return ? IteratorClose(_iterated_, _error_).
             1. Let _intLimit_ be ! ToIntegerOrInfinity(_numberLimit_).
             1. If _intLimit_ &lt; 0, then
               1. Let _error_ be ThrowCompletion(a newly created *RangeError* object).
               1. Return ? IteratorClose(_iterated_, _error_).
             1. Set _iterated_ to ? GetIteratorDirect(_obj_).
             1. Let _closure_ be a new Abstract Closure with no parameters that captures _iterated_ and _intLimit_ and performs the following steps when called:
-              1. Let _remaining_ be _intLimit_.
-              1. Repeat, while _remaining_ > 0,
-                1. If _remaining_ ≠ +∞, then
-                  1. Set _remaining_ to _remaining_ - 1.
+              1. Let _remaining_ be 𝔽(_intLimit_).
+              1. Repeat, while _remaining_ > *+0*<sub>𝔽</sub>,
+                1. Set _remaining_ to _remaining_ - *1*<sub>𝔽</sub>.
                 1. Let _next_ be ? IteratorStep(_iterated_).
                 1. If _next_ is ~done~, return ReturnCompletion(*undefined*).
               1. Repeat,
@@ -49418,14 +49420,15 @@ THH:mm:ss.sss
               1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
               1. Return ? IteratorClose(_iterated_, _error_).
             1. Set _iterated_ to ? GetIteratorDirect(_obj_).
-            1. Let _counter_ be 0.
+            1. Let _counter_ be *+0*<sub>𝔽</sub>.
             1. Repeat,
               1. Let _value_ be ? IteratorStepValue(_iterated_).
               1. If _value_ is ~done~, return *true*.
-              1. Let _result_ be Completion(Call(_predicate_, *undefined*, « _value_, 𝔽(_counter_) »)).
+              1. Let _result_ be Completion(Call(_predicate_, *undefined*, « _value_, _counter_ »)).
               1. IfAbruptCloseIterator(_result_, _iterated_).
               1. If ToBoolean(_result_) is *false*, return ? IteratorClose(_iterated_, NormalCompletion(*false*)).
-              1. Set _counter_ to _counter_ + 1.
+              1. NOTE: The following step will not change _counter_ once it reaches *2<sup>53</sup>*<sub>𝔽</sub>.
+              1. Set _counter_ to _counter_ + *1*<sub>𝔽</sub>.
           </emu-alg>
         </emu-clause>
 
@@ -49441,16 +49444,17 @@ THH:mm:ss.sss
               1. Return ? IteratorClose(_iterated_, _error_).
             1. Set _iterated_ to ? GetIteratorDirect(_obj_).
             1. Let _closure_ be a new Abstract Closure with no parameters that captures _iterated_ and _predicate_ and performs the following steps when called:
-              1. Let _counter_ be 0.
+              1. Let _counter_ be *+0*<sub>𝔽</sub>.
               1. Repeat,
                 1. Let _value_ be ? IteratorStepValue(_iterated_).
                 1. If _value_ is ~done~, return ReturnCompletion(*undefined*).
-                1. Let _selected_ be Completion(Call(_predicate_, *undefined*, « _value_, 𝔽(_counter_) »)).
+                1. Let _selected_ be Completion(Call(_predicate_, *undefined*, « _value_, _counter_ »)).
                 1. IfAbruptCloseIterator(_selected_, _iterated_).
                 1. If ToBoolean(_selected_) is *true*, then
                   1. Let _completion_ be Completion(Yield(_value_)).
                   1. IfAbruptCloseIterator(_completion_, _iterated_).
-                1. Set _counter_ to _counter_ + 1.
+                1. NOTE: The following step will not change _counter_ once it reaches *2<sup>53</sup>*<sub>𝔽</sub>.
+                1. Set _counter_ to _counter_ + *1*<sub>𝔽</sub>.
             1. Let _result_ be CreateIteratorFromClosure(_closure_, *"Iterator Helper"*, %IteratorHelperPrototype%, « [[UnderlyingIterators]] »).
             1. Set _result_.[[UnderlyingIterators]] to « _iterated_ ».
             1. Return _result_.
@@ -49468,14 +49472,15 @@ THH:mm:ss.sss
               1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
               1. Return ? IteratorClose(_iterated_, _error_).
             1. Set _iterated_ to ? GetIteratorDirect(_obj_).
-            1. Let _counter_ be 0.
+            1. Let _counter_ be *+0*<sub>𝔽</sub>.
             1. Repeat,
               1. Let _value_ be ? IteratorStepValue(_iterated_).
               1. If _value_ is ~done~, return *undefined*.
-              1. Let _result_ be Completion(Call(_predicate_, *undefined*, « _value_, 𝔽(_counter_) »)).
+              1. Let _result_ be Completion(Call(_predicate_, *undefined*, « _value_, _counter_ »)).
               1. IfAbruptCloseIterator(_result_, _iterated_).
               1. If ToBoolean(_result_) is *true*, return ? IteratorClose(_iterated_, NormalCompletion(_value_)).
-              1. Set _counter_ to _counter_ + 1.
+              1. NOTE: The following step will not change _counter_ once it reaches *2<sup>53</sup>*<sub>𝔽</sub>.
+              1. Set _counter_ to _counter_ + *1*<sub>𝔽</sub>.
           </emu-alg>
         </emu-clause>
 
@@ -49491,11 +49496,11 @@ THH:mm:ss.sss
               1. Return ? IteratorClose(_iterated_, _error_).
             1. Set _iterated_ to ? GetIteratorDirect(_obj_).
             1. Let _closure_ be a new Abstract Closure with no parameters that captures _iterated_ and _mapper_ and performs the following steps when called:
-              1. Let _counter_ be 0.
+              1. Let _counter_ be *+0*<sub>𝔽</sub>.
               1. Repeat,
                 1. Let _value_ be ? IteratorStepValue(_iterated_).
                 1. If _value_ is ~done~, return ReturnCompletion(*undefined*).
-                1. Let _mapped_ be Completion(Call(_mapper_, *undefined*, « _value_, 𝔽(_counter_) »)).
+                1. Let _mapped_ be Completion(Call(_mapper_, *undefined*, « _value_, _counter_ »)).
                 1. IfAbruptCloseIterator(_mapped_, _iterated_).
                 1. Let _innerIterator_ be Completion(GetIteratorFlattenable(_mapped_, ~reject-primitives~)).
                 1. IfAbruptCloseIterator(_innerIterator_, _iterated_).
@@ -49511,7 +49516,8 @@ THH:mm:ss.sss
                       1. Let _backupCompletion_ be Completion(IteratorClose(_innerIterator_, _completion_)).
                       1. IfAbruptCloseIterator(_backupCompletion_, _iterated_).
                       1. Return ? IteratorClose(_iterated_, _completion_).
-                1. Set _counter_ to _counter_ + 1.
+                1. NOTE: The following step will not change _counter_ once it reaches *2<sup>53</sup>*<sub>𝔽</sub>.
+                1. Set _counter_ to _counter_ + *1*<sub>𝔽</sub>.
             1. Let _result_ be CreateIteratorFromClosure(_closure_, *"Iterator Helper"*, %IteratorHelperPrototype%, « [[UnderlyingIterators]] »).
             1. Set _result_.[[UnderlyingIterators]] to « _iterated_ ».
             1. Return _result_.
@@ -49529,13 +49535,14 @@ THH:mm:ss.sss
               1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
               1. Return ? IteratorClose(_iterated_, _error_).
             1. Set _iterated_ to ? GetIteratorDirect(_obj_).
-            1. Let _counter_ be 0.
+            1. Let _counter_ be *+0*<sub>𝔽</sub>.
             1. Repeat,
               1. Let _value_ be ? IteratorStepValue(_iterated_).
               1. If _value_ is ~done~, return *undefined*.
-              1. Let _result_ be Completion(Call(_procedure_, *undefined*, « _value_, 𝔽(_counter_) »)).
+              1. Let _result_ be Completion(Call(_procedure_, *undefined*, « _value_, _counter_ »)).
               1. IfAbruptCloseIterator(_result_, _iterated_).
-              1. Set _counter_ to _counter_ + 1.
+              1. NOTE: The following step will not change _counter_ once it reaches *2<sup>53</sup>*<sub>𝔽</sub>.
+              1. Set _counter_ to _counter_ + *1*<sub>𝔽</sub>.
           </emu-alg>
         </emu-clause>
 
@@ -49551,15 +49558,16 @@ THH:mm:ss.sss
               1. Return ? IteratorClose(_iterated_, _error_).
             1. Set _iterated_ to ? GetIteratorDirect(_obj_).
             1. Let _closure_ be a new Abstract Closure with no parameters that captures _iterated_ and _mapper_ and performs the following steps when called:
-              1. Let _counter_ be 0.
+              1. Let _counter_ be *+0*<sub>𝔽</sub>.
               1. Repeat,
                 1. Let _value_ be ? IteratorStepValue(_iterated_).
                 1. If _value_ is ~done~, return ReturnCompletion(*undefined*).
-                1. Let _mapped_ be Completion(Call(_mapper_, *undefined*, « _value_, 𝔽(_counter_) »)).
+                1. Let _mapped_ be Completion(Call(_mapper_, *undefined*, « _value_, _counter_ »)).
                 1. IfAbruptCloseIterator(_mapped_, _iterated_).
                 1. Let _completion_ be Completion(Yield(_mapped_)).
                 1. IfAbruptCloseIterator(_completion_, _iterated_).
-                1. Set _counter_ to _counter_ + 1.
+                1. NOTE: The following step will not change _counter_ once it reaches *2<sup>53</sup>*<sub>𝔽</sub>.
+                1. Set _counter_ to _counter_ + *1*<sub>𝔽</sub>.
             1. Let _result_ be CreateIteratorFromClosure(_closure_, *"Iterator Helper"*, %IteratorHelperPrototype%, « [[UnderlyingIterators]] »).
             1. Set _result_.[[UnderlyingIterators]] to « _iterated_ ».
             1. Return _result_.
@@ -49580,17 +49588,18 @@ THH:mm:ss.sss
             1. If _initialValue_ is not present, then
               1. Let _accumulator_ be ? IteratorStepValue(_iterated_).
               1. If _accumulator_ is ~done~, throw a *TypeError* exception.
-              1. Let _counter_ be 1.
+              1. Let _counter_ be *1*<sub>𝔽</sub>.
             1. Else,
               1. Let _accumulator_ be _initialValue_.
-              1. Let _counter_ be 0.
+              1. Let _counter_ be *+0*<sub>𝔽</sub>.
             1. Repeat,
               1. Let _value_ be ? IteratorStepValue(_iterated_).
               1. If _value_ is ~done~, return _accumulator_.
-              1. Let _result_ be Completion(Call(_reducer_, *undefined*, « _accumulator_, _value_, 𝔽(_counter_) »)).
+              1. Let _result_ be Completion(Call(_reducer_, *undefined*, « _accumulator_, _value_, _counter_ »)).
               1. IfAbruptCloseIterator(_result_, _iterated_).
               1. Set _accumulator_ to _result_.
-              1. Set _counter_ to _counter_ + 1.
+              1. NOTE: The following step will not change _counter_ once it reaches *2<sup>53</sup>*<sub>𝔽</sub>.
+              1. Set _counter_ to _counter_ + *1*<sub>𝔽</sub>.
           </emu-alg>
         </emu-clause>
 
@@ -49605,14 +49614,15 @@ THH:mm:ss.sss
               1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
               1. Return ? IteratorClose(_iterated_, _error_).
             1. Set _iterated_ to ? GetIteratorDirect(_obj_).
-            1. Let _counter_ be 0.
+            1. Let _counter_ be *+0*<sub>𝔽</sub>.
             1. Repeat,
               1. Let _value_ be ? IteratorStepValue(_iterated_).
               1. If _value_ is ~done~, return *false*.
-              1. Let _result_ be Completion(Call(_predicate_, *undefined*, « _value_, 𝔽(_counter_) »)).
+              1. Let _result_ be Completion(Call(_predicate_, *undefined*, « _value_, _counter_ »)).
               1. IfAbruptCloseIterator(_result_, _iterated_).
               1. If ToBoolean(_result_) is *true*, return ? IteratorClose(_iterated_, NormalCompletion(*true*)).
-              1. Set _counter_ to _counter_ + 1.
+              1. NOTE: The following step will not change _counter_ once it reaches *2<sup>53</sup>*<sub>𝔽</sub>.
+              1. Set _counter_ to _counter_ + *1*<sub>𝔽</sub>.
           </emu-alg>
         </emu-clause>
 
@@ -49628,18 +49638,20 @@ THH:mm:ss.sss
             1. If _numberLimit_ is *NaN*, then
               1. Let _error_ be ThrowCompletion(a newly created *RangeError* object).
               1. Return ? IteratorClose(_iterated_, _error_).
+            1. If _numberLimit_ is finite and _numberLimit_ > 𝔽(2<sup>53</sup> - 1), then
+              1. Let _error_ be ThrowCompletion(a newly created *RangeError* object).
+              1. Return ? IteratorClose(_iterated_, _error_).
             1. Let _intLimit_ be ! ToIntegerOrInfinity(_numberLimit_).
             1. If _intLimit_ &lt; 0, then
               1. Let _error_ be ThrowCompletion(a newly created *RangeError* object).
               1. Return ? IteratorClose(_iterated_, _error_).
             1. Set _iterated_ to ? GetIteratorDirect(_obj_).
             1. Let _closure_ be a new Abstract Closure with no parameters that captures _iterated_ and _intLimit_ and performs the following steps when called:
-              1. Let _remaining_ be _intLimit_.
+              1. Let _remaining_ be 𝔽(_intLimit_).
               1. Repeat,
-                1. If _remaining_ = 0, then
+                1. If _remaining_ is *+0*<sub>𝔽</sub>, then
                   1. Return ? IteratorClose(_iterated_, ReturnCompletion(*undefined*)).
-                1. If _remaining_ ≠ +∞, then
-                  1. Set _remaining_ to _remaining_ - 1.
+                1. Set _remaining_ to _remaining_ - *1*<sub>𝔽</sub>.
                 1. Let _value_ be ? IteratorStepValue(_iterated_).
                 1. If _value_ is ~done~, return ReturnCompletion(*undefined*).
                 1. Let _completion_ be Completion(Yield(_value_)).


### PR DESCRIPTION
All known engines are currently non-compliant. If they use Numbers as counters today, they'll stop advancing at 2<sup>53</sup>. So counters passed to user-provided callbacks will always be 2<sup>53</sup> once they reach that point and take/drop will behave as if Infinity was passed. With this change, internal counters are now Numbers, so the argument passed to user-provided callbacks is expected to repeat at 2<sup>53</sup> (matching implementations today). In addition, take/drop throw a RangeError on finite inputs ≥ 2<sup>53</sup>.

See https://github.com/tc39/proposal-iterator-includes/issues/12 for context.