### PR TITLE
Editorial: manually adjust table column widths for better balance

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -3,12 +3,6 @@
 <meta charset="utf-8">
 <link rel="icon" href="img/favicon.ico">
 <style>
-  .unicode-property-table {
-    table-layout: fixed;
-    width: 100%;
-    font-size: 80%;
-  }
-
   #metadata-block {
     margin: 4em 0;
     padding: 10px;
@@ -111,16 +105,6 @@
   /* 29.X extremely long note */
   #sec-shared-memory-guidelines > emu-note {
     break-inside: auto;
-  }
-
-  .unicode-property-table {
-    table-layout: initial;
-    width: auto;
-    font-size: 90%;
-  }
-
-  .unicode-property-table th:first-of-type {
-    width: 33%;
   }
 
   .corner-cell {
@@ -2862,7 +2846,7 @@
                 <th>Types of property for which it is present</th>
                 <th>Value Domain</th>
                 <th>Default Value</th>
-                <th>Description</th>
+                <th style="width: 40%">Description</th>
               </tr>
             </thead>
             <tr>
@@ -3006,7 +2990,7 @@
                 <th>
                   Signature
                 </th>
-                <th>
+                <th style="width: 50%">
                   Description
                 </th>
               </tr>
@@ -3145,7 +3129,7 @@
                 <th>
                   Signature
                 </th>
-                <th>
+                <th style="width: 60%">
                   Description
                 </th>
               </tr>
@@ -4360,7 +4344,7 @@
             <tr>
               <th>Field Name</th>
               <th>Value</th>
-              <th>Meaning</th>
+              <th style="width: 50%">Meaning</th>
             </tr>
           </thead>
           <tr>
@@ -4820,7 +4804,7 @@
               <th>
                 Field Name
               </th>
-              <th>
+              <th style="width: 20%">
                 Values of the [[Kind]] field for which it is present
               </th>
               <th>
@@ -10162,7 +10146,7 @@
               <th>
                 Method
               </th>
-              <th>
+              <th style="width: 40%">
                 Purpose
               </th>
               <th>
@@ -10778,7 +10762,7 @@
                 <th>
                   Value
                 </th>
-                <th>
+                <th style="width: 50%">
                   Meaning
                 </th>
               </tr>
@@ -10924,7 +10908,7 @@
                 <th>
                   Value
                 </th>
-                <th>
+                <th style="width: 50%">
                   Meaning
                 </th>
               </tr>
@@ -11535,7 +11519,7 @@
             <th>
               Value Type
             </th>
-            <th>
+            <th style="width: 50%">
               Meaning
             </th>
           </tr>
@@ -11785,7 +11769,7 @@
             <th>
               Component
             </th>
-            <th>
+            <th style="width: 70%">
               Purpose
             </th>
           </tr>
@@ -12194,7 +12178,7 @@
           <tr>
             <th>Field Name</th>
             <th>Value</th>
-            <th>Meaning</th>
+            <th style="width: 50%">Meaning</th>
           </tr>
         </thead>
         <tr>
@@ -13155,7 +13139,7 @@
             <th>
               Type
             </th>
-            <th>
+            <th style="width: 50%">
               Description
             </th>
           </tr>
@@ -14041,7 +14025,7 @@
               <th>
                 Type
               </th>
-              <th>
+              <th style="width: 50%">
                 Description
               </th>
             </tr>
@@ -15120,7 +15104,7 @@
               <th>
                 Type
               </th>
-              <th>
+              <th style="width: 60%">
                 Description
               </th>
             </tr>
@@ -22608,7 +22592,7 @@
                   <th>
                     Type
                   </th>
-                  <th>
+                  <th style="width: 60%">
                     Description
                   </th>
                 </tr>
@@ -26048,7 +26032,7 @@
               <th>
                 Value Type
               </th>
-              <th>
+              <th style="width: 50%">
                 Meaning
               </th>
             </tr>
@@ -26586,7 +26570,7 @@
                 <th>
                   Value Type
                 </th>
-                <th>
+                <th style="width: 50%">
                   Meaning
                 </th>
               </tr>
@@ -26644,7 +26628,7 @@
                 <th>
                   Method
                 </th>
-                <th>
+                <th style="width: 40%">
                   Purpose
                 </th>
                 <th>
@@ -26761,7 +26745,7 @@
                 <th>
                   Value Type
                 </th>
-                <th>
+                <th style="width: 50%">
                   Meaning
                 </th>
               </tr>
@@ -26897,7 +26881,7 @@
                 <th>
                   Method
                 </th>
-                <th>
+                <th style="width: 40%">
                   Purpose
                 </th>
                 <th>
@@ -26943,7 +26927,7 @@
                 <th>
                   Value Type
                 </th>
-                <th>
+                <th style="width: 50%">
                   Meaning
                 </th>
               </tr>
@@ -27916,7 +27900,7 @@
                 <th>
                   Value Type
                 </th>
-                <th>
+                <th style="width: 50%">
                   Meaning
                 </th>
               </tr>
@@ -28011,7 +27995,7 @@
                 <th>
                   Value Type
                 </th>
-                <th>
+                <th style="width: 60%">
                   Meaning
                 </th>
               </tr>
@@ -28149,7 +28133,7 @@
                 <th>
                   Value Type
                 </th>
-                <th>
+                <th style="width: 50%">
                   Meaning
                 </th>
               </tr>
@@ -28680,7 +28664,7 @@
               <tr>
                 <th>Field Name</th>
                 <th>Value Type</th>
-                <th>Meaning</th>
+                <th style="width: 60%">Meaning</th>
               </tr>
             </thead>
             <tr>
@@ -45893,7 +45877,7 @@ THH:mm:ss.sss
                 <th>
                   Value
                 </th>
-                <th>
+                <th style="width: 50%">
                   Meaning
                 </th>
               </tr>
@@ -46426,7 +46410,7 @@ THH:mm:ss.sss
               <th>
                 Value
               </th>
-              <th>
+              <th style="width: 50%">
                 Meaning
               </th>
             </tr>
@@ -46493,7 +46477,7 @@ THH:mm:ss.sss
               <th>
                 Value
               </th>
-              <th>
+              <th style="width: 60%">
                 Meaning
               </th>
             </tr>
@@ -47404,7 +47388,7 @@ THH:mm:ss.sss
               <tr>
                 <th>Field Name</th>
                 <th>Value</th>
-                <th>Meaning</th>
+                <th style="width: 50%">Meaning</th>
               </tr>
             </thead>
             <tr>
@@ -48037,7 +48021,7 @@ THH:mm:ss.sss
                 <th>
                   Value
                 </th>
-                <th>
+                <th style="width: 70%">
                   Requirements
                 </th>
               </tr>
@@ -48068,7 +48052,7 @@ THH:mm:ss.sss
                 <th>
                   Value
                 </th>
-                <th>
+                <th style="width: 70%">
                   Requirements
                 </th>
               </tr>
@@ -48132,7 +48116,7 @@ THH:mm:ss.sss
               <tr>
                 <th>Property</th>
                 <th>Value</th>
-                <th>Requirements</th>
+                <th style="width: 70%">Requirements</th>
               </tr>
             </thead>
             <tr>
@@ -48155,7 +48139,7 @@ THH:mm:ss.sss
               <tr>
                 <th>Property</th>
                 <th>Value</th>
-                <th>Requirements</th>
+                <th style="width: 70%">Requirements</th>
               </tr>
             </thead>
             <tr>
@@ -48196,7 +48180,7 @@ THH:mm:ss.sss
                 <th>
                   Value
                 </th>
-                <th>
+                <th style="width: 70%">
                   Requirements
                 </th>
               </tr>
@@ -49068,7 +49052,7 @@ THH:mm:ss.sss
                 <th>
                   Value
                 </th>
-                <th>
+                <th style="width: 60%">
                   Meaning
                 </th>
               </tr>
@@ -49932,7 +49916,7 @@ THH:mm:ss.sss
               <th>
                 Type
               </th>
-              <th>
+              <th style="width: 50%">
                 Description
               </th>
             </tr>
@@ -50274,7 +50258,7 @@ THH:mm:ss.sss
               <th>
                 Type
               </th>
-              <th>
+              <th style="width: 50%">
                 Description
               </th>
             </tr>
@@ -51374,7 +51358,7 @@ THH:mm:ss.sss
           <tr>
             <th>Field Name</th>
             <th>Value</th>
-            <th>Meaning</th>
+            <th style="width: 60%">Meaning</th>
           </tr>
         </thead>
         <tr>
@@ -51411,7 +51395,7 @@ THH:mm:ss.sss
           <tr>
             <th>Field Name</th>
             <th>Value</th>
-            <th>Meaning</th>
+            <th style="width: 60%">Meaning</th>
           </tr>
         </thead>
         <tr>
@@ -51453,7 +51437,7 @@ THH:mm:ss.sss
           <tr>
             <th>Field Name</th>
             <th>Value</th>
-            <th>Meaning</th>
+            <th style="width: 60%">Meaning</th>
           </tr>
         </thead>
         <tr>
@@ -51542,7 +51526,7 @@ THH:mm:ss.sss
           <tr>
             <th>Field Name</th>
             <th>Value</th>
-            <th>Meaning</th>
+            <th style="width: 60%">Meaning</th>
           </tr>
         </thead>
         <tr>
@@ -51568,7 +51552,7 @@ THH:mm:ss.sss
           <tr>
             <th>Field Name</th>
             <th>Value</th>
-            <th>Meaning</th>
+            <th style="width: 60%">Meaning</th>
           </tr>
         </thead>
         <tr>

--- a/table-binary-unicode-properties-of-strings.html
+++ b/table-binary-unicode-properties-of-strings.html
@@ -1,6 +1,6 @@
 <emu-table id="table-binary-unicode-properties-of-strings">
   <emu-caption>Binary Unicode properties of strings</emu-caption>
-  <table class="real-table unicode-property-table">
+  <table>
     <thead>
       <tr>
         <th><emu-not-ref>Property name</emu-not-ref></th>

--- a/table-binary-unicode-properties.html
+++ b/table-binary-unicode-properties.html
@@ -1,6 +1,6 @@
 <emu-table id="table-binary-unicode-properties">
   <emu-caption>Binary Unicode property aliases and their canonical <emu-not-ref>property names</emu-not-ref></emu-caption>
-  <table class="real-table unicode-property-table">
+  <table>
     <thead>
       <tr>
         <th><emu-not-ref>Property name and aliases</emu-not-ref></th>

--- a/table-nonbinary-unicode-properties.html
+++ b/table-nonbinary-unicode-properties.html
@@ -1,6 +1,6 @@
 <emu-table id="table-nonbinary-unicode-properties">
   <emu-caption>Non-binary Unicode property aliases and their canonical <emu-not-ref>property names</emu-not-ref></emu-caption>
-  <table class="real-table unicode-property-table">
+  <table>
     <thead>
       <tr>
         <th><emu-not-ref>Property name and aliases</emu-not-ref></th>


### PR DESCRIPTION
Fixes #3747. I don't love the approach, but it seems to work well. It's unfortunate that the browsers don't just balance table columns better on their own. Also, did you know there's 97 tables?! I didn't.

For review, just go to the rendered diff, inspect the `<th>` and toggle the manual style off/on.