### PR TITLE
Editorial: allow [[AsyncEvaluationOrder]] to have any value when errored

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -26873,7 +26873,7 @@
                 ~unset~, an integer, or ~done~
               </td>
               <td>
-                This field is initially set to ~unset~, and remains ~unset~ for fully synchronous modules. For modules that are either themselves asynchronous or have an asynchronous dependency, it is set to an integer that determines the order in which execution of pending modules is queued by <emu-xref href="#sec-async-module-execution-fulfilled"></emu-xref>. Once the pending module is executed, the field is set to ~done~.
+                This field is initially set to ~unset~, and remains ~unset~ for fully synchronous modules. For modules that are either themselves asynchronous or have an asynchronous dependency, it is set to an integer that determines the order in which execution of pending modules is queued by <emu-xref href="#sec-async-module-execution-fulfilled"></emu-xref>. Once the pending module is successfully executed, the field is set to ~done~.
               </td>
             </tr>
             <tr>
@@ -27224,7 +27224,6 @@
               1. If _result_ is an abrupt completion, then
                 1. For each Cyclic Module Record _m_ of _stack_, do
                   1. Assert: _m_.[[Status]] is ~evaluating~.
-                  1. Assert: _m_.[[AsyncEvaluationOrder]] is ~unset~.
                   1. Set _m_.[[Status]] to ~evaluated~.
                   1. Set _m_.[[EvaluationError]] to _result_.
                 1. Assert: _module_.[[Status]] is ~evaluated~.


### PR DESCRIPTION
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)
* [WebAssembly](https://webassembly.github.io/spec/) - [file an issue](https://github.com/WebAssembly/spec/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->

Fixes https://github.com/tc39/ecma262/pull/3613#issuecomment-4128203391. 

[[AsyncEvaluationOrder]] is only use/used for non-yet evaluated modules.

- `~DONE~` was added to distinguish the "not an integer and never was" case an assertion (https://github.com/tc39/ecma262/pull/3613#issuecomment-4128203391) from "not an integer anymore" case (before we would just transition back from an integer to UNSET, or from **true** to **false** when using booleans). The goal of that assertion was to assert that "when we start executing an async module, we never tried to execute it before": leaving [[AsyncEvaluationOrder]] as an integer still fulfills that goal.
- it is possible we can now leave [[AsyncEvaluationOrder]] as an integer forever also for non-error cases. Historically that was not possible because Evaluate() checked if the root module was still pending by checking that [[AsyncEvaluation]] was **false** (which, after the rewrite to [[AsyncEvaluationOrder]], would be equivalent to "[[AsyncEvaluationOrder]] is not an integer"), but now it's just checking that [[Status]] is EVALUATED. 
  - This would be a follow up if we want to do it.