### PR TITLE
Editorial: move non-normative statements about CRLF to a note

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -16646,7 +16646,7 @@
         </tr>
       </table>
     </emu-table>
-    <p>Only the Unicode code points in <emu-xref href="#table-line-terminator-code-points"></emu-xref> are treated as line terminators. Other new line or line breaking Unicode code points are not treated as line terminators but are treated as white space if they meet the requirements listed in <emu-xref href="#table-white-space-code-points"></emu-xref>. The sequence &lt;CR>&lt;LF> is commonly used as a line terminator. It should be considered a single |SourceCharacter| for the purpose of reporting line numbers.</p>
+    <p>Only the Unicode code points in <emu-xref href="#table-line-terminator-code-points"></emu-xref> are treated as line terminators. Other new line or line breaking Unicode code points are not treated as line terminators but are treated as white space if they meet the requirements listed in <emu-xref href="#table-white-space-code-points"></emu-xref>.</p>
     <h2>Syntax</h2>
     <emu-grammar type="definition">
       LineTerminator ::
@@ -16662,6 +16662,9 @@
         &lt;PS&gt;
         &lt;CR&gt; &lt;LF&gt;
     </emu-grammar>
+    <emu-note>
+      <p>The production <emu-grammar>LineTerminatorSequence :: &lt;CR>&lt;LF></emu-grammar> matches a sequence of code points that should collectively operate as a single line terminator, such as when reporting line numbers in diagnostics.</p>
+    </emu-note>
   </emu-clause>
 
   <emu-clause id="sec-comments">

--- a/spec.html
+++ b/spec.html
@@ -16663,7 +16663,7 @@
         &lt;CR&gt; &lt;LF&gt;
     </emu-grammar>
     <emu-note>
-      <p>The production <emu-grammar>LineTerminatorSequence :: &lt;CR>&lt;LF></emu-grammar> matches a sequence of code points that should collectively operate as a single line terminator, such as when reporting line numbers in diagnostics.</p>
+      <p>The production <emu-grammar>LineTerminatorSequence :: &lt;CR&gt; &lt;LF&gt;</emu-grammar> matches a sequence of code points that should collectively operate as a single line terminator, such as when reporting line numbers in diagnostics.</p>
     </emu-note>
   </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -17054,7 +17054,7 @@
         </tr>
       </table>
     </emu-table>
-    <p>Only the Unicode code points in <emu-xref href="#table-line-terminator-code-points"></emu-xref> are treated as line terminators. Other new line or line breaking Unicode code points are not treated as line terminators but are treated as white space if they meet the requirements listed in <emu-xref href="#table-white-space-code-points"></emu-xref>. The sequence &lt;CR>&lt;LF> is commonly used as a line terminator. It should be considered a single |SourceCharacter| for the purpose of reporting line numbers.</p>
+    <p>Only the Unicode code points in <emu-xref href="#table-line-terminator-code-points"></emu-xref> are treated as line terminators. Other new line or line breaking Unicode code points are not treated as line terminators but are treated as white space if they meet the requirements listed in <emu-xref href="#table-white-space-code-points"></emu-xref>.</p>
     <h2>Syntax</h2>
     <emu-grammar type="definition">
       LineTerminator ::
@@ -17070,6 +17070,9 @@
         &lt;PS&gt;
         &lt;CR&gt; &lt;LF&gt;
     </emu-grammar>
+    <emu-note>
+      <p>The production <emu-grammar>LineTerminatorSequence :: &lt;CR&gt; &lt;LF&gt;</emu-grammar> matches a sequence of code points that should collectively operate as a single line terminator, such as when reporting line numbers in diagnostics.</p>
+    </emu-note>
   </emu-clause>
 
   <emu-clause id="sec-comments">


### PR DESCRIPTION
Also clarified that it's not a "single |SourceCharacter|", whatever that means. It's a single logical line terminator.