### PR TITLE
Editorial: remove incorrect note about [[NoTear]]

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -52131,7 +52131,6 @@ THH:mm:ss.sss
       </emu-alg>
 
       <emu-note>
-        <p>A Shared Data Block event's [[NoTear]] field is *true* when that event was introduced via accessing an integer TypedArray, and *false* when introduced via accessing a floating point TypedArray or DataView.</p>
         <p>Intuitively, this requirement says when a memory range is accessed in an aligned fashion via an integer TypedArray, a single write event on that range must "win" when in a data race with other write events with equal ranges. More precisely, this requirement says an aligned read event cannot read a value composed of bytes from multiple, different write events all with equal ranges. It is possible, however, for an aligned read event to read from multiple write events with overlapping ranges.</p>
       </emu-note>
     </emu-clause>


### PR DESCRIPTION
A Shared Data Block event's `[[NoTear]]` field is typically (but not always) determined by `IsNoTearConfiguration`. This operation returns false for `Uint8ClampedArray`s and *sometimes* for `BigInt64Array`/`BigUint64Array`, depending on order. So this note is just disconnected from reality and should be removed.