### PR TITLE
Editorial: [[HomeObject]] can be undefined

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -13284,7 +13284,7 @@
             [[HomeObject]]
           </td>
           <td>
-            an Object
+            an Object or *undefined*
           </td>
           <td>
             If the function uses `super`, this is the object whose [[GetPrototypeOf]] provides the object where `super` property lookups begin.


### PR DESCRIPTION
See, for example, `OrdinaryFunctionCreate` or `HasSuperBinding` on function environment records.