### PR TITLE
Meta: use gh-action-mutex in the pr-preview action

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -63,6 +63,10 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Acquire mutex
+        uses: ben-z/gh-action-mutex@v1.0.0-alpha.10
+        with:
+          branch: pr-preview-mutex
       - name: Remove 'request preview' label
         if: github.event.action == 'labeled' && github.event.label.name == 'request preview'
         uses: actions/github-script@v7


### PR DESCRIPTION
This will avoid the problem where the PR preview push to gh-pages fails when multiple PRs are running through CI at the same time. Now they will queue up and run in sequence.