### PR TITLE
Editorial: Introduce an operation for backing To{Int,Uint}{8,16,32} and To{BigInt,BigUint}64

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -5317,6 +5317,30 @@
       </emu-note>
     </emu-clause>
 
+    <emu-clause id="sec-tofixedsizeinteger" type="abstract operation">
+      <h1>
+        ToFixedSizeInteger (
+          _int_: an integer, +∞, or -∞,
+          _signed_: ~unsigned~ or ~signed~,
+          _bitWidth_: a positive integer,
+        ): an integer
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It maps _int_ to one of 2<sup>_bitWidth_</sup> integers in the inclusive interval from 0 to 2<sup>_bitWidth_</sup> - 1 (if _signed_ is ~unsigned~) or -2<sup>_bitWidth_ - 1</sup> to 2<sup>_bitWidth_ - 1</sup> - 1 (if _signed_ is ~signed~).</dd>
+      </dl>
+      <emu-alg>
+        1. If _int_ = +∞ or _int_ = -∞, return 0.
+        1. Let _fixedInt_ be _int_ modulo 2<sup>_bitWidth_</sup>.
+        1. NOTE: The following step does not change the two's complement representation of _fixedInt_.
+        1. If _signed_ is ~signed~ and _fixedInt_ ≥ 2<sup>_bitWidth_ - 1</sup>, set _fixedInt_ to _fixedInt_ - 2<sup>_bitWidth_</sup>.
+        1. Return _fixedInt_.
+      </emu-alg>
+      <emu-note>
+        <p>ToFixedSizeInteger is idempotent: for any ECMAScript language value _x_, ToFixedSizeInteger(ToFixedSizeInteger(_x_, _signed_, _bitWidth_), _signed_, _bitWidth_) is the same as ToFixedSizeInteger(_x_, _signed_, _bitWidth_). In fact, because +∞ and -∞ are mapped to 0, this invariant even survives inversion of _signed_ (e.g., ToFixedSizeInteger(ToFixedSizeInteger(_x_, ~signed~, 32), ~unsigned~, 32) is the same as ToFixedSizeInteger(_x_, ~unsigned~, 32)).</p>
+      </emu-note>
+    </emu-clause>
+
     <emu-clause id="sec-toint32" type="abstract operation">
       <h1>
         ToInt32 (
@@ -5325,29 +5349,12 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It converts _argument_ to one of 2<sup>32</sup> integral Number values in the inclusive interval from 𝔽(-2<sup>31</sup>) to 𝔽(2<sup>31</sup> - 1).</dd>
+        <dd>It converts _argument_ to one of 2<sup>32</sup> integral Number values in the inclusive interval from 𝔽(-2<sup>31</sup>) to 𝔽(2<sup>31</sup> - 1), excluding *-0*<sub>𝔽</sub>.</dd>
       </dl>
       <emu-alg>
         1. Let _int_ be ? ToIntegerOrInfinity(_argument_).
-        1. If _int_ is not finite, return *+0*<sub>𝔽</sub>.
-        1. Let _int32bit_ be _int_ modulo 2<sup>32</sup>.
-        1. If _int32bit_ ≥ 2<sup>31</sup>, return 𝔽(_int32bit_ - 2<sup>32</sup>).
-        1. Return 𝔽(_int32bit_).
+        1. Return 𝔽(ToFixedSizeInteger(_int_, ~signed~, 32)).
       </emu-alg>
-      <emu-note>
-        <p>Given the above definition:</p>
-        <ul>
-          <li>
-            It is idempotent: for any ECMAScript language value _x_, ToInt32(ToInt32(_x_)) is the same as ToInt32(_x_).
-          </li>
-          <li>
-            For any ECMAScript language value _x_, ToInt32(ToUint32(_x_)) is the same as ToInt32(_x_). (It is to preserve this property that *+∞*<sub>𝔽</sub> and *-∞*<sub>𝔽</sub> are mapped to *+0*<sub>𝔽</sub>.)
-          </li>
-          <li>
-            ToInt32 maps *-0*<sub>𝔽</sub> to *+0*<sub>𝔽</sub>.
-          </li>
-        </ul>
-      </emu-note>
     </emu-clause>
 
     <emu-clause id="sec-touint32" type="abstract operation">
@@ -5362,27 +5369,8 @@
       </dl>
       <emu-alg>
         1. Let _int_ be ? ToIntegerOrInfinity(_argument_).
-        1. If _int_ is not finite, return *+0*<sub>𝔽</sub>.
-        1. Let _int32bit_ be _int_ modulo 2<sup>32</sup>.
-        1. [id="step-touint32-return"] Return 𝔽(_int32bit_).
+        1. Return 𝔽(ToFixedSizeInteger(_int_, ~unsigned~, 32)).
       </emu-alg>
-      <emu-note>
-        <p>Given the above definition:</p>
-        <ul>
-          <li>
-            Step <emu-xref href="#step-touint32-return"></emu-xref> is the only difference between ToUint32 and ToInt32.
-          </li>
-          <li>
-            It is idempotent: for any ECMAScript language value _x_, ToUint32(ToUint32(_x_)) is the same as ToUint32(_x_).
-          </li>
-          <li>
-            For any ECMAScript language value _x_, ToUint32(ToInt32(_x_)) is the same as ToUint32(_x_). (It is to preserve this property that *+∞*<sub>𝔽</sub> and *-∞*<sub>𝔽</sub> are mapped to *+0*<sub>𝔽</sub>.)
-          </li>
-          <li>
-            ToUint32 maps *-0*<sub>𝔽</sub> to *+0*<sub>𝔽</sub>.
-          </li>
-        </ul>
-      </emu-note>
     </emu-clause>
 
     <emu-clause id="sec-toint16" type="abstract operation">
@@ -5393,14 +5381,11 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It converts _argument_ to one of 2<sup>16</sup> integral Number values in the inclusive interval from 𝔽(-2<sup>15</sup>) to 𝔽(2<sup>15</sup> - 1).</dd>
+        <dd>It converts _argument_ to one of 2<sup>16</sup> integral Number values in the inclusive interval from 𝔽(-2<sup>15</sup>) to 𝔽(2<sup>15</sup> - 1), excluding *-0*<sub>𝔽</sub>.</dd>
       </dl>
       <emu-alg>
         1. Let _int_ be ? ToIntegerOrInfinity(_argument_).
-        1. If _int_ is not finite, return *+0*<sub>𝔽</sub>.
-        1. Let _int16bit_ be _int_ modulo 2<sup>16</sup>.
-        1. If _int16bit_ ≥ 2<sup>15</sup>, return 𝔽(_int16bit_ - 2<sup>16</sup>).
-        1. Return 𝔽(_int16bit_).
+        1. Return 𝔽(ToFixedSizeInteger(_int_, ~signed~, 16)).
       </emu-alg>
     </emu-clause>
 
@@ -5416,21 +5401,8 @@
       </dl>
       <emu-alg>
         1. Let _int_ be ? ToIntegerOrInfinity(_argument_).
-        1. If _int_ is not finite, return *+0*<sub>𝔽</sub>.
-        1. [id="step-touint16-mod"] Let _int16bit_ be _int_ modulo 2<sup>16</sup>.
-        1. Return 𝔽(_int16bit_).
+        1. Return 𝔽(ToFixedSizeInteger(_int_, ~unsigned~, 16)).
       </emu-alg>
-      <emu-note>
-        <p>Given the above definition:</p>
-        <ul>
-          <li>
-            The substitution of 2<sup>16</sup> for 2<sup>32</sup> in step <emu-xref href="#step-touint16-mod"></emu-xref> is the only difference between ToUint32 and ToUint16.
-          </li>
-          <li>
-            ToUint16 maps *-0*<sub>𝔽</sub> to *+0*<sub>𝔽</sub>.
-          </li>
-        </ul>
-      </emu-note>
     </emu-clause>
 
     <emu-clause id="sec-toint8" type="abstract operation">
@@ -5441,14 +5413,11 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It converts _argument_ to one of 2<sup>8</sup> integral Number values in the inclusive interval from *-128*<sub>𝔽</sub> to *127*<sub>𝔽</sub>.</dd>
+        <dd>It converts _argument_ to one of 2<sup>8</sup> integral Number values in the inclusive interval from *-128*<sub>𝔽</sub> to *127*<sub>𝔽</sub>, excluding *-0*<sub>𝔽</sub>.</dd>
       </dl>
       <emu-alg>
         1. Let _int_ be ? ToIntegerOrInfinity(_argument_).
-        1. If _int_ is not finite, return *+0*<sub>𝔽</sub>.
-        1. Let _int8bit_ be _int_ modulo 2<sup>8</sup>.
-        1. If _int8bit_ ≥ 2<sup>7</sup>, return 𝔽(_int8bit_ - 2<sup>8</sup>).
-        1. Return 𝔽(_int8bit_).
+        1. Return 𝔽(ToFixedSizeInteger(_int_, ~signed~, 8)).
       </emu-alg>
     </emu-clause>
 
@@ -5464,9 +5433,7 @@
       </dl>
       <emu-alg>
         1. Let _int_ be ? ToIntegerOrInfinity(_argument_).
-        1. If _int_ is not finite, return *+0*<sub>𝔽</sub>.
-        1. Let _int8bit_ be _int_ modulo 2<sup>8</sup>.
-        1. Return 𝔽(_int8bit_).
+        1. Return 𝔽(ToFixedSizeInteger(_int_, ~unsigned~, 8)).
       </emu-alg>
     </emu-clause>
 
@@ -5641,10 +5608,8 @@
         <dd>It converts _argument_ to one of 2<sup>64</sup> BigInt values in the inclusive interval from ℤ(-2<sup>63</sup>) to ℤ(2<sup>63</sup> - 1).</dd>
       </dl>
       <emu-alg>
-        1. Let _n_ be ? ToBigInt(_argument_).
-        1. Let _int64bit_ be ℝ(_n_) modulo 2<sup>64</sup>.
-        1. If _int64bit_ ≥ 2<sup>63</sup>, return ℤ(_int64bit_ - 2<sup>64</sup>).
-        1. Return ℤ(_int64bit_).
+        1. Let _int_ be ℝ(? ToBigInt(_argument_)).
+        1. Return ℤ(ToFixedSizeInteger(_int_, ~signed~, 64)).
       </emu-alg>
     </emu-clause>
 
@@ -5659,9 +5624,8 @@
         <dd>It converts _argument_ to one of 2<sup>64</sup> BigInt values in the inclusive interval from *0*<sub>ℤ</sub> to ℤ(2<sup>64</sup> - 1).</dd>
       </dl>
       <emu-alg>
-        1. Let _n_ be ? ToBigInt(_argument_).
-        1. Let _int64bit_ be ℝ(_n_) modulo 2<sup>64</sup>.
-        1. Return ℤ(_int64bit_).
+        1. Let _int_ be ℝ(? ToBigInt(_argument_)).
+        1. Return ℤ(ToFixedSizeInteger(_int_, ~unsigned~, 64)).
       </emu-alg>
     </emu-clause>
 


### PR DESCRIPTION
Ref #3792

As suggested in #3792, ToFixedSizeInteger provides a single place to comment on the invariants of fixed-size integer conversion. However, in this PR it joins the supported operations in the existing [Type Conversion](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-type-conversion) section rather than splitting them out into a new subsection.