### PR TITLE
Editorial: Refactor parseInt into more cleanly-separated phases

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -30716,28 +30716,26 @@
       <p>It performs the following steps when called:</p>
       <emu-alg>
         1. Let _inputString_ be ? ToString(_string_).
-        1. Let _trimmedString_ be ! TrimString(_inputString_, ~start~).
-        1. Let _sign_ be 1.
-        1. If _trimmedString_ is not empty and the first code unit of _trimmedString_ is the code unit 0x002D (HYPHEN-MINUS), set _sign_ to -1.
-        1. If _trimmedString_ is not empty and the first code unit of _trimmedString_ is either the code unit 0x002B (PLUS SIGN) or the code unit 0x002D (HYPHEN-MINUS), set _trimmedString_ to the substring of _trimmedString_ from index 1.
         1. Let _radixMV_ be ℝ(? ToInt32(_radix_)).
-        1. Let _stripPrefix_ be *true*.
-        1. If _radixMV_ ≠ 0, then
-          1. If _radixMV_ &lt; 2 or _radixMV_ > 36, return *NaN*.
-          1. If _radixMV_ ≠ 16, set _stripPrefix_ to *false*.
-        1. Else,
-          1. Set _radixMV_ to 10.
-        1. If _stripPrefix_ is *true*, then
-          1. If the length of _trimmedString_ ≥ 2 and the first two code units of _trimmedString_ are either *"0x"* or *"0X"*, then
-            1. Set _trimmedString_ to the substring of _trimmedString_ from index 2.
+        1. If _radixMV_ ≠ 0 and _radixMV_ is not in the inclusive interval from 2 to 36, return *NaN*.
+        1. Let _trimmedString_ be ! TrimString(_inputString_, ~start~).
+        1. If _trimmedString_ is the empty String, return *NaN*.
+        1. Let _sign_ be 1.
+        1. If the first code unit of _trimmedString_ is the code unit 0x002D (HYPHEN-MINUS), then
+          1. Set _sign_ to -1.
+          1. Set _trimmedString_ to the substring of _trimmedString_ from 1.
+        1. Else if the first code unit of _trimmedString_ is the code unit 0x002B (PLUS SIGN), then
+          1. Set _trimmedString_ to the substring of _trimmedString_ from 1.
+        1. If _radixMV_ = 0 or _radixMV_ = 16, then
+          1. If the length of _trimmedString_ ≥ 2 and the substring of _trimmedString_ from 0 to 2 is either *"0x"* or *"0X"*, then
+            1. Set _trimmedString_ to the substring of _trimmedString_ from 2.
             1. Set _radixMV_ to 16.
+        1. If _radixMV_ = 0, set _radixMV_ to 10.
         1. If _trimmedString_ contains a code unit that is not a radix-_radixMV_ digit, let _end_ be the index within _trimmedString_ of the first such code unit; else let _end_ be the length of _trimmedString_.
         1. Let _numberString_ be the substring of _trimmedString_ from 0 to _end_.
         1. If _numberString_ is empty, return *NaN*.
         1. Let _mathInt_ be the integer value that is represented by _numberString_ in radix-_radixMV_ notation, using the letters <b>A</b> through <b>Z</b> and <b>a</b> through <b>z</b> for digits with values 10 through 35. (However, if _radixMV_ = 10 and _numberString_ contains more than 20 significant digits, every significant digit after the 20th may be replaced by a 0 digit, at the option of the implementation; and if _radixMV_ is not one of 2, 4, 8, 10, 16, or 32, then _mathInt_ may be an implementation-approximated integer representing the integer value denoted by _numberString_ in radix-_radixMV_ notation.)
-        1. If _mathInt_ = 0, then
-          1. If _sign_ = -1, return *-0*<sub>𝔽</sub>.
-          1. Return *+0*<sub>𝔽</sub>.
+        1. If _sign_ = -1 and _mathInt_ = 0, return *-0*<sub>𝔽</sub>.
         1. Return 𝔽(_sign_ × _mathInt_).
       </emu-alg>
       <emu-note>


### PR DESCRIPTION
When double-checking how `parseInt` treats empty-string input, I found its algorithm to be excessively convoluted.