### PR TITLE
Editorial: Factor out AO RunCallerContext()

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -12009,7 +12009,7 @@
         1. Let _genContext_ be the running execution context.
         1. Remove _genContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
         1. Let _callerContext_ be the running execution context.
-        1. Resume _callerContext_ passing NormalCompletion(_value_).
+        1. Resume _callerContext_, passing NormalCompletion(_value_).
         1. NOTE: The above step transfers control to _callerContext_ and pauses. The only way for it to un-pause and have control proceed to the subsequent steps in this algorithm is for _genContext_ to be resumed again, which might never happen.
         1. Assert: _genContext_ is the running execution context.
         1. Let _result_ be the Completion Record with which _genContext_ was just resumed.

--- a/spec.html
+++ b/spec.html
@@ -11994,6 +11994,26 @@
         1. Return Completion(_result_).
       </emu-alg>
     </emu-clause>
+
+    <emu-clause id="sec-runcallercontext" type="abstract operation">
+      <h1>
+        RunCallerContext (
+          _value_: an ECMAScript language value or ~empty~,
+        ): a Completion Record
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It resumes the caller context (sending it _value_ as the resumption value), and waits for the result, if any.</dd>
+      </dl>
+      <emu-alg>
+        1. Let _genContext_ be the running execution context.
+        1. Remove _genContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
+        1. Let _callerContext_ be the running execution context.
+        1. Resume _callerContext_ passing NormalCompletion(_value_). If _genContext_ is ever resumed again, let _result_ be the Completion Record with which it is resumed.
+        1. Assert: If control reaches here, then _genContext_ is the running execution context again.
+        1. Return Completion(_result_).
+      </emu-alg>
+    </emu-clause>
   </emu-clause>
 
   <emu-clause id="sec-jobs" oldids="sec-jobs-and-job-queues,sec-enqueuejob,sec-runjobs,job-queue">
@@ -50684,10 +50704,7 @@ THH:mm:ss.sss
           1. Let _generator_ be the value of the Generator component of _genContext_.
           1. Assert: GetGeneratorKind() is ~sync~.
           1. Set _generator_.[[GeneratorState]] to ~suspended-yield~.
-          1. Remove _genContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
-          1. Let _callerContext_ be the running execution context.
-          1. Resume _callerContext_ passing NormalCompletion(_iteratorResult_). If _genContext_ is ever resumed again, let _resumptionValue_ be the Completion Record with which it is resumed.
-          1. Assert: If control reaches here, then _genContext_ is the running execution context again.
+          1. Let _resumptionValue_ be Completion(RunCallerContext(_iteratorResult_)).
           1. Return _resumptionValue_.
         </emu-alg>
       </emu-clause>
@@ -51067,10 +51084,7 @@ THH:mm:ss.sss
             1. Let _resumptionValue_ be Completion(_toYield_.[[Completion]]).
             1. Return ? AsyncGeneratorUnwrapYieldResumption(_resumptionValue_).
           1. Set _generator_.[[AsyncGeneratorState]] to ~suspended-yield~.
-          1. Remove _genContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
-          1. Let _callerContext_ be the running execution context.
-          1. Resume _callerContext_ passing *undefined*. If _genContext_ is ever resumed again, let _resumptionValue_ be the Completion Record with which it is resumed.
-          1. Assert: If control reaches here, then _genContext_ is the running execution context again.
+          1. Let _resumptionValue_ be Completion(RunCallerContext(*undefined*)).
           1. Return ? AsyncGeneratorUnwrapYieldResumption(_resumptionValue_).
         </emu-alg>
       </emu-clause>
@@ -51318,10 +51332,7 @@ THH:mm:ss.sss
             1. Return NormalCompletion(*undefined*).
           1. Let _onRejected_ be CreateBuiltinFunction(_rejectedClosure_, 1, *""*, « »).
           1. Perform PerformPromiseThen(_promise_, _onFulfilled_, _onRejected_).
-          1. Remove _asyncContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
-          1. Let _callerContext_ be the running execution context.
-          1. Resume _callerContext_ passing ~empty~. If _asyncContext_ is ever resumed again, let _completion_ be the Completion Record with which it is resumed.
-          1. Assert: If control reaches here, then _asyncContext_ is the running execution context again.
+          1. Let _completion_ be Completion(RunCallerContext(~empty~)).
           1. Return _completion_.
         </emu-alg>
       </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -12009,8 +12009,10 @@
         1. Let _genContext_ be the running execution context.
         1. Remove _genContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
         1. Let _callerContext_ be the running execution context.
-        1. Resume _callerContext_ passing NormalCompletion(_value_). If _genContext_ is ever resumed again, let _result_ be the Completion Record with which it is resumed.
-        1. Assert: If control reaches here, then _genContext_ is the running execution context again.
+        1. Resume _callerContext_ passing NormalCompletion(_value_).
+        1. NOTE: The above step transfers control to _callerContext_ and pauses. The only way for it to un-pause and have control proceed to the subsequent steps in this algorithm is for _genContext_ to be resumed again, which might never happen.
+        1. Assert: _genContext_ is the running execution context.
+        1. Let _result_ be the Completion Record with which _genContext_ was just resumed.
         1. Return Completion(_result_).
       </emu-alg>
     </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -12407,6 +12407,28 @@
         1. Return Completion(_result_).
       </emu-alg>
     </emu-clause>
+
+    <emu-clause id="sec-runcallercontext" type="abstract operation">
+      <h1>
+        RunCallerContext (
+          _value_: an ECMAScript language value or ~empty~,
+        ): a Completion Record
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It resumes the caller context (sending it _value_ as the resumption value), and waits for the result, if any.</dd>
+      </dl>
+      <emu-alg>
+        1. Let _genContext_ be the running execution context.
+        1. Remove _genContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
+        1. Let _callerContext_ be the running execution context.
+        1. Resume _callerContext_, passing NormalCompletion(_value_).
+        1. NOTE: The above step transfers control to _callerContext_ and pauses. The only way for it to un-pause and have control proceed to the subsequent steps in this algorithm is for _genContext_ to be resumed again, which might never happen.
+        1. Assert: _genContext_ is the running execution context.
+        1. Let _result_ be the Completion Record with which _genContext_ was just resumed.
+        1. Return Completion(_result_).
+      </emu-alg>
+    </emu-clause>
   </emu-clause>
 
   <emu-clause id="sec-jobs" oldids="sec-jobs-and-job-queues,sec-enqueuejob,sec-runjobs,job-queue">
@@ -52044,8 +52066,6 @@ THH:mm:ss.sss
           ): either a normal completion containing an ECMAScript language value or an abrupt completion
         </h1>
         <dl class="header">
-          <dt>skip return checks</dt>
-          <dd>true</dd>
         </dl>
         <emu-alg>
           1. Let _genContext_ be the running execution context.
@@ -52053,11 +52073,7 @@ THH:mm:ss.sss
           1. Let _gen_ be the value of the Generator component of _genContext_.
           1. Assert: GetGeneratorKind() is ~sync~.
           1. Set _gen_.[[GeneratorState]] to ~suspended-yield~.
-          1. Remove _genContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
-          1. Let _callerContext_ be the running execution context.
-          1. Resume _callerContext_ passing NormalCompletion(_iteratorResult_). If _genContext_ is ever resumed again, let _resumptionValue_ be the Completion Record with which it is resumed.
-          1. Assert: If control reaches here, then _genContext_ is the running execution context again.
-          1. Return _resumptionValue_.
+          1. Return ? RunCallerContext(_iteratorResult_).
         </emu-alg>
       </emu-clause>
 
@@ -52436,10 +52452,7 @@ THH:mm:ss.sss
             1. Let _resumptionValue_ be Completion(_toYield_.[[Completion]]).
             1. Return ? AsyncGeneratorUnwrapYieldResumption(_resumptionValue_).
           1. Set _gen_.[[AsyncGeneratorState]] to ~suspended-yield~.
-          1. Remove _genContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
-          1. Let _callerContext_ be the running execution context.
-          1. Resume _callerContext_ passing *undefined*. If _genContext_ is ever resumed again, let _resumptionValue_ be the Completion Record with which it is resumed.
-          1. Assert: If control reaches here, then _genContext_ is the running execution context again.
+          1. Let _resumptionValue_ be Completion(RunCallerContext(*undefined*)).
           1. Return ? AsyncGeneratorUnwrapYieldResumption(_resumptionValue_).
         </emu-alg>
       </emu-clause>
@@ -52687,11 +52700,7 @@ THH:mm:ss.sss
             1. Return NormalCompletion(*undefined*).
           1. Let _onRejected_ be CreateBuiltinFunction(_rejectedClosure_, 1, *""*, « »).
           1. Perform PerformPromiseThen(_promise_, _onFulfilled_, _onRejected_).
-          1. Remove _asyncContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
-          1. Let _callerContext_ be the running execution context.
-          1. Resume _callerContext_ passing ~empty~. If _asyncContext_ is ever resumed again, let _completion_ be the Completion Record with which it is resumed.
-          1. Assert: If control reaches here, then _asyncContext_ is the running execution context again.
-          1. Return _completion_.
+          1. Return ? RunCallerContext(~empty~).
         </emu-alg>
       </emu-clause>
     </emu-clause>


### PR DESCRIPTION
This is the complement to `RunSuspendedContext` defined in PR #2664.
In particular, see https://github.com/tc39/ecma262/pull/2664#issuecomment-4306762914