### PR TITLE
Layering: Allow ParseScript and ParseModule to be called with string input

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -26143,7 +26143,7 @@
     <emu-clause id="sec-parse-script" type="abstract operation">
       <h1>
         ParseScript (
-          _sourceText_: ECMAScript source text,
+          _sourceText_: a String or a sequence of Unicode code points,
           _realm_: a Realm Record,
           _hostDefined_: anything,
         ): a Script Record or a non-empty List of *SyntaxError* objects
@@ -28439,7 +28439,7 @@
         <emu-clause id="sec-parsemodule" type="abstract operation">
           <h1>
             ParseModule (
-              _sourceText_: ECMAScript source text,
+              _sourceText_: a String or a sequence of Unicode code points,
               _realm_: a Realm Record,
               _hostDefined_: anything,
             ): a Source Text Module Record or a non-empty List of *SyntaxError* objects


### PR DESCRIPTION
Fixes #3848

Note that normativity here is debatable—hosts are already providing strings (e.g., HTML [create a JavaScript module script](https://html.spec.whatwg.org/multipage/webappapis.html#creating-a-javascript-module-script) and [create a classic script](https://html.spec.whatwg.org/multipage/webappapis.html#creating-a-classic-script)), which are already handled by the associated algorithms via ParseText.