### PR TITLE
Normative: Require internal consistency w.r.t. prefixing {get,set} in SetFunctionName

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -13727,12 +13727,13 @@
           1. Set _func_.[[InitialName]] to _name_.
         1. If _prefix_ is present, then
           1. Set _name_ to the string-concatenation of _prefix_, the code unit 0x0020 (SPACE), and _name_.
-          1. If _func_ has an [[InitialName]] internal slot, then
-            1. NOTE: The choice in the following step is made independently each time this Abstract Operation is invoked.
-            1. Optionally, set _func_.[[InitialName]] to _name_.
+          1. [normative-optional] If _func_ has an [[InitialName]] internal slot, set _func_.[[InitialName]] to _name_.
         1. Perform ! DefinePropertyOrThrow(_func_, *"name"*, PropertyDescriptor { [[Value]]: _name_, [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
         1. Return ~unused~.
       </emu-alg>
+      <emu-note>
+        <p>The choice of whether or not to prepend _prefix_ to _func_.[[InitialName]] affects the output of <emu-xref href="#sec-function.prototype.tostring" title></emu-xref>, and is implementation-defined but must apply uniformly to all built-in functions.</p>
+      </emu-note>
     </emu-clause>
 
     <emu-clause id="sec-setfunctionlength" type="abstract operation">


### PR DESCRIPTION
As observable via Function.prototype.toString.
Fixes #3851
Ref #3652