### PR TITLE
Editorial: Restore anchor for sec-returnifabrupt-shorthands

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1106,7 +1106,7 @@
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-shorthands-for-unwrapping-completion-records" oldids="sec-returnifabrupt">
+      <emu-clause id="sec-shorthands-for-unwrapping-completion-records" oldids="sec-returnifabrupt,sec-returnifabrupt-shorthands">
         <h1>Shorthands for Unwrapping Completion Records</h1>
         <p>Prefix `?` and `!` are used as shorthands which unwrap Completion Records. `?` is used to propagate an abrupt completion to the caller, or otherwise to unwrap a normal completion. `!` is used to assert that a Completion Record is normal and unwrap it. Formally, the step</p>
         <emu-alg example>


### PR DESCRIPTION
Fixes #3858

Looks like this was accidentally dropped by #3705.