### PR TITLE
Markup: Move `</li>` to end of line

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -176,7 +176,7 @@
     <li>
       Editors:
       <ul>
-        <li><a href="mailto:ecma262 at chronicles dot org">Ron Buckton</a></li> (<a href="https://bsky.app/profile/chronicles.org">@chronicles.org</a>)
+        <li><a href="mailto:ecma262 at chronicles dot org">Ron Buckton</a> (<a href="https://bsky.app/profile/chronicles.org">@chronicles.org</a>)</li>
         <li><a href="mailto:ecma262-editor-list at michael dot ficarra dot me">Michael Ficarra</a> (<a href="https://bsky.app/profile/michael.ficarra.me">@michael.ficarra.me</a>)</li>
         <li><a href="mailto:richard.gibson at gmail dot com">Richard Gibson</a></li>
         <li><a href="mailto:mail@linusgroh.de">Linus Groh</a></li>


### PR DESCRIPTION
The `li` element for Ron Buckton should presumably encompass all of his info.

I expect this will eliminate a spurious line-break that appears in the status quo:
<img width="395" height="216" alt="262_editors_block" src="https://github.com/user-attachments/assets/02debcbe-db9d-4a2f-86f1-dfbaa3e50a3d" />

