### PR TITLE
Editorial: use UpdateEmpty for empty normal completion handling

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -26176,8 +26176,7 @@
         1. Let _result_ be Completion(GlobalDeclarationInstantiation(_script_, _globalEnv_)).
         1. If _result_ is a normal completion, then
           1. Set _result_ to Completion(Evaluation of _script_).
-          1. If _result_ is a normal completion and _result_.[[Value]] is ~empty~, then
-            1. Set _result_ to NormalCompletion(*undefined*).
+          1. If _result_ is a normal completion, set _result_ to UpdateEmpty(_result_, *undefined*).
         1. Suspend _scriptContext_ and remove it from the execution context stack.
         1. Assert: The execution context stack is not empty.
         1. Resume the context that is now on the top of the execution context stack as the running execution context.
@@ -29053,9 +29052,7 @@
         <emu-grammar>ModuleBody : ModuleItemList</emu-grammar>
         <emu-alg>
           1. Let _result_ be Completion(Evaluation of |ModuleItemList|).
-          1. If _result_ is a normal completion and _result_.[[Value]] is ~empty~, then
-            1. Return *undefined*.
-          1. Return ? _result_.
+          1. Return ? UpdateEmpty(_result_, *undefined*).
         </emu-alg>
         <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
         <emu-alg>
@@ -29859,8 +29856,7 @@
           1. Let _result_ be Completion(EvalDeclarationInstantiation(_body_, _varEnv_, _lexEnv_, _privateEnv_, _strictEval_)).
           1. If _result_ is a normal completion, then
             1. Set _result_ to Completion(Evaluation of _body_).
-          1. If _result_ is a normal completion and _result_.[[Value]] is ~empty~, then
-            1. Set _result_ to NormalCompletion(*undefined*).
+          1. If _result_ is a normal completion, set _result_ to UpdateEmpty(_result_, *undefined*).
           1. Suspend _evalContext_ and remove it from the execution context stack.
           1. Resume the context that is now on the top of the execution context stack as the running execution context.
           1. Return ? _result_.


### PR DESCRIPTION
Fixes #3853

Replace manual empty-value checks with `UpdateEmpty` in three algorithms:

- **ScriptEvaluation** (§16.1.6): `If _result_ is a normal completion and _result_.[[Value]] is ~empty~` → `If _result_ is a normal completion, set _result_ to UpdateEmpty(_result_, *undefined*)`
- **ModuleBody Evaluation** (§16.2.1.14): three-step manual check → `Return ? UpdateEmpty(_result_, *undefined*)`
- **PerformEval** (§19.2.1.1): same as ScriptEvaluation

Note: §14.13.4 LabelledEvaluation (BreakableStatement) was excluded — those cases convert a break completion to normal, which `UpdateEmpty` does not do, so the manual check is necessary there.