### PR TITLE
Editorial: add NOTE to CreateGlobalVarBinding about InitializeBinding Proxy behavior

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -11264,9 +11264,12 @@
             1. Let _extensible_ be ? IsExtensible(_globalObject_).
             1. If _hasProperty_ is *false* and _extensible_ is *true*, then
               1. Perform ? <emu-meta effects="user-code">_objectRecord_.CreateMutableBinding(_name_, _deletable_)</emu-meta>.
-              1. Perform ? <emu-meta effects="user-code">_objectRecord_.InitializeBinding(_name_, *undefined*)</emu-meta>.
+              1. [id="step-createglobalvarbinding-initialize"] Perform ? <emu-meta effects="user-code">_objectRecord_.InitializeBinding(_name_, *undefined*)</emu-meta>.
             1. Return ~unused~.
           </emu-alg>
+          <emu-note>
+            <p>Step <emu-xref href="#step-createglobalvarbinding-initialize"></emu-xref> is equivalent to what calling the InitializeBinding concrete method would do and if _globalObject_ is a Proxy will produce the same sequence of Proxy trap calls.</p>
+          </emu-note>
         </emu-clause>
 
         <emu-clause id="sec-createglobalfunctionbinding" type="abstract operation">

--- a/spec.html
+++ b/spec.html
@@ -26176,8 +26176,7 @@
         1. Let _result_ be Completion(GlobalDeclarationInstantiation(_script_, _globalEnv_)).
         1. If _result_ is a normal completion, then
           1. Set _result_ to Completion(Evaluation of _script_).
-          1. If _result_ is a normal completion and _result_.[[Value]] is ~empty~, then
-            1. Set _result_ to NormalCompletion(*undefined*).
+          1. If _result_ is a normal completion, set _result_ to UpdateEmpty(_result_, *undefined*).
         1. Suspend _scriptContext_ and remove it from the execution context stack.
         1. Assert: The execution context stack is not empty.
         1. Resume the context that is now on the top of the execution context stack as the running execution context.
@@ -29053,9 +29052,7 @@
         <emu-grammar>ModuleBody : ModuleItemList</emu-grammar>
         <emu-alg>
           1. Let _result_ be Completion(Evaluation of |ModuleItemList|).
-          1. If _result_ is a normal completion and _result_.[[Value]] is ~empty~, then
-            1. Return *undefined*.
-          1. Return ? _result_.
+          1. Return ? UpdateEmpty(_result_, *undefined*).
         </emu-alg>
         <emu-grammar>ModuleItemList : ModuleItemList ModuleItem</emu-grammar>
         <emu-alg>
@@ -29859,8 +29856,7 @@
           1. Let _result_ be Completion(EvalDeclarationInstantiation(_body_, _varEnv_, _lexEnv_, _privateEnv_, _strictEval_)).
           1. If _result_ is a normal completion, then
             1. Set _result_ to Completion(Evaluation of _body_).
-          1. If _result_ is a normal completion and _result_.[[Value]] is ~empty~, then
-            1. Set _result_ to NormalCompletion(*undefined*).
+          1. If _result_ is a normal completion, set _result_ to UpdateEmpty(_result_, *undefined*).
           1. Suspend _evalContext_ and remove it from the execution context stack.
           1. Resume the context that is now on the top of the execution context stack as the running execution context.
           1. Return ? _result_.


### PR DESCRIPTION
Fixes #3854

`CreateGlobalFunctionBinding` (§9.1.1.4.17) has a NOTE explaining that its `Set` call produces the same Proxy trap sequence as `InitializeBinding`. `CreateGlobalVarBinding` (§9.1.1.4.16) has an analogous `InitializeBinding` call but no such NOTE, leaving it ambiguous whether the resulting `[[Set]]` trap on Proxy global objects is intentional.

This PR adds a NOTE to `CreateGlobalVarBinding` mirroring the existing one in `CreateGlobalFunctionBinding`.