### PR TITLE
Editorial: consistently use "includes the properties" phrasing

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -48252,7 +48252,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-iterable-interface">
         <h1>The Iterable Interface</h1>
-        <p>The <dfn variants="iterable,iterables,iterable object,iterable objects">iterable interface</dfn> includes the property described in <emu-xref href="#table-iterable-interface-required-properties"></emu-xref>:</p>
+        <p>The <dfn variants="iterable,iterables,iterable object,iterable objects">iterable interface</dfn> includes the properties described in <emu-xref href="#table-iterable-interface-required-properties"></emu-xref>:</p>
         <emu-table id="table-iterable-interface-required-properties" caption="Iterable Interface Required Properties" oldids="table-52">
           <table>
             <thead>


### PR DESCRIPTION
Even though there's only one property listed in the table, I still prefer to use consistent phrasing for this.