### PR TITLE
Editorial: reword description of subclassing

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -42848,7 +42848,7 @@ THH:mm:ss.sss
         <li>is an intrinsic object that has the structure described below, differing only in the name used as the constructor name instead of _TypedArray_, in <emu-xref href="#table-the-typedarray-constructors"></emu-xref>, except where otherwise noted.</li>
         <li>is a function whose behaviour differs based upon the number and types of its arguments. The actual behaviour of a call of _TypedArray_ depends upon the number and kind of arguments that are passed to it.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
-        <li>may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified _TypedArray_ behaviour must include a `super` call to the _TypedArray_ constructor to create and initialize the subclass instance with the internal state necessary to support the %TypedArray%`.prototype` built-in methods.</li>
+        <li>may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified _TypedArray_ behaviour must include a `super` call to the _TypedArray_ constructor to create and initialize the subclass instance with the internal state necessary to support the built-in methods of %TypedArray%`.prototype`.</li>
       </ul>
 
       <emu-clause id="sec-typedarray" oldids="sec-typedarray-length,sec-typedarray-object" type="built-in function">
@@ -43519,7 +43519,7 @@ THH:mm:ss.sss
         <li>is the initial value of the *"Map"* property of the global object.</li>
         <li>creates and initializes a new Map when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
-        <li>may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified Map behaviour must include a `super` call to the Map constructor to create and initialize the subclass instance with the internal state necessary to support the `Map.prototype` built-in methods.</li>
+        <li>may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified Map behaviour must include a `super` call to the Map constructor to create and initialize the subclass instance with the internal state necessary to support the built-in methods of `Map.prototype`.</li>
       </ul>
 
       <emu-clause id="sec-map-iterable" type="built-in function">
@@ -44057,7 +44057,7 @@ THH:mm:ss.sss
         <li>is the initial value of the *"Set"* property of the global object.</li>
         <li>creates and initializes a new Set object when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
-        <li>may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified Set behaviour must include a `super` call to the Set constructor to create and initialize the subclass instance with the internal state necessary to support the `Set.prototype` built-in methods.</li>
+        <li>may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified Set behaviour must include a `super` call to the Set constructor to create and initialize the subclass instance with the internal state necessary to support the built-in methods of `Set.prototype`.</li>
       </ul>
 
       <emu-clause id="sec-set-iterable" type="built-in function">
@@ -44547,7 +44547,7 @@ THH:mm:ss.sss
         <li>is the initial value of the *"WeakMap"* property of the global object.</li>
         <li>creates and initializes a new WeakMap when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
-        <li>may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified WeakMap behaviour must include a `super` call to the WeakMap constructor to create and initialize the subclass instance with the internal state necessary to support the `WeakMap.prototype` built-in methods.</li>
+        <li>may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified WeakMap behaviour must include a `super` call to the WeakMap constructor to create and initialize the subclass instance with the internal state necessary to support the built-in methods of `WeakMap.prototype`.</li>
       </ul>
 
       <emu-clause id="sec-weakmap-iterable" type="built-in function">
@@ -44727,7 +44727,7 @@ THH:mm:ss.sss
         <li>is the initial value of the *"WeakSet"* property of the global object.</li>
         <li>creates and initializes a new WeakSet when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
-        <li>may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified WeakSet behaviour must include a `super` call to the WeakSet constructor to create and initialize the subclass instance with the internal state necessary to support the `WeakSet.prototype` built-in methods.</li>
+        <li>may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified WeakSet behaviour must include a `super` call to the WeakSet constructor to create and initialize the subclass instance with the internal state necessary to support the built-in methods of `WeakSet.prototype`.</li>
       </ul>
 
       <emu-clause id="sec-weakset-iterable" type="built-in function">
@@ -45355,7 +45355,7 @@ THH:mm:ss.sss
         <li>is the initial value of the *"ArrayBuffer"* property of the global object.</li>
         <li>creates and initializes a new ArrayBuffer when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
-        <li>may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified ArrayBuffer behaviour must include a `super` call to the ArrayBuffer constructor to create and initialize subclass instances with the internal state necessary to support the `ArrayBuffer.prototype` built-in methods.</li>
+        <li>may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified ArrayBuffer behaviour must include a `super` call to the ArrayBuffer constructor to create and initialize subclass instances with the internal state necessary to support the built-in methods of `ArrayBuffer.prototype`.</li>
       </ul>
 
       <emu-clause id="sec-arraybuffer-length" type="built-in function">
@@ -45699,7 +45699,7 @@ THH:mm:ss.sss
         <li>is the initial value of the *"SharedArrayBuffer"* property of the global object, if that property is present (see below).</li>
         <li>creates and initializes a new SharedArrayBuffer when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
-        <li>may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified SharedArrayBuffer behaviour must include a `super` call to the SharedArrayBuffer constructor to create and initialize subclass instances with the internal state necessary to support the `SharedArrayBuffer.prototype` built-in methods.</li>
+        <li>may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified SharedArrayBuffer behaviour must include a `super` call to the SharedArrayBuffer constructor to create and initialize subclass instances with the internal state necessary to support the built-in methods of `SharedArrayBuffer.prototype`.</li>
       </ul>
 
       <p>Whenever a host does not provide concurrent access to SharedArrayBuffers it may omit the *"SharedArrayBuffer"* property of the global object.</p>
@@ -46087,7 +46087,7 @@ THH:mm:ss.sss
         <li>is the initial value of the *"DataView"* property of the global object.</li>
         <li>creates and initializes a new DataView when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
-        <li>may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified DataView behaviour must include a `super` call to the DataView constructor to create and initialize subclass instances with the internal state necessary to support the `DataView.prototype` built-in methods.</li>
+        <li>may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified DataView behaviour must include a `super` call to the DataView constructor to create and initialize subclass instances with the internal state necessary to support the built-in methods of `DataView.prototype`.</li>
       </ul>
 
       <emu-clause id="sec-dataview-buffer-byteoffset-bytelength" type="built-in function">
@@ -48001,7 +48001,7 @@ THH:mm:ss.sss
           is not intended to be called as a function and will throw an exception when called in that manner.
         </li>
         <li>
-          may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `WeakRef` behaviour must include a `super` call to the `WeakRef` constructor to create and initialize the subclass instance with the internal state necessary to support the `WeakRef.prototype` built-in methods.
+          may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `WeakRef` behaviour must include a `super` call to the `WeakRef` constructor to create and initialize the subclass instance with the internal state necessary to support the built-in methods of `WeakRef.prototype`.
         </li>
       </ul>
 
@@ -48137,7 +48137,7 @@ THH:mm:ss.sss
           is not intended to be called as a function and will throw an exception when called in that manner.
         </li>
         <li>
-          may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `FinalizationRegistry` behaviour must include a `super` call to the `FinalizationRegistry` constructor to create and initialize the subclass instance with the internal state necessary to support the `FinalizationRegistry.prototype` built-in methods.
+          may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `FinalizationRegistry` behaviour must include a `super` call to the `FinalizationRegistry` constructor to create and initialize the subclass instance with the internal state necessary to support the built-in methods of `FinalizationRegistry.prototype`.
         </li>
       </ul>
 
@@ -49806,7 +49806,7 @@ THH:mm:ss.sss
         <li>is the initial value of the *"Promise"* property of the global object.</li>
         <li>creates and initializes a new Promise when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
-        <li>may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified Promise behaviour must include a `super` call to the Promise constructor to create and initialize the subclass instance with the internal state necessary to support the `Promise` and `Promise.prototype` built-in methods.</li>
+        <li>may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified Promise behaviour must include a `super` call to the Promise constructor to create and initialize the subclass instance with the internal state necessary to support the built-in methods of `Promise` and `Promise.prototype`.</li>
       </ul>
 
       <emu-clause id="sec-promise-executor" type="built-in function">


### PR DESCRIPTION
I kept misreading this, thinking the word "constructor" was missing from this sentence, forgetting that Promise static methods even existed. I've reworded it so it's not confusing.