### PR TITLE
Editorial: Encourage internal consistency w.r.t. prefixing {get,set} in SetFunctionName

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -14140,7 +14140,7 @@
         1. Return ~unused~.
       </emu-alg>
       <emu-note>
-        <p>The choice of whether or not to use _prefixedName_ for _func_.[[InitialName]] affects the output of <emu-xref href="#sec-function.prototype.tostring" title></emu-xref>, and is implementation-defined but should apply uniformly to all built-in functions. Using _prefixedName_ in step <emu-xref href="#step-setfunctionname-maybe-prefix-initialname"></emu-xref> for some built-in functions but not others is discouraged legacy behaviour.</p>
+        <p>The choice of whether or not to use _prefixedName_ for _func_.[[InitialName]] affects the output of <emu-xref href="#sec-function.prototype.tostring" title></emu-xref>. Making different choices for different built-in functions in step <emu-xref href="#step-setfunctionname-maybe-prefix-initialname"></emu-xref> is discouraged legacy behaviour.</p>
       </emu-note>
     </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -14129,19 +14129,18 @@
           1. Else, set _name_ to the string-concatenation of *"["*, _description_, and *"]"*.
         1. Else if _name_ is a Private Name, then
           1. Set _name_ to _name_.[[Description]].
-        1. If _func_ has an [[InitialName]] internal slot, then
-          1. Set _func_.[[InitialName]] to _name_.
+        1. Let _initialName_ be _name_.
         1. If _prefix_ is present, then
           1. Let _prefixedName_ be the string-concatenation of _prefix_, the code unit 0x0020 (SPACE), and _name_.
-          1. If _func_ has an [[InitialName]] internal slot, then
-            1. Set _func_.[[InitialName]] to _prefixedName_.
-            1. [normative-optional, legacy] Set _func_.[[InitialName]] to an implementation-defined choice of either _name_ or _prefixedName_.
+          1. Set _initialName_ to _prefixedName_.
+          1. [id="step-setfunctionname-maybe-prefix-initialname", normative-optional, legacy] Set _initialName_ to an implementation-defined choice of either _name_ or _prefixedName_.
           1. Set _name_ to _prefixedName_.
+        1. If _func_ has an [[InitialName]] internal slot, set _func_.[[InitialName]] to _initialName_.
         1. Perform ! DefinePropertyOrThrow(_func_, *"name"*, PropertyDescriptor { [[Value]]: _name_, [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
         1. Return ~unused~.
       </emu-alg>
       <emu-note>
-        <p>The choice of whether or not to include _prefix_ in _func_.[[InitialName]] affects the output of <emu-xref href="#sec-function.prototype.tostring" title></emu-xref>, and is implementation-defined but should apply uniformly to all built-in functions. Including _prefix_ in [[InitialName]] for some built-in functions but not others is discouraged legacy behaviour.</p>
+        <p>The choice of whether or not to use _prefixedName_ for _func_.[[InitialName]] affects the output of <emu-xref href="#sec-function.prototype.tostring" title></emu-xref>, and is implementation-defined but should apply uniformly to all built-in functions. Using _prefixedName_ in step <emu-xref href="#step-setfunctionname-maybe-prefix-initialname"></emu-xref> for some built-in functions but not others is discouraged legacy behaviour.</p>
       </emu-note>
     </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -14134,12 +14134,15 @@
         1. If _prefix_ is present, then
           1. Let _prefixedName_ be the string-concatenation of _prefix_, the code unit 0x0020 (SPACE), and _name_.
           1. If _func_ has an [[InitialName]] internal slot, then
-            1. NOTE: The choice in the following step is made independently each time this Abstract Operation is invoked.
-            1. Set _func_.[[InitialName]] to an implementation-defined choice of either _name_ or _prefixedName_.
+            1. Set _func_.[[InitialName]] to _prefixedName_.
+            1. [normative-optional, legacy] Set _func_.[[InitialName]] to an implementation-defined choice of either _name_ or _prefixedName_.
           1. Set _name_ to _prefixedName_.
         1. Perform ! DefinePropertyOrThrow(_func_, *"name"*, PropertyDescriptor { [[Value]]: _name_, [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
         1. Return ~unused~.
       </emu-alg>
+      <emu-note>
+        <p>The choice of whether or not to include _prefix_ in _func_.[[InitialName]] affects the output of <emu-xref href="#sec-function.prototype.tostring" title></emu-xref>, and is implementation-defined but should apply uniformly to all built-in functions. Including _prefix_ in [[InitialName]] for some built-in functions but not others is discouraged legacy behaviour.</p>
+      </emu-note>
     </emu-clause>
 
     <emu-clause id="sec-setfunctionlength" type="abstract operation">

--- a/spec.html
+++ b/spec.html
@@ -14182,19 +14182,18 @@
           1. Else, set _name_ to the string-concatenation of *"["*, _description_, and *"]"*.
         1. Else if _name_ is a Private Name, then
           1. Set _name_ to _name_.[[Description]].
-        1. If _func_ has an [[InitialName]] internal slot, then
-          1. Set _func_.[[InitialName]] to _name_.
+        1. Let _initialName_ be _name_.
         1. If _prefix_ is present, then
           1. Let _prefixedName_ be the string-concatenation of _prefix_, the code unit 0x0020 (SPACE), and _name_.
-          1. If _func_ has an [[InitialName]] internal slot, then
-            1. Set _func_.[[InitialName]] to _prefixedName_.
-            1. [normative-optional, legacy] Set _func_.[[InitialName]] to an implementation-defined choice of either _name_ or _prefixedName_.
+          1. Set _initialName_ to _prefixedName_.
+          1. [id="step-setfunctionname-maybe-prefix-initialname", normative-optional, legacy] Set _initialName_ to an implementation-defined choice of either _name_ or _prefixedName_.
           1. Set _name_ to _prefixedName_.
+        1. If _func_ has an [[InitialName]] internal slot, set _func_.[[InitialName]] to _initialName_.
         1. Perform ! DefinePropertyOrThrow(_func_, *"name"*, PropertyDescriptor { [[Value]]: _name_, [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
         1. Return ~unused~.
       </emu-alg>
       <emu-note>
-        <p>The choice of whether or not to include _prefix_ in _func_.[[InitialName]] affects the output of <emu-xref href="#sec-function.prototype.tostring" title></emu-xref>, and is implementation-defined but should apply uniformly to all built-in functions. Including _prefix_ in [[InitialName]] for some built-in functions but not others is discouraged legacy behaviour.</p>
+        <p>The choice of whether or not to use _prefixedName_ for _func_.[[InitialName]] affects the output of <emu-xref href="#sec-function.prototype.tostring" title></emu-xref>, and is implementation-defined but should apply uniformly to all built-in functions. Using _prefixedName_ in step <emu-xref href="#step-setfunctionname-maybe-prefix-initialname"></emu-xref> for some built-in functions but not others is discouraged legacy behaviour.</p>
       </emu-note>
     </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -14193,7 +14193,7 @@
         1. Return ~unused~.
       </emu-alg>
       <emu-note>
-        <p>The choice of whether or not to use _prefixedName_ for _func_.[[InitialName]] affects the output of <emu-xref href="#sec-function.prototype.tostring" title></emu-xref>, and is implementation-defined but should apply uniformly to all built-in functions. Using _prefixedName_ in step <emu-xref href="#step-setfunctionname-maybe-prefix-initialname"></emu-xref> for some built-in functions but not others is discouraged legacy behaviour.</p>
+        <p>The choice of whether or not to use _prefixedName_ for _func_.[[InitialName]] affects the output of <emu-xref href="#sec-function.prototype.tostring" title></emu-xref>. Making different choices for different built-in functions in step <emu-xref href="#step-setfunctionname-maybe-prefix-initialname"></emu-xref> is discouraged legacy behaviour.</p>
       </emu-note>
     </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -14187,12 +14187,15 @@
         1. If _prefix_ is present, then
           1. Let _prefixedName_ be the string-concatenation of _prefix_, the code unit 0x0020 (SPACE), and _name_.
           1. If _func_ has an [[InitialName]] internal slot, then
-            1. NOTE: The choice in the following step is made independently each time this Abstract Operation is invoked.
-            1. Set _func_.[[InitialName]] to an implementation-defined choice of either _name_ or _prefixedName_.
+            1. Set _func_.[[InitialName]] to _prefixedName_.
+            1. [normative-optional, legacy] Set _func_.[[InitialName]] to an implementation-defined choice of either _name_ or _prefixedName_.
           1. Set _name_ to _prefixedName_.
         1. Perform ! DefinePropertyOrThrow(_func_, *"name"*, PropertyDescriptor { [[Value]]: _name_, [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
         1. Return ~unused~.
       </emu-alg>
+      <emu-note>
+        <p>The choice of whether or not to include _prefix_ in _func_.[[InitialName]] affects the output of <emu-xref href="#sec-function.prototype.tostring" title></emu-xref>, and is implementation-defined but should apply uniformly to all built-in functions. Including _prefix_ in [[InitialName]] for some built-in functions but not others is discouraged legacy behaviour.</p>
+      </emu-note>
     </emu-clause>
 
     <emu-clause id="sec-setfunctionlength" type="abstract operation">


### PR DESCRIPTION
As observable via Function.prototype.toString.

Ref #3851
Ref #3652

This is a less-constraining alternative to #3855.