### PR TITLE
Editorial: assert the FromBase64 multiple-of-3 byte invariant

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -43401,6 +43401,7 @@ THH:mm:ss.sss
           1. Let _index_ be 0.
           1. Let _length_ be the length of _string_.
           1. Repeat,
+            1. Assert: The number of elements in _bytes_ is evenly divisible by 3.
             1. Set _index_ to SkipAsciiWhitespace(_string_, _index_).
             1. If _index_ = _length_, then
               1. If _chunkLength_ > 0, then


### PR DESCRIPTION
`FromBase64` only appends bytes via `DecodeFullLengthBase64Chunk` (always 3 bytes at a time) inside step 10.l, and step 10.i preempts further reading when continuing to the next full chunk would exceed `maxLength`. Together these guarantee that, at the top of each iteration of the Repeat loop, the number of elements in `bytes` is a multiple of 3; partial outputs (1 or 2 bytes) only ever occur at end-of-stream via `DecodeFinalBase64Chunk` (step 10.b.i and step 10.e).

This invariant is currently implicit; making it an explicit Assert clarifies the algorithm's structure for both readers and implementers (e.g., it justifies why step 10.i's two conditions are exhaustive)