### PR TITLE
Markup: Fix intrinsic proto string in NativeError constructor

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -31990,7 +31990,7 @@
           <p>Each _NativeError_ function performs the following steps when called:</p>
           <emu-alg>
             1. If NewTarget is *undefined*, let _newTarget_ be the active function object; else let _newTarget_ be NewTarget.
-            1. [id="step-nativeerror-ordinarycreatefromconstructor"] Let _obj_ be ? OrdinaryCreateFromConstructor(_newTarget_, <code>"%<var>NativeError</var>.prototype%"</code>, « [[ErrorData]] »).
+            1. [id="step-nativeerror-ordinarycreatefromconstructor"] Let _obj_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%<var>NativeError</var>.prototype%"*, « [[ErrorData]] »).
             1. If _message_ is not *undefined*, then
               1. Let _messageString_ be ? ToString(_message_).
               1. Perform CreateNonEnumerableDataPropertyOrThrow(_obj_, *"message"*, _messageString_).


### PR DESCRIPTION
Just because there's a var in there doesn't mean we should render it as code, regular string works perfectly fine.