### PR TITLE
Editorial: Clean up Well-Known Intrinsic Objects table

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -3418,10 +3418,10 @@
                 %AggregateError%
               </td>
               <td>
-                `AggregateError`
+                *"AggregateError"*
               </td>
               <td>
-                The `AggregateError` constructor (<emu-xref href="#sec-aggregate-error-constructor"></emu-xref>)
+                The `AggregateError` <emu-not-ref>constructor</emu-not-ref> (<emu-xref href="#sec-aggregate-error-constructor"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3429,10 +3429,10 @@
                 %Array%
               </td>
               <td>
-                `Array`
+                *"Array"*
               </td>
               <td>
-                The Array constructor (<emu-xref href="#sec-array-constructor"></emu-xref>)
+                The `Array` <emu-not-ref>constructor</emu-not-ref> (<emu-xref href="#sec-array-constructor"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3440,10 +3440,10 @@
                 %ArrayBuffer%
               </td>
               <td>
-                `ArrayBuffer`
+                *"ArrayBuffer"*
               </td>
               <td>
-                The ArrayBuffer constructor (<emu-xref href="#sec-arraybuffer-constructor"></emu-xref>)
+                The `ArrayBuffer` <emu-not-ref>constructor</emu-not-ref> (<emu-xref href="#sec-arraybuffer-constructor"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3473,7 +3473,7 @@
               <td>
               </td>
               <td>
-                The constructor of async function objects (<emu-xref href="#sec-async-function-constructor"></emu-xref>)
+                The <emu-not-ref>constructor</emu-not-ref> of async function objects (<emu-xref href="#sec-async-function-constructor"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3483,7 +3483,7 @@
               <td>
               </td>
               <td>
-                The constructor of async generator function objects (<emu-xref href="#sec-asyncgeneratorfunction-constructor"></emu-xref>)
+                The <emu-not-ref>constructor</emu-not-ref> of async generator function objects (<emu-xref href="#sec-asyncgeneratorfunction-constructor"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3511,7 +3511,7 @@
                 %Atomics%
               </td>
               <td>
-                `Atomics`
+                *"Atomics"*
               </td>
               <td>
                 The `Atomics` object (<emu-xref href="#sec-atomics-object"></emu-xref>)
@@ -3522,10 +3522,10 @@
                 %BigInt%
               </td>
               <td>
-                `BigInt`
+                *"BigInt"*
               </td>
               <td>
-                The BigInt constructor (<emu-xref href="#sec-bigint-constructor"></emu-xref>)
+                The `BigInt` <emu-not-ref>constructor</emu-not-ref> (<emu-xref href="#sec-bigint-constructor"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3533,10 +3533,10 @@
                 %BigInt64Array%
               </td>
               <td>
-                `BigInt64Array`
+                *"BigInt64Array"*
               </td>
               <td>
-                The BigInt64Array constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
+                The `BigInt64Array` <emu-not-ref>constructor</emu-not-ref> (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3544,10 +3544,10 @@
                 %BigUint64Array%
               </td>
               <td>
-                `BigUint64Array`
+                *"BigUint64Array"*
               </td>
               <td>
-                The BigUint64Array constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
+                The `BigUint64Array` <emu-not-ref>constructor</emu-not-ref> (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3555,10 +3555,10 @@
                 %Boolean%
               </td>
               <td>
-                `Boolean`
+                *"Boolean"*
               </td>
               <td>
-                The Boolean constructor (<emu-xref href="#sec-boolean-constructor"></emu-xref>)
+                The `Boolean` <emu-not-ref>constructor</emu-not-ref> (<emu-xref href="#sec-boolean-constructor"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3566,10 +3566,10 @@
                 %DataView%
               </td>
               <td>
-                `DataView`
+                *"DataView"*
               </td>
               <td>
-                The DataView constructor (<emu-xref href="#sec-dataview-constructor"></emu-xref>)
+                The `DataView` <emu-not-ref>constructor</emu-not-ref> (<emu-xref href="#sec-dataview-constructor"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3577,10 +3577,10 @@
                 %Date%
               </td>
               <td>
-                `Date`
+                *"Date"*
               </td>
               <td>
-                The Date constructor (<emu-xref href="#sec-date-constructor"></emu-xref>)
+                The `Date` <emu-not-ref>constructor</emu-not-ref> (<emu-xref href="#sec-date-constructor"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3588,7 +3588,7 @@
                 %decodeURI%
               </td>
               <td>
-                `decodeURI`
+                *"decodeURI"*
               </td>
               <td>
                 The `decodeURI` function (<emu-xref href="#sec-decodeuri-encodeduri"></emu-xref>)
@@ -3599,7 +3599,7 @@
                 %decodeURIComponent%
               </td>
               <td>
-                `decodeURIComponent`
+                *"decodeURIComponent"*
               </td>
               <td>
                 The `decodeURIComponent` function (<emu-xref href="#sec-decodeuricomponent-encodeduricomponent"></emu-xref>)
@@ -3610,7 +3610,7 @@
                 %encodeURI%
               </td>
               <td>
-                `encodeURI`
+                *"encodeURI"*
               </td>
               <td>
                 The `encodeURI` function (<emu-xref href="#sec-encodeuri-uri"></emu-xref>)
@@ -3621,7 +3621,7 @@
                 %encodeURIComponent%
               </td>
               <td>
-                `encodeURIComponent`
+                *"encodeURIComponent"*
               </td>
               <td>
                 The `encodeURIComponent` function (<emu-xref href="#sec-encodeuricomponent-uricomponent"></emu-xref>)
@@ -3632,10 +3632,10 @@
                 %Error%
               </td>
               <td>
-                `Error`
+                *"Error"*
               </td>
               <td>
-                The Error constructor (<emu-xref href="#sec-error-constructor"></emu-xref>)
+                The `Error` <emu-not-ref>constructor</emu-not-ref> (<emu-xref href="#sec-error-constructor"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3643,7 +3643,7 @@
                 %eval%
               </td>
               <td>
-                `eval`
+                *"eval"*
               </td>
               <td>
                 The `eval` function (<emu-xref href="#sec-eval-x"></emu-xref>)
@@ -3654,10 +3654,10 @@
                 %EvalError%
               </td>
               <td>
-                `EvalError`
+                *"EvalError"*
               </td>
               <td>
-                The EvalError constructor (<emu-xref href="#sec-native-error-types-used-in-this-standard-evalerror"></emu-xref>)
+                The `EvalError` <emu-not-ref>constructor</emu-not-ref> (<emu-xref href="#sec-native-error-types-used-in-this-standard-evalerror"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3665,10 +3665,10 @@
                 %FinalizationRegistry%
               </td>
               <td>
-                `FinalizationRegistry`
+                *"FinalizationRegistry"*
               </td>
               <td>
-                The FinalizationRegistry constructor (<emu-xref href="#sec-finalization-registry-constructor"></emu-xref>)
+                The `FinalizationRegistry` <emu-not-ref>constructor</emu-not-ref> (<emu-xref href="#sec-finalization-registry-constructor"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3676,10 +3676,10 @@
                 %Float16Array%
               </td>
               <td>
-                `Float16Array`
+                *"Float16Array"*
               </td>
               <td>
-                The Float16Array constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
+                The `Float16Array` <emu-not-ref>constructor</emu-not-ref> (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3687,10 +3687,10 @@
                 %Float32Array%
               </td>
               <td>
-                `Float32Array`
+                *"Float32Array"*
               </td>
               <td>
-                The Float32Array constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
+                The `Float32Array` <emu-not-ref>constructor</emu-not-ref> (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3698,10 +3698,10 @@
                 %Float64Array%
               </td>
               <td>
-                `Float64Array`
+                *"Float64Array"*
               </td>
               <td>
-                The Float64Array constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
+                The `Float64Array` <emu-not-ref>constructor</emu-not-ref> (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3719,10 +3719,10 @@
                 %Function%
               </td>
               <td>
-                `Function`
+                *"Function"*
               </td>
               <td>
-                The Function constructor (<emu-xref href="#sec-function-constructor"></emu-xref>)
+                The `Function` <emu-not-ref>constructor</emu-not-ref> (<emu-xref href="#sec-function-constructor"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3732,7 +3732,7 @@
               <td>
               </td>
               <td>
-                The constructor of generator function objects (<emu-xref href="#sec-generatorfunction-constructor"></emu-xref>)
+                The <emu-not-ref>constructor</emu-not-ref> of generator function objects (<emu-xref href="#sec-generatorfunction-constructor"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3750,10 +3750,10 @@
                 %Int8Array%
               </td>
               <td>
-                `Int8Array`
+                *"Int8Array"*
               </td>
               <td>
-                The Int8Array constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
+                The `Int8Array` <emu-not-ref>constructor</emu-not-ref> (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3761,10 +3761,10 @@
                 %Int16Array%
               </td>
               <td>
-                `Int16Array`
+                *"Int16Array"*
               </td>
               <td>
-                The Int16Array constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
+                The `Int16Array` <emu-not-ref>constructor</emu-not-ref> (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3772,10 +3772,10 @@
                 %Int32Array%
               </td>
               <td>
-                `Int32Array`
+                *"Int32Array"*
               </td>
               <td>
-                The Int32Array constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
+                The `Int32Array` <emu-not-ref>constructor</emu-not-ref> (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3783,7 +3783,7 @@
                 %isFinite%
               </td>
               <td>
-                `isFinite`
+                *"isFinite"*
               </td>
               <td>
                 The `isFinite` function (<emu-xref href="#sec-isfinite-number"></emu-xref>)
@@ -3794,7 +3794,7 @@
                 %isNaN%
               </td>
               <td>
-                `isNaN`
+                *"isNaN"*
               </td>
               <td>
                 The `isNaN` function (<emu-xref href="#sec-isnan-number"></emu-xref>)
@@ -3805,10 +3805,10 @@
                 %Iterator%
               </td>
               <td>
-                `Iterator`
+                *"Iterator"*
               </td>
               <td>
-                The `Iterator` constructor (<emu-xref href="#sec-iterator-constructor"></emu-xref>)
+                The `Iterator` <emu-not-ref>constructor</emu-not-ref> (<emu-xref href="#sec-iterator-constructor"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3826,7 +3826,7 @@
                 %JSON%
               </td>
               <td>
-                `JSON`
+                *"JSON"*
               </td>
               <td>
                 The `JSON` object (<emu-xref href="#sec-json-object"></emu-xref>)
@@ -3837,10 +3837,10 @@
                 %Map%
               </td>
               <td>
-                `Map`
+                *"Map"*
               </td>
               <td>
-                The Map constructor (<emu-xref href="#sec-map-constructor"></emu-xref>)
+                The `Map` <emu-not-ref>constructor</emu-not-ref> (<emu-xref href="#sec-map-constructor"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3858,7 +3858,7 @@
                 %Math%
               </td>
               <td>
-                `Math`
+                *"Math"*
               </td>
               <td>
                 The `Math` object (<emu-xref href="#sec-math-object"></emu-xref>)
@@ -3869,10 +3869,10 @@
                 %Number%
               </td>
               <td>
-                `Number`
+                *"Number"*
               </td>
               <td>
-                The Number constructor (<emu-xref href="#sec-number-constructor"></emu-xref>)
+                The `Number` <emu-not-ref>constructor</emu-not-ref> (<emu-xref href="#sec-number-constructor"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3880,10 +3880,10 @@
                 %Object%
               </td>
               <td>
-                `Object`
+                *"Object"*
               </td>
               <td>
-                The Object constructor (<emu-xref href="#sec-object-constructor"></emu-xref>)
+                The `Object` <emu-not-ref>constructor</emu-not-ref> (<emu-xref href="#sec-object-constructor"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3891,7 +3891,7 @@
                 %parseFloat%
               </td>
               <td>
-                `parseFloat`
+                *"parseFloat"*
               </td>
               <td>
                 The `parseFloat` function (<emu-xref href="#sec-parsefloat-string"></emu-xref>)
@@ -3902,7 +3902,7 @@
                 %parseInt%
               </td>
               <td>
-                `parseInt`
+                *"parseInt"*
               </td>
               <td>
                 The `parseInt` function (<emu-xref href="#sec-parseint-string-radix"></emu-xref>)
@@ -3913,10 +3913,10 @@
                 %Promise%
               </td>
               <td>
-                `Promise`
+                *"Promise"*
               </td>
               <td>
-                The Promise constructor (<emu-xref href="#sec-promise-constructor"></emu-xref>)
+                The `Promise` <emu-not-ref>constructor</emu-not-ref> (<emu-xref href="#sec-promise-constructor"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3924,10 +3924,10 @@
                 %Proxy%
               </td>
               <td>
-                `Proxy`
+                *"Proxy"*
               </td>
               <td>
-                The Proxy constructor (<emu-xref href="#sec-proxy-constructor"></emu-xref>)
+                The `Proxy` <emu-not-ref>constructor</emu-not-ref> (<emu-xref href="#sec-proxy-constructor"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3935,10 +3935,10 @@
                 %RangeError%
               </td>
               <td>
-                `RangeError`
+                *"RangeError"*
               </td>
               <td>
-                The RangeError constructor (<emu-xref href="#sec-native-error-types-used-in-this-standard-rangeerror"></emu-xref>)
+                The `RangeError` <emu-not-ref>constructor</emu-not-ref> (<emu-xref href="#sec-native-error-types-used-in-this-standard-rangeerror"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3946,10 +3946,10 @@
                 %ReferenceError%
               </td>
               <td>
-                `ReferenceError`
+                *"ReferenceError"*
               </td>
               <td>
-                The ReferenceError constructor (<emu-xref href="#sec-native-error-types-used-in-this-standard-referenceerror"></emu-xref>)
+                The `ReferenceError` <emu-not-ref>constructor</emu-not-ref> (<emu-xref href="#sec-native-error-types-used-in-this-standard-referenceerror"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3957,7 +3957,7 @@
                 %Reflect%
               </td>
               <td>
-                `Reflect`
+                *"Reflect"*
               </td>
               <td>
                 The `Reflect` object (<emu-xref href="#sec-reflect-object"></emu-xref>)
@@ -3968,10 +3968,10 @@
                 %RegExp%
               </td>
               <td>
-                `RegExp`
+                *"RegExp"*
               </td>
               <td>
-                The RegExp constructor (<emu-xref href="#sec-regexp-constructor"></emu-xref>)
+                The `RegExp` <emu-not-ref>constructor</emu-not-ref> (<emu-xref href="#sec-regexp-constructor"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -3989,10 +3989,10 @@
                 %Set%
               </td>
               <td>
-                `Set`
+                *"Set"*
               </td>
               <td>
-                The Set constructor (<emu-xref href="#sec-set-constructor"></emu-xref>)
+                The `Set` <emu-not-ref>constructor</emu-not-ref> (<emu-xref href="#sec-set-constructor"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -4010,10 +4010,10 @@
                 %SharedArrayBuffer%
               </td>
               <td>
-                `SharedArrayBuffer`
+                *"SharedArrayBuffer"*
               </td>
               <td>
-                The SharedArrayBuffer constructor (<emu-xref href="#sec-sharedarraybuffer-constructor"></emu-xref>)
+                The `SharedArrayBuffer` <emu-not-ref>constructor</emu-not-ref> (<emu-xref href="#sec-sharedarraybuffer-constructor"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -4021,10 +4021,10 @@
                 %String%
               </td>
               <td>
-                `String`
+                *"String"*
               </td>
               <td>
-                The String constructor (<emu-xref href="#sec-string-constructor"></emu-xref>)
+                The `String` <emu-not-ref>constructor</emu-not-ref> (<emu-xref href="#sec-string-constructor"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -4042,10 +4042,10 @@
                 %Symbol%
               </td>
               <td>
-                `Symbol`
+                *"Symbol"*
               </td>
               <td>
-                The Symbol constructor (<emu-xref href="#sec-symbol-constructor"></emu-xref>)
+                The `Symbol` <emu-not-ref>constructor</emu-not-ref> (<emu-xref href="#sec-symbol-constructor"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -4053,10 +4053,10 @@
                 %SyntaxError%
               </td>
               <td>
-                `SyntaxError`
+                *"SyntaxError"*
               </td>
               <td>
-                The SyntaxError constructor (<emu-xref href="#sec-native-error-types-used-in-this-standard-syntaxerror"></emu-xref>)
+                The `SyntaxError` <emu-not-ref>constructor</emu-not-ref> (<emu-xref href="#sec-native-error-types-used-in-this-standard-syntaxerror"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -4076,7 +4076,7 @@
               <td>
               </td>
               <td>
-                The super class of all typed Array constructors (<emu-xref href="#sec-%typedarray%-intrinsic-object"></emu-xref>)
+                The super class of all typed Array <emu-not-ref>constructors</emu-not-ref> (<emu-xref href="#sec-%typedarray%-intrinsic-object"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -4084,10 +4084,10 @@
                 %TypeError%
               </td>
               <td>
-                `TypeError`
+                *"TypeError"*
               </td>
               <td>
-                The TypeError constructor (<emu-xref href="#sec-native-error-types-used-in-this-standard-typeerror"></emu-xref>)
+                The `TypeError` <emu-not-ref>constructor</emu-not-ref> (<emu-xref href="#sec-native-error-types-used-in-this-standard-typeerror"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -4095,10 +4095,10 @@
                 %Uint8Array%
               </td>
               <td>
-                `Uint8Array`
+                *"Uint8Array"*
               </td>
               <td>
-                The Uint8Array constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
+                The `Uint8Array` <emu-not-ref>constructor</emu-not-ref> (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -4106,10 +4106,10 @@
                 %Uint8ClampedArray%
               </td>
               <td>
-                `Uint8ClampedArray`
+                *"Uint8ClampedArray"*
               </td>
               <td>
-                The Uint8ClampedArray constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
+                The `Uint8ClampedArray` <emu-not-ref>constructor</emu-not-ref> (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -4117,10 +4117,10 @@
                 %Uint16Array%
               </td>
               <td>
-                `Uint16Array`
+                *"Uint16Array"*
               </td>
               <td>
-                The Uint16Array constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
+                The `Uint16Array` <emu-not-ref>constructor</emu-not-ref> (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -4128,10 +4128,10 @@
                 %Uint32Array%
               </td>
               <td>
-                `Uint32Array`
+                *"Uint32Array"*
               </td>
               <td>
-                The Uint32Array constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
+                The `Uint32Array` <emu-not-ref>constructor</emu-not-ref> (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -4139,10 +4139,10 @@
                 %URIError%
               </td>
               <td>
-                `URIError`
+                *"URIError"*
               </td>
               <td>
-                The URIError constructor (<emu-xref href="#sec-native-error-types-used-in-this-standard-urierror"></emu-xref>)
+                The `URIError` <emu-not-ref>constructor</emu-not-ref> (<emu-xref href="#sec-native-error-types-used-in-this-standard-urierror"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -4150,10 +4150,10 @@
                 %WeakMap%
               </td>
               <td>
-                `WeakMap`
+                *"WeakMap"*
               </td>
               <td>
-                The WeakMap constructor (<emu-xref href="#sec-weakmap-constructor"></emu-xref>)
+                The `WeakMap` <emu-not-ref>constructor</emu-not-ref> (<emu-xref href="#sec-weakmap-constructor"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -4161,10 +4161,10 @@
                 %WeakRef%
               </td>
               <td>
-                `WeakRef`
+                *"WeakRef"*
               </td>
               <td>
-                The WeakRef constructor (<emu-xref href="#sec-weak-ref-constructor"></emu-xref>)
+                The `WeakRef` <emu-not-ref>constructor</emu-not-ref> (<emu-xref href="#sec-weak-ref-constructor"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -4172,10 +4172,10 @@
                 %WeakSet%
               </td>
               <td>
-                `WeakSet`
+                *"WeakSet"*
               </td>
               <td>
-                The WeakSet constructor (<emu-xref href="#sec-weakset-constructor"></emu-xref>)
+                The `WeakSet` <emu-not-ref>constructor</emu-not-ref> (<emu-xref href="#sec-weakset-constructor"></emu-xref>)
               </td>
             </tr>
             <tr>
@@ -4185,7 +4185,7 @@
               <td>
               </td>
               <td>
-                The prototype of wrapped iterator objects returned by Iterator.from (<emu-xref href="#sec-%wrapforvaliditeratorprototype%-object"></emu-xref>)
+                The prototype of wrapped iterator objects returned by `Iterator.from` (<emu-xref href="#sec-%wrapforvaliditeratorprototype%-object"></emu-xref>)
               </td>
             </tr>
           </table>
@@ -53217,7 +53217,7 @@ THH:mm:ss.sss
               %escape%
             </td>
             <td>
-              `escape`
+              *"escape"*
             </td>
             <td>
               The `escape` function (<emu-xref href="#sec-escape-string"></emu-xref>)
@@ -53228,7 +53228,7 @@ THH:mm:ss.sss
               %unescape%
             </td>
             <td>
-              `unescape`
+              *"unescape"*
             </td>
             <td>
               The `unescape` function (<emu-xref href="#sec-unescape-string"></emu-xref>)

--- a/spec.html
+++ b/spec.html
@@ -29784,17 +29784,20 @@
 
     <emu-clause id="sec-value-properties-of-the-global-object-infinity">
       <h1>Infinity</h1>
-      <p>The value of `Infinity` is *+∞*<sub>𝔽</sub> (see <emu-xref href="#sec-ecmascript-language-types-number-type"></emu-xref>). This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
+      <p>The initial value of the *"Infinity"* property of the global object is *+∞*<sub>𝔽</sub> (see <emu-xref href="#sec-ecmascript-language-types-number-type"></emu-xref>).</p>
+      <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
     </emu-clause>
 
     <emu-clause id="sec-value-properties-of-the-global-object-nan">
       <h1>NaN</h1>
-      <p>The value of `NaN` is *NaN* (see <emu-xref href="#sec-ecmascript-language-types-number-type"></emu-xref>). This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
+      <p>The initial value of the *"NaN"* property of the global object is *NaN* (see <emu-xref href="#sec-ecmascript-language-types-number-type"></emu-xref>).</p>
+      <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
     </emu-clause>
 
     <emu-clause id="sec-undefined">
       <h1>undefined</h1>
-      <p>The value of `undefined` is *undefined* (see <emu-xref href="#sec-ecmascript-language-types-undefined-type"></emu-xref>). This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
+      <p>The initial value of the *"undefined"* property of the global object is *undefined* (see <emu-xref href="#sec-ecmascript-language-types-undefined-type"></emu-xref>).</p>
+      <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
     </emu-clause>
   </emu-clause>
 


### PR DESCRIPTION
Closes #3836.

When we discussed this there was skepticism about using strings for the _Global Name_ column due to the amount of visual noise but ultimately I prefer it over the monospace rendering because property names are represented as strings across the spec. Monospace rendering works best for informal mention of functions in prose IMO.

There's little precedent but at least https://tc39.es/ecma262/#sec-common-iteration-interfaces contains tables with property names in a similar fashion.

We could possibly use this column to replace the hand-wavy `Let name be the String value of the property name.` in `SetDefaultGlobalBindings` in the future (but might have to introduce a third table for the value properties to do so).

| Before | After |
| - | - |
| <img width="1933" height="4819" alt="image" src="https://github.com/user-attachments/assets/ee0aede8-b06a-4b21-9582-20c8e2cb255c" /> | <img width="1935" height="4821" alt="image" src="https://github.com/user-attachments/assets/844d729e-86ab-45fc-ad3c-8129acfa7ebf" />