### PR TITLE
Normative: make Promise.try use PromiseResolve in non-error case

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -50164,13 +50164,13 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _ctor_ be the *this* value.
           1. If _ctor_ is not an Object, throw a *TypeError* exception.
-          1. Let _promiseCapability_ be ? NewPromiseCapability(_ctor_).
           1. Let _status_ be Completion(Call(_callback_, *undefined*, _args_)).
           1. If _status_ is an abrupt completion, then
+            1. Let _promiseCapability_ be ? NewPromiseCapability(_ctor_).
             1. Perform ? Call(_promiseCapability_.[[Reject]], *undefined*, « _status_.[[Value]] »).
+            1. Return _promiseCapability_.[[Promise]].
           1. Else,
-            1. Perform ? Call(_promiseCapability_.[[Resolve]], *undefined*, « _status_.[[Value]] »).
-          1. Return _promiseCapability_.[[Promise]].
+            1. Return ? PromiseResolve(_ctor_, ! _status_).
         </emu-alg>
         <emu-note>
           <p>This function expects its *this* value to be a constructor function that supports the parameter conventions of the Promise constructor.</p>

--- a/spec.html
+++ b/spec.html
@@ -51269,13 +51269,13 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _ctor_ be the *this* value.
           1. If _ctor_ is not an Object, throw a *TypeError* exception.
-          1. Let _promiseCapability_ be ? NewPromiseCapability(_ctor_).
           1. Let _status_ be Completion(Call(_callback_, *undefined*, _args_)).
           1. If _status_ is an abrupt completion, then
+            1. Let _promiseCapability_ be ? NewPromiseCapability(_ctor_).
             1. Perform ? Call(_promiseCapability_.[[Reject]], *undefined*, « _status_.[[Value]] »).
+            1. Return _promiseCapability_.[[Promise]].
           1. Else,
-            1. Perform ? Call(_promiseCapability_.[[Resolve]], *undefined*, « _status_.[[Value]] »).
-          1. Return _promiseCapability_.[[Promise]].
+            1. Return ? PromiseResolve(_ctor_, ! _status_).
         </emu-alg>
         <emu-note>
           <p>This function expects its *this* value to be a constructor function that supports the parameter conventions of the Promise constructor.</p>


### PR DESCRIPTION
Using [PromiseResolve](https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise-resolve) differs from the current behavior in that when the argument returns a Promise whose `.constructor` is whatever the `this` value of the `Promise.try` call is[^1], we just return that Promise directly instead of wrapping it in a new one. Otherwise it's exactly the same.

This has the advantage of better matching [the intuition](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/try#description) that this is for cases where you want to write `Promise.resolve(foo())` but you also want to wrap sync errors in rejected Promises. Now it actually works exactly like

```js
try {
  result = Promise.resolve(foo());
} catch (e) {
  result = Promise.reject(e);
}
```

As a bonus, it also means this costs zero microtask ticks in the case where the argument is actually an async function, instead of (as currently) two.

See matrix chat [1](https://matrixlogs.bakkot.com/TC39_Delegates/2026-06-01) [2](https://matrixlogs.bakkot.com/TC39_Delegates/2026-06-02).


[^1]: Precise check [might change](https://github.com/tc39/ecma262/pull/3689).