### PR TITLE
Editorial: Fix ordering of Atomics functions

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -47121,6 +47121,32 @@ THH:mm:ss.sss
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-atomics.notify" type="built-in function">
+      <h1>Atomics.notify ( _ta_, _index_, _count_ )</h1>
+      <p>This function notifies some agents that are sleeping in the wait queue.</p>
+      <p>It performs the following steps when called:</p>
+      <emu-alg>
+        1. Let _taRecord_ be ? ValidateIntegerTypedArray(_ta_, *true*).
+        1. Let _byteIndexInBuffer_ be ? ValidateAtomicAccess(_taRecord_, _index_).
+        1. If _count_ is *undefined*, then
+          1. Set _count_ to +∞.
+        1. Else,
+          1. Let _intCount_ be ? ToIntegerOrInfinity(_count_).
+          1. Set _count_ to max(_intCount_, 0).
+        1. Let _buffer_ be _ta_.[[ViewedArrayBuffer]].
+        1. Let _block_ be _buffer_.[[ArrayBufferData]].
+        1. If IsSharedArrayBuffer(_buffer_) is *false*, return *+0*<sub>𝔽</sub>.
+        1. Let _waiterList_ be GetWaiterList(_block_, _byteIndexInBuffer_).
+        1. Perform EnterCriticalSection(_waiterList_).
+        1. Let _waiters_ be RemoveWaiters(_waiterList_, _count_).
+        1. For each element _waiterRecord_ of _waiters_, do
+          1. Perform NotifyWaiter(_waiterList_, _waiterRecord_).
+        1. Perform LeaveCriticalSection(_waiterList_).
+        1. Let _waitersCount_ be the number of elements in _waiters_.
+        1. Return 𝔽(_waitersCount_).
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-atomics.or" type="built-in function">
       <h1>Atomics.or ( _ta_, _index_, _value_ )</h1>
       <p>This function performs the following steps when called:</p>
@@ -47129,6 +47155,24 @@ THH:mm:ss.sss
           1. Return ByteListBitwiseOp(`|`, _xBytes_, _yBytes_).
         1. Return ? AtomicReadModifyWrite(_ta_, _index_, _value_, _or_).
       </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-atomics.pause" type="built-in function">
+      <h1>Atomics.pause ( )</h1>
+      <p>This function provides a hint to the CPU that the program is spin looping while waiting on a value.</p>
+      <p>It performs the following steps when called:</p>
+      <emu-alg>
+        1. If the execution environment of the ECMAScript implementation supports signaling to the operating system or CPU that the current executing code is in a spin-wait loop, send that signal.
+        1. Return *undefined*.
+      </emu-alg>
+      <emu-note>
+        <p>This method is designed for programs implementing spin-wait loops, such as spinlock fast paths inside of mutexes, to provide a hint to the CPU that it is spinning while waiting on a value. It has no observable behaviour other than timing.</p>
+        <p>Implementations are expected to implement a pause or yield instruction if the best practices of the underlying architecture recommends such instructions in spin loops. For example, the <a href="https://www.intel.com/content/www/us/en/content-details/671488/intel-64-and-ia-32-architectures-optimization-reference-manual-volume-1.html">Intel Optimization Manual</a> recommends the <code>pause</code> instruction.</p>
+        <p>Implementations are encouraged to have an internal upper bound on the maximum amount of time paused on the order of tens to hundreds of nanoseconds.</p>
+      </emu-note>
+      <emu-note>
+        <p>Due to the overhead of function calls, it is reasonable that an inlined call to this method in an optimizing compiler waits a different amount of time than a non-inlined call.</p>
+      </emu-note>
     </emu-clause>
 
     <emu-clause id="sec-atomics.store" type="built-in function">
@@ -47184,50 +47228,6 @@ THH:mm:ss.sss
       <emu-alg>
         1. Return ? DoWait(~async~, _ta_, _index_, _value_, _timeout_).
       </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-atomics.notify" type="built-in function">
-      <h1>Atomics.notify ( _ta_, _index_, _count_ )</h1>
-      <p>This function notifies some agents that are sleeping in the wait queue.</p>
-      <p>It performs the following steps when called:</p>
-      <emu-alg>
-        1. Let _taRecord_ be ? ValidateIntegerTypedArray(_ta_, *true*).
-        1. Let _byteIndexInBuffer_ be ? ValidateAtomicAccess(_taRecord_, _index_).
-        1. If _count_ is *undefined*, then
-          1. Set _count_ to +∞.
-        1. Else,
-          1. Let _intCount_ be ? ToIntegerOrInfinity(_count_).
-          1. Set _count_ to max(_intCount_, 0).
-        1. Let _buffer_ be _ta_.[[ViewedArrayBuffer]].
-        1. Let _block_ be _buffer_.[[ArrayBufferData]].
-        1. If IsSharedArrayBuffer(_buffer_) is *false*, return *+0*<sub>𝔽</sub>.
-        1. Let _waiterList_ be GetWaiterList(_block_, _byteIndexInBuffer_).
-        1. Perform EnterCriticalSection(_waiterList_).
-        1. Let _waiters_ be RemoveWaiters(_waiterList_, _count_).
-        1. For each element _waiterRecord_ of _waiters_, do
-          1. Perform NotifyWaiter(_waiterList_, _waiterRecord_).
-        1. Perform LeaveCriticalSection(_waiterList_).
-        1. Let _waitersCount_ be the number of elements in _waiters_.
-        1. Return 𝔽(_waitersCount_).
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="Atomics.pause">
-      <h1>Atomics.pause ( )</h1>
-      <p>This function provides a hint to the CPU that the program is spin looping while waiting on a value.</p>
-      <p>It performs the following steps when called:</p>
-      <emu-alg>
-        1. If the execution environment of the ECMAScript implementation supports signaling to the operating system or CPU that the current executing code is in a spin-wait loop, send that signal.
-        1. Return *undefined*.
-      </emu-alg>
-      <emu-note>
-        <p>This method is designed for programs implementing spin-wait loops, such as spinlock fast paths inside of mutexes, to provide a hint to the CPU that it is spinning while waiting on a value. It has no observable behaviour other than timing.</p>
-        <p>Implementations are expected to implement a pause or yield instruction if the best practices of the underlying architecture recommends such instructions in spin loops. For example, the <a href="https://www.intel.com/content/www/us/en/content-details/671488/intel-64-and-ia-32-architectures-optimization-reference-manual-volume-1.html">Intel Optimization Manual</a> recommends the <code>pause</code> instruction.</p>
-        <p>Implementations are encouraged to have an internal upper bound on the maximum amount of time paused on the order of tens to hundreds of nanoseconds.</p>
-      </emu-note>
-      <emu-note>
-        <p>Due to the overhead of function calls, it is reasonable that an inlined call to this method in an optimizing compiler waits a different amount of time than a non-inlined call.</p>
-      </emu-note>
     </emu-clause>
 
     <emu-clause id="sec-atomics.xor" type="built-in function">


### PR DESCRIPTION
Unfortunately didn't notice this while reviewing #3847, but I think we can get away without oldids for this one.