### PR TITLE
Meta: Improve the snapshot warning

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -98,7 +98,7 @@ jobs:
           node-version: lts/*
           use-npm-ci: true
       - run: npm run build-only
-      - run: node scripts/insert-snapshot-warning.js
+      - run: node scripts/insert-snapshot-warning.js --pr ${{ github.event.number }}
       - run: ./scripts/deploy-github-pages.sh --pr ${{ github.event.number }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/insert-snapshot-warning.js
+++ b/scripts/insert-snapshot-warning.js
@@ -33,7 +33,7 @@ const PR = (() => {
     return ghEvent.number;
   } catch (_err) {}
 })();
-const SUMMARY = PR ? `PR #${PR}` : COMMIT.slice(0, 8);
+const SUMMARY = PR ? `PR #${PR}` : `commit ${COMMIT.slice(0, 8)}`;
 
 const WARNING_HTML = `
 <details class="annoying-warning" open="">

--- a/scripts/insert-snapshot-warning.js
+++ b/scripts/insert-snapshot-warning.js
@@ -2,24 +2,53 @@
 
 const fs = require('fs');
 const path = require('path');
+const util = require('util');
 const { JSDOM, VirtualConsole } = require('jsdom');
 const { execSync } = require('child_process');
 
+const makeHref = (parentHref, path) =>
+  new URL(path, parentHref.replace(/\/?$/, '/')).href;
+
+// https://docs.github.com/en/actions/reference/workflows-and-actions/variables
+const {
+  GITHUB_EVENT_PATH,
+  GITHUB_SERVER_URL = 'https://github.com',
+  GITHUB_REPOSITORY = 'tc39/ecma262',
+} = process.env;
+const REPO_URL = makeHref(GITHUB_SERVER_URL, GITHUB_REPOSITORY);
+
 const COMMIT = String(execSync('git rev-parse --verify HEAD')).trim();
+const PR = (() => {
+  const cliOptions = {
+    pr: { type: 'string' },
+  };
+  const args = util.parseArgs({ options: cliOptions }).values;
+  if (args.pr) return args.pr;
+
+  try {
+    const ghEventJson = fs.readFileSync(GITHUB_EVENT_PATH, 'utf8');
+    const ghEvent = JSON.parse(ghEventJson);
+    // https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_target
+    // https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request
+    return ghEvent.number;
+  } catch (_err) {}
+})();
+const SUMMARY = PR ? `PR #${PR}` : COMMIT.slice(0, 8);
 
 const WARNING_HTML = `
 <details class="annoying-warning" open="">
-  <summary>This is a commit snapshot of the specification</summary>
+  <summary>${SUMMARY}</summary>
   <p>
-    This document contains the contents of the specification as of
-    <a href="https://github.com/tc39/ecma262/commit/${COMMIT}">commit ${COMMIT}</a>,
+    This document is a preview of the specification for
+    ${PR ? `<a href="${encodeURI(makeHref(REPO_URL, `pull/${PR}`))}">PR #${PR}</a>` : ''}
+    commit <a href="${encodeURI(makeHref(REPO_URL, `commit/${COMMIT}`))}">${COMMIT}</a>,
     and should only be used as a historical reference. This commit may not
     have even been merged into the specification.
   </p>
   <p>
     Do not attempt to implement this version of the specification. Do not
     reference this version as authoritative in any way. Instead, see
-    <a href="https://tc39.es/ecma262">https://tc39.es/ecma262</a> for the
+    <a href="${encodeURI(REPO_URL)}">${REPO_URL.replaceAll('<', '&lt;')}</a> for the
     living specification.
   </p>
 </details>
@@ -68,31 +97,26 @@ const WARNING_CSS = `
 details.annoying-warning {
   background-color: #920800;
   background-image: linear-gradient(transparent 40%, rgba(255, 255, 255, 0.2));
-  border: solid rgba(0, 0, 0, 0.4);
-  border-radius: 3px;
-  border-width: 1px 1px 0 1px;
-  box-shadow: 0 0 0.5em rgba(0, 0, 0, 0.5);
+  border: 2px solid white;
   color: rgba(255, 255, 255, 0.95);
   opacity: .95;
   position: fixed;
-  left: 5%;
-  margin: 0 auto;
-  right: 5%;
+  top: 0;
+  right: 0;
   z-index: 10;
 }
 
 details.annoying-warning[open] {
   top: 10%;
   top: calc(5vw + 5vh);
-  max-width: 1024px;
+  left: 5%;
+  right: 5%;
+  margin: 0 auto;
+  max-width: 800px;
   outline: solid 10000px rgba(255, 255, 255, 0.6);
-}
-
-details.annoying-warning:not([open]) {
-  bottom: 0;
-  left: 0;
-  right: 0;
-  border-radius: 0;
+  border: 1px solid rgba(0, 0, 0, 0.4);
+  border-radius: 3px;
+  box-shadow: 0 0 0.5em rgba(0, 0, 0, 0.5);
 }
 
 details.annoying-warning > summary {
@@ -100,15 +124,15 @@ details.annoying-warning > summary {
   font-size: 0.875em;
   font-weight: bold;
   letter-spacing: 0.02em;
-  padding: 10px 5px;
+  padding: 0.5ex 1ex;
   text-align: center;
   text-transform: uppercase;
   text-shadow: 0px 1px 2px rgba(0, 0, 0, 0.85);
   cursor: default;
 }
 
-details.annoying-warning > summary::after {
-  content: " Expand";
+details.annoying-warning[open] > summary::after {
+  content: " Collapse";
   position: absolute;
   top: 0;
   right: 5px;
@@ -116,14 +140,9 @@ details.annoying-warning > summary::after {
   font-weight: bold;
 }
 
-details.annoying-warning[open] > summary::after {
-  content: " Collapse";
-}
-
 details.annoying-warning p {
-  padding: 0 7.5% 1em;
   line-height: 1.4;
-  margin: 0;
+  margin: 1em;
   text-shadow: 0px 1px 1px rgba(0, 0, 0, 0.85);
 }
 


### PR DESCRIPTION
Link to the associated PR, and move its collapsed box to top right (where it won't obscure the References pane).

The preview for _this_ PR won't include its changes because [pr-preview.yml](https://github.com/tc39/ecma262/blob/main/.github/workflows/pr-preview.yml) overwrites insert-snapshot-warning.js with contents from main, but the output will be similar to e.g. https://tc39.es/proposal-immutable-arraybuffer/pr/62/ (modulo making only minimal changes to the expanded text contents here, although I'd certainly be willing to further tweak those as well).

Fixes #3158