### PR TITLE
Markup: updated print-only styles for >= 2026 edition

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -66,11 +66,13 @@
     min-width: 135mm;
   }
 
-  /* 2.2 Examples of legacy/normative-optional are small enough to be aggressive against breaks */
-  #sec-conformance [example],
-  /* 16.2.1.xxx many tables */
-  #sec-example-cyclic-module-record-graphs table {
-    break-inside: avoid-page;
+  /* 9.1.1 The Environment Record Type Hierarchy (Table 14) is long enough, and rows are tall enough, that R1 can be a widow */
+  #table-abstract-methods-of-environment-records tr:first-of-type {
+    break-after: initial;
+  }
+
+  #table-abstract-methods-of-environment-records td:nth-of-type(2) {
+   width: 40%;
   }
 
   /* 12.10.1 long note can break wherever it wants */
@@ -79,83 +81,43 @@
     break-inside: initial;
   }
 
-  /* 12.10.X Sections start with an <em> not inside a <p> */
-  #sec-examples-of-automatic-semicolon-insertion > em,
-  #sec-interesting-cases-of-automatic-semicolon-insertion > em,
-  #sec-asi-cases-with-no-lineterminator-here > em {
-    display: block;
-    margin-top: 1.25ex;
+  /* 16.2.1.5 Abstract Module Records (Table 39) */
+  #table-abstract-methods-of-module-records td:nth-of-type(2) {
+    width: 50%;
   }
 
-  /* 15.1.X missing spacing between intro and first emu-grammar */
-  #sec-static-semantics-containsexpression > emu-grammar:first-of-type {
-    margin-top: 2ex;
+  /* 16.2.1.6 Additional Abstract Methods of Cyclic Module Records (Table 41) */
+  #table-cyclic-module-methods td:nth-of-type(3) {
+    width: 30%;
   }
 
-  /* 15.3 A very long term combined with inline-block, nowrap, and justified text resulting in weird punctuation */
-  #sec-arrow-function-definitions > p > emu-grammar {
-    text-align: left;
+  /* 21.4.4.41.2 DateString (Tables 60-61) table too narrow for caption */
+  #sec-todatestring-day-names table,
+  #sec-todatestring-month-names table {
+    text-align: center;
+    width: 70mm;
   }
 
-  /* 20.X legacy title */
-  #sec-object\.prototype\.__proto__ > .attributes-tag {
-    break-before: avoid-page;
-    break-after: avoid-page;
+  /* 22.2.2.9.7 UnicodeMatchProperty (Table 66) table too narrow for caption */
+  #table-binary-unicode-properties-of-strings table {
+    width: 90mm;
   }
 
-  /* 21.X table middle column is too narrow */
-  #table-time-zone-identifier-record-fields > figure > table th:nth-of-type(2) {
-    min-width: 19mm;
+  /* 22.2.9.3 Properties of RegExp String Iterator Instances (Table 68) */
+  #table-regexp-string-iterator-instance-slots td:nth-of-type(2) {
+    width: 12%
   }
 
-  /* 29.X extremely long note */
+  /* 29.11 extremely long note */
   #sec-shared-memory-guidelines > emu-note {
     break-inside: auto;
-  }
-
-  .unicode-property-table {
-    table-layout: initial;
-    width: auto;
-    font-size: 90%;
-  }
-
-  .unicode-property-table th:first-of-type {
-    width: 33%;
-  }
-
-  .corner-cell {
-    background-image: url(data:image/svg+xml;base64,PHN2ZyBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGZpbGwtcnVsZT0iZXZlbm9kZCIgaGVpZ2h0PSI0NiIgc3Ryb2tlLWxpbmVjYXA9InNxdWFyZSIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgc3Ryb2tlLW1pdGVybGltaXQ9IjEuNSIgd2lkdGg9IjI0MiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cGF0aCBkPSJtMzE1LjI2NiAzOTYuMzQzIDI0MS4zOTQgNDUuMTU1IiBmaWxsPSJub25lIiBzdHJva2U9IiMwMDAiIHN0cm9rZS13aWR0aD0iMS4wNCIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoLTMxNC45MyAtMzk1LjkzNSkiLz48L3N2Zz4=);
-    background-repeat: no-repeat;
-    background-size: 100% 3em;
-    height: 3em;
-    padding: 0;
-    vertical-align: inherit;
-    position: static;
-  }
-
-  .corner-cell .slash {
-    display: none;
-  }
-
-  .corner-cell > .column, .corner-cell > .row {
-    display: block;
-    position: relative;
-  }
-
-  .corner-cell > .row {
-    text-align: right;
-    top: -0.75em
-  }
-
-  .corner-cell > .column {
-    text-align: left;
-    bottom: -1.25em;
   }
 </style>
 <pre class="metadata">
   title: ECMAScript<sup>&reg;</sup> 2027 Language&nbsp;Specification
   shortname: ECMA-262
   status: draft
+  committee: 39
   location: https://tc39.es/ecma262/
   markEffects: true
   boilerplate:


### PR DESCRIPTION
Corner cell styles have been integrated into ecmarkup, along with legacy unicode property table styles. Clause-specific styles updated in annual audit.