### PR TITLE
Editorial: consistently refer to Strings using a capital S

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -36882,10 +36882,10 @@ THH:mm:ss.sss
         <emu-grammar>UnicodePropertyValueExpression :: LoneUnicodePropertyNameOrValue</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the source text matched by |LoneUnicodePropertyNameOrValue| is not a Unicode property value or property value alias for the General_Category (gc) property listed in <a href="https://unicode.org/Public/UCD/latest/ucd/PropertyValueAliases.txt"><code>PropertyValueAliases.txt</code></a>, nor a binary property or binary property alias listed in the “<emu-not-ref>Property name and aliases</emu-not-ref>” column of <emu-xref href="#table-binary-unicode-properties"></emu-xref>, nor a binary property of Strings listed in the “<emu-not-ref>Property name</emu-not-ref>” column of <emu-xref href="#table-binary-unicode-properties-of-strings"></emu-xref>.
+            It is a Syntax Error if the source text matched by |LoneUnicodePropertyNameOrValue| is not a Unicode property value or property value alias for the General_Category (gc) property listed in <a href="https://unicode.org/Public/UCD/latest/ucd/PropertyValueAliases.txt"><code>PropertyValueAliases.txt</code></a>, nor a binary property or binary property alias listed in the “<emu-not-ref>Property name and aliases</emu-not-ref>” column of <emu-xref href="#table-binary-unicode-properties"></emu-xref>, nor a binary property of strings listed in the “<emu-not-ref>Property name</emu-not-ref>” column of <emu-xref href="#table-binary-unicode-properties-of-strings"></emu-xref>.
           </li>
           <li>
-            It is a Syntax Error if the enclosing |Pattern| does not have a <sub>[UnicodeSetsMode]</sub> parameter and the source text matched by |LoneUnicodePropertyNameOrValue| is a binary property of Strings listed in the “<emu-not-ref>Property name</emu-not-ref>” column of <emu-xref href="#table-binary-unicode-properties-of-strings"></emu-xref>.
+            It is a Syntax Error if the enclosing |Pattern| does not have a <sub>[UnicodeSetsMode]</sub> parameter and the source text matched by |LoneUnicodePropertyNameOrValue| is a binary property of strings listed in the “<emu-not-ref>Property name</emu-not-ref>” column of <emu-xref href="#table-binary-unicode-properties-of-strings"></emu-xref>.
           </li>
         </ul>
         <emu-grammar>CharacterClassEscape :: `P{` UnicodePropertyValueExpression `}`</emu-grammar>
@@ -37255,7 +37255,7 @@ THH:mm:ss.sss
         </emu-alg>
         <emu-grammar>UnicodePropertyValueExpression :: LoneUnicodePropertyNameOrValue</emu-grammar>
         <emu-alg>
-          1. If the source text matched by |LoneUnicodePropertyNameOrValue| is a binary property of Strings listed in the “<emu-not-ref>Property name</emu-not-ref>” column of <emu-xref href="#table-binary-unicode-properties-of-strings"></emu-xref>, return *true*.
+          1. If the source text matched by |LoneUnicodePropertyNameOrValue| is a binary property of strings listed in the “<emu-not-ref>Property name</emu-not-ref>” column of <emu-xref href="#table-binary-unicode-properties-of-strings"></emu-xref>, return *true*.
           1. Return *false*.
         </emu-alg>
         <emu-grammar>ClassUnion :: ClassSetRange ClassUnion?</emu-grammar>

--- a/spec.html
+++ b/spec.html
@@ -201,21 +201,21 @@
   <p>This Ecma Standard defines the ECMAScript 2027 Language. It is the eighteenth edition of the ECMAScript Language Specification. ECMAScript is based on several originating technologies, the most well-known being JavaScript (Netscape) and JScript (Microsoft). The language was invented by Brendan Eich at Netscape and first appeared in that company's Navigator 2.0 browser. Though best known as the language embedded in web browsers, it has also been widely adopted for use outside the browser, including server and embedded applications, and has grown to be one of the world's most widely used general-purpose programming languages.</p>
   <p>The development of the ECMAScript Language Specification started in November 1996. The first edition of this Ecma Standard was adopted by the Ecma General Assembly of June 1997.</p>
   <p>That Ecma Standard was submitted to ISO/IEC JTC 1 for adoption under the fast-track procedure, and approved as international standard ISO/IEC 16262, in April 1998. The Ecma General Assembly of June 1998 approved the second edition of ECMA-262 to keep it fully aligned with ISO/IEC 16262. Changes between the first and the second edition are editorial in nature.</p>
-  <p>The third edition of the Standard introduced powerful regular expressions, better string handling, new control statements, try/catch exception handling, tighter definition of errors, formatting for numeric output and minor changes in anticipation of future language growth. The third edition of the ECMAScript standard was adopted by the Ecma General Assembly of December 1999 and published as ISO/IEC 16262:2002 in June 2002.</p>
+  <p>The third edition of the Standard introduced powerful regular expressions, better String handling, new control statements, try/catch exception handling, tighter definition of errors, formatting for numeric output and minor changes in anticipation of future language growth. The third edition of the ECMAScript standard was adopted by the Ecma General Assembly of December 1999 and published as ISO/IEC 16262:2002 in June 2002.</p>
   <p>After publication of the third edition, ECMAScript achieved massive adoption in conjunction with the World Wide Web where it has become the programming language that is supported by essentially all web browsers. Significant work was done to develop a fourth edition of ECMAScript. However, that work was not completed and not published as the fourth edition of ECMAScript but some of it was incorporated into the development of the sixth edition.</p>
   <p>The fifth edition of ECMAScript (published as ECMA-262 5<sup>th</sup> edition) codified de facto interpretations of the language specification that have become common among browser implementations and added support for new features that had emerged since the publication of the third edition. Such features include accessor properties, reflective creation and inspection of objects, program control of property attributes, additional array manipulation functions, support for the JSON object encoding format, and a strict mode that provides enhanced error checking and program security. The fifth edition was adopted by the Ecma General Assembly of December 2009.</p>
   <p>The fifth edition was submitted to ISO/IEC JTC 1 for adoption under the fast-track procedure, and approved as international standard ISO/IEC 16262:2011. Edition 5.1 of the ECMAScript Standard incorporated minor corrections and is the same text as ISO/IEC 16262:2011. The 5.1 Edition was adopted by the Ecma General Assembly of June 2011.</p>
-  <p>Focused development of the sixth edition started in 2009, as the fifth edition was being prepared for publication. However, this was preceded by significant experimentation and language enhancement design efforts dating to the publication of the third edition in 1999. In a very real sense, the completion of the sixth edition is the culmination of a fifteen year effort. The goals for this edition included providing better support for large applications, library creation, and for use of ECMAScript as a compilation target for other languages. Some of its major enhancements included modules, class declarations, lexical block scoping, iterators and generators, promises for asynchronous programming, destructuring patterns, and proper tail calls. The ECMAScript library of built-ins was expanded to support additional data abstractions including maps, sets, and arrays of binary numeric values as well as additional support for Unicode supplementary characters in strings and regular expressions. The built-ins were also made extensible via subclassing. The sixth edition provides the foundation for regular, incremental language and library enhancements. The sixth edition was adopted by the General Assembly of June 2015.</p>
+  <p>Focused development of the sixth edition started in 2009, as the fifth edition was being prepared for publication. However, this was preceded by significant experimentation and language enhancement design efforts dating to the publication of the third edition in 1999. In a very real sense, the completion of the sixth edition is the culmination of a fifteen year effort. The goals for this edition included providing better support for large applications, library creation, and for use of ECMAScript as a compilation target for other languages. Some of its major enhancements included modules, class declarations, lexical block scoping, iterators and generators, promises for asynchronous programming, destructuring patterns, and proper tail calls. The ECMAScript library of built-ins was expanded to support additional data abstractions including maps, sets, and arrays of binary numeric values as well as additional support for Unicode supplementary characters in Strings and regular expressions. The built-ins were also made extensible via subclassing. The sixth edition provides the foundation for regular, incremental language and library enhancements. The sixth edition was adopted by the General Assembly of June 2015.</p>
   <p>ECMAScript 2016 was the first ECMAScript edition released under Ecma TC39's new yearly release cadence and open development process. A plain-text source document was built from the ECMAScript 2015 source document to serve as the base for further development entirely on GitHub. Over the year of this standard's development, hundreds of pull requests and issues were filed representing thousands of bug fixes, editorial fixes and other improvements. Additionally, numerous software tools were developed to aid in this effort including Ecmarkup, Ecmarkdown, and Grammarkdown. ES2016 also included support for a new exponentiation operator and adds a new method to `Array.prototype` called `includes`.</p>
   <p>ECMAScript 2017 introduced Async Functions, Shared Memory, and Atomics along with smaller language and library enhancements, bug fixes, and editorial updates. Async functions improve the asynchronous programming experience by providing syntax for promise-returning functions. Shared Memory and Atomics introduce a new memory model that allows multi-agent programs to communicate using atomic operations that ensure a well-defined execution order even on parallel CPUs. It also included new static methods on Object: `Object.values`, `Object.entries`, and `Object.getOwnPropertyDescriptors`.</p>
   <p>ECMAScript 2018 introduced support for asynchronous iteration via the async iterator protocol and async generators. It also included four new regular expression features: the `dotAll` flag, named capture groups, Unicode property escapes, and look-behind assertions. Lastly it included object rest and spread properties.</p>
-  <p>ECMAScript 2019 introduced a few new built-in functions: `flat` and `flatMap` on `Array.prototype` for flattening arrays, `Object.fromEntries` for directly turning the return value of `Object.entries` into a new Object, and `trimStart` and `trimEnd` on `String.prototype` as better-named alternatives to the widely implemented but non-standard `String.prototype.trimLeft` and `trimRight` built-ins. In addition, it included a few minor updates to syntax and semantics. Updated syntax included optional catch binding parameters and allowing U+2028 (LINE SEPARATOR) and U+2029 (PARAGRAPH SEPARATOR) in string literals to align with JSON. Other updates included requiring that `Array.prototype.sort` be a stable sort, requiring that `JSON.stringify` return well-formed UTF-8 regardless of input, and clarifying `Function.prototype.toString` by requiring that it either return the corresponding original source text or a standard placeholder.</p>
+  <p>ECMAScript 2019 introduced a few new built-in functions: `flat` and `flatMap` on `Array.prototype` for flattening arrays, `Object.fromEntries` for directly turning the return value of `Object.entries` into a new Object, and `trimStart` and `trimEnd` on `String.prototype` as better-named alternatives to the widely implemented but non-standard `String.prototype.trimLeft` and `trimRight` built-ins. In addition, it included a few minor updates to syntax and semantics. Updated syntax included optional catch binding parameters and allowing U+2028 (LINE SEPARATOR) and U+2029 (PARAGRAPH SEPARATOR) in String literals to align with JSON. Other updates included requiring that `Array.prototype.sort` be a stable sort, requiring that `JSON.stringify` return well-formed UTF-8 regardless of input, and clarifying `Function.prototype.toString` by requiring that it either return the corresponding original source text or a standard placeholder.</p>
   <p>ECMAScript 2020, the 11<sup>th</sup> edition, introduced the `matchAll` method for Strings, to produce an iterator for all match objects generated by a global regular expression; `import()`, a syntax to asynchronously import Modules with a dynamic specifier; `BigInt`, a new number primitive for working with arbitrary precision integers; `Promise.allSettled`, a new Promise combinator that does not short-circuit; `globalThis`, a universal way to access the global `this` value; dedicated `export * as ns from 'module'` syntax for use within modules; increased standardization of `for-in` enumeration order; `import.meta`, a host-populated object available in Modules that may contain contextual information about the Module; as well as adding two new syntax features to improve working with “nullish” values (*undefined* or *null*): nullish coalescing, a value selection operator; and optional chaining, a property access and function invocation operator that short-circuits if the value to access/invoke is nullish.</p>
   <p>ECMAScript 2021, the 12<sup>th</sup> edition, introduced the `replaceAll` method for Strings; `Promise.any`, a Promise combinator that short-circuits when an input value is fulfilled; `AggregateError`, a new Error type to represent multiple errors at once; logical assignment operators (`??=`, `&&=`, `||=`); `WeakRef`, for referring to a target object without preserving it from garbage collection, and `FinalizationRegistry`, to manage registration and unregistration of cleanup operations performed when target objects are garbage collected; separators for numeric literals (`1_000`); and `Array.prototype.sort` was made more precise, reducing the amount of cases that result in an implementation-defined sort order.</p>
   <p>ECMAScript 2022, the 13<sup>th</sup> edition, introduced top-level `await`, allowing the keyword to be used at the top level of modules; new class elements: public and private instance fields, public and private static fields, private instance methods and accessors, and private static methods and accessors; static blocks inside classes, to perform per-class evaluation initialization; the `#x in obj` syntax, to test for presence of private fields on objects; regular expression match indices via the `/d` flag, which provides start and end indices for matched substrings; the `cause` property on `Error` objects, which can be used to record a causation chain in errors; the `at` method for Strings, Arrays, and TypedArrays, which allows relative indexing; and `Object.hasOwn`, a convenient alternative to `Object.prototype.hasOwnProperty`.</p>
   <p>ECMAScript 2023, the 14<sup>th</sup> edition, introduced the `toSorted`, `toReversed`, `with`, `findLast`, and `findLastIndex` methods on `Array.prototype` and `TypedArray.prototype`, as well as the `toSpliced` method on `Array.prototype`; added support for `#!` comments at the beginning of files to better facilitate executable ECMAScript files; and allowed the use of most Symbols as keys in weak collections.</p>
-  <p>ECMAScript 2024, the 15<sup>th</sup> edition, added facilities for resizing and transferring ArrayBuffers and SharedArrayBuffers; added a new RegExp `/v` flag for creating RegExps with more advanced features for working with sets of strings; and introduced the `Promise.withResolvers` convenience method for constructing Promises, the `Object.groupBy` and `Map.groupBy` methods for aggregating data, the `Atomics.waitAsync` method for asynchronously waiting for a change to shared memory, and the `String.prototype.isWellFormed` and `String.prototype.toWellFormed` methods for checking and ensuring that strings contain only well-formed Unicode.</p>
-  <p>ECMAScript 2025, the 16<sup>th</sup> edition, added a new `Iterator` global with associated static and prototype methods for working with iterators; added methods to `Set.prototype` for performing common operations on Sets; added support for importing JSON modules as well as syntax for declaring attributes of imported modules; added the `RegExp.escape` method for escaping a string to be safely used in a regular expression; added syntax for enabling and disabling modifier flags inline within regular expressions; added the `Promise.try` method for calling functions which may or may not return a `Promise` and ensuring the result is always a `Promise`; and added a new `Float16Array` TypedArray kind as well as the related `DataView.prototype.getFloat16`, `DataView.prototype.setFloat16`, and `Math.f16round` methods.</p>
+  <p>ECMAScript 2024, the 15<sup>th</sup> edition, added facilities for resizing and transferring ArrayBuffers and SharedArrayBuffers; added a new RegExp `/v` flag for creating RegExps with more advanced features for working with sets of Strings; and introduced the `Promise.withResolvers` convenience method for constructing Promises, the `Object.groupBy` and `Map.groupBy` methods for aggregating data, the `Atomics.waitAsync` method for asynchronously waiting for a change to shared memory, and the `String.prototype.isWellFormed` and `String.prototype.toWellFormed` methods for checking and ensuring that Strings contain only well-formed Unicode.</p>
+  <p>ECMAScript 2025, the 16<sup>th</sup> edition, added a new `Iterator` global with associated static and prototype methods for working with iterators; added methods to `Set.prototype` for performing common operations on Sets; added support for importing JSON modules as well as syntax for declaring attributes of imported modules; added the `RegExp.escape` method for escaping a String to be safely used in a regular expression; added syntax for enabling and disabling modifier flags inline within regular expressions; added the `Promise.try` method for calling functions which may or may not return a `Promise` and ensuring the result is always a `Promise`; and added a new `Float16Array` TypedArray kind as well as the related `DataView.prototype.getFloat16`, `DataView.prototype.setFloat16`, and `Math.f16round` methods.</p>
   <p>ECMAScript 2026, the 17<sup>th</sup> edition, added `Math.sumPrecise` for summing an iterable of Numbers of varying magnitude while minimizing precision loss; `Iterator.concat` for sequencing iterators; `Array.fromAsync` for constructing Arrays from async iterables and other async sources; `Error.isError` for identifying error objects; methods to `Map.prototype` and `WeakMap.prototype` for providing a default value to use during retrieval when a key is not already present; methods to `Uint8Array` for converting to and from Strings of hexadecimal- and base64-encoded binary data; a parameter to `JSON.parse` revivers to access the matched segment of JSON source; and `JSON.rawJSON` for fine control over `JSON.stringify` output for primitive values.</p>
   <p>Dozens of individuals representing many organizations have made very significant contributions within Ecma TC39 to the development of this edition and to the prior editions. In addition, a vibrant community has emerged supporting TC39's ECMAScript efforts. This community has reviewed numerous drafts, filed thousands of bug reports, performed implementation experiments, contributed test suites, and educated the world-wide developer community about ECMAScript. Unfortunately, it is impossible to identify and acknowledge every person and organization who has contributed to this effort.</p>
   <p>
@@ -356,7 +356,7 @@
 
     <emu-clause id="sec-objects">
       <h1>Objects</h1>
-      <p>Even though ECMAScript includes syntax for class definitions, ECMAScript objects are not fundamentally class-based such as those in C++, Smalltalk, or Java. Instead objects may be created in various ways including via a literal notation or via <em>constructors</em> which create objects and then execute code that initializes all or part of them by assigning initial values to their properties. Each constructor is a function that has a property named *"prototype"* that is used to implement <em>prototype-based inheritance</em> and <em>shared properties</em>. Objects are created by using constructors in <b>new</b> expressions; for example, `new Date(2009, 11)` creates a new Date object. Invoking a constructor without using <b>new</b> has consequences that depend on the constructor. For example, `Date()` produces a string representation of the current date and time rather than an object.</p>
+      <p>Even though ECMAScript includes syntax for class definitions, ECMAScript objects are not fundamentally class-based such as those in C++, Smalltalk, or Java. Instead objects may be created in various ways including via a literal notation or via <em>constructors</em> which create objects and then execute code that initializes all or part of them by assigning initial values to their properties. Each constructor is a function that has a property named *"prototype"* that is used to implement <em>prototype-based inheritance</em> and <em>shared properties</em>. Objects are created by using constructors in <b>new</b> expressions; for example, `new Date(2009, 11)` creates a new Date object. Invoking a constructor without using <b>new</b> has consequences that depend on the constructor. For example, `Date()` produces a String representation of the current date and time rather than an object.</p>
       <p>Every object created by a constructor has an implicit reference (called the object's <em>prototype</em>) to the value of its constructor's *"prototype"* property. Furthermore, a prototype may have a non-*null* implicit reference to its prototype, and so on; this is called the <em>prototype chain</em>. When a reference is made to a property in an object, that reference is to the property of that name in the first object in the prototype chain that contains a property of that name. In other words, first the object mentioned directly is examined for such a property; if that object contains the named property, that is the property to which the reference refers; if that object does not contain the named property, the prototype for that object is examined next; and so on.</p>
       <emu-figure id="figure-1" caption="Object/Prototype Relationships">
         <img alt="An image of lots of boxes and arrows." height="354" src="img/figure-1.svg" width="719">
@@ -682,8 +682,8 @@
 
     <emu-clause id="sec-numeric-string-grammar">
       <h1>The Numeric String Grammar</h1>
-      <p>A <em>numeric string grammar</em> appears in <emu-xref href="#sec-tonumber-applied-to-the-string-type"></emu-xref>. It has as its terminal symbols |SourceCharacter|, and is used for translating Strings into numeric values starting from the goal symbol |StringNumericLiteral| (which is similar to but distinct from the <emu-xref href="#sec-literals-numeric-literals">lexical grammar for numeric literals</emu-xref>).</p>
-      <p>Productions of the numeric string grammar are distinguished by having three colons “<b>:::</b>” as punctuation, and are never used for parsing source text.</p>
+      <p>A <em>numeric String grammar</em> appears in <emu-xref href="#sec-tonumber-applied-to-the-string-type"></emu-xref>. It has as its terminal symbols |SourceCharacter|, and is used for translating Strings into numeric values starting from the goal symbol |StringNumericLiteral| (which is similar to but distinct from the <emu-xref href="#sec-literals-numeric-literals">lexical grammar for numeric literals</emu-xref>).</p>
+      <p>Productions of the numeric String grammar are distinguished by having three colons “<b>:::</b>” as punctuation, and are never used for parsing source text.</p>
     </emu-clause>
 
     <emu-clause id="sec-syntactic-grammar">
@@ -723,7 +723,7 @@
       <emu-clause id="sec-terminal-symbols">
         <h1>Terminal Symbols</h1>
         <p>In the ECMAScript grammars, some terminal symbols are shown in `fixed-width` font. These are to appear in a source text exactly as written. All terminal symbol code points specified in this way are to be understood as the appropriate Unicode code points from the Basic Latin block, as opposed to any similar-looking code points from other Unicode ranges. A code point in a terminal symbol cannot be expressed by a `\\` |UnicodeEscapeSequence|.</p>
-        <p>In grammars whose terminal symbols are individual Unicode code points (i.e., the lexical, RegExp, and numeric string grammars), a contiguous run of multiple fixed-width code points appearing in a production is a simple shorthand for the same sequence of code points, written as standalone terminal symbols.</p>
+        <p>In grammars whose terminal symbols are individual Unicode code points (i.e., the lexical, RegExp, and numeric String grammars), a contiguous run of multiple fixed-width code points appearing in a production is a simple shorthand for the same sequence of code points, written as standalone terminal symbols.</p>
         <p>For example, the production:</p>
         <emu-grammar type="definition" example>
           HexIntegerLiteral :: `0x` HexDigits
@@ -1280,9 +1280,9 @@
           A code unit that is a leading surrogate or trailing surrogate, but is not part of a surrogate pair, is interpreted as a code point with the same value.
         </li>
       </ul>
-      <p>The function `String.prototype.normalize` (see <emu-xref href="#sec-string.prototype.normalize"></emu-xref>) can be used to explicitly normalize a String value. `String.prototype.localeCompare` (see <emu-xref href="#sec-string.prototype.localecompare"></emu-xref>) internally normalizes String values, but no other operations implicitly normalize the strings upon which they operate. Operation results are not language- and/or locale-sensitive unless stated otherwise.</p>
+      <p>The function `String.prototype.normalize` (see <emu-xref href="#sec-string.prototype.normalize"></emu-xref>) can be used to explicitly normalize a String value. `String.prototype.localeCompare` (see <emu-xref href="#sec-string.prototype.localecompare"></emu-xref>) internally normalizes String values, but no other operations implicitly normalize the Strings upon which they operate. Operation results are not language- and/or locale-sensitive unless stated otherwise.</p>
       <emu-note>
-        <p>The rationale behind this design was to keep the implementation of Strings as simple and high-performing as possible. If ECMAScript source text is in Normalized Form C, string literals are guaranteed to also be normalized, as long as they do not contain any Unicode escape sequences.</p>
+        <p>The rationale behind this design was to keep the implementation of Strings as simple and high-performing as possible. If ECMAScript source text is in Normalized Form C, String literals are guaranteed to also be normalized, as long as they do not contain any Unicode escape sequences.</p>
       </emu-note>
       <p>In this specification, the phrase “the <dfn id="string-concatenation">string-concatenation</dfn> of _A_, _B_, ...” (where each argument is a String value, a code unit, or a sequence of code units) denotes the String value whose sequence of code units is the concatenation of the code units (in order) of each of the arguments (in order).</p>
       <p>The phrase “the <dfn id="substring">substring</dfn> of _string_ from _inclusiveStart_ to _exclusiveEnd_” (where _string_ is a String value or a sequence of code units and _inclusiveStart_ and _exclusiveEnd_ are integers) denotes the String value consisting of the consecutive code units of _string_ beginning at index _inclusiveStart_ and ending immediately before index _exclusiveEnd_ (which is the empty String when _inclusiveStart_ = _exclusiveEnd_). If the "to" suffix is omitted, the length of _string_ is used as the value of _exclusiveEnd_.</p>
@@ -1312,7 +1312,7 @@
           1. Return ~not-found~.
         </emu-alg>
         <emu-note>
-          <p>If _searchValue_ is the empty String and _fromIndex_ ≤ the length of _string_, this algorithm returns _fromIndex_. The empty String is effectively found at every position within a string, including after the last code unit.</p>
+          <p>If _searchValue_ is the empty String and _fromIndex_ ≤ the length of _string_, this algorithm returns _fromIndex_. The empty String is effectively found at every position within a String, including after the last code unit.</p>
         </emu-note>
         <emu-note>
           <p>This algorithm always returns ~not-found~ if _fromIndex_ + the length of _searchValue_ > the length of _string_.</p>
@@ -1339,7 +1339,7 @@
           1. Return ~not-found~.
         </emu-alg>
         <emu-note>
-          <p>If _searchValue_ is the empty String, this algorithm returns _fromIndex_. The empty String is effectively found at every position within a string, including after the last code unit.</p>
+          <p>If _searchValue_ is the empty String, this algorithm returns _fromIndex_. The empty String is effectively found at every position within a String, including after the last code unit.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -1422,7 +1422,7 @@
                 *"Symbol.match"*
               </td>
               <td>
-                A regular expression method that matches the regular expression against a string. Called by the <emu-xref href="#sec-string.prototype.match">`String.prototype.match`</emu-xref> method.
+                A regular expression method that matches the regular expression against a String. Called by the <emu-xref href="#sec-string.prototype.match">`String.prototype.match`</emu-xref> method.
               </td>
             </tr>
             <tr>
@@ -1433,7 +1433,7 @@
                 *"Symbol.matchAll"*
               </td>
               <td>
-                A regular expression method that returns an iterator that yields matches of the regular expression against a string. Called by the <emu-xref href="#sec-string.prototype.matchall">`String.prototype.matchAll`</emu-xref> method.
+                A regular expression method that returns an iterator that yields matches of the regular expression against a String. Called by the <emu-xref href="#sec-string.prototype.matchall">`String.prototype.matchAll`</emu-xref> method.
               </td>
             </tr>
             <tr>
@@ -1444,7 +1444,7 @@
                 *"Symbol.replace"*
               </td>
               <td>
-                A regular expression method that replaces matched substrings of a string. Called by the <emu-xref href="#sec-string.prototype.replace">`String.prototype.replace`</emu-xref> method.
+                A regular expression method that replaces matched substrings of a String. Called by the <emu-xref href="#sec-string.prototype.replace">`String.prototype.replace`</emu-xref> method.
               </td>
             </tr>
             <tr>
@@ -1455,7 +1455,7 @@
                 *"Symbol.search"*
               </td>
               <td>
-                A regular expression method that returns the index within a string that matches the regular expression. Called by the <emu-xref href="#sec-string.prototype.search">`String.prototype.search`</emu-xref> method.
+                A regular expression method that returns the index within a String that matches the regular expression. Called by the <emu-xref href="#sec-string.prototype.search">`String.prototype.search`</emu-xref> method.
               </td>
             </tr>
             <tr>
@@ -1477,7 +1477,7 @@
                 *"Symbol.split"*
               </td>
               <td>
-                A regular expression method that splits a string at the indices that match the regular expression. Called by the <emu-xref href="#sec-string.prototype.split">`String.prototype.split`</emu-xref> method.
+                A regular expression method that splits a String at the indices that match the regular expression. Called by the <emu-xref href="#sec-string.prototype.split">`String.prototype.split`</emu-xref> method.
               </td>
             </tr>
             <tr>
@@ -4212,7 +4212,7 @@
       <p>When an algorithm iterates over the elements of a List without specifying an order, the order used is the order of the elements in the List.</p>
       <p>For notational convenience within this specification, a literal syntax can be used to express a new List value. For example, « 1, 2 » defines a List value that has two elements each of which is initialized to a specific value. A new empty List can be expressed as « ».</p>
       <p>In this specification, the phrase “the <dfn id="list-concatenation">list-concatenation</dfn> of _A_, _B_, ...” (where each argument is a possibly empty List) denotes a new List value whose elements are the concatenation of the elements (in order) of each of the arguments (in order).</p>
-      <p>As applied to a List of Strings, the phrase “sorted according to <dfn id="lexicographic-code-unit-order">lexicographic code unit order</dfn>” means sorting by the numeric value of each code unit up to the length of the shorter string, and sorting the shorter string before the longer string if all are equal, as described in the abstract operation IsLessThan.</p>
+      <p>As applied to a List of Strings, the phrase “sorted according to <dfn id="lexicographic-code-unit-order">lexicographic code unit order</dfn>” means sorting by the numeric value of each code unit up to the length of the shorter String, and sorting the shorter String before the longer String if all are equal, as described in the abstract operation IsLessThan.</p>
       <p>The <dfn variants="Records">Record</dfn> type is used to describe data aggregations within the algorithms of this specification. A Record type value consists of one or more named fields. The value of each field is an ECMAScript language value or specification value. Field names are always enclosed in double brackets, for example [[Value]].</p>
       <p>For notational convenience within this specification, an object literal-like syntax can be used to express a Record value. For example, { [[Field1]]: 42, [[Field2]]: *false*, [[Field3]]: ~empty~ } defines a Record value that has three fields, each of which is initialized to a specific value. Field name order is not significant. Any fields that are not explicitly listed are considered to be absent.</p>
       <p>In specification text and algorithms, dot notation may be used to refer to a specific field of a Record value. For example, if R is the record shown in the previous paragraph then R.[[Field2]] is shorthand for “the field of R named [[Field2]]”.</p>
@@ -5728,7 +5728,7 @@
         1. If ! ToString(_n_) is _arg_, return _n_.
         1. Return *undefined*.
       </emu-alg>
-      <p>A <dfn variants="canonical numeric strings">canonical numeric string</dfn> is any String for which the CanonicalNumericIndexString abstract operation does not return *undefined*.</p>
+      <p>A <dfn variants="canonical numeric Strings">canonical numeric String</dfn> is any String for which the CanonicalNumericIndexString abstract operation does not return *undefined*.</p>
     </emu-clause>
 
     <emu-clause id="sec-toindex" type="abstract operation">
@@ -6031,7 +6031,7 @@
         <p>Step <emu-xref href="#step-arc-string-check"></emu-xref> differs from step <emu-xref href="#step-binary-op-string-check"></emu-xref> in the algorithm that handles the addition operator `+` (<emu-xref href="#sec-applystringornumericbinaryoperator"></emu-xref>) by using the logical-and operation instead of the logical-or operation.</p>
       </emu-note>
       <emu-note>
-        <p>The comparison of Strings uses a simple lexicographic ordering on sequences of UTF-16 code unit values. There is no attempt to use the more complex, semantically oriented definitions of character or string equality and collating order defined in the Unicode specification. Therefore String values that are canonically equal according to the Unicode Standard but not in the same normalization form could test as unequal. Also note that lexicographic ordering by <em>code unit</em> differs from ordering by <em>code point</em> for Strings containing surrogate pairs.</p>
+        <p>The comparison of Strings uses a simple lexicographic ordering on sequences of UTF-16 code unit values. There is no attempt to use the more complex, semantically oriented definitions of character or String equality and collating order defined in the Unicode specification. Therefore String values that are canonically equal according to the Unicode Standard but not in the same normalization form could test as unequal. Also note that lexicographic ordering by <em>code unit</em> differs from ordering by <em>code point</em> for Strings containing surrogate pairs.</p>
       </emu-note>
     </emu-clause>
 
@@ -7364,7 +7364,7 @@
       <dl class="header">
       </dl>
       <emu-note id="note-star-default-star">
-        <p>*"\*default\*"* is used within this specification as a synthetic name for a module's default export when it does not have another name. An entry in the module's [[Environment]] is created with that name and holds the corresponding value, and resolving the export named *"default"* by calling <emu-xref href="#sec-resolveexport" title></emu-xref> for the module will return a ResolvedBinding Record whose [[BindingName]] is *"\*default\*"*, which will then resolve in the module's [[Environment]] to the above-mentioned value. This is done only for ease of specification, so that anonymous default exports can be resolved like any other export. This *"\*default\*"* string is never accessible to ECMAScript code or to the module linking algorithm.</p>
+        <p>*"\*default\*"* is used within this specification as a synthetic name for a module's default export when it does not have another name. An entry in the module's [[Environment]] is created with that name and holds the corresponding value, and resolving the export named *"default"* by calling <emu-xref href="#sec-resolveexport" title></emu-xref> for the module will return a ResolvedBinding Record whose [[BindingName]] is *"\*default\*"*, which will then resolve in the module's [[Environment]] to the above-mentioned value. This is done only for ease of specification, so that anonymous default exports can be resolved like any other export. This *"\*default\*"* String is never accessible to ECMAScript code or to the module linking algorithm.</p>
       </emu-note>
       <emu-grammar>BindingIdentifier : Identifier</emu-grammar>
       <emu-alg>
@@ -10531,7 +10531,7 @@
 
       <emu-clause id="sec-object-environment-records">
         <h1>Object Environment Records</h1>
-        <p>Each <dfn variants="Object Environment Records">Object Environment Record</dfn> is associated with an object called its <em>binding object</em>. An Object Environment Record binds the set of string identifier names that directly correspond to the property names of its binding object. Property keys that are not strings in the form of an |IdentifierName| are not included in the set of bound identifiers. Both own and inherited properties are included in the set regardless of the setting of their [[Enumerable]] attribute. Because properties can be dynamically added and deleted from objects, the set of identifiers bound by an Object Environment Record may potentially change as a side-effect of any operation that adds or deletes properties. Any bindings that are created as a result of such a side-effect are considered to be a mutable binding even if the Writable attribute of the corresponding property is *false*. Immutable bindings do not exist for Object Environment Records.</p>
+        <p>Each <dfn variants="Object Environment Records">Object Environment Record</dfn> is associated with an object called its <em>binding object</em>. An Object Environment Record binds the set of String identifier names that directly correspond to the property names of its binding object. Property keys that are not Strings in the form of an |IdentifierName| are not included in the set of bound identifiers. Both own and inherited properties are included in the set regardless of the setting of their [[Enumerable]] attribute. Because properties can be dynamically added and deleted from objects, the set of identifiers bound by an Object Environment Record may potentially change as a side-effect of any operation that adds or deletes properties. Any bindings that are created as a result of such a side-effect are considered to be a mutable binding even if the Writable attribute of the corresponding property is *false*. Immutable bindings do not exist for Object Environment Records.</p>
         <p>Object Environment Records created for `with` statements (<emu-xref href="#sec-with-statement"></emu-xref>) can provide their binding object as an implicit *this* value for use in function calls. The capability is controlled by a Boolean [[IsWithEnvironment]] field.</p>
         <p>Object Environment Records have the additional state fields listed in <emu-xref href="#table-additional-fields-of-object-environment-records"></emu-xref>.</p>
         <emu-table id="table-additional-fields-of-object-environment-records" caption="Additional Fields of Object Environment Records">
@@ -11689,7 +11689,7 @@
             a List of LoadedModuleRequest Records
           </td>
           <td>
-            <p>A map from the specifier strings imported by this realm to the resolved Module Record. The list does not contain two different Records _r1_ and _r2_ such that ModuleRequestsEqual(_r1_, _r2_) is *true*.</p>
+            <p>A map from the specifier Strings imported by this realm to the resolved Module Record. The list does not contain two different Records _r1_ and _r2_ such that ModuleRequestsEqual(_r1_, _r2_) is *true*.</p>
             <emu-note>
               As mentioned in HostLoadImportedModule (<emu-xref href="#note-HostLoadImportedModule-referrer-Realm-Record"></emu-xref>), [[LoadedModules]] in Realm Records is only used when running an `import()` expression in a context where there is no active script or module.
             </emu-note>
@@ -14703,9 +14703,9 @@
 
     <emu-clause id="sec-typedarray-exotic-objects" oldids="sec-integer-indexed-exotic-objects">
       <h1>TypedArray Exotic Objects</h1>
-      <p>A TypedArray is an exotic object that performs special handling of property keys that are canonical numeric strings, using the subset that are in-bounds integer indices to index elements of uniform type and enforcing the invariant that the remainder are absent without incurring prototype chain traversal.</p>
+      <p>A TypedArray is an exotic object that performs special handling of property keys that are canonical numeric Strings, using the subset that are in-bounds integer indices to index elements of uniform type and enforcing the invariant that the remainder are absent without incurring prototype chain traversal.</p>
       <emu-note>
-        <p>Because ToString(_n_) for any Number _n_ is a canonical numeric string, an implementation may treat Numbers as property keys for TypedArrays without actually performing the string conversion.</p>
+        <p>Because ToString(_n_) for any Number _n_ is a canonical numeric String, an implementation may treat Numbers as property keys for TypedArrays without actually performing the String conversion.</p>
       </emu-note>
       <p>TypedArrays have the same internal slots as ordinary objects and additionally [[ViewedArrayBuffer]], [[TypedArrayName]], [[ContentType]], [[ByteLength]], [[ByteOffset]], and [[ArrayLength]] internal slots.</p>
       <p>An object is a <dfn id="typedarray" oldids="integer-indexed-exotic-object" variants="TypedArrays">TypedArray</dfn> if its [[PreventExtensions]], [[GetOwnProperty]], [[HasProperty]], [[DefineOwnProperty]], [[Get]], [[Set]], [[Delete]], and [[OwnPropertyKeys]], internal methods use the definitions in this section, and its other essential internal methods use the definitions found in <emu-xref href="#sec-ordinary-object-internal-methods-and-internal-slots"></emu-xref>. These methods are installed by TypedArrayCreate.</p>
@@ -16193,8 +16193,8 @@
     <p><dfn>ECMAScript source text</dfn> is a sequence of Unicode code points. All Unicode code point values from U+0000 to U+10FFFF, including surrogate code points, may occur in ECMAScript source text where permitted by the ECMAScript grammars. The actual encodings used to store and interchange ECMAScript source text is not relevant to this specification. Regardless of the external source text encoding, a conforming ECMAScript implementation processes the source text as if it was an equivalent sequence of |SourceCharacter| values, each |SourceCharacter| being a Unicode code point. Conforming ECMAScript implementations are not required to perform any normalization of source text, or behave as though they were performing normalization of source text.</p>
     <p>The components of a combining character sequence are treated as individual Unicode code points even though a user might think of the whole sequence as a single character.</p>
     <emu-note>
-      <p>In string literals, regular expression literals, template literals and identifiers, any Unicode code point may also be expressed using Unicode escape sequences that explicitly express a code point's numeric value. Within a comment, such an escape sequence is effectively ignored as part of the comment.</p>
-      <p>ECMAScript differs from the Java programming language in the behaviour of Unicode escape sequences. In a Java program, if the Unicode escape sequence `\\u000A`, for example, occurs within a single-line comment, it is interpreted as a line terminator (Unicode code point U+000A is LINE FEED (LF)) and therefore the next code point is not part of the comment. Similarly, if the Unicode escape sequence `\\u000A` occurs within a string literal in a Java program, it is likewise interpreted as a line terminator, which is not allowed within a string literal—one must write `\\n` instead of `\\u000A` to cause a LINE FEED (LF) to be part of the value of a string literal. In an ECMAScript program, a Unicode escape sequence occurring within a comment is never interpreted and therefore cannot contribute to termination of the comment. Similarly, a Unicode escape sequence occurring within a string literal in an ECMAScript program always contributes to the literal and is never interpreted as a line terminator or as a code point that might terminate the string literal.</p>
+      <p>In String literals, regular expression literals, template literals and identifiers, any Unicode code point may also be expressed using Unicode escape sequences that explicitly express a code point's numeric value. Within a comment, such an escape sequence is effectively ignored as part of the comment.</p>
+      <p>ECMAScript differs from the Java programming language in the behaviour of Unicode escape sequences. In a Java program, if the Unicode escape sequence `\\u000A`, for example, occurs within a single-line comment, it is interpreted as a line terminator (Unicode code point U+000A is LINE FEED (LF)) and therefore the next code point is not part of the comment. Similarly, if the Unicode escape sequence `\\u000A` occurs within a String literal in a Java program, it is likewise interpreted as a line terminator, which is not allowed within a String literal—one must write `\\n` instead of `\\u000A` to cause a LINE FEED (LF) to be part of the value of a String literal. In an ECMAScript program, a Unicode escape sequence occurring within a comment is never interpreted and therefore cannot contribute to termination of the comment. Similarly, a Unicode escape sequence occurring within a String literal in an ECMAScript program always contributes to the literal and is never interpreted as a line terminator or as a code point that might terminate the String literal.</p>
     </emu-note>
 
     <emu-clause id="sec-utf16encodecodepoint" type="abstract operation" oldids="sec-utf16encoding,sec-codepointtoutf16codeunits">
@@ -16474,8 +16474,8 @@
   <emu-clause id="sec-unicode-format-control-characters">
     <h1>Unicode Format-Control Characters</h1>
     <p>The Unicode format-control characters (i.e., the characters in category “Cf” in the Unicode Character Database such as LEFT-TO-RIGHT MARK or RIGHT-TO-LEFT MARK) are control codes used to control the formatting of a range of text in the absence of higher-level protocols for this (such as mark-up languages).</p>
-    <p>It is useful to allow format-control characters in source text to facilitate editing and display. All format control characters may be used within comments, and within string literals, template literals, and regular expression literals.</p>
-    <p>U+FEFF (ZERO WIDTH NO-BREAK SPACE) is a format-control character used primarily at the start of a text to mark it as Unicode and to allow detection of the text's encoding and byte order. &lt;ZWNBSP> characters intended for this purpose can sometimes also appear after the start of a text, for example as a result of concatenating files. In ECMAScript source text &lt;ZWNBSP> code points are treated as white space characters (see <emu-xref href="#sec-white-space"></emu-xref>) outside of comments, string literals, template literals, and regular expression literals.</p>
+    <p>It is useful to allow format-control characters in source text to facilitate editing and display. All format control characters may be used within comments, and within String literals, template literals, and regular expression literals.</p>
+    <p>U+FEFF (ZERO WIDTH NO-BREAK SPACE) is a format-control character used primarily at the start of a text to mark it as Unicode and to allow detection of the text's encoding and byte order. &lt;ZWNBSP> characters intended for this purpose can sometimes also appear after the start of a text, for example as a result of concatenating files. In ECMAScript source text &lt;ZWNBSP> code points are treated as white space characters (see <emu-xref href="#sec-white-space"></emu-xref>) outside of comments, String literals, template literals, and regular expression literals.</p>
   </emu-clause>
 
   <emu-clause id="sec-white-space">
@@ -17247,7 +17247,7 @@
     <emu-clause id="sec-literals-string-literals" oldids="sec-additional-syntax-string-literals">
       <h1>String Literals</h1>
       <emu-note>
-        <p>A string literal is 0 or more Unicode code points enclosed in single or double quotes. Unicode code points may also be represented by an escape sequence. All code points may appear literally in a string literal except for the closing quote code points, U+005C (REVERSE SOLIDUS), U+000D (CARRIAGE RETURN), and U+000A (LINE FEED). Any code points may appear in the form of an escape sequence. String literals evaluate to ECMAScript String values. When generating these String values Unicode code points are UTF-16 encoded as defined in <emu-xref href="#sec-utf16encodecodepoint"></emu-xref>. Code points belonging to the Basic Multilingual Plane are encoded as a single code unit element of the string. All other code points are encoded as two code unit elements of the string.</p>
+        <p>A String literal is 0 or more Unicode code points enclosed in single or double quotes. Unicode code points may also be represented by an escape sequence. All code points may appear literally in a String literal except for the closing quote code points, U+005C (REVERSE SOLIDUS), U+000D (CARRIAGE RETURN), and U+000A (LINE FEED). Any code points may appear in the form of an escape sequence. String literals evaluate to ECMAScript String values. When generating these String values Unicode code points are UTF-16 encoded as defined in <emu-xref href="#sec-utf16encodecodepoint"></emu-xref>. Code points belonging to the Basic Multilingual Plane are encoded as a single code unit element of the String. All other code points are encoded as two code unit elements of the String.</p>
       </emu-note>
       <h2>Syntax</h2>
       <emu-grammar type="definition">
@@ -17333,7 +17333,7 @@
       </emu-grammar>
       <p>The definition of the nonterminal |HexDigit| is given in <emu-xref href="#sec-literals-numeric-literals"></emu-xref>. |SourceCharacter| is defined in <emu-xref href="#sec-source-text"></emu-xref>.</p>
       <emu-note>
-        <p>&lt;LF> and &lt;CR> cannot appear in a string literal, except as part of a |LineContinuation| to produce the empty code points sequence. The proper way to include either in the String value of a string literal is to use an escape sequence such as `\\n` or `\\u000A`.</p>
+        <p>&lt;LF> and &lt;CR> cannot appear in a String literal, except as part of a |LineContinuation| to produce the empty code points sequence. The proper way to include either in the String value of a String literal is to use an escape sequence such as `\\n` or `\\u000A`.</p>
       </emu-note>
 
       <emu-clause id="sec-string-literals-early-errors">
@@ -17348,7 +17348,7 @@
         </ul>
         <emu-note>In non-strict code, this syntax is Legacy.</emu-note>
         <emu-note>
-          <p>It is possible for string literals to precede a Use Strict Directive that places the enclosing code in <emu-xref href="#sec-strict-mode-code">strict mode</emu-xref>, and implementations must take care to enforce the above rules for such literals. For example, the following source text contains a Syntax Error:</p>
+          <p>It is possible for String literals to precede a Use Strict Directive that places the enclosing code in <emu-xref href="#sec-strict-mode-code">strict mode</emu-xref>, and implementations must take care to enforce the above rules for such literals. For example, the following source text contains a Syntax Error:</p>
           <pre><code class="javascript">
             function invalid() { "\7"; "use strict"; }
           </code></pre>
@@ -17360,7 +17360,7 @@
         <dl class="header">
           <dt>description</dt>
           <dd>
-            <p>A string literal stands for a value of the String type. SV produces String values for string literals through recursive application on the various parts of the string literal. As part of this process, some Unicode code points within the string literal are interpreted as having a mathematical value, as described below or in <emu-xref href="#sec-literals-numeric-literals"></emu-xref>.</p>
+            <p>A String literal stands for a value of the String type. SV produces String values for String literals through recursive application on the various parts of the String literal. As part of this process, some Unicode code points within the String literal are interpreted as having a mathematical value, as described below or in <emu-xref href="#sec-literals-numeric-literals"></emu-xref>.</p>
           </dd>
         </dl>
         <ul>
@@ -19081,7 +19081,7 @@
           1. Return the string-concatenation of _head_, _middle_, and _tail_.
         </emu-alg>
         <emu-note>
-          <p>The string conversion semantics applied to the |Expression| value are like `String.prototype.concat` rather than the `+` operator.</p>
+          <p>The String conversion semantics applied to the |Expression| value are like `String.prototype.concat` rather than the `+` operator.</p>
         </emu-note>
         <emu-grammar>TemplateSpans : TemplateTail</emu-grammar>
         <emu-alg>
@@ -19102,7 +19102,7 @@
           1. Return the string-concatenation of _head_ and _middle_.
         </emu-alg>
         <emu-note>
-          <p>The string conversion semantics applied to the |Expression| value are like `String.prototype.concat` rather than the `+` operator.</p>
+          <p>The String conversion semantics applied to the |Expression| value are like `String.prototype.concat` rather than the `+` operator.</p>
         </emu-note>
         <emu-grammar>TemplateMiddleList : TemplateMiddleList TemplateMiddle Expression</emu-grammar>
         <emu-alg>
@@ -19114,7 +19114,7 @@
           1. Return the string-concatenation of _rest_, _middle_, and _last_.
         </emu-alg>
         <emu-note>
-          <p>The string conversion semantics applied to the |Expression| value are like `String.prototype.concat` rather than the `+` operator.</p>
+          <p>The String conversion semantics applied to the |Expression| value are like `String.prototype.concat` rather than the `+` operator.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -20317,7 +20317,7 @@
     <emu-clause id="sec-addition-operator-plus">
       <h1>The Addition Operator ( `+` )</h1>
       <emu-note>
-        <p>The addition operator either performs string concatenation or numeric addition.</p>
+        <p>The addition operator either performs String concatenation or numeric addition.</p>
       </emu-note>
 
       <emu-clause id="sec-addition-operator-plus-runtime-semantics-evaluation" type="sdo">
@@ -20597,7 +20597,7 @@
         </ul>
       </emu-note>
       <emu-note>
-        <p>Comparison of Strings uses a simple equality test on sequences of code unit values. There is no attempt to use the more complex, semantically oriented definitions of character or string equality and collating order defined in the Unicode specification. Therefore Strings values that are canonically equal according to the Unicode Standard could test as unequal. In effect this algorithm assumes that both Strings are already in normalized form.</p>
+        <p>Comparison of Strings uses a simple equality test on sequences of code unit values. There is no attempt to use the more complex, semantically oriented definitions of character or String equality and collating order defined in the Unicode specification. Therefore Strings values that are canonically equal according to the Unicode Standard could test as unequal. In effect this algorithm assumes that both Strings are already in normalized form.</p>
       </emu-note>
     </emu-clause>
   </emu-clause>
@@ -22593,7 +22593,7 @@
           </h1>
           <dl class="header">
             <dt>description</dt>
-            <dd>It is used to create a For-In Iterator object which iterates over the own and inherited enumerable string properties of _obj_ in a specific order.</dd>
+            <dd>It is used to create a For-In Iterator object which iterates over the own and inherited enumerable String properties of _obj_ in a specific order.</dd>
           </dl>
           <emu-alg>
             1. Let _iterator_ be OrdinaryObjectCreate(%ForInIteratorPrototype%, « [[Object]], [[ObjectWasVisited]], [[VisitedKeys]], [[RemainingKeys]] »).
@@ -26131,7 +26131,7 @@
               a List of LoadedModuleRequest Records
             </td>
             <td>
-              A map from the specifier strings imported by this script to the resolved Module Record. The list does not contain two different Records _r1_ and _r2_ such that ModuleRequestsEqual(_r1_, _r2_) is *true*.
+              A map from the specifier Strings imported by this script to the resolved Module Record. The list does not contain two different Records _r1_ and _r2_ such that ModuleRequestsEqual(_r1_, _r2_) is *true*.
             </td>
           </tr>
           <tr>
@@ -26866,7 +26866,7 @@
                 a List of LoadedModuleRequest Records
               </td>
               <td>
-                A map from the specifier strings used by the module represented by this record to request the importation of a module with the relative import attributes to the resolved Module Record. The list does not contain two different Records _r1_ and _r2_ such that ModuleRequestsEqual(_r1_, _r2_) is *true*.
+                A map from the specifier Strings used by the module represented by this record to request the importation of a module with the relative import attributes to the resolved Module Record. The list does not contain two different Records _r1_ and _r2_ such that ModuleRequestsEqual(_r1_, _r2_) is *true*.
               </td>
             </tr>
             <tr>
@@ -29762,7 +29762,7 @@
     <p>For example, the function object that is the initial value of the *"map"* property of the Array prototype object is described under the subclause heading «Array.prototype.map (callback [ , thisArg])» which shows the two named arguments callback and thisArg, the latter being optional; therefore the value of the *"length"* property of that function object is *1*<sub>𝔽</sub>.</p>
   </emu-note>
   <p>Unless otherwise specified, the *"length"* property of a built-in function object has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
-  <p>Every built-in function object, including constructors, has a *"name"* property whose value is a String. Unless otherwise specified, this value is the name that is given to the function in this specification. Functions that are identified as anonymous functions use the empty String as the value of the *"name"* property. For functions that are specified as properties of objects, the name value is the property name string used to access the function. Functions that are specified as get or set accessor functions of built-in properties have *"get"* or *"set"* (respectively) passed to the _prefix_ parameter when calling CreateBuiltinFunction.</p>
+  <p>Every built-in function object, including constructors, has a *"name"* property whose value is a String. Unless otherwise specified, this value is the name that is given to the function in this specification. Functions that are identified as anonymous functions use the empty String as the value of the *"name"* property. For functions that are specified as properties of objects, the value is the property name used to access the function. Functions that are specified as get or set accessor functions of built-in properties have *"get"* or *"set"* (respectively) passed to the _prefix_ parameter when calling CreateBuiltinFunction.</p>
   <p>The value of the *"name"* property is explicitly specified for each built-in functions whose property key is a Symbol value. If such an explicitly specified value starts with the prefix *"get "* or *"set "* and the function for which it is specified is a get or set accessor function of a built-in property, the value without the prefix is passed to the _name_ parameter, and the value *"get"* or *"set"* (respectively) is passed to the _prefix_ parameter when calling CreateBuiltinFunction.</p>
   <p>Unless otherwise specified, the *"name"* property of a built-in function object has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
   <p>Every other data property described in clauses <emu-xref href="#sec-global-object"></emu-xref> through <emu-xref href="#sec-reflection"></emu-xref> and in Annex <emu-xref href="#sec-additional-built-in-properties"></emu-xref> has the attributes { [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* } unless otherwise specified.</p>
@@ -29904,10 +29904,10 @@
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It allows host environments to block certain ECMAScript functions which allow developers to interpret and evaluate strings as ECMAScript code.</dd>
+          <dd>It allows host environments to block certain ECMAScript functions which allow developers to interpret and evaluate Strings as ECMAScript code.</dd>
         </dl>
         <p>
-          _paramStrings_ represents the strings that, when using one of the function constructors, will be concatenated together to build the parameters list. _bodyString_ represents the function body or the string passed to an `eval` call.
+          _paramStrings_ represents the Strings that, when using one of the function constructors, will be concatenated together to build the parameters list. _bodyString_ represents the function body or the String passed to an `eval` call.
           _direct_ signifies whether the evaluation is a direct eval.
         </p>
         <p>The default implementation of HostEnsureCanCompileStrings is to return NormalCompletion(~unused~).</p>
@@ -31797,7 +31797,7 @@
             <tr>
               <td>[[Key]]</td>
               <td>a String</td>
-              <td>A string key used to globally identify a Symbol.</td>
+              <td>A String key used to globally identify a Symbol.</td>
             </tr>
             <tr>
               <td>[[Symbol]]</td>
@@ -31998,7 +31998,7 @@
             1. Perform ? InstallErrorCause(_obj_, _options_).
             1. Return _obj_.
           </emu-alg>
-          <p>The actual value of the string passed in step <emu-xref href="#step-nativeerror-ordinarycreatefromconstructor"></emu-xref> is either *"%EvalError.prototype%"*, *"%RangeError.prototype%"*, *"%ReferenceError.prototype%"*, *"%SyntaxError.prototype%"*, *"%TypeError.prototype%"*, or *"%URIError.prototype%"* corresponding to which _NativeError_ constructor is being defined.</p>
+          <p>The actual value of the String passed in step <emu-xref href="#step-nativeerror-ordinarycreatefromconstructor"></emu-xref> is either *"%EvalError.prototype%"*, *"%RangeError.prototype%"*, *"%ReferenceError.prototype%"*, *"%SyntaxError.prototype%"*, *"%TypeError.prototype%"*, or *"%URIError.prototype%"* corresponding to which _NativeError_ constructor is being defined.</p>
         </emu-clause>
       </emu-clause>
 
@@ -34030,7 +34030,7 @@
 
       <emu-clause id="sec-date-time-string-format">
         <h1>Date Time String Format</h1>
-        <p>ECMAScript defines a string interchange format for date-times based upon a simplification of the ISO 8601 calendar date extended format. The format is as follows: `YYYY-MM-DDTHH:mm:ss.sssZ`</p>
+        <p>ECMAScript defines a String interchange format for date-times based upon a simplification of the ISO 8601 calendar date extended format. The format is as follows: `YYYY-MM-DDTHH:mm:ss.sssZ`</p>
         <p>Where the elements are as follows:</p>
         <figure>
           <table class="lightweight-table">
@@ -34047,7 +34047,7 @@
                 `-`
               </td>
               <td>
-                *"-"* (hyphen) appears literally twice in the string.
+                *"-"* (hyphen) appears literally twice in the String.
               </td>
             </tr>
             <tr>
@@ -34071,7 +34071,7 @@
                 `T`
               </td>
               <td>
-                *"T"* appears literally in the string, to indicate the beginning of the time element.
+                *"T"* appears literally in the String, to indicate the beginning of the time element.
               </td>
             </tr>
             <tr>
@@ -34087,7 +34087,7 @@
                 `:`
               </td>
               <td>
-                *":"* (colon) appears literally twice in the string.
+                *":"* (colon) appears literally twice in the String.
               </td>
             </tr>
             <tr>
@@ -34111,7 +34111,7 @@
                 `.`
               </td>
               <td>
-                *"."* (dot) appears literally in the string.
+                *"."* (dot) appears literally in the String.
               </td>
             </tr>
             <tr>
@@ -34127,7 +34127,7 @@
                 `Z`
               </td>
               <td>
-                is the UTC offset representation specified as *"Z"* (for UTC with no offset) or as either *"+"* or *"-"* followed by a time expression `HH:mm` (a subset of the <emu-xref href="#sec-time-zone-offset-strings">time zone offset string format</emu-xref> for indicating local time ahead of or behind UTC, respectively)
+                is the UTC offset representation specified as *"Z"* (for UTC with no offset) or as either *"+"* or *"-"* followed by a time expression `HH:mm` (a subset of the <emu-xref href="#sec-time-zone-offset-strings">time zone offset String format</emu-xref> for indicating local time ahead of or behind UTC, respectively)
               </td>
             </tr>
           </table>
@@ -34144,7 +34144,7 @@ THH:mm
 THH:mm:ss
 THH:mm:ss.sss
         </pre>
-        <p>A string containing out-of-bounds or nonconforming elements is not a valid instance of this format.</p>
+        <p>A String containing out-of-bounds or nonconforming elements is not a valid instance of this format.</p>
         <emu-note>
           <p>As every day both starts and ends with midnight, the two notations `00:00` and `24:00` are available to distinguish the two midnights that can be associated with one date. This means that the following two notations refer to exactly the same point in time: `1995-02-04T24:00` and `1995-02-05T00:00`. This interpretation of the latter form as “end of a calendar day” is consistent with ISO 8601, even though that specification reserves it for describing time intervals and does not permit it within representations of single points in time.</p>
         </emu-note>
@@ -34197,7 +34197,7 @@ THH:mm:ss.sss
         <h1>Time Zone Offset String Format</h1>
 
         <p>
-          ECMAScript defines a string interchange format for UTC offsets, derived from ISO 8601.
+          ECMAScript defines a String interchange format for UTC offsets, derived from ISO 8601.
           The format is described by the following grammar.
         </p>
 
@@ -35290,7 +35290,7 @@ THH:mm:ss.sss
               1. Let _absOffset_ be -_offset_.
             1. Let _offsetMin_ be ToZeroPaddedDecimalString(ℝ(MinFromTime(_absOffset_)), 2).
             1. Let _offsetHour_ be ToZeroPaddedDecimalString(ℝ(HourFromTime(_absOffset_)), 2).
-            1. Let _tzName_ be an implementation-defined string that is either the empty String or the string-concatenation of the code unit 0x0020 (SPACE), the code unit 0x0028 (LEFT PARENTHESIS), an implementation-defined timezone name, and the code unit 0x0029 (RIGHT PARENTHESIS).
+            1. Let _tzName_ be an implementation-defined String that is either the empty String or the string-concatenation of the code unit 0x0020 (SPACE), the code unit 0x0028 (LEFT PARENTHESIS), an implementation-defined timezone name, and the code unit 0x0029 (RIGHT PARENTHESIS).
             1. Return the string-concatenation of _offsetSign_, _offsetHour_, _offsetMin_, and _tzName_.
           </emu-alg>
         </emu-clause>
@@ -35559,7 +35559,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-string.prototype.codepointat" type="built-in function">
         <h1>String.prototype.codePointAt ( _position_ )</h1>
         <emu-note>
-          <p>This method returns a non-negative integral Number less than or equal to *0x10FFFF*<sub>𝔽</sub> that is the numeric value of the UTF-16 encoded code point (<emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>) starting at the string element at index _position_ within the String resulting from converting this object to a String. If there is no element at that index, the result is *undefined*. If a valid UTF-16 surrogate pair does not begin at _position_, the result is the code unit at _position_.</p>
+          <p>This method returns a non-negative integral Number less than or equal to *0x10FFFF*<sub>𝔽</sub> that is the numeric value of the UTF-16 encoded code point (<emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>) starting at the String element at index _position_ within the String resulting from converting this object to a String. If there is no element at that index, the result is *undefined*. If a valid UTF-16 surrogate pair does not begin at _position_, the result is the code unit at _position_.</p>
         </emu-note>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
@@ -36882,10 +36882,10 @@ THH:mm:ss.sss
         <emu-grammar>UnicodePropertyValueExpression :: LoneUnicodePropertyNameOrValue</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the source text matched by |LoneUnicodePropertyNameOrValue| is not a Unicode property value or property value alias for the General_Category (gc) property listed in <a href="https://unicode.org/Public/UCD/latest/ucd/PropertyValueAliases.txt"><code>PropertyValueAliases.txt</code></a>, nor a binary property or binary property alias listed in the “<emu-not-ref>Property name and aliases</emu-not-ref>” column of <emu-xref href="#table-binary-unicode-properties"></emu-xref>, nor a binary property of strings listed in the “<emu-not-ref>Property name</emu-not-ref>” column of <emu-xref href="#table-binary-unicode-properties-of-strings"></emu-xref>.
+            It is a Syntax Error if the source text matched by |LoneUnicodePropertyNameOrValue| is not a Unicode property value or property value alias for the General_Category (gc) property listed in <a href="https://unicode.org/Public/UCD/latest/ucd/PropertyValueAliases.txt"><code>PropertyValueAliases.txt</code></a>, nor a binary property or binary property alias listed in the “<emu-not-ref>Property name and aliases</emu-not-ref>” column of <emu-xref href="#table-binary-unicode-properties"></emu-xref>, nor a binary property of Strings listed in the “<emu-not-ref>Property name</emu-not-ref>” column of <emu-xref href="#table-binary-unicode-properties-of-strings"></emu-xref>.
           </li>
           <li>
-            It is a Syntax Error if the enclosing |Pattern| does not have a <sub>[UnicodeSetsMode]</sub> parameter and the source text matched by |LoneUnicodePropertyNameOrValue| is a binary property of strings listed in the “<emu-not-ref>Property name</emu-not-ref>” column of <emu-xref href="#table-binary-unicode-properties-of-strings"></emu-xref>.
+            It is a Syntax Error if the enclosing |Pattern| does not have a <sub>[UnicodeSetsMode]</sub> parameter and the source text matched by |LoneUnicodePropertyNameOrValue| is a binary property of Strings listed in the “<emu-not-ref>Property name</emu-not-ref>” column of <emu-xref href="#table-binary-unicode-properties-of-strings"></emu-xref>.
           </li>
         </ul>
         <emu-grammar>CharacterClassEscape :: `P{` UnicodePropertyValueExpression `}`</emu-grammar>
@@ -37255,7 +37255,7 @@ THH:mm:ss.sss
         </emu-alg>
         <emu-grammar>UnicodePropertyValueExpression :: LoneUnicodePropertyNameOrValue</emu-grammar>
         <emu-alg>
-          1. If the source text matched by |LoneUnicodePropertyNameOrValue| is a binary property of strings listed in the “<emu-not-ref>Property name</emu-not-ref>” column of <emu-xref href="#table-binary-unicode-properties-of-strings"></emu-xref>, return *true*.
+          1. If the source text matched by |LoneUnicodePropertyNameOrValue| is a binary property of Strings listed in the “<emu-not-ref>Property name</emu-not-ref>” column of <emu-xref href="#table-binary-unicode-properties-of-strings"></emu-xref>, return *true*.
           1. Return *false*.
         </emu-alg>
         <emu-grammar>ClassUnion :: ClassSetRange ClassUnion?</emu-grammar>
@@ -37398,7 +37398,7 @@ THH:mm:ss.sss
       <p>The syntax and semantics of |Pattern| is defined as if the source text for the |Pattern| was a List of |SourceCharacter| values where each |SourceCharacter| corresponds to a Unicode code point. If a BMP pattern contains a non-BMP |SourceCharacter| the entire pattern is encoded using UTF-16 and the individual code units of that encoding are used as the elements of the List.</p>
       <emu-note>
         <p>For example, consider a pattern expressed in source text as the single non-BMP character U+1D11E (MUSICAL SYMBOL G CLEF). Interpreted as a Unicode pattern, it would be a single element (character) List consisting of the single code point U+1D11E. However, interpreted as a BMP pattern, it is first UTF-16 encoded to produce a two element List consisting of the code units 0xD834 and 0xDD1E.</p>
-        <p>Patterns are passed to the RegExp constructor as ECMAScript String values in which non-BMP characters are UTF-16 encoded. For example, the single character MUSICAL SYMBOL G CLEF pattern, expressed as a String value, is a String of length 2 whose elements were the code units 0xD834 and 0xDD1E. So no further translation of the string would be necessary to process it as a BMP pattern consisting of two pattern characters. However, to process it as a Unicode pattern UTF16SurrogatePairToCodePoint must be used in producing a List whose sole element is a single pattern character, the code point U+1D11E.</p>
+        <p>Patterns are passed to the RegExp constructor as ECMAScript String values in which non-BMP characters are UTF-16 encoded. For example, the single character MUSICAL SYMBOL G CLEF pattern, expressed as a String value, is a String of length 2 whose elements were the code units 0xD834 and 0xDD1E. So no further translation of the String would be necessary to process it as a BMP pattern consisting of two pattern characters. However, to process it as a Unicode pattern UTF16SurrogatePairToCodePoint must be used in producing a List whose sole element is a single pattern character, the code point U+1D11E.</p>
         <p>An implementation may not actually perform such translations to or from UTF-16, but the semantics of this specification requires that the result of pattern matching be as if such translations were performed.</p>
       </emu-note>
 
@@ -38173,7 +38173,7 @@ THH:mm:ss.sss
           </emu-alg>
           <emu-note>
             <p>In case-insignificant matches when HasEitherUnicodeFlag(_regexpRecord_) is *true*, all characters are implicitly case-folded using the simple mapping provided by the Unicode Standard immediately before they are compared. The simple mapping always maps to a single code point, so it does not map, for example, `ß` (U+00DF LATIN SMALL LETTER SHARP S) to `ss` or `SS`. It may however map code points outside the Basic Latin block to code points within it—for example, `ſ` (U+017F LATIN SMALL LETTER LONG S) case-folds to `s` (U+0073 LATIN SMALL LETTER S) and `K` (U+212A KELVIN SIGN) case-folds to `k` (U+006B LATIN SMALL LETTER K). Strings containing those code points are matched by regular expressions such as `/[a-z]/ui`.</p>
-            <p>In case-insignificant matches when HasEitherUnicodeFlag(_regexpRecord_) is *false*, the mapping is based on Unicode Default Case Conversion algorithm toUppercase rather than toCasefold, which results in some subtle differences. For example, `Ω` (U+2126 OHM SIGN) is mapped by toUppercase to itself but by toCasefold to `ω` (U+03C9 GREEK SMALL LETTER OMEGA) along with `Ω` (U+03A9 GREEK CAPITAL LETTER OMEGA), so *"\u2126"* is matched by `/[ω]/ui` and `/[\u03A9]/ui` but not by `/[ω]/i` or `/[\u03A9]/i`. Also, no code point outside the Basic Latin block is mapped to a code point within it, so strings such as *"\u017F ſ"* and *"\u212A K"* are not matched by `/[a-z]/i`.</p>
+            <p>In case-insignificant matches when HasEitherUnicodeFlag(_regexpRecord_) is *false*, the mapping is based on Unicode Default Case Conversion algorithm toUppercase rather than toCasefold, which results in some subtle differences. For example, `Ω` (U+2126 OHM SIGN) is mapped by toUppercase to itself but by toCasefold to `ω` (U+03C9 GREEK SMALL LETTER OMEGA) along with `Ω` (U+03A9 GREEK CAPITAL LETTER OMEGA), so *"\u2126"* is matched by `/[ω]/ui` and `/[\u03A9]/ui` but not by `/[ω]/i` or `/[\u03A9]/i`. Also, no code point outside the Basic Latin block is mapped to a code point within it, so Strings such as *"\u017F ſ"* and *"\u212A K"* are not matched by `/[a-z]/i`.</p>
           </emu-note>
         </emu-clause>
 
@@ -38369,7 +38369,7 @@ THH:mm:ss.sss
           1. If UnicodeMatchPropertyValue(`General_Category`, _s_) is a Unicode property value or property value alias for the General_Category (gc) property listed in <a href="https://unicode.org/Public/UCD/latest/ucd/PropertyValueAliases.txt"><code>PropertyValueAliases.txt</code></a>, then
             1. Return the CharSet containing all Unicode code points whose character database definition includes the property “General_Category” with value _s_.
           1. Let _p_ be UnicodeMatchProperty(_regexpRecord_, _s_).
-          1. Assert: _p_ is a binary Unicode property or binary property alias listed in the “<emu-not-ref>Property name and aliases</emu-not-ref>” column of <emu-xref href="#table-binary-unicode-properties"></emu-xref>, or a binary Unicode property of strings listed in the “<emu-not-ref>Property name</emu-not-ref>” column of <emu-xref href="#table-binary-unicode-properties-of-strings"></emu-xref>.
+          1. Assert: _p_ is a binary Unicode property or binary property alias listed in the “<emu-not-ref>Property name and aliases</emu-not-ref>” column of <emu-xref href="#table-binary-unicode-properties"></emu-xref>, or a binary Unicode property of Strings listed in the “<emu-not-ref>Property name</emu-not-ref>” column of <emu-xref href="#table-binary-unicode-properties-of-strings"></emu-xref>.
           1. Let _charSet_ be the CharSet containing all CharSetElements whose character database definition includes the property _p_ with value “True”.
           1. Return MaybeSimpleCaseFolding(_regexpRecord_, _charSet_).
         </emu-alg>
@@ -38472,12 +38472,12 @@ THH:mm:ss.sss
         <emu-grammar>ClassStringDisjunctionContents :: ClassString</emu-grammar>
         <emu-alg>
           1. Let _s_ be CompileClassSetString of |ClassString| with argument _regexpRecord_.
-          1. Return the CharSet containing the one string _s_.
+          1. Return the CharSet containing the one String _s_.
         </emu-alg>
         <emu-grammar>ClassStringDisjunctionContents :: ClassString `|` ClassStringDisjunctionContents</emu-grammar>
         <emu-alg>
           1. Let _s_ be CompileClassSetString of |ClassString| with argument _regexpRecord_.
-          1. Let _charSet_ be the CharSet containing the one string _s_.
+          1. Let _charSet_ be the CharSet containing the one String _s_.
           1. Let _otherSet_ be CompileToCharSet of |ClassStringDisjunctionContents| with argument _regexpRecord_.
           1. Return the union of CharSets _charSet_ and _otherSet_.
         </emu-alg>
@@ -38864,7 +38864,7 @@ THH:mm:ss.sss
         </emu-alg>
 
         <emu-note>
-          <p>Despite having similar names, EscapeRegExpPattern and `RegExp.escape` do not perform similar actions. The former escapes a pattern for representation as a string, while this function escapes a string for representation inside a pattern.</p>
+          <p>Despite having similar names, EscapeRegExpPattern and `RegExp.escape` do not perform similar actions. The former escapes a pattern for representation as a String, while this function escapes a String for representation inside a pattern.</p>
         </emu-note>
 
         <emu-clause id="sec-encodeforregexpescape" type="abstract operation">
@@ -38882,7 +38882,7 @@ THH:mm:ss.sss
             1. If _codePoint_ is matched by |SyntaxCharacter| or _codePoint_ is U+002F (SOLIDUS), then
               1. Return the string-concatenation of 0x005C (REVERSE SOLIDUS) and UTF16EncodeCodePoint(_codePoint_).
             1. If _codePoint_ is a code point listed in the “Code Point” column of <emu-xref href="#table-controlescape-code-point-values"></emu-xref>, then
-              1. Return the string-concatenation of 0x005C (REVERSE SOLIDUS) and the string in the “ControlEscape” column of the row whose “Code Point” column contains _codePoint_.
+              1. Return the string-concatenation of 0x005C (REVERSE SOLIDUS) and the String in the “ControlEscape” column of the row whose “Code Point” column contains _codePoint_.
             1. Let _otherPunctuators_ be the string-concatenation of *",-=&lt;>#&amp;!%:;@~'`"* and the code unit 0x0022 (QUOTATION MARK).
             1. Let _toEscape_ be StringToCodePoints(_otherPunctuators_).
             1. If _toEscape_ contains _codePoint_, _codePoint_ is matched by either |WhiteSpace| or |LineTerminator|, or _codePoint_ has the same numeric value as a leading surrogate or trailing surrogate, then
@@ -39230,7 +39230,7 @@ THH:mm:ss.sss
           </emu-alg>
 
           <emu-note>
-            <p>Despite having similar names, `RegExp.escape` and EscapeRegExpPattern do not perform similar actions. The former escapes a string for representation inside a pattern, while this function escapes a pattern for representation as a string.</p>
+            <p>Despite having similar names, `RegExp.escape` and EscapeRegExpPattern do not perform similar actions. The former escapes a String for representation inside a pattern, while this function escapes a pattern for representation as a String.</p>
           </emu-note>
         </emu-clause>
       </emu-clause>
@@ -39549,12 +39549,12 @@ THH:mm:ss.sss
             <tr>
               <td>[[StartIndex]]</td>
               <td>a non-negative integer</td>
-              <td>The number of code units from the start of a string at which the match begins (inclusive).</td>
+              <td>The number of code units from the start of a String at which the match begins (inclusive).</td>
             </tr>
             <tr>
               <td>[[EndIndex]]</td>
               <td>an integer ≥ [[StartIndex]]</td>
-              <td>The number of code units from the start of a string at which the match ends (exclusive).</td>
+              <td>The number of code units from the start of a String at which the match ends (exclusive).</td>
             </tr>
           </table>
         </emu-table>
@@ -42538,7 +42538,7 @@ THH:mm:ss.sss
           1. Let _obj_ be the *this* value.
           1. Let _taRecord_ be ? ValidateTypedArray(_obj_, ~seq-cst~).
           1. Let _length_ be TypedArrayLength(_taRecord_).
-          1. NOTE: The following closure performs a numeric comparison rather than the string comparison used in <emu-xref href="#sec-array.prototype.sort"></emu-xref>.
+          1. NOTE: The following closure performs a numeric comparison rather than the String comparison used in <emu-xref href="#sec-array.prototype.sort"></emu-xref>.
           1. Let _sortCompare_ be a new Abstract Closure with parameters (_x_, _y_) that captures _comparator_ and performs the following steps when called:
             1. Return ? CompareTypedArrayElements(_x_, _y_, _comparator_).
           1. Let _sortedList_ be ? SortIndexedProperties(_obj_, _length_, _sortCompare_, ~read-through-holes~).
@@ -42625,7 +42625,7 @@ THH:mm:ss.sss
           1. Let _taRecord_ be ? ValidateTypedArray(_obj_, ~seq-cst~).
           1. Let _length_ be TypedArrayLength(_taRecord_).
           1. Let _resultArray_ be ? TypedArrayCreateSameType(_obj_, _length_).
-          1. NOTE: The following closure performs a numeric comparison rather than the string comparison used in <emu-xref href="#sec-array.prototype.tosorted"></emu-xref>.
+          1. NOTE: The following closure performs a numeric comparison rather than the String comparison used in <emu-xref href="#sec-array.prototype.tosorted"></emu-xref>.
           1. Let _sortCompare_ be a new Abstract Closure with parameters (_x_, _y_) that captures _comparator_ and performs the following steps when called:
             1. Return ? CompareTypedArrayElements(_x_, _y_, _comparator_).
           1. Let _sortedList_ be ? SortIndexedProperties(_obj_, _length_, _sortCompare_, ~read-through-holes~).
@@ -42834,7 +42834,7 @@ THH:mm:ss.sss
           1. Return *+0*<sub>𝔽</sub>.
         </emu-alg>
         <emu-note>
-          This performs a numeric comparison rather than the string comparison used in <emu-xref href="#sec-comparearrayelements"></emu-xref>.
+          This performs a numeric comparison rather than the String comparison used in <emu-xref href="#sec-comparearrayelements"></emu-xref>.
         </emu-note>
       </emu-clause>
     </emu-clause>
@@ -53897,7 +53897,7 @@ THH:mm:ss.sss
 <emu-annex id="sec-additions-and-changes-that-introduce-incompatibilities-with-prior-editions">
   <h1>Additions and Changes That Introduce Incompatibilities with Prior Editions</h1>
   <p><emu-xref href="#sec-reference-record-specification-type"></emu-xref>: In ECMAScript 2015, Function calls are not allowed to return a Reference Record.</p>
-  <p><emu-xref href="#sec-tonumber-applied-to-the-string-type"></emu-xref>: In ECMAScript 2015, ToNumber applied to a String value now recognizes and converts |BinaryIntegerLiteral| and |OctalIntegerLiteral| numeric strings. In previous editions such strings were converted to *NaN*.</p>
+  <p><emu-xref href="#sec-tonumber-applied-to-the-string-type"></emu-xref>: In ECMAScript 2015, ToNumber applied to a String value now recognizes and converts |BinaryIntegerLiteral| and |OctalIntegerLiteral| numeric Strings. In previous editions such Strings were converted to *NaN*.</p>
   <p><emu-xref href="#sec-code-realms"></emu-xref>: In ECMAScript 2018, Template objects are canonicalized based on Parse Node (source location), instead of across all occurrences of that template literal or tagged template in a Realm in previous editions.</p>
   <p><emu-xref href="#sec-white-space"></emu-xref>: In ECMAScript 2016, Unicode 8.0.0 or higher is mandated, as opposed to ECMAScript 2015 which mandated Unicode 5.1. In particular, this caused U+180E MONGOLIAN VOWEL SEPARATOR, which was in the `Space_Separator` (`Zs`) category and thus treated as whitespace in ECMAScript 2015, to be moved to the `Format` (`Cf`) category (as of Unicode 6.3.0). This causes whitespace-sensitive methods to behave differently. For example, `"\u180E".trim().length` was `0` in previous editions, but `1` in ECMAScript 2016 and later. Additionally, ECMAScript 2017 mandated always using the latest version of the Unicode Standard.</p>
   <p><emu-xref href="#sec-names-and-keywords"></emu-xref>: In ECMAScript 2015, the valid code points for an |IdentifierName| are specified in terms of the Unicode properties “ID_Start” and “ID_Continue”. In previous editions, the valid |IdentifierName| or |Identifier| code points were specified by enumerating various Unicode code point categories.</p>

--- a/table-binary-unicode-properties-of-strings.html
+++ b/table-binary-unicode-properties-of-strings.html
@@ -1,5 +1,5 @@
 <emu-table id="table-binary-unicode-properties-of-strings">
-  <emu-caption>Binary Unicode properties of strings</emu-caption>
+  <emu-caption>Binary Unicode properties of Strings</emu-caption>
   <table class="real-table unicode-property-table">
     <thead>
       <tr>

--- a/table-binary-unicode-properties-of-strings.html
+++ b/table-binary-unicode-properties-of-strings.html
@@ -1,5 +1,5 @@
 <emu-table id="table-binary-unicode-properties-of-strings">
-  <emu-caption>Binary Unicode properties of Strings</emu-caption>
+  <emu-caption>Binary Unicode properties of strings</emu-caption>
   <table class="real-table unicode-property-table">
     <thead>
       <tr>


### PR DESCRIPTION
The remaining uses of lowercase `s` "string", after filtering out clause IDs, "bit string", "substring", "string-concatenation", "stringify", etc.:

1. 1\. NOTE: Applications of StringToNumber below do not lose precision, since each of the parsed values is guaranteed to be a sufficiently short string of decimal digits.
2. <p>This function parses a JSON text (a JSON-formatted String) and produces an ECMAScript language value. The JSON format represents literals, arrays, and objects with a syntax similar to the syntax for ECMAScript literals, Array Initializers, and Object Initializers. After parsing, JSON objects are realized as ECMAScript objects. JSON arrays are realized as ECMAScript Array instances. JSON strings, numbers, booleans, and null are realized as ECMAScript Strings, Numbers, Booleans, and *null*.</p>
3. <p>This function returns an object representing raw JSON text of a string, number, boolean, or null value.</p>

**edit:** There's now 1093 uses of "String" or "Strings", which means we were already over 93% consistent with capitalisation.