### PR TITLE
Editorial: replace uses of "Record value" with just "Record"

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -4232,9 +4232,9 @@
       <p>In this specification, the phrase “the <dfn id="list-concatenation">list-concatenation</dfn> of _A_, _B_, ...” (where each argument is a possibly empty List) denotes a new List value whose elements are the concatenation of the elements (in order) of each of the arguments (in order).</p>
       <p>As applied to a List of Strings, the phrase “sorted according to <dfn id="lexicographic-code-unit-order">lexicographic code unit order</dfn>” means sorting by the numeric value of each code unit up to the length of the shorter string, and sorting the shorter string before the longer string if all are equal, as described in the abstract operation IsLessThan.</p>
       <p>The <dfn variants="Records">Record</dfn> type is used to describe data aggregations within the algorithms of this specification. A Record type value consists of one or more named fields. The value of each field is an ECMAScript language value or specification value. Field names are always enclosed in double brackets, for example [[Value]].</p>
-      <p>For notational convenience within this specification, an object literal-like syntax can be used to express a Record value. For example, { [[Field1]]: 42, [[Field2]]: *false*, [[Field3]]: ~empty~ } defines a Record value that has three fields, each of which is initialized to a specific value. Field name order is not significant. Any fields that are not explicitly listed are considered to be absent.</p>
-      <p>In specification text and algorithms, dot notation may be used to refer to a specific field of a Record value. For example, if R is the record shown in the previous paragraph then R.[[Field2]] is shorthand for “the field of R named [[Field2]]”.</p>
-      <p>Schema for commonly used Record field combinations may be named, and that name may be used as a prefix to a literal Record value to identify the specific kind of aggregations that is being described. For example: PropertyDescriptor { [[Value]]: 42, [[Writable]]: *false*, [[Configurable]]: *true* }.</p>
+      <p>For notational convenience within this specification, an object literal-like syntax can be used to express a Record. For example, { [[Field1]]: 42, [[Field2]]: *false*, [[Field3]]: ~empty~ } defines a Record that has three fields, each of which is initialized to a specific value. Field name order is not significant. Any fields that are not explicitly listed are considered to be absent.</p>
+      <p>In specification text and algorithms, dot notation may be used to refer to a specific field of a Record. For example, if R is the record shown in the previous paragraph then R.[[Field2]] is shorthand for “the field of R named [[Field2]]”.</p>
+      <p>Schema for commonly used Record field combinations may be named, and that name may be used as a prefix to a literal Record to identify the specific kind of aggregations that is being described. For example: PropertyDescriptor { [[Value]]: 42, [[Writable]]: *false*, [[Configurable]]: *true* }.</p>
     </emu-clause>
 
     <emu-clause id="sec-set-and-relation-specification-type">
@@ -4858,7 +4858,7 @@
     <emu-clause id="sec-privateelement-specification-type">
       <h1>The PrivateElement Specification Type</h1>
       <p>The PrivateElement type is a Record used in the specification of private class fields, methods, and accessors. Although Property Descriptors are not used for private elements, private fields behave similarly to non-configurable, non-enumerable, writable data properties, private methods behave similarly to non-configurable, non-enumerable, non-writable data properties, and private accessors behave similarly to non-configurable, non-enumerable accessor properties.</p>
-      <p>Values of the PrivateElement type are Record values whose fields are defined by <emu-xref href="#table-privateelement-fields"></emu-xref>. Such values are referred to as <dfn variants="PrivateElement">PrivateElements</dfn>.</p>
+      <p>Values of the PrivateElement type are Records whose fields are defined by <emu-xref href="#table-privateelement-fields"></emu-xref>. Such values are referred to as <dfn variants="PrivateElement">PrivateElements</dfn>.</p>
       <emu-table id="table-privateelement-fields" caption="PrivateElement Fields">
         <table>
           <thead>
@@ -4954,7 +4954,7 @@
     <emu-clause id="sec-classfielddefinition-record-specification-type">
       <h1>The ClassFieldDefinition Record Specification Type</h1>
       <p>The ClassFieldDefinition type is a Record used in the specification of class fields.</p>
-      <p>Values of the ClassFieldDefinition type are Record values whose fields are defined by <emu-xref href="#table-classfielddefinition-fields"></emu-xref>. Such values are referred to as <dfn variants="ClassFieldDefinition Record">ClassFieldDefinition Records</dfn>.</p>
+      <p>Values of the ClassFieldDefinition type are Records whose fields are defined by <emu-xref href="#table-classfielddefinition-fields"></emu-xref>. Such values are referred to as <dfn variants="ClassFieldDefinition Record">ClassFieldDefinition Records</dfn>.</p>
       <emu-table id="table-classfielddefinition-fields" caption="ClassFieldDefinition Record Fields">
         <table>
           <thead>
@@ -5003,7 +5003,7 @@
 
     <emu-clause id="sec-classstaticblockdefinition-record-specification-type">
       <h1>The ClassStaticBlockDefinition Record Specification Type</h1>
-      <p>A <dfn variants="ClassStaticBlockDefinition Records">ClassStaticBlockDefinition Record</dfn> is a Record value used to encapsulate the executable code for a class static initialization block.</p>
+      <p>A <dfn variants="ClassStaticBlockDefinition Records">ClassStaticBlockDefinition Record</dfn> is a Record used to encapsulate the executable code for a class static initialization block.</p>
       <p>ClassStaticBlockDefinition Records have the fields listed in <emu-xref href="#table-classstaticblockdefinition-record-fields"></emu-xref>.</p>
       <emu-table id="table-classstaticblockdefinition-record-fields" caption="ClassStaticBlockDefinition Record Fields">
         <table>
@@ -6955,7 +6955,7 @@
 
     <emu-clause id="sec-iterator-records">
       <h1>Iterator Records</h1>
-      <p>An <dfn variants="Iterator Records">Iterator Record</dfn> is a Record value used to encapsulate an iterator or async iterator along with the `next` method.</p>
+      <p>An <dfn variants="Iterator Records">Iterator Record</dfn> is a Record used to encapsulate an iterator or async iterator along with the `next` method.</p>
       <p>Iterator Records have the fields listed in <emu-xref href="#table-iterator-record-fields"></emu-xref>.</p>
       <emu-table id="table-iterator-record-fields" caption="Iterator Record Fields">
         <table>
@@ -10482,7 +10482,7 @@
   <emu-clause id="sec-environment-records" oldids="sec-lexical-environments">
     <h1>Environment Records</h1>
     <p><dfn variants="Environment Records">Environment Record</dfn> is a specification type used to define the association of |Identifier|s to specific variables and functions, based upon the lexical nesting structure of ECMAScript code. Usually an Environment Record is associated with some specific syntactic structure of ECMAScript code such as a |FunctionDeclaration|, a |BlockStatement|, or a |Catch| clause of a |TryStatement|. Each time such code is evaluated, a new Environment Record is created to record the identifier bindings that are created by that code.</p>
-    <p>Every Environment Record has an [[OuterEnv]] field, which is either *null* or a reference to an outer Environment Record. This is used to model the logical nesting of Environment Record values. The outer reference of an (inner) Environment Record is a reference to the Environment Record that logically surrounds the inner Environment Record. An outer Environment Record may, of course, have its own outer Environment Record. An Environment Record may serve as the outer environment for multiple inner Environment Records. For example, if a |FunctionDeclaration| contains two nested |FunctionDeclaration|s then the Environment Records of each of the nested functions will have as their outer Environment Record the Environment Record of the current evaluation of the surrounding function.</p>
+    <p>Every Environment Record has an [[OuterEnv]] field, which is either *null* or a reference to an outer Environment Record. This is used to model the logical nesting of Environment Records. The outer reference of an (inner) Environment Record is a reference to the Environment Record that logically surrounds the inner Environment Record. An outer Environment Record may, of course, have its own outer Environment Record. An Environment Record may serve as the outer environment for multiple inner Environment Records. For example, if a |FunctionDeclaration| contains two nested |FunctionDeclaration|s then the Environment Records of each of the nested functions will have as their outer Environment Record the Environment Record of the current evaluation of the surrounding function.</p>
     <p>Environment Records are purely specification mechanisms and need not correspond to any specific artefact of an ECMAScript implementation. It is impossible for an ECMAScript program to directly access or manipulate such values.</p>
 
     <emu-clause id="sec-the-environment-record-type-hierarchy">
@@ -12437,7 +12437,7 @@
 
     <emu-clause id="sec-jobcallback-records">
       <h1>JobCallback Records</h1>
-      <p>A <dfn variants="JobCallback Records">JobCallback Record</dfn> is a Record value used to store a function object and a host-defined value. Function objects that are invoked via a Job enqueued by the host may have additional host-defined context. To propagate the state, Job Abstract Closures should not capture and call function objects directly. Instead, use HostMakeJobCallback and HostCallJobCallback.</p>
+      <p>A <dfn variants="JobCallback Records">JobCallback Record</dfn> is a Record used to store a function object and a host-defined value. Function objects that are invoked via a Job enqueued by the host may have additional host-defined context. To propagate the state, Job Abstract Closures should not capture and call function objects directly. Instead, use HostMakeJobCallback and HostCallJobCallback.</p>
       <emu-note>
         <p>The WHATWG HTML specification (<a href="https://html.spec.whatwg.org/">https://html.spec.whatwg.org/</a>), for example, uses the host-defined value to propagate the incumbent settings object for Promise callbacks.</p>
       </emu-note>
@@ -15259,7 +15259,7 @@
 
       <emu-clause id="sec-typedarray-with-buffer-witness-records" oldids="sec-integer-indexed-object-with-buffer-witness-records">
         <h1>TypedArray With Buffer Witness Records</h1>
-        <p>An <dfn variants="TypedArray With Buffer Witness Records">TypedArray With Buffer Witness Record</dfn> is a Record value used to encapsulate a TypedArray along with a cached byte length of the viewed buffer. It is used to help ensure there is a single ReadSharedMemory event of the byte length data block when the viewed buffer is a growable SharedArrayBuffer.</p>
+        <p>An <dfn variants="TypedArray With Buffer Witness Records">TypedArray With Buffer Witness Record</dfn> is a Record used to encapsulate a TypedArray along with a cached byte length of the viewed buffer. It is used to help ensure there is a single ReadSharedMemory event of the byte length data block when the viewed buffer is a growable SharedArrayBuffer.</p>
         <p>TypedArray With Buffer Witness Records have the fields listed in <emu-xref href="#table-typedarray-with-buffer-witness-record-fields"></emu-xref>.</p>
         <emu-table id="table-typedarray-with-buffer-witness-record-fields" oldids="table-integer-indexed-object-with-buffer-witness-record-fields" caption="TypedArray With Buffer Witness Record Fields">
           <table>
@@ -27196,7 +27196,7 @@
       <emu-clause id="sec-abstract-module-records">
         <h1>Abstract Module Records</h1>
         <p>A <dfn variants="Module Records">Module Record</dfn> encapsulates structural information about the imports and exports of a single module. This information is used to link the imports and exports of sets of connected modules. A Module Record includes four fields that are only used when evaluating a module.</p>
-        <p>For specification purposes Module Record values are values of the Record specification type and can be thought of as existing in a simple object-oriented hierarchy where Module Record is an abstract class with both abstract and concrete subclasses. This specification defines the abstract subclass named Cyclic Module Record and its concrete subclass named Source Text Module Record. Other specifications and implementations may define additional Module Record subclasses corresponding to alternative module definition facilities that they defined.</p>
+        <p>For specification purposes Module Records are values of the Record specification type and can be thought of as existing in a simple object-oriented hierarchy where Module Record is an abstract class with both abstract and concrete subclasses. This specification defines the abstract subclass named Cyclic Module Record and its concrete subclass named Source Text Module Record. Other specifications and implementations may define additional Module Record subclasses corresponding to alternative module definition facilities that they defined.</p>
         <p>Module Record defines the fields listed in <emu-xref href="#table-module-record-fields"></emu-xref>. All Module Definition subclasses include at least those fields. Module Record also defines the abstract method list in <emu-xref href="#table-abstract-methods-of-module-records"></emu-xref>. All Module definition subclasses must provide concrete implementations of these abstract methods.</p>
         <emu-table id="table-module-record-fields" caption="Module Record Fields" oldids="table-36">
           <table>
@@ -32372,7 +32372,7 @@
 
       <emu-clause id="sec-globalsymbolregistry-records">
         <h1>GlobalSymbolRegistry Records</h1>
-        <p>A <dfn variants="GlobalSymbolRegistry Records">GlobalSymbolRegistry Record</dfn> is a Record value used to associate a String key with a Symbol value registered through <emu-xref href="#sec-symbol.for">Symbol.for</emu-xref>.</p>
+        <p>A <dfn variants="GlobalSymbolRegistry Records">GlobalSymbolRegistry Record</dfn> is a Record used to associate a String key with a Symbol value registered through <emu-xref href="#sec-symbol.for">Symbol.for</emu-xref>.</p>
         <p>GlobalSymbolRegistry Records have the fields listed in <emu-xref href="#table-globalsymbolregistry-record-fields"></emu-xref>.</p>
         <emu-table id="table-globalsymbolregistry-record-fields" caption="GlobalSymbolRegistry Record Fields" oldids="table-44">
           <table>
@@ -38101,7 +38101,7 @@ THH:mm:ss.sss
 
         <emu-clause id="sec-regexp-records">
           <h1>RegExp Records</h1>
-          <p>A <dfn variants="RegExp Records">RegExp Record</dfn> is a Record value used to store information about a RegExp that is needed during compilation and possibly during matching.</p>
+          <p>A <dfn variants="RegExp Records">RegExp Record</dfn> is a Record used to store information about a RegExp that is needed during compilation and possibly during matching.</p>
           <p>It has the following fields:</p>
           <emu-table id="table-regexp-record-fields" caption="RegExp Record Fields">
             <table>
@@ -40200,7 +40200,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-match-records">
         <h1>Match Records</h1>
-        <p>A <dfn variants="Match Records">Match Record</dfn> is a Record value used to encapsulate the start and end indices of a regular expression match or capture.</p>
+        <p>A <dfn variants="Match Records">Match Record</dfn> is a Record used to encapsulate the start and end indices of a regular expression match or capture.</p>
         <p>Match Records have the fields listed in <emu-xref href="#table-match-record"></emu-xref>.</p>
         <emu-table id="table-match-record" caption="Match Record Fields">
           <table>
@@ -44571,7 +44571,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-set-records">
         <h1>Set Records</h1>
-        <p>A <dfn variants="Set Records">Set Record</dfn> is a Record value used to encapsulate the interface of a Set or similar object.</p>
+        <p>A <dfn variants="Set Records">Set Record</dfn> is a Record used to encapsulate the interface of a Set or similar object.</p>
         <p>Set Records have the fields listed in <emu-xref href="#table-set-record-fields"></emu-xref>.</p>
         <emu-table id="table-set-record-fields" caption="Set Record Fields">
           <table>
@@ -46569,7 +46569,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-dataview-with-buffer-witness-records">
         <h1>DataView With Buffer Witness Records</h1>
-        <p>A <dfn variants="DataView With Buffer Witness Records">DataView With Buffer Witness Record</dfn> is a Record value used to encapsulate a DataView along with a cached byte length of the viewed buffer. It is used to help ensure there is a single ReadSharedMemory event of the byte length data block when the viewed buffer is a growable SharedArrayBuffer.</p>
+        <p>A <dfn variants="DataView With Buffer Witness Records">DataView With Buffer Witness Record</dfn> is a Record used to encapsulate a DataView along with a cached byte length of the viewed buffer. It is used to help ensure there is a single ReadSharedMemory event of the byte length data block when the viewed buffer is a growable SharedArrayBuffer.</p>
         <p>DataView With Buffer Witness Records have the fields listed in <emu-xref href="#table-dataview-with-buffer-witness-record-fields"></emu-xref>.</p>
         <emu-table id="table-dataview-with-buffer-witness-record-fields" caption="DataView With Buffer Witness Record Fields">
           <table>
@@ -47102,7 +47102,7 @@ THH:mm:ss.sss
 
     <emu-clause id="sec-waiter-record">
       <h1>Waiter Record</h1>
-      <p>A <dfn variants="Waiter Records">Waiter Record</dfn> is a Record value used to denote a particular call to `Atomics.wait` or `Atomics.waitAsync`.</p>
+      <p>A <dfn variants="Waiter Records">Waiter Record</dfn> is a Record used to denote a particular call to `Atomics.wait` or `Atomics.waitAsync`.</p>
       <p>A Waiter Record has fields listed in <emu-xref href="#table-waiterrecord"></emu-xref>.</p>
       <emu-table id="table-waiterrecord" caption="Waiter Record Fields">
         <table>
@@ -47983,7 +47983,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-json-parse-record">
         <h1>JSON Parse Record</h1>
-        <p>A <dfn variants="JSON Parse Records">JSON Parse Record</dfn> is a Record value used to describe the initial state of a value parsed from JSON text.</p>
+        <p>A <dfn variants="JSON Parse Records">JSON Parse Record</dfn> is a Record used to describe the initial state of a value parsed from JSON text.</p>
         <p>JSON Parse Records have the fields listed in <emu-xref href="#table-json-parse-record"></emu-xref>.</p>
         <emu-table id="table-json-parse-record" caption="JSON Parse Record Fields">
           <table>
@@ -48317,7 +48317,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-json-serialization-record">
         <h1>JSON Serialization Record</h1>
-        <p>A <dfn variants="JSON Serialization Records">JSON Serialization Record</dfn> is a Record value used to enable serialization to the JSON format.</p>
+        <p>A <dfn variants="JSON Serialization Records">JSON Serialization Record</dfn> is a Record used to enable serialization to the JSON format.</p>
         <p>JSON Serialization Records have the fields listed in <emu-xref href="#table-json-serialization-record"></emu-xref>.</p>
         <emu-table id="table-json-serialization-record" caption="JSON Serialization Record Fields">
           <table>
@@ -50576,7 +50576,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-promisecapability-records">
         <h1>PromiseCapability Records</h1>
-        <p>A <dfn variants="PromiseCapability Records">PromiseCapability Record</dfn> is a Record value used to encapsulate a Promise or promise-like object along with the functions that are capable of resolving or rejecting that promise. PromiseCapability Records are produced by the NewPromiseCapability abstract operation.</p>
+        <p>A <dfn variants="PromiseCapability Records">PromiseCapability Record</dfn> is a Record used to encapsulate a Promise or promise-like object along with the functions that are capable of resolving or rejecting that promise. PromiseCapability Records are produced by the NewPromiseCapability abstract operation.</p>
         <p>PromiseCapability Records have the fields listed in <emu-xref href="#table-promisecapability-record-fields"></emu-xref>.</p>
         <emu-table id="table-promisecapability-record-fields" caption="PromiseCapability Record Fields" oldids="table-57">
           <table>
@@ -50648,7 +50648,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-promisereaction-records">
         <h1>PromiseReaction Records</h1>
-        <p>A <dfn variants="PromiseReaction Records">PromiseReaction Record</dfn> is a Record value used to store information about how a promise should react when it becomes resolved or rejected with a given value. PromiseReaction Records are created by the PerformPromiseThen abstract operation, and are used by the Abstract Closure returned by NewPromiseReactionJob.</p>
+        <p>A <dfn variants="PromiseReaction Records">PromiseReaction Record</dfn> is a Record used to store information about how a promise should react when it becomes resolved or rejected with a given value. PromiseReaction Records are created by the PerformPromiseThen abstract operation, and are used by the Abstract Closure returned by NewPromiseReactionJob.</p>
         <p>PromiseReaction Records have the fields listed in <emu-xref href="#table-promisereaction-record-fields"></emu-xref>.</p>
         <emu-table id="table-promisereaction-record-fields" caption="PromiseReaction Record Fields" oldids="table-58">
           <table>
@@ -52234,7 +52234,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-asyncgeneratorrequest-records">
         <h1>AsyncGeneratorRequest Records</h1>
-        <p>An <dfn variants="AsyncGeneratorRequests">AsyncGeneratorRequest</dfn> is a Record value used to store information about how an async generator should be resumed and contains capabilities for fulfilling or rejecting the corresponding promise.</p>
+        <p>An <dfn variants="AsyncGeneratorRequests">AsyncGeneratorRequest</dfn> is a Record used to store information about how an async generator should be resumed and contains capabilities for fulfilling or rejecting the corresponding promise.</p>
         <p>They have the following fields:</p>
         <emu-table caption="AsyncGeneratorRequest Record Fields">
           <table>


### PR DESCRIPTION
Most of these are just conforming with our existing editorial convention

> don't say "value" after the name of a spec type when following a [determiner](https://en.wikipedia.org/wiki/English_determiners): prefer "a String" over "a String value"

The remaining couple just fully eliminates all uses of "Record value". In the long term, we should do this for other spec types as well: Number value, Boolean value, String value, etc.