### PR TITLE
Editorial: rename alias that slipped past CI

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -22978,13 +22978,13 @@
           1. If _lhsKind_ is ~lexical-binding~, then
             1. Assert: _lhs_ is a |ForDeclaration|.
             1. If IsAwaitUsingDeclaration of _lhs_ is *true*, then
-              1. Let _declarationKind_ be ~async-dispose~.
+              1. Let _declKind_ be ~async-dispose~.
             1. Else if IsUsingDeclaration of _lhs_ is *true*, then
-              1. Let _declarationKind_ be ~sync-dispose~.
+              1. Let _declKind_ be ~sync-dispose~.
             1. Else,
-              1. Let _declarationKind_ be ~normal~.
+              1. Let _declKind_ be ~normal~.
           1. Else,
-            1. Let _declarationKind_ be ~normal~.
+            1. Let _declKind_ be ~normal~.
           1. Let _destructuring_ be IsDestructuring of _lhs_.
           1. If _destructuring_ is *true* and _lhsKind_ is ~assignment~, then
             1. Assert: _lhs_ is a |LeftHandSideExpression|.
@@ -23024,11 +23024,11 @@
                 1. Assert: _lhs_ binds a single name.
                 1. Let _lhsName_ be the sole element of the BoundNames of _lhs_.
                 1. Let _lhsRef_ be ! ResolveBinding(_lhsName_).
-                1. If _declarationKind_ is not ~normal~, then
+                1. If _declKind_ is not ~normal~, then
                   1. Assert: IsUnresolvableReference(_lhsRef_) is *false*.
                   1. Let _base_ be _lhsRef_.[[Base]].
                   1. Assert: _base_ is a Declarative Environment Record.
-                  1. Let _status_ be Completion(AddDisposableResource(_base_.[[DisposableResourceStack]], _nextValue_, _declarationKind_)).
+                  1. Let _status_ be Completion(AddDisposableResource(_base_.[[DisposableResourceStack]], _nextValue_, _declKind_)).
                 1. Else,
                   1. Let _status_ be NormalCompletion(~unused~).
                 1. If _status_ is a normal completion, then


### PR DESCRIPTION
Looks like this snuck in in #3000 and is now causing warnings in unrelated PRs.