### PR TITLE
Editorial: do not use "Return" to transfer control between execution contexts

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -12392,13 +12392,13 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It resumes _context_ (sending it _completionRecord_ as the resumption value), and waits for the result.</dd>
+        <dd>It resumes _context_ (passing it _completionRecord_ as the resumption value), and waits for the result.</dd>
       </dl>
       <emu-alg>
         1. Let _callerContext_ be the running execution context.
         1. Suspend _callerContext_.
         1. Push _context_ onto the execution context stack; _context_ is now the running execution context.
-        1. <emu-meta effects="user-code">Resume the suspended evaluation of _context_</emu-meta> using _completionRecord_ as the result of the operation that suspended it. Let _result_ be the Completion Record returned by the resumed computation.
+        1. <emu-meta effects="user-code">Resume the suspended evaluation of _context_</emu-meta> passing _completionRecord_ as the result of the operation that suspended it. Let _result_ be the Completion Record passed by the resumed computation.
         1. Assert: When we reach this step, _context_ has already been removed from the execution context stack and _callerContext_ is the running execution context again.
         1. Return Completion(_result_).
       </emu-alg>
@@ -12412,7 +12412,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It resumes the caller context (sending it _value_ as the resumption value), and waits for the result, if any.</dd>
+        <dd>It resumes the caller context (passing it _value_ as the resumption value), and waits for the result, if any.</dd>
       </dl>
       <emu-alg>
         1. Let _genContext_ be the running execution context.
@@ -51866,14 +51866,17 @@ THH:mm:ss.sss
             1. Remove _acGenContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
             1. Set _acGen_.[[GeneratorState]] to ~completed~.
             1. NOTE: Once a generator enters the ~completed~ state it never leaves it and its associated execution context is never resumed. Any execution state associated with _acGen_ can be discarded at this point.
-            1. If _result_ is a normal completion, then
-              1. Let _resultValue_ be *undefined*.
-            1. Else if _result_ is a return completion, then
-              1. Let _resultValue_ be _result_.[[Value]].
+            1. If _result_ is a throw completion, then
+              1. Let _resumption_ be _result_.
             1. Else,
-              1. Assert: _result_ is a throw completion.
-              1. Return ? _result_.
-            1. Return NormalCompletion(CreateIteratorResultObject(_resultValue_, *true*)).
+              1. If _result_ is a normal completion, then
+                1. Let _resultValue_ be *undefined*.
+              1. Else if _result_ is a return completion, then
+                1. Let _resultValue_ be _result_.[[Value]].
+              1. Let _resumption_ be NormalCompletion(CreateIteratorResultObject(_resultValue_, *true*)).
+            1. Let _callerContext_ be the running execution context.
+            1. Resume _callerContext_, passing _resumption_.
+            1. Assert: This step is never reached.
           1. Set the code evaluation state of _genContext_ such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
           1. Set _gen_.[[GeneratorContext]] to _genContext_.
           1. Return ~unused~.
@@ -52217,7 +52220,9 @@ THH:mm:ss.sss
             1. If _result_ is a return completion, set _result_ to NormalCompletion(_result_.[[Value]]).
             1. Perform AsyncGeneratorCompleteStep(_acGen_, _result_, *true*).
             1. Perform AsyncGeneratorDrainQueue(_acGen_).
-            1. Return NormalCompletion(*undefined*).
+            1. Let _callerContext_ be the running execution context.
+            1. Resume _callerContext_, passing NormalCompletion(*undefined*).
+            1. Assert: This step is never reached.
           1. Set the code evaluation state of _genContext_ such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
           1. Set _gen_.[[AsyncGeneratorContext]] to _genContext_.
           1. Set _gen_.[[AsyncGeneratorQueue]] to a new empty List.
@@ -52570,7 +52575,9 @@ THH:mm:ss.sss
             1. Else,
               1. Assert: _result_ is a throw completion.
               1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, « _result_.[[Value]] »).
-            1. [id="step-asyncblockstart-return-undefined"] Return NormalCompletion(~unused~).
+            1. Let _callerContext_ be the running execution context.
+            1. [id="step-asyncblockstart-return-undefined"] Resume _callerContext_, passing NormalCompletion(~unused~).
+            1. Assert: This step is never reached.
           1. Set the code evaluation state of _asyncContext_ such that when evaluation is resumed for that execution context, _closure_ will be called with no arguments.
           1. Let _result_ be ! RunSuspendedContext(_asyncContext_, NormalCompletion(~empty~)).
           1. Assert: _result_ is ~unused~.


### PR DESCRIPTION
This is basically the remaining bits of https://github.com/tc39/ecma262/pull/2429.

[RunCallerContext](https://tc39.es/ecma262/multipage/executable-code-and-execution-contexts.html#sec-runcallercontext) is how control gets from Await / Yield to the thing which previously resumed the async function / generator, but you can also transfer control by simply finishing execution of the async function / generator. RunCallerContext does this by suspending the running context, then resuming the old context with a value. The end-of-function cases did it by suspending the running context, then `Return`ing a value. This makes the end-of-function cases use the same resume-with-a-value wording as RunCallerContext.

Also consistently uses "passing" to describe these values being transferred between execution contexts.