### PR TITLE
Meta: update actions/checkout to v7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ljharb/actions/node/install@7f214d8efdbdcefc96ad9689663ef387a195deec
         name: 'nvm install lts/* && npm ci --no-audit'
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
     if: ${{ github.repository == 'tc39/ecma262' }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ljharb/actions/node/install@7f214d8efdbdcefc96ad9689663ef387a195deec
         name: 'nvm install lts/* && npm ci --no-audit'
         env:

--- a/.github/workflows/enforce-format.yml
+++ b/.github/workflows/enforce-format.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ljharb/actions/node/install@7f214d8efdbdcefc96ad9689663ef387a195deec
         name: 'nvm install lts/* && npm ci --no-audit'
         env:

--- a/.github/workflows/esmeta-typecheck.yml
+++ b/.github/workflows/esmeta-typecheck.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: install esmeta
         uses: ./.github/workflows/esmeta-installer
       - name: typecheck

--- a/.github/workflows/esmeta-yetcheck.yml
+++ b/.github/workflows/esmeta-yetcheck.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: install esmeta

--- a/.github/workflows/ipr.yml
+++ b/.github/workflows/ipr.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ljharb/actions/node/install@7f214d8efdbdcefc96ad9689663ef387a195deec
         name: 'nvm install lts/* && npm ci --no-audit'
         env:

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -79,10 +79,11 @@ jobs:
               name: 'request preview'
             });
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
+          allow-unsafe-pr-checkout: true # only delegate PRs, and maintainer-trusted-via-label SHAs, run here
 
       - name: Overwrite snapshot scripts with versions from main
         run: |

--- a/.github/workflows/publish-biblio.yml
+++ b/.github/workflows/publish-biblio.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - run: sudo apt-get install aspell
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           # Number of commits to fetch. 0 indicates all history for all branches and tags.
           # Default: 1
@@ -28,5 +28,5 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - run: node scripts/check-alias-abbreviations.mjs


### PR DESCRIPTION
checkout v7 blocks checking out fork PR code in pull_request_target workflows by default; pr-preview opts out via allow-unsafe-pr-checkout, since previews only build for tc39 org members or PRs explicitly given the 'request preview' label by a collaborator.