### PR TITLE
Editorial: Make the shared similarities of private elements more clear

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -4857,7 +4857,7 @@
 
     <emu-clause id="sec-privateelement-specification-type">
       <h1>The PrivateElement Specification Type</h1>
-      <p>The PrivateElement type is a Record used in the specification of private class fields, methods, and accessors. Although Property Descriptors are not used for private elements, private fields behave similarly to non-configurable, non-enumerable, writable data properties, private methods behave similarly to non-configurable, non-enumerable, non-writable data properties, and private accessors behave similarly to non-configurable, non-enumerable accessor properties.</p>
+      <p>The PrivateElement type is a Record used in the specification of private class fields, methods, and accessors. Although private elements are not associated with Property Descriptors, and are not properties, the runtime semantics of expressions that refer to them are in some ways similar to those of non-configurable properties (private fields are analogous to writable data properties, private methods are analogous to non-writable data properties, and private accessors are analogous to accessor properties) and the corresponding Record fields are used for similar purposes.</p>
       <p>Values of the PrivateElement type are Records whose fields are defined by <emu-xref href="#table-privateelement-fields"></emu-xref>. Such values are referred to as <dfn variants="PrivateElement">PrivateElements</dfn>.</p>
       <emu-table id="table-privateelement-fields" caption="PrivateElement Fields">
         <table>


### PR DESCRIPTION
All private elements are similar to non-configurable, non-enumerable properties.