### PR TITLE
Editorial: Swap order of OR conditions in InnerModuleEvaluation

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -27883,7 +27883,7 @@
                     1. If _requiredModule_.[[AsyncEvaluationOrder]] is an integer, then
                       1. Set _module_.[[PendingAsyncDependencies]] to _module_.[[PendingAsyncDependencies]] + 1.
                       1. Append _module_ to _requiredModule_.[[AsyncParentModules]].
-                1. If _module_.[[PendingAsyncDependencies]] > 0 or _module_.[[HasTLA]] is *true*, then
+                1. If _module_.[[HasTLA]] is *true* or _module_.[[PendingAsyncDependencies]] > 0, then
                   1. Assert: _module_.[[AsyncEvaluationOrder]] is ~unset~.
                   1. Set _module_.[[AsyncEvaluationOrder]] to IncrementModuleAsyncEvaluationCount().
                   1. If _module_.[[PendingAsyncDependencies]] = 0, perform ExecuteAsyncModule(_module_).


### PR DESCRIPTION
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)
* [WebAssembly](https://webassembly.github.io/spec/) - [file an issue](https://github.com/WebAssembly/spec/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->

This is incredibly minor, but this week _two different people_ that have spent the last few months reading through module algorithms have been independently confused by how step (c) (`If _module_.[[PendingAsyncDependencies]] = 0, ...`) can be true if the condition that it is nested into checks that `If _module_.[[PendingAsyncDependencies]] > 0 or ...`. The feedback was that the `module.[[<Something Long>]]` at the beginning of these four lines is very well aligned, making you glaze over the second condition when skimming through it:
<img width="995" height="144" alt="image" src="https://github.com/user-attachments/assets/37edb8b3-7df6-43cf-8b68-3ad9c3293154" />

In both cases it just took 30 seconds to re-read the condition and realize that there is [[HasTLA]] that can be true and then we don't necessarily have more than 0 [[PendingAsyncDependencies]], but maybe swapping them helps :sweat_smile: