### PR TITLE
Normative: RegExp Buffer Boundaries

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -37194,6 +37194,9 @@ THH:mm:ss.sss
         Assertion[UnicodeMode, UnicodeSetsMode, NamedCaptureGroups] ::
           `^`
           `$`
+          [+UnicodeMode] `\` `A`
+          [+UnicodeMode] `\` `z`
+          [+UnicodeMode] `\` `Z`
           `\b`
           `\B`
           `(?=` Disjunction[?UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups] `)`
@@ -38432,6 +38435,47 @@ THH:mm:ss.sss
             1. Let _e_ be _matchState_.[[EndIndex]].
             1. Let _inputLength_ be the number of elements in _input_.
             1. If _e_ = _inputLength_, or if _regexpRecord_.[[Multiline]] is *true* and the character _input_[_e_] is matched by |LineTerminator|, then
+              1. Return _continue_(_matchState_).
+            1. Return ~failure~.
+        </emu-alg>
+        <emu-grammar>
+          Assertion :: `\` `A`
+        </emu-grammar>
+        <emu-alg>
+          1. Return a new Matcher with parameters (_matchState_, _continue_) that captures nothing and performs the following steps when called:
+            1. Assert: _matchState_ is a MatchState.
+            1. Assert: _continue_ is a MatcherContinuation.
+            1. Let _e_ be _matchState_.[[EndIndex]].
+            1. If _e_ = 0, return _continue_(_matchState_).
+            1. Return ~failure~.
+        </emu-alg>
+        <emu-grammar>
+          Assertion :: `\` `z`
+        </emu-grammar>
+        <emu-alg>
+          1. Return a new Matcher with parameters (_matchState_, _continue_) that captures nothing and performs the following steps when called:
+            1. Assert: _matchState_ is a MatchState.
+            1. Assert: _continue_ is a MatcherContinuation.
+            1. Let _input_ be _matchState_.[[Input]].
+            1. Let _e_ be _matchState_.[[EndIndex]].
+            1. Let _inputLength_ be the number of elements in _input_.
+            1. If _e_ = _inputLength_, return _continue_(_matchState_).
+            1. Return ~failure~.
+        </emu-alg>
+        <emu-grammar>
+          Assertion :: `\` `Z`
+        </emu-grammar>
+        <emu-alg>
+          1. Return a new Matcher with parameters (_matchState_, _continue_) that captures nothing and performs the following steps when called:
+            1. Assert: _matchState_ is a MatchState.
+            1. Assert: _continue_ is a MatcherContinuation.
+            1. Let _input_ be _matchState_.[[Input]].
+            1. Let _e_ be _matchState_.[[EndIndex]].
+            1. Let _inputLength_ be the number of elements in _input_.
+            1. If _e_ = _inputLength_, return _continue_(_matchState_).
+            1. If _e_ = _inputLength_ - 1 and the character _input_[_e_] is matched by |LineTerminator|, then
+              1. Return _continue_(_matchState_).
+            1. If _e_ = _inputLength_ - 2, the character _input_[_e_] is &lt;CR>, and the character _input_[_e_ + 1] is &lt;LF>, then
               1. Return _continue_(_matchState_).
             1. Return ~failure~.
         </emu-alg>
@@ -54122,6 +54166,9 @@ THH:mm:ss.sss
         Assertion[UnicodeMode, UnicodeSetsMode, NamedCaptureGroups] ::
           `^`
           `$`
+          [+UnicodeMode] `\` `A`
+          [+UnicodeMode] `\` `z`
+          [+UnicodeMode] `\` `Z`
           `\b`
           `\B`
           [+UnicodeMode] `(?=` Disjunction[+UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups] `)`


### PR DESCRIPTION
This PR contains the Stage 3 specification text for the [RegExp Buffer Boundaries Proposal](https://github.com/tc39/proposal-regexp-buffer-boundaries).

Test262 Tests can be found at https://github.com/tc39/test262/pull/4975