### PR TITLE
Editorial: Restrict IsUsingDeclaration to plain 'using'

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -7924,27 +7924,25 @@
       <emu-alg>
         1. Return *false*.
       </emu-alg>
-      <emu-grammar>
-        UsingDeclaration :
-          `using` BindingList `;`
-
-        AwaitUsingDeclaration :
-          CoverAwaitExpressionAndAwaitUsingDeclarationHead BindingList `;`
-      </emu-grammar>
+      <emu-grammar>UsingDeclaration : `using` BindingList `;`</emu-grammar>
       <emu-alg>
         1. Return *true*.
+      </emu-alg>
+      <emu-grammar>AwaitUsingDeclaration : CoverAwaitExpressionAndAwaitUsingDeclarationHead BindingList `;`</emu-grammar>
+      <emu-alg>
+        1. Return *false*.
       </emu-alg>
       <emu-grammar>ForDeclaration : LetOrConst ForBinding</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
-      <emu-grammar>
-        ForDeclaration :
-          `using` ForBinding
-          `await` `using` ForBinding
-      </emu-grammar>
+      <emu-grammar>ForDeclaration : `using` ForBinding</emu-grammar>
       <emu-alg>
         1. Return *true*.
+      </emu-alg>
+      <emu-grammar>ForDeclaration : `await` `using` ForBinding</emu-grammar>
+      <emu-alg>
+        1. Return *false*.
       </emu-alg>
       <emu-grammar>
         FunctionDeclaration :


### PR DESCRIPTION
The only two callers are both accompanied by IsAwaitUsingDeclaration so there is no behavior change. Closes #3904.