### PR TITLE
Editorial: improve linking of essential internal methods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://tc39.es/ecma262/#sec-copyright-and-software-license",
       "devDependencies": {
-        "ecmarkup": "^24.2.1",
+        "ecmarkup": "^25.0.0",
         "jsdom": "^27.0.0"
       }
     },
@@ -882,9 +882,9 @@
       }
     },
     "node_modules/ecmarkup": {
-      "version": "24.2.1",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-24.2.1.tgz",
-      "integrity": "sha512-J2y1AEtAbV7EKBKQO1vsdYosDzS2oSVZe7ZjgdvXHijG7XRyuoZu+LhkMvQ2sQ9hT/sHJr05EypDAhjAOjwiVg==",
+      "version": "25.0.0",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-25.0.0.tgz",
+      "integrity": "sha512-5pEM7qUQ+s2Xg4pV8TyezbS+ouBopRpTCyvOGXlG0ZzAy2nE726uoZcN9VTiGBy3GinB7KU5y89j9VI2knnGjQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://tc39.es/ecma262/#sec-copyright-and-software-license",
       "devDependencies": {
-        "ecmarkup": "^24.2.1",
+        "ecmarkup": "^25.0.1",
         "jsdom": "^27.0.0"
       }
     },
@@ -882,9 +882,9 @@
       }
     },
     "node_modules/ecmarkup": {
-      "version": "24.2.1",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-24.2.1.tgz",
-      "integrity": "sha512-J2y1AEtAbV7EKBKQO1vsdYosDzS2oSVZe7ZjgdvXHijG7XRyuoZu+LhkMvQ2sQ9hT/sHJr05EypDAhjAOjwiVg==",
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-25.0.1.tgz",
+      "integrity": "sha512-niW1wmHD67pOqaZhRiwtkH8utUWj8U7/wOxsQjxhK3BrMmXoLwDMInYyzHjHfuKXib9/skwMh9afpW/E4ujLUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "license": "SEE LICENSE IN https://tc39.es/ecma262/#sec-copyright-and-software-license",
   "homepage": "https://tc39.es/ecma262/",
   "devDependencies": {
-    "ecmarkup": "^24.2.1",
+    "ecmarkup": "^25.0.0",
     "jsdom": "^27.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "license": "SEE LICENSE IN https://tc39.es/ecma262/#sec-copyright-and-software-license",
   "homepage": "https://tc39.es/ecma262/",
   "devDependencies": {
-    "ecmarkup": "^24.2.1",
+    "ecmarkup": "^25.0.1",
     "jsdom": "^27.0.0"
   }
 }

--- a/spec.html
+++ b/spec.html
@@ -3027,7 +3027,7 @@
             <tr id="internal-method-getprototypeof">
               <td>[[GetPrototypeOf]] ( ): either a normal completion containing either an Object or *null*, or a throw completion</td>
               <td>
-                It determines the object that provides inherited properties for this object. A *null* value indicates that there are no inherited properties.
+                It determines the object that provides inherited properties for this object. A *null* value indicates that there is no such object.
               </td>
               <td>
                 Within this specification it has definitions in the following types; hosts may provide additional types with their own definitions:
@@ -3041,7 +3041,7 @@
                 ): either a normal completion containing a Boolean or a throw completion
               </td>
               <td>
-                It associates this object with another object that provides inherited properties. Passing *null* indicates that there are no inherited properties. Returns *true* indicating that the operation was completed successfully or *false* indicating that the operation was not successful.
+                It associates this object with another object that provides inherited properties. Passing *null* indicates that there is no object that provides inherited properties. Returns *true* indicating that the operation was completed successfully or *false* indicating that the operation was not successful.
               </td>
               <td>
                 Within this specification it has definitions in the following types; hosts may provide additional types with their own definitions:
@@ -3090,7 +3090,7 @@
                 ): either a normal completion containing a Boolean or a throw completion
               </td>
               <td>
-                It creates or alters the own property whose key is _propertyKey_ to have the state described by _propertyDesc_. Returns *true* if that property was successfully created/updated or *false* if the property could not be created or updated.
+                It creates or alters the own property whose key is _propertyKey_ to have the state described by _propertyDesc_. Returns *true* if the operation was successful or *false* if the property could not be created or updated.
               </td>
               <td>
                 Within this specification it has definitions in the following types; hosts may provide additional types with their own definitions:

--- a/spec.html
+++ b/spec.html
@@ -3006,10 +3006,10 @@
         </ul>
         <p>An <dfn id="exotic-object" variants="exotic objects">exotic object</dfn> is an object that is not an ordinary object.</p>
         <p>This specification recognizes different kinds of exotic objects by those objects' internal methods. An object that is behaviourally equivalent to a particular kind of exotic object (such as an Array exotic object or a bound function exotic object), but does not have the same collection of internal methods specified for that kind, is not recognized as that kind of exotic object.</p>
-        <p>The “Signature” column of <emu-xref href="#table-essential-internal-methods"></emu-xref> and other similar tables describes the invocation pattern for each internal method. The invocation pattern always includes a parenthesized list of descriptive parameter names. If a parameter name is the same as an ECMAScript type name then the name describes the required type of the parameter value. If an internal method explicitly returns a value, its parameter list is followed by the symbol “→” and the type name of the returned value. The type names used in signatures refer to the types defined in clause <emu-xref href="#sec-ecmascript-data-types-and-values"></emu-xref> augmented by the following additional names. “<em>any</em>” means the value may be any ECMAScript language type.</p>
+        <p><emu-xref href="#table-essential-internal-methods"></emu-xref> and other similar tables describe the invocation pattern for each internal method. The invocation pattern always includes a parenthesized list of descriptive parameter names.</p>
         <p>In addition to its parameters, an internal method always has access to the object that is the target of the method invocation.</p>
         <p>An internal method implicitly returns a Completion Record, either a normal completion that wraps a value of the return type shown in its invocation pattern, or a throw completion.</p>
-        <emu-table id="table-essential-internal-methods" caption="Essential Internal Methods" oldids="table-5">
+        <emu-table id="table-essential-internal-methods" caption="Essential Internal Methods" oldids="table-5" type="internal methods" of="all objects">
           <table>
             <thead>
               <tr>
@@ -3017,138 +3017,159 @@
                   Internal Method
                 </th>
                 <th>
-                  Signature
+                  Description
                 </th>
                 <th>
-                  Description
+                  Definitions
                 </th>
               </tr>
             </thead>
-            <tr>
+            <tr id="internal-method-getprototypeof">
+              <td>[[GetPrototypeOf]] ( ): either a normal completion containing either an Object or *null*, or a throw completion</td>
               <td>
-                [[GetPrototypeOf]]
+                It determines the object that provides inherited properties for this object. A *null* value indicates that there are no inherited properties.
               </td>
               <td>
-                ( ) <b>→</b> Object | Null
-              </td>
-              <td>
-                Determine the object that provides inherited properties for this object. A *null* value indicates that there are no inherited properties.
-              </td>
-            </tr>
-            <tr>
-              <td>
-                [[SetPrototypeOf]]
-              </td>
-              <td>
-                (Object | Null) <b>→</b> Boolean
-              </td>
-              <td>
-                Associate this object with another object that provides inherited properties. Passing *null* indicates that there are no inherited properties. Returns *true* indicating that the operation was completed successfully or *false* indicating that the operation was not successful.
+                Within this specification it has definitions in the following types; hosts may provide additional types with their own definitions:
+                <emu-internal-method-dfns for="[[GetPrototypeOf]]"></emu-internal-method-dfns>
               </td>
             </tr>
-            <tr>
+            <tr id="internal-method-setprototypeof">
               <td>
-                [[IsExtensible]]
+                [[SetPrototypeOf]] (
+                  _proto_: an Object or *null*,
+                ): either a normal completion containing a Boolean or a throw completion
               </td>
               <td>
-                ( ) <b>→</b> Boolean
+                It associates this object with another object that provides inherited properties. Passing *null* indicates that there are no inherited properties. Returns *true* indicating that the operation was completed successfully or *false* indicating that the operation was not successful.
               </td>
               <td>
-                Determine whether it is permitted to add additional properties to this object.
-              </td>
-            </tr>
-            <tr>
-              <td>
-                [[PreventExtensions]]
-              </td>
-              <td>
-                ( ) <b>→</b> Boolean
-              </td>
-              <td>
-                Control whether new properties may be added to this object. Returns *true* if the operation was successful or *false* if the operation was unsuccessful.
+                Within this specification it has definitions in the following types; hosts may provide additional types with their own definitions:
+                <emu-internal-method-dfns for="[[SetPrototypeOf]]"></emu-internal-method-dfns>
               </td>
             </tr>
-            <tr>
+            <tr id="internal-method-isextensible">
+              <td>[[IsExtensible]] ( ): either a normal completion containing a Boolean or a throw completion</td>
               <td>
-                [[GetOwnProperty]]
+                It determines whether it is permitted to add additional properties to this object.
               </td>
               <td>
-                (_propertyKey_) <b>→</b> Undefined | Property Descriptor
-              </td>
-              <td>
-                Return a Property Descriptor for the own property of this object whose key is _propertyKey_, or *undefined* if no such property exists.
-              </td>
-            </tr>
-            <tr>
-              <td>
-                [[DefineOwnProperty]]
-              </td>
-              <td>
-                (_propertyKey_, _propertyDesc_) <b>→</b> Boolean
-              </td>
-              <td>
-                Create or alter the own property, whose key is _propertyKey_, to have the state described by _propertyDesc_. Return *true* if that property was successfully created/updated or *false* if the property could not be created or updated.
+                Within this specification it has definitions in the following types; hosts may provide additional types with their own definitions:
+                <emu-internal-method-dfns for="[[IsExtensible]]"></emu-internal-method-dfns>
               </td>
             </tr>
-            <tr>
+            <tr id="internal-method-preventextensions">
+              <td>[[PreventExtensions]] ( ): either a normal completion containing a Boolean or a throw completion</td>
               <td>
-                [[HasProperty]]
+                It controls whether new properties may be added to this object. Returns *true* if the operation was successful or *false* if the operation was unsuccessful.
               </td>
               <td>
-                (_propertyKey_) <b>→</b> Boolean
-              </td>
-              <td>
-                Return a Boolean value indicating whether this object already has either an own or inherited property whose key is _propertyKey_.
-              </td>
-            </tr>
-            <tr>
-              <td>
-                [[Get]]
-              </td>
-              <td>
-                (_propertyKey_, _receiver_) <b>→</b> <em>any</em>
-              </td>
-              <td>
-                Return the value of the property whose key is _propertyKey_ from this object. If any ECMAScript code must be executed to retrieve the property value, _receiver_ is used as the *this* value when evaluating the code.
+                Within this specification it has definitions in the following types; hosts may provide additional types with their own definitions:
+                <emu-internal-method-dfns for="[[PreventExtensions]]"></emu-internal-method-dfns>
               </td>
             </tr>
-            <tr>
+            <tr id="internal-method-getownproperty">
               <td>
-                [[Set]]
+                [[GetOwnProperty]] (
+                  _propertyKey_: a property key,
+                ): either a normal completion containing either a Property Descriptor or *undefined*, or a throw completion
               </td>
               <td>
-                (_propertyKey_, _value_, _receiver_) <b>→</b> Boolean
+                It returns a Property Descriptor for the own property of this object whose key is _propertyKey_, or *undefined* if no such property exists.
               </td>
               <td>
-                Set the value of the property whose key is _propertyKey_ to _value_. If any ECMAScript code must be executed to set the property value, _receiver_ is used as the *this* value when evaluating the code. Returns *true* if the property value was set or *false* if it could not be set.
-              </td>
-            </tr>
-            <tr>
-              <td>
-                [[Delete]]
-              </td>
-              <td>
-                (_propertyKey_) <b>→</b> Boolean
-              </td>
-              <td>
-                Remove the own property whose key is _propertyKey_ from this object. Return *false* if the property was not deleted and is still present. Return *true* if the property was deleted or is not present.
+                Within this specification it has definitions in the following types; hosts may provide additional types with their own definitions:
+                <emu-internal-method-dfns for="[[GetOwnProperty]]"></emu-internal-method-dfns>
               </td>
             </tr>
-            <tr>
+            <tr id="internal-method-defineownproperty">
               <td>
-                [[OwnPropertyKeys]]
+                [[DefineOwnProperty]] (
+                  _propertyKey_: a property key,
+                  _propertyDesc_: a Property Descriptor,
+                ): either a normal completion containing a Boolean or a throw completion
               </td>
               <td>
-                ( ) <b>→</b> List of property keys
+                It creates or alters the own property whose key is _propertyKey_ to have the state described by _propertyDesc_. Returns *true* if that property was successfully created/updated or *false* if the property could not be created or updated.
               </td>
               <td>
-                Return a List whose elements are all of the own property keys for the object.
+                Within this specification it has definitions in the following types; hosts may provide additional types with their own definitions:
+                <emu-internal-method-dfns for="[[DefineOwnProperty]]"></emu-internal-method-dfns>
+              </td>
+            </tr>
+            <tr id="internal-method-hasproperty">
+              <td>
+                [[HasProperty]] (
+                  _propertyKey_: a property key,
+                ): either a normal completion containing a Boolean or a throw completion
+              </td>
+              <td>
+                It returns a Boolean indicating whether this object already has either an own or inherited property whose key is _propertyKey_.
+              </td>
+              <td>
+                Within this specification it has definitions in the following types; hosts may provide additional types with their own definitions:
+                <emu-internal-method-dfns for="[[HasProperty]]"></emu-internal-method-dfns>
+              </td>
+            </tr>
+            <tr id="internal-method-get">
+              <td>
+                [[Get]] (
+                  _propertyKey_: a property key,
+                  _receiver_: an ECMAScript language value,
+                ): either a normal completion containing an ECMAScript language value or a throw completion
+              </td>
+              <td>
+                It returns the value of the property whose key is _propertyKey_ from this object. If any ECMAScript code must be executed to retrieve the property value, _receiver_ is used as the *this* value when evaluating the code.
+              </td>
+              <td>
+                Within this specification it has definitions in the following types; hosts may provide additional types with their own definitions:
+                <emu-internal-method-dfns for="[[Get]]"></emu-internal-method-dfns>
+              </td>
+            </tr>
+            <tr id="internal-method-set">
+              <td>
+                [[Set]] (
+                  _propertyKey_: a property key,
+                  _value_: an ECMAScript language value,
+                  _receiver_: an ECMAScript language value,
+                ): either a normal completion containing a Boolean or a throw completion
+              </td>
+              <td>
+                It sets the value of the property whose key is _propertyKey_ to _value_. If any ECMAScript code must be executed to set the property value, _receiver_ is used as the *this* value when evaluating the code. Returns *true* if the property value was set or *false* if it could not be set.
+              </td>
+              <td>
+                Within this specification it has definitions in the following types; hosts may provide additional types with their own definitions:
+                <emu-internal-method-dfns for="[[Set]]"></emu-internal-method-dfns>
+              </td>
+            </tr>
+            <tr id="internal-method-delete">
+              <td>
+                [[Delete]] (
+                  _propertyKey_: a property key,
+                ): either a normal completion containing a Boolean or a throw completion
+              </td>
+              <td>
+                It removes the own property whose key is _propertyKey_ from this object. Returns *false* if the property was not deleted and is still present. Returns *true* if the property was deleted or is not present.
+              </td>
+              <td>
+                Within this specification it has definitions in the following types; hosts may provide additional types with their own definitions:
+                <emu-internal-method-dfns for="[[Delete]]"></emu-internal-method-dfns>
+              </td>
+            </tr>
+            <tr id="internal-method-ownpropertykeys">
+              <td>[[OwnPropertyKeys]] ( ): either a normal completion containing a List of property keys or a throw completion</td>
+              <td>
+                It returns a List whose elements are all of the own property keys for the object.
+              </td>
+              <td>
+                Within this specification it has definitions in the following types; hosts may provide additional types with their own definitions:
+                <emu-internal-method-dfns for="[[OwnPropertyKeys]]"></emu-internal-method-dfns>
               </td>
             </tr>
           </table>
         </emu-table>
         <p><emu-xref href="#table-additional-essential-internal-methods-of-function-objects"></emu-xref> summarizes additional essential internal methods that are supported by objects that may be called as functions. A <dfn id="function-object" variants="function objects">function object</dfn> is an object that supports the [[Call]] internal method. A <dfn id="constructor" variants="constructors">constructor</dfn> is an object that supports the [[Construct]] internal method. Every object that supports [[Construct]] must support [[Call]]; that is, every constructor must be a function object. Therefore, a constructor may also be referred to as a <em>constructor function</em> or <em>constructor function object</em>.</p>
-        <emu-table id="table-additional-essential-internal-methods-of-function-objects" caption="Additional Essential Internal Methods of Function Objects" oldids="table-6">
+        <emu-table id="table-additional-essential-internal-methods-of-function-objects" caption="Additional Essential Internal Methods of Function Objects" oldids="table-6" type="internal methods" of="function objects">
           <table>
             <thead>
               <tr>
@@ -3156,33 +3177,41 @@
                   Internal Method
                 </th>
                 <th>
-                  Signature
+                  Description
                 </th>
                 <th>
-                  Description
+                  Definitions
                 </th>
               </tr>
             </thead>
-            <tr>
+            <tr id="internal-method-call">
               <td>
-                [[Call]]
+                [[Call]] (
+                  _thisArg_: an ECMAScript language value,
+                  _argList_: a List of ECMAScript language values,
+                ): either a normal completion containing an ECMAScript language value or a throw completion
               </td>
               <td>
-                (<em>any</em>, a List of <em>any</em>) <b>→</b> <em>any</em>
+                It executes code associated with this object. Invoked via a function call expression. The arguments to the internal method are a *this* value and a List whose elements are the arguments passed to the function by a call expression. Objects that implement this internal method are <em>callable</em>.
               </td>
               <td>
-                Executes code associated with this object. Invoked via a function call expression. The arguments to the internal method are a *this* value and a List whose elements are the arguments passed to the function by a call expression. Objects that implement this internal method are <em>callable</em>.
+                Within this specification it has definitions in the following types; hosts may provide additional types with their own definitions:
+                <emu-internal-method-dfns for="[[Call]]"></emu-internal-method-dfns>
               </td>
             </tr>
-            <tr>
+            <tr id="internal-method-construct">
               <td>
-                [[Construct]]
+                [[Construct]] (
+                  _argList_: a List of ECMAScript language values,
+                  _newTarget_: a constructor,
+                ): either a normal completion containing an Object or a throw completion
               </td>
               <td>
-                (a List of <em>any</em>, Object) <b>→</b> Object
+                It creates an object. Invoked via the `new` operator or a `super` call. The first argument to the internal method is a List whose elements are the arguments of the constructor invocation or the `super` call. The second argument is the object to which the `new` operator was initially applied. Objects that implement this internal method are called <em>constructors</em>. A function object is not necessarily a constructor and such non-constructor function objects do not have a [[Construct]] internal method.
               </td>
               <td>
-                Creates an object. Invoked via the `new` operator or a `super` call. The first argument to the internal method is a List whose elements are the arguments of the constructor invocation or the `super` call. The second argument is the object to which the `new` operator was initially applied. Objects that implement this internal method are called <em>constructors</em>. A function object is not necessarily a constructor and such non-constructor function objects do not have a [[Construct]] internal method.
+                Within this specification it has definitions in the following types; hosts may provide additional types with their own definitions:
+                <emu-internal-method-dfns for="[[Construct]]"></emu-internal-method-dfns>
               </td>
             </tr>
           </table>


### PR DESCRIPTION
Includes https://github.com/tc39/ecmarkup/pull/711.

I did this one by hand. Kinda silly because it's more mechanical than the ecmarkup PR but somehow we have arrived in a world where that's what made sense.