### PR TITLE
Editorial: assert that MethodDefinitionEvaluation on object properties does not produce a PrivateElement

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -19233,7 +19233,8 @@
         </emu-alg>
         <emu-grammar>PropertyDefinition : MethodDefinition</emu-grammar>
         <emu-alg>
-          1. Perform ? MethodDefinitionEvaluation of |MethodDefinition| with arguments _obj_ and *true*.
+          1. Let _result_ be ? MethodDefinitionEvaluation of |MethodDefinition| with arguments _obj_ and *true*.
+          1. Assert: _result_ is ~empty~.
           1. Return ~unused~.
         </emu-alg>
       </emu-clause>
@@ -25829,6 +25830,8 @@
             1. Else, append _element_ to _staticElements_.
           1. Else if _element_ is a ClassStaticBlockDefinition Record, then
             1. Append _element_ to _staticElements_.
+          1. Else,
+            1. Assert: _element_ is ~empty~.
         1. Set the running execution context's LexicalEnvironment to _envRecord_.
         1. If _classBinding_ is not *undefined*, then
           1. Perform ! _classEnv_.InitializeBinding(_classBinding_, _ctorFunc_).


### PR DESCRIPTION
Also assert that the switch over the return value of MethodDefinitionEvaluation in ClassDefinitionEvaluation is exhaustive.

~~It's kinda weird to use `~unused~` for this; I'd feel better about `~empty~`. But whatever, that can be a follow-up.~~ Done in #3922.

There's a callsite of [DefineMethodProperty](https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-definemethodproperty) in ClassDefinitionEvaluation that could use this assert as well, but I think it's less needed, so I left it out:

> 19. Perform ! DefineMethodProperty(proto, "constructor", ctorFunc, false).