### PR TITLE
Editorial: avoid some unions with ~unused~

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -14128,7 +14128,7 @@
           _name_: a property key or Private Name,
           _closure_: a function object,
           _enumerable_: a Boolean,
-        ): either a normal completion containing either a PrivateElement or ~unused~, or an abrupt completion
+        ): either a normal completion containing either a PrivateElement or ~empty~, or an abrupt completion
       </h1>
       <dl class="header">
       </dl>
@@ -14138,7 +14138,7 @@
         1. Let _propertyDesc_ be the PropertyDescriptor { [[Value]]: _closure_, [[Writable]]: *true*, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
         1. Perform ? DefinePropertyOrThrow(_homeObj_, _name_, _propertyDesc_).
         1. NOTE: DefinePropertyOrThrow only returns an abrupt completion when attempting to define a class static method whose _name_ is *"prototype"*.
-        1. Return ~unused~.
+        1. Return ~empty~.
       </emu-alg>
     </emu-clause>
 
@@ -24634,7 +24634,7 @@
         Runtime Semantics: MethodDefinitionEvaluation (
           _obj_: an Object,
           _enumerable_: a Boolean,
-        ): either a normal completion containing either a PrivateElement or ~unused~, or an abrupt completion
+        ): either a normal completion containing either a PrivateElement or ~empty~, or an abrupt completion
       </h1>
       <dl class="header">
       </dl>
@@ -24658,7 +24658,7 @@
           1. Return PrivateElement { [[Key]]: _propertyKey_, [[Kind]]: ~accessor~, [[Getter]]: _closure_, [[Setter]]: *undefined* }.
         1. Let _propertyDesc_ be the PropertyDescriptor { [[Getter]]: _closure_, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
         1. Perform ? DefinePropertyOrThrow(_obj_, _propertyKey_, _propertyDesc_).
-        1. Return ~unused~.
+        1. Return ~empty~.
       </emu-alg>
       <emu-grammar>MethodDefinition : `set` ClassElementName `(` PropertySetParameterList `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
@@ -24673,7 +24673,7 @@
           1. Return PrivateElement { [[Key]]: _propertyKey_, [[Kind]]: ~accessor~, [[Getter]]: *undefined*, [[Setter]]: _closure_ }.
         1. Let _propertyDesc_ be the PropertyDescriptor { [[Setter]]: _closure_, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
         1. Perform ? DefinePropertyOrThrow(_obj_, _propertyKey_, _propertyDesc_).
-        1. Return ~unused~.
+        1. Return ~empty~.
       </emu-alg>
       <emu-grammar>GeneratorMethod : `*` ClassElementName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
@@ -25681,7 +25681,7 @@
       <h1>
         Runtime Semantics: ClassElementEvaluation (
           _obj_: an Object,
-        ): either a normal completion containing either a ClassFieldDefinition Record, a ClassStaticBlockDefinition Record, a PrivateElement, or ~unused~, or an abrupt completion
+        ): either a normal completion containing either a ClassFieldDefinition Record, a ClassStaticBlockDefinition Record, a PrivateElement, or ~empty~, or an abrupt completion
       </h1>
       <dl class="header">
       </dl>
@@ -25713,7 +25713,7 @@
         ClassElement : `;`
       </emu-grammar>
       <emu-alg>
-        1. Return ~unused~.
+        1. Return ~empty~.
       </emu-alg>
     </emu-clause>
 


### PR DESCRIPTION
Per https://github.com/tc39/ecma262/pull/3921#discussion_r3642102522.

There is still an instance in RunSuspendedContext. But it's a little buggy currently (see https://matrixlogs.bakkot.com/TC39_Editors/2026-06-26) and also we have multiple changes in flight (https://github.com/tc39/ecma262/pull/3896, https://github.com/tc39/ecma262/pull/2962) so I'm not touching it right now. We can address it either as part of those or after they land.

I ran https://github.com/tc39/ecmarkup/pull/714 against this and got no errors, which is not perfect assurance, but is some.

I will still want to do #3921 after this lands.