### PR TITLE
Editorial: Replace negative check with simpler positive one

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -45834,7 +45834,7 @@ THH:mm:ss.sss
         </dl>
         <emu-alg>
           1. If IsUnclampedIntegerElementType(_type_) is *true*, return *true*.
-          1. If IsBigIntElementType(_type_) is *true* and _order_ is neither ~init~ nor ~unordered~, return *true*.
+          1. If IsBigIntElementType(_type_) is *true* and _order_ is ~seq-cst~, return *true*.
           1. Return *false*.
         </emu-alg>
       </emu-clause>


### PR DESCRIPTION
<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)
* [WebAssembly](https://webassembly.github.io/spec/) - [file an issue](https://github.com/WebAssembly/spec/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->

Noticed while reviewing https://github.com/tc39/ecma262/pull/3817. This enum has 3 possible value, so rather than checking the variable _is not_ one of two we can check if it _is_ the third one.