### PR TITLE
Normative: Update RevalidateAtomicAccess to account for all bytes of a TypedArray element

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -47213,7 +47213,9 @@ THH:mm:ss.sss
           1. NOTE: Bounds checking is not a synchronizing operation when _ta_'s backing buffer is a growable SharedArrayBuffer.
           1. Let _taRecord_ be ? ValidateTypedArrayBounds(_ta_, ~unordered~).
           1. Assert: _byteIndexInBuffer_ ≥ _ta_.[[ByteOffset]].
-          1. If _byteIndexInBuffer_ ≥ _taRecord_.[[CachedBufferByteLength]], throw a *RangeError* exception.
+          1. Let _elementSize_ be TypedArrayElementSize(_ta_).
+          1. Let _elementLastByteIndex_ be _byteIndexInBuffer_ + _elementSize_ - 1.
+          1. If _elementLastByteIndex_ ≥ _taRecord_.[[CachedBufferByteLength]], throw a *RangeError* exception.
           1. Return ~unused~.
         </emu-alg>
       </emu-clause>
@@ -47720,8 +47722,8 @@ THH:mm:ss.sss
           1. Let _intCount_ be ? ToIntegerOrInfinity(_count_).
           1. Set _count_ to max(_intCount_, 0).
         1. Let _buffer_ be _ta_.[[ViewedArrayBuffer]].
-        1. Let _block_ be _buffer_.[[ArrayBufferData]].
         1. If IsSharedArrayBuffer(_buffer_) is *false*, return *+0*<sub>𝔽</sub>.
+        1. Let _block_ be _buffer_.[[ArrayBufferData]].
         1. Let _waiterList_ be GetWaiterList(_block_, _byteIndexInBuffer_).
         1. Perform EnterCriticalSection(_waiterList_).
         1. Let _waiters_ be RemoveWaiters(_waiterList_, _count_).


### PR DESCRIPTION
Fixes #3924
Ref #3200