### PR TITLE
Editorial: Normalize all RFC references

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -43836,10 +43836,10 @@ THH:mm:ss.sss
           1. Let _omitPadding_ be ToBoolean(? Get(_opts_, *"omitPadding"*)).
           1. Let _toEncode_ be ? GetUint8ArrayBytes(_obj_).
           1. If _alphabet_ is *"base64"*, then
-            1. Let _outAscii_ be the sequence of code points which results from encoding _toEncode_ according to the base64 encoding specified in section 4 of <a href="https://datatracker.ietf.org/doc/html/rfc4648">RFC 4648</a>. Padding is included if and only if _omitPadding_ is *false*.
+            1. Let _outAscii_ be the sequence of code points which results from encoding _toEncode_ according to the base64 encoding specified in section 4 of <a href="https://rfc-editor.org/info/rfc4648">RFC 4648</a>. Padding is included if and only if _omitPadding_ is *false*.
           1. Else,
             1. Assert: _alphabet_ is *"base64url"*.
-            1. Let _outAscii_ be the sequence of code points which results from encoding _toEncode_ according to the base64url encoding specified in section 5 of <a href="https://datatracker.ietf.org/doc/html/rfc4648">RFC 4648</a>. Padding is included if and only if _omitPadding_ is *false*.
+            1. Let _outAscii_ be the sequence of code points which results from encoding _toEncode_ according to the base64url encoding specified in section 5 of <a href="https://rfc-editor.org/info/rfc4648">RFC 4648</a>. Padding is included if and only if _omitPadding_ is *false*.
           1. Return CodePointsToString(_outAscii_).
         </emu-alg>
       </emu-clause>
@@ -43977,7 +43977,7 @@ THH:mm:ss.sss
         </dl>
         <p>The <dfn id="standard-base64-alphabet">standard base64 alphabet</dfn> is *"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"*, i.e., the String whose elements are the code units corresponding to every letter and number in the Unicode Basic Latin block along with *"+"* and *"/"*.</p>
         <emu-alg>
-          1. Let _byteSequence_ be the unique sequence of 3 bytes resulting from decoding _chunk_ as base64 (i.e., the sequence such that applying the base64 encoding specified in section 4 of <a href="https://datatracker.ietf.org/doc/html/rfc4648">RFC 4648</a> to _byteSequence_ would produce _chunk_).
+          1. Let _byteSequence_ be the unique sequence of 3 bytes resulting from decoding _chunk_ as base64 (i.e., the sequence such that applying the base64 encoding specified in section 4 of <a href="https://rfc-editor.org/info/rfc4648">RFC 4648</a> to _byteSequence_ would produce _chunk_).
           1. Return a List whose elements are the elements of _byteSequence_, in order.
         </emu-alg>
       </emu-clause>
@@ -55085,16 +55085,16 @@ THH:mm:ss.sss
       ISO 8601:2004(E) <i>Data elements and interchange formats — Information interchange — Representation of dates and times</i>
     </li>
     <li>
-      <i>RFC 1738 “Uniform Resource Locators (URL)”</i>, available at &lt;<a href="https://tools.ietf.org/html/rfc1738">https://tools.ietf.org/html/rfc1738</a>>
+      <i>RFC 1738 “Uniform Resource Locators (URL)”</i>, available at &lt;<a href="https://rfc-editor.org/info/rfc1738">https://rfc-editor.org/info/rfc1738</a>>
     </li>
     <li>
-      <i>RFC 2396 “Uniform Resource Identifiers (URI): Generic Syntax”</i>, available at &lt;<a href="https://tools.ietf.org/html/rfc2396">https://tools.ietf.org/html/rfc2396</a>>
+      <i>RFC 2396 “Uniform Resource Identifiers (URI): Generic Syntax”</i>, available at &lt;<a href="https://rfc-editor.org/info/rfc2396">https://rfc-editor.org/info/rfc2396</a>>
     </li>
     <li>
-      <i>RFC 3629 “UTF-8, a transformation format of ISO 10646”</i>, available at &lt;<a href="https://tools.ietf.org/html/rfc3629">https://tools.ietf.org/html/rfc3629</a>>
+      <i>RFC 3629 “UTF-8, a transformation format of ISO 10646”</i>, available at &lt;<a href="https://rfc-editor.org/info/rfc3629">https://rfc-editor.org/info/rfc3629</a>>
     </li>
     <li>
-      <i>RFC 7231 “Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content”</i>, available at &lt;<a href="https://tools.ietf.org/html/rfc7231">https://tools.ietf.org/html/rfc7231</a>>
+      <i>RFC 7231 “Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content”</i>, available at &lt;<a href="https://rfc-editor.org/info/rfc7231">https://rfc-editor.org/info/rfc7231</a>>
     </li>
   </ol>
 </emu-annex>


### PR DESCRIPTION
The canonical links for RFCs are of the form `https://rfc-editor.org/info/rfcNNNN`. The datatracker.ietf.org links were used for tracking drafts, and should not be in normative text.

https://github.com/tc39/ecma262/pull/3759#discussion_r3425615894

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)
* [WebAssembly](https://webassembly.github.io/spec/) - [file an issue](https://github.com/WebAssembly/spec/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
