### PR TITLE
Editorial: Update notes about 24:00 and ISO 8601

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -34748,7 +34748,7 @@
 
       <emu-clause id="sec-date-time-string-format">
         <h1>Date Time String Format</h1>
-        <p>ECMAScript defines a string interchange format for date-times based upon a simplification of the ISO 8601 calendar date extended format. The format is as follows: `YYYY-MM-DDTHH:mm:ss.sssZ`</p>
+        <p>ECMAScript defines a string interchange format for date-times which is adapted from the ISO 8601 calendar date extended format. The format is as follows: `YYYY-MM-DDTHH:mm:ss.sssZ`</p>
         <p>Where the elements are as follows:</p>
         <figure>
           <table class="lightweight-table">
@@ -34864,10 +34864,10 @@ THH:mm:ss.sss
         </pre>
         <p>A string containing out-of-bounds or nonconforming elements is not a valid instance of this format.</p>
         <emu-note>
-          <p>As every day both starts and ends with midnight, the two notations `00:00` and `24:00` are available to distinguish the two midnights that can be associated with one date. This means that the following two notations refer to exactly the same point in time: `1995-02-04T24:00` and `1995-02-05T00:00`. This interpretation of the latter form as “end of a calendar day” is consistent with ISO 8601, even though that specification reserves it for describing time intervals and does not permit it within representations of single points in time.</p>
+          <p>As every day both starts and ends with midnight, the two notations `00:00` and `24:00` are available to distinguish the two midnights that can be associated with one date. This means that the following two notations refer to exactly the same point in time: `1995-02-04T24:00` and `1995-02-05T00:00`.</p>
         </emu-note>
         <emu-note>
-          <p>There exists no international standard that specifies abbreviations for civil time zones like CET, EST, etc. and sometimes the same abbreviation is even used for two very different time zones. For this reason, both ISO 8601 and this format specify numeric representations of time zone offsets.</p>
+          <p>This format does not support annotations with a time zone name as defined in RFC 9557, only a numeric representation of the time zone offset.</p>
         </emu-note>
 
         <emu-clause id="sec-expanded-years" oldids="sec-extended-years">
@@ -55091,7 +55091,7 @@ THH:mm:ss.sss
       <i>IANA Time Zone Database</i>, available at &lt;<a href="https://www.iana.org/time-zones">https://www.iana.org/time-zones</a>>
     </li>
     <li>
-      ISO 8601:2004(E) <i>Data elements and interchange formats — Information interchange — Representation of dates and times</i>
+      ISO 8601-1:2019(E) <i>Date and time — Representations for information interchange — Part 1: Basic rules</i> plus Amendment 1:2022.
     </li>
     <li>
       <i>RFC 1738 “Uniform Resource Locators (URL)”</i>, available at &lt;<a href="https://rfc-editor.org/info/rfc1738">https://rfc-editor.org/info/rfc1738</a>>
@@ -55104,6 +55104,9 @@ THH:mm:ss.sss
     </li>
     <li>
       <i>RFC 7231 “Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content”</i>, available at &lt;<a href="https://rfc-editor.org/info/rfc7231">https://rfc-editor.org/info/rfc7231</a>>
+    </li>
+    <li>
+      <i>RFC 9557 “Date and Time on the Internet: Timestamps with Additional Information”</i>, available at &lt;<a href="https://rfc-editor.org/info/rfc9557">https://rfc-editor.org/info/rfc9557</a>>
     </li>
   </ol>
 </emu-annex>


### PR DESCRIPTION
Since the 2022 amendment to ISO 8601 there is support for the 24:00 notation, as an instant in time and not just the end of a duration, unlike the 2004 edition which we previously cited in the bibliography. Also update the note about a standard for time zone names not existing; this exists now with RFC 9557.

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)
* [WebAssembly](https://webassembly.github.io/spec/) - [file an issue](https://github.com/WebAssembly/spec/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
