### PR TITLE
Editorial: decouple JSON.parse from ES evaluation semantics

### DIFF
--- a/ecma404biblio.json
+++ b/ecma404biblio.json
@@ -1,0 +1,203 @@
+{
+  "location": "https://tc39.es/ecma404/",
+  "entries": [
+    {
+      "type": "clause",
+      "id": "sec-intro",
+      "aoid": null,
+      "title": "Introduction",
+      "titleHTML": "Introduction",
+      "number": ""
+    },
+    {
+      "type": "clause",
+      "id": "sec-scope",
+      "aoid": null,
+      "title": "Scope",
+      "titleHTML": "Scope",
+      "number": "1"
+    },
+    {
+      "type": "clause",
+      "id": "sec-conformance",
+      "aoid": null,
+      "title": "Conformance",
+      "titleHTML": "Conformance",
+      "number": "2"
+    },
+    {
+      "type": "clause",
+      "id": "sec-normative-references",
+      "aoid": null,
+      "title": "Normative References",
+      "titleHTML": "Normative References",
+      "number": "3"
+    },
+    {
+      "type": "table",
+      "id": "table-structural-tokens",
+      "number": 1,
+      "caption": "Table 1: Structural Tokens"
+    },
+    {
+      "type": "table",
+      "id": "table-literal-tokens",
+      "number": 2,
+      "caption": "Table 2: Literal Name Tokens"
+    },
+    {
+      "type": "clause",
+      "id": "sec-json-text",
+      "aoid": null,
+      "title": "JSON Text",
+      "titleHTML": "JSON Text",
+      "number": "4"
+    },
+    {
+      "type": "figure",
+      "id": "figure-value",
+      "number": 1,
+      "caption": "Figure 1: value"
+    },
+    { "type": "production", "id": "prod-JSONValue", "name": "JSONValue" },
+    {
+      "type": "clause",
+      "id": "sec-json-values",
+      "aoid": null,
+      "title": "JSON Values",
+      "titleHTML": "JSON Values",
+      "number": "5"
+    },
+    {
+      "type": "figure",
+      "id": "figure-object",
+      "number": 2,
+      "caption": "Figure 2: object"
+    },
+    { "type": "production", "id": "prod-JSONObject", "name": "JSONObject" },
+    {
+      "type": "production",
+      "id": "prod-JSONMemberList",
+      "name": "JSONMemberList"
+    },
+    { "type": "production", "id": "prod-JSONMember", "name": "JSONMember" },
+    {
+      "type": "clause",
+      "id": "sec-objects",
+      "aoid": null,
+      "title": "Objects",
+      "titleHTML": "Objects",
+      "number": "6"
+    },
+    {
+      "type": "figure",
+      "id": "figure-array",
+      "number": 3,
+      "caption": "Figure 3: array"
+    },
+    { "type": "production", "id": "prod-JSONArray", "name": "JSONArray" },
+    {
+      "type": "production",
+      "id": "prod-JSONElementList",
+      "name": "JSONElementList"
+    },
+    {
+      "type": "clause",
+      "id": "sec-arrays",
+      "aoid": null,
+      "title": "Arrays",
+      "titleHTML": "Arrays",
+      "number": "7"
+    },
+    {
+      "type": "figure",
+      "id": "figure-number",
+      "number": 4,
+      "caption": "Figure 4: number"
+    },
+    { "type": "production", "id": "prod-JSONNumber", "name": "JSONNumber" },
+    { "type": "production", "id": "prod-JSONInteger", "name": "JSONInteger" },
+    { "type": "production", "id": "prod-JSONFraction", "name": "JSONFraction" },
+    { "type": "production", "id": "prod-JSONExponent", "name": "JSONExponent" },
+    {
+      "type": "production",
+      "id": "prod-JSONExponentIndicator",
+      "name": "JSONExponentIndicator"
+    },
+    { "type": "production", "id": "prod-JSONSign", "name": "JSONSign" },
+    { "type": "production", "id": "prod-JSONDigits", "name": "JSONDigits" },
+    { "type": "production", "id": "prod-JSONDigit", "name": "JSONDigit" },
+    { "type": "production", "id": "prod-NonZeroDigit", "name": "NonZeroDigit" },
+    {
+      "type": "clause",
+      "id": "sec-numbers",
+      "aoid": null,
+      "title": "Numbers",
+      "titleHTML": "Numbers",
+      "number": "8"
+    },
+    {
+      "type": "table",
+      "id": "table-escape-sequences",
+      "number": 3,
+      "caption": "Table 3: Escape Sequences"
+    },
+    {
+      "type": "figure",
+      "id": "figure-string",
+      "number": 5,
+      "caption": "Figure 5: string"
+    },
+    { "type": "production", "id": "prod-JSONString", "name": "JSONString" },
+    {
+      "type": "production",
+      "id": "prod-JSONStringCharacters",
+      "name": "JSONStringCharacters"
+    },
+    {
+      "type": "production",
+      "id": "prod-JSONStringCharacter",
+      "name": "JSONStringCharacter"
+    },
+    {
+      "type": "production",
+      "id": "prod-JSONEscapeSequence",
+      "name": "JSONEscapeSequence"
+    },
+    {
+      "type": "production",
+      "id": "prod-JSONEscapeCharacter",
+      "name": "JSONEscapeCharacter"
+    },
+    { "type": "production", "id": "prod-JSONHexDigit", "name": "JSONHexDigit" },
+    {
+      "type": "production",
+      "id": "prod-JSONSourceCharacter",
+      "name": "JSONSourceCharacter"
+    },
+    {
+      "type": "clause",
+      "id": "sec-strings",
+      "aoid": null,
+      "title": "Strings",
+      "titleHTML": "Strings",
+      "number": "9"
+    },
+    {
+      "type": "clause",
+      "id": "sec-bibliography",
+      "aoid": null,
+      "title": "Bibliography",
+      "titleHTML": "Bibliography",
+      "number": "A"
+    },
+    {
+      "type": "clause",
+      "id": "sec-copyright-and-software-license",
+      "aoid": null,
+      "title": "Copyright & Software License",
+      "titleHTML": "Copyright &amp; Software License",
+      "number": "B"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "ipr-check": "node scripts/check-form tc39/ecma262",
     "build-head": "npm run build-only -- --lint-spec --strict",
     "prebuild-only": "npm run clean && mkdir out && cp -R img out",
-    "build-only": "ecmarkup --verbose spec.html --multipage out",
+    "build-only": "ecmarkup --load-biblio ./ecma404biblio.json --verbose spec.html --multipage out",
     "build": "npm run build-head",
     "build-for-pdf": "npm run prebuild-only && ecmarkup --verbose spec.html out/index.html --assets external --assets-dir out --printable --lint-spec --strict",
     "pdf": "npm run build-for-pdf && prince-books --script ./node_modules/ecmarkup/js/print.js out/index.html -o out/ECMA-262.pdf",

--- a/spec.html
+++ b/spec.html
@@ -47989,7 +47989,6 @@ THH:mm:ss.sss
           1. Let _jsonParseNode_ be ParseText(_text_, |JSONValue|).
           1. If _jsonParseNode_ is not a Parse Node, throw a *SyntaxError* exception.
           1. Let _result_ be the JSONEvaluation of _jsonParseNode_.
-          1. [id="step-json-parse-assert-type"] Assert: _result_ is either a String, a Number, a Boolean, an Object that is defined by either an |ArrayLiteral| or an |ObjectLiteral|, or *null*.
           1. Return the Record { [[ParseNode]]: _jsonParseNode_, [[Value]]: _result_ }.
         </emu-alg>
         <p>It is not permitted for a conforming implementation of `JSON.parse` to extend the JSON grammars. If an implementation wishes to support a modified or extended JSON interchange format it must do so by defining a different parse function.</p>
@@ -48041,10 +48040,10 @@ THH:mm:ss.sss
         </emu-table>
       </emu-clause>
 
-      <emu-clause id="sec-createjsonparserecord" type="abstract operation">
+      <emu-clause id="sec-createjsonparserecord" type="abstract operation" oldids="sec-shallowestcontainedjsonvalue">
         <h1>
           CreateJSONParseRecord (
-            _parseNode_: a Parse Node,
+            _parseNode_: a |JSONValue| Parse Node,
             _key_: a property name,
             _value_: an ECMAScript language value,
           ): a JSON Parse Record
@@ -48054,42 +48053,35 @@ THH:mm:ss.sss
           <dd>It recursively combines a _parseNode_ parsed from JSON text and the _value_ produced by its evaluation.</dd>
         </dl>
         <emu-alg>
+          1. Assert: _parseNode_ has exactly one child.
+          1. Let _typedValueNode_ be the first child of _parseNode_.
           1. Let _elements_ be a new empty List.
           1. Let _entries_ be a new empty List.
-          1. If _value_ is an Object, then
-            1. Let _isArray_ be ! <emu-meta suppress-effects="user-code">IsArray(_value_)</emu-meta>.
-            1. If _isArray_ is *true*, then
-              1. Assert: _parseNode_ is an instance of the production <emu-grammar>JSONValue : JSONArray</emu-grammar>.
-              1. Let _typedValueNode_ be the |JSONArray| of _parseNode_.
-              1. Let _contentNodes_ be the JSONArrayLiteralContentNodes of _typedValueNode_.
-              1. Let _length_ be the number of elements in _contentNodes_.
-              1. Let _valueLength_ be ! <emu-meta suppress-effects="user-code">LengthOfArrayLike(_value_)</emu-meta>.
-              1. Assert: _valueLength_ is _length_.
-              1. Let _index_ be 0.
-              1. Repeat, while _index_ &lt; _length_,
-                1. Let _propertyName_ be ! ToString(𝔽(_index_)).
-                1. Let _elementParseRecord_ be CreateJSONParseRecord(_contentNodes_[_index_], _propertyName_, ! <emu-meta suppress-effects="user-code">Get(_value_, _propertyName_)</emu-meta>).
-                1. Append _elementParseRecord_ to _elements_.
-                1. Set _index_ to _index_ + 1.
-            1. Else,
-              1. Assert: _parseNode_ is an instance of the production <emu-grammar>JSONValue : JSONObject</emu-grammar>.
-              1. Let _typedValueNode_ be the |JSONObject| of _parseNode_.
-              1. Let _propertyNodes_ be the JSONObjectLiteralContentNodes of _typedValueNode_.
-              1. NOTE: Because _value_ was produced from JSON text and has not been modified, all of its property keys are Strings and will be exhaustively enumerated.
-              1. Let _keys_ be ! <emu-meta suppress-effects="user-code">EnumerableOwnProperties(_value_, ~key~)</emu-meta>.
-              1. For each String _propertyKey_ of _keys_, do
-                1. NOTE: In the case of JSON text specifying multiple name/value pairs with the same name for a single object (such as <code>{"a":"lost","a":"kept"}</code>), the value for the corresponding property of the resulting ECMAScript object is specified by the last pair with that name.
-                1. Let _propertyDefinition_ be ~empty~.
-                1. For each Parse Node _propertyNode_ of _propertyNodes_, do
-                  1. Let _propertyName_ be the PropName of _propertyNode_.
-                  1. If _propertyName_ is _propertyKey_, set _propertyDefinition_ to _propertyNode_.
-                1. Assert: _propertyDefinition_ is <emu-grammar>JSONMember : JSONString `:` JSONValue</emu-grammar>.
-                1. Let _propertyValueNode_ be the |JSONValue| of _propertyDefinition_.
-                1. Let _entryParseRecord_ be CreateJSONParseRecord(_propertyValueNode_, _propertyKey_, ! <emu-meta suppress-effects="user-code">Get(_value_, _propertyKey_)</emu-meta>).
-                1. Append _entryParseRecord_ to _entries_.
-          1. Else,
-            1. Let _typedValueNode_ be _parseNode_.
-            1. Assert: _typedValueNode_ is neither a |JSONArray| Parse Node nor a |JSONObject| Parse Node.
+          1. If _typedValueNode_ is a |JSONArray| Parse Node, then:
+            1. Let _contentNodes_ be the JSONArrayLiteralContentNodes of _typedValueNode_.
+            1. Let _length_ be the number of elements in _contentNodes_.
+            1. Let _valueLength_ be ! <emu-meta suppress-effects="user-code">LengthOfArrayLike(_value_)</emu-meta>.
+            1. Assert: _valueLength_ is _length_.
+            1. Let _index_ be 0.
+            1. Repeat, while _index_ &lt; _length_,
+              1. Let _propertyName_ be ! ToString(𝔽(_index_)).
+              1. Let _elementParseRecord_ be CreateJSONParseRecord(_contentNodes_[_index_], _propertyName_, ! <emu-meta suppress-effects="user-code">Get(_value_, _propertyName_)</emu-meta>).
+              1. Append _elementParseRecord_ to _elements_.
+              1. Set _index_ to _index_ + 1.
+          1. Else if _typedValueNode_ is a |JSONObject| Parse Node,
+            1. Let _propertyNodes_ be the JSONObjectLiteralContentNodes of _typedValueNode_.
+            1. NOTE: Because _value_ was produced from JSON text and has not been modified, all of its property keys are Strings and will be exhaustively enumerated.
+            1. Let _keys_ be ! <emu-meta suppress-effects="user-code">EnumerableOwnProperties(_value_, ~key~)</emu-meta>.
+            1. For each String _propertyKey_ of _keys_, do
+              1. NOTE: In the case of JSON text specifying multiple name/value pairs with the same name for a single object (such as <code>{"a":"lost","a":"kept"}</code>), the value for the corresponding property of the resulting ECMAScript object is specified by the last pair with that name.
+              1. Let _propertyDefinition_ be ~empty~.
+              1. For each Parse Node _propertyNode_ of _propertyNodes_, do
+                1. Let _propertyName_ be the PropName of _propertyNode_.
+                1. If _propertyName_ is _propertyKey_, set _propertyDefinition_ to _propertyNode_.
+              1. Assert: _propertyDefinition_ is <emu-grammar>JSONMember : JSONString `:` JSONValue</emu-grammar>.
+              1. Let _propertyValueNode_ be the |JSONValue| of _propertyDefinition_.
+              1. Let _entryParseRecord_ be CreateJSONParseRecord(_propertyValueNode_, _propertyKey_, ! <emu-meta suppress-effects="user-code">Get(_value_, _propertyKey_)</emu-meta>).
+              1. Append _entryParseRecord_ to _entries_.
           1. Return the JSON Parse Record { [[ParseNode]]: _typedValueNode_, [[Key]]: _key_, [[Value]]: _value_, [[Elements]]: _elements_, [[Entries]]: _entries_ }.
         </emu-alg>
       </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -48242,23 +48242,24 @@ THH:mm:ss.sss
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It is just like PropertyDefinitionEvaluation, except 1) it is defined over a much narrower grammar, 2) it does not include the special handling of *"__proto__"* described in <emu-xref href="#sec-jsonevaluation"></emu-xref>, and 3) it calls JSONEvaluation instead of Evaluation.</dd>
+          <dd>It is analagous to PropertyDefinitionEvaluation, except 1) it is defined over a much narrower grammar, 2) it does not include the special handling of *"__proto__"* described in <emu-xref href="#sec-jsonevaluation"></emu-xref>, and 3) it calls JSONEvaluation instead of Evaluation.</dd>
         </dl>
         <emu-grammar>JSONMemberList : JSONMemberList `,` JSONMember</emu-grammar>
         <emu-alg>
-          1. Perform JSONMemberListEvaluation of the derived |JSONMemberList| with arguments _obj_, _entries_, and _how_.
-          1. Perform JSONMemberListEvaluation of |JSONMember| with argument _obj_, _entries_, and _how_.
+          1. Perform JSONMemberListEvaluation of the derived |JSONMemberList| with arguments _obj_, _deepNodes_, and _entries_.
+          1. Perform JSONMemberListEvaluation of |JSONMember| with arguments _obj_, _deepNodes_, and _entries_.
           1. Return ~unused~.
         </emu-alg>
         <emu-grammar>JSONMember : JSONString `:` JSONValue</emu-grammar>
         <emu-alg>
-          1. Let _propertyKeyRecord_ be the JSONEvaluation of |JSONString| with argument _how_.
-          1. Let _propertyValueRecord_ be the JSONEvaluation of |JSONValue| with argument _how_.
+          1. Let _dummyKey_ be the empty String.
+          1. Let _propertyKeyRecord_ be the JSONEvaluation of |JSONString| with arguments _dummyKey_ and _deepNodes_.
+          1. Let _key_ be _propertyKeyRecord_.[[Value]].
+          1. Assert: _key_ is a property name.
+          1. Let _propertyValueRecord_ be the JSONEvaluation of |JSONValue| with arguments _key_ and _deepNodes_.
           1. Assert: _obj_ is an ordinary, extensible object with no non-configurable properties.
-          1. Perform ! CreateDataPropertyOrThrow(_obj_, _propertyKeyRecord_.[[Value]], _propertyValueRecord_.[[Value]]).
-          1. If ~how~ is deep, then
-            1. Set _propertyValueRecord_.[[Key]] to _propertyKeyRecord_.[[Value]].
-            1. Append _propertyValueRecord_ to _entries_.
+          1. Perform ! CreateDataPropertyOrThrow(_obj_, _key_, _propertyValueRecord_.[[Value]]).
+          1. If _deepNodes_ is ~keep-nodes~, append _propertyValueRecord_ to _entries_.
           1. Return ~unused~.
         </emu-alg>
       </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -19011,8 +19011,7 @@
         </emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the PropertyNameList of |PropertyDefinitionList| contains any duplicate entries for *"__proto__"* and at least two of those entries were obtained from productions of the form <emu-grammar>PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar>. This rule is not applied if this |ObjectLiteral| is contained within a |Script| that is being parsed for ParseJSON (see step <emu-xref href="#step-json-parse-parse"></emu-xref> of ParseJSON).
-          </li>
+            It is a Syntax Error if the PropertyNameList of |PropertyDefinitionList| contains any duplicate entries for *"__proto__"* and at least two of those entries were obtained from productions of the form <emu-grammar>PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar>. Note that the corresponding |JSONObject| production in ECMA-404 (which is used by the ParseJSON in this specification) does not raise a corresponding early error.
         </ul>
         <emu-note>
           <p>The List returned by PropertyNameList does not include property names defined using a |ComputedPropertyName|.</p>
@@ -47982,17 +47981,17 @@ THH:mm:ss.sss
         </h1>
         <dl class="header">
         </dl>
+        <emu-note>
+          <p>This algorithm references the |JSONValue| nonterminal from ECMA-404.</p>
+        </emu-note>
         <emu-alg>
           1. [id="step-json-parse-validate"] If StringToCodePoints(_text_) is not a valid JSON text as specified in ECMA-404, throw a *SyntaxError* exception.
           1. Let _scriptString_ be the string-concatenation of *"("*, _text_, and *");"*.
-          1. [id="step-json-parse-parse"] Let _script_ be ParseText(_scriptString_, |Script|).
-          1. NOTE: The early error rules defined in <emu-xref href="#sec-object-initializer-static-semantics-early-errors"></emu-xref> have special handling for the above invocation of ParseText.
-          1. Assert: _script_ is a Parse Node.
-          1. Let _jsonParseNode_ be ShallowestContainedJSONValue(_script_).
-          1. Assert: _jsonParseNode_ is not ~empty~.
+          1. [id="step-json-parse-parse"] Let _jsonParseNode_ be ParseText(_scriptString_, |JSONValue|).
+          1. Assert: _jsonParseNode_ is a Parse Node.
           1. [id="step-json-parse-eval"] Let _result_ be ! <emu-meta suppress-effects="user-code">JSONEvaluation of _jsonParseNode_</emu-meta>.
           1. [id="step-json-parse-assert-type"] Assert: _result_ is either a String, a Number, a Boolean, an Object that is defined by either an |ArrayLiteral| or an |ObjectLiteral|, or *null*.
-          1. Return the Record { [[ParseNode]]: _script_, [[Value]]: _result_ }.
+          1. Return the Record { [[ParseNode]]: _jsonParseNode_, [[Value]]: _result_ }.
         </emu-alg>
         <p>It is not permitted for a conforming implementation of `JSON.parse` to extend the JSON grammars. If an implementation wishes to support a modified or extended JSON interchange format it must do so by defining a different parse function.</p>
         <emu-note>
@@ -48057,14 +48056,13 @@ THH:mm:ss.sss
           <dd>It recursively combines a _parseNode_ parsed from JSON text and the _value_ produced by its evaluation.</dd>
         </dl>
         <emu-alg>
-          1. Let _typedValueNode_ be ShallowestContainedJSONValue(_parseNode_).
-          1. Assert: _typedValueNode_ is not ~empty~.
           1. Let _elements_ be a new empty List.
           1. Let _entries_ be a new empty List.
           1. If _value_ is an Object, then
             1. Let _isArray_ be ! <emu-meta suppress-effects="user-code">IsArray(_value_)</emu-meta>.
             1. If _isArray_ is *true*, then
-              1. Assert: _typedValueNode_ is an |ArrayLiteral| Parse Node.
+              1. Assert: _parseNode_ is a <emu-grammar>JSONValue : JSONArray</emu-grammar>.
+              1. Let _typedValueNode_ be the |JSONArray| Parse Node of _parseNode_.
               1. Let _contentNodes_ be the JSONArrayLiteralContentNodes of _typedValueNode_.
               1. Let _length_ be the number of elements in _contentNodes_.
               1. Let _valueLength_ be ! <emu-meta suppress-effects="user-code">LengthOfArrayLike(_value_)</emu-meta>.
@@ -48076,8 +48074,9 @@ THH:mm:ss.sss
                 1. Append _elementParseRecord_ to _elements_.
                 1. Set _index_ to _index_ + 1.
             1. Else,
-              1. Assert: _typedValueNode_ is an |ObjectLiteral| Parse Node.
-              1. Let _propertyNodes_ be the PropertyDefinitionNodes of _typedValueNode_.
+              1. Assert: _parseNode_ is a <emu-grammar>JSONValue : JSONObject</emu-grammar>.
+              1. Let _typedValueNode_ be the |JSONObject| Parse Node of _parseNode_.
+              1. Let _propertyNodes_ be the JSONObjectLiteralContentNodes of _typedValueNode_.
               1. NOTE: Because _value_ was produced from JSON text and has not been modified, all of its property keys are Strings and will be exhaustively enumerated.
               1. Let _keys_ be ! <emu-meta suppress-effects="user-code">EnumerableOwnProperties(_value_, ~key~)</emu-meta>.
               1. For each String _propertyKey_ of _keys_, do
@@ -48086,12 +48085,12 @@ THH:mm:ss.sss
                 1. For each Parse Node _propertyNode_ of _propertyNodes_, do
                   1. Let _propertyName_ be the PropName of _propertyNode_.
                   1. If _propertyName_ is _propertyKey_, set _propertyDefinition_ to _propertyNode_.
-                1. Assert: _propertyDefinition_ is <emu-grammar>PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar>.
-                1. Let _propertyValueNode_ be the |AssignmentExpression| of _propertyDefinition_.
+                1. Assert: _propertyDefinition_ is <emu-grammar>JSONMember : JSONString `:` JSONValue</emu-grammar>.
+                1. Let _propertyValueNode_ be the |JSONValue| of _propertyDefinition_.
                 1. Let _entryParseRecord_ be CreateJSONParseRecord(_propertyValueNode_, _propertyKey_, ! <emu-meta suppress-effects="user-code">Get(_value_, _propertyKey_)</emu-meta>).
                 1. Append _entryParseRecord_ to _entries_.
           1. Else,
-            1. Assert: _typedValueNode_ is neither an |ArrayLiteral| Parse Node nor an |ObjectLiteral| Parse Node.
+            1. Assert: _typedValueNode_ is neither a |JSONArray| Parse Node nor a |JSONObject| Parse Node.
           1. Return the JSON Parse Record { [[ParseNode]]: _typedValueNode_, [[Key]]: _key_, [[Value]]: _value_, [[Elements]]: _elements_, [[Entries]]: _entries_ }.
         </emu-alg>
       </emu-clause>
@@ -48117,7 +48116,7 @@ THH:mm:ss.sss
           1. If _parseRecord_ is a JSON Parse Record and SameValue(_parseRecord_.[[Value]], _value_) is *true*, then
             1. If _value_ is not an Object, then
               1. Let _parseNode_ be _parseRecord_.[[ParseNode]].
-              1. Assert: _parseNode_ is neither an |ArrayLiteral| Parse Node nor an |ObjectLiteral| Parse Node.
+              1. Assert: _parseNode_ is neither a |JSONArray| Parse Node nor a |JSONObject| Parse Node.
               1. Let _sourceText_ be the source text matched by _parseNode_.
               1. Perform ! CreateDataPropertyOrThrow(_context_, *"source"*, CodePointsToString(_sourceText_)).
             1. Let _elementRecords_ be _parseRecord_.[[Elements]].
@@ -48153,134 +48152,148 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-shallowestcontainedjsonvalue" type="abstract operation">
-        <h1>
-          Static Semantics: ShallowestContainedJSONValue (
-            _root_: a Parse Node,
-          ): a Parse Node or ~empty~
-        </h1>
-        <dl class="header">
-          <dt>description</dt>
-          <dd>It performs a breadth-first search of the parse tree rooted at _root_, and returns the first node that is an instance of a nonterminal corresponding to a JSON value, or ~empty~ if there is no such node.</dd>
-        </dl>
-        <emu-alg>
-          1. Let _activeFunc_ be the active function object.
-          1. Assert: _activeFunc_ is a `JSON.parse` built-in function object (see <emu-xref href="#sec-json.parse">JSON.parse</emu-xref>).
-          1. Let _types_ be « |NullLiteral|, |BooleanLiteral|, |NumericLiteral|, |StringLiteral|, |ArrayLiteral|, |ObjectLiteral|, |UnaryExpression| ».
-          1. Let _unaryExpr_ be ~empty~.
-          1. Let _queue_ be « _root_ ».
-          1. Repeat, while _queue_ is not empty,
-            1. Let _candidate_ be the first element of _queue_.
-            1. Remove the first element from _queue_.
-            1. Let _queuedChildren_ be *false*.
-            1. For each nonterminal _type_ of _types_, do
-              1. If _candidate_ is an instance of _type_, then
-                1. NOTE: In the JSON grammar, a <code>number</code> token may represent a negative value. In ECMAScript, negation is represented as a unary operation in which a |UnaryExpression| parses to a `-` followed by a derived |UnaryExpression|.
-                1. If _type_ is |UnaryExpression|, then
-                  1. If the parent of _candidate_ is not a |UnaryExpression| Parse Node, set _unaryExpr_ to _candidate_.
-                1. Else if _type_ is |NumericLiteral|, then
-                  1. Assert: _candidate_ is contained within _unaryExpr_.
-                  1. Return _unaryExpr_.
-                1. Else,
-                  1. Return _candidate_.
-              1. If _queuedChildren_ is *false*, _candidate_ is an instance of a nonterminal, and _candidate_ Contains _type_ is *true*, then
-                1. Let _children_ be a List containing each child node of _candidate_, in order.
-                1. Set _queue_ to the list-concatenation of _queue_ and _children_.
-                1. Set _queuedChildren_ to *true*.
-          1. Return ~empty~.
-        </emu-alg>
-      </emu-clause>
-
       <emu-clause id="sec-static-semantics-jsonarrayliteralcontentnodes" type="sdo">
         <h1>Static Semantics: JSONArrayLiteralContentNodes ( ): a List of Parse Nodes</h1>
         <dl class="header">
         </dl>
         <emu-grammar>
-          ArrayLiteral :
-            `[` Elision? `]`
-            `[` ElementList `]`
-            `[` ElementList `,` Elision? `]`
+          JSONArray :
+            `[` `]`
+            `[` JSONElementList `]`
         </emu-grammar>
         <emu-alg>
-          1. Assert: |Elision| is not present.
-          1. If |ElementList| is not present, return a new empty List.
-          1. Return the JSONArrayLiteralContentNodes of |ElementList|.
+          1. If |JSONElementList| is not present, return a new empty List.
+          1. Return the JSONArrayLiteralContentNodes of |JSONElementList|.
         </emu-alg>
 
-        <emu-grammar>ElementList : Elision? AssignmentExpression</emu-grammar>
+        <emu-grammar>JSONElementList : JSONValue</emu-grammar>
         <emu-alg>
-          1. Assert: |Elision| is not present.
-          1. Return « |AssignmentExpression| ».
+          1. Return « |JSONValue| ».
         </emu-alg>
 
-        <emu-grammar>ElementList : ElementList `,` Elision? AssignmentExpression</emu-grammar>
+        <emu-grammar>JSONElementList : JSONElementList `,` JSONValue</emu-grammar>
         <emu-alg>
-          1. Assert: |Elision| is not present.
-          1. Let _elements_ be the JSONArrayLiteralContentNodes of the derived |ElementList|.
-          1. Return the list-concatenation of _elements_ and « |AssignmentExpression| ».
+          1. Let _elements_ be the JSONArrayLiteralContentNodes of the derived |JSONElementList|.
+          1. Return the list-concatenation of _elements_ and « |JSONValue| ».
         </emu-alg>
+      </emu-clause>
 
+      <emu-clause id="sec-static-semantics-jsonobjectliteralcontentnodes" type="sdo">
+        <h1>Static Semantics: JSONObjectLiteralContentNodes ( ): a List of Parse Nodes</h1>
+        <dl class="header">
+        </dl>
         <emu-grammar>
-          ElementList :
-            Elision? SpreadElement
-            ElementList `,` Elision? SpreadElement
+          JSONObject :
+            `{` `}`
+            `{` JSONMemberList `}`
         </emu-grammar>
         <emu-alg>
-          1. NOTE: JSON text as specified in ECMA-404 does not include |SpreadElement|.
-          1. Assert: This step is never reached.
+          1. If |JSONMemberList| is not present, return a new empty List.
+          1. Return the JSONObjectLiteralContentNodes of |JSONMemberList|.
+        </emu-alg>
+
+        <emu-grammar>JSONMemberList : JSONMember</emu-grammar>
+        <emu-alg>
+          1. Return « |JSONMember| ».
+        </emu-alg>
+
+        <emu-grammar>JSONMemberList : JSONMemberList `,` JSONMember</emu-grammar>
+        <emu-alg>
+          1. Let _elements_ be the JSONObjectLiteralContentNodes of the derived |JSONMemberList|.
+          1. Return the list-concatenation of _elements_ and « |JSONMember| ».
         </emu-alg>
       </emu-clause>
 
       <emu-clause id="sec-jsonevaluation" type="sdo">
-        <h1>Runtime Semantics: JSONEvaluation ( ): either a normal completion containing an ECMAScript language value or a throw completion</h1>
+        <h1>Runtime Semantics: JSONEvaluation ( ): an ECMAScript language value</h1>
         <dl class="header">
         </dl>
         <emu-grammar>
-          Literal :
-            NullLiteral
-            BooleanLiteral
-            NumericLiteral
-            StringLiteral
+          JSONValue : null
         </emu-grammar>
         <emu-alg>
-          1. Let _value_ be ! Evaluation of |Literal|.
-          1. Assert: _value_ is either a String, a Number, a Boolean, or *null*.
+          1. Return *null*.
+        </emu-alg>
+
+        <emu-grammar>
+          JSONValue : true
+        </emu-grammar>
+        <emu-alg>
+          1. Return *true*.
+        </emu-alg>
+
+        <emu-grammar>
+          JSONValue : false
+        </emu-grammar>
+        <emu-alg>
+          1. Return *false*.
+        </emu-alg>
+
+        <emu-grammar>
+          JSONValue : JSONNumber
+        </emu-grammar>
+        <emu-alg>
+          1. Let _source_ be the source text matched by |JSONNumber|.
+          1. Let _esNode_ be ParseText(_source_, |UnaryExpression|).
+          1. Assert: _esNode_ is a |UnaryExpression| Parse Node.
+          1. Let _completion_ be Evaluation of _esNode_.
+          1. Assert: _completion_ is not an abrupt completion.
+          1. Let _value_ be _completion_.[[Value]].
           1. Return _value_.
         </emu-alg>
 
         <emu-grammar>
-          UnaryExpression :
-            `delete` UnaryExpression
-            `void` UnaryExpression
-            `typeof` UnaryExpression
-            `+` UnaryExpression
-            `~` UnaryExpression
-            `!` UnaryExpression
-            CoverAwaitExpressionAndAwaitUsingDeclarationHead
+          JSONValue : JSONString
         </emu-grammar>
         <emu-alg>
-          1. NOTE: JSON text as specified in ECMA-404 does not include |UnaryExpression| except literals and the negative operator.
-          1. Assert: This step is never reached.
+          1. Return JSONEvaluation of |JSONString|.
         </emu-alg>
 
-        <emu-grammar>UnaryExpression : `-` UnaryExpression</emu-grammar>
+        <emu-grammer>
+          JSONString :
+            `"` JSONStringCharacters? `"`
+        </emu-grammer>
         <emu-alg>
-          1. Let _value_ be ! Evaluation of the parent |UnaryExpression|.
-          1. Assert: _value_ is a Number.
+          1. Let _source_ be the source text matched by |JSONString|.
+          1. Let _esNode_ be ParseText(_source_, |StringLiteral|).
+          1. Assert: _esNode_ is a |StringLiteral| Parse Node.
+          1. Let _value_ be SV of _esNode_.
           1. Return _value_.
         </emu-alg>
 
         <emu-grammar>
-          ArrayLiteral : `[` ElementList `]`
+          JSONValue : JSONArray
+        </emu-grammar>
+        <emu-alg>
+          1. Return JSONEvaluation of |JSONArray|.
+        </emu-alg>
+
+        <emu-grammar>
+          JSONArray : `[` `]`
         </emu-grammar>
         <emu-alg>
           1. Let _array_ be ! ArrayCreate(0).
-          1. Perform ? JSONArrayAccumulation of |ElementList| with arguments _array_ and 0.
           1. Return _array_.
         </emu-alg>
 
         <emu-grammar>
-          ObjectLiteral : `{` `}`
+          JSONArray : `[` JSONElementList `]`
+        </emu-grammar>
+        <emu-alg>
+          1. Let _array_ be ! ArrayCreate(0).
+          1. Perform JSONArrayAccumulation of |JSONElementList| with arguments _array_ and 0.
+          1. Return _array_.
+        </emu-alg>
+
+        <emu-grammar>
+          JSONValue : JSONObject
+        </emu-grammar>
+        <emu-alg>
+          1. Return JSONEvaluation of |JSONObject|.
+        </emu-alg>
+
+        <emu-grammar>
+          JSONObject : `{` `}`
         </emu-grammar>
         <emu-alg>
           1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%).
@@ -48288,11 +48301,11 @@ THH:mm:ss.sss
         </emu-alg>
 
         <emu-grammar>
-          ObjectLiteral : `{` PropertyDefinitionList `}`
+          JSONObject : `{` JSONMemberList `}`
         </emu-grammar>
         <emu-alg>
           1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%).
-          1. Perform ? JSONPropertyDefinitionEvaluation of |PropertyDefinitionList| with argument _obj_.
+          1. Perform JSONMemberListEvaluation of |JSONMemberList| with argument _obj_.
           1. Return _obj_.
         </emu-alg>
       </emu-clause>
@@ -48302,79 +48315,50 @@ THH:mm:ss.sss
           Runtime Semantics: JSONArrayAccumulation (
             _array_: an Array,
             _nextIndex_: an integer,
-          ): a Completion Record
+          ): ~unused~
         </h1>
         <dl class="header">
         </dl>
-        <emu-grammar>ElementList : Elision? AssignmentExpression</emu-grammar>
+        <emu-grammar>JSONElementList : JSONValue</emu-grammar>
         <emu-alg>
-          1. Assert: |Elision| is not present.
-          1. Let _node_ be ShallowestContainedJSONValue(|AssignmentExpression|).
-          1. Assert: _node_ is not ~empty~.
-          1. Let _result_ be ? JSONEvaluation of _node_.
+          1. Return JSONEvaluation of |JSONValue|.
+        </emu-alg>
+        <emu-grammar>JSONElementList : JSONElementList `,` JSONValue</emu-grammar>
+        <emu-alg>
+          1. Set _nextIndex_ to ? JSONArrayAccumulation of the derived |JSONElementList| with arguments _array_ and _nextIndex_.
+          1. Let _value_ be JSONEvaluation of |JSONValue|.
           1. Perform ! CreateDataPropertyOrThrow(_array_, ! ToString(𝔽(_nextIndex_)), _result_).
           1. Return _nextIndex_ + 1.
-        </emu-alg>
-        <emu-grammar>ElementList : Elision? SpreadElement</emu-grammar>
-        <emu-alg>
-          1. NOTE: JSON text as specified in ECMA-404 does not include |SpreadElement|.
-          1. Assert: This step is never reached.
-        </emu-alg>
-        <emu-grammar>ElementList : ElementList `,` Elision? AssignmentExpression</emu-grammar>
-        <emu-alg>
-          1. Set _nextIndex_ to ? JSONArrayAccumulation of the derived |ElementList| with arguments _array_ and _nextIndex_.
-          1. Assert: |Elision| is not present.
-          1. Let _node_ be ShallowestContainedJSONValue(|AssignmentExpression|).
-          1. Assert: _node_ is not ~empty~.
-          1. Let _result_ be ? JSONEvaluation of _node_.
-          1. Perform ! CreateDataPropertyOrThrow(_array_, ! ToString(𝔽(_nextIndex_)), _result_).
-          1. Return _nextIndex_ + 1.
-        </emu-alg>
-        <emu-grammar>ElementList : ElementList `,` Elision? SpreadElement</emu-grammar>
-        <emu-alg>
-          1. NOTE: JSON text as specified in ECMA-404 does not include |SpreadElement|.
-          1. Assert: This step is never reached.
         </emu-alg>
       </emu-clause>
 
       <emu-clause id="sec-jsonpropertydefinitionevaluation" type="sdo">
         <h1>
-          Runtime Semantics: JSONPropertyDefinitionEvaluation (
+          Runtime Semantics: JSONMemberListEvaluation (
             _obj_: an Object,
-          ): either a normal completion containing ~unused~ or an abrupt completion
+          ): ~unused~
         </h1>
         <dl class="header">
         </dl>
-        <emu-grammar>PropertyDefinitionList : PropertyDefinitionList `,` PropertyDefinition</emu-grammar>
+        <emu-grammar>JSONMemberList : JSONMember</emu-grammar>
         <emu-alg>
-          1. Perform ? JSONPropertyDefinitionEvaluation of |PropertyDefinitionList| with arguments _obj_.
-          1. Perform ? JSONPropertyDefinitionEvaluation of |PropertyDefinition| with arguments _obj_.
+          1. Perform JSONMemberListEvaluation of |JSONMember| with arguments _obj_.
           1. Return ~unused~.
         </emu-alg>
-        <emu-grammar>PropertyDefinition : `...` AssignmentExpression</emu-grammar>
+        <emu-grammar>JSONMemberList : JSONMemberList `,` JSONMember</emu-grammar>
         <emu-alg>
-          1. NOTE: JSON text as specified in ECMA-404 does not include `...`.
-          1. Assert: This step is never reached.
+          1. Perform JSONMemberListEvaluation of |JSONMemberList| with arguments _obj_.
+          1. Perform JSONMemberListEvaluation of |JSONMember| with arguments _obj_.
+          1. Return ~unused~.
         </emu-alg>
-        <emu-grammar>PropertyDefinition : IdentifierReference</emu-grammar>
+        <emu-grammar>JSONMember : JSONString `:` JSONValue</emu-grammar>
         <emu-alg>
-          1. NOTE: JSON text as specified in ECMA-404 does not include object shorthand notation.
-          1. Assert: This step is never reached.
-        </emu-alg>
-        <emu-grammar>PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar>
-        <emu-alg>
-          1. Let _propertyKey_ be ? Evaluation of |PropertyName|.
-          1. Let _node_ be ShallowestContainedJSONValue(|AssignmentExpression|).
-          1. Assert: _node_ is not ~empty~.
-          1. Let _propertyValue_ be ? JSONEvaluation of _node_.
+          1. Let _propertyKey_ be JSONEvaluation of |JSONString|.
+          1. Let _propertyValue_ be JSONEvaluation of |JSONValue|.
           1. Assert: _obj_ is an ordinary, extensible object with no non-configurable properties.
-          1. Perform ! CreateDataPropertyOrThrow(_obj_, _propertyKey_, _propertyValue_).
+          1. Let _completion_ be CreateDataPropertyOrThrow(_obj_, _propertyKey_, _propertyValue_).
+          1. Assert: _completion_ is not an abrupt completion.
           1. Return ~unused~.
-        </emu-alg>
-        <emu-grammar>PropertyDefinition : MethodDefinition</emu-grammar>
-        <emu-alg>
-          1. NOTE: JSON text as specified in ECMA-404 does not include |MethodDefinition|.
-          1. Assert: This step is never reached.
         </emu-alg>
       </emu-clause>
     </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -47988,8 +47988,9 @@ THH:mm:ss.sss
           1. [id="step-json-parse-parse"] Let _script_ be ParseText(_scriptString_, |Script|).
           1. NOTE: The early error rules defined in <emu-xref href="#sec-object-initializer-static-semantics-early-errors"></emu-xref> have special handling for the above invocation of ParseText.
           1. Assert: _script_ is a Parse Node.
-          1. [id="step-json-parse-eval"] Let _result_ be ! <emu-meta suppress-effects="user-code">JSONEvaluation of _script_</emu-meta>.
-          1. NOTE: The PropertyDefinitionEvaluation semantics defined in <emu-xref href="#sec-runtime-semantics-propertydefinitionevaluation"></emu-xref> have special handling for the above evaluation.
+          1. Let _jsonParseNode_ be ShallowestContainedJSONValue(_script_).
+          1. Assert: _jsonParseNode_ is not ~empty~.
+          1. [id="step-json-parse-eval"] Let _result_ be ! <emu-meta suppress-effects="user-code">JSONEvaluation of _jsonParseNode_</emu-meta>.
           1. [id="step-json-parse-assert-type"] Assert: _result_ is either a String, a Number, a Boolean, an Object that is defined by either an |ArrayLiteral| or an |ObjectLiteral|, or *null*.
           1. Return the Record { [[ParseNode]]: _script_, [[Value]]: _result_ }.
         </emu-alg>

--- a/spec.html
+++ b/spec.html
@@ -47963,14 +47963,17 @@ THH:mm:ss.sss
       <p>The optional _reviver_ parameter is a function that can filter and transform the results. For each value produced by the parse, _reviver_ is called with three arguments (the associated property key, the value, and a context object). If the property is unmodified and its value is primitive, the provided context object has a *"source"* property containing source text of the corresponding Parse Node. If the call returns *undefined*, the property is deleted. Otherwise, the property is redefined to use the return value.</p>
       <emu-alg>
         1. Let _jsonString_ be ? ToString(_text_).
-        1. Let _parseResult_ be ? ParseJSON(_jsonString_).
+        1. Let _deep_ be IsCallable(_reviver_).
+        1. If _deep_ is *false*, then,
+          1. Let _parseResult_ be ? ParseJSON(_jsonString_, ~shallow~).
+          1. Return _parseResult_.[[Value]].
+        1. Let _parseResult be ? ParseJSON(_jsonString_, ~deep~).
         1. Let _unfiltered_ be _parseResult_.[[Value]].
-        1. If IsCallable(_reviver_) is *false*, return _unfiltered_.
         1. Let _root_ be OrdinaryObjectCreate(%Object.prototype%).
         1. Let _rootName_ be the empty String.
         1. Perform ! CreateDataPropertyOrThrow(_root_, _rootName_, _unfiltered_).
-        1. Let _snapshot_ be <emu-meta suppress-effects="user-code">CreateJSONParseRecord(_parseResult_.[[ParseNode]], _rootName_, _unfiltered_)</emu-meta>.
-        1. Return ? InternalizeJSONProperty(_root_, _rootName_, _reviver_, _snapshot_).
+        1. Let _parseResult_.[[Key]] be _rootName_.
+        1. Return ? InternalizeJSONProperty(_root_, _rootName_, _reviver_, _parseResult_).
       </emu-alg>
       <p>The *"length"* property of this function is *2*<sub>𝔽</sub>.</p>
 
@@ -47978,7 +47981,8 @@ THH:mm:ss.sss
         <h1>
           ParseJSON (
             _text_: a String,
-          ): either a normal completion containing a Record with fields [[ParseNode]] (a Parse Node) and [[Value]] (an ECMAScript language value), or a throw completion
+            _how_: ~shallow~ or ~deep~,
+          ): either a normal completion containing a JSON Parse Record, or a throw completion
         </h1>
         <dl class="header">
         </dl>
@@ -47988,8 +47992,8 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _jsonParseNode_ be ParseText(_text_, |JSONValue|).
           1. If _jsonParseNode_ is not a Parse Node, throw a *SyntaxError* exception.
-          1. Let _result_ be the JSONEvaluation of _jsonParseNode_.
-          1. Return the Record { [[ParseNode]]: _jsonParseNode_, [[Value]]: _result_ }.
+          1. Let _result_ be the JSONEvaluation of _jsonParseNode_ with argument _how_.
+          1. Return _result_.
         </emu-alg>
         <p>It is not permitted for a conforming implementation of `JSON.parse` to extend the JSON grammars. If an implementation wishes to support a modified or extended JSON interchange format it must do so by defining a different parse function.</p>
         <emu-note>
@@ -48018,7 +48022,7 @@ THH:mm:ss.sss
             </tr>
             <tr>
               <td>[[Key]]</td>
-              <td>a property name</td>
+              <td>a property name or ~EMPTY~</td>
               <td>The property name with which [[Value]] is associated.</td>
             </tr>
             <tr>
@@ -48040,49 +48044,21 @@ THH:mm:ss.sss
         </emu-table>
       </emu-clause>
 
-      <emu-clause id="sec-createjsonparserecord" type="abstract operation" oldids="sec-shallowestcontainedjsonvalue">
+      <emu-clause id="sec-cratejsonparserecord" type="abstract operation" oldids="sec-shallowestcontainedjsonvalue">
         <h1>
           CreateJSONParseRecord (
             _parseNode_: a |JSONValue| Parse Node,
-            _key_: a property name,
             _value_: an ECMAScript language value,
+            optional _key_: a property name,
           ): a JSON Parse Record
         </h1>
         <dl class="header">
-          <dt>description</dt>
-          <dd>It recursively combines a _parseNode_ parsed from JSON text and the _value_ produced by its evaluation.</dd>
         </dl>
         <emu-alg>
-          1. Assert: _parseNode_ has exactly one child.
-          1. Let _typedValueNode_ be the first child of _parseNode_.
+          1. If _key_ is not present, let _key_ be ~EMPTY~.
           1. Let _elements_ be a new empty List.
           1. Let _entries_ be a new empty List.
-          1. If _typedValueNode_ is a |JSONArray| Parse Node, then:
-            1. Let _contentNodes_ be the JSONArrayLiteralContentNodes of _typedValueNode_.
-            1. Let _length_ be the number of elements in _contentNodes_.
-            1. Let _valueLength_ be ! <emu-meta suppress-effects="user-code">LengthOfArrayLike(_value_)</emu-meta>.
-            1. Assert: _valueLength_ is _length_.
-            1. Let _index_ be 0.
-            1. Repeat, while _index_ &lt; _length_,
-              1. Let _propertyName_ be ! ToString(𝔽(_index_)).
-              1. Let _elementParseRecord_ be CreateJSONParseRecord(_contentNodes_[_index_], _propertyName_, ! <emu-meta suppress-effects="user-code">Get(_value_, _propertyName_)</emu-meta>).
-              1. Append _elementParseRecord_ to _elements_.
-              1. Set _index_ to _index_ + 1.
-          1. Else if _typedValueNode_ is a |JSONObject| Parse Node,
-            1. Let _propertyNodes_ be the JSONObjectLiteralContentNodes of _typedValueNode_.
-            1. NOTE: Because _value_ was produced from JSON text and has not been modified, all of its property keys are Strings and will be exhaustively enumerated.
-            1. Let _keys_ be ! <emu-meta suppress-effects="user-code">EnumerableOwnProperties(_value_, ~key~)</emu-meta>.
-            1. For each String _propertyKey_ of _keys_, do
-              1. NOTE: In the case of JSON text specifying multiple name/value pairs with the same name for a single object (such as <code>{"a":"lost","a":"kept"}</code>), the value for the corresponding property of the resulting ECMAScript object is specified by the last pair with that name.
-              1. Let _propertyDefinition_ be ~empty~.
-              1. For each Parse Node _propertyNode_ of _propertyNodes_, do
-                1. Let _propertyName_ be the PropName of _propertyNode_.
-                1. If _propertyName_ is _propertyKey_, set _propertyDefinition_ to _propertyNode_.
-              1. Assert: _propertyDefinition_ is <emu-grammar>JSONMember : JSONString `:` JSONValue</emu-grammar>.
-              1. Let _propertyValueNode_ be the |JSONValue| of _propertyDefinition_.
-              1. Let _entryParseRecord_ be CreateJSONParseRecord(_propertyValueNode_, _propertyKey_, ! <emu-meta suppress-effects="user-code">Get(_value_, _propertyKey_)</emu-meta>).
-              1. Append _entryParseRecord_ to _entries_.
-          1. Return the JSON Parse Record { [[ParseNode]]: _typedValueNode_, [[Key]]: _key_, [[Value]]: _value_, [[Elements]]: _elements_, [[Entries]]: _entries_ }.
+          1. Return the JSON Parse Record { [[ParseNode]]: _parseNode_, [[Key]]: _key_, [[Value]]: _value_, [[Elements]]: _elements_, [[Entries]]: _entries_ }.
         </emu-alg>
       </emu-clause>
 
@@ -48143,60 +48119,10 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-static-semantics-jsonarrayliteralcontentnodes" type="sdo">
-        <h1>Static Semantics: JSONArrayLiteralContentNodes ( ): a List of Parse Nodes</h1>
-        <dl class="header">
-        </dl>
-        <emu-grammar>
-          JSONArray :
-            `[` `]`
-            `[` JSONElementList `]`
-        </emu-grammar>
-        <emu-alg>
-          1. If |JSONElementList| is not present, return a new empty List.
-          1. Return the JSONArrayLiteralContentNodes of |JSONElementList|.
-        </emu-alg>
-
-        <emu-grammar>JSONElementList : JSONValue</emu-grammar>
-        <emu-alg>
-          1. Return « |JSONValue| ».
-        </emu-alg>
-
-        <emu-grammar>JSONElementList : JSONElementList `,` JSONValue</emu-grammar>
-        <emu-alg>
-          1. Let _elements_ be the JSONArrayLiteralContentNodes of the derived |JSONElementList|.
-          1. Return the list-concatenation of _elements_ and « |JSONValue| ».
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-static-semantics-jsonobjectliteralcontentnodes" type="sdo">
-        <h1>Static Semantics: JSONObjectLiteralContentNodes ( ): a List of Parse Nodes</h1>
-        <dl class="header">
-        </dl>
-        <emu-grammar>
-          JSONObject :
-            `{` `}`
-            `{` JSONMemberList `}`
-        </emu-grammar>
-        <emu-alg>
-          1. If |JSONMemberList| is not present, return a new empty List.
-          1. Return the JSONObjectLiteralContentNodes of |JSONMemberList|.
-        </emu-alg>
-
-        <emu-grammar>JSONMemberList : JSONMember</emu-grammar>
-        <emu-alg>
-          1. Return « |JSONMember| ».
-        </emu-alg>
-
-        <emu-grammar>JSONMemberList : JSONMemberList `,` JSONMember</emu-grammar>
-        <emu-alg>
-          1. Let _elements_ be the JSONObjectLiteralContentNodes of the derived |JSONMemberList|.
-          1. Return the list-concatenation of _elements_ and « |JSONMember| ».
-        </emu-alg>
-      </emu-clause>
-
       <emu-clause id="sec-jsonevaluation" type="sdo">
-        <h1>Runtime Semantics: JSONEvaluation ( ): an ECMAScript language value</h1>
+        <h1>Runtime Semantics: JSONEvaluation (
+            _how_: ~shallow~ or ~deep~,
+          ): a JSON Parse Record</h1>
         <dl class="header">
           <dt>description</dt>
           <dd>
@@ -48207,21 +48133,24 @@ THH:mm:ss.sss
           JSONValue : `null`
         </emu-grammar>
         <emu-alg>
-          1. Return *null*.
+          1. Let _result_ be CreateJSONParseRecord(`null`, *null*).
+          1. Return _result_.
         </emu-alg>
 
         <emu-grammar>
           JSONValue : `true`
         </emu-grammar>
         <emu-alg>
-          1. Return *true*.
+          1. Let _result_ be CreateJSONParseRecord(`true`, *true*).
+          1. Return _result_.
         </emu-alg>
 
         <emu-grammar>
           JSONValue : `false`
         </emu-grammar>
         <emu-alg>
-          1. Return *false*.
+          1. Let _result_ be CreateJSONParseRecord(`false`, *false*).
+          1. Return _result_.
         </emu-alg>
 
         <emu-grammar>
@@ -48231,7 +48160,8 @@ THH:mm:ss.sss
           1. Let _source_ be the source text matched by |JSONNumber|.
           1. Let _number_ be StringToNumber(CodePointsToString(_source_)).
           1. Assert: _number_ is not *NaN*.
-          1. Return _number_.
+          1. Let _result_ be CreateJSONParseRecord(|JSONNumber|, _number_).
+          1. Return _result_.
         </emu-alg>
 
         <emu-grammar>
@@ -48243,7 +48173,8 @@ THH:mm:ss.sss
           1. Let _esNode_ be ParseText(_source_, |StringLiteral|).
           1. Assert: _esNode_ is a |StringLiteral| Parse Node.
           1. Let _value_ be the SV of _esNode_.
-          1. Return _value_.
+          1. Let _result_ be CreateJSONParseRecord(|JSONString|, _value_).
+          1. Return _result_.
         </emu-alg>
 
         <emu-grammar>
@@ -48253,8 +48184,11 @@ THH:mm:ss.sss
         </emu-grammar>
         <emu-alg>
           1. Let _array_ be ! ArrayCreate(0).
-          1. If |JSONElementList| is present, perform JSONArrayAccumulation of |JSONElementList| with arguments _array_ and 0.
-          1. Return _array_.
+          1. Let _elements_ be a new empty List.
+          1. If |JSONElementList| is present, perform JSONArrayAccumulation of |JSONElementList| with arguments _array_, _elements_, 0, and _how_.
+          1. Let _result_ be CreateJSONParseRecord(|JSONArray|, _array_).
+          1. Set _result_.[[Elements]] to _elements_.
+          1. Return _result_.
         </emu-alg>
 
         <emu-grammar>
@@ -48264,8 +48198,11 @@ THH:mm:ss.sss
         </emu-grammar>
         <emu-alg>
           1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%).
-          1. If |JSONMemberList| is present, perform JSONMemberListEvaluation of |JSONMemberList| with argument _obj_.
-          1. Return _obj_.
+          1. Let _entries_ be a new empty List.
+          1. If |JSONMemberList| is present, perform JSONMemberListEvaluation of |JSONMemberList| with argument _obj_, _entries_, and _how_.
+          1. Let _result_ be CreateJSONParseRecord(|JSONObject|, _obj_);
+          1. Set _result_.[[Entries]] to _entries_.
+          1. Return _result_.
         </emu-alg>
       </emu-clause>
 
@@ -48273,24 +48210,28 @@ THH:mm:ss.sss
         <h1>
           Runtime Semantics: JSONArrayAccumulation (
             _array_: an Array,
+            _elements_: a List of JSON Parse Records,
             _nextIndex_: a non-negative integer,
+            _how_: ~shallow~ or ~deep~,
           ): a non-negative integer
         </h1>
         <dl class="header">
           <dt>description</dt>
           <dd>It is just like ArrayAccumulation, except defined over a much narrower grammar (namely ECMA-404), and calling JSONEvaluation on its elements, rather than Evaluation.</dd>
         </dl>
-        <emu-grammar>JSONElementList : JSONValue</emu-grammar>
+        <emu-grammar>
+          JSONElementList :
+            JSONValue
+            JSONElementList `,` JSONValue
+          </emu-grammar>
         <emu-alg>
-          1. Let _value_ be the JSONEvaluation of |JSONValue|.
-          1. Perform ! CreateDataPropertyOrThrow(_array_, ! ToString(𝔽(_nextIndex_)), _value_).
-          1. Return _nextIndex_ + 1.
-        </emu-alg>
-        <emu-grammar>JSONElementList : JSONElementList `,` JSONValue</emu-grammar>
-        <emu-alg>
-          1. Set _nextIndex_ to the JSONArrayAccumulation of the derived |JSONElementList| with arguments _array_ and _nextIndex_.
-          1. Let _value_ be the JSONEvaluation of |JSONValue|.
-          1. Perform ! CreateDataPropertyOrThrow(_array_, ! ToString(𝔽(_nextIndex_)), _value_).
+          1. If a derived |JSONElementList| is present, set _nextIndex_ to the JSONArrayAccumulation of the derived |JSONElementList| with arguments _array_, _elements_, _nextIndex_, and _how_.
+          1. Let _key_ be ! ToString(𝔽(_nextIndex_)).
+          1. Let _parseRecord_ be the JSONEvaluation of |JSONValue| with argument ~how~.
+          1. Perform ! CreateDataPropertyOrThrow(_array_, _key_, _parseRecord_.[[Value]]).
+          1. If _how_ is ~deep~, then
+            1. Set _parseRecord_.[[Key]] to _key_.
+            1. Append _parseRecord_ to _elements_.
           1. Return _nextIndex_ + 1.
         </emu-alg>
       </emu-clause>
@@ -48299,6 +48240,8 @@ THH:mm:ss.sss
         <h1>
           Runtime Semantics: JSONMemberListEvaluation (
             _obj_: an Object,
+            _entries_: a List of Parse Nodes,
+            _how_: ~shallow~ or ~deep~,
           ): ~unused~
         </h1>
         <dl class="header">
@@ -48307,16 +48250,19 @@ THH:mm:ss.sss
         </dl>
         <emu-grammar>JSONMemberList : JSONMemberList `,` JSONMember</emu-grammar>
         <emu-alg>
-          1. Perform JSONMemberListEvaluation of the derived |JSONMemberList| with argument _obj_.
-          1. Perform JSONMemberListEvaluation of |JSONMember| with argument _obj_.
+          1. Perform JSONMemberListEvaluation of the derived |JSONMemberList| with arguments _obj_, _entries_, and _how_.
+          1. Perform JSONMemberListEvaluation of |JSONMember| with argument _obj_, _entries_, and _how_.
           1. Return ~unused~.
         </emu-alg>
         <emu-grammar>JSONMember : JSONString `:` JSONValue</emu-grammar>
         <emu-alg>
-          1. Let _propertyKey_ be the JSONEvaluation of |JSONString|.
-          1. Let _propertyValue_ be the JSONEvaluation of |JSONValue|.
+          1. Let _propertyKeyRecord_ be the JSONEvaluation of |JSONString| with argument _how_.
+          1. Let _propertyValueRecord_ be the JSONEvaluation of |JSONValue| with argument _how_.
           1. Assert: _obj_ is an ordinary, extensible object with no non-configurable properties.
-          1. Perform ! CreateDataPropertyOrThrow(_obj_, _propertyKey_, _propertyValue_).
+          1. Perform ! CreateDataPropertyOrThrow(_obj_, _propertyKeyRecord_.[[Value]], _propertyValueRecord_.[[Value]]).
+          1. If ~how~ is deep, then
+            1. Set _propertyValueRecord_.[[Key]] to _propertyKeyRecord_.[[Value]].
+            2. Append _propertyValueRecord_ to _entries_.
           1. Return ~unused~.
         </emu-alg>
       </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -29337,7 +29337,7 @@
           </dl>
 
           <emu-alg>
-            1. Let _parseResult_ be ? ParseJSON(_source_).
+            1. Let _parseResult_ be ? ParseJSON(_source_, ~shallow~).
             1. Return CreateDefaultExportSyntheticModule(_parseResult_.[[Value]]).
           </emu-alg>
         </emu-clause>
@@ -47964,7 +47964,7 @@ THH:mm:ss.sss
       <emu-alg>
         1. Let _jsonString_ be ? ToString(_text_).
         1. Let _deep_ be IsCallable(_reviver_).
-        1. If _deep_ is *false*, then,
+        1. If _deep_ is *false*, then
           1. Let _parseResult_ be ? ParseJSON(_jsonString_, ~shallow~).
           1. Return _parseResult_.[[Value]].
         1. Let _parseResult be ? ParseJSON(_jsonString_, ~deep~).
@@ -48055,7 +48055,6 @@ THH:mm:ss.sss
         <dl class="header">
         </dl>
         <emu-alg>
-          1. If _key_ is not present, let _key_ be ~EMPTY~.
           1. Let _elements_ be a new empty List.
           1. Let _entries_ be a new empty List.
           1. Return the JSON Parse Record { [[ParseNode]]: _parseNode_, [[Key]]: _key_, [[Value]]: _value_, [[Elements]]: _elements_, [[Entries]]: _entries_ }.
@@ -48120,9 +48119,11 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-jsonevaluation" type="sdo">
-        <h1>Runtime Semantics: JSONEvaluation (
+        <h1>
+          Runtime Semantics: JSONEvaluation (
             _how_: ~shallow~ or ~deep~,
-          ): a JSON Parse Record</h1>
+          ): a JSON Parse Record
+        </h1>
         <dl class="header">
           <dt>description</dt>
           <dd>
@@ -48200,7 +48201,7 @@ THH:mm:ss.sss
           1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%).
           1. Let _entries_ be a new empty List.
           1. If |JSONMemberList| is present, perform JSONMemberListEvaluation of |JSONMemberList| with argument _obj_, _entries_, and _how_.
-          1. Let _result_ be CreateJSONParseRecord(|JSONObject|, _obj_);
+          1. Let _result_ be CreateJSONParseRecord(|JSONObject|, _obj_).
           1. Set _result_.[[Entries]] to _entries_.
           1. Return _result_.
         </emu-alg>
@@ -48223,11 +48224,11 @@ THH:mm:ss.sss
           JSONElementList :
             JSONValue
             JSONElementList `,` JSONValue
-          </emu-grammar>
+        </emu-grammar>
         <emu-alg>
           1. If a derived |JSONElementList| is present, set _nextIndex_ to the JSONArrayAccumulation of the derived |JSONElementList| with arguments _array_, _elements_, _nextIndex_, and _how_.
           1. Let _key_ be ! ToString(𝔽(_nextIndex_)).
-          1. Let _parseRecord_ be the JSONEvaluation of |JSONValue| with argument ~how~.
+          1. Let _parseRecord_ be the JSONEvaluation of |JSONValue| with argument _how_.
           1. Perform ! CreateDataPropertyOrThrow(_array_, _key_, _parseRecord_.[[Value]]).
           1. If _how_ is ~deep~, then
             1. Set _parseRecord_.[[Key]] to _key_.
@@ -48262,7 +48263,7 @@ THH:mm:ss.sss
           1. Perform ! CreateDataPropertyOrThrow(_obj_, _propertyKeyRecord_.[[Value]], _propertyValueRecord_.[[Value]]).
           1. If ~how~ is deep, then
             1. Set _propertyValueRecord_.[[Key]] to _propertyKeyRecord_.[[Value]].
-            2. Append _propertyValueRecord_ to _entries_.
+            1. Append _propertyValueRecord_ to _entries_.
           1. Return ~unused~.
         </emu-alg>
       </emu-clause>
@@ -48276,7 +48277,7 @@ THH:mm:ss.sss
         1. If _jsonString_ is the empty String, throw a *SyntaxError* exception.
         1. If the first code unit of _jsonString_ is not either an ASCII lowercase letter code unit (0x0061 through 0x007A, inclusive), an ASCII digit code unit (0x0030 through 0x0039, inclusive), 0x0022 (QUOTATION MARK), or 0x002D (HYPHEN-MINUS), throw a *SyntaxError* exception.
         1. If the last code unit of _jsonString_ is not either an ASCII lowercase letter code unit (0x0061 through 0x007A, inclusive), an ASCII digit code unit (0x0030 through 0x0039, inclusive), or 0x0022 (QUOTATION MARK), throw a *SyntaxError* exception.
-        1. Let _parseResult_ be ? ParseJSON(_jsonString_).
+        1. Let _parseResult_ be ? ParseJSON(_jsonString_, ~shallow~).
         1. Assert: _parseResult_.[[Value]] is either a String, a Number, a Boolean, or *null*.
         1. Let _internalSlotsList_ be « [[IsRawJSON]] ».
         1. Let _obj_ be OrdinaryObjectCreate(*null*, _internalSlotsList_).

--- a/spec.html
+++ b/spec.html
@@ -19174,9 +19174,7 @@
         <emu-grammar>PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar>
         <emu-alg>
           1. Let _propertyKey_ be ? Evaluation of |PropertyName|.
-          1. If this |PropertyDefinition| is contained within a |Script| that is being evaluated for ParseJSON (see step <emu-xref href="#step-json-parse-eval"></emu-xref> of ParseJSON), then
-            1. Let _isProtoSetter_ be *false*.
-          1. Else if _propertyKey_ is *"__proto__"* and IsComputedPropertyKey of |PropertyName| is *false*, then
+          1. If _propertyKey_ is *"__proto__"* and IsComputedPropertyKey of |PropertyName| is *false*, then
             1. Let _isProtoSetter_ be *true*.
           1. Else,
             1. Let _isProtoSetter_ be *false*.
@@ -47990,7 +47988,7 @@ THH:mm:ss.sss
           1. [id="step-json-parse-parse"] Let _script_ be ParseText(_scriptString_, |Script|).
           1. NOTE: The early error rules defined in <emu-xref href="#sec-object-initializer-static-semantics-early-errors"></emu-xref> have special handling for the above invocation of ParseText.
           1. Assert: _script_ is a Parse Node.
-          1. [id="step-json-parse-eval"] Let _result_ be ! <emu-meta suppress-effects="user-code">Evaluation of _script_</emu-meta>.
+          1. [id="step-json-parse-eval"] Let _result_ be ! <emu-meta suppress-effects="user-code">JSONEvaluation of _script_</emu-meta>.
           1. NOTE: The PropertyDefinitionEvaluation semantics defined in <emu-xref href="#sec-runtime-semantics-propertydefinitionevaluation"></emu-xref> have special handling for the above evaluation.
           1. [id="step-json-parse-assert-type"] Assert: _result_ is either a String, a Number, a Boolean, an Object that is defined by either an |ArrayLiteral| or an |ObjectLiteral|, or *null*.
           1. Return the Record { [[ParseNode]]: _script_, [[Value]]: _result_ }.
@@ -47998,7 +47996,7 @@ THH:mm:ss.sss
         <p>It is not permitted for a conforming implementation of `JSON.parse` to extend the JSON grammars. If an implementation wishes to support a modified or extended JSON interchange format it must do so by defining a different parse function.</p>
         <emu-note>
           <p>Valid JSON text is a subset of the ECMAScript |PrimaryExpression| syntax. Step <emu-xref href="#step-json-parse-validate"></emu-xref> verifies that _jsonString_ conforms to that subset, and step <emu-xref href="#step-json-parse-assert-type"></emu-xref> asserts that evaluation returns a value of an appropriate type.</p>
-          <p>However, because <emu-xref href="#sec-runtime-semantics-propertydefinitionevaluation"></emu-xref> behaves differently during ParseJSON, the same source text can produce different results when evaluated as a |PrimaryExpression| rather than as JSON. Furthermore, the Early Error for duplicate *"__proto__"* properties in object literals, which likewise does not apply during ParseJSON, means that not all texts accepted by ParseJSON are valid as a |PrimaryExpression|, despite matching the grammar.</p>
+          <p>However, because JSONEvaluation behaves differently than Evaluation, the same source text can produce different results when evaluated as a |PrimaryExpression| rather than as JSON. Furthermore, the Early Error for duplicate *"__proto__"* properties in object literals, which likewise does not apply during ParseJSON, means that not all texts accepted by ParseJSON are valid as a |PrimaryExpression|, despite matching the grammar.</p>
         </emu-note>
         <emu-note>
           <p>In the case where there are duplicate name Strings within an object, lexically preceding values for the same key shall be overwritten.</p>
@@ -48228,6 +48226,170 @@ THH:mm:ss.sss
         </emu-grammar>
         <emu-alg>
           1. NOTE: JSON text as specified in ECMA-404 does not include |SpreadElement|.
+          1. Assert: This step is never reached.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-jsonevaluation" type="sdo">
+        <h1><ins>Runtime Semantics: JSONEvaluation (
+          ): either a normal completion containing an ECMAScript language value or a throw completion
+          </ins>
+        </h1>
+        <dl class="header">
+        </dl>
+        <emu-grammar>
+        Literal :
+          NullLiteral
+          BooleanLiteral
+          NumericLiteral
+          StringLiteral
+        </emu-grammar>
+        <emu-alg>
+          1. Let _value_ be ! Evaluation of |Literal|.
+          1. Assert: _value_ is either a String, a Number, a Boolean, or *null*.
+          1. Return _value_.
+        </emu-alg>
+
+        <emu-grammar>
+        Literal :
+          NullLiteral
+          BooleanLiteral
+          NumericLiteral
+          StringLiteral
+        </emu-grammar>
+        <emu-alg>
+          1. Let _value_ be ! Evaluation of |Literal|.
+          1. Assert: _value_ is either a String, a Number, a Boolean, or *null*.
+          1. Return _value_.
+        </emu-alg>
+
+        <emu-grammar>
+          UnaryExpression :
+            `delete` UnaryExpression
+            `void` UnaryExpression
+            `typeof` UnaryExpression
+            `+` UnaryExpression
+            `~` UnaryExpression
+            `!` UnaryExpression
+            CoverAwaitExpressionAndAwaitUsingDeclarationHead
+        </emu-grammar>
+        <emu-alg>
+          1. NOTE: JSON text as specified in ECMA-404 does not include |UnaryExpression| except literals and the negative operator.
+          1. Assert: This step is never reached.
+        </emu-alg>
+
+        <emu-grammar>UnaryExpression : `-` UnaryExpression</emu-grammar>
+        <emu-alg>
+          1. Let _value_ be ! Evaluation of the parent |UnaryExpression|.
+          1. Assert: _value_ is a Number.
+          1. Return _value_.
+        </emu-alg>
+
+        <emu-grammar>
+          ArrayLiteral : `[` ElementList `]`
+        </emu-grammar>
+        <emu-alg>
+          1. Let _array_ be ! ArrayCreate(0).
+          1. Perform ? JSONArrayAccumulation of |ElementList| with arguments _array_ and 0.
+          1. Return _array_.
+        </emu-alg>
+
+        <emu-grammar>
+          ObjectLiteral : `{` `}`
+        </emu-grammar>
+        <emu-alg>
+          1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%).
+          1. Return _obj_.
+        </emu-alg>
+
+        <emu-grammar>
+          ObjectLiteral : `{` PropertyDefinitionList `}`
+        </emu-grammar>
+        <emu-alg>
+          1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%).
+          1. Perform ? JSONPropertyDefinitionEvaluation of |PropertyDefinitionList| with argument _obj_.
+          1. Return _obj_.
+        </emu-alg>
+      </emu-clause>
+      <emu-clause id="sec-jsonarrayaccumulation" type="sdo">
+        <h1>
+          <ins>
+            Runtime Semantics: JSONArrayAccumulation (
+              _array_: an Array,
+              _nextIndex_: an integer,
+            ): a Completion Record
+          </ins>
+        </h1>
+        <dl class="header">
+        </dl>
+        <emu-grammar>ElementList : Elision? AssignmentExpression</emu-grammar>
+        <emu-alg>
+          1. Assert: |Elision| is not present.
+          1. Let _node_ be ShallowestContainedJSONValue(|AssignmentExpression|).
+          1. Assert: _node_ is not ~empty~.
+          1. Let _result_ be ? JSONEvaluation of _node_.
+          1. Perform ! CreateDataPropertyOrThrow(_array_, ! ToString(𝔽(_nextIndex_)), _result_).
+          1. Return _nextIndex_ + 1.
+        </emu-alg>
+        <emu-grammar>ElementList : Elision? SpreadElement</emu-grammar>
+        <emu-alg>
+          1. NOTE: JSON text as specified in ECMA-404 does not include |SpreadElement|.
+          1. Assert: This step is never reached.
+        </emu-alg>
+        <emu-grammar>ElementList : ElementList `,` Elision? AssignmentExpression</emu-grammar>
+        <emu-alg>
+          1. Set _nextIndex_ to ? JSONArrayAccumulation of the derived |ElementList| with arguments _array_, _nextIndex_, and _options_.
+          1. Assert: |Elision| is not present.
+          1. Let _node_ be ShallowestContainedJSONValue(|AssignmentExpression|).
+          1. Assert: _node_ is not ~empty~.
+          1. Let _result_ be ? JSONEvaluation of _node_.
+          1. Perform ! CreateDataPropertyOrThrow(_array_, ! ToString(𝔽(_nextIndex_)), _result_).
+          1. Return _nextIndex_ + 1.
+        </emu-alg>
+        <emu-grammar>ElementList : ElementList `,` Elision? SpreadElement</emu-grammar>
+        <emu-alg>
+          1. NOTE: JSON text as specified in ECMA-404 does not include |SpreadElement|.
+          1. Assert: This step is never reached.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-jsonpropertydefinitionevaluation" type="sdo">
+        <h1><ins>Runtime Semantics: JSONPropertyDefinitionEvaluation (
+            _obj_: an Object,
+          ): either a normal completion containing ~unused~ or an abrupt completion
+          </ins>
+        </h1>
+        <dl class="header">
+        </dl>
+        <emu-grammar>PropertyDefinitionList : PropertyDefinitionList `,` PropertyDefinition</emu-grammar>
+        <emu-alg>
+          1. Perform ? JSONPropertyDefinitionEvaluation of |PropertyDefinitionList| with arguments _obj_.
+          1. Perform ? JSONPropertyDefinitionEvaluation of |PropertyDefinition| with arguments _obj_.
+          1. Return ~unused~.
+        </emu-alg>
+        <emu-grammar>PropertyDefinition : `...` AssignmentExpression</emu-grammar>
+        <emu-alg>
+          1. NOTE: JSON text as specified in ECMA-404 does not include `...`.
+          1. Assert: This step is never reached.
+        </emu-alg>
+        <emu-grammar>PropertyDefinition : IdentifierReference</emu-grammar>
+        <emu-alg>
+          1. NOTE: JSON text as specified in ECMA-404 does not include object shorthand notation.
+          1. Assert: This step is never reached.
+        </emu-alg>
+        <emu-grammar>PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar>
+        <emu-alg>
+          1. Let _propertyKey_ be ? Evaluation of |PropertyName|.
+          1. Let _node_ be ShallowestContainedJSONValue(|AssignmentExpression|).
+          1. Assert: _node_ is not ~empty~.
+          1. Let _value_ be ? JSONEvaluation of _node_.
+          1. Assert: _obj_ is an ordinary, extensible object with no non-configurable properties.
+          1. Perform ! CreateDataPropertyOrThrow(_obj_, _propertyKey_, _propertyValue_).
+          1. Return ~unused~.
+        </emu-alg>
+        <emu-grammar>PropertyDefinition : MethodDefinition</emu-grammar>
+        <emu-alg>
+          1. NOTE: JSON text as specified in ECMA-404 does not include |MethodDefinition|.
           1. Assert: This step is never reached.
         </emu-alg>
       </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -29378,7 +29378,7 @@
           </dl>
 
           <emu-alg>
-            1. Let _parseResult_ be ? ParseJSON(_source_, ~discard-nodes~).
+            1. Let _parseResult_ be ? ParseJSON(_source_).
             1. Return CreateDefaultExportSyntheticModule(_parseResult_.[[Value]]).
           </emu-alg>
         </emu-clause>
@@ -47877,11 +47877,8 @@ THH:mm:ss.sss
       <p>The optional _reviver_ parameter is a function that can filter and transform the results. For each value produced by the parse, _reviver_ is called with three arguments (the associated property key, the value, and a context object). If the property is unmodified and its value is primitive, the provided context object has a *"source"* property containing source text of the corresponding Parse Node. If the call returns *undefined*, the property is deleted. Otherwise, the property is redefined to use the return value.</p>
       <emu-alg>
         1. Let _jsonString_ be ? ToString(_text_).
-        1. Let _deep_ be IsCallable(_reviver_).
-        1. If _deep_ is *false*, then
-          1. Let _parseResult_ be ? ParseJSON(_jsonString_, ~discard-nodes~).
-          1. Return _parseResult_.[[Value]].
-        1. Let _parseResult_ be ? ParseJSON(_jsonString_, ~keep-nodes~).
+        1. Let _parseResult_ be ? ParseJSON(_jsonString_).
+        1. If IsCallable(_reviver_) is *false*, return _parseResult_.[[Value]].
         1. Let _root_ be OrdinaryObjectCreate(%Object.prototype%).
         1. Assert: _parseResult_.[[Key]] is the empty String.
         1. Perform ! CreateDataPropertyOrThrow(_root_, _parseResult_.[[Key]], _parseResult_.[[Value]]).
@@ -47893,7 +47890,6 @@ THH:mm:ss.sss
         <h1>
           ParseJSON (
             _text_: a String,
-            _deepNodes_: ~discard-nodes~ or ~keep-nodes~,
           ): either a normal completion containing a JSON Parse Record, or a throw completion
         </h1>
         <dl class="header">
@@ -47907,7 +47903,7 @@ THH:mm:ss.sss
           1. Let _jsonParseNode_ be ParseText(_text_, |JSONValue|).
           1. If _jsonParseNode_ is not a Parse Node, throw a *SyntaxError* exception.
           1. Let _key_ be the empty String.
-          1. Let _result_ be the JSONEvaluation of _jsonParseNode_ with arguments _key_ and _deepNodes_.
+          1. Let _result_ be the JSONEvaluation of _jsonParseNode_ with argument _key_.
           1. Return _result_.
         </emu-alg>
         <p>It is not permitted for a conforming implementation of `JSON.parse` to extend the JSON grammars. If an implementation wishes to support a modified or extended JSON interchange format it must do so by defining a different parse function.</p>
@@ -47915,7 +47911,7 @@ THH:mm:ss.sss
           <p>Valid JSON text is a syntactic subset of the ECMAScript |PrimaryExpression| syntax. However, because JSONEvaluation behaves differently than Evaluation, the same source text can produce different results when evaluated as a |PrimaryExpression| rather than as JSON. Furthermore, the early error for duplicate *"__proto__"* properties in object literals (<emu-xref href="#sec-object-initializer-static-semantics-early-errors"></emu-xref>), which has no analogue in JSON, means that some texts accepted by ParseJSON are not valid as a |PrimaryExpression|, (e.g., <code>{"__proto__":null,"__proto__":null}</code>).</p>
         </emu-note>
         <emu-note>
-          <p>In the case where there are duplicate name Strings within an object, lexically preceding values for the same key shall be overwritten.</p>
+          <p>In the case where there are duplicate name Strings within an object, lexically preceding values for the same key will be overwritten.</p>
         </emu-note>
       </emu-clause>
 
@@ -48020,7 +48016,6 @@ THH:mm:ss.sss
         <h1>
           Runtime Semantics: JSONEvaluation (
             _key_: a property name,
-            _deepNodes_: ~discard-nodes~ or ~keep-nodes~,
           ): a JSON Parse Record
         </h1>
         <dl class="header">
@@ -48069,9 +48064,9 @@ THH:mm:ss.sss
         </emu-grammar>
         <emu-alg>
           1. Let _source_ be the source text matched by |JSONString|.
-          1. Let _esNode_ be ParseText(_source_, |StringLiteral|).
-          1. Assert: _esNode_ is a |StringLiteral| Parse Node.
-          1. Let _string_ be the SV of _esNode_.
+          1. Let _stringNode_ be ParseText(_source_, |StringLiteral|).
+          1. Assert: _stringNode_ is a |StringLiteral| Parse Node.
+          1. Let _string_ be the SV of _stringNode_.
           1. Return the JSON Parse Record { [[ParseNode]]: |JSONString|, [[Key]]: _key_, [[Value]]: _string_, [[Elements]]: « », [[Entries]]: « » }.
         </emu-alg>
 
@@ -48083,7 +48078,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _array_ be ! ArrayCreate(0).
           1. Let _elements_ be a new empty List.
-          1. If |JSONElementList| is present, perform JSONArrayAccumulation of |JSONElementList| with arguments _array_, _deepNodes_, _elements_, and 0.
+          1. If |JSONElementList| is present, perform JSONArrayAccumulation of |JSONElementList| with arguments _array_, _elements_, and 0.
           1. Return the JSON Parse Record { [[ParseNode]]: |JSONArray|, [[Key]]: _key_, [[Value]]: _array_, [[Elements]]: _elements_, [[Entries]]: « » }.
         </emu-alg>
 
@@ -48095,7 +48090,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%).
           1. Let _entries_ be a new empty List.
-          1. If |JSONMemberList| is present, perform JSONMemberListEvaluation of |JSONMemberList| with arguments _obj_, _deepNodes_, and _entries_.
+          1. If |JSONMemberList| is present, perform JSONMemberListEvaluation of |JSONMemberList| with arguments _obj_ and _entries_.
           1. Return the JSON Parse Record { [[ParseNode]]: |JSONObject|, [[Key]]: _key_, [[Value]]: _obj_, [[Elements]]: « », [[Entries]]: _entries_ }.
         </emu-alg>
       </emu-clause>
@@ -48104,7 +48099,6 @@ THH:mm:ss.sss
         <h1>
           Runtime Semantics: JSONArrayAccumulation (
             _array_: an Array,
-            _deepNodes_: ~discard-nodes~ or ~keep-nodes~,
             _elements_: a List of JSON Parse Records,
             _nextIndex_: a non-negative integer,
           ): a non-negative integer
@@ -48119,11 +48113,11 @@ THH:mm:ss.sss
             JSONElementList `,` JSONValue
         </emu-grammar>
         <emu-alg>
-          1. If the derived |JSONElementList| is present, set _nextIndex_ to the JSONArrayAccumulation of the derived |JSONElementList| with arguments _array_, _deepNodes_, _elements_, and _nextIndex_.
+          1. If the derived |JSONElementList| is present, set _nextIndex_ to the JSONArrayAccumulation of the derived |JSONElementList| with arguments _array_, _elements_, and _nextIndex_.
           1. Let _key_ be ! ToString(𝔽(_nextIndex_)).
-          1. Let _parseRecord_ be the JSONEvaluation of |JSONValue| with arguments _key_ and _deepNodes_.
+          1. Let _parseRecord_ be the JSONEvaluation of |JSONValue| with argument _key_.
           1. Perform ! CreateDataPropertyOrThrow(_array_, _key_, _parseRecord_.[[Value]]).
-          1. If _deepNodes_ is ~keep-nodes~, append _parseRecord_ to _elements_.
+          1. Append _parseRecord_ to _elements_.
           1. Return _nextIndex_ + 1.
         </emu-alg>
       </emu-clause>
@@ -48132,7 +48126,6 @@ THH:mm:ss.sss
         <h1>
           Runtime Semantics: JSONMemberListEvaluation (
             _obj_: an Object,
-            _deepNodes_: ~discard-nodes~ or ~keep-nodes~,
             _entries_: a List of JSON Parse Records,
           ): ~unused~
         </h1>
@@ -48142,20 +48135,20 @@ THH:mm:ss.sss
         </dl>
         <emu-grammar>JSONMemberList : JSONMemberList `,` JSONMember</emu-grammar>
         <emu-alg>
-          1. Perform JSONMemberListEvaluation of the derived |JSONMemberList| with arguments _obj_, _deepNodes_, and _entries_.
-          1. Perform JSONMemberListEvaluation of |JSONMember| with arguments _obj_, _deepNodes_, and _entries_.
+          1. Perform JSONMemberListEvaluation of the derived |JSONMemberList| with arguments _obj_ and _entries_.
+          1. Perform JSONMemberListEvaluation of |JSONMember| with arguments _obj_ and _entries_.
           1. Return ~unused~.
         </emu-alg>
         <emu-grammar>JSONMember : JSONString `:` JSONValue</emu-grammar>
         <emu-alg>
           1. Let _dummyKey_ be the empty String.
-          1. Let _propertyKeyRecord_ be the JSONEvaluation of |JSONString| with arguments _dummyKey_ and _deepNodes_.
+          1. Let _propertyKeyRecord_ be the JSONEvaluation of |JSONString| with argument _dummyKey_.
           1. Let _key_ be _propertyKeyRecord_.[[Value]].
           1. Assert: _key_ is a property name.
-          1. Let _propertyValueRecord_ be the JSONEvaluation of |JSONValue| with arguments _key_ and _deepNodes_.
+          1. Let _propertyValueRecord_ be the JSONEvaluation of |JSONValue| with argument _key_.
           1. Assert: _obj_ is an ordinary, extensible object with no non-configurable properties.
           1. Perform ! CreateDataPropertyOrThrow(_obj_, _key_, _propertyValueRecord_.[[Value]]).
-          1. If _deepNodes_ is ~keep-nodes~, append _propertyValueRecord_ to _entries_.
+          1. Append _propertyValueRecord_ to _entries_.
           1. Return ~unused~.
         </emu-alg>
       </emu-clause>
@@ -48169,7 +48162,7 @@ THH:mm:ss.sss
         1. If _jsonString_ is the empty String, throw a *SyntaxError* exception.
         1. If the first code unit of _jsonString_ is not either an ASCII lowercase letter code unit (0x0061 through 0x007A, inclusive), an ASCII digit code unit (0x0030 through 0x0039, inclusive), 0x0022 (QUOTATION MARK), or 0x002D (HYPHEN-MINUS), throw a *SyntaxError* exception.
         1. If the last code unit of _jsonString_ is not either an ASCII lowercase letter code unit (0x0061 through 0x007A, inclusive), an ASCII digit code unit (0x0030 through 0x0039, inclusive), or 0x0022 (QUOTATION MARK), throw a *SyntaxError* exception.
-        1. Let _parseResult_ be ? ParseJSON(_jsonString_, ~discard-nodes~).
+        1. Let _parseResult_ be ? ParseJSON(_jsonString_).
         1. Assert: _parseResult_.[[Value]] is either a String, a Number, a Boolean, or *null*.
         1. Let _internalSlotsList_ be « [[IsRawJSON]] ».
         1. Let _obj_ be OrdinaryObjectCreate(*null*, _internalSlotsList_).

--- a/spec.html
+++ b/spec.html
@@ -48105,7 +48105,7 @@ THH:mm:ss.sss
       <emu-clause id="sec-jsonevaluation" type="sdo" oldids="sec-createjsonparserecord,sec-shallowestcontainedjsonvalue">
         <h1>
           Runtime Semantics: JSONEvaluation (
-            _key_: a property key,
+            _key_: a property name,
             _deepNodes_: ~discard-nodes~ or ~keep-nodes~,
           ): a JSON Parse Record
         </h1>
@@ -48181,7 +48181,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%).
           1. Let _entries_ be a new empty List.
-          1. If |JSONMemberList| is present, perform JSONMemberListEvaluation of |JSONMemberList| with argument _obj_, _deepNodes_, and _entries_.
+          1. If |JSONMemberList| is present, perform JSONMemberListEvaluation of |JSONMemberList| with arguments _obj_, _deepNodes_, and _entries_.
           1. Return the JSON Parse Record { [[ParseNode]]: |JSONObject|, [[Key]]: _key_, [[Value]]: _obj_, [[Elements]]: « », [[Entries]]: _entries_ }.
         </emu-alg>
       </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -48054,7 +48054,6 @@ THH:mm:ss.sss
             1. Return ~unused~.
           </emu-alg>
         </emu-clause>
-
       </emu-clause>
 
       <emu-clause id="sec-json-parse-record">

--- a/spec.html
+++ b/spec.html
@@ -47990,7 +47990,7 @@ THH:mm:ss.sss
           1. Let _scriptString_ be the string-concatenation of *"("*, _text_, and *");"*.
           1. [id="step-json-parse-parse"] Let _jsonParseNode_ be ParseText(_scriptString_, |JSONValue|).
           1. Assert: _jsonParseNode_ is a Parse Node.
-          1. [id="step-json-parse-eval"] Let _result_ be ! <emu-meta suppress-effects="user-code">JSONEvaluation of _jsonParseNode_</emu-meta>.
+          1. [id="step-json-parse-eval"] Let _result_ be <emu-meta suppress-effects="user-code">JSONEvaluation of _jsonParseNode_</emu-meta>.
           1. [id="step-json-parse-assert-type"] Assert: _result_ is either a String, a Number, a Boolean, an Object that is defined by either an |ArrayLiteral| or an |ObjectLiteral|, or *null*.
           1. Return the Record { [[ParseNode]]: _jsonParseNode_, [[Value]]: _result_ }.
         </emu-alg>
@@ -48208,6 +48208,9 @@ THH:mm:ss.sss
       <emu-clause id="sec-jsonevaluation" type="sdo">
         <h1>Runtime Semantics: JSONEvaluation ( ): an ECMAScript language value</h1>
         <dl class="header">
+          <dt>description</dt>
+          <dd><p>It generally produces the same values as Evaluation given the same inputs, but is defined over a much narrower set of productions, namely ECMA-404's |JSONValue|. Unlike Evaluation, it does not raise an early error when *"__proto__"* appears twice as a key (see <emu-xref href="#sec-object-initializer-static-semantics-early-errors"></emu-xref>). It also does not perform [[SetPrototypeOf]] when encountering a *"__proto__"* key, and instead creates an ordinary data property (see <emu-xref href="#sec-runtime-semantics-propertydefinitionevaluation"></emu-xref>).</p>
+          <p>The |JSONNumber| and |JSONString| productions are reparsed as ECMA-262 productions and call out to ECMA-262 Evaluation.</p> </dd>
         </dl>
         <emu-grammar>
           JSONValue : `null`
@@ -48248,10 +48251,10 @@ THH:mm:ss.sss
           1. Return JSONEvaluation of |JSONString|.
         </emu-alg>
 
-        <emu-grammer>
+        <emu-grammar>
           JSONString :
-          `"` JSONStringCharacters? `"`
-        </emu-grammer>
+            `"` JSONStringCharacters? `"`
+        </emu-grammar>
         <emu-alg>
           1. Let _source_ be the source text matched by |JSONString|.
           1. Let _esNode_ be ParseText(_source_, |StringLiteral|).
@@ -48317,6 +48320,8 @@ THH:mm:ss.sss
           ): a Number
         </h1>
         <dl class="header">
+          <dt>description</dt>
+          <dd>It is just like ArrayAccumulation, except defined over a much narrower grammer (namely ECMA-404), and calling JSONEvaluation on its elements, rather than Evaluation.</dd>
         </dl>
         <emu-grammar>JSONElementList : JSONValue</emu-grammar>
         <emu-alg>
@@ -48333,13 +48338,15 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-jsonpropertydefinitionevaluation" type="sdo">
+      <emu-clause id="sec-jsonmemberlistevaluation" type="sdo">
         <h1>
           Runtime Semantics: JSONMemberListEvaluation (
             _obj_: an Object,
           ): ~unused~
         </h1>
         <dl class="header">
+          <dt>description</dt>
+          <dd>It is just like PropertyDefinitionEvaluation, except 1) it is defined over a much narrower grammar, 2) it does not include the special handling of *"__proto__"* described in <emu-xref href="#sec-jsonevaluation"></emu-xref>, and 3) it calls JSONEvaluation instead of Evaluation. </dd>
         </dl>
         <emu-grammar>JSONMemberList : JSONMember</emu-grammar>
         <emu-alg>

--- a/spec.html
+++ b/spec.html
@@ -47967,12 +47967,12 @@ THH:mm:ss.sss
         1. If _deep_ is *false*, then
           1. Let _parseResult_ be ? ParseJSON(_jsonString_, ~shallow~).
           1. Return _parseResult_.[[Value]].
-        1. Let _parseResult be ? ParseJSON(_jsonString_, ~deep~).
+        1. Let _rootName_ be the empty String.
+        1. Let _parseResult be ? ParseJSON(_jsonString_, ~keep-nodes~, _rootName_).
         1. Let _unfiltered_ be _parseResult_.[[Value]].
         1. Let _root_ be OrdinaryObjectCreate(%Object.prototype%).
         1. Let _rootName_ be the empty String.
         1. Perform ! CreateDataPropertyOrThrow(_root_, _rootName_, _unfiltered_).
-        1. Let _parseResult_.[[Key]] be _rootName_.
         1. Return ? InternalizeJSONProperty(_root_, _rootName_, _reviver_, _parseResult_).
       </emu-alg>
       <p>The *"length"* property of this function is *2*<sub>𝔽</sub>.</p>
@@ -47981,7 +47981,8 @@ THH:mm:ss.sss
         <h1>
           ParseJSON (
             _text_: a String,
-            _how_: ~shallow~ or ~deep~,
+            _how_: ~discard-nodes~ or ~keep-nodes~,
+            optional _key_: a property name,
           ): either a normal completion containing a JSON Parse Record, or a throw completion
         </h1>
         <dl class="header">
@@ -47992,6 +47993,7 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _jsonParseNode_ be ParseText(_text_, |JSONValue|).
           1. If _jsonParseNode_ is not a Parse Node, throw a *SyntaxError* exception.
+          1. If _key_ is absent, set _key_ to the empty String.
           1. Let _result_ be the JSONEvaluation of _jsonParseNode_ with argument _how_.
           1. Return _result_.
         </emu-alg>
@@ -48022,7 +48024,7 @@ THH:mm:ss.sss
             </tr>
             <tr>
               <td>[[Key]]</td>
-              <td>a property name or ~EMPTY~</td>
+              <td>a property name</td>
               <td>The property name with which [[Value]] is associated.</td>
             </tr>
             <tr>
@@ -48044,12 +48046,12 @@ THH:mm:ss.sss
         </emu-table>
       </emu-clause>
 
-      <emu-clause id="sec-cratejsonparserecord" type="abstract operation" oldids="sec-shallowestcontainedjsonvalue">
+      <emu-clause id="sec-createjsonparserecord" type="abstract operation" oldids="sec-shallowestcontainedjsonvalue">
         <h1>
           CreateJSONParseRecord (
             _parseNode_: a |JSONValue| Parse Node,
             _value_: an ECMAScript language value,
-            optional _key_: a property name,
+            _key_: a property name,
           ): a JSON Parse Record
         </h1>
         <dl class="header">
@@ -48121,7 +48123,8 @@ THH:mm:ss.sss
       <emu-clause id="sec-jsonevaluation" type="sdo">
         <h1>
           Runtime Semantics: JSONEvaluation (
-            _how_: ~shallow~ or ~deep~,
+            _key_: a property key,
+            _deepNodes_: ~discard-nodes~ or ~keep-nodes~,
           ): a JSON Parse Record
         </h1>
         <dl class="header">
@@ -48134,24 +48137,24 @@ THH:mm:ss.sss
           JSONValue : `null`
         </emu-grammar>
         <emu-alg>
-          1. Let _result_ be CreateJSONParseRecord(`null`, *null*).
-          1. Return _result_.
+          1. Let _leaf_ be the first child of |JSONValue|.
+          1. Return the JSON Parse Record { [[ParseNode]]: _leaf_, [[Key]]: _key_, [[Value]]: *null*, [[Elements]]: « », [[Entries]]: « » }.
         </emu-alg>
 
         <emu-grammar>
           JSONValue : `true`
         </emu-grammar>
         <emu-alg>
-          1. Let _result_ be CreateJSONParseRecord(`true`, *true*).
-          1. Return _result_.
+          1. Let _leaf_ be the first child of |JSONValue|.
+          1. Return the JSON Parse Record { [[ParseNode]]: _leaf_, [[Key]]: _key_, [[Value]]: *true*, [[Elements]]: « », [[Entries]]: « » }.
         </emu-alg>
 
         <emu-grammar>
           JSONValue : `false`
         </emu-grammar>
         <emu-alg>
-          1. Let _result_ be CreateJSONParseRecord(`false`, *false*).
-          1. Return _result_.
+          1. Let _leaf_ be the first child of |JSONValue|.
+          1. Return the JSON Parse Record { [[ParseNode]]: _leaf_, [[Key]]: _key_, [[Value]]: *false*, [[Elements]]: « », [[Entries]]: « » }.
         </emu-alg>
 
         <emu-grammar>
@@ -48161,8 +48164,7 @@ THH:mm:ss.sss
           1. Let _source_ be the source text matched by |JSONNumber|.
           1. Let _number_ be StringToNumber(CodePointsToString(_source_)).
           1. Assert: _number_ is not *NaN*.
-          1. Let _result_ be CreateJSONParseRecord(|JSONNumber|, _number_).
-          1. Return _result_.
+          1. Return the JSON Parse Record { [[ParseNode]]: |JSONNumber|, [[Key]]: _key_, [[Value]]: number, [[Elements]]: « », [[Entries]]: « » }.
         </emu-alg>
 
         <emu-grammar>
@@ -48173,9 +48175,8 @@ THH:mm:ss.sss
           1. Let _source_ be the source text matched by |JSONString|.
           1. Let _esNode_ be ParseText(_source_, |StringLiteral|).
           1. Assert: _esNode_ is a |StringLiteral| Parse Node.
-          1. Let _value_ be the SV of _esNode_.
-          1. Let _result_ be CreateJSONParseRecord(|JSONString|, _value_).
-          1. Return _result_.
+          1. Let _string_ be the SV of _esNode_.
+          1. Return the JSON Parse Record { [[ParseNode]]: |JSONString|, [[Key]]: _key_, [[Value]]: _string_, [[Elements]]: « », [[Entries]]: « » }.
         </emu-alg>
 
         <emu-grammar>
@@ -48186,10 +48187,8 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _array_ be ! ArrayCreate(0).
           1. Let _elements_ be a new empty List.
-          1. If |JSONElementList| is present, perform JSONArrayAccumulation of |JSONElementList| with arguments _array_, _elements_, 0, and _how_.
-          1. Let _result_ be CreateJSONParseRecord(|JSONArray|, _array_).
-          1. Set _result_.[[Elements]] to _elements_.
-          1. Return _result_.
+          1. If |JSONElementList| is present, perform JSONArrayAccumulation of |JSONElementList| with arguments _array_, _deepNodes_, _elements_, and 0.
+          1. Return the JSON Parse Record { [[ParseNode]]: |JSONArray|, [[Key]]: _key_, [[Value]]: _array_, [[Elements]]: _elements_, [[Entries]]: « » }.
         </emu-alg>
 
         <emu-grammar>
@@ -48200,10 +48199,8 @@ THH:mm:ss.sss
         <emu-alg>
           1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%).
           1. Let _entries_ be a new empty List.
-          1. If |JSONMemberList| is present, perform JSONMemberListEvaluation of |JSONMemberList| with argument _obj_, _entries_, and _how_.
-          1. Let _result_ be CreateJSONParseRecord(|JSONObject|, _obj_).
-          1. Set _result_.[[Entries]] to _entries_.
-          1. Return _result_.
+          1. If |JSONMemberList| is present, perform JSONMemberListEvaluation of |JSONMemberList| with argument _obj_, _deepNodes_, and _entries_.
+          1. Return the JSON Parse Record { [[ParseNode]]: |JSONObject|, [[Key]]: _key_, [[Value]]: _obj_, [[Elements]]: « », [[Entries]]: _entries_ }.
         </emu-alg>
       </emu-clause>
 
@@ -48211,14 +48208,14 @@ THH:mm:ss.sss
         <h1>
           Runtime Semantics: JSONArrayAccumulation (
             _array_: an Array,
+            _deepNodes_: ~discard-nodes~ or ~keep-nodes~,
             _elements_: a List of JSON Parse Records,
             _nextIndex_: a non-negative integer,
-            _how_: ~shallow~ or ~deep~,
           ): a non-negative integer
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It is just like ArrayAccumulation, except defined over a much narrower grammar (namely ECMA-404), and calling JSONEvaluation on its elements, rather than Evaluation.</dd>
+          <dd>It is analagous ArrayAccumulation, except defined over a much narrower grammar (namely ECMA-404), and calling JSONEvaluation on its elements, rather than Evaluation.</dd>
         </dl>
         <emu-grammar>
           JSONElementList :
@@ -48226,13 +48223,11 @@ THH:mm:ss.sss
             JSONElementList `,` JSONValue
         </emu-grammar>
         <emu-alg>
-          1. If a derived |JSONElementList| is present, set _nextIndex_ to the JSONArrayAccumulation of the derived |JSONElementList| with arguments _array_, _elements_, _nextIndex_, and _how_.
+          1. If the derived |JSONElementList| is present, set _nextIndex_ to the JSONArrayAccumulation of the derived |JSONElementList| with arguments _array_, _deepNodes_, _elements_, and _nextIndex_.
           1. Let _key_ be ! ToString(𝔽(_nextIndex_)).
-          1. Let _parseRecord_ be the JSONEvaluation of |JSONValue| with argument _how_.
+          1. Let _parseRecord_ be the JSONEvaluation of |JSONValue| with arguments _key_ and _deepNodes_.
           1. Perform ! CreateDataPropertyOrThrow(_array_, _key_, _parseRecord_.[[Value]]).
-          1. If _how_ is ~deep~, then
-            1. Set _parseRecord_.[[Key]] to _key_.
-            1. Append _parseRecord_ to _elements_.
+          1. If _deepNodes_ is ~keep-nodes~, append _parseRecord_ to _elements_.
           1. Return _nextIndex_ + 1.
         </emu-alg>
       </emu-clause>
@@ -48241,8 +48236,8 @@ THH:mm:ss.sss
         <h1>
           Runtime Semantics: JSONMemberListEvaluation (
             _obj_: an Object,
-            _entries_: a List of Parse Nodes,
-            _how_: ~shallow~ or ~deep~,
+            _deepNodes_: ~discard-nodes~ or ~keep-nodes~,
+            _entries_: a List of JSON Parse Records,
           ): ~unused~
         </h1>
         <dl class="header">

--- a/spec.html
+++ b/spec.html
@@ -47967,11 +47967,9 @@ THH:mm:ss.sss
         1. If _deep_ is *false*, then
           1. Let _parseResult_ be ? ParseJSON(_jsonString_, ~discard-nodes~).
           1. Return _parseResult_.[[Value]].
-        1. Let _rootName_ be the empty String.
-        1. Let _parseResult be ? ParseJSON(_jsonString_, ~keep-nodes~, _rootName_).
-        1. Let _unfiltered_ be _parseResult_.[[Value]].
+        1. Let _parseResult_ be ? ParseJSON(_jsonString_, ~keep-nodes~).
         1. Let _root_ be OrdinaryObjectCreate(%Object.prototype%).
-        1. Perform ! CreateDataPropertyOrThrow(_root_, _rootName_, _unfiltered_).
+        1. Perform ! CreateDataPropertyOrThrow(_root_, _rootName_, _parseResult_.[[Value]]).
         1. Return ? InternalizeJSONProperty(_root_, _rootName_, _reviver_, _parseResult_).
       </emu-alg>
       <p>The *"length"* property of this function is *2*<sub>𝔽</sub>.</p>
@@ -47981,7 +47979,6 @@ THH:mm:ss.sss
           ParseJSON (
             _text_: a String,
             _deepNodes_: ~discard-nodes~ or ~keep-nodes~,
-            optional _key_: a property name,
           ): either a normal completion containing a JSON Parse Record, or a throw completion
         </h1>
         <dl class="header">
@@ -47990,9 +47987,11 @@ THH:mm:ss.sss
           <p>This algorithm references the |JSONValue| nonterminal from ECMA-404.</p>
         </emu-note>
         <emu-alg>
+          1. If StringToCodePoints(_text_) is not a valid JSON text as specified in ECMA-404, throw a *SyntaxError* exception.
+          1. NOTE: JSON whitespace is a strict subset of |WhiteSpace|, and JSON syntax does not support comments.
           1. Let _jsonParseNode_ be ParseText(_text_, |JSONValue|).
           1. If _jsonParseNode_ is not a Parse Node, throw a *SyntaxError* exception.
-          1. If _key_ is absent, set _key_ to the empty String.
+          1. Let _key_ be the empty String.
           1. Let _result_ be the JSONEvaluation of _jsonParseNode_ with arguments _key_ and _deepNodes_.
           1. Return _result_.
         </emu-alg>
@@ -48146,7 +48145,7 @@ THH:mm:ss.sss
           1. Let _source_ be the source text matched by |JSONNumber|.
           1. Let _number_ be StringToNumber(CodePointsToString(_source_)).
           1. Assert: _number_ is not *NaN*.
-          1. Return the JSON Parse Record { [[ParseNode]]: |JSONNumber|, [[Key]]: _key_, [[Value]]: number, [[Elements]]: « », [[Entries]]: « » }.
+          1. Return the JSON Parse Record { [[ParseNode]]: |JSONNumber|, [[Key]]: _key_, [[Value]]: _number_, [[Elements]]: « », [[Entries]]: « » }.
         </emu-alg>
 
         <emu-grammar>
@@ -48197,7 +48196,7 @@ THH:mm:ss.sss
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It is analagous ArrayAccumulation, except defined over a much narrower grammar (namely ECMA-404), and calling JSONEvaluation on its elements, rather than Evaluation.</dd>
+          <dd>It is analagous to ArrayAccumulation, except defined over a much narrower grammar (namely ECMA-404), and calls JSONEvaluation on its elements, rather than Evaluation.</dd>
         </dl>
         <emu-grammar>
           JSONElementList :

--- a/spec.html
+++ b/spec.html
@@ -48266,14 +48266,6 @@ THH:mm:ss.sss
         </emu-alg>
 
         <emu-grammar>
-          JSONObject : `{` `}`
-        </emu-grammar>
-        <emu-alg>
-          1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%).
-          1. Return _obj_.
-        </emu-alg>
-
-        <emu-grammar>
           JSONObject :
             `{` `}`
             `{` JSONMemberList `}`

--- a/spec.html
+++ b/spec.html
@@ -48209,8 +48209,10 @@ THH:mm:ss.sss
         <h1>Runtime Semantics: JSONEvaluation ( ): an ECMAScript language value</h1>
         <dl class="header">
           <dt>description</dt>
-          <dd><p>It generally produces the same values as Evaluation given the same inputs, but is defined over a much narrower set of productions, namely ECMA-404's |JSONValue|. Unlike Evaluation, it does not raise an early error when *"__proto__"* appears twice as a key (see <emu-xref href="#sec-object-initializer-static-semantics-early-errors"></emu-xref>). It also does not perform [[SetPrototypeOf]] when encountering a *"__proto__"* key, and instead creates an ordinary data property (see <emu-xref href="#sec-runtime-semantics-propertydefinitionevaluation"></emu-xref>).</p>
-          <p>The |JSONNumber| and |JSONString| productions are reparsed as ECMA-262 productions and call out to ECMA-262 Evaluation.</p> </dd>
+          <dd>
+            <p>It generally produces the same values as Evaluation given the same inputs, but is defined over a much narrower set of productions, namely ECMA-404's |JSONValue|. Unlike Evaluation, it does not raise an early error when *"__proto__"* appears twice as a key (see <emu-xref href="#sec-object-initializer-static-semantics-early-errors"></emu-xref>). It also does not perform [[SetPrototypeOf]] when encountering a *"__proto__"* key, and instead creates an ordinary data property (see <emu-xref href="#sec-runtime-semantics-propertydefinitionevaluation"></emu-xref>).</p>
+            <p>The |JSONNumber| and |JSONString| productions are reparsed as ECMA-262 productions and call out to ECMA-262 Evaluation.</p>
+          </dd>
         </dl>
         <emu-grammar>
           JSONValue : `null`
@@ -48346,7 +48348,7 @@ THH:mm:ss.sss
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It is just like PropertyDefinitionEvaluation, except 1) it is defined over a much narrower grammar, 2) it does not include the special handling of *"__proto__"* described in <emu-xref href="#sec-jsonevaluation"></emu-xref>, and 3) it calls JSONEvaluation instead of Evaluation. </dd>
+          <dd>It is just like PropertyDefinitionEvaluation, except 1) it is defined over a much narrower grammar, 2) it does not include the special handling of *"__proto__"* described in <emu-xref href="#sec-jsonevaluation"></emu-xref>, and 3) it calls JSONEvaluation instead of Evaluation.</dd>
         </dl>
         <emu-grammar>JSONMemberList : JSONMember</emu-grammar>
         <emu-alg>

--- a/spec.html
+++ b/spec.html
@@ -47986,17 +47986,15 @@ THH:mm:ss.sss
           <p>This algorithm references the |JSONValue| nonterminal from ECMA-404.</p>
         </emu-note>
         <emu-alg>
-          1. [id="step-json-parse-validate"] If StringToCodePoints(_text_) is not a valid JSON text as specified in ECMA-404, throw a *SyntaxError* exception.
-          1. [id="step-json-parse-parse"] Let _jsonParseNode_ be ParseText(_text_, |JSONValue|).
-          1. Assert: _jsonParseNode_ is a Parse Node.
-          1. [id="step-json-parse-eval"] Let _result_ be the <emu-meta suppress-effects="user-code">JSONEvaluation of _jsonParseNode_</emu-meta>.
+          1. Let _jsonParseNode_ be ParseText(_text_, |JSONValue|).
+          1. If _jsonParseNode_ is not a Parse Node, throw a *SyntaxError* exception.
+          1. Let _result_ be the JSONEvaluation of _jsonParseNode_.
           1. [id="step-json-parse-assert-type"] Assert: _result_ is either a String, a Number, a Boolean, an Object that is defined by either an |ArrayLiteral| or an |ObjectLiteral|, or *null*.
           1. Return the Record { [[ParseNode]]: _jsonParseNode_, [[Value]]: _result_ }.
         </emu-alg>
         <p>It is not permitted for a conforming implementation of `JSON.parse` to extend the JSON grammars. If an implementation wishes to support a modified or extended JSON interchange format it must do so by defining a different parse function.</p>
         <emu-note>
-          <p>Valid JSON text is a subset of the ECMAScript |PrimaryExpression| syntax. Step <emu-xref href="#step-json-parse-validate"></emu-xref> verifies that _jsonString_ conforms to that subset, and step <emu-xref href="#step-json-parse-assert-type"></emu-xref> asserts that evaluation returns a value of an appropriate type.</p>
-          <p>However, because JSONEvaluation behaves differently than Evaluation, the same source text can produce different results when evaluated as a |PrimaryExpression| rather than as JSON. Furthermore, the Early Error for duplicate *"__proto__"* properties in object literals, which likewise does not apply during ParseJSON, means that not all texts accepted by ParseJSON are valid as a |PrimaryExpression|, despite the JSON grammar being a subset of the |PrimaryExpression| one.</p>
+          <p>Valid JSON text is a syntactic subset of the ECMAScript |PrimaryExpression| syntax. However, because JSONEvaluation behaves differently than Evaluation, the same source text can produce different results when evaluated as a |PrimaryExpression| rather than as JSON. Furthermore, the early error for duplicate *"__proto__"* properties in object literals (<emu-xref href="#sec-object-initializer-static-semantics-early-errors"></emu-xref>), which has no analogue in JSON, means that some texts accepted by ParseJSON are not valid as a |PrimaryExpression|, (e.g., <code>{"__proto__":null,"__proto__":null}</code>).</p>
         </emu-note>
         <emu-note>
           <p>In the case where there are duplicate name Strings within an object, lexically preceding values for the same key shall be overwritten.</p>
@@ -48211,7 +48209,6 @@ THH:mm:ss.sss
           <dt>description</dt>
           <dd>
             <p>It generally produces the same values as Evaluation given the same inputs, but is defined over a much narrower set of productions, namely ECMA-404's |JSONValue|. Unlike Evaluation, it does not raise an early error when *"__proto__"* appears twice as a key (see <emu-xref href="#sec-object-initializer-static-semantics-early-errors"></emu-xref>). It also does not perform [[SetPrototypeOf]] when encountering a *"__proto__"* key, and instead creates an ordinary data property (see <emu-xref href="#sec-runtime-semantics-propertydefinitionevaluation"></emu-xref>).</p>
-            <p>The |JSONNumber| and |JSONString| productions are reparsed as ECMA-262 productions and call out to ECMA-262 Evaluation.</p>
           </dd>
         </dl>
         <emu-grammar>
@@ -48240,10 +48237,9 @@ THH:mm:ss.sss
         </emu-grammar>
         <emu-alg>
           1. Let _source_ be the source text matched by |JSONNumber|.
-          1. Let _esNode_ be ParseText(_source_, |UnaryExpression|).
-          1. Assert: _esNode_ is a |UnaryExpression| Parse Node.
-          1. Let _value_ be ! Evaluation of _esNode_.
-          1. Return _value_.
+          1. Let _number_ be StringToNumber(CodePointsToString(_source_)).
+          1. Assert: _number_ is not *NaN*.
+          1. Return _number_.
         </emu-alg>
 
         <emu-grammar>
@@ -48259,19 +48255,13 @@ THH:mm:ss.sss
         </emu-alg>
 
         <emu-grammar>
-          JSONArray : `[` `]`
+          JSONArray :
+            `[` `]`
+            `[` JSONElementList `]`
         </emu-grammar>
         <emu-alg>
           1. Let _array_ be ! ArrayCreate(0).
-          1. Return _array_.
-        </emu-alg>
-
-        <emu-grammar>
-          JSONArray : `[` JSONElementList `]`
-        </emu-grammar>
-        <emu-alg>
-          1. Let _array_ be ! ArrayCreate(0).
-          1. Perform JSONArrayAccumulation of |JSONElementList| with arguments _array_ and 0.
+          1. If |JSONElementList| is present, perform JSONArrayAccumulation of |JSONElementList| with arguments _array_ and 0.
           1. Return _array_.
         </emu-alg>
 
@@ -48284,11 +48274,13 @@ THH:mm:ss.sss
         </emu-alg>
 
         <emu-grammar>
-          JSONObject : `{` JSONMemberList `}`
+          JSONObject :
+            `{` `}`
+            `{` JSONMemberList `}`
         </emu-grammar>
         <emu-alg>
           1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%).
-          1. Perform JSONMemberListEvaluation of |JSONMemberList| with argument _obj_.
+          1. If |JSONMemberList| is present, perform JSONMemberListEvaluation of |JSONMemberList| with argument _obj_.
           1. Return _obj_.
         </emu-alg>
       </emu-clause>
@@ -48302,7 +48294,7 @@ THH:mm:ss.sss
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It is just like ArrayAccumulation, except defined over a much narrower grammer (namely ECMA-404), and calling JSONEvaluation on its elements, rather than Evaluation.</dd>
+          <dd>It is just like ArrayAccumulation, except defined over a much narrower grammar (namely ECMA-404), and calling JSONEvaluation on its elements, rather than Evaluation.</dd>
         </dl>
         <emu-grammar>JSONElementList : JSONValue</emu-grammar>
         <emu-alg>

--- a/spec.html
+++ b/spec.html
@@ -47969,8 +47969,9 @@ THH:mm:ss.sss
           1. Return _parseResult_.[[Value]].
         1. Let _parseResult_ be ? ParseJSON(_jsonString_, ~keep-nodes~).
         1. Let _root_ be OrdinaryObjectCreate(%Object.prototype%).
-        1. Perform ! CreateDataPropertyOrThrow(_root_, _rootName_, _parseResult_.[[Value]]).
-        1. Return ? InternalizeJSONProperty(_root_, _rootName_, _reviver_, _parseResult_).
+        1. Assert: _parseResult_.[[Key]] is the empty String.
+        1. Perform ! CreateDataPropertyOrThrow(_root_, _parseResult_.[[Key]], _parseResult_.[[Value]]).
+        1. Return ? InternalizeJSONProperty(_root_, _parseResult_.[[Key]], _reviver_, _parseResult_).
       </emu-alg>
       <p>The *"length"* property of this function is *2*<sub>𝔽</sub>.</p>
 

--- a/spec.html
+++ b/spec.html
@@ -48237,9 +48237,7 @@ THH:mm:ss.sss
           1. Let _source_ be the source text matched by |JSONNumber|.
           1. Let _esNode_ be ParseText(_source_, |UnaryExpression|).
           1. Assert: _esNode_ is a |UnaryExpression| Parse Node.
-          1. Let _completion_ be Evaluation of _esNode_.
-          1. Assert: _completion_ is not an abrupt completion.
-          1. Let _value_ be _completion_.[[Value]].
+          1. Let _value_ be ! Evaluation of _esNode_.
           1. Return _value_.
         </emu-alg>
 
@@ -48316,19 +48314,21 @@ THH:mm:ss.sss
           Runtime Semantics: JSONArrayAccumulation (
             _array_: an Array,
             _nextIndex_: an integer,
-          ): ~unused~
+          ): a Number
         </h1>
         <dl class="header">
         </dl>
         <emu-grammar>JSONElementList : JSONValue</emu-grammar>
         <emu-alg>
-          1. Return JSONEvaluation of |JSONValue|.
+          1. Let _value_ be JSONEvaluation of |JSONValue|.
+          1. Perform ! CreateDataPropertyOrThrow(_array_, ! ToString(𝔽(_nextIndex_)), _value_).
+          1. Return _nextIndex_ + 1.
         </emu-alg>
         <emu-grammar>JSONElementList : JSONElementList `,` JSONValue</emu-grammar>
         <emu-alg>
-          1. Set _nextIndex_ to ? JSONArrayAccumulation of the derived |JSONElementList| with arguments _array_ and _nextIndex_.
+          1. Set _nextIndex_ to JSONArrayAccumulation of the derived |JSONElementList| with arguments _array_ and _nextIndex_.
           1. Let _value_ be JSONEvaluation of |JSONValue|.
-          1. Perform ! CreateDataPropertyOrThrow(_array_, ! ToString(𝔽(_nextIndex_)), _result_).
+          1. Perform ! CreateDataPropertyOrThrow(_array_, ! ToString(𝔽(_nextIndex_)), _value_).
           1. Return _nextIndex_ + 1.
         </emu-alg>
       </emu-clause>
@@ -48357,8 +48357,7 @@ THH:mm:ss.sss
           1. Let _propertyKey_ be JSONEvaluation of |JSONString|.
           1. Let _propertyValue_ be JSONEvaluation of |JSONValue|.
           1. Assert: _obj_ is an ordinary, extensible object with no non-configurable properties.
-          1. Let _completion_ be CreateDataPropertyOrThrow(_obj_, _propertyKey_, _propertyValue_).
-          1. Assert: _completion_ is not an abrupt completion.
+          1. Perform ! CreateDataPropertyOrThrow(_obj_, _propertyKey_, _propertyValue_).
           1. Return ~unused~.
         </emu-alg>
       </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -19012,6 +19012,7 @@
         <ul>
           <li>
             It is a Syntax Error if the PropertyNameList of |PropertyDefinitionList| contains any duplicate entries for *"__proto__"* and at least two of those entries were obtained from productions of the form <emu-grammar>PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar>.
+          </li>
         </ul>
         <emu-note>
           <p>The List returned by PropertyNameList does not include property names defined using a |ComputedPropertyName|.</p>

--- a/spec.html
+++ b/spec.html
@@ -29337,7 +29337,7 @@
           </dl>
 
           <emu-alg>
-            1. Let _parseResult_ be ? ParseJSON(_source_, ~shallow~).
+            1. Let _parseResult_ be ? ParseJSON(_source_, ~discard-nodes~).
             1. Return CreateDefaultExportSyntheticModule(_parseResult_.[[Value]]).
           </emu-alg>
         </emu-clause>
@@ -47965,13 +47965,12 @@ THH:mm:ss.sss
         1. Let _jsonString_ be ? ToString(_text_).
         1. Let _deep_ be IsCallable(_reviver_).
         1. If _deep_ is *false*, then
-          1. Let _parseResult_ be ? ParseJSON(_jsonString_, ~shallow~).
+          1. Let _parseResult_ be ? ParseJSON(_jsonString_, ~discard-nodes~).
           1. Return _parseResult_.[[Value]].
         1. Let _rootName_ be the empty String.
         1. Let _parseResult be ? ParseJSON(_jsonString_, ~keep-nodes~, _rootName_).
         1. Let _unfiltered_ be _parseResult_.[[Value]].
         1. Let _root_ be OrdinaryObjectCreate(%Object.prototype%).
-        1. Let _rootName_ be the empty String.
         1. Perform ! CreateDataPropertyOrThrow(_root_, _rootName_, _unfiltered_).
         1. Return ? InternalizeJSONProperty(_root_, _rootName_, _reviver_, _parseResult_).
       </emu-alg>
@@ -47981,7 +47980,7 @@ THH:mm:ss.sss
         <h1>
           ParseJSON (
             _text_: a String,
-            _how_: ~discard-nodes~ or ~keep-nodes~,
+            _deepNodes_: ~discard-nodes~ or ~keep-nodes~,
             optional _key_: a property name,
           ): either a normal completion containing a JSON Parse Record, or a throw completion
         </h1>
@@ -47994,7 +47993,7 @@ THH:mm:ss.sss
           1. Let _jsonParseNode_ be ParseText(_text_, |JSONValue|).
           1. If _jsonParseNode_ is not a Parse Node, throw a *SyntaxError* exception.
           1. If _key_ is absent, set _key_ to the empty String.
-          1. Let _result_ be the JSONEvaluation of _jsonParseNode_ with argument _how_.
+          1. Let _result_ be the JSONEvaluation of _jsonParseNode_ with arguments _key_ and _deepNodes_.
           1. Return _result_.
         </emu-alg>
         <p>It is not permitted for a conforming implementation of `JSON.parse` to extend the JSON grammars. If an implementation wishes to support a modified or extended JSON interchange format it must do so by defining a different parse function.</p>
@@ -48044,23 +48043,6 @@ THH:mm:ss.sss
             </tr>
           </table>
         </emu-table>
-      </emu-clause>
-
-      <emu-clause id="sec-createjsonparserecord" type="abstract operation" oldids="sec-shallowestcontainedjsonvalue">
-        <h1>
-          CreateJSONParseRecord (
-            _parseNode_: a |JSONValue| Parse Node,
-            _value_: an ECMAScript language value,
-            _key_: a property name,
-          ): a JSON Parse Record
-        </h1>
-        <dl class="header">
-        </dl>
-        <emu-alg>
-          1. Let _elements_ be a new empty List.
-          1. Let _entries_ be a new empty List.
-          1. Return the JSON Parse Record { [[ParseNode]]: _parseNode_, [[Key]]: _key_, [[Value]]: _value_, [[Elements]]: _elements_, [[Entries]]: _entries_ }.
-        </emu-alg>
       </emu-clause>
 
       <emu-clause id="sec-internalizejsonproperty" type="abstract operation">
@@ -48120,7 +48102,7 @@ THH:mm:ss.sss
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-jsonevaluation" type="sdo">
+      <emu-clause id="sec-jsonevaluation" type="sdo" oldids="sec-createjsonparserecord,sec-shallowestcontainedjsonvalue">
         <h1>
           Runtime Semantics: JSONEvaluation (
             _key_: a property key,
@@ -48273,7 +48255,7 @@ THH:mm:ss.sss
         1. If _jsonString_ is the empty String, throw a *SyntaxError* exception.
         1. If the first code unit of _jsonString_ is not either an ASCII lowercase letter code unit (0x0061 through 0x007A, inclusive), an ASCII digit code unit (0x0030 through 0x0039, inclusive), 0x0022 (QUOTATION MARK), or 0x002D (HYPHEN-MINUS), throw a *SyntaxError* exception.
         1. If the last code unit of _jsonString_ is not either an ASCII lowercase letter code unit (0x0061 through 0x007A, inclusive), an ASCII digit code unit (0x0030 through 0x0039, inclusive), or 0x0022 (QUOTATION MARK), throw a *SyntaxError* exception.
-        1. Let _parseResult_ be ? ParseJSON(_jsonString_, ~shallow~).
+        1. Let _parseResult_ be ? ParseJSON(_jsonString_, ~discard-nodes~).
         1. Assert: _parseResult_.[[Value]] is either a String, a Number, a Boolean, or *null*.
         1. Let _internalSlotsList_ be « [[IsRawJSON]] ».
         1. Let _obj_ be OrdinaryObjectCreate(*null*, _internalSlotsList_).

--- a/spec.html
+++ b/spec.html
@@ -270,7 +270,7 @@
   </p>
   <p>
     ECMA-404, <i>The JSON Data Interchange Format</i>.<br>
-    <a href="https://www.ecma-international.org/publications-and-standards/standards/ecma-404/">https://www.ecma-international.org/publications-and-standards/standards/ecma-404/</a>
+    <a href="https://tc39.es/ecma404">https://tc39.es/ecma404</a>
   </p>
 </emu-clause>
 
@@ -47913,6 +47913,148 @@ THH:mm:ss.sss
         <emu-note>
           <p>In the case where there are duplicate name Strings within an object, lexically preceding values for the same key will be overwritten.</p>
         </emu-note>
+
+        <emu-clause id="sec-jsonevaluation" type="sdo" oldids="sec-createjsonparserecord,sec-shallowestcontainedjsonvalue">
+          <h1>
+            Runtime Semantics: JSONEvaluation (
+              _key_: a property name,
+            ): a JSON Parse Record
+          </h1>
+          <dl class="header">
+            <dt>description</dt>
+            <dd>
+              <p>It generally produces the same values as Evaluation given the same inputs, but is defined over a much narrower set of productions, namely ECMA-404's |JSONValue|. Unlike Evaluation, it does not raise an early error when *"__proto__"* appears twice as a key (see <emu-xref href="#sec-object-initializer-static-semantics-early-errors"></emu-xref>). It also does not perform [[SetPrototypeOf]] when encountering a *"__proto__"* key, and instead creates an ordinary data property (see <emu-xref href="#sec-runtime-semantics-propertydefinitionevaluation"></emu-xref>).</p>
+            </dd>
+          </dl>
+          <emu-grammar>
+            JSONValue : `null`
+          </emu-grammar>
+          <emu-alg>
+            1. Let _leaf_ be the first child of |JSONValue|.
+            1. Return the JSON Parse Record { [[ParseNode]]: _leaf_, [[Key]]: _key_, [[Value]]: *null*, [[Elements]]: « », [[Entries]]: « » }.
+          </emu-alg>
+
+          <emu-grammar>
+            JSONValue : `true`
+          </emu-grammar>
+          <emu-alg>
+            1. Let _leaf_ be the first child of |JSONValue|.
+            1. Return the JSON Parse Record { [[ParseNode]]: _leaf_, [[Key]]: _key_, [[Value]]: *true*, [[Elements]]: « », [[Entries]]: « » }.
+          </emu-alg>
+
+          <emu-grammar>
+            JSONValue : `false`
+          </emu-grammar>
+          <emu-alg>
+            1. Let _leaf_ be the first child of |JSONValue|.
+            1. Return the JSON Parse Record { [[ParseNode]]: _leaf_, [[Key]]: _key_, [[Value]]: *false*, [[Elements]]: « », [[Entries]]: « » }.
+          </emu-alg>
+
+          <emu-grammar>
+            JSONValue : JSONNumber
+          </emu-grammar>
+          <emu-alg>
+            1. Let _source_ be the source text matched by |JSONNumber|.
+            1. Let _number_ be StringToNumber(CodePointsToString(_source_)).
+            1. Assert: _number_ is not *NaN*.
+            1. Return the JSON Parse Record { [[ParseNode]]: |JSONNumber|, [[Key]]: _key_, [[Value]]: _number_, [[Elements]]: « », [[Entries]]: « » }.
+          </emu-alg>
+
+          <emu-grammar>
+            JSONString :
+              `"` JSONStringCharacters? `"`
+          </emu-grammar>
+          <emu-alg>
+            1. Let _source_ be the source text matched by |JSONString|.
+            1. Let _stringNode_ be ParseText(_source_, |StringLiteral|).
+            1. Assert: _stringNode_ is a |StringLiteral| Parse Node.
+            1. Let _string_ be the SV of _stringNode_.
+            1. Return the JSON Parse Record { [[ParseNode]]: |JSONString|, [[Key]]: _key_, [[Value]]: _string_, [[Elements]]: « », [[Entries]]: « » }.
+          </emu-alg>
+
+          <emu-grammar>
+            JSONArray :
+              `[` `]`
+              `[` JSONElementList `]`
+          </emu-grammar>
+          <emu-alg>
+            1. Let _array_ be ! ArrayCreate(0).
+            1. Let _elements_ be a new empty List.
+            1. If |JSONElementList| is present, perform JSONArrayAccumulation of |JSONElementList| with arguments _array_, _elements_, and 0.
+            1. Return the JSON Parse Record { [[ParseNode]]: |JSONArray|, [[Key]]: _key_, [[Value]]: _array_, [[Elements]]: _elements_, [[Entries]]: « » }.
+          </emu-alg>
+
+          <emu-grammar>
+            JSONObject :
+              `{` `}`
+              `{` JSONMemberList `}`
+          </emu-grammar>
+          <emu-alg>
+            1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%).
+            1. Let _entries_ be a new empty List.
+            1. If |JSONMemberList| is present, perform JSONMemberListEvaluation of |JSONMemberList| with arguments _obj_ and _entries_.
+            1. Return the JSON Parse Record { [[ParseNode]]: |JSONObject|, [[Key]]: _key_, [[Value]]: _obj_, [[Elements]]: « », [[Entries]]: _entries_ }.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-jsonarrayaccumulation" type="sdo">
+          <h1>
+            Runtime Semantics: JSONArrayAccumulation (
+              _array_: an Array,
+              _elements_: a List of JSON Parse Records,
+              _nextIndex_: a non-negative integer,
+            ): a non-negative integer
+          </h1>
+          <dl class="header">
+            <dt>description</dt>
+            <dd>It is analagous to ArrayAccumulation, except defined over a much narrower grammar (namely ECMA-404), and calls JSONEvaluation on its elements, rather than Evaluation.</dd>
+          </dl>
+          <emu-grammar>
+            JSONElementList :
+              JSONValue
+              JSONElementList `,` JSONValue
+          </emu-grammar>
+          <emu-alg>
+            1. If the derived |JSONElementList| is present, set _nextIndex_ to the JSONArrayAccumulation of the derived |JSONElementList| with arguments _array_, _elements_, and _nextIndex_.
+            1. Let _key_ be ! ToString(𝔽(_nextIndex_)).
+            1. Let _parseRecord_ be the JSONEvaluation of |JSONValue| with argument _key_.
+            1. Perform ! CreateDataPropertyOrThrow(_array_, _key_, _parseRecord_.[[Value]]).
+            1. Append _parseRecord_ to _elements_.
+            1. Return _nextIndex_ + 1.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-jsonmemberlistevaluation" type="sdo">
+          <h1>
+            Runtime Semantics: JSONMemberListEvaluation (
+              _obj_: an Object,
+              _entries_: a List of JSON Parse Records,
+            ): ~unused~
+          </h1>
+          <dl class="header">
+            <dt>description</dt>
+            <dd>It is analagous to PropertyDefinitionEvaluation, except 1) it is defined over a much narrower grammar, 2) it does not include the special handling of *"__proto__"* described in <emu-xref href="#sec-jsonevaluation"></emu-xref>, and 3) it calls JSONEvaluation instead of Evaluation.</dd>
+          </dl>
+          <emu-grammar>JSONMemberList : JSONMemberList `,` JSONMember</emu-grammar>
+          <emu-alg>
+            1. Perform JSONMemberListEvaluation of the derived |JSONMemberList| with arguments _obj_ and _entries_.
+            1. Perform JSONMemberListEvaluation of |JSONMember| with arguments _obj_ and _entries_.
+            1. Return ~unused~.
+          </emu-alg>
+          <emu-grammar>JSONMember : JSONString `:` JSONValue</emu-grammar>
+          <emu-alg>
+            1. Let _dummyKey_ be the empty String.
+            1. Let _propertyKeyRecord_ be the JSONEvaluation of |JSONString| with argument _dummyKey_.
+            1. Let _key_ be _propertyKeyRecord_.[[Value]].
+            1. Assert: _key_ is a property name.
+            1. Let _propertyValueRecord_ be the JSONEvaluation of |JSONValue| with argument _key_.
+            1. Assert: _obj_ is an ordinary, extensible object with no non-configurable properties.
+            1. Perform ! CreateDataPropertyOrThrow(_obj_, _key_, _propertyValueRecord_.[[Value]]).
+            1. Append _propertyValueRecord_ to _entries_.
+            1. Return ~unused~.
+          </emu-alg>
+        </emu-clause>
+
       </emu-clause>
 
       <emu-clause id="sec-json-parse-record">
@@ -48009,147 +48151,6 @@ THH:mm:ss.sss
                 1. Else,
                   1. Perform ? CreateDataProperty(_value_, _propertyKey_, _newElement_).
           1. Return ? Call(_reviver_, _holder_, « _name_, _value_, _context_ »).
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-jsonevaluation" type="sdo" oldids="sec-createjsonparserecord,sec-shallowestcontainedjsonvalue">
-        <h1>
-          Runtime Semantics: JSONEvaluation (
-            _key_: a property name,
-          ): a JSON Parse Record
-        </h1>
-        <dl class="header">
-          <dt>description</dt>
-          <dd>
-            <p>It generally produces the same values as Evaluation given the same inputs, but is defined over a much narrower set of productions, namely ECMA-404's |JSONValue|. Unlike Evaluation, it does not raise an early error when *"__proto__"* appears twice as a key (see <emu-xref href="#sec-object-initializer-static-semantics-early-errors"></emu-xref>). It also does not perform [[SetPrototypeOf]] when encountering a *"__proto__"* key, and instead creates an ordinary data property (see <emu-xref href="#sec-runtime-semantics-propertydefinitionevaluation"></emu-xref>).</p>
-          </dd>
-        </dl>
-        <emu-grammar>
-          JSONValue : `null`
-        </emu-grammar>
-        <emu-alg>
-          1. Let _leaf_ be the first child of |JSONValue|.
-          1. Return the JSON Parse Record { [[ParseNode]]: _leaf_, [[Key]]: _key_, [[Value]]: *null*, [[Elements]]: « », [[Entries]]: « » }.
-        </emu-alg>
-
-        <emu-grammar>
-          JSONValue : `true`
-        </emu-grammar>
-        <emu-alg>
-          1. Let _leaf_ be the first child of |JSONValue|.
-          1. Return the JSON Parse Record { [[ParseNode]]: _leaf_, [[Key]]: _key_, [[Value]]: *true*, [[Elements]]: « », [[Entries]]: « » }.
-        </emu-alg>
-
-        <emu-grammar>
-          JSONValue : `false`
-        </emu-grammar>
-        <emu-alg>
-          1. Let _leaf_ be the first child of |JSONValue|.
-          1. Return the JSON Parse Record { [[ParseNode]]: _leaf_, [[Key]]: _key_, [[Value]]: *false*, [[Elements]]: « », [[Entries]]: « » }.
-        </emu-alg>
-
-        <emu-grammar>
-          JSONValue : JSONNumber
-        </emu-grammar>
-        <emu-alg>
-          1. Let _source_ be the source text matched by |JSONNumber|.
-          1. Let _number_ be StringToNumber(CodePointsToString(_source_)).
-          1. Assert: _number_ is not *NaN*.
-          1. Return the JSON Parse Record { [[ParseNode]]: |JSONNumber|, [[Key]]: _key_, [[Value]]: _number_, [[Elements]]: « », [[Entries]]: « » }.
-        </emu-alg>
-
-        <emu-grammar>
-          JSONString :
-            `"` JSONStringCharacters? `"`
-        </emu-grammar>
-        <emu-alg>
-          1. Let _source_ be the source text matched by |JSONString|.
-          1. Let _stringNode_ be ParseText(_source_, |StringLiteral|).
-          1. Assert: _stringNode_ is a |StringLiteral| Parse Node.
-          1. Let _string_ be the SV of _stringNode_.
-          1. Return the JSON Parse Record { [[ParseNode]]: |JSONString|, [[Key]]: _key_, [[Value]]: _string_, [[Elements]]: « », [[Entries]]: « » }.
-        </emu-alg>
-
-        <emu-grammar>
-          JSONArray :
-            `[` `]`
-            `[` JSONElementList `]`
-        </emu-grammar>
-        <emu-alg>
-          1. Let _array_ be ! ArrayCreate(0).
-          1. Let _elements_ be a new empty List.
-          1. If |JSONElementList| is present, perform JSONArrayAccumulation of |JSONElementList| with arguments _array_, _elements_, and 0.
-          1. Return the JSON Parse Record { [[ParseNode]]: |JSONArray|, [[Key]]: _key_, [[Value]]: _array_, [[Elements]]: _elements_, [[Entries]]: « » }.
-        </emu-alg>
-
-        <emu-grammar>
-          JSONObject :
-            `{` `}`
-            `{` JSONMemberList `}`
-        </emu-grammar>
-        <emu-alg>
-          1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%).
-          1. Let _entries_ be a new empty List.
-          1. If |JSONMemberList| is present, perform JSONMemberListEvaluation of |JSONMemberList| with arguments _obj_ and _entries_.
-          1. Return the JSON Parse Record { [[ParseNode]]: |JSONObject|, [[Key]]: _key_, [[Value]]: _obj_, [[Elements]]: « », [[Entries]]: _entries_ }.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-jsonarrayaccumulation" type="sdo">
-        <h1>
-          Runtime Semantics: JSONArrayAccumulation (
-            _array_: an Array,
-            _elements_: a List of JSON Parse Records,
-            _nextIndex_: a non-negative integer,
-          ): a non-negative integer
-        </h1>
-        <dl class="header">
-          <dt>description</dt>
-          <dd>It is analagous to ArrayAccumulation, except defined over a much narrower grammar (namely ECMA-404), and calls JSONEvaluation on its elements, rather than Evaluation.</dd>
-        </dl>
-        <emu-grammar>
-          JSONElementList :
-            JSONValue
-            JSONElementList `,` JSONValue
-        </emu-grammar>
-        <emu-alg>
-          1. If the derived |JSONElementList| is present, set _nextIndex_ to the JSONArrayAccumulation of the derived |JSONElementList| with arguments _array_, _elements_, and _nextIndex_.
-          1. Let _key_ be ! ToString(𝔽(_nextIndex_)).
-          1. Let _parseRecord_ be the JSONEvaluation of |JSONValue| with argument _key_.
-          1. Perform ! CreateDataPropertyOrThrow(_array_, _key_, _parseRecord_.[[Value]]).
-          1. Append _parseRecord_ to _elements_.
-          1. Return _nextIndex_ + 1.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-jsonmemberlistevaluation" type="sdo">
-        <h1>
-          Runtime Semantics: JSONMemberListEvaluation (
-            _obj_: an Object,
-            _entries_: a List of JSON Parse Records,
-          ): ~unused~
-        </h1>
-        <dl class="header">
-          <dt>description</dt>
-          <dd>It is analagous to PropertyDefinitionEvaluation, except 1) it is defined over a much narrower grammar, 2) it does not include the special handling of *"__proto__"* described in <emu-xref href="#sec-jsonevaluation"></emu-xref>, and 3) it calls JSONEvaluation instead of Evaluation.</dd>
-        </dl>
-        <emu-grammar>JSONMemberList : JSONMemberList `,` JSONMember</emu-grammar>
-        <emu-alg>
-          1. Perform JSONMemberListEvaluation of the derived |JSONMemberList| with arguments _obj_ and _entries_.
-          1. Perform JSONMemberListEvaluation of |JSONMember| with arguments _obj_ and _entries_.
-          1. Return ~unused~.
-        </emu-alg>
-        <emu-grammar>JSONMember : JSONString `:` JSONValue</emu-grammar>
-        <emu-alg>
-          1. Let _dummyKey_ be the empty String.
-          1. Let _propertyKeyRecord_ be the JSONEvaluation of |JSONString| with argument _dummyKey_.
-          1. Let _key_ be _propertyKeyRecord_.[[Value]].
-          1. Assert: _key_ is a property name.
-          1. Let _propertyValueRecord_ be the JSONEvaluation of |JSONValue| with argument _key_.
-          1. Assert: _obj_ is an ordinary, extensible object with no non-configurable properties.
-          1. Perform ! CreateDataPropertyOrThrow(_obj_, _key_, _propertyValueRecord_.[[Value]]).
-          1. Append _propertyValueRecord_ to _entries_.
-          1. Return ~unused~.
         </emu-alg>
       </emu-clause>
     </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -48248,19 +48248,6 @@ THH:mm:ss.sss
         </emu-alg>
 
         <emu-grammar>
-          Literal :
-            NullLiteral
-            BooleanLiteral
-            NumericLiteral
-            StringLiteral
-        </emu-grammar>
-        <emu-alg>
-          1. Let _value_ be ! Evaluation of |Literal|.
-          1. Assert: _value_ is either a String, a Number, a Boolean, or *null*.
-          1. Return _value_.
-        </emu-alg>
-
-        <emu-grammar>
           UnaryExpression :
             `delete` UnaryExpression
             `void` UnaryExpression

--- a/spec.html
+++ b/spec.html
@@ -19011,8 +19011,7 @@
         </emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the PropertyNameList of |PropertyDefinitionList| contains any duplicate entries for *"__proto__"* and at least two of those entries were obtained from productions of the form <emu-grammar>PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar>. Note that the corresponding |JSONObject| production in ECMA-404 (which is used by the ParseJSON in this specification) does not raise a corresponding early error.
-          </li>
+            It is a Syntax Error if the PropertyNameList of |PropertyDefinitionList| contains any duplicate entries for *"__proto__"* and at least two of those entries were obtained from productions of the form <emu-grammar>PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar>.
         </ul>
         <emu-note>
           <p>The List returned by PropertyNameList does not include property names defined using a |ComputedPropertyName|.</p>
@@ -47987,8 +47986,7 @@ THH:mm:ss.sss
         </emu-note>
         <emu-alg>
           1. [id="step-json-parse-validate"] If StringToCodePoints(_text_) is not a valid JSON text as specified in ECMA-404, throw a *SyntaxError* exception.
-          1. Let _scriptString_ be the string-concatenation of *"("*, _text_, and *");"*.
-          1. [id="step-json-parse-parse"] Let _jsonParseNode_ be ParseText(_scriptString_, |JSONValue|).
+          1. [id="step-json-parse-parse"] Let _jsonParseNode_ be ParseText(_text_, |JSONValue|).
           1. Assert: _jsonParseNode_ is a Parse Node.
           1. [id="step-json-parse-eval"] Let _result_ be <emu-meta suppress-effects="user-code">JSONEvaluation of _jsonParseNode_</emu-meta>.
           1. [id="step-json-parse-assert-type"] Assert: _result_ is either a String, a Number, a Boolean, an Object that is defined by either an |ArrayLiteral| or an |ObjectLiteral|, or *null*.
@@ -47997,7 +47995,7 @@ THH:mm:ss.sss
         <p>It is not permitted for a conforming implementation of `JSON.parse` to extend the JSON grammars. If an implementation wishes to support a modified or extended JSON interchange format it must do so by defining a different parse function.</p>
         <emu-note>
           <p>Valid JSON text is a subset of the ECMAScript |PrimaryExpression| syntax. Step <emu-xref href="#step-json-parse-validate"></emu-xref> verifies that _jsonString_ conforms to that subset, and step <emu-xref href="#step-json-parse-assert-type"></emu-xref> asserts that evaluation returns a value of an appropriate type.</p>
-          <p>However, because JSONEvaluation behaves differently than Evaluation, the same source text can produce different results when evaluated as a |PrimaryExpression| rather than as JSON. Furthermore, the Early Error for duplicate *"__proto__"* properties in object literals, which likewise does not apply during ParseJSON, means that not all texts accepted by ParseJSON are valid as a |PrimaryExpression|, despite matching the grammar.</p>
+          <p>However, because JSONEvaluation behaves differently than Evaluation, the same source text can produce different results when evaluated as a |PrimaryExpression| rather than as JSON. Furthermore, the Early Error for duplicate *"__proto__"* properties in object literals, which likewise does not apply during ParseJSON, means that not all texts accepted by ParseJSON are valid as a |PrimaryExpression|, despite the JSON grammar being a subset of the |PrimaryExpression| one.</p>
         </emu-note>
         <emu-note>
           <p>In the case where there are duplicate name Strings within an object, lexically preceding values for the same key shall be overwritten.</p>
@@ -48062,8 +48060,8 @@ THH:mm:ss.sss
           1. If _value_ is an Object, then
             1. Let _isArray_ be ! <emu-meta suppress-effects="user-code">IsArray(_value_)</emu-meta>.
             1. If _isArray_ is *true*, then
-              1. Assert: _parseNode_ is a <emu-grammar>JSONValue : JSONArray</emu-grammar>.
-              1. Let _typedValueNode_ be the |JSONArray| Parse Node of _parseNode_.
+              1. Assert: _parseNode_ is an instance of the production <emu-grammar>JSONValue : JSONArray</emu-grammar>.
+              1. Let _typedValueNode_ be the |JSONArray| of _parseNode_.
               1. Let _contentNodes_ be the JSONArrayLiteralContentNodes of _typedValueNode_.
               1. Let _length_ be the number of elements in _contentNodes_.
               1. Let _valueLength_ be ! <emu-meta suppress-effects="user-code">LengthOfArrayLike(_value_)</emu-meta>.
@@ -48075,8 +48073,8 @@ THH:mm:ss.sss
                 1. Append _elementParseRecord_ to _elements_.
                 1. Set _index_ to _index_ + 1.
             1. Else,
-              1. Assert: _parseNode_ is a <emu-grammar>JSONValue : JSONObject</emu-grammar>.
-              1. Let _typedValueNode_ be the |JSONObject| Parse Node of _parseNode_.
+              1. Assert: _parseNode_ is an instance of the production <emu-grammar>JSONValue : JSONObject</emu-grammar>.
+              1. Let _typedValueNode_ be the |JSONObject| of _parseNode_.
               1. Let _propertyNodes_ be the JSONObjectLiteralContentNodes of _typedValueNode_.
               1. NOTE: Because _value_ was produced from JSON text and has not been modified, all of its property keys are Strings and will be exhaustively enumerated.
               1. Let _keys_ be ! <emu-meta suppress-effects="user-code">EnumerableOwnProperties(_value_, ~key~)</emu-meta>.
@@ -48091,6 +48089,7 @@ THH:mm:ss.sss
                 1. Let _entryParseRecord_ be CreateJSONParseRecord(_propertyValueNode_, _propertyKey_, ! <emu-meta suppress-effects="user-code">Get(_value_, _propertyKey_)</emu-meta>).
                 1. Append _entryParseRecord_ to _entries_.
           1. Else,
+            1. Let _typedValueNode_ be _parseNode_.
             1. Assert: _typedValueNode_ is neither a |JSONArray| Parse Node nor a |JSONObject| Parse Node.
           1. Return the JSON Parse Record { [[ParseNode]]: _typedValueNode_, [[Key]]: _key_, [[Value]]: _value_, [[Elements]]: _elements_, [[Entries]]: _entries_ }.
         </emu-alg>
@@ -48247,13 +48246,6 @@ THH:mm:ss.sss
         </emu-alg>
 
         <emu-grammar>
-          JSONValue : JSONString
-        </emu-grammar>
-        <emu-alg>
-          1. Return JSONEvaluation of |JSONString|.
-        </emu-alg>
-
-        <emu-grammar>
           JSONString :
             `"` JSONStringCharacters? `"`
         </emu-grammar>
@@ -48261,15 +48253,8 @@ THH:mm:ss.sss
           1. Let _source_ be the source text matched by |JSONString|.
           1. Let _esNode_ be ParseText(_source_, |StringLiteral|).
           1. Assert: _esNode_ is a |StringLiteral| Parse Node.
-          1. Let _value_ be SV of _esNode_.
+          1. Let _value_ be the SV of _esNode_.
           1. Return _value_.
-        </emu-alg>
-
-        <emu-grammar>
-          JSONValue : JSONArray
-        </emu-grammar>
-        <emu-alg>
-          1. Return JSONEvaluation of |JSONArray|.
         </emu-alg>
 
         <emu-grammar>
@@ -48287,13 +48272,6 @@ THH:mm:ss.sss
           1. Let _array_ be ! ArrayCreate(0).
           1. Perform JSONArrayAccumulation of |JSONElementList| with arguments _array_ and 0.
           1. Return _array_.
-        </emu-alg>
-
-        <emu-grammar>
-          JSONValue : JSONObject
-        </emu-grammar>
-        <emu-alg>
-          1. Return JSONEvaluation of |JSONObject|.
         </emu-alg>
 
         <emu-grammar>

--- a/spec.html
+++ b/spec.html
@@ -19012,6 +19012,7 @@
         <ul>
           <li>
             It is a Syntax Error if the PropertyNameList of |PropertyDefinitionList| contains any duplicate entries for *"__proto__"* and at least two of those entries were obtained from productions of the form <emu-grammar>PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar>. Note that the corresponding |JSONObject| production in ECMA-404 (which is used by the ParseJSON in this specification) does not raise a corresponding early error.
+          </li>
         </ul>
         <emu-note>
           <p>The List returned by PropertyNameList does not include property names defined using a |ComputedPropertyName|.</p>
@@ -48209,21 +48210,21 @@ THH:mm:ss.sss
         <dl class="header">
         </dl>
         <emu-grammar>
-          JSONValue : null
+          JSONValue : `null`
         </emu-grammar>
         <emu-alg>
           1. Return *null*.
         </emu-alg>
 
         <emu-grammar>
-          JSONValue : true
+          JSONValue : `true`
         </emu-grammar>
         <emu-alg>
           1. Return *true*.
         </emu-alg>
 
         <emu-grammar>
-          JSONValue : false
+          JSONValue : `false`
         </emu-grammar>
         <emu-alg>
           1. Return *false*.
@@ -48251,7 +48252,7 @@ THH:mm:ss.sss
 
         <emu-grammer>
           JSONString :
-            `"` JSONStringCharacters? `"`
+          `"` JSONStringCharacters? `"`
         </emu-grammer>
         <emu-alg>
           1. Let _source_ be the source text matched by |JSONString|.

--- a/spec.html
+++ b/spec.html
@@ -47988,7 +47988,7 @@ THH:mm:ss.sss
           1. [id="step-json-parse-validate"] If StringToCodePoints(_text_) is not a valid JSON text as specified in ECMA-404, throw a *SyntaxError* exception.
           1. [id="step-json-parse-parse"] Let _jsonParseNode_ be ParseText(_text_, |JSONValue|).
           1. Assert: _jsonParseNode_ is a Parse Node.
-          1. [id="step-json-parse-eval"] Let _result_ be <emu-meta suppress-effects="user-code">JSONEvaluation of _jsonParseNode_</emu-meta>.
+          1. [id="step-json-parse-eval"] Let _result_ be the <emu-meta suppress-effects="user-code">JSONEvaluation of _jsonParseNode_</emu-meta>.
           1. [id="step-json-parse-assert-type"] Assert: _result_ is either a String, a Number, a Boolean, an Object that is defined by either an |ArrayLiteral| or an |ObjectLiteral|, or *null*.
           1. Return the Record { [[ParseNode]]: _jsonParseNode_, [[Value]]: _result_ }.
         </emu-alg>
@@ -48296,8 +48296,8 @@ THH:mm:ss.sss
         <h1>
           Runtime Semantics: JSONArrayAccumulation (
             _array_: an Array,
-            _nextIndex_: an integer,
-          ): a Number
+            _nextIndex_: a non-negative integer,
+          ): a non-negative integer
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -48305,14 +48305,14 @@ THH:mm:ss.sss
         </dl>
         <emu-grammar>JSONElementList : JSONValue</emu-grammar>
         <emu-alg>
-          1. Let _value_ be JSONEvaluation of |JSONValue|.
+          1. Let _value_ be the JSONEvaluation of |JSONValue|.
           1. Perform ! CreateDataPropertyOrThrow(_array_, ! ToString(𝔽(_nextIndex_)), _value_).
           1. Return _nextIndex_ + 1.
         </emu-alg>
         <emu-grammar>JSONElementList : JSONElementList `,` JSONValue</emu-grammar>
         <emu-alg>
-          1. Set _nextIndex_ to JSONArrayAccumulation of the derived |JSONElementList| with arguments _array_ and _nextIndex_.
-          1. Let _value_ be JSONEvaluation of |JSONValue|.
+          1. Set _nextIndex_ to the JSONArrayAccumulation of the derived |JSONElementList| with arguments _array_ and _nextIndex_.
+          1. Let _value_ be the JSONEvaluation of |JSONValue|.
           1. Perform ! CreateDataPropertyOrThrow(_array_, ! ToString(𝔽(_nextIndex_)), _value_).
           1. Return _nextIndex_ + 1.
         </emu-alg>
@@ -48328,21 +48328,16 @@ THH:mm:ss.sss
           <dt>description</dt>
           <dd>It is just like PropertyDefinitionEvaluation, except 1) it is defined over a much narrower grammar, 2) it does not include the special handling of *"__proto__"* described in <emu-xref href="#sec-jsonevaluation"></emu-xref>, and 3) it calls JSONEvaluation instead of Evaluation.</dd>
         </dl>
-        <emu-grammar>JSONMemberList : JSONMember</emu-grammar>
-        <emu-alg>
-          1. Perform JSONMemberListEvaluation of |JSONMember| with arguments _obj_.
-          1. Return ~unused~.
-        </emu-alg>
         <emu-grammar>JSONMemberList : JSONMemberList `,` JSONMember</emu-grammar>
         <emu-alg>
-          1. Perform JSONMemberListEvaluation of |JSONMemberList| with arguments _obj_.
-          1. Perform JSONMemberListEvaluation of |JSONMember| with arguments _obj_.
+          1. Perform JSONMemberListEvaluation of the derived |JSONMemberList| with argument _obj_.
+          1. Perform JSONMemberListEvaluation of |JSONMember| with argument _obj_.
           1. Return ~unused~.
         </emu-alg>
         <emu-grammar>JSONMember : JSONString `:` JSONValue</emu-grammar>
         <emu-alg>
-          1. Let _propertyKey_ be JSONEvaluation of |JSONString|.
-          1. Let _propertyValue_ be JSONEvaluation of |JSONValue|.
+          1. Let _propertyKey_ be the JSONEvaluation of |JSONString|.
+          1. Let _propertyValue_ be the JSONEvaluation of |JSONValue|.
           1. Assert: _obj_ is an ordinary, extensible object with no non-configurable properties.
           1. Perform ! CreateDataPropertyOrThrow(_obj_, _propertyKey_, _propertyValue_).
           1. Return ~unused~.

--- a/spec.html
+++ b/spec.html
@@ -48231,7 +48231,7 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-jsonevaluation" type="sdo">
-        <h1><ins>Runtime Semantics: JSONEvaluation ( ): either a normal completion containing an ECMAScript language value or a throw completion</ins></h1>
+        <h1>Runtime Semantics: JSONEvaluation ( ): either a normal completion containing an ECMAScript language value or a throw completion</h1>
         <dl class="header">
         </dl>
         <emu-grammar>
@@ -48311,10 +48311,10 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-jsonarrayaccumulation" type="sdo">
         <h1>
-          <ins>Runtime Semantics: JSONArrayAccumulation (
+          Runtime Semantics: JSONArrayAccumulation (
             _array_: an Array,
             _nextIndex_: an integer,
-          ): a Completion Record</ins>
+          ): a Completion Record
         </h1>
         <dl class="header">
         </dl>
@@ -48351,9 +48351,9 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-jsonpropertydefinitionevaluation" type="sdo">
         <h1>
-          <ins>Runtime Semantics: JSONPropertyDefinitionEvaluation (
+          Runtime Semantics: JSONPropertyDefinitionEvaluation (
             _obj_: an Object,
-          ): either a normal completion containing ~unused~ or an abrupt completion</ins>
+          ): either a normal completion containing ~unused~ or an abrupt completion
         </h1>
         <dl class="header">
         </dl>

--- a/spec.html
+++ b/spec.html
@@ -48231,18 +48231,15 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-jsonevaluation" type="sdo">
-        <h1><ins>Runtime Semantics: JSONEvaluation (
-          ): either a normal completion containing an ECMAScript language value or a throw completion
-          </ins>
-        </h1>
+        <h1><ins>Runtime Semantics: JSONEvaluation ( ): either a normal completion containing an ECMAScript language value or a throw completion</ins></h1>
         <dl class="header">
         </dl>
         <emu-grammar>
-        Literal :
-          NullLiteral
-          BooleanLiteral
-          NumericLiteral
-          StringLiteral
+          Literal :
+            NullLiteral
+            BooleanLiteral
+            NumericLiteral
+            StringLiteral
         </emu-grammar>
         <emu-alg>
           1. Let _value_ be ! Evaluation of |Literal|.
@@ -48251,11 +48248,11 @@ THH:mm:ss.sss
         </emu-alg>
 
         <emu-grammar>
-        Literal :
-          NullLiteral
-          BooleanLiteral
-          NumericLiteral
-          StringLiteral
+          Literal :
+            NullLiteral
+            BooleanLiteral
+            NumericLiteral
+            StringLiteral
         </emu-grammar>
         <emu-alg>
           1. Let _value_ be ! Evaluation of |Literal|.
@@ -48311,14 +48308,13 @@ THH:mm:ss.sss
           1. Return _obj_.
         </emu-alg>
       </emu-clause>
+
       <emu-clause id="sec-jsonarrayaccumulation" type="sdo">
         <h1>
-          <ins>
-            Runtime Semantics: JSONArrayAccumulation (
-              _array_: an Array,
-              _nextIndex_: an integer,
-            ): a Completion Record
-          </ins>
+          <ins>Runtime Semantics: JSONArrayAccumulation (
+            _array_: an Array,
+            _nextIndex_: an integer,
+          ): a Completion Record</ins>
         </h1>
         <dl class="header">
         </dl>
@@ -48338,7 +48334,7 @@ THH:mm:ss.sss
         </emu-alg>
         <emu-grammar>ElementList : ElementList `,` Elision? AssignmentExpression</emu-grammar>
         <emu-alg>
-          1. Set _nextIndex_ to ? JSONArrayAccumulation of the derived |ElementList| with arguments _array_, _nextIndex_, and _options_.
+          1. Set _nextIndex_ to ? JSONArrayAccumulation of the derived |ElementList| with arguments _array_ and _nextIndex_.
           1. Assert: |Elision| is not present.
           1. Let _node_ be ShallowestContainedJSONValue(|AssignmentExpression|).
           1. Assert: _node_ is not ~empty~.
@@ -48354,10 +48350,10 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-jsonpropertydefinitionevaluation" type="sdo">
-        <h1><ins>Runtime Semantics: JSONPropertyDefinitionEvaluation (
+        <h1>
+          <ins>Runtime Semantics: JSONPropertyDefinitionEvaluation (
             _obj_: an Object,
-          ): either a normal completion containing ~unused~ or an abrupt completion
-          </ins>
+          ): either a normal completion containing ~unused~ or an abrupt completion</ins>
         </h1>
         <dl class="header">
         </dl>
@@ -48382,7 +48378,7 @@ THH:mm:ss.sss
           1. Let _propertyKey_ be ? Evaluation of |PropertyName|.
           1. Let _node_ be ShallowestContainedJSONValue(|AssignmentExpression|).
           1. Assert: _node_ is not ~empty~.
-          1. Let _value_ be ? JSONEvaluation of _node_.
+          1. Let _propertyValue_ be ? JSONEvaluation of _node_.
           1. Assert: _obj_ is an ordinary, extensible object with no non-configurable properties.
           1. Perform ! CreateDataPropertyOrThrow(_obj_, _propertyKey_, _propertyValue_).
           1. Return ~unused~.


### PR DESCRIPTION
Creates a distinct `JSONEvaluation` sdo for `JSON.parse` to use instead of awkwardly reusing `Evaluation`

See https://github.com/tc39/ecma262/issues/1681#issuecomment-526852584