### PR TITLE
Editorial: Simplify optional-trailing-comma productions

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -10046,11 +10046,7 @@
       <emu-alg>
         1. Return ~unused~.
       </emu-alg>
-      <emu-grammar>
-        ObjectBindingPattern :
-          `{` BindingPropertyList `}`
-          `{` BindingPropertyList `,` `}`
-      </emu-grammar>
+      <emu-grammar>ObjectBindingPattern : `{` BindingPropertyList `,`? `}`</emu-grammar>
       <emu-alg>
         1. Perform ? PropertyBindingInitialization of |BindingPropertyList| with arguments _value_ and _envRecord_.
         1. Return ~unused~.
@@ -18802,9 +18798,8 @@
         CoverParenthesizedExpressionAndArrowParameterList[?Yield, ?Await] #parencover
 
       CoverParenthesizedExpressionAndArrowParameterList[Yield, Await] :
-        `(` Expression[+In, ?Yield, ?Await] `)`
-        `(` Expression[+In, ?Yield, ?Await] `,` `)`
         `(` `)`
+        `(` Expression[+In, ?Yield, ?Await] `,`? `)`
         `(` `...` BindingIdentifier[?Yield, ?Await] `)`
         `(` `...` BindingPattern[?Yield, ?Await] `)`
         `(` Expression[+In, ?Yield, ?Await] `,` `...` BindingIdentifier[?Yield, ?Await] `)`
@@ -19001,8 +18996,7 @@
       <emu-grammar type="definition">
         ObjectLiteral[Yield, Await] :
           `{` `}`
-          `{` PropertyDefinitionList[?Yield, ?Await] `}`
-          `{` PropertyDefinitionList[?Yield, ?Await] `,` `}`
+          `{` PropertyDefinitionList[?Yield, ?Await] `,`? `}`
 
         PropertyDefinitionList[Yield, Await] :
           PropertyDefinition[?Yield, ?Await]
@@ -19042,11 +19036,7 @@
 
       <emu-clause id="sec-object-initializer-static-semantics-early-errors" oldids="sec-__proto__-property-names-in-object-initializers">
         <h1>Static Semantics: Early Errors</h1>
-        <emu-grammar>
-          ObjectLiteral :
-            `{` PropertyDefinitionList `}`
-            `{` PropertyDefinitionList `,` `}`
-        </emu-grammar>
+        <emu-grammar>ObjectLiteral : `{` PropertyDefinitionList `,`? `}`</emu-grammar>
         <ul>
           <li>
             It is a Syntax Error if the PropertyNameList of |PropertyDefinitionList| contains any duplicate entries for *"__proto__"* and at least two of those entries were obtained from productions of the form <emu-grammar>PropertyDefinition : PropertyName `:` AssignmentExpression</emu-grammar>. This rule is not applied if this |ObjectLiteral| is contained within a |Script| that is being parsed for ParseJSON (see step <emu-xref href="#step-json-parse-parse"></emu-xref> of ParseJSON).
@@ -19147,11 +19137,7 @@
         <emu-alg>
           1. Return OrdinaryObjectCreate(%Object.prototype%).
         </emu-alg>
-        <emu-grammar>
-          ObjectLiteral :
-            `{` PropertyDefinitionList `}`
-            `{` PropertyDefinitionList `,` `}`
-        </emu-grammar>
+        <emu-grammar>ObjectLiteral : `{` PropertyDefinitionList `,`? `}`</emu-grammar>
         <emu-alg>
           1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%).
           1. Perform ? PropertyDefinitionEvaluation of |PropertyDefinitionList| with argument _obj_.
@@ -19641,8 +19627,7 @@
 
       Arguments[Yield, Await] :
         `(` `)`
-        `(` ArgumentList[?Yield, ?Await] `)`
-        `(` ArgumentList[?Yield, ?Await] `,` `)`
+        `(` ArgumentList[?Yield, ?Await] `,`? `)`
 
       ArgumentList[Yield, Await] :
         AssignmentExpression[+In, ?Yield, ?Await]
@@ -21445,8 +21430,8 @@
         ObjectAssignmentPattern[Yield, Await] :
           `{` `}`
           `{` AssignmentRestProperty[?Yield, ?Await] `}`
-          `{` AssignmentPropertyList[?Yield, ?Await] `}`
-          `{` AssignmentPropertyList[?Yield, ?Await] `,` AssignmentRestProperty[?Yield, ?Await]? `}`
+          `{` AssignmentPropertyList[?Yield, ?Await] `,`? `}`
+          `{` AssignmentPropertyList[?Yield, ?Await] `,` AssignmentRestProperty[?Yield, ?Await] `}`
 
         ArrayAssignmentPattern[Yield, Await] :
           `[` Elision? AssignmentRestElement[?Yield, ?Await]? `]`
@@ -21519,11 +21504,7 @@
           1. Perform ? RequireObjectCoercible(_value_).
           1. Return ~unused~.
         </emu-alg>
-        <emu-grammar>
-          ObjectAssignmentPattern :
-            `{` AssignmentPropertyList `}`
-            `{` AssignmentPropertyList `,` `}`
-        </emu-grammar>
+        <emu-grammar>ObjectAssignmentPattern : `{` AssignmentPropertyList `,`? `}`</emu-grammar>
         <emu-alg>
           1. Perform ? RequireObjectCoercible(_value_).
           1. Perform ? PropertyDestructuringAssignmentEvaluation of |AssignmentPropertyList| with argument _value_.
@@ -22202,8 +22183,8 @@
         ObjectBindingPattern[Yield, Await] :
           `{` `}`
           `{` BindingRestProperty[?Yield, ?Await] `}`
-          `{` BindingPropertyList[?Yield, ?Await] `}`
-          `{` BindingPropertyList[?Yield, ?Await] `,` BindingRestProperty[?Yield, ?Await]? `}`
+          `{` BindingPropertyList[?Yield, ?Await] `,`? `}`
+          `{` BindingPropertyList[?Yield, ?Await] `,` BindingRestProperty[?Yield, ?Await] `}`
 
         ArrayBindingPattern[Yield, Await] :
           `[` Elision? BindingRestElement[?Yield, ?Await]? `]`
@@ -29731,8 +29712,7 @@
 
         NamedImports :
           `{` `}`
-          `{` ImportsList `}`
-          `{` ImportsList `,` `}`
+          `{` ImportsList `,`? `}`
 
         FromClause :
           `from` ModuleSpecifier
@@ -29929,8 +29909,7 @@
 
         NamedExports :
           `{` `}`
-          `{` ExportsList `}`
-          `{` ExportsList `,` `}`
+          `{` ExportsList `,`? `}`
 
         ExportsList :
           ExportSpecifier


### PR DESCRIPTION
In alignment with e.g. [|ImportCall|](https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-ImportCall) and [|WithClause|](https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#prod-WithClause), replace production pairs that differ only by presence of ``` `,` ``` with a single ``` `,`? ``` production.