### PR TITLE
Editorial: Improve references to IANA Time Zone Database

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -34366,8 +34366,8 @@
         </p>
         <p>
           Implementations that follow the requirements for time zones as described in the ECMA-402 Internationalization API specification are called <dfn>time zone aware</dfn>.
-          Time zone aware implementations must support available named time zones corresponding to the Zone and Link names of the IANA Time Zone Database, and only such names.
-          In time zone aware implementations, a primary time zone identifier is a Zone name, and a non-primary time zone identifier is a Link name, respectively, in the IANA Time Zone Database except as specifically overridden by AvailableNamedTimeZoneIdentifiers as specified in the ECMA-402 specification.
+          Time zone aware implementations must support available named time zones corresponding to the “Zone” and “<emu-not-ref>Link</emu-not-ref>” names of the <a href="https://www.iana.org/time-zones">IANA Time Zone Database</a>, and only such names.
+          In time zone aware implementations, a primary time zone identifier is a “Zone” name, and a non-primary time zone identifier is a “<emu-not-ref>Link</emu-not-ref>” name, respectively, in the IANA Time Zone Database except as specifically overridden by AvailableNamedTimeZoneIdentifiers as specified in the ECMA-402 specification.
           Implementations that do not support the entire IANA Time Zone Database are still recommended to use IANA Time Zone Database names as identifiers to represent time zones.
         </p>
       </emu-clause>
@@ -34405,7 +34405,7 @@
           1. Return « _epochNanoseconds_ ».
         </emu-alg>
         <emu-note>
-          <p>It is required for time zone aware implementations (and recommended for all others) to use the time zone information of the IANA Time Zone Database <a href="https://www.iana.org/time-zones/">https://www.iana.org/time-zones/</a>.</p>
+          <p>It is required for time zone aware implementations (and recommended for all others) to use the time zone information of the <a href="https://www.iana.org/time-zones">IANA Time Zone Database</a>.</p>
           <p>1:30 AM on 5 November 2017 in America/New_York is repeated twice, so GetNamedTimeZoneEpochNanoseconds(*"America/New_York"*, 2017, 11, 5, 1, 30, 0, 0, 0, 0) would return a List of length 2 in which the first element represents 05:30 UTC (corresponding with 01:30 US Eastern Daylight Time at UTC offset -04:00) and the second element represents 06:30 UTC (corresponding with 01:30 US Eastern Standard Time at UTC offset -05:00).</p>
           <p>2:30 AM on 12 March 2017 in America/New_York does not exist, so GetNamedTimeZoneEpochNanoseconds(*"America/New_York"*, 2017, 3, 12, 2, 30, 0, 0, 0, 0) would return an empty List.</p>
         </emu-note>
@@ -34588,7 +34588,7 @@
         </p>
         <p>If political rules for the local time _t_ are not available within the implementation, the result is _t_ because SystemTimeZoneIdentifier returns *"UTC"* and GetNamedTimeZoneOffsetNanoseconds returns 0.</p>
         <emu-note>
-          <p>It is required for time zone aware implementations (and recommended for all others) to use the time zone information of the IANA Time Zone Database <a href="https://www.iana.org/time-zones/">https://www.iana.org/time-zones/</a>.</p>
+          <p>It is required for time zone aware implementations (and recommended for all others) to use the time zone information of the <a href="https://www.iana.org/time-zones">IANA Time Zone Database</a>.</p>
           <p>
             1:30 AM on 5 November 2017 in America/New_York is repeated twice (fall backward), but it must be interpreted as 1:30 AM UTC-04 instead of 1:30 AM UTC-05.
             In UTC(TimeClip(MakeDate(MakeDay(2017, 10, 5), MakeTime(1, 30, 0, 0)))), the value of _offsetMs_ is <emu-eqn>-4 × msPerHour</emu-eqn>.


### PR DESCRIPTION
The IANA Time Zone Database already appears in the bibliography. Regularize all existing uses of the term to link to the landing page. As per https://github.com/tc39/ecma262/pull/3759#discussion_r3430108367, quote Zone and Link whenever they appear, and ensure that Link does not link to the dfn about module linking.

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)
* [WebAssembly](https://webassembly.github.io/spec/) - [file an issue](https://github.com/WebAssembly/spec/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
