### PR TITLE
Editorial: Reword "specified in the ECMA-402 specification"

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -47948,7 +47948,7 @@ THH:mm:ss.sss
       <li>does not have a [[Construct]] internal method; it cannot be used as a constructor with the `new` operator.</li>
       <li>does not have a [[Call]] internal method; it cannot be invoked as a function.</li>
     </ul>
-    <p>The JSON Data Interchange Format is defined in ECMA-404. The JSON interchange format used in this specification is exactly that described by ECMA-404. Conforming implementations of `JSON.parse` and `JSON.stringify` must support the exact interchange format described in the ECMA-404 specification without any deletions or extensions to the format.</p>
+    <p>The JSON Data Interchange Format is defined in ECMA-404. The JSON interchange format used in this specification is exactly that described by ECMA-404. Conforming implementations of `JSON.parse` and `JSON.stringify` must support the exact interchange format described in ECMA-404 without any deletions or extensions to the format.</p>
 
     <emu-clause id="sec-json.israwjson" type="built-in function">
       <h1>JSON.isRawJSON ( _obj_ )</h1>

--- a/spec.html
+++ b/spec.html
@@ -33144,9 +33144,9 @@
 
       <emu-clause id="sec-number.prototype.tolocalestring" type="built-in function">
         <h1>Number.prototype.toLocaleString ( [ _reserved1_ [ , _reserved2_ ] ] )</h1>
-        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used:</p>
+        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in ECMA-402. Otherwise, the following specification of this method is used:</p>
         <p>This method produces a String value that represents this Number value formatted according to the conventions of the host environment's current locale. This method is implementation-defined, and it is permissible, but not encouraged, for it to return the same thing as `toString`.</p>
-        <p>The meanings of the optional parameters to this method are defined in the ECMA-402 specification; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
+        <p>The meanings of the optional parameters to this method are defined in ECMA-402; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
       </emu-clause>
 
       <emu-clause id="sec-number.prototype.toprecision" type="built-in function">
@@ -33335,9 +33335,9 @@
 
       <emu-clause id="sec-bigint.prototype.tolocalestring" type="built-in function">
         <h1>BigInt.prototype.toLocaleString ( [ _reserved1_ [ , _reserved2_ ] ] )</h1>
-        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used:</p>
+        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in ECMA-402. Otherwise, the following specification of this method is used:</p>
         <p>This method produces a String value that represents this BigInt value formatted according to the conventions of the host environment's current locale. This method is implementation-defined, and it is permissible, but not encouraged, for it to return the same thing as `toString`.</p>
-        <p>The meanings of the optional parameters to this method are defined in the ECMA-402 specification; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
+        <p>The meanings of the optional parameters to this method are defined in ECMA-402; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
       </emu-clause>
 
       <emu-clause id="sec-bigint.prototype.tostring" type="built-in function">
@@ -34402,7 +34402,7 @@
         <p>
           Implementations that follow the requirements for time zones as described in the ECMA-402 Internationalization API specification are called <dfn>time zone aware</dfn>.
           Time zone aware implementations must support available named time zones corresponding to the “Zone” and “<emu-not-ref>Link</emu-not-ref>” names of the <a href="https://www.iana.org/time-zones">IANA Time Zone Database</a>, and only such names.
-          In time zone aware implementations, a primary time zone identifier is a “Zone” name, and a non-primary time zone identifier is a “<emu-not-ref>Link</emu-not-ref>” name, respectively, in the IANA Time Zone Database except as specifically overridden by AvailableNamedTimeZoneIdentifiers as specified in the ECMA-402 specification.
+          In time zone aware implementations, a primary time zone identifier is a “Zone” name, and a non-primary time zone identifier is a “<emu-not-ref>Link</emu-not-ref>” name, respectively, in the IANA Time Zone Database except as specifically overridden by AvailableNamedTimeZoneIdentifiers as specified in ECMA-402.
           Implementations that do not support the entire IANA Time Zone Database are still recommended to use IANA Time Zone Database names as identifiers to represent time zones.
         </p>
       </emu-clause>
@@ -34506,8 +34506,8 @@
           </dd>
         </dl>
         <p>
-          Time zone aware implementations, including all implementations that implement the ECMA-402 Internationalization API, must implement the AvailableNamedTimeZoneIdentifiers abstract operation as specified in the ECMA-402 specification.
-          For implementations that are not time zone aware, AvailableNamedTimeZoneIdentifiers performs the following steps when called:
+          Time zone aware implementations, including all implementations that implement the ECMA-402 Internationalization API, must implement the AvailableNamedTimeZoneIdentifiers abstract operation as specified in ECMA-402.
+          Otherwise, AvailableNamedTimeZoneIdentifiers performs the following steps when called:
         </p>
         <emu-alg>
           1. If the implementation does not include local political rules for any time zones, then
@@ -35732,23 +35732,23 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype.tolocaledatestring" type="built-in function">
         <h1>Date.prototype.toLocaleDateString ( [ _reserved1_ [ , _reserved2_ ] ] )</h1>
-        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used:</p>
+        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in ECMA-402. Otherwise, the following specification of this method is used:</p>
         <p>This method returns a String value. The contents of the String are implementation-defined, but are intended to represent the “date” portion of the Date in the current time zone in a convenient, human-readable form that corresponds to the conventions of the host environment's current locale.</p>
-        <p>The meaning of the optional parameters to this method are defined in the ECMA-402 specification; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
+        <p>The meaning of the optional parameters to this method are defined in ECMA-402; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
       </emu-clause>
 
       <emu-clause id="sec-date.prototype.tolocalestring" type="built-in function">
         <h1>Date.prototype.toLocaleString ( [ _reserved1_ [ , _reserved2_ ] ] )</h1>
-        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used:</p>
+        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in ECMA-402. Otherwise, the following specification of this method is used:</p>
         <p>This method returns a String value. The contents of the String are implementation-defined, but are intended to represent the Date in the current time zone in a convenient, human-readable form that corresponds to the conventions of the host environment's current locale.</p>
-        <p>The meaning of the optional parameters to this method are defined in the ECMA-402 specification; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
+        <p>The meaning of the optional parameters to this method are defined in ECMA-402; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
       </emu-clause>
 
       <emu-clause id="sec-date.prototype.tolocaletimestring" type="built-in function">
         <h1>Date.prototype.toLocaleTimeString ( [ _reserved1_ [ , _reserved2_ ] ] )</h1>
-        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used:</p>
+        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in ECMA-402. Otherwise, the following specification of this method is used:</p>
         <p>This method returns a String value. The contents of the String are implementation-defined, but are intended to represent the “time” portion of the Date in the current time zone in a convenient, human-readable form that corresponds to the conventions of the host environment's current locale.</p>
-        <p>The meaning of the optional parameters to this method are defined in the ECMA-402 specification; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
+        <p>The meaning of the optional parameters to this method are defined in ECMA-402; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
       </emu-clause>
 
       <emu-clause id="sec-date.prototype.tostring" type="built-in function">
@@ -36434,7 +36434,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-string.prototype.localecompare" type="built-in function">
         <h1>String.prototype.localeCompare ( _that_ [ , _reserved1_ [ , _reserved2_ ] ] )</h1>
-        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used:</p>
+        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in ECMA-402. Otherwise, the following specification of this method is used:</p>
         <p>This method returns a Number other than *NaN* representing the result of an implementation-defined locale-sensitive String comparison of the *this* value (converted to a String _string_) with _that_ (converted to a String _thatValue_). The result is intended to correspond with a sort order of String values according to conventions of the host environment's current locale, and will be negative when _string_ is ordered before _thatValue_, positive when _string_ is ordered after _thatValue_, and zero in all other cases (representing no relative ordering between _string_ and _thatValue_).</p>
         <p>Before performing the comparisons, this method performs the following steps to prepare the Strings:</p>
         <emu-alg>
@@ -36443,7 +36443,7 @@ THH:mm:ss.sss
           1. Let _string_ be ? ToString(_thisValue_).
           1. Let _thatValue_ be ? ToString(_that_).
         </emu-alg>
-        <p>The meaning of the optional second and third parameters to this method are defined in the ECMA-402 specification; implementations that do not include ECMA-402 support must not assign any other interpretation to those parameter positions.</p>
+        <p>The meaning of the optional second and third parameters to this method are defined in ECMA-402; implementations that do not include ECMA-402 support must not assign any other interpretation to those parameter positions.</p>
         <p>The actual return values are implementation-defined to permit encoding additional information in them, but this method, when considered as a method of two arguments, is required to be a consistent comparator defining a total ordering on the set of all Strings. This method is also required to recognize and honour canonical equivalence according to the Unicode Standard, including returning *+0*<sub>𝔽</sub> when comparing distinguishable Strings that are canonically equivalent.</p>
         <emu-note>
           <p>This method itself is not directly suitable as an argument to `Array.prototype.sort` because the latter requires a function of two arguments.</p>
@@ -36946,10 +36946,10 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-string.prototype.tolocalelowercase" type="built-in function">
         <h1>String.prototype.toLocaleLowerCase ( [ _reserved1_ [ , _reserved2_ ] ] )</h1>
-        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used:</p>
+        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in ECMA-402. Otherwise, the following specification of this method is used:</p>
         <p>This method interprets a String value as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>.</p>
         <p>It works exactly the same as `toLowerCase` except that it is intended to yield a locale-sensitive result corresponding with conventions of the host environment's current locale. There will only be a difference in the few cases (such as Turkish) where the rules for that language conflict with the regular Unicode case mappings.</p>
-        <p>The meaning of the optional parameters to this method are defined in the ECMA-402 specification; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
+        <p>The meaning of the optional parameters to this method are defined in ECMA-402; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
         <emu-note>
           <p>This method is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
@@ -36957,10 +36957,10 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-string.prototype.tolocaleuppercase" type="built-in function">
         <h1>String.prototype.toLocaleUpperCase ( [ _reserved1_ [ , _reserved2_ ] ] )</h1>
-        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used:</p>
+        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in ECMA-402. Otherwise, the following specification of this method is used:</p>
         <p>This method interprets a String value as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>.</p>
         <p>It works exactly the same as `toUpperCase` except that it is intended to yield a locale-sensitive result corresponding with conventions of the host environment's current locale. There will only be a difference in the few cases (such as Turkish) where the rules for that language conflict with the regular Unicode case mappings.</p>
-        <p>The meaning of the optional parameters to this method are defined in the ECMA-402 specification; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
+        <p>The meaning of the optional parameters to this method are defined in ECMA-402; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
         <emu-note>
           <p>This method is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
@@ -41765,11 +41765,11 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-array.prototype.tolocalestring" type="built-in function">
         <h1>Array.prototype.toLocaleString ( [ _reserved1_ [ , _reserved2_ ] ] )</h1>
-        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used.</p>
+        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in ECMA-402. Otherwise, the following specification of this method is used.</p>
         <emu-note>
           <p>The first edition of ECMA-402 did not include a replacement specification for this method.</p>
         </emu-note>
-        <p>The meanings of the optional parameters to this method are defined in the ECMA-402 specification; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
+        <p>The meanings of the optional parameters to this method are defined in ECMA-402; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _array_ be ? ToObject(*this* value).
@@ -43196,7 +43196,7 @@ THH:mm:ss.sss
         <p>This is a distinct method that implements the same algorithm as `Array.prototype.toLocaleString` as defined in <emu-xref href="#sec-array.prototype.tolocalestring"></emu-xref> except that TypedArrayLength is called in place of performing a [[Get]] of *"length"*. The implementation of the algorithm may be optimized with the knowledge that the *this* value has a fixed length when the underlying buffer is not resizable and whose integer-indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
         <p>This method is not generic. ValidateTypedArray is called with the *this* value and ~seq-cst~ as arguments prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
         <emu-note>
-          <p>If the ECMAScript implementation includes the ECMA-402 Internationalization API this method is based upon the algorithm for `Array.prototype.toLocaleString` that is in the ECMA-402 specification.</p>
+          <p>If the ECMAScript implementation includes the ECMA-402 Internationalization API this method is based upon the algorithm for `Array.prototype.toLocaleString` that is in ECMA-402.</p>
         </emu-note>
       </emu-clause>
 
@@ -47859,7 +47859,7 @@ THH:mm:ss.sss
       <li>does not have a [[Construct]] internal method; it cannot be used as a constructor with the `new` operator.</li>
       <li>does not have a [[Call]] internal method; it cannot be invoked as a function.</li>
     </ul>
-    <p>The JSON Data Interchange Format is defined in ECMA-404. The JSON interchange format used in this specification is exactly that described by ECMA-404. Conforming implementations of `JSON.parse` and `JSON.stringify` must support the exact interchange format described in the ECMA-404 specification without any deletions or extensions to the format.</p>
+    <p>The JSON Data Interchange Format is defined in ECMA-404. The JSON interchange format used in this specification is exactly that described by ECMA-404. Conforming implementations of `JSON.parse` and `JSON.stringify` must support the exact interchange format described in ECMA-404 without any deletions or extensions to the format.</p>
 
     <emu-clause id="sec-json.israwjson" type="built-in function">
       <h1>JSON.isRawJSON ( _obj_ )</h1>

--- a/spec.html
+++ b/spec.html
@@ -33099,9 +33099,9 @@
 
       <emu-clause id="sec-number.prototype.tolocalestring" type="built-in function">
         <h1>Number.prototype.toLocaleString ( [ _reserved1_ [ , _reserved2_ ] ] )</h1>
-        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used:</p>
+        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in ECMA-402. If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used:</p>
         <p>This method produces a String value that represents this Number value formatted according to the conventions of the host environment's current locale. This method is implementation-defined, and it is permissible, but not encouraged, for it to return the same thing as `toString`.</p>
-        <p>The meanings of the optional parameters to this method are defined in the ECMA-402 specification; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
+        <p>The meanings of the optional parameters to this method are defined in ECMA-402; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
       </emu-clause>
 
       <emu-clause id="sec-number.prototype.toprecision" type="built-in function">
@@ -33291,9 +33291,9 @@
 
       <emu-clause id="sec-bigint.prototype.tolocalestring" type="built-in function">
         <h1>BigInt.prototype.toLocaleString ( [ _reserved1_ [ , _reserved2_ ] ] )</h1>
-        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used:</p>
+        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in ECMA-402. If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used:</p>
         <p>This method produces a String value that represents this BigInt value formatted according to the conventions of the host environment's current locale. This method is implementation-defined, and it is permissible, but not encouraged, for it to return the same thing as `toString`.</p>
-        <p>The meanings of the optional parameters to this method are defined in the ECMA-402 specification; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
+        <p>The meanings of the optional parameters to this method are defined in ECMA-402; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
       </emu-clause>
 
       <emu-clause id="sec-bigint.prototype.tostring" type="built-in function">
@@ -34362,7 +34362,7 @@
         <p>
           Implementations that follow the requirements for time zones as described in the ECMA-402 Internationalization API specification are called <dfn>time zone aware</dfn>.
           Time zone aware implementations must support available named time zones corresponding to the Zone and Link names of the IANA Time Zone Database, and only such names.
-          In time zone aware implementations, a primary time zone identifier is a Zone name, and a non-primary time zone identifier is a Link name, respectively, in the IANA Time Zone Database except as specifically overridden by AvailableNamedTimeZoneIdentifiers as specified in the ECMA-402 specification.
+          In time zone aware implementations, a primary time zone identifier is a Zone name, and a non-primary time zone identifier is a Link name, respectively, in the IANA Time Zone Database except as specifically overridden by AvailableNamedTimeZoneIdentifiers as specified in ECMA-402.
           Implementations that do not support the entire IANA Time Zone Database are still recommended to use IANA Time Zone Database names as identifiers to represent time zones.
         </p>
       </emu-clause>
@@ -34466,7 +34466,7 @@
           </dd>
         </dl>
         <p>
-          Time zone aware implementations, including all implementations that implement the ECMA-402 Internationalization API, must implement the AvailableNamedTimeZoneIdentifiers abstract operation as specified in the ECMA-402 specification.
+          Time zone aware implementations, including all implementations that implement the ECMA-402 Internationalization API, must implement the AvailableNamedTimeZoneIdentifiers abstract operation as specified in ECMA-402.
           For implementations that are not time zone aware, AvailableNamedTimeZoneIdentifiers performs the following steps when called:
         </p>
         <emu-alg>
@@ -35692,23 +35692,23 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype.tolocaledatestring" type="built-in function">
         <h1>Date.prototype.toLocaleDateString ( [ _reserved1_ [ , _reserved2_ ] ] )</h1>
-        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used:</p>
+        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in ECMA-402. If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used:</p>
         <p>This method returns a String value. The contents of the String are implementation-defined, but are intended to represent the “date” portion of the Date in the current time zone in a convenient, human-readable form that corresponds to the conventions of the host environment's current locale.</p>
-        <p>The meaning of the optional parameters to this method are defined in the ECMA-402 specification; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
+        <p>The meaning of the optional parameters to this method are defined in ECMA-402; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
       </emu-clause>
 
       <emu-clause id="sec-date.prototype.tolocalestring" type="built-in function">
         <h1>Date.prototype.toLocaleString ( [ _reserved1_ [ , _reserved2_ ] ] )</h1>
-        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used:</p>
+        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in ECMA-402. If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used:</p>
         <p>This method returns a String value. The contents of the String are implementation-defined, but are intended to represent the Date in the current time zone in a convenient, human-readable form that corresponds to the conventions of the host environment's current locale.</p>
-        <p>The meaning of the optional parameters to this method are defined in the ECMA-402 specification; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
+        <p>The meaning of the optional parameters to this method are defined in ECMA-402; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
       </emu-clause>
 
       <emu-clause id="sec-date.prototype.tolocaletimestring" type="built-in function">
         <h1>Date.prototype.toLocaleTimeString ( [ _reserved1_ [ , _reserved2_ ] ] )</h1>
-        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used:</p>
+        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in ECMA-402. If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used:</p>
         <p>This method returns a String value. The contents of the String are implementation-defined, but are intended to represent the “time” portion of the Date in the current time zone in a convenient, human-readable form that corresponds to the conventions of the host environment's current locale.</p>
-        <p>The meaning of the optional parameters to this method are defined in the ECMA-402 specification; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
+        <p>The meaning of the optional parameters to this method are defined in ECMA-402; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
       </emu-clause>
 
       <emu-clause id="sec-date.prototype.tostring" type="built-in function">
@@ -36401,7 +36401,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-string.prototype.localecompare" type="built-in function">
         <h1>String.prototype.localeCompare ( _that_ [ , _reserved1_ [ , _reserved2_ ] ] )</h1>
-        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used:</p>
+        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in ECMA-402. If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used:</p>
         <p>This method returns a Number other than *NaN* representing the result of an implementation-defined locale-sensitive String comparison of the *this* value (converted to a String _string_) with _that_ (converted to a String _thatValue_). The result is intended to correspond with a sort order of String values according to conventions of the host environment's current locale, and will be negative when _string_ is ordered before _thatValue_, positive when _string_ is ordered after _thatValue_, and zero in all other cases (representing no relative ordering between _string_ and _thatValue_).</p>
         <p>Before performing the comparisons, this method performs the following steps to prepare the Strings:</p>
         <emu-alg>
@@ -36410,7 +36410,7 @@ THH:mm:ss.sss
           1. Let _string_ be ? ToString(_thisValue_).
           1. Let _thatValue_ be ? ToString(_that_).
         </emu-alg>
-        <p>The meaning of the optional second and third parameters to this method are defined in the ECMA-402 specification; implementations that do not include ECMA-402 support must not assign any other interpretation to those parameter positions.</p>
+        <p>The meaning of the optional second and third parameters to this method are defined in ECMA-402; implementations that do not include ECMA-402 support must not assign any other interpretation to those parameter positions.</p>
         <p>The actual return values are implementation-defined to permit encoding additional information in them, but this method, when considered as a method of two arguments, is required to be a consistent comparator defining a total ordering on the set of all Strings. This method is also required to recognize and honour canonical equivalence according to the Unicode Standard, including returning *+0*<sub>𝔽</sub> when comparing distinguishable Strings that are canonically equivalent.</p>
         <emu-note>
           <p>This method itself is not directly suitable as an argument to `Array.prototype.sort` because the latter requires a function of two arguments.</p>
@@ -36920,10 +36920,10 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-string.prototype.tolocalelowercase" type="built-in function">
         <h1>String.prototype.toLocaleLowerCase ( [ _reserved1_ [ , _reserved2_ ] ] )</h1>
-        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used:</p>
+        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in ECMA-402. If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used:</p>
         <p>This method interprets a String value as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>.</p>
         <p>It works exactly the same as `toLowerCase` except that it is intended to yield a locale-sensitive result corresponding with conventions of the host environment's current locale. There will only be a difference in the few cases (such as Turkish) where the rules for that language conflict with the regular Unicode case mappings.</p>
-        <p>The meaning of the optional parameters to this method are defined in the ECMA-402 specification; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
+        <p>The meaning of the optional parameters to this method are defined in ECMA-402; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
         <emu-note>
           <p>This method is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
@@ -36931,10 +36931,10 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-string.prototype.tolocaleuppercase" type="built-in function">
         <h1>String.prototype.toLocaleUpperCase ( [ _reserved1_ [ , _reserved2_ ] ] )</h1>
-        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used:</p>
+        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in ECMA-402. If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used:</p>
         <p>This method interprets a String value as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>.</p>
         <p>It works exactly the same as `toUpperCase` except that it is intended to yield a locale-sensitive result corresponding with conventions of the host environment's current locale. There will only be a difference in the few cases (such as Turkish) where the rules for that language conflict with the regular Unicode case mappings.</p>
-        <p>The meaning of the optional parameters to this method are defined in the ECMA-402 specification; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
+        <p>The meaning of the optional parameters to this method are defined in ECMA-402; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
         <emu-note>
           <p>This method is intentionally generic; it does not require that its *this* value be a String object. Therefore, it can be transferred to other kinds of objects for use as a method.</p>
         </emu-note>
@@ -41787,11 +41787,11 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-array.prototype.tolocalestring" type="built-in function">
         <h1>Array.prototype.toLocaleString ( [ _reserved1_ [ , _reserved2_ ] ] )</h1>
-        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used.</p>
+        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in ECMA-402. If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used.</p>
         <emu-note>
           <p>The first edition of ECMA-402 did not include a replacement specification for this method.</p>
         </emu-note>
-        <p>The meanings of the optional parameters to this method are defined in the ECMA-402 specification; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
+        <p>The meanings of the optional parameters to this method are defined in ECMA-402; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _array_ be ? ToObject(*this* value).
@@ -43282,7 +43282,7 @@ THH:mm:ss.sss
         <p>This is a distinct method that implements the same algorithm as `Array.prototype.toLocaleString` as defined in <emu-xref href="#sec-array.prototype.tolocalestring"></emu-xref> except that TypedArrayLength is called in place of performing a [[Get]] of *"length"*. The implementation of the algorithm may be optimized with the knowledge that the *this* value has a fixed length when the underlying buffer is not resizable and whose integer-indexed properties are not sparse. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
         <p>This method is not generic. ValidateTypedArray is called with the *this* value and ~seq-cst~ as arguments prior to evaluating the algorithm. If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.</p>
         <emu-note>
-          <p>If the ECMAScript implementation includes the ECMA-402 Internationalization API this method is based upon the algorithm for `Array.prototype.toLocaleString` that is in the ECMA-402 specification.</p>
+          <p>If the ECMAScript implementation includes the ECMA-402 Internationalization API this method is based upon the algorithm for `Array.prototype.toLocaleString` that is in ECMA-402.</p>
         </emu-note>
       </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -33099,7 +33099,7 @@
 
       <emu-clause id="sec-number.prototype.tolocalestring" type="built-in function">
         <h1>Number.prototype.toLocaleString ( [ _reserved1_ [ , _reserved2_ ] ] )</h1>
-        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in ECMA-402. If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used:</p>
+        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in ECMA-402. Otherwise, the following specification of this method is used:</p>
         <p>This method produces a String value that represents this Number value formatted according to the conventions of the host environment's current locale. This method is implementation-defined, and it is permissible, but not encouraged, for it to return the same thing as `toString`.</p>
         <p>The meanings of the optional parameters to this method are defined in ECMA-402; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
       </emu-clause>
@@ -33291,7 +33291,7 @@
 
       <emu-clause id="sec-bigint.prototype.tolocalestring" type="built-in function">
         <h1>BigInt.prototype.toLocaleString ( [ _reserved1_ [ , _reserved2_ ] ] )</h1>
-        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in ECMA-402. If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used:</p>
+        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in ECMA-402. Otherwise, the following specification of this method is used:</p>
         <p>This method produces a String value that represents this BigInt value formatted according to the conventions of the host environment's current locale. This method is implementation-defined, and it is permissible, but not encouraged, for it to return the same thing as `toString`.</p>
         <p>The meanings of the optional parameters to this method are defined in ECMA-402; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
       </emu-clause>
@@ -34467,7 +34467,7 @@
         </dl>
         <p>
           Time zone aware implementations, including all implementations that implement the ECMA-402 Internationalization API, must implement the AvailableNamedTimeZoneIdentifiers abstract operation as specified in ECMA-402.
-          For implementations that are not time zone aware, AvailableNamedTimeZoneIdentifiers performs the following steps when called:
+          Otherwise, AvailableNamedTimeZoneIdentifiers performs the following steps when called:
         </p>
         <emu-alg>
           1. If the implementation does not include local political rules for any time zones, then
@@ -35692,21 +35692,21 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-date.prototype.tolocaledatestring" type="built-in function">
         <h1>Date.prototype.toLocaleDateString ( [ _reserved1_ [ , _reserved2_ ] ] )</h1>
-        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in ECMA-402. If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used:</p>
+        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in ECMA-402. Otherwise, the following specification of this method is used:</p>
         <p>This method returns a String value. The contents of the String are implementation-defined, but are intended to represent the “date” portion of the Date in the current time zone in a convenient, human-readable form that corresponds to the conventions of the host environment's current locale.</p>
         <p>The meaning of the optional parameters to this method are defined in ECMA-402; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
       </emu-clause>
 
       <emu-clause id="sec-date.prototype.tolocalestring" type="built-in function">
         <h1>Date.prototype.toLocaleString ( [ _reserved1_ [ , _reserved2_ ] ] )</h1>
-        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in ECMA-402. If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used:</p>
+        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in ECMA-402. Otherwise, the following specification of this method is used:</p>
         <p>This method returns a String value. The contents of the String are implementation-defined, but are intended to represent the Date in the current time zone in a convenient, human-readable form that corresponds to the conventions of the host environment's current locale.</p>
         <p>The meaning of the optional parameters to this method are defined in ECMA-402; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
       </emu-clause>
 
       <emu-clause id="sec-date.prototype.tolocaletimestring" type="built-in function">
         <h1>Date.prototype.toLocaleTimeString ( [ _reserved1_ [ , _reserved2_ ] ] )</h1>
-        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in ECMA-402. If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used:</p>
+        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in ECMA-402. Otherwise, the following specification of this method is used:</p>
         <p>This method returns a String value. The contents of the String are implementation-defined, but are intended to represent the “time” portion of the Date in the current time zone in a convenient, human-readable form that corresponds to the conventions of the host environment's current locale.</p>
         <p>The meaning of the optional parameters to this method are defined in ECMA-402; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
       </emu-clause>
@@ -36401,7 +36401,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-string.prototype.localecompare" type="built-in function">
         <h1>String.prototype.localeCompare ( _that_ [ , _reserved1_ [ , _reserved2_ ] ] )</h1>
-        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in ECMA-402. If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used:</p>
+        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in ECMA-402. Otherwise, the following specification of this method is used:</p>
         <p>This method returns a Number other than *NaN* representing the result of an implementation-defined locale-sensitive String comparison of the *this* value (converted to a String _string_) with _that_ (converted to a String _thatValue_). The result is intended to correspond with a sort order of String values according to conventions of the host environment's current locale, and will be negative when _string_ is ordered before _thatValue_, positive when _string_ is ordered after _thatValue_, and zero in all other cases (representing no relative ordering between _string_ and _thatValue_).</p>
         <p>Before performing the comparisons, this method performs the following steps to prepare the Strings:</p>
         <emu-alg>
@@ -36920,7 +36920,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-string.prototype.tolocalelowercase" type="built-in function">
         <h1>String.prototype.toLocaleLowerCase ( [ _reserved1_ [ , _reserved2_ ] ] )</h1>
-        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in ECMA-402. If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used:</p>
+        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in ECMA-402. Otherwise, the following specification of this method is used:</p>
         <p>This method interprets a String value as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>.</p>
         <p>It works exactly the same as `toLowerCase` except that it is intended to yield a locale-sensitive result corresponding with conventions of the host environment's current locale. There will only be a difference in the few cases (such as Turkish) where the rules for that language conflict with the regular Unicode case mappings.</p>
         <p>The meaning of the optional parameters to this method are defined in ECMA-402; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
@@ -36931,7 +36931,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-string.prototype.tolocaleuppercase" type="built-in function">
         <h1>String.prototype.toLocaleUpperCase ( [ _reserved1_ [ , _reserved2_ ] ] )</h1>
-        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in ECMA-402. If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used:</p>
+        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in ECMA-402. Otherwise, the following specification of this method is used:</p>
         <p>This method interprets a String value as a sequence of UTF-16 encoded code points, as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>.</p>
         <p>It works exactly the same as `toUpperCase` except that it is intended to yield a locale-sensitive result corresponding with conventions of the host environment's current locale. There will only be a difference in the few cases (such as Turkish) where the rules for that language conflict with the regular Unicode case mappings.</p>
         <p>The meaning of the optional parameters to this method are defined in ECMA-402; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.</p>
@@ -41787,7 +41787,7 @@ THH:mm:ss.sss
 
       <emu-clause id="sec-array.prototype.tolocalestring" type="built-in function">
         <h1>Array.prototype.toLocaleString ( [ _reserved1_ [ , _reserved2_ ] ] )</h1>
-        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in ECMA-402. If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used.</p>
+        <p>An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in ECMA-402. Otherwise, the following specification of this method is used.</p>
         <emu-note>
           <p>The first edition of ECMA-402 did not include a replacement specification for this method.</p>
         </emu-note>


### PR DESCRIPTION
Refer to "ECMA-402", not "the ECMA-402 specification" throughout, as per https://github.com/tc39/ecma262/pull/3759#discussion_r3430123796

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)
* [WebAssembly](https://webassembly.github.io/spec/) - [file an issue](https://github.com/WebAssembly/spec/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
