### PR TITLE
Editorial: Introduce "epoch nanoseconds count" definition

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -34068,9 +34068,12 @@
         <emu-eqn id="eqn-msPerMinute" aoid="msPerMinute">msPerMinute = 60000 = msPerSecond × SecondsPerMinute</emu-eqn>
         <emu-eqn id="eqn-msPerHour" aoid="msPerHour">msPerHour = 3600000 = msPerMinute × MinutesPerHour</emu-eqn>
         <emu-eqn id="eqn-msPerDay" aoid="msPerDay">msPerDay = 86400000 = msPerHour × HoursPerDay</emu-eqn>
+        <emu-eqn id="eqn-NanosecondsPerDay" aoid="NanosecondsPerDay">NanosecondsPerDay = 10<sup>6</sup> × msPerDay = 8.64 × 10<sup>13</sup></emu-eqn>
         <emu-eqn id="eqn-nsPerSecond" aoid="nsPerSecond">nsPerSecond = 10<sup>6</sup> × msPerSecond = 10<sup>9</sup></emu-eqn>
         <emu-eqn id="eqn-nsPerMillisecond" aoid="nsPerMillisecond">nsPerMillisecond = 10<sup>6</sup></emu-eqn>
         <emu-eqn id="eqn-nsPerMicrosecond" aoid="nsPerMicrosecond">nsPerMicrosecond = 10<sup>3</sup></emu-eqn>
+        <emu-eqn id="eqn-MaxEpochNanoseconds" aoid="MaxEpochNanoseconds">MaxEpochNanoseconds = 10<sup>8</sup> × NanosecondsPerDay = 8.64 × 10<sup>21</sup></emu-eqn>
+        <emu-eqn id="eqn-MinEpochNanoseconds" aoid="MinEpochNanoseconds">MinEpochNanoseconds = -MaxEpochNanoseconds = -8.64 × 10<sup>21</sup></emu-eqn>
       </emu-clause>
 
       <emu-clause id="sec-day" type="abstract operation" oldids="eqn-Day,sec-day-number-and-time-within-day">
@@ -34319,6 +34322,14 @@
         </emu-alg>
       </emu-clause>
 
+      <emu-clause id="sec-epoch-nanoseconds">
+        <h1>Epoch Nanoseconds and Range</h1>
+
+        <p>An <dfn variants="epoch nanoseconds counts">epoch nanoseconds count</dfn> is an integer that represents an instant in time to nanosecond precision. It supports the same range as a time value but expressed in nanoseconds, from MinEpochNanoseconds to MaxEpochNanoseconds. There is no nanosecond equivalent of the time value *NaN*; there is no representation for no specific instant.</p>
+
+        <p>The exact moment of midnight at the beginning of 1 January 1970 UTC is represented by the value 0. The maximum value is MaxEpochNanoseconds, and the minimum value is MinEpochNanoseconds.</p>
+      </emu-clause>
+
       <emu-clause id="sec-getutcepochnanoseconds" type="abstract operation">
         <h1>
           GetUTCEpochNanoseconds (
@@ -34331,18 +34342,18 @@
             _millisecond_: an integer in the inclusive interval from 0 to 999,
             _microsecond_: an integer in the inclusive interval from 0 to 999,
             _nanosecond_: an integer in the inclusive interval from 0 to 999,
-          ): a BigInt
+          ): an epoch nanoseconds count
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>The returned value represents a number of nanoseconds since the epoch that corresponds to the given ISO 8601 calendar date and wall-clock time in UTC.</dd>
+          <dd>The returned value is the epoch nanoseconds count that corresponds to the given ISO 8601 calendar date and wall-clock time in UTC.</dd>
         </dl>
         <emu-alg>
           1. Let _date_ be MakeDay(𝔽(_year_), 𝔽(_month_ - 1), 𝔽(_day_)).
           1. Let _time_ be MakeTime(𝔽(_hour_), 𝔽(_minute_), 𝔽(_second_), 𝔽(_millisecond_)).
           1. Let _ms_ be MakeDate(_date_, _time_).
           1. Assert: _ms_ is an integral Number.
-          1. Return ℤ(ℝ(_ms_) × nsPerMillisecond + _microsecond_ × nsPerMicrosecond + _nanosecond_).
+          1. Return ℝ(_ms_) × nsPerMillisecond + _microsecond_ × nsPerMicrosecond + _nanosecond_.
         </emu-alg>
       </emu-clause>
 
@@ -34385,12 +34396,12 @@
             _millisecond_: an integer in the inclusive interval from 0 to 999,
             _microsecond_: an integer in the inclusive interval from 0 to 999,
             _nanosecond_: an integer in the inclusive interval from 0 to 999,
-          ): a List of BigInts
+          ): a List of epoch nanoseconds counts
         </h1>
         <dl class="header">
           <dt>description</dt>
           <dd>
-            Each value in the returned List represents a number of nanoseconds since the epoch that corresponds to the given ISO 8601 calendar date and wall-clock time in the named time zone identified by _timeZoneIdentifier_.
+            Each value in the returned List represents an epoch nanoseconds count that corresponds to the given ISO 8601 calendar date and wall-clock time in the named time zone identified by _timeZoneIdentifier_.
           </dd>
         </dl>
         <p>
@@ -34415,12 +34426,12 @@
         <h1>
           GetNamedTimeZoneOffsetNanoseconds (
             _timeZoneIdentifier_: a String,
-            _epochNanoseconds_: a BigInt,
+            _epochNanoseconds_: an epoch nanoseconds count,
           ): an integer
         </h1>
         <dl class="header">
         </dl>
-        <p>The returned integer represents the offset from UTC of the named time zone identified by _timeZoneIdentifier_, at the instant corresponding with _epochNanoseconds_ relative to the epoch, both in nanoseconds.</p>
+        <p>The returned integer represents the offset from UTC, in nanoseconds, of the named time zone identified by _timeZoneIdentifier_, at the instant corresponding with the epoch nanoseconds count _epochNanoseconds_.</p>
         <p>The default implementation of GetNamedTimeZoneOffsetNanoseconds, to be used for ECMAScript implementations that do not include local political rules for any time zones, performs the following steps when called:</p>
         <emu-alg>
           1. Assert: _timeZoneIdentifier_ is *"UTC"*.
@@ -34533,7 +34544,7 @@
           1. If IsTimeZoneOffsetString(_systemTimeZoneIdentifier_) is *true*, then
             1. Let _offsetNs_ be ParseTimeZoneOffsetString(_systemTimeZoneIdentifier_).
           1. Else,
-            1. Let _offsetNs_ be GetNamedTimeZoneOffsetNanoseconds(_systemTimeZoneIdentifier_, ℤ(ℝ(_tv_) × nsPerMillisecond)).
+            1. Let _offsetNs_ be GetNamedTimeZoneOffsetNanoseconds(_systemTimeZoneIdentifier_, ℝ(_tv_) × nsPerMillisecond).
           1. Let _offsetMs_ be truncate(_offsetNs_ / nsPerMillisecond).
           1. Return _tv_ + 𝔽(_offsetMs_).
         </emu-alg>
@@ -35960,7 +35971,7 @@ THH:mm:ss.sss
             1. If IsTimeZoneOffsetString(_systemTimeZoneIdentifier_) is *true*, then
               1. Let _offsetNs_ be ParseTimeZoneOffsetString(_systemTimeZoneIdentifier_).
             1. Else,
-              1. Let _offsetNs_ be GetNamedTimeZoneOffsetNanoseconds(_systemTimeZoneIdentifier_, ℤ(ℝ(_tv_) × nsPerMillisecond)).
+              1. Let _offsetNs_ be GetNamedTimeZoneOffsetNanoseconds(_systemTimeZoneIdentifier_, ℝ(_tv_) × nsPerMillisecond).
             1. Let _offset_ be truncate(_offsetNs_ / nsPerMillisecond).
             1. If _offset_ ≥ 0, then
               1. Let _offsetSign_ be *"+"*.


### PR DESCRIPTION
For exact times expressed in nanoseconds since the Unix epoch, use the term "epoch nanoseconds count" and the alias _epochNanoseconds_. Do not use BigInt for this type anymore.

The definition text is similar to the text that will be introduced in the Temporal section in #3759, but without any direct reference to Temporal objects.

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)
* [WebAssembly](https://webassembly.github.io/spec/) - [file an issue](https://github.com/WebAssembly/spec/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
