### PR TITLE
Editorial: Write out offsetNanoseconds and offsetMilliseconds

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -34552,11 +34552,11 @@
         <emu-alg>
           1. Let _systemTimeZoneIdentifier_ be SystemTimeZoneIdentifier().
           1. If IsTimeZoneOffsetString(_systemTimeZoneIdentifier_) is *true*, then
-            1. Let _offsetNs_ be ParseTimeZoneOffsetString(_systemTimeZoneIdentifier_).
+            1. Let _offsetNanoseconds_ be ParseTimeZoneOffsetString(_systemTimeZoneIdentifier_).
           1. Else,
-            1. Let _offsetNs_ be GetNamedTimeZoneOffsetNanoseconds(_systemTimeZoneIdentifier_, ℤ(ℝ(_tv_) × nsPerMillisecond)).
-          1. Let _offsetMs_ be truncate(_offsetNs_ / nsPerMillisecond).
-          1. Return _tv_ + 𝔽(_offsetMs_).
+            1. Let _offsetNanoseconds_ be GetNamedTimeZoneOffsetNanoseconds(_systemTimeZoneIdentifier_, ℤ(ℝ(_tv_) × nsPerMillisecond)).
+          1. Let _offsetMilliseconds_ be truncate(_offsetNanoseconds_ / nsPerMillisecond).
+          1. Return _tv_ + 𝔽(_offsetMilliseconds_).
         </emu-alg>
         <emu-note>
           <p>If political rules for the local time _tv_ are not available within the implementation, the result is _tv_ because SystemTimeZoneIdentifier returns *"UTC"* and GetNamedTimeZoneOffsetNanoseconds returns 0.</p>
@@ -34587,7 +34587,7 @@
           1. If _t_ is not finite, return *NaN*.
           1. Let _systemTimeZoneIdentifier_ be SystemTimeZoneIdentifier().
           1. If IsTimeZoneOffsetString(_systemTimeZoneIdentifier_) is *true*, then
-            1. Let _offsetNs_ be ParseTimeZoneOffsetString(_systemTimeZoneIdentifier_).
+            1. Let _offsetNanoseconds_ be ParseTimeZoneOffsetString(_systemTimeZoneIdentifier_).
           1. Else,
             1. Let _possibleInstants_ be GetNamedTimeZoneEpochNanoseconds(_systemTimeZoneIdentifier_, YearFromTime(_t_), MonthFromTime(_t_) + 1, DateFromTime(_t_), HourFromTime(_t_), MinFromTime(_t_), SecFromTime(_t_), MillisecFromTime(_t_), 0, 0).
             1. NOTE: The following steps ensure that when _t_ represents local time repeating multiple times at a negative time zone transition (e.g. when the daylight saving time ends or the time zone offset is decreased due to a time zone rule change) or skipped local time at a positive time zone transition (e.g. when the daylight saving time starts or the time zone offset is increased due to a time zone rule change), _t_ is interpreted using the time zone offset before the transition.
@@ -34597,9 +34597,9 @@
               1. NOTE: _t_ represents a local time skipped at a positive time zone transition (e.g. due to daylight saving time starting or a time zone rule change increasing the UTC offset).
               1. [declared="tBefore"] Let _possibleInstantsBefore_ be GetNamedTimeZoneEpochNanoseconds(_systemTimeZoneIdentifier_, YearFromTime(_tBefore_), MonthFromTime(_tBefore_) + 1, DateFromTime(_tBefore_), HourFromTime(_tBefore_), MinFromTime(_tBefore_), SecFromTime(_tBefore_), MillisecFromTime(_tBefore_), 0, 0), where _tBefore_ is the largest integral Number &lt; _t_ for which _possibleInstantsBefore_ is not empty (i.e., _tBefore_ represents the last local time before the transition).
               1. Let _disambiguatedInstant_ be the last element of _possibleInstantsBefore_.
-            1. Let _offsetNs_ be GetNamedTimeZoneOffsetNanoseconds(_systemTimeZoneIdentifier_, _disambiguatedInstant_).
-          1. Let _offsetMs_ be truncate(_offsetNs_ / nsPerMillisecond).
-          1. Return _t_ - 𝔽(_offsetMs_).
+            1. Let _offsetNanoseconds_ be GetNamedTimeZoneOffsetNanoseconds(_systemTimeZoneIdentifier_, _disambiguatedInstant_).
+          1. Let _offsetMilliseconds_ be truncate(_offsetNanoseconds_ / nsPerMillisecond).
+          1. Return _t_ - 𝔽(_offsetMilliseconds_).
         </emu-alg>
         <p>
           Input _t_ is nominally a time value but may be any Number value.
@@ -34612,11 +34612,11 @@
           <p>It is required for time zone aware implementations (and recommended for all others) to use the time zone information of the IANA Time Zone Database <a href="https://www.iana.org/time-zones/">https://www.iana.org/time-zones/</a>.</p>
           <p>
             1:30 AM on 5 November 2017 in America/New_York is repeated twice (fall backward), but it must be interpreted as 1:30 AM UTC-04 instead of 1:30 AM UTC-05.
-            In UTC(TimeClip(MakeDate(MakeDay(2017, 10, 5), MakeTime(1, 30, 0, 0)))), the value of _offsetMs_ is <emu-eqn>-4 × msPerHour</emu-eqn>.
+            In UTC(TimeClip(MakeDate(MakeDay(2017, 10, 5), MakeTime(1, 30, 0, 0)))), the value of _offsetMilliseconds_ is <emu-eqn>-4 × msPerHour</emu-eqn>.
           </p>
           <p>
             2:30 AM on 12 March 2017 in America/New_York does not exist, but it must be interpreted as 2:30 AM UTC-05 (equivalent to 3:30 AM UTC-04).
-            In UTC(TimeClip(MakeDate(MakeDay(2017, 2, 12), MakeTime(2, 30, 0, 0)))), the value of _offsetMs_ is <emu-eqn>-5 × msPerHour</emu-eqn>.
+            In UTC(TimeClip(MakeDate(MakeDay(2017, 2, 12), MakeTime(2, 30, 0, 0)))), the value of _offsetMilliseconds_ is <emu-eqn>-5 × msPerHour</emu-eqn>.
           </p>
         </emu-note>
         <emu-note>
@@ -35979,18 +35979,18 @@ THH:mm:ss.sss
           <emu-alg>
             1. Let _systemTimeZoneIdentifier_ be SystemTimeZoneIdentifier().
             1. If IsTimeZoneOffsetString(_systemTimeZoneIdentifier_) is *true*, then
-              1. Let _offsetNs_ be ParseTimeZoneOffsetString(_systemTimeZoneIdentifier_).
+              1. Let _offsetNanoseconds_ be ParseTimeZoneOffsetString(_systemTimeZoneIdentifier_).
             1. Else,
-              1. Let _offsetNs_ be GetNamedTimeZoneOffsetNanoseconds(_systemTimeZoneIdentifier_, ℤ(ℝ(_tv_) × nsPerMillisecond)).
-            1. Let _offset_ be truncate(_offsetNs_ / nsPerMillisecond).
-            1. If _offset_ ≥ 0, then
+              1. Let _offsetNanoseconds_ be GetNamedTimeZoneOffsetNanoseconds(_systemTimeZoneIdentifier_, ℤ(ℝ(_tv_) × nsPerMillisecond)).
+            1. Let _offsetMilliseconds_ be truncate(_offsetNanoseconds_ / nsPerMillisecond).
+            1. If _offsetMilliseconds_ ≥ 0, then
               1. Let _offsetSign_ be *"+"*.
-              1. Let _absOffset_ be _offset_.
+              1. Let _absOffsetMilliseconds_ be _offsetMilliseconds_.
             1. Else,
               1. Let _offsetSign_ be *"-"*.
-              1. Let _absOffset_ be -_offset_.
-            1. Let _offsetMin_ be ToZeroPaddedDecimalString(MinFromTime(𝔽(_absOffset_)), 2).
-            1. Let _offsetHour_ be ToZeroPaddedDecimalString(HourFromTime(𝔽(_absOffset_)), 2).
+              1. Let _absOffsetMilliseconds_ be -_offsetMilliseconds_.
+            1. Let _offsetMin_ be ToZeroPaddedDecimalString(MinFromTime(𝔽(_absOffsetMilliseconds_)), 2).
+            1. Let _offsetHour_ be ToZeroPaddedDecimalString(HourFromTime(𝔽(_absOffsetMilliseconds_)), 2).
             1. Let _tzName_ be an implementation-defined string that is either the empty String or the string-concatenation of the code unit 0x0020 (SPACE), the code unit 0x0028 (LEFT PARENTHESIS), an implementation-defined timezone name, and the code unit 0x0029 (RIGHT PARENTHESIS).
             1. Return the string-concatenation of _offsetSign_, _offsetHour_, _offsetMin_, and _tzName_.
           </emu-alg>


### PR DESCRIPTION
Instead of offsetNs and offsetMs, write out nanoseconds and milliseconds.

"ns" and "ms" are still used in the names of the constants msPerDay, nsPerMinute, etc., and the Date methods still use _ms_ as an alias. These seem fine in context.

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)
* [WebAssembly](https://webassembly.github.io/spec/) - [file an issue](https://github.com/WebAssembly/spec/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
