### PR TITLE
Editorial: Add SnapToInteger to handle finite-only integer conversion

### DIFF
--- a/esmeta-ignore.json
+++ b/esmeta-ignore.json
@@ -9,5 +9,6 @@
   "FunctionDeclarationInstantiation",
   "GetViewByteLength",
   "Record[SourceTextModuleRecord].ExecuteModule",
+  "SnapToInteger",
   "TypedArrayLength"
 ]

--- a/spec.html
+++ b/spec.html
@@ -5335,6 +5335,31 @@
       </emu-note>
     </emu-clause>
 
+    <emu-clause id="sec-snaptointeger" type="abstract operation">
+      <h1>
+        SnapToInteger (
+          _arg_: an ECMAScript language value,
+          _nonIntHandling_: ~reject~ or ~truncate~,
+          optional _minimum_: an integer,
+          optional _maximum_: an integer,
+        ): either a normal completion containing an integer or a throw completion
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It converts _arg_ to an integer representing its Number value, rejecting a non-finite value and handling a finite non-<emu-xref href="#integral-number">integral</emu-xref> value by either rejecting or truncating it, and optionally imposes inclusive constraining bounds.</dd>
+      </dl>
+      <emu-alg>
+        1. Let _number_ be ? ToNumber(_arg_).
+        1. If _number_ is one of *NaN*, *+∞*<sub>𝔽</sub>, or *-∞*<sub>𝔽</sub>, throw a *RangeError* exception.
+        1. Let _mv_ be ℝ(_number_).
+        1. If _nonIntHandling_ is ~truncate~, set _mv_ to truncate(_mv_).
+        1. If _mv_ is not an integer, throw a *RangeError* exception.
+        1. If _minimum_ is present and _mv_ &lt; _minimum_, throw a *RangeError* exception.
+        1. If _maximum_ is present and _mv_ > _maximum_, throw a *RangeError* exception.
+        1. Return _mv_.
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-tofixedsizeinteger" type="abstract operation">
       <h1>
         ToFixedSizeInteger (
@@ -33176,8 +33201,7 @@
         <emu-alg>
           1. Let _x_ be ? ThisNumberValue(*this* value).
           1. If _radix_ is *undefined*, let _radixMV_ be 10.
-          1. Else, let _radixMV_ be ? ToIntegerOrInfinity(_radix_).
-          1. If _radixMV_ is not in the inclusive interval from 2 to 36, throw a *RangeError* exception.
+          1. Else, let _radixMV_ be ? SnapToInteger(_radix_, ~truncate~, 2, 36).
           1. Return Number::toString(_x_, _radixMV_).
         </emu-alg>
         <p>This method is not generic; it throws a *TypeError* exception if its *this* value is not a Number or a Number object. Therefore, it cannot be transferred to other kinds of objects for use as a method.</p>
@@ -33324,8 +33348,7 @@
         <emu-alg>
           1. Let _x_ be ? ThisBigIntValue(*this* value).
           1. If _radix_ is *undefined*, let _radixMV_ be 10.
-          1. Else, let _radixMV_ be ? ToIntegerOrInfinity(_radix_).
-          1. If _radixMV_ is not in the inclusive interval from 2 to 36, throw a *RangeError* exception.
+          1. Else, let _radixMV_ be ? SnapToInteger(_radix_, ~truncate~, 2, 36).
           1. Return BigInt::toString(_x_, _radixMV_).
         </emu-alg>
         <p>This method is not generic; it throws a *TypeError* exception if its *this* value is not a BigInt or a BigInt object. Therefore, it cannot be transferred to other kinds of objects for use as a method.</p>


### PR DESCRIPTION
SnapToInteger will be used extensively in Temporal but there are two call sites where it could already be introduced in the spec.

https://github.com/tc39/proposal-amount/pull/94#pullrequestreview-4051540906 for the initial suggestion of SnapToInteger. (Note _mode_ has been renamed to _nonIntegerHandling_, `~strict~` to `~reject~`, and `~truncate-strict~` to `~truncate~`.

It'd be possible to introduce the third mode (`~loose~`, or maybe more descriptively renamed to `~truncate-accept-nan~`) mentioned in that comment and use this operation in more places, but I've left that for a followup for now.

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)
* [WebAssembly](https://webassembly.github.io/spec/) - [file an issue](https://github.com/WebAssembly/spec/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
