### PR TITLE
Editorial: rename genContext to calleeContext in RunCallerContext

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -12415,13 +12415,13 @@
         <dd>It resumes the caller context (passing it _value_ as the resumption value), and waits for the result, if any.</dd>
       </dl>
       <emu-alg>
-        1. Let _genContext_ be the running execution context.
-        1. Remove _genContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
+        1. Let _calleeContext_ be the running execution context.
+        1. Remove _calleeContext_ from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
         1. Let _callerContext_ be the running execution context.
         1. Resume _callerContext_, passing NormalCompletion(_value_).
-        1. NOTE: The above step transfers control to _callerContext_ and pauses. The only way for it to un-pause and have control proceed to the subsequent steps in this algorithm is for _genContext_ to be resumed again, which might never happen.
-        1. Assert: _genContext_ is the running execution context.
-        1. Let _result_ be the Completion Record with which _genContext_ was just resumed.
+        1. NOTE: The above step transfers control to _callerContext_ and pauses. The only way for it to un-pause and have control proceed to the subsequent steps in this algorithm is for _calleeContext_ to be resumed again, which might never happen.
+        1. Assert: _calleeContext_ is the running execution context.
+        1. Let _result_ be the Completion Record with which _calleeContext_ was just resumed.
         1. Return Completion(_result_).
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
The [running execution context in `RunCallerContext`](https://tc39.es/ecma262/#sec-runcallercontext) (step 1) is named `genContext`, even though `RunCallerContext` is also called from `Await`, so the context can also be just a normal async function rather than a generator, which makes the current name a bit confusing in my opinion. This pr renames it to `calleeContext`.