### PR TITLE
Editorial: Write out names for time quantities in full, and regularize

### DIFF
--- a/esmeta-ignore.json
+++ b/esmeta-ignore.json
@@ -8,6 +8,10 @@
   "FunctionBody[0,0].EvaluateFunctionBody",
   "FunctionDeclarationInstantiation",
   "GetViewByteLength",
+  "INTRINSICS.Date.prototype.setHours",
+  "INTRINSICS.Date.prototype.setMonth",
+  "INTRINSICS.Date.prototype.setUTCHours",
+  "INTRINSICS.Date.prototype.setUTCMonth",
   "Record[SourceTextModuleRecord].ExecuteModule",
   "TypedArrayLength"
 ]

--- a/spec.html
+++ b/spec.html
@@ -34072,7 +34072,7 @@
       <emu-clause id="sec-time-values-and-time-range">
         <h1>Time Values and Time Range</h1>
         <p>Time measurement in ECMAScript is analogous to time measurement in POSIX, in particular sharing definition in terms of the proleptic Gregorian calendar, an <dfn id="epoch">epoch</dfn> of midnight at the beginning of 1 January 1970 UTC, and an accounting of every day as comprising exactly 86,400 seconds (each of which is 1000 milliseconds long).</p>
-        <p>An ECMAScript <dfn variants="time values">time value</dfn> is a Number, either a finite integral Number representing an instant in time to millisecond precision or *NaN* representing no specific instant. A time value that is an integer multiple of msPerDay (i.e., is msPerDay × _d_ for some integer _d_) represents the instant at the start of the UTC day that follows the epoch by _d_ whole UTC days (preceding the epoch for negative _d_). Every other finite time value _tv_ is defined relative to the greatest preceding time value _s_ that is such a multiple, and represents the instant that occurs within the same UTC day as _s_ but follows it by (_tv_ - _s_) milliseconds.</p>
+        <p>An ECMAScript <dfn variants="time values">time value</dfn> is a Number, either a finite integral Number representing an instant in time to millisecond precision or *NaN* representing no specific instant. A time value that is an integer multiple of MillisecondsPerDay (i.e., is MillisecondsPerDay × _d_ for some integer _d_) represents the instant at the start of the UTC day that follows the epoch by _d_ whole UTC days (preceding the epoch for negative _d_). Every other finite time value _tv_ is defined relative to the greatest preceding time value _s_ that is such a multiple, and represents the instant that occurs within the same UTC day as _s_ but follows it by (_tv_ - _s_) milliseconds.</p>
         <p>Time values do not account for UTC leap seconds—there are no time values representing instants within positive leap seconds, and there are time values representing instants removed from the UTC timeline by negative leap seconds. However, the definition of time values nonetheless yields piecewise alignment with UTC, with discontinuities only at leap second boundaries and zero difference outside of leap seconds.</p>
         <p>A Number can exactly represent all integers from -9,007,199,254,740,992 to 9,007,199,254,740,992 (<emu-xref href="#sec-number.min_safe_integer"></emu-xref> and <emu-xref href="#sec-number.max_safe_integer"></emu-xref>). A time value supports a slightly smaller range of -8,640,000,000,000,000 to 8,640,000,000,000,000 milliseconds. This yields a supported time value range of exactly -100,000,000 days to 100,000,000 days relative to midnight at the beginning of 1 January 1970 UTC.</p>
         <p>The exact moment of midnight at the beginning of 1 January 1970 UTC is represented by the time value *+0*<sub>𝔽</sub>.</p>
@@ -34088,14 +34088,14 @@
         <emu-eqn id="eqn-HoursPerDay" aoid="HoursPerDay">HoursPerDay = 24</emu-eqn>
         <emu-eqn id="eqn-MinutesPerHour" aoid="MinutesPerHour">MinutesPerHour = 60</emu-eqn>
         <emu-eqn id="eqn-SecondsPerMinute" aoid="SecondsPerMinute">SecondsPerMinute = 60</emu-eqn>
-        <emu-eqn id="eqn-msPerSecond" aoid="msPerSecond">msPerSecond = 1000</emu-eqn>
-        <emu-eqn id="eqn-msPerMinute" aoid="msPerMinute">msPerMinute = 60000 = msPerSecond × SecondsPerMinute</emu-eqn>
-        <emu-eqn id="eqn-msPerHour" aoid="msPerHour">msPerHour = 3600000 = msPerMinute × MinutesPerHour</emu-eqn>
-        <emu-eqn id="eqn-msPerDay" aoid="msPerDay">msPerDay = 86400000 = msPerHour × HoursPerDay</emu-eqn>
-        <emu-eqn id="eqn-NanosecondsPerDay" aoid="NanosecondsPerDay">NanosecondsPerDay = 10<sup>6</sup> × msPerDay = 8.64 × 10<sup>13</sup></emu-eqn>
-        <emu-eqn id="eqn-nsPerSecond" aoid="nsPerSecond">nsPerSecond = 10<sup>6</sup> × msPerSecond = 10<sup>9</sup></emu-eqn>
-        <emu-eqn id="eqn-nsPerMillisecond" aoid="nsPerMillisecond">nsPerMillisecond = 10<sup>6</sup></emu-eqn>
-        <emu-eqn id="eqn-nsPerMicrosecond" aoid="nsPerMicrosecond">nsPerMicrosecond = 10<sup>3</sup></emu-eqn>
+        <emu-eqn id="eqn-MillisecondsPerSecond" oldids="eqn-msPerSecond" aoid="MillisecondsPerSecond">MillisecondsPerSecond = 1000</emu-eqn>
+        <emu-eqn id="eqn-MillisecondsPerMinute" oldids="eqn-msPerMinute" aoid="MillisecondsPerMinute">MillisecondsPerMinute = 60000 = MillisecondsPerSecond × SecondsPerMinute</emu-eqn>
+        <emu-eqn id="eqn-MillisecondsPerHour" oldids="eqn-msPerHour" aoid="MillisecondsPerHour">MillisecondsPerHour = 3600000 = MillisecondsPerMinute × MinutesPerHour</emu-eqn>
+        <emu-eqn id="eqn-MillisecondsPerDay" oldids="eqn-msPerDay" aoid="MillisecondsPerDay">MillisecondsPerDay = 86400000 = MillisecondsPerHour × HoursPerDay</emu-eqn>
+        <emu-eqn id="eqn-NanosecondsPerDay" aoid="NanosecondsPerDay">NanosecondsPerDay = 10<sup>6</sup> × MillisecondsPerDay = 8.64 × 10<sup>13</sup></emu-eqn>
+        <emu-eqn id="eqn-NanosecondsPerSecond" oldids="eqn-nsPerSecond" aoid="NanosecondsPerSecond">NanosecondsPerSecond = 10<sup>6</sup> × MillisecondsPerSecond = 10<sup>9</sup></emu-eqn>
+        <emu-eqn id="eqn-NanosecondsPerMillisecond" oldids="eqn-nsPerMillisecond" aoid="NanosecondsPerMillisecond">NanosecondsPerMillisecond = 10<sup>6</sup></emu-eqn>
+        <emu-eqn id="eqn-NanosecondsPerMicrosecond" oldids="eqn-nsPerMicrosecond" aoid="NanosecondsPerMicrosecond">NanosecondsPerMicrosecond = 10<sup>3</sup></emu-eqn>
         <emu-eqn id="eqn-MaxEpochNanoseconds" aoid="MaxEpochNanoseconds">MaxEpochNanoseconds = 10<sup>8</sup> × NanosecondsPerDay = 8.64 × 10<sup>21</sup></emu-eqn>
         <emu-eqn id="eqn-MinEpochNanoseconds" aoid="MinEpochNanoseconds">MinEpochNanoseconds = -MaxEpochNanoseconds = -8.64 × 10<sup>21</sup></emu-eqn>
       </emu-clause>
@@ -34111,7 +34111,7 @@
           <dd>It returns the day number of the day in which _tv_ falls.</dd>
         </dl>
         <emu-alg>
-          1. Return floor(ℝ(_tv_) / msPerDay).
+          1. Return floor(ℝ(_tv_) / MillisecondsPerDay).
         </emu-alg>
       </emu-clause>
 
@@ -34119,14 +34119,14 @@
         <h1>
           TimeWithinDay (
             _tv_: a finite time value,
-          ): an integer in the interval from 0 (inclusive) to msPerDay (exclusive)
+          ): an integer in the interval from 0 (inclusive) to MillisecondsPerDay (exclusive)
         </h1>
         <dl class="header">
           <dt>description</dt>
           <dd>It returns the number of milliseconds since the start of the day in which _tv_ falls.</dd>
         </dl>
         <emu-alg>
-          1. Return ℝ(_tv_) modulo msPerDay.
+          1. Return ℝ(_tv_) modulo MillisecondsPerDay.
         </emu-alg>
       </emu-clause>
 
@@ -34161,7 +34161,7 @@
           <dd>It returns the time value of the start of year _y_.</dd>
         </dl>
         <emu-alg>
-          1. Return 𝔽(msPerDay × DayFromYear(_y_)).
+          1. Return 𝔽(MillisecondsPerDay × DayFromYear(_y_)).
         </emu-alg>
       </emu-clause>
 
@@ -34297,13 +34297,13 @@
           <dd>It returns the hour of the day in which _tv_ falls.</dd>
         </dl>
         <emu-alg>
-          1. Return floor(ℝ(_tv_) / msPerHour) modulo HoursPerDay.
+          1. Return floor(ℝ(_tv_) / MillisecondsPerHour) modulo HoursPerDay.
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-minfromtime" type="abstract operation" oldids="eqn-MinFromTime">
+      <emu-clause id="sec-minutefromtime" type="abstract operation" oldids="eqn-MinFromTime,sec-minfromtime">
         <h1>
-          MinFromTime (
+          MinuteFromTime (
             _tv_: a finite time value,
           ): an integer in the inclusive interval from 0 to 59
         </h1>
@@ -34312,13 +34312,13 @@
           <dd>It returns the minute of the hour in which _tv_ falls.</dd>
         </dl>
         <emu-alg>
-          1. Return floor(ℝ(_tv_) / msPerMinute) modulo MinutesPerHour.
+          1. Return floor(ℝ(_tv_) / MillisecondsPerMinute) modulo MinutesPerHour.
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-secfromtime" type="abstract operation" oldids="eqn-SecFromTime">
+      <emu-clause id="sec-secondfromtime" type="abstract operation" oldids="eqn-SecFromTime,sec-secfromtime">
         <h1>
-          SecFromTime (
+          SecondFromTime (
             _tv_: a finite time value,
           ): an integer in the inclusive interval from 0 to 59
         </h1>
@@ -34327,13 +34327,13 @@
           <dd>It returns the second of the minute in which _tv_ falls.</dd>
         </dl>
         <emu-alg>
-          1. Return floor(ℝ(_tv_) / msPerSecond) modulo SecondsPerMinute.
+          1. Return floor(ℝ(_tv_) / MillisecondsPerSecond) modulo SecondsPerMinute.
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-millisecfromtime" type="abstract operation" oldids="sec-msfromtime,eqn-msFromTime">
+      <emu-clause id="sec-millisecondfromtime" type="abstract operation" oldids="sec-msfromtime,eqn-msFromTime,sec-millisecfromtime">
         <h1>
-          MillisecFromTime (
+          MillisecondFromTime (
             _tv_: a finite time value,
           ): an integer in the inclusive interval from 0 to 999
         </h1>
@@ -34342,7 +34342,7 @@
           <dd>It returns the millisecond of the second in which _tv_ falls.</dd>
         </dl>
         <emu-alg>
-          1. Return ℝ(_tv_) modulo msPerSecond.
+          1. Return ℝ(_tv_) modulo MillisecondsPerSecond.
         </emu-alg>
       </emu-clause>
 
@@ -34375,9 +34375,9 @@
         <emu-alg>
           1. Let _date_ be MakeDay(𝔽(_year_), 𝔽(_month_ - 1), 𝔽(_day_)).
           1. Let _time_ be MakeTime(𝔽(_hour_), 𝔽(_minute_), 𝔽(_second_), 𝔽(_millisecond_)).
-          1. Let _ms_ be MakeDate(_date_, _time_).
-          1. Assert: _ms_ is an integral Number.
-          1. Return ℝ(_ms_) × nsPerMillisecond + _microsecond_ × nsPerMicrosecond + _nanosecond_.
+          1. Let _epochMilliseconds_ be MakeDate(_date_, _time_).
+          1. Assert: _epochMilliseconds_ is an integral Number.
+          1. Return ℝ(_epochMilliseconds_) × NanosecondsPerMillisecond + _microsecond_ × NanosecondsPerMicrosecond + _nanosecond_.
         </emu-alg>
       </emu-clause>
 
@@ -34566,11 +34566,11 @@
         <emu-alg>
           1. Let _systemTimeZoneIdentifier_ be SystemTimeZoneIdentifier().
           1. If IsTimeZoneOffsetString(_systemTimeZoneIdentifier_) is *true*, then
-            1. Let _offsetNs_ be ParseTimeZoneOffsetString(_systemTimeZoneIdentifier_).
+            1. Let _offsetNanoseconds_ be ParseTimeZoneOffsetString(_systemTimeZoneIdentifier_).
           1. Else,
-            1. Let _offsetNs_ be GetNamedTimeZoneOffsetNanoseconds(_systemTimeZoneIdentifier_, ℝ(_tv_) × nsPerMillisecond).
-          1. Let _offsetMs_ be truncate(_offsetNs_ / nsPerMillisecond).
-          1. Return _tv_ + 𝔽(_offsetMs_).
+            1. Let _offsetNanoseconds_ be GetNamedTimeZoneOffsetNanoseconds(_systemTimeZoneIdentifier_, ℝ(_tv_) × NanosecondsPerMillisecond).
+          1. Let _offsetMilliseconds_ be truncate(_offsetNanoseconds_ / NanosecondsPerMillisecond).
+          1. Return _tv_ + 𝔽(_offsetMilliseconds_).
         </emu-alg>
         <emu-note>
           <p>If political rules for the local time _tv_ are not available within the implementation, the result is _tv_ because SystemTimeZoneIdentifier returns *"UTC"* and GetNamedTimeZoneOffsetNanoseconds returns 0.</p>
@@ -34601,19 +34601,19 @@
           1. If _t_ is not finite, return *NaN*.
           1. Let _systemTimeZoneIdentifier_ be SystemTimeZoneIdentifier().
           1. If IsTimeZoneOffsetString(_systemTimeZoneIdentifier_) is *true*, then
-            1. Let _offsetNs_ be ParseTimeZoneOffsetString(_systemTimeZoneIdentifier_).
+            1. Let _offsetNanoseconds_ be ParseTimeZoneOffsetString(_systemTimeZoneIdentifier_).
           1. Else,
-            1. Let _possibleInstants_ be GetNamedTimeZoneEpochNanoseconds(_systemTimeZoneIdentifier_, YearFromTime(_t_), MonthFromTime(_t_) + 1, DateFromTime(_t_), HourFromTime(_t_), MinFromTime(_t_), SecFromTime(_t_), MillisecFromTime(_t_), 0, 0).
+            1. Let _possibleInstants_ be GetNamedTimeZoneEpochNanoseconds(_systemTimeZoneIdentifier_, YearFromTime(_t_), MonthFromTime(_t_) + 1, DateFromTime(_t_), HourFromTime(_t_), MinuteFromTime(_t_), SecondFromTime(_t_), MillisecondFromTime(_t_), 0, 0).
             1. NOTE: The following steps ensure that when _t_ represents local time repeating multiple times at a negative time zone transition (e.g. when the daylight saving time ends or the time zone offset is decreased due to a time zone rule change) or skipped local time at a positive time zone transition (e.g. when the daylight saving time starts or the time zone offset is increased due to a time zone rule change), _t_ is interpreted using the time zone offset before the transition.
             1. If _possibleInstants_ is not empty, then
               1. Let _disambiguatedInstant_ be _possibleInstants_[0].
             1. Else,
               1. NOTE: _t_ represents a local time skipped at a positive time zone transition (e.g. due to daylight saving time starting or a time zone rule change increasing the UTC offset).
-              1. [declared="tBefore"] Let _possibleInstantsBefore_ be GetNamedTimeZoneEpochNanoseconds(_systemTimeZoneIdentifier_, YearFromTime(_tBefore_), MonthFromTime(_tBefore_) + 1, DateFromTime(_tBefore_), HourFromTime(_tBefore_), MinFromTime(_tBefore_), SecFromTime(_tBefore_), MillisecFromTime(_tBefore_), 0, 0), where _tBefore_ is the largest integral Number &lt; _t_ for which _possibleInstantsBefore_ is not empty (i.e., _tBefore_ represents the last local time before the transition).
+              1. [declared="tBefore"] Let _possibleInstantsBefore_ be GetNamedTimeZoneEpochNanoseconds(_systemTimeZoneIdentifier_, YearFromTime(_tBefore_), MonthFromTime(_tBefore_) + 1, DateFromTime(_tBefore_), HourFromTime(_tBefore_), MinuteFromTime(_tBefore_), SecondFromTime(_tBefore_), MillisecondFromTime(_tBefore_), 0, 0), where _tBefore_ is the largest integral Number &lt; _t_ for which _possibleInstantsBefore_ is not empty (i.e., _tBefore_ represents the last local time before the transition).
               1. Let _disambiguatedInstant_ be the last element of _possibleInstantsBefore_.
-            1. Let _offsetNs_ be GetNamedTimeZoneOffsetNanoseconds(_systemTimeZoneIdentifier_, _disambiguatedInstant_).
-          1. Let _offsetMs_ be truncate(_offsetNs_ / nsPerMillisecond).
-          1. Return _t_ - 𝔽(_offsetMs_).
+            1. Let _offsetNanoseconds_ be GetNamedTimeZoneOffsetNanoseconds(_systemTimeZoneIdentifier_, _disambiguatedInstant_).
+          1. Let _offsetMilliseconds_ be truncate(_offsetNanoseconds_ / NanosecondsPerMillisecond).
+          1. Return _t_ - 𝔽(_offsetMilliseconds_).
         </emu-alg>
         <p>
           Input _t_ is nominally a time value but may be any Number value.
@@ -34626,11 +34626,11 @@
           <p>It is required for time zone aware implementations (and recommended for all others) to use the time zone information of the <a href="https://www.iana.org/time-zones">IANA Time Zone Database</a>.</p>
           <p>
             1:30 AM on 5 November 2017 in America/New_York is repeated twice (fall backward), but it must be interpreted as 1:30 AM UTC-04 instead of 1:30 AM UTC-05.
-            In UTC(TimeClip(MakeDate(MakeDay(2017, 10, 5), MakeTime(1, 30, 0, 0)))), the value of _offsetMs_ is <emu-eqn>-4 × msPerHour</emu-eqn>.
+            In UTC(TimeClip(MakeDate(MakeDay(2017, 10, 5), MakeTime(1, 30, 0, 0)))), the value of _offsetMilliseconds_ is <emu-eqn>-4 × MillisecondsPerHour</emu-eqn>.
           </p>
           <p>
             2:30 AM on 12 March 2017 in America/New_York does not exist, but it must be interpreted as 2:30 AM UTC-05 (equivalent to 3:30 AM UTC-04).
-            In UTC(TimeClip(MakeDate(MakeDay(2017, 2, 12), MakeTime(2, 30, 0, 0)))), the value of _offsetMs_ is <emu-eqn>-5 × msPerHour</emu-eqn>.
+            In UTC(TimeClip(MakeDate(MakeDay(2017, 2, 12), MakeTime(2, 30, 0, 0)))), the value of _offsetMilliseconds_ is <emu-eqn>-5 × MillisecondsPerHour</emu-eqn>.
           </p>
         </emu-note>
         <emu-note>
@@ -34642,9 +34642,9 @@
         <h1>
           MakeTime (
             _hour_: a Number,
-            _min_: a Number,
-            _sec_: a Number,
-            _ms_: a Number,
+            _minute_: a Number,
+            _second_: a Number,
+            _millisecond_: a Number,
           ): a Number
         </h1>
         <dl class="header">
@@ -34652,12 +34652,12 @@
           <dd>It calculates a number of milliseconds.</dd>
         </dl>
         <emu-alg>
-          1. If _hour_ is not finite, _min_ is not finite, _sec_ is not finite, or _ms_ is not finite, return *NaN*.
-          1. Let _h_ be ! ToIntegerOrInfinity(_hour_).
-          1. Let _m_ be ! ToIntegerOrInfinity(_min_).
-          1. Let _s_ be ! ToIntegerOrInfinity(_sec_).
-          1. Let _milli_ be ! ToIntegerOrInfinity(_ms_).
-          1. Return ((𝔽(_h_) × 𝔽(msPerHour) + 𝔽(_m_) × 𝔽(msPerMinute)) + 𝔽(_s_) × 𝔽(msPerSecond)) + 𝔽(_milli_).
+          1. If _hour_ is not finite, _minute_ is not finite, _second_ is not finite, or _millisecond_ is not finite, return *NaN*.
+          1. Let _hourMV_ be ! ToIntegerOrInfinity(_hour_).
+          1. Let _minuteMV_ be ! ToIntegerOrInfinity(_minute_).
+          1. Let _secondMV_ be ! ToIntegerOrInfinity(_second_).
+          1. Let _millisecondMV_ be ! ToIntegerOrInfinity(_millisecond_).
+          1. Return ((𝔽(_hourMV_) × 𝔽(MillisecondsPerHour) + 𝔽(_minuteMV_) × 𝔽(MillisecondsPerMinute)) + 𝔽(_secondMV_) × 𝔽(MillisecondsPerSecond)) + 𝔽(_millisecondMV_).
         </emu-alg>
         <emu-note>
           <p>The arithmetic in MakeTime is floating-point arithmetic, which is not associative, so the operations must be performed in the correct order.</p>
@@ -34669,7 +34669,7 @@
           MakeDay (
             _year_: a Number,
             _month_: a Number,
-            _date_: a Number,
+            _day_: a Number,
           ): a finite Number or *NaN*
         </h1>
         <dl class="header">
@@ -34677,15 +34677,15 @@
           <dd>It calculates a number of days.</dd>
         </dl>
         <emu-alg>
-          1. If _year_ is not finite, _month_ is not finite, or _date_ is not finite, return *NaN*.
-          1. Let _y_ be ! ToIntegerOrInfinity(_year_).
-          1. Let _m_ be ! ToIntegerOrInfinity(_month_).
-          1. Let _dt_ be ! ToIntegerOrInfinity(_date_).
-          1. Let _ym_ be 𝔽(_y_) + 𝔽(floor(_m_ / 12)).
-          1. If _ym_ is not finite, return *NaN*.
-          1. Let _mn_ be _m_ modulo 12.
-          1. Find a finite time value _tv_ such that YearFromTime(_tv_) = ℝ(_ym_), MonthFromTime(_tv_) = _mn_, and DateFromTime(_tv_) = 1; but if this is not possible (because some argument is out of range), return *NaN*.
-          1. Return 𝔽(Day(_tv_)) + 𝔽(_dt_) - *1*<sub>𝔽</sub>.
+          1. If _year_ is not finite, _month_ is not finite, or _day_ is not finite, return *NaN*.
+          1. Let _yearMV_ be ! ToIntegerOrInfinity(_year_).
+          1. Let _monthMV_ be ! ToIntegerOrInfinity(_month_).
+          1. Let _dayMV_ be ! ToIntegerOrInfinity(_day_).
+          1. Let _balancedYear_ be 𝔽(_yearMV_) + 𝔽(floor(_monthMV_ / 12)).
+          1. If _balancedYear_ is not finite, return *NaN*.
+          1. Let _balancedMonthMV_ be _monthMV_ modulo 12.
+          1. Find a finite time value _tv_ such that YearFromTime(_tv_) = ℝ(_balancedYear_), MonthFromTime(_tv_) = _balancedMonthMV_, and DateFromTime(_tv_) = 1; but if this is not possible (because some argument is out of range), return *NaN*.
+          1. Return 𝔽(Day(_tv_)) + 𝔽(_dayMV_) - *1*<sub>𝔽</sub>.
         </emu-alg>
       </emu-clause>
 
@@ -34702,7 +34702,7 @@
         </dl>
         <emu-alg>
           1. If _day_ is not finite or _time_ is not finite, return *NaN*.
-          1. Let _tv_ be _day_ × 𝔽(msPerDay) + _time_.
+          1. Let _tv_ be _day_ × 𝔽(MillisecondsPerDay) + _time_.
           1. If _tv_ is not finite, return *NaN*.
           1. Return _tv_.
         </emu-alg>
@@ -35022,7 +35022,7 @@ THH:mm:ss.sss
               1. Let _fraction_ be the string-concatenation of CodePointsToString(_parsedFraction_) and *"000000000"*.
               1. Let _nanosecondsString_ be the substring of _fraction_ from 1 to 10.
               1. Let _nanoseconds_ be ℝ(StringToNumber(_nanosecondsString_)).
-            1. Return _sign_ × (((_hours_ × MinutesPerHour + _minutes_) × SecondsPerMinute + _seconds_) × nsPerSecond + _nanoseconds_).
+            1. Return _sign_ × (((_hours_ × MinutesPerHour + _minutes_) × SecondsPerMinute + _seconds_) × NanosecondsPerSecond + _nanoseconds_).
           </emu-alg>
         </emu-clause>
       </emu-clause>
@@ -35064,15 +35064,15 @@ THH:mm:ss.sss
             1. Let _dv_ be TimeClip(_tv_).
           1. Else,
             1. Assert: _numberOfArgs_ ≥ 2.
-            1. Let _y_ be ? ToNumber(_values_[0]).
-            1. Let _m_ be ? ToNumber(_values_[1]).
-            1. If _numberOfArgs_ > 2, let _dt_ be ? ToNumber(_values_[2]); else let _dt_ be *1*<sub>𝔽</sub>.
-            1. If _numberOfArgs_ > 3, let _h_ be ? ToNumber(_values_[3]); else let _h_ be *+0*<sub>𝔽</sub>.
-            1. If _numberOfArgs_ > 4, let _min_ be ? ToNumber(_values_[4]); else let _min_ be *+0*<sub>𝔽</sub>.
-            1. If _numberOfArgs_ > 5, let _s_ be ? ToNumber(_values_[5]); else let _s_ be *+0*<sub>𝔽</sub>.
-            1. If _numberOfArgs_ > 6, let _milli_ be ? ToNumber(_values_[6]); else let _milli_ be *+0*<sub>𝔽</sub>.
-            1. Let _yr_ be MakeFullYear(_y_).
-            1. Let _finalDate_ be MakeDate(MakeDay(_yr_, _m_, _dt_), MakeTime(_h_, _min_, _s_, _milli_)).
+            1. Let _yearNumber_ be ? ToNumber(_values_[0]).
+            1. Let _monthNumber_ be ? ToNumber(_values_[1]).
+            1. If _numberOfArgs_ > 2, let _dayNumber_ be ? ToNumber(_values_[2]); else let _dayNumber_ be *1*<sub>𝔽</sub>.
+            1. If _numberOfArgs_ > 3, let _hourNumber_ be ? ToNumber(_values_[3]); else let _hourNumber_ be *+0*<sub>𝔽</sub>.
+            1. If _numberOfArgs_ > 4, let _minuteNumber_ be ? ToNumber(_values_[4]); else let _minuteNumber_ be *+0*<sub>𝔽</sub>.
+            1. If _numberOfArgs_ > 5, let _secondNumber_ be ? ToNumber(_values_[5]); else let _secondNumber_ be *+0*<sub>𝔽</sub>.
+            1. If _numberOfArgs_ > 6, let _millisecondNumber_ be ? ToNumber(_values_[6]); else let _millisecondNumber_ be *+0*<sub>𝔽</sub>.
+            1. Set _yearNumber_ to MakeFullYear(_yearNumber_).
+            1. Let _finalDate_ be MakeDate(MakeDay(_yearNumber_, _monthNumber_, _dayNumber_), MakeTime(_hourNumber_, _minuteNumber_, _secondNumber_, _millisecondNumber_)).
             1. Let _dv_ be TimeClip(UTC(_finalDate_)).
           1. Let _obj_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Date.prototype%"*, « [[DateValue]] »).
           1. Set _obj_.[[DateValue]] to _dv_.
@@ -35120,18 +35120,18 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-date.utc" type="built-in function">
-        <h1>Date.UTC ( _year_ [ , _month_ [ , _date_ [ , _hours_ [ , _minutes_ [ , _seconds_ [ , _ms_ ] ] ] ] ] ] )</h1>
+        <h1>Date.UTC ( _year_ [ , _month_ [ , _day_ [ , _hour_ [ , _minute_ [ , _second_ [ , _millisecond_ ] ] ] ] ] ] )</h1>
         <p>This function performs the following steps when called:</p>
         <emu-alg>
-          1. Let _y_ be ? ToNumber(_year_).
-          1. If _month_ is present, let _m_ be ? ToNumber(_month_); else let _m_ be *+0*<sub>𝔽</sub>.
-          1. If _date_ is present, let _dt_ be ? ToNumber(_date_); else let _dt_ be *1*<sub>𝔽</sub>.
-          1. If _hours_ is present, let _h_ be ? ToNumber(_hours_); else let _h_ be *+0*<sub>𝔽</sub>.
-          1. If _minutes_ is present, let _min_ be ? ToNumber(_minutes_); else let _min_ be *+0*<sub>𝔽</sub>.
-          1. If _seconds_ is present, let _s_ be ? ToNumber(_seconds_); else let _s_ be *+0*<sub>𝔽</sub>.
-          1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_); else let _milli_ be *+0*<sub>𝔽</sub>.
-          1. Let _yr_ be MakeFullYear(_y_).
-          1. Return TimeClip(MakeDate(MakeDay(_yr_, _m_, _dt_), MakeTime(_h_, _min_, _s_, _milli_))).
+          1. Let _yearNumber_ be ? ToNumber(_year_).
+          1. If _month_ is present, let _monthNumber_ be ? ToNumber(_month_); else let _monthNumber_ be *+0*<sub>𝔽</sub>.
+          1. If _day_ is present, let _dayNumber_ be ? ToNumber(_day_); else let _dayNumber_ be *1*<sub>𝔽</sub>.
+          1. If _hour_ is present, let _hourNumber_ be ? ToNumber(_hour_); else let _hourNumber_ be *+0*<sub>𝔽</sub>.
+          1. If _minute_ is present, let _minuteNumber_ be ? ToNumber(_minute_); else let _minuteNumber_ be *+0*<sub>𝔽</sub>.
+          1. If _second_ is present, let _secondNumber_ be ? ToNumber(_second_); else let _secondNumber_ be *+0*<sub>𝔽</sub>.
+          1. If _millisecond_ is present, let _millisecondNumber_ be ? ToNumber(_millisecond_); else let _millisecondNumber_ be *+0*<sub>𝔽</sub>.
+          1. Set _yearNumber_ to MakeFullYear(_yearNumber_).
+          1. Return TimeClip(MakeDate(MakeDay(_yearNumber_, _monthNumber_, _dayNumber_), MakeTime(_hourNumber_, _minuteNumber_, _secondNumber_, _millisecondNumber_))).
         </emu-alg>
         <p>The *"length"* property of this function is *7*<sub>𝔽</sub>.</p>
         <emu-note>
@@ -35212,7 +35212,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
           1. If _tv_ is *NaN*, return *NaN*.
-          1. Return 𝔽(MillisecFromTime(LocalTime(_tv_))).
+          1. Return 𝔽(MillisecondFromTime(LocalTime(_tv_))).
         </emu-alg>
       </emu-clause>
 
@@ -35224,7 +35224,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
           1. If _tv_ is *NaN*, return *NaN*.
-          1. Return 𝔽(MinFromTime(LocalTime(_tv_))).
+          1. Return 𝔽(MinuteFromTime(LocalTime(_tv_))).
         </emu-alg>
       </emu-clause>
 
@@ -35248,7 +35248,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
           1. If _tv_ is *NaN*, return *NaN*.
-          1. Return 𝔽(SecFromTime(LocalTime(_tv_))).
+          1. Return 𝔽(SecondFromTime(LocalTime(_tv_))).
         </emu-alg>
       </emu-clause>
 
@@ -35270,7 +35270,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
           1. If _tv_ is *NaN*, return *NaN*.
-          1. Return (_tv_ - LocalTime(_tv_)) / 𝔽(msPerMinute).
+          1. Return (_tv_ - LocalTime(_tv_)) / 𝔽(MillisecondsPerMinute).
         </emu-alg>
       </emu-clause>
 
@@ -35330,7 +35330,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
           1. If _tv_ is *NaN*, return *NaN*.
-          1. Return 𝔽(MillisecFromTime(_tv_)).
+          1. Return 𝔽(MillisecondFromTime(_tv_)).
         </emu-alg>
       </emu-clause>
 
@@ -35342,7 +35342,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
           1. If _tv_ is *NaN*, return *NaN*.
-          1. Return 𝔽(MinFromTime(_tv_)).
+          1. Return 𝔽(MinuteFromTime(_tv_)).
         </emu-alg>
       </emu-clause>
 
@@ -35366,21 +35366,21 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
           1. If _tv_ is *NaN*, return *NaN*.
-          1. Return 𝔽(SecFromTime(_tv_)).
+          1. Return 𝔽(SecondFromTime(_tv_)).
         </emu-alg>
       </emu-clause>
 
       <emu-clause id="sec-date.prototype.setdate" type="built-in function">
-        <h1>Date.prototype.setDate ( _date_ )</h1>
+        <h1>Date.prototype.setDate ( _day_ )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _dateObj_ be the *this* value.
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
-          1. Let _dt_ be ? ToNumber(_date_).
+          1. Let _dayNumber_ be ? ToNumber(_day_).
           1. If _tv_ is *NaN*, return *NaN*.
           1. Set _tv_ to LocalTime(_tv_).
-          1. Let _newDate_ be MakeDate(MakeDay(𝔽(YearFromTime(_tv_)), 𝔽(MonthFromTime(_tv_)), _dt_), 𝔽(TimeWithinDay(_tv_))).
+          1. Let _newDate_ be MakeDate(MakeDay(𝔽(YearFromTime(_tv_)), 𝔽(MonthFromTime(_tv_)), _dayNumber_), 𝔽(TimeWithinDay(_tv_))).
           1. Let _u_ be TimeClip(UTC(_newDate_)).
           1. Set _dateObj_.[[DateValue]] to _u_.
           1. Return _u_.
@@ -35388,65 +35388,65 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-date.prototype.setfullyear" type="built-in function">
-        <h1>Date.prototype.setFullYear ( _year_ [ , _month_ [ , _date_ ] ] )</h1>
+        <h1>Date.prototype.setFullYear ( _year_ [ , _month_ [ , _day_ ] ] )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _dateObj_ be the *this* value.
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
-          1. Let _y_ be ? ToNumber(_year_).
+          1. Let _yearNumber_ be ? ToNumber(_year_).
           1. If _tv_ is *NaN*, set _tv_ to *+0*<sub>𝔽</sub>; else set _tv_ to LocalTime(_tv_).
-          1. If _month_ is present, let _m_ be ? ToNumber(_month_); else let _m_ be 𝔽(MonthFromTime(_tv_)).
-          1. If _date_ is present, let _dt_ be ? ToNumber(_date_); else let _dt_ be 𝔽(DateFromTime(_tv_)).
-          1. Let _newDate_ be MakeDate(MakeDay(_y_, _m_, _dt_), 𝔽(TimeWithinDay(_tv_))).
+          1. If _month_ is present, let _monthNumber_ be ? ToNumber(_month_); else let _monthNumber_ be 𝔽(MonthFromTime(_tv_)).
+          1. If _day_ is present, let _dayNumber_ be ? ToNumber(_day_); else let _dayNumber_ be 𝔽(DateFromTime(_tv_)).
+          1. Let _newDate_ be MakeDate(MakeDay(_yearNumber_, _monthNumber_, _dayNumber_), 𝔽(TimeWithinDay(_tv_))).
           1. Let _u_ be TimeClip(UTC(_newDate_)).
           1. Set _dateObj_.[[DateValue]] to _u_.
           1. Return _u_.
         </emu-alg>
         <p>The *"length"* property of this method is *3*<sub>𝔽</sub>.</p>
         <emu-note>
-          <p>If _month_ is not present, this method behaves as if _month_ was present with the value `getMonth()`. If _date_ is not present, it behaves as if _date_ was present with the value `getDate()`.</p>
+          <p>If _month_ is not present, this method behaves as if _month_ was present with the value `getMonth()`. If _day_ is not present, it behaves as if _day_ was present with the value `getDate()`.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-date.prototype.sethours" type="built-in function">
-        <h1>Date.prototype.setHours ( _hour_ [ , _min_ [ , _sec_ [ , _ms_ ] ] ] )</h1>
+        <h1>Date.prototype.setHours ( _hour_ [ , _minute_ [ , _second_ [ , _millisecond_ ] ] ] )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _dateObj_ be the *this* value.
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
-          1. Let _h_ be ? ToNumber(_hour_).
-          1. If _min_ is present, let _m_ be ? ToNumber(_min_).
-          1. If _sec_ is present, let _s_ be ? ToNumber(_sec_).
-          1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_).
+          1. Let _hourNumber_ be ? ToNumber(_hour_).
+          1. If _minute_ is present, let _minuteNumber_ be ? ToNumber(_minute_).
+          1. If _second_ is present, let _secondNumber_ be ? ToNumber(_second_).
+          1. If _millisecond_ is present, let _millisecondNumber_ be ? ToNumber(_millisecond_).
           1. If _tv_ is *NaN*, return *NaN*.
           1. Set _tv_ to LocalTime(_tv_).
-          1. If _min_ is not present, let _m_ be 𝔽(MinFromTime(_tv_)).
-          1. If _sec_ is not present, let _s_ be 𝔽(SecFromTime(_tv_)).
-          1. If _ms_ is not present, let _milli_ be 𝔽(MillisecFromTime(_tv_)).
-          1. Let _date_ be MakeDate(𝔽(Day(_tv_)), MakeTime(_h_, _m_, _s_, _milli_)).
+          1. If _minute_ is not present, let _minuteNumber_ be 𝔽(MinuteFromTime(_tv_)).
+          1. If _second_ is not present, let _secondNumber_ be 𝔽(SecondFromTime(_tv_)).
+          1. If _millisecond_ is not present, let _millisecondNumber_ be 𝔽(MillisecondFromTime(_tv_)).
+          1. Let _date_ be MakeDate(𝔽(Day(_tv_)), MakeTime(_hourNumber_, _minuteNumber_, _secondNumber_, _millisecondNumber_)).
           1. Let _u_ be TimeClip(UTC(_date_)).
           1. Set _dateObj_.[[DateValue]] to _u_.
           1. Return _u_.
         </emu-alg>
         <p>The *"length"* property of this method is *4*<sub>𝔽</sub>.</p>
         <emu-note>
-          <p>If _min_ is not present, this method behaves as if _min_ was present with the value `getMinutes()`. If _sec_ is not present, it behaves as if _sec_ was present with the value `getSeconds()`. If _ms_ is not present, it behaves as if _ms_ was present with the value `getMilliseconds()`.</p>
+          <p>If _minute_ is not present, this method behaves as if _minute_ was present with the value `getMinutes()`. If _second_ is not present, it behaves as if _second_ was present with the value `getSeconds()`. If _millisecond_ is not present, it behaves as if _millisecond_ was present with the value `getMilliseconds()`.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-date.prototype.setmilliseconds" type="built-in function">
-        <h1>Date.prototype.setMilliseconds ( _ms_ )</h1>
+        <h1>Date.prototype.setMilliseconds ( _millisecond_ )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _dateObj_ be the *this* value.
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
-          1. Set _ms_ to ? ToNumber(_ms_).
+          1. Let _millisecondNumber_ be ? ToNumber(_millisecond_).
           1. If _tv_ is *NaN*, return *NaN*.
           1. Set _tv_ to LocalTime(_tv_).
-          1. Let _time_ be MakeTime(𝔽(HourFromTime(_tv_)), 𝔽(MinFromTime(_tv_)), 𝔽(SecFromTime(_tv_)), _ms_).
+          1. Let _time_ be MakeTime(𝔽(HourFromTime(_tv_)), 𝔽(MinuteFromTime(_tv_)), 𝔽(SecondFromTime(_tv_)), _millisecondNumber_).
           1. Let _u_ be TimeClip(UTC(MakeDate(𝔽(Day(_tv_)), _time_))).
           1. Set _dateObj_.[[DateValue]] to _u_.
           1. Return _u_.
@@ -35454,73 +35454,73 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-date.prototype.setminutes" type="built-in function">
-        <h1>Date.prototype.setMinutes ( _min_ [ , _sec_ [ , _ms_ ] ] )</h1>
+        <h1>Date.prototype.setMinutes ( _minute_ [ , _second_ [ , _millisecond_ ] ] )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _dateObj_ be the *this* value.
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
-          1. Let _m_ be ? ToNumber(_min_).
-          1. If _sec_ is present, let _s_ be ? ToNumber(_sec_).
-          1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_).
+          1. Let _minuteNumber_ be ? ToNumber(_minute_).
+          1. If _second_ is present, let _secondNumber_ be ? ToNumber(_second_).
+          1. If _millisecond_ is present, let _millisecondNumber_ be ? ToNumber(_millisecond_).
           1. If _tv_ is *NaN*, return *NaN*.
           1. Set _tv_ to LocalTime(_tv_).
-          1. If _sec_ is not present, let _s_ be 𝔽(SecFromTime(_tv_)).
-          1. If _ms_ is not present, let _milli_ be 𝔽(MillisecFromTime(_tv_)).
-          1. Let _date_ be MakeDate(𝔽(Day(_tv_)), MakeTime(𝔽(HourFromTime(_tv_)), _m_, _s_, _milli_)).
+          1. If _second_ is not present, let _secondNumber_ be 𝔽(SecondFromTime(_tv_)).
+          1. If _millisecond_ is not present, let _millisecondNumber_ be 𝔽(MillisecondFromTime(_tv_)).
+          1. Let _date_ be MakeDate(𝔽(Day(_tv_)), MakeTime(𝔽(HourFromTime(_tv_)), _minuteNumber_, _secondNumber_, _millisecondNumber_)).
           1. Let _u_ be TimeClip(UTC(_date_)).
           1. Set _dateObj_.[[DateValue]] to _u_.
           1. Return _u_.
         </emu-alg>
         <p>The *"length"* property of this method is *3*<sub>𝔽</sub>.</p>
         <emu-note>
-          <p>If _sec_ is not present, this method behaves as if _sec_ was present with the value `getSeconds()`. If _ms_ is not present, this behaves as if _ms_ was present with the value `getMilliseconds()`.</p>
+          <p>If _second_ is not present, this method behaves as if _second_ was present with the value `getSeconds()`. If _millisecond_ is not present, this behaves as if _millisecond_ was present with the value `getMilliseconds()`.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-date.prototype.setmonth" type="built-in function">
-        <h1>Date.prototype.setMonth ( _month_ [ , _date_ ] )</h1>
+        <h1>Date.prototype.setMonth ( _month_ [ , _day_ ] )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _dateObj_ be the *this* value.
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
-          1. Let _m_ be ? ToNumber(_month_).
-          1. If _date_ is present, let _dt_ be ? ToNumber(_date_).
+          1. Let _monthNumber_ be ? ToNumber(_month_).
+          1. If _day_ is present, let _dayNumber_ be ? ToNumber(_day_).
           1. If _tv_ is *NaN*, return *NaN*.
           1. Set _tv_ to LocalTime(_tv_).
-          1. If _date_ is not present, let _dt_ be 𝔽(DateFromTime(_tv_)).
-          1. Let _newDate_ be MakeDate(MakeDay(𝔽(YearFromTime(_tv_)), _m_, _dt_), 𝔽(TimeWithinDay(_tv_))).
+          1. If _day_ is not present, let _dayNumber_ be 𝔽(DateFromTime(_tv_)).
+          1. Let _newDate_ be MakeDate(MakeDay(𝔽(YearFromTime(_tv_)), _monthNumber_, _dayNumber_), 𝔽(TimeWithinDay(_tv_))).
           1. Let _u_ be TimeClip(UTC(_newDate_)).
           1. Set _dateObj_.[[DateValue]] to _u_.
           1. Return _u_.
         </emu-alg>
         <p>The *"length"* property of this method is *2*<sub>𝔽</sub>.</p>
         <emu-note>
-          <p>If _date_ is not present, this method behaves as if _date_ was present with the value `getDate()`.</p>
+          <p>If _day_ is not present, this method behaves as if _day_ was present with the value `getDate()`.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-date.prototype.setseconds" type="built-in function">
-        <h1>Date.prototype.setSeconds ( _sec_ [ , _ms_ ] )</h1>
+        <h1>Date.prototype.setSeconds ( _second_ [ , _millisecond_ ] )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _dateObj_ be the *this* value.
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
-          1. Let _s_ be ? ToNumber(_sec_).
-          1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_).
+          1. Let _secondNumber_ be ? ToNumber(_second_).
+          1. If _millisecond_ is present, let _millisecondNumber_ be ? ToNumber(_millisecond_).
           1. If _tv_ is *NaN*, return *NaN*.
           1. Set _tv_ to LocalTime(_tv_).
-          1. If _ms_ is not present, let _milli_ be 𝔽(MillisecFromTime(_tv_)).
-          1. Let _date_ be MakeDate(𝔽(Day(_tv_)), MakeTime(𝔽(HourFromTime(_tv_)), 𝔽(MinFromTime(_tv_)), _s_, _milli_)).
+          1. If _millisecond_ is not present, let _millisecondNumber_ be 𝔽(MillisecondFromTime(_tv_)).
+          1. Let _date_ be MakeDate(𝔽(Day(_tv_)), MakeTime(𝔽(HourFromTime(_tv_)), 𝔽(MinuteFromTime(_tv_)), _secondNumber_, _millisecondNumber_)).
           1. Let _u_ be TimeClip(UTC(_date_)).
           1. Set _dateObj_.[[DateValue]] to _u_.
           1. Return _u_.
         </emu-alg>
         <p>The *"length"* property of this method is *2*<sub>𝔽</sub>.</p>
         <emu-note>
-          <p>If _ms_ is not present, this method behaves as if _ms_ was present with the value `getMilliseconds()`.</p>
+          <p>If _millisecond_ is not present, this method behaves as if _millisecond_ was present with the value `getMilliseconds()`.</p>
         </emu-note>
       </emu-clause>
 
@@ -35538,15 +35538,15 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-date.prototype.setutcdate" type="built-in function">
-        <h1>Date.prototype.setUTCDate ( _date_ )</h1>
+        <h1>Date.prototype.setUTCDate ( _day_ )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _dateObj_ be the *this* value.
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
-          1. Let _dt_ be ? ToNumber(_date_).
+          1. Let _dayNumber_ be ? ToNumber(_day_).
           1. If _tv_ is *NaN*, return *NaN*.
-          1. Let _newDate_ be MakeDate(MakeDay(𝔽(YearFromTime(_tv_)), 𝔽(MonthFromTime(_tv_)), _dt_), 𝔽(TimeWithinDay(_tv_))).
+          1. Let _newDate_ be MakeDate(MakeDay(𝔽(YearFromTime(_tv_)), 𝔽(MonthFromTime(_tv_)), _dayNumber_), 𝔽(TimeWithinDay(_tv_))).
           1. Let _v_ be TimeClip(_newDate_).
           1. Set _dateObj_.[[DateValue]] to _v_.
           1. Return _v_.
@@ -35554,63 +35554,63 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-date.prototype.setutcfullyear" type="built-in function">
-        <h1>Date.prototype.setUTCFullYear ( _year_ [ , _month_ [ , _date_ ] ] )</h1>
+        <h1>Date.prototype.setUTCFullYear ( _year_ [ , _month_ [ , _day_ ] ] )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _dateObj_ be the *this* value.
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
           1. If _tv_ is *NaN*, set _tv_ to *+0*<sub>𝔽</sub>.
-          1. Let _y_ be ? ToNumber(_year_).
-          1. If _month_ is present, let _m_ be ? ToNumber(_month_); else let _m_ be 𝔽(MonthFromTime(_tv_)).
-          1. If _date_ is present, let _dt_ be ? ToNumber(_date_); else let _dt_ be 𝔽(DateFromTime(_tv_)).
-          1. Let _newDate_ be MakeDate(MakeDay(_y_, _m_, _dt_), 𝔽(TimeWithinDay(_tv_))).
+          1. Let _yearNumber_ be ? ToNumber(_year_).
+          1. If _month_ is present, let _monthNumber_ be ? ToNumber(_month_); else let _monthNumber_ be 𝔽(MonthFromTime(_tv_)).
+          1. If _day_ is present, let _dayNumber_ be ? ToNumber(_day_); else let _dayNumber_ be 𝔽(DateFromTime(_tv_)).
+          1. Let _newDate_ be MakeDate(MakeDay(_yearNumber_, _monthNumber_, _dayNumber_), 𝔽(TimeWithinDay(_tv_))).
           1. Let _v_ be TimeClip(_newDate_).
           1. Set _dateObj_.[[DateValue]] to _v_.
           1. Return _v_.
         </emu-alg>
         <p>The *"length"* property of this method is *3*<sub>𝔽</sub>.</p>
         <emu-note>
-          <p>If _month_ is not present, this method behaves as if _month_ was present with the value `getUTCMonth()`. If _date_ is not present, it behaves as if _date_ was present with the value `getUTCDate()`.</p>
+          <p>If _month_ is not present, this method behaves as if _month_ was present with the value `getUTCMonth()`. If _day_ is not present, it behaves as if _day_ was present with the value `getUTCDate()`.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-date.prototype.setutchours" type="built-in function">
-        <h1>Date.prototype.setUTCHours ( _hour_ [ , _min_ [ , _sec_ [ , _ms_ ] ] ] )</h1>
+        <h1>Date.prototype.setUTCHours ( _hour_ [ , _minute_ [ , _second_ [ , _millisecond_ ] ] ] )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _dateObj_ be the *this* value.
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
-          1. Let _h_ be ? ToNumber(_hour_).
-          1. If _min_ is present, let _m_ be ? ToNumber(_min_).
-          1. If _sec_ is present, let _s_ be ? ToNumber(_sec_).
-          1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_).
+          1. Let _hourNumber_ be ? ToNumber(_hour_).
+          1. If _minute_ is present, let _minuteNumber_ be ? ToNumber(_minute_).
+          1. If _second_ is present, let _secondNumber_ be ? ToNumber(_second_).
+          1. If _millisecond_ is present, let _millisecondNumber_ be ? ToNumber(_millisecond_).
           1. If _tv_ is *NaN*, return *NaN*.
-          1. If _min_ is not present, let _m_ be 𝔽(MinFromTime(_tv_)).
-          1. If _sec_ is not present, let _s_ be 𝔽(SecFromTime(_tv_)).
-          1. If _ms_ is not present, let _milli_ be 𝔽(MillisecFromTime(_tv_)).
-          1. Let _date_ be MakeDate(𝔽(Day(_tv_)), MakeTime(_h_, _m_, _s_, _milli_)).
+          1. If _minute_ is not present, let _minuteNumber_ be 𝔽(MinuteFromTime(_tv_)).
+          1. If _second_ is not present, let _secondNumber_ be 𝔽(SecondFromTime(_tv_)).
+          1. If _millisecond_ is not present, let _millisecondNumber_ be 𝔽(MillisecondFromTime(_tv_)).
+          1. Let _date_ be MakeDate(𝔽(Day(_tv_)), MakeTime(_hourNumber_, _minuteNumber_, _secondNumber_, _millisecondNumber_)).
           1. Let _v_ be TimeClip(_date_).
           1. Set _dateObj_.[[DateValue]] to _v_.
           1. Return _v_.
         </emu-alg>
         <p>The *"length"* property of this method is *4*<sub>𝔽</sub>.</p>
         <emu-note>
-          <p>If _min_ is not present, this method behaves as if _min_ was present with the value `getUTCMinutes()`. If _sec_ is not present, it behaves as if _sec_ was present with the value `getUTCSeconds()`. If _ms_ is not present, it behaves as if _ms_ was present with the value `getUTCMilliseconds()`.</p>
+          <p>If _minute_ is not present, this method behaves as if _minute_ was present with the value `getUTCMinutes()`. If _second_ is not present, it behaves as if _second_ was present with the value `getUTCSeconds()`. If _millisecond_ is not present, it behaves as if _millisecond_ was present with the value `getUTCMilliseconds()`.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-date.prototype.setutcmilliseconds" type="built-in function">
-        <h1>Date.prototype.setUTCMilliseconds ( _ms_ )</h1>
+        <h1>Date.prototype.setUTCMilliseconds ( _millisecond_ )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _dateObj_ be the *this* value.
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
-          1. Set _ms_ to ? ToNumber(_ms_).
+          1. Let _millisecondNumber_ be ? ToNumber(_millisecond_).
           1. If _tv_ is *NaN*, return *NaN*.
-          1. Let _time_ be MakeTime(𝔽(HourFromTime(_tv_)), 𝔽(MinFromTime(_tv_)), 𝔽(SecFromTime(_tv_)), _ms_).
+          1. Let _time_ be MakeTime(𝔽(HourFromTime(_tv_)), 𝔽(MinuteFromTime(_tv_)), 𝔽(SecondFromTime(_tv_)), _millisecondNumber_).
           1. Let _v_ be TimeClip(MakeDate(𝔽(Day(_tv_)), _time_)).
           1. Set _dateObj_.[[DateValue]] to _v_.
           1. Return _v_.
@@ -35618,70 +35618,70 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-date.prototype.setutcminutes" type="built-in function">
-        <h1>Date.prototype.setUTCMinutes ( _min_ [ , _sec_ [ , _ms_ ] ] )</h1>
+        <h1>Date.prototype.setUTCMinutes ( _minute_ [ , _second_ [ , _millisecond_ ] ] )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _dateObj_ be the *this* value.
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
-          1. Let _m_ be ? ToNumber(_min_).
-          1. If _sec_ is present, let _s_ be ? ToNumber(_sec_).
-          1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_).
+          1. Let _minuteNumber_ be ? ToNumber(_minute_).
+          1. If _second_ is present, let _secondNumber_ be ? ToNumber(_second_).
+          1. If _millisecond_ is present, let _millisecondNumber_ be ? ToNumber(_millisecond_).
           1. If _tv_ is *NaN*, return *NaN*.
-          1. If _sec_ is not present, let _s_ be 𝔽(SecFromTime(_tv_)).
-          1. If _ms_ is not present, let _milli_ be 𝔽(MillisecFromTime(_tv_)).
-          1. Let _date_ be MakeDate(𝔽(Day(_tv_)), MakeTime(𝔽(HourFromTime(_tv_)), _m_, _s_, _milli_)).
+          1. If _second_ is not present, let _secondNumber_ be 𝔽(SecondFromTime(_tv_)).
+          1. If _millisecond_ is not present, let _millisecondNumber_ be 𝔽(MillisecondFromTime(_tv_)).
+          1. Let _date_ be MakeDate(𝔽(Day(_tv_)), MakeTime(𝔽(HourFromTime(_tv_)), _minuteNumber_, _secondNumber_, _millisecondNumber_)).
           1. Let _v_ be TimeClip(_date_).
           1. Set _dateObj_.[[DateValue]] to _v_.
           1. Return _v_.
         </emu-alg>
         <p>The *"length"* property of this method is *3*<sub>𝔽</sub>.</p>
         <emu-note>
-          <p>If _sec_ is not present, this method behaves as if _sec_ was present with the value `getUTCSeconds()`. If _ms_ is not present, it behaves as if _ms_ was present with the value return by `getUTCMilliseconds()`.</p>
+          <p>If _second_ is not present, this method behaves as if _second_ was present with the value `getUTCSeconds()`. If _millisecond_ is not present, it behaves as if _millisecond_ was present with the value return by `getUTCMilliseconds()`.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-date.prototype.setutcmonth" type="built-in function">
-        <h1>Date.prototype.setUTCMonth ( _month_ [ , _date_ ] )</h1>
+        <h1>Date.prototype.setUTCMonth ( _month_ [ , _day_ ] )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _dateObj_ be the *this* value.
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
-          1. Let _m_ be ? ToNumber(_month_).
-          1. If _date_ is present, let _dt_ be ? ToNumber(_date_).
+          1. Let _monthNumber_ be ? ToNumber(_month_).
+          1. If _day_ is present, let _dayNumber_ be ? ToNumber(_day_).
           1. If _tv_ is *NaN*, return *NaN*.
-          1. If _date_ is not present, let _dt_ be 𝔽(DateFromTime(_tv_)).
-          1. Let _newDate_ be MakeDate(MakeDay(𝔽(YearFromTime(_tv_)), _m_, _dt_), 𝔽(TimeWithinDay(_tv_))).
+          1. If _day_ is not present, let _dayNumber_ be 𝔽(DateFromTime(_tv_)).
+          1. Let _newDate_ be MakeDate(MakeDay(𝔽(YearFromTime(_tv_)), _monthNumber_, _dayNumber_), 𝔽(TimeWithinDay(_tv_))).
           1. Let _v_ be TimeClip(_newDate_).
           1. Set _dateObj_.[[DateValue]] to _v_.
           1. Return _v_.
         </emu-alg>
         <p>The *"length"* property of this method is *2*<sub>𝔽</sub>.</p>
         <emu-note>
-          <p>If _date_ is not present, this method behaves as if _date_ was present with the value `getUTCDate()`.</p>
+          <p>If _day_ is not present, this method behaves as if _day_ was present with the value `getUTCDate()`.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-date.prototype.setutcseconds" type="built-in function">
-        <h1>Date.prototype.setUTCSeconds ( _sec_ [ , _ms_ ] )</h1>
+        <h1>Date.prototype.setUTCSeconds ( _second_ [ , _millisecond_ ] )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _dateObj_ be the *this* value.
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
-          1. Let _s_ be ? ToNumber(_sec_).
-          1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_).
+          1. Let _secondNumber_ be ? ToNumber(_second_).
+          1. If _millisecond_ is present, let _millisecondNumber_ be ? ToNumber(_millisecond_).
           1. If _tv_ is *NaN*, return *NaN*.
-          1. If _ms_ is not present, let _milli_ be 𝔽(MillisecFromTime(_tv_)).
-          1. Let _date_ be MakeDate(𝔽(Day(_tv_)), MakeTime(𝔽(HourFromTime(_tv_)), 𝔽(MinFromTime(_tv_)), _s_, _milli_)).
+          1. If _millisecond_ is not present, let _millisecondNumber_ be 𝔽(MillisecondFromTime(_tv_)).
+          1. Let _date_ be MakeDate(𝔽(Day(_tv_)), MakeTime(𝔽(HourFromTime(_tv_)), 𝔽(MinuteFromTime(_tv_)), _secondNumber_, _millisecondNumber_)).
           1. Let _v_ be TimeClip(_date_).
           1. Set _dateObj_.[[DateValue]] to _v_.
           1. Return _v_.
         </emu-alg>
         <p>The *"length"* property of this method is *2*<sub>𝔽</sub>.</p>
         <emu-note>
-          <p>If _ms_ is not present, this method behaves as if _ms_ was present with the value `getUTCMilliseconds()`.</p>
+          <p>If _millisecond_ is not present, this method behaves as if _millisecond_ was present with the value `getUTCMilliseconds()`.</p>
         </emu-note>
       </emu-clause>
 
@@ -35777,8 +35777,8 @@ THH:mm:ss.sss
           </dl>
           <emu-alg>
             1. Let _hour_ be ToZeroPaddedDecimalString(HourFromTime(_tv_), 2).
-            1. Let _minute_ be ToZeroPaddedDecimalString(MinFromTime(_tv_), 2).
-            1. Let _second_ be ToZeroPaddedDecimalString(SecFromTime(_tv_), 2).
+            1. Let _minute_ be ToZeroPaddedDecimalString(MinuteFromTime(_tv_), 2).
+            1. Let _second_ be ToZeroPaddedDecimalString(SecondFromTime(_tv_), 2).
             1. Return the string-concatenation of _hour_, *":"*, _minute_, *":"*, _second_, the code unit 0x0020 (SPACE), and *"GMT"*.
           </emu-alg>
         </emu-clause>
@@ -35993,20 +35993,20 @@ THH:mm:ss.sss
           <emu-alg>
             1. Let _systemTimeZoneIdentifier_ be SystemTimeZoneIdentifier().
             1. If IsTimeZoneOffsetString(_systemTimeZoneIdentifier_) is *true*, then
-              1. Let _offsetNs_ be ParseTimeZoneOffsetString(_systemTimeZoneIdentifier_).
+              1. Let _offsetNanoseconds_ be ParseTimeZoneOffsetString(_systemTimeZoneIdentifier_).
             1. Else,
-              1. Let _offsetNs_ be GetNamedTimeZoneOffsetNanoseconds(_systemTimeZoneIdentifier_, ℝ(_tv_) × nsPerMillisecond).
-            1. Let _offset_ be truncate(_offsetNs_ / nsPerMillisecond).
-            1. If _offset_ ≥ 0, then
+              1. Let _offsetNanoseconds_ be GetNamedTimeZoneOffsetNanoseconds(_systemTimeZoneIdentifier_, ℝ(_tv_) × NanosecondsPerMillisecond).
+            1. Let _offsetMilliseconds_ be truncate(_offsetNanoseconds_ / NanosecondsPerMillisecond).
+            1. If _offsetMilliseconds_ ≥ 0, then
               1. Let _offsetSign_ be *"+"*.
-              1. Let _absOffset_ be _offset_.
+              1. Let _absOffsetMilliseconds_ be _offsetMilliseconds_.
             1. Else,
               1. Let _offsetSign_ be *"-"*.
-              1. Let _absOffset_ be -_offset_.
-            1. Let _offsetMin_ be ToZeroPaddedDecimalString(MinFromTime(𝔽(_absOffset_)), 2).
-            1. Let _offsetHour_ be ToZeroPaddedDecimalString(HourFromTime(𝔽(_absOffset_)), 2).
+              1. Let _absOffsetMilliseconds_ be -_offsetMilliseconds_.
+            1. Let _offsetMinute_ be ToZeroPaddedDecimalString(MinuteFromTime(𝔽(_absOffsetMilliseconds_)), 2).
+            1. Let _offsetHour_ be ToZeroPaddedDecimalString(HourFromTime(𝔽(_absOffsetMilliseconds_)), 2).
             1. Let _tzName_ be an implementation-defined string that is either the empty String or the string-concatenation of the code unit 0x0020 (SPACE), the code unit 0x0028 (LEFT PARENTHESIS), an implementation-defined timezone name, and the code unit 0x0029 (RIGHT PARENTHESIS).
-            1. Return the string-concatenation of _offsetSign_, _offsetHour_, _offsetMin_, and _tzName_.
+            1. Return the string-concatenation of _offsetSign_, _offsetHour_, _offsetMinute_, and _tzName_.
           </emu-alg>
         </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -34069,7 +34069,7 @@
       <emu-clause id="sec-time-values-and-time-range">
         <h1>Time Values and Time Range</h1>
         <p>Time measurement in ECMAScript is analogous to time measurement in POSIX, in particular sharing definition in terms of the proleptic Gregorian calendar, an <dfn id="epoch">epoch</dfn> of midnight at the beginning of 1 January 1970 UTC, and an accounting of every day as comprising exactly 86,400 seconds (each of which is 1000 milliseconds long).</p>
-        <p>An ECMAScript <dfn variants="time values">time value</dfn> is a Number, either a finite integral Number representing an instant in time to millisecond precision or *NaN* representing no specific instant. A time value that is an integer multiple of msPerDay (i.e., is msPerDay × _d_ for some integer _d_) represents the instant at the start of the UTC day that follows the epoch by _d_ whole UTC days (preceding the epoch for negative _d_). Every other finite time value _tv_ is defined relative to the greatest preceding time value _s_ that is such a multiple, and represents the instant that occurs within the same UTC day as _s_ but follows it by (_tv_ - _s_) milliseconds.</p>
+        <p>An ECMAScript <dfn variants="time values">time value</dfn> is a Number, either a finite integral Number representing an instant in time to millisecond precision or *NaN* representing no specific instant. A time value that is an integer multiple of MillisecondsPerDay (i.e., is MillisecondsPerDay × _d_ for some integer _d_) represents the instant at the start of the UTC day that follows the epoch by _d_ whole UTC days (preceding the epoch for negative _d_). Every other finite time value _tv_ is defined relative to the greatest preceding time value _s_ that is such a multiple, and represents the instant that occurs within the same UTC day as _s_ but follows it by (_tv_ - _s_) milliseconds.</p>
         <p>Time values do not account for UTC leap seconds—there are no time values representing instants within positive leap seconds, and there are time values representing instants removed from the UTC timeline by negative leap seconds. However, the definition of time values nonetheless yields piecewise alignment with UTC, with discontinuities only at leap second boundaries and zero difference outside of leap seconds.</p>
         <p>A Number can exactly represent all integers from -9,007,199,254,740,992 to 9,007,199,254,740,992 (<emu-xref href="#sec-number.min_safe_integer"></emu-xref> and <emu-xref href="#sec-number.max_safe_integer"></emu-xref>). A time value supports a slightly smaller range of -8,640,000,000,000,000 to 8,640,000,000,000,000 milliseconds. This yields a supported time value range of exactly -100,000,000 days to 100,000,000 days relative to midnight at the beginning of 1 January 1970 UTC.</p>
         <p>The exact moment of midnight at the beginning of 1 January 1970 UTC is represented by the time value *+0*<sub>𝔽</sub>.</p>
@@ -34085,13 +34085,13 @@
         <emu-eqn id="eqn-HoursPerDay" aoid="HoursPerDay">HoursPerDay = 24</emu-eqn>
         <emu-eqn id="eqn-MinutesPerHour" aoid="MinutesPerHour">MinutesPerHour = 60</emu-eqn>
         <emu-eqn id="eqn-SecondsPerMinute" aoid="SecondsPerMinute">SecondsPerMinute = 60</emu-eqn>
-        <emu-eqn id="eqn-msPerSecond" aoid="msPerSecond">msPerSecond = 1000</emu-eqn>
-        <emu-eqn id="eqn-msPerMinute" aoid="msPerMinute">msPerMinute = 60000 = msPerSecond × SecondsPerMinute</emu-eqn>
-        <emu-eqn id="eqn-msPerHour" aoid="msPerHour">msPerHour = 3600000 = msPerMinute × MinutesPerHour</emu-eqn>
-        <emu-eqn id="eqn-msPerDay" aoid="msPerDay">msPerDay = 86400000 = msPerHour × HoursPerDay</emu-eqn>
-        <emu-eqn id="eqn-nsPerSecond" aoid="nsPerSecond">nsPerSecond = 10<sup>6</sup> × msPerSecond = 10<sup>9</sup></emu-eqn>
-        <emu-eqn id="eqn-nsPerMillisecond" aoid="nsPerMillisecond">nsPerMillisecond = 10<sup>6</sup></emu-eqn>
-        <emu-eqn id="eqn-nsPerMicrosecond" aoid="nsPerMicrosecond">nsPerMicrosecond = 10<sup>3</sup></emu-eqn>
+        <emu-eqn id="eqn-MillisecondsPerSecond" oldids="eqn-msPerSecond" aoid="MillisecondsPerSecond">MillisecondsPerSecond = 1000</emu-eqn>
+        <emu-eqn id="eqn-MillisecondsPerMinute" oldids="eqn-msPerMinute" aoid="MillisecondsPerMinute">MillisecondsPerMinute = 60000 = MillisecondsPerSecond × SecondsPerMinute</emu-eqn>
+        <emu-eqn id="eqn-MillisecondsPerHour" oldids="eqn-msPerHour" aoid="MillisecondsPerHour">MillisecondsPerHour = 3600000 = MillisecondsPerMinute × MinutesPerHour</emu-eqn>
+        <emu-eqn id="eqn-MillisecondsPerDay" oldids="eqn-msPerDay" aoid="MillisecondsPerDay">MillisecondsPerDay = 86400000 = MillisecondsPerHour × HoursPerDay</emu-eqn>
+        <emu-eqn id="eqn-NanosecondsPerSecond" oldids="eqn-nsPerSecond" aoid="NanosecondsPerSecond">NanosecondsPerSecond = 10<sup>6</sup> × MillisecondsPerSecond = 10<sup>9</sup></emu-eqn>
+        <emu-eqn id="eqn-NanosecondsPerMillisecond" oldids="eqn-nsPerMillisecond" aoid="NanosecondsPerMillisecond">NanosecondsPerMillisecond = 10<sup>6</sup></emu-eqn>
+        <emu-eqn id="eqn-NanosecondsPerMicrosecond" oldids="eqn-nsPerMicrosecond" aoid="NanosecondsPerMicrosecond">NanosecondsPerMicrosecond = 10<sup>3</sup></emu-eqn>
       </emu-clause>
 
       <emu-clause id="sec-day" type="abstract operation" oldids="eqn-Day,sec-day-number-and-time-within-day">
@@ -34105,7 +34105,7 @@
           <dd>It returns the day number of the day in which _tv_ falls.</dd>
         </dl>
         <emu-alg>
-          1. Return floor(ℝ(_tv_) / msPerDay).
+          1. Return floor(ℝ(_tv_) / MillisecondsPerDay).
         </emu-alg>
       </emu-clause>
 
@@ -34113,14 +34113,14 @@
         <h1>
           TimeWithinDay (
             _tv_: a finite time value,
-          ): an integer in the interval from 0 (inclusive) to msPerDay (exclusive)
+          ): an integer in the interval from 0 (inclusive) to MillisecondsPerDay (exclusive)
         </h1>
         <dl class="header">
           <dt>description</dt>
           <dd>It returns the number of milliseconds since the start of the day in which _tv_ falls.</dd>
         </dl>
         <emu-alg>
-          1. Return ℝ(_tv_) modulo msPerDay.
+          1. Return ℝ(_tv_) modulo MillisecondsPerDay.
         </emu-alg>
       </emu-clause>
 
@@ -34155,7 +34155,7 @@
           <dd>It returns the time value of the start of year _y_.</dd>
         </dl>
         <emu-alg>
-          1. Return 𝔽(msPerDay × DayFromYear(_y_)).
+          1. Return 𝔽(MillisecondsPerDay × DayFromYear(_y_)).
         </emu-alg>
       </emu-clause>
 
@@ -34291,13 +34291,13 @@
           <dd>It returns the hour of the day in which _tv_ falls.</dd>
         </dl>
         <emu-alg>
-          1. Return floor(ℝ(_tv_) / msPerHour) modulo HoursPerDay.
+          1. Return floor(ℝ(_tv_) / MillisecondsPerHour) modulo HoursPerDay.
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-minfromtime" type="abstract operation" oldids="eqn-MinFromTime">
+      <emu-clause id="sec-minutefromtime" type="abstract operation" oldids="eqn-MinFromTime,sec-minfromtime">
         <h1>
-          MinFromTime (
+          MinuteFromTime (
             _tv_: a finite time value,
           ): an integer in the inclusive interval from 0 to 59
         </h1>
@@ -34306,13 +34306,13 @@
           <dd>It returns the minute of the hour in which _tv_ falls.</dd>
         </dl>
         <emu-alg>
-          1. Return floor(ℝ(_tv_) / msPerMinute) modulo MinutesPerHour.
+          1. Return floor(ℝ(_tv_) / MillisecondsPerMinute) modulo MinutesPerHour.
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-secfromtime" type="abstract operation" oldids="eqn-SecFromTime">
+      <emu-clause id="sec-secondfromtime" type="abstract operation" oldids="eqn-SecFromTime,sec-secfromtime">
         <h1>
-          SecFromTime (
+          SecondFromTime (
             _tv_: a finite time value,
           ): an integer in the inclusive interval from 0 to 59
         </h1>
@@ -34321,13 +34321,13 @@
           <dd>It returns the second of the minute in which _tv_ falls.</dd>
         </dl>
         <emu-alg>
-          1. Return floor(ℝ(_tv_) / msPerSecond) modulo SecondsPerMinute.
+          1. Return floor(ℝ(_tv_) / MillisecondsPerSecond) modulo SecondsPerMinute.
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-millisecfromtime" type="abstract operation" oldids="sec-msfromtime,eqn-msFromTime">
+      <emu-clause id="sec-millisecondfromtime" type="abstract operation" oldids="sec-msfromtime,eqn-msFromTime,sec-millisecfromtime">
         <h1>
-          MillisecFromTime (
+          MillisecondFromTime (
             _tv_: a finite time value,
           ): an integer in the inclusive interval from 0 to 999
         </h1>
@@ -34336,7 +34336,7 @@
           <dd>It returns the millisecond of the second in which _tv_ falls.</dd>
         </dl>
         <emu-alg>
-          1. Return ℝ(_tv_) modulo msPerSecond.
+          1. Return ℝ(_tv_) modulo MillisecondsPerSecond.
         </emu-alg>
       </emu-clause>
 
@@ -34361,9 +34361,9 @@
         <emu-alg>
           1. Let _date_ be MakeDay(𝔽(_year_), 𝔽(_month_ - 1), 𝔽(_day_)).
           1. Let _time_ be MakeTime(𝔽(_hour_), 𝔽(_minute_), 𝔽(_second_), 𝔽(_millisecond_)).
-          1. Let _ms_ be MakeDate(_date_, _time_).
-          1. Assert: _ms_ is an integral Number.
-          1. Return ℤ(ℝ(_ms_) × nsPerMillisecond + _microsecond_ × nsPerMicrosecond + _nanosecond_).
+          1. Let _epochMilliseconds_ be MakeDate(_date_, _time_).
+          1. Assert: _epochMilliseconds_ is an integral Number.
+          1. Return ℤ(ℝ(_epochMilliseconds_) × NanosecondsPerMillisecond + _microsecond_ × NanosecondsPerMicrosecond + _nanosecond_).
         </emu-alg>
       </emu-clause>
 
@@ -34552,11 +34552,11 @@
         <emu-alg>
           1. Let _systemTimeZoneIdentifier_ be SystemTimeZoneIdentifier().
           1. If IsTimeZoneOffsetString(_systemTimeZoneIdentifier_) is *true*, then
-            1. Let _offsetNs_ be ParseTimeZoneOffsetString(_systemTimeZoneIdentifier_).
+            1. Let _offsetNanoseconds_ be ParseTimeZoneOffsetString(_systemTimeZoneIdentifier_).
           1. Else,
-            1. Let _offsetNs_ be GetNamedTimeZoneOffsetNanoseconds(_systemTimeZoneIdentifier_, ℤ(ℝ(_tv_) × nsPerMillisecond)).
-          1. Let _offsetMs_ be truncate(_offsetNs_ / nsPerMillisecond).
-          1. Return _tv_ + 𝔽(_offsetMs_).
+            1. Let _offsetNanoseconds_ be GetNamedTimeZoneOffsetNanoseconds(_systemTimeZoneIdentifier_, ℤ(ℝ(_tv_) × NanosecondsPerMillisecond)).
+          1. Let _offsetMilliseconds_ be truncate(_offsetNanoseconds_ / NanosecondsPerMillisecond).
+          1. Return _tv_ + 𝔽(_offsetMilliseconds_).
         </emu-alg>
         <emu-note>
           <p>If political rules for the local time _tv_ are not available within the implementation, the result is _tv_ because SystemTimeZoneIdentifier returns *"UTC"* and GetNamedTimeZoneOffsetNanoseconds returns 0.</p>
@@ -34587,19 +34587,19 @@
           1. If _t_ is not finite, return *NaN*.
           1. Let _systemTimeZoneIdentifier_ be SystemTimeZoneIdentifier().
           1. If IsTimeZoneOffsetString(_systemTimeZoneIdentifier_) is *true*, then
-            1. Let _offsetNs_ be ParseTimeZoneOffsetString(_systemTimeZoneIdentifier_).
+            1. Let _offsetNanoseconds_ be ParseTimeZoneOffsetString(_systemTimeZoneIdentifier_).
           1. Else,
-            1. Let _possibleInstants_ be GetNamedTimeZoneEpochNanoseconds(_systemTimeZoneIdentifier_, YearFromTime(_t_), MonthFromTime(_t_) + 1, DateFromTime(_t_), HourFromTime(_t_), MinFromTime(_t_), SecFromTime(_t_), MillisecFromTime(_t_), 0, 0).
+            1. Let _possibleInstants_ be GetNamedTimeZoneEpochNanoseconds(_systemTimeZoneIdentifier_, YearFromTime(_t_), MonthFromTime(_t_) + 1, DateFromTime(_t_), HourFromTime(_t_), MinuteFromTime(_t_), SecondFromTime(_t_), MillisecondFromTime(_t_), 0, 0).
             1. NOTE: The following steps ensure that when _t_ represents local time repeating multiple times at a negative time zone transition (e.g. when the daylight saving time ends or the time zone offset is decreased due to a time zone rule change) or skipped local time at a positive time zone transition (e.g. when the daylight saving time starts or the time zone offset is increased due to a time zone rule change), _t_ is interpreted using the time zone offset before the transition.
             1. If _possibleInstants_ is not empty, then
               1. Let _disambiguatedInstant_ be _possibleInstants_[0].
             1. Else,
               1. NOTE: _t_ represents a local time skipped at a positive time zone transition (e.g. due to daylight saving time starting or a time zone rule change increasing the UTC offset).
-              1. [declared="tBefore"] Let _possibleInstantsBefore_ be GetNamedTimeZoneEpochNanoseconds(_systemTimeZoneIdentifier_, YearFromTime(_tBefore_), MonthFromTime(_tBefore_) + 1, DateFromTime(_tBefore_), HourFromTime(_tBefore_), MinFromTime(_tBefore_), SecFromTime(_tBefore_), MillisecFromTime(_tBefore_), 0, 0), where _tBefore_ is the largest integral Number &lt; _t_ for which _possibleInstantsBefore_ is not empty (i.e., _tBefore_ represents the last local time before the transition).
+              1. [declared="tBefore"] Let _possibleInstantsBefore_ be GetNamedTimeZoneEpochNanoseconds(_systemTimeZoneIdentifier_, YearFromTime(_tBefore_), MonthFromTime(_tBefore_) + 1, DateFromTime(_tBefore_), HourFromTime(_tBefore_), MinuteFromTime(_tBefore_), SecondFromTime(_tBefore_), MillisecondFromTime(_tBefore_), 0, 0), where _tBefore_ is the largest integral Number &lt; _t_ for which _possibleInstantsBefore_ is not empty (i.e., _tBefore_ represents the last local time before the transition).
               1. Let _disambiguatedInstant_ be the last element of _possibleInstantsBefore_.
-            1. Let _offsetNs_ be GetNamedTimeZoneOffsetNanoseconds(_systemTimeZoneIdentifier_, _disambiguatedInstant_).
-          1. Let _offsetMs_ be truncate(_offsetNs_ / nsPerMillisecond).
-          1. Return _t_ - 𝔽(_offsetMs_).
+            1. Let _offsetNanoseconds_ be GetNamedTimeZoneOffsetNanoseconds(_systemTimeZoneIdentifier_, _disambiguatedInstant_).
+          1. Let _offsetMilliseconds_ be truncate(_offsetNanoseconds_ / NanosecondsPerMillisecond).
+          1. Return _t_ - 𝔽(_offsetMilliseconds_).
         </emu-alg>
         <p>
           Input _t_ is nominally a time value but may be any Number value.
@@ -34612,11 +34612,11 @@
           <p>It is required for time zone aware implementations (and recommended for all others) to use the time zone information of the IANA Time Zone Database <a href="https://www.iana.org/time-zones/">https://www.iana.org/time-zones/</a>.</p>
           <p>
             1:30 AM on 5 November 2017 in America/New_York is repeated twice (fall backward), but it must be interpreted as 1:30 AM UTC-04 instead of 1:30 AM UTC-05.
-            In UTC(TimeClip(MakeDate(MakeDay(2017, 10, 5), MakeTime(1, 30, 0, 0)))), the value of _offsetMs_ is <emu-eqn>-4 × msPerHour</emu-eqn>.
+            In UTC(TimeClip(MakeDate(MakeDay(2017, 10, 5), MakeTime(1, 30, 0, 0)))), the value of _offsetMilliseconds_ is <emu-eqn>-4 × MillisecondsPerHour</emu-eqn>.
           </p>
           <p>
             2:30 AM on 12 March 2017 in America/New_York does not exist, but it must be interpreted as 2:30 AM UTC-05 (equivalent to 3:30 AM UTC-04).
-            In UTC(TimeClip(MakeDate(MakeDay(2017, 2, 12), MakeTime(2, 30, 0, 0)))), the value of _offsetMs_ is <emu-eqn>-5 × msPerHour</emu-eqn>.
+            In UTC(TimeClip(MakeDate(MakeDay(2017, 2, 12), MakeTime(2, 30, 0, 0)))), the value of _offsetMilliseconds_ is <emu-eqn>-5 × MillisecondsPerHour</emu-eqn>.
           </p>
         </emu-note>
         <emu-note>
@@ -34628,9 +34628,9 @@
         <h1>
           MakeTime (
             _hour_: a Number,
-            _min_: a Number,
-            _sec_: a Number,
-            _ms_: a Number,
+            _minute_: a Number,
+            _second_: a Number,
+            _millisecond_: a Number,
           ): a Number
         </h1>
         <dl class="header">
@@ -34638,12 +34638,12 @@
           <dd>It calculates a number of milliseconds.</dd>
         </dl>
         <emu-alg>
-          1. If _hour_ is not finite, _min_ is not finite, _sec_ is not finite, or _ms_ is not finite, return *NaN*.
-          1. Let _h_ be ! ToIntegerOrInfinity(_hour_).
-          1. Let _m_ be ! ToIntegerOrInfinity(_min_).
-          1. Let _s_ be ! ToIntegerOrInfinity(_sec_).
-          1. Let _milli_ be ! ToIntegerOrInfinity(_ms_).
-          1. Return ((𝔽(_h_) × 𝔽(msPerHour) + 𝔽(_m_) × 𝔽(msPerMinute)) + 𝔽(_s_) × 𝔽(msPerSecond)) + 𝔽(_milli_).
+          1. If _hour_ is not finite, _minute_ is not finite, _second_ is not finite, or _millisecond_ is not finite, return *NaN*.
+          1. Set _hour_ to ! ToIntegerOrInfinity(_hour_).
+          1. Set _minute_ to ! ToIntegerOrInfinity(_minute_).
+          1. Set _second_ to ! ToIntegerOrInfinity(_second_).
+          1. Set _millisecond_ be ! ToIntegerOrInfinity(_millisecond_).
+          1. Return ((𝔽(_hour_) × 𝔽(MillisecondsPerHour) + 𝔽(_minute_) × 𝔽(MillisecondsPerMinute)) + 𝔽(_second_) × 𝔽(MillisecondsPerSecond)) + 𝔽(_millisecond_).
         </emu-alg>
         <emu-note>
           <p>The arithmetic in MakeTime is floating-point arithmetic, which is not associative, so the operations must be performed in the correct order.</p>
@@ -34655,7 +34655,7 @@
           MakeDay (
             _year_: a Number,
             _month_: a Number,
-            _date_: a Number,
+            _day_: a Number,
           ): a finite Number or *NaN*
         </h1>
         <dl class="header">
@@ -34663,15 +34663,15 @@
           <dd>It calculates a number of days.</dd>
         </dl>
         <emu-alg>
-          1. If _year_ is not finite, _month_ is not finite, or _date_ is not finite, return *NaN*.
-          1. Let _y_ be ! ToIntegerOrInfinity(_year_).
-          1. Let _m_ be ! ToIntegerOrInfinity(_month_).
-          1. Let _dt_ be ! ToIntegerOrInfinity(_date_).
-          1. Let _ym_ be 𝔽(_y_) + 𝔽(floor(_m_ / 12)).
-          1. If _ym_ is not finite, return *NaN*.
-          1. Let _mn_ be _m_ modulo 12.
-          1. Find a finite time value _tv_ such that YearFromTime(_tv_) = ℝ(_ym_), MonthFromTime(_tv_) = _mn_, and DateFromTime(_tv_) = 1; but if this is not possible (because some argument is out of range), return *NaN*.
-          1. Return 𝔽(Day(_tv_)) + 𝔽(_dt_) - *1*<sub>𝔽</sub>.
+          1. If _year_ is not finite, _month_ is not finite, or _day_ is not finite, return *NaN*.
+          1. Set _year_ to ! ToIntegerOrInfinity(_year_).
+          1. Set _month_ to ! ToIntegerOrInfinity(_month_).
+          1. Set _day_ be ! ToIntegerOrInfinity(_day_).
+          1. Set _year_ to 𝔽(_year_) + 𝔽(floor(_month_ / 12)).
+          1. If _year_ is not finite, return *NaN*.
+          1. Set _month_ to _month_ modulo 12.
+          1. Find a finite time value _tv_ such that YearFromTime(_tv_) = ℝ(_year_), MonthFromTime(_tv_) = _month_, and DateFromTime(_tv_) = 1; but if this is not possible (because some argument is out of range), return *NaN*.
+          1. Return 𝔽(Day(_tv_)) + 𝔽(_day_) - *1*<sub>𝔽</sub>.
         </emu-alg>
       </emu-clause>
 
@@ -34688,7 +34688,7 @@
         </dl>
         <emu-alg>
           1. If _day_ is not finite or _time_ is not finite, return *NaN*.
-          1. Let _tv_ be _day_ × 𝔽(msPerDay) + _time_.
+          1. Let _tv_ be _day_ × 𝔽(MillisecondsPerDay) + _time_.
           1. If _tv_ is not finite, return *NaN*.
           1. Return _tv_.
         </emu-alg>
@@ -35008,7 +35008,7 @@ THH:mm:ss.sss
               1. Let _fraction_ be the string-concatenation of CodePointsToString(_parsedFraction_) and *"000000000"*.
               1. Let _nanosecondsString_ be the substring of _fraction_ from 1 to 10.
               1. Let _nanoseconds_ be ℝ(StringToNumber(_nanosecondsString_)).
-            1. Return _sign_ × (((_hours_ × MinutesPerHour + _minutes_) × SecondsPerMinute + _seconds_) × nsPerSecond + _nanoseconds_).
+            1. Return _sign_ × (((_hours_ × MinutesPerHour + _minutes_) × SecondsPerMinute + _seconds_) × NanosecondsPerSecond + _nanoseconds_).
           </emu-alg>
         </emu-clause>
       </emu-clause>
@@ -35050,15 +35050,15 @@ THH:mm:ss.sss
             1. Let _dv_ be TimeClip(_tv_).
           1. Else,
             1. Assert: _numberOfArgs_ ≥ 2.
-            1. Let _y_ be ? ToNumber(_values_[0]).
-            1. Let _m_ be ? ToNumber(_values_[1]).
-            1. If _numberOfArgs_ > 2, let _dt_ be ? ToNumber(_values_[2]); else let _dt_ be *1*<sub>𝔽</sub>.
-            1. If _numberOfArgs_ > 3, let _h_ be ? ToNumber(_values_[3]); else let _h_ be *+0*<sub>𝔽</sub>.
-            1. If _numberOfArgs_ > 4, let _min_ be ? ToNumber(_values_[4]); else let _min_ be *+0*<sub>𝔽</sub>.
-            1. If _numberOfArgs_ > 5, let _s_ be ? ToNumber(_values_[5]); else let _s_ be *+0*<sub>𝔽</sub>.
-            1. If _numberOfArgs_ > 6, let _milli_ be ? ToNumber(_values_[6]); else let _milli_ be *+0*<sub>𝔽</sub>.
-            1. Let _yr_ be MakeFullYear(_y_).
-            1. Let _finalDate_ be MakeDate(MakeDay(_yr_, _m_, _dt_), MakeTime(_h_, _min_, _s_, _milli_)).
+            1. Let _year_ be ? ToNumber(_values_[0]).
+            1. Let _month_ be ? ToNumber(_values_[1]).
+            1. If _numberOfArgs_ > 2, let _day_ be ? ToNumber(_values_[2]); else let _day_ be *1*<sub>𝔽</sub>.
+            1. If _numberOfArgs_ > 3, let _hour_ be ? ToNumber(_values_[3]); else let _hour_ be *+0*<sub>𝔽</sub>.
+            1. If _numberOfArgs_ > 4, let _minute_ be ? ToNumber(_values_[4]); else let _minute_ be *+0*<sub>𝔽</sub>.
+            1. If _numberOfArgs_ > 5, let _second_ be ? ToNumber(_values_[5]); else let _second_ be *+0*<sub>𝔽</sub>.
+            1. If _numberOfArgs_ > 6, let _millisecond_ be ? ToNumber(_values_[6]); else let _millisecond_ be *+0*<sub>𝔽</sub>.
+            1. Set _year_ to MakeFullYear(_year_).
+            1. Let _finalDate_ be MakeDate(MakeDay(_year_, _month_, _day_), MakeTime(_hour_, _minute_, _second_, _millisecond_)).
             1. Let _dv_ be TimeClip(UTC(_finalDate_)).
           1. Let _obj_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Date.prototype%"*, « [[DateValue]] »).
           1. Set _obj_.[[DateValue]] to _dv_.
@@ -35106,18 +35106,18 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-date.utc" type="built-in function">
-        <h1>Date.UTC ( _year_ [ , _month_ [ , _date_ [ , _hours_ [ , _minutes_ [ , _seconds_ [ , _ms_ ] ] ] ] ] ] )</h1>
+        <h1>Date.UTC ( _year_ [ , _month_ [ , _day_ [ , _hour_ [ , _minute_ [ , _second_ [ , _millisecond_ ] ] ] ] ] ] )</h1>
         <p>This function performs the following steps when called:</p>
         <emu-alg>
-          1. Let _y_ be ? ToNumber(_year_).
-          1. If _month_ is present, let _m_ be ? ToNumber(_month_); else let _m_ be *+0*<sub>𝔽</sub>.
-          1. If _date_ is present, let _dt_ be ? ToNumber(_date_); else let _dt_ be *1*<sub>𝔽</sub>.
-          1. If _hours_ is present, let _h_ be ? ToNumber(_hours_); else let _h_ be *+0*<sub>𝔽</sub>.
-          1. If _minutes_ is present, let _min_ be ? ToNumber(_minutes_); else let _min_ be *+0*<sub>𝔽</sub>.
-          1. If _seconds_ is present, let _s_ be ? ToNumber(_seconds_); else let _s_ be *+0*<sub>𝔽</sub>.
-          1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_); else let _milli_ be *+0*<sub>𝔽</sub>.
-          1. Let _yr_ be MakeFullYear(_y_).
-          1. Return TimeClip(MakeDate(MakeDay(_yr_, _m_, _dt_), MakeTime(_h_, _min_, _s_, _milli_))).
+          1. Set _year_ to ? ToNumber(_year_).
+          1. If _month_ is present, set _month_ to ? ToNumber(_month_); else set _month_ to *+0*<sub>𝔽</sub>.
+          1. If _day_ is present, set _day_ to ? ToNumber(_day_); else set _day_ to *1*<sub>𝔽</sub>.
+          1. If _hour_ is present, set _hour_ to ? ToNumber(_hour_); else set _hour_ to *+0*<sub>𝔽</sub>.
+          1. If _minute_ is present, set _minute_ to ? ToNumber(_minute_); else set _minute_ to *+0*<sub>𝔽</sub>.
+          1. If _second_ is present, set _second_ to ? ToNumber(_second_); else set _second_ to *+0*<sub>𝔽</sub>.
+          1. If _millisecond_ is present, set _millisecond_ to ? ToNumber(_millisecond_); else set _millisecond_ to *+0*<sub>𝔽</sub>.
+          1. Set _year_ to MakeFullYear(_year_).
+          1. Return TimeClip(MakeDate(MakeDay(_year_, _month_, _day_), MakeTime(_hour_, _minute_, _second_, _millisecond_))).
         </emu-alg>
         <p>The *"length"* property of this function is *7*<sub>𝔽</sub>.</p>
         <emu-note>
@@ -35198,7 +35198,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
           1. If _tv_ is *NaN*, return *NaN*.
-          1. Return 𝔽(MillisecFromTime(LocalTime(_tv_))).
+          1. Return 𝔽(MillisecondFromTime(LocalTime(_tv_))).
         </emu-alg>
       </emu-clause>
 
@@ -35210,7 +35210,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
           1. If _tv_ is *NaN*, return *NaN*.
-          1. Return 𝔽(MinFromTime(LocalTime(_tv_))).
+          1. Return 𝔽(MinuteFromTime(LocalTime(_tv_))).
         </emu-alg>
       </emu-clause>
 
@@ -35234,7 +35234,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
           1. If _tv_ is *NaN*, return *NaN*.
-          1. Return 𝔽(SecFromTime(LocalTime(_tv_))).
+          1. Return 𝔽(SecondFromTime(LocalTime(_tv_))).
         </emu-alg>
       </emu-clause>
 
@@ -35256,7 +35256,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
           1. If _tv_ is *NaN*, return *NaN*.
-          1. Return (_tv_ - LocalTime(_tv_)) / 𝔽(msPerMinute).
+          1. Return (_tv_ - LocalTime(_tv_)) / 𝔽(MillisecondsPerMinute).
         </emu-alg>
       </emu-clause>
 
@@ -35316,7 +35316,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
           1. If _tv_ is *NaN*, return *NaN*.
-          1. Return 𝔽(MillisecFromTime(_tv_)).
+          1. Return 𝔽(MillisecondFromTime(_tv_)).
         </emu-alg>
       </emu-clause>
 
@@ -35328,7 +35328,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
           1. If _tv_ is *NaN*, return *NaN*.
-          1. Return 𝔽(MinFromTime(_tv_)).
+          1. Return 𝔽(MinuteFromTime(_tv_)).
         </emu-alg>
       </emu-clause>
 
@@ -35352,21 +35352,21 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
           1. If _tv_ is *NaN*, return *NaN*.
-          1. Return 𝔽(SecFromTime(_tv_)).
+          1. Return 𝔽(SecondFromTime(_tv_)).
         </emu-alg>
       </emu-clause>
 
       <emu-clause id="sec-date.prototype.setdate" type="built-in function">
-        <h1>Date.prototype.setDate ( _date_ )</h1>
+        <h1>Date.prototype.setDate ( _day_ )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _dateObj_ be the *this* value.
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
-          1. Let _dt_ be ? ToNumber(_date_).
+          1. Set _day_ to ? ToNumber(_day_).
           1. If _tv_ is *NaN*, return *NaN*.
           1. Set _tv_ to LocalTime(_tv_).
-          1. Let _newDate_ be MakeDate(MakeDay(𝔽(YearFromTime(_tv_)), 𝔽(MonthFromTime(_tv_)), _dt_), 𝔽(TimeWithinDay(_tv_))).
+          1. Let _newDate_ be MakeDate(MakeDay(𝔽(YearFromTime(_tv_)), 𝔽(MonthFromTime(_tv_)), _day_), 𝔽(TimeWithinDay(_tv_))).
           1. Let _u_ be TimeClip(UTC(_newDate_)).
           1. Set _dateObj_.[[DateValue]] to _u_.
           1. Return _u_.
@@ -35374,65 +35374,65 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-date.prototype.setfullyear" type="built-in function">
-        <h1>Date.prototype.setFullYear ( _year_ [ , _month_ [ , _date_ ] ] )</h1>
+        <h1>Date.prototype.setFullYear ( _year_ [ , _month_ [ , _day_ ] ] )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _dateObj_ be the *this* value.
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
-          1. Let _y_ be ? ToNumber(_year_).
+          1. Set _year_ to ? ToNumber(_year_).
           1. If _tv_ is *NaN*, set _tv_ to *+0*<sub>𝔽</sub>; else set _tv_ to LocalTime(_tv_).
-          1. If _month_ is present, let _m_ be ? ToNumber(_month_); else let _m_ be 𝔽(MonthFromTime(_tv_)).
-          1. If _date_ is present, let _dt_ be ? ToNumber(_date_); else let _dt_ be 𝔽(DateFromTime(_tv_)).
-          1. Let _newDate_ be MakeDate(MakeDay(_y_, _m_, _dt_), 𝔽(TimeWithinDay(_tv_))).
+          1. If _month_ is present, set _month_ to ? ToNumber(_month_); else set _month_ to 𝔽(MonthFromTime(_tv_)).
+          1. If _day_ is present, set _day_ to ? ToNumber(_day_); else set _day_ to 𝔽(DateFromTime(_tv_)).
+          1. Let _newDate_ be MakeDate(MakeDay(_year_, _month_, _day_), 𝔽(TimeWithinDay(_tv_))).
           1. Let _u_ be TimeClip(UTC(_newDate_)).
           1. Set _dateObj_.[[DateValue]] to _u_.
           1. Return _u_.
         </emu-alg>
         <p>The *"length"* property of this method is *3*<sub>𝔽</sub>.</p>
         <emu-note>
-          <p>If _month_ is not present, this method behaves as if _month_ was present with the value `getMonth()`. If _date_ is not present, it behaves as if _date_ was present with the value `getDate()`.</p>
+          <p>If _month_ is not present, this method behaves as if _month_ was present with the value `getMonth()`. If _day_ is not present, it behaves as if _day_ was present with the value `getDate()`.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-date.prototype.sethours" type="built-in function">
-        <h1>Date.prototype.setHours ( _hour_ [ , _min_ [ , _sec_ [ , _ms_ ] ] ] )</h1>
+        <h1>Date.prototype.setHours ( _hour_ [ , _minute_ [ , _second_ [ , _millisecond_ ] ] ] )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _dateObj_ be the *this* value.
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
-          1. Let _h_ be ? ToNumber(_hour_).
-          1. If _min_ is present, let _m_ be ? ToNumber(_min_).
-          1. If _sec_ is present, let _s_ be ? ToNumber(_sec_).
-          1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_).
+          1. Set _hour_ to ? ToNumber(_hour_).
+          1. If _minute_ is present, set _minute_ to ? ToNumber(_minute_).
+          1. If _second_ is present, set _second_ to ? ToNumber(_second_).
+          1. If _millisecond_ is present, set _millisecond_ to ? ToNumber(_millisecond_).
           1. If _tv_ is *NaN*, return *NaN*.
           1. Set _tv_ to LocalTime(_tv_).
-          1. If _min_ is not present, let _m_ be 𝔽(MinFromTime(_tv_)).
-          1. If _sec_ is not present, let _s_ be 𝔽(SecFromTime(_tv_)).
-          1. If _ms_ is not present, let _milli_ be 𝔽(MillisecFromTime(_tv_)).
-          1. Let _date_ be MakeDate(𝔽(Day(_tv_)), MakeTime(_h_, _m_, _s_, _milli_)).
+          1. If _minute_ is not present, set _minute_ to 𝔽(MinuteFromTime(_tv_)).
+          1. If _second_ is not present, set _second_ to 𝔽(SecondFromTime(_tv_)).
+          1. If _millisecond_ is not present, set _millisecond_ to 𝔽(MillisecondFromTime(_tv_)).
+          1. Let _date_ be MakeDate(𝔽(Day(_tv_)), MakeTime(_hour_, _minute_, _second_, _millisecond_)).
           1. Let _u_ be TimeClip(UTC(_date_)).
           1. Set _dateObj_.[[DateValue]] to _u_.
           1. Return _u_.
         </emu-alg>
         <p>The *"length"* property of this method is *4*<sub>𝔽</sub>.</p>
         <emu-note>
-          <p>If _min_ is not present, this method behaves as if _min_ was present with the value `getMinutes()`. If _sec_ is not present, it behaves as if _sec_ was present with the value `getSeconds()`. If _ms_ is not present, it behaves as if _ms_ was present with the value `getMilliseconds()`.</p>
+          <p>If _minute_ is not present, this method behaves as if _minute_ was present with the value `getMinutes()`. If _second_ is not present, it behaves as if _second_ was present with the value `getSeconds()`. If _millisecond_ is not present, it behaves as if _millisecond_ was present with the value `getMilliseconds()`.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-date.prototype.setmilliseconds" type="built-in function">
-        <h1>Date.prototype.setMilliseconds ( _ms_ )</h1>
+        <h1>Date.prototype.setMilliseconds ( _millisecond_ )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _dateObj_ be the *this* value.
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
-          1. Set _ms_ to ? ToNumber(_ms_).
+          1. Set _millisecond_ to ? ToNumber(_millisecond_).
           1. If _tv_ is *NaN*, return *NaN*.
           1. Set _tv_ to LocalTime(_tv_).
-          1. Let _time_ be MakeTime(𝔽(HourFromTime(_tv_)), 𝔽(MinFromTime(_tv_)), 𝔽(SecFromTime(_tv_)), _ms_).
+          1. Let _time_ be MakeTime(𝔽(HourFromTime(_tv_)), 𝔽(MinuteFromTime(_tv_)), 𝔽(SecondFromTime(_tv_)), _millisecond_).
           1. Let _u_ be TimeClip(UTC(MakeDate(𝔽(Day(_tv_)), _time_))).
           1. Set _dateObj_.[[DateValue]] to _u_.
           1. Return _u_.
@@ -35440,73 +35440,73 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-date.prototype.setminutes" type="built-in function">
-        <h1>Date.prototype.setMinutes ( _min_ [ , _sec_ [ , _ms_ ] ] )</h1>
+        <h1>Date.prototype.setMinutes ( _minute_ [ , _second_ [ , _millisecond_ ] ] )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _dateObj_ be the *this* value.
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
-          1. Let _m_ be ? ToNumber(_min_).
-          1. If _sec_ is present, let _s_ be ? ToNumber(_sec_).
-          1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_).
+          1. Set _minute_ to ? ToNumber(_minute_).
+          1. If _second_ is present, set _second_ to ? ToNumber(_second_).
+          1. If _millisecond_ is present, set _millisecond_ to ? ToNumber(_millisecond_).
           1. If _tv_ is *NaN*, return *NaN*.
           1. Set _tv_ to LocalTime(_tv_).
-          1. If _sec_ is not present, let _s_ be 𝔽(SecFromTime(_tv_)).
-          1. If _ms_ is not present, let _milli_ be 𝔽(MillisecFromTime(_tv_)).
-          1. Let _date_ be MakeDate(𝔽(Day(_tv_)), MakeTime(𝔽(HourFromTime(_tv_)), _m_, _s_, _milli_)).
+          1. If _second_ is not present, set _second_ to 𝔽(SecondFromTime(_tv_)).
+          1. If _millisecond_ is not present, set _millisecond_ to 𝔽(MillisecondFromTime(_tv_)).
+          1. Let _date_ be MakeDate(𝔽(Day(_tv_)), MakeTime(𝔽(HourFromTime(_tv_)), _minute_, _second_, _millisecond_)).
           1. Let _u_ be TimeClip(UTC(_date_)).
           1. Set _dateObj_.[[DateValue]] to _u_.
           1. Return _u_.
         </emu-alg>
         <p>The *"length"* property of this method is *3*<sub>𝔽</sub>.</p>
         <emu-note>
-          <p>If _sec_ is not present, this method behaves as if _sec_ was present with the value `getSeconds()`. If _ms_ is not present, this behaves as if _ms_ was present with the value `getMilliseconds()`.</p>
+          <p>If _second_ is not present, this method behaves as if _second_ was present with the value `getSeconds()`. If _millisecond_ is not present, this behaves as if _millisecond_ was present with the value `getMilliseconds()`.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-date.prototype.setmonth" type="built-in function">
-        <h1>Date.prototype.setMonth ( _month_ [ , _date_ ] )</h1>
+        <h1>Date.prototype.setMonth ( _month_ [ , _day_ ] )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _dateObj_ be the *this* value.
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
-          1. Let _m_ be ? ToNumber(_month_).
-          1. If _date_ is present, let _dt_ be ? ToNumber(_date_).
+          1. Set _month_ to ? ToNumber(_month_).
+          1. If _day_ is present, set _day_ to ? ToNumber(_day_).
           1. If _tv_ is *NaN*, return *NaN*.
           1. Set _tv_ to LocalTime(_tv_).
-          1. If _date_ is not present, let _dt_ be 𝔽(DateFromTime(_tv_)).
-          1. Let _newDate_ be MakeDate(MakeDay(𝔽(YearFromTime(_tv_)), _m_, _dt_), 𝔽(TimeWithinDay(_tv_))).
+          1. If _day_ is not present, set _day_ to 𝔽(DateFromTime(_tv_)).
+          1. Let _newDate_ be MakeDate(MakeDay(𝔽(YearFromTime(_tv_)), _month_, _day_), 𝔽(TimeWithinDay(_tv_))).
           1. Let _u_ be TimeClip(UTC(_newDate_)).
           1. Set _dateObj_.[[DateValue]] to _u_.
           1. Return _u_.
         </emu-alg>
         <p>The *"length"* property of this method is *2*<sub>𝔽</sub>.</p>
         <emu-note>
-          <p>If _date_ is not present, this method behaves as if _date_ was present with the value `getDate()`.</p>
+          <p>If _day_ is not present, this method behaves as if _day_ was present with the value `getDate()`.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-date.prototype.setseconds" type="built-in function">
-        <h1>Date.prototype.setSeconds ( _sec_ [ , _ms_ ] )</h1>
+        <h1>Date.prototype.setSeconds ( _second_ [ , _millisecond_ ] )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _dateObj_ be the *this* value.
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
-          1. Let _s_ be ? ToNumber(_sec_).
-          1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_).
+          1. Set _second_ to ? ToNumber(_second_).
+          1. If _millisecond_ is present, set _millisecond_ to ? ToNumber(_millisecond_).
           1. If _tv_ is *NaN*, return *NaN*.
           1. Set _tv_ to LocalTime(_tv_).
-          1. If _ms_ is not present, let _milli_ be 𝔽(MillisecFromTime(_tv_)).
-          1. Let _date_ be MakeDate(𝔽(Day(_tv_)), MakeTime(𝔽(HourFromTime(_tv_)), 𝔽(MinFromTime(_tv_)), _s_, _milli_)).
+          1. If _millisecond_ is not present, set _millisecond_ to 𝔽(MillisecondFromTime(_tv_)).
+          1. Let _date_ be MakeDate(𝔽(Day(_tv_)), MakeTime(𝔽(HourFromTime(_tv_)), 𝔽(MinuteFromTime(_tv_)), _second_, _millisecond_)).
           1. Let _u_ be TimeClip(UTC(_date_)).
           1. Set _dateObj_.[[DateValue]] to _u_.
           1. Return _u_.
         </emu-alg>
         <p>The *"length"* property of this method is *2*<sub>𝔽</sub>.</p>
         <emu-note>
-          <p>If _ms_ is not present, this method behaves as if _ms_ was present with the value `getMilliseconds()`.</p>
+          <p>If _millisecond_ is not present, this method behaves as if _millisecond_ was present with the value `getMilliseconds()`.</p>
         </emu-note>
       </emu-clause>
 
@@ -35524,15 +35524,15 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-date.prototype.setutcdate" type="built-in function">
-        <h1>Date.prototype.setUTCDate ( _date_ )</h1>
+        <h1>Date.prototype.setUTCDate ( _day_ )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _dateObj_ be the *this* value.
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
-          1. Let _dt_ be ? ToNumber(_date_).
+          1. Set _day_ to ? ToNumber(_day_).
           1. If _tv_ is *NaN*, return *NaN*.
-          1. Let _newDate_ be MakeDate(MakeDay(𝔽(YearFromTime(_tv_)), 𝔽(MonthFromTime(_tv_)), _dt_), 𝔽(TimeWithinDay(_tv_))).
+          1. Let _newDate_ be MakeDate(MakeDay(𝔽(YearFromTime(_tv_)), 𝔽(MonthFromTime(_tv_)), _day_), 𝔽(TimeWithinDay(_tv_))).
           1. Let _v_ be TimeClip(_newDate_).
           1. Set _dateObj_.[[DateValue]] to _v_.
           1. Return _v_.
@@ -35540,63 +35540,63 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-date.prototype.setutcfullyear" type="built-in function">
-        <h1>Date.prototype.setUTCFullYear ( _year_ [ , _month_ [ , _date_ ] ] )</h1>
+        <h1>Date.prototype.setUTCFullYear ( _year_ [ , _month_ [ , _day_ ] ] )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _dateObj_ be the *this* value.
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
           1. If _tv_ is *NaN*, set _tv_ to *+0*<sub>𝔽</sub>.
-          1. Let _y_ be ? ToNumber(_year_).
-          1. If _month_ is present, let _m_ be ? ToNumber(_month_); else let _m_ be 𝔽(MonthFromTime(_tv_)).
-          1. If _date_ is present, let _dt_ be ? ToNumber(_date_); else let _dt_ be 𝔽(DateFromTime(_tv_)).
-          1. Let _newDate_ be MakeDate(MakeDay(_y_, _m_, _dt_), 𝔽(TimeWithinDay(_tv_))).
+          1. Set _year_ to ? ToNumber(_year_).
+          1. If _month_ is present, set _month_ to ? ToNumber(_month_); else set _month_ to 𝔽(MonthFromTime(_tv_)).
+          1. If _day_ is present, set _day_ to ? ToNumber(_day_); else set _day_ to 𝔽(DateFromTime(_tv_)).
+          1. Let _newDate_ be MakeDate(MakeDay(_year_, _month_, _day_), 𝔽(TimeWithinDay(_tv_))).
           1. Let _v_ be TimeClip(_newDate_).
           1. Set _dateObj_.[[DateValue]] to _v_.
           1. Return _v_.
         </emu-alg>
         <p>The *"length"* property of this method is *3*<sub>𝔽</sub>.</p>
         <emu-note>
-          <p>If _month_ is not present, this method behaves as if _month_ was present with the value `getUTCMonth()`. If _date_ is not present, it behaves as if _date_ was present with the value `getUTCDate()`.</p>
+          <p>If _month_ is not present, this method behaves as if _month_ was present with the value `getUTCMonth()`. If _day_ is not present, it behaves as if _day_ was present with the value `getUTCDate()`.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-date.prototype.setutchours" type="built-in function">
-        <h1>Date.prototype.setUTCHours ( _hour_ [ , _min_ [ , _sec_ [ , _ms_ ] ] ] )</h1>
+        <h1>Date.prototype.setUTCHours ( _hour_ [ , _minute_ [ , _second_ [ , _millisecond_ ] ] ] )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _dateObj_ be the *this* value.
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
-          1. Let _h_ be ? ToNumber(_hour_).
-          1. If _min_ is present, let _m_ be ? ToNumber(_min_).
-          1. If _sec_ is present, let _s_ be ? ToNumber(_sec_).
-          1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_).
+          1. Set _hour_ to ? ToNumber(_hour_).
+          1. If _minute_ is present, set _minute_ to ? ToNumber(_minute_).
+          1. If _second_ is present, set _second_ to ? ToNumber(_second_).
+          1. If _millisecond_ is present, set _millisecond_ to ? ToNumber(_millisecond_).
           1. If _tv_ is *NaN*, return *NaN*.
-          1. If _min_ is not present, let _m_ be 𝔽(MinFromTime(_tv_)).
-          1. If _sec_ is not present, let _s_ be 𝔽(SecFromTime(_tv_)).
-          1. If _ms_ is not present, let _milli_ be 𝔽(MillisecFromTime(_tv_)).
-          1. Let _date_ be MakeDate(𝔽(Day(_tv_)), MakeTime(_h_, _m_, _s_, _milli_)).
+          1. If _minute_ is not present, set _minute_ to 𝔽(MinuteFromTime(_tv_)).
+          1. If _second_ is not present, set _second_ to 𝔽(SecondFromTime(_tv_)).
+          1. If _millisecond_ is not present, set _millisecond_ to 𝔽(MillisecondFromTime(_tv_)).
+          1. Let _date_ be MakeDate(𝔽(Day(_tv_)), MakeTime(_hour_, _minute_, _second_, _millisecond_)).
           1. Let _v_ be TimeClip(_date_).
           1. Set _dateObj_.[[DateValue]] to _v_.
           1. Return _v_.
         </emu-alg>
         <p>The *"length"* property of this method is *4*<sub>𝔽</sub>.</p>
         <emu-note>
-          <p>If _min_ is not present, this method behaves as if _min_ was present with the value `getUTCMinutes()`. If _sec_ is not present, it behaves as if _sec_ was present with the value `getUTCSeconds()`. If _ms_ is not present, it behaves as if _ms_ was present with the value `getUTCMilliseconds()`.</p>
+          <p>If _minute_ is not present, this method behaves as if _minute_ was present with the value `getUTCMinutes()`. If _second_ is not present, it behaves as if _second_ was present with the value `getUTCSeconds()`. If _millisecond_ is not present, it behaves as if _millisecond_ was present with the value `getUTCMilliseconds()`.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-date.prototype.setutcmilliseconds" type="built-in function">
-        <h1>Date.prototype.setUTCMilliseconds ( _ms_ )</h1>
+        <h1>Date.prototype.setUTCMilliseconds ( _millisecond_ )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _dateObj_ be the *this* value.
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
-          1. Set _ms_ to ? ToNumber(_ms_).
+          1. Set _millisecond_ to ? ToNumber(_millisecond_).
           1. If _tv_ is *NaN*, return *NaN*.
-          1. Let _time_ be MakeTime(𝔽(HourFromTime(_tv_)), 𝔽(MinFromTime(_tv_)), 𝔽(SecFromTime(_tv_)), _ms_).
+          1. Let _time_ be MakeTime(𝔽(HourFromTime(_tv_)), 𝔽(MinuteFromTime(_tv_)), 𝔽(SecondFromTime(_tv_)), _millisecond_).
           1. Let _v_ be TimeClip(MakeDate(𝔽(Day(_tv_)), _time_)).
           1. Set _dateObj_.[[DateValue]] to _v_.
           1. Return _v_.
@@ -35604,70 +35604,70 @@ THH:mm:ss.sss
       </emu-clause>
 
       <emu-clause id="sec-date.prototype.setutcminutes" type="built-in function">
-        <h1>Date.prototype.setUTCMinutes ( _min_ [ , _sec_ [ , _ms_ ] ] )</h1>
+        <h1>Date.prototype.setUTCMinutes ( _minute_ [ , _second_ [ , _millisecond_ ] ] )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _dateObj_ be the *this* value.
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
-          1. Let _m_ be ? ToNumber(_min_).
-          1. If _sec_ is present, let _s_ be ? ToNumber(_sec_).
-          1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_).
+          1. Set _minute_ to ? ToNumber(_minute_).
+          1. If _second_ is present, set _second_ to ? ToNumber(_second_).
+          1. If _millisecond_ is present, set _millisecond_ to ? ToNumber(_millisecond_).
           1. If _tv_ is *NaN*, return *NaN*.
-          1. If _sec_ is not present, let _s_ be 𝔽(SecFromTime(_tv_)).
-          1. If _ms_ is not present, let _milli_ be 𝔽(MillisecFromTime(_tv_)).
-          1. Let _date_ be MakeDate(𝔽(Day(_tv_)), MakeTime(𝔽(HourFromTime(_tv_)), _m_, _s_, _milli_)).
+          1. If _second_ is not present, set _second_ to 𝔽(SecondFromTime(_tv_)).
+          1. If _millisecond_ is not present, set _millisecond_ to 𝔽(MillisecondFromTime(_tv_)).
+          1. Let _date_ be MakeDate(𝔽(Day(_tv_)), MakeTime(𝔽(HourFromTime(_tv_)), _minute_, _second_, _millisecond_)).
           1. Let _v_ be TimeClip(_date_).
           1. Set _dateObj_.[[DateValue]] to _v_.
           1. Return _v_.
         </emu-alg>
         <p>The *"length"* property of this method is *3*<sub>𝔽</sub>.</p>
         <emu-note>
-          <p>If _sec_ is not present, this method behaves as if _sec_ was present with the value `getUTCSeconds()`. If _ms_ is not present, it behaves as if _ms_ was present with the value return by `getUTCMilliseconds()`.</p>
+          <p>If _second_ is not present, this method behaves as if _second_ was present with the value `getUTCSeconds()`. If _millisecond_ is not present, it behaves as if _millisecond_ was present with the value return by `getUTCMilliseconds()`.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-date.prototype.setutcmonth" type="built-in function">
-        <h1>Date.prototype.setUTCMonth ( _month_ [ , _date_ ] )</h1>
+        <h1>Date.prototype.setUTCMonth ( _month_ [ , _day_ ] )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _dateObj_ be the *this* value.
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
-          1. Let _m_ be ? ToNumber(_month_).
-          1. If _date_ is present, let _dt_ be ? ToNumber(_date_).
+          1. Set _month_ to ? ToNumber(_month_).
+          1. If _day_ is present, set _day_ to ? ToNumber(_day_).
           1. If _tv_ is *NaN*, return *NaN*.
-          1. If _date_ is not present, let _dt_ be 𝔽(DateFromTime(_tv_)).
-          1. Let _newDate_ be MakeDate(MakeDay(𝔽(YearFromTime(_tv_)), _m_, _dt_), 𝔽(TimeWithinDay(_tv_))).
+          1. If _day_ is not present, set _day_ to 𝔽(DateFromTime(_tv_)).
+          1. Let _newDate_ be MakeDate(MakeDay(𝔽(YearFromTime(_tv_)), _month_, _day_), 𝔽(TimeWithinDay(_tv_))).
           1. Let _v_ be TimeClip(_newDate_).
           1. Set _dateObj_.[[DateValue]] to _v_.
           1. Return _v_.
         </emu-alg>
         <p>The *"length"* property of this method is *2*<sub>𝔽</sub>.</p>
         <emu-note>
-          <p>If _date_ is not present, this method behaves as if _date_ was present with the value `getUTCDate()`.</p>
+          <p>If _day_ is not present, this method behaves as if _day_ was present with the value `getUTCDate()`.</p>
         </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-date.prototype.setutcseconds" type="built-in function">
-        <h1>Date.prototype.setUTCSeconds ( _sec_ [ , _ms_ ] )</h1>
+        <h1>Date.prototype.setUTCSeconds ( _second_ [ , _millisecond_ ] )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _dateObj_ be the *this* value.
           1. Perform ? RequireInternalSlot(_dateObj_, [[DateValue]]).
           1. Let _tv_ be _dateObj_.[[DateValue]].
-          1. Let _s_ be ? ToNumber(_sec_).
-          1. If _ms_ is present, let _milli_ be ? ToNumber(_ms_).
+          1. Set _second_ to ? ToNumber(_second_).
+          1. If _millisecond_ is present, set _millisecond_ to ? ToNumber(_millisecond_).
           1. If _tv_ is *NaN*, return *NaN*.
-          1. If _ms_ is not present, let _milli_ be 𝔽(MillisecFromTime(_tv_)).
-          1. Let _date_ be MakeDate(𝔽(Day(_tv_)), MakeTime(𝔽(HourFromTime(_tv_)), 𝔽(MinFromTime(_tv_)), _s_, _milli_)).
+          1. If _millisecond_ is not present, set _millisecond_ to 𝔽(MillisecondFromTime(_tv_)).
+          1. Let _date_ be MakeDate(𝔽(Day(_tv_)), MakeTime(𝔽(HourFromTime(_tv_)), 𝔽(MinuteFromTime(_tv_)), _second_, _millisecond_)).
           1. Let _v_ be TimeClip(_date_).
           1. Set _dateObj_.[[DateValue]] to _v_.
           1. Return _v_.
         </emu-alg>
         <p>The *"length"* property of this method is *2*<sub>𝔽</sub>.</p>
         <emu-note>
-          <p>If _ms_ is not present, this method behaves as if _ms_ was present with the value `getUTCMilliseconds()`.</p>
+          <p>If _millisecond_ is not present, this method behaves as if _millisecond_ was present with the value `getUTCMilliseconds()`.</p>
         </emu-note>
       </emu-clause>
 
@@ -35763,8 +35763,8 @@ THH:mm:ss.sss
           </dl>
           <emu-alg>
             1. Let _hour_ be ToZeroPaddedDecimalString(HourFromTime(_tv_), 2).
-            1. Let _minute_ be ToZeroPaddedDecimalString(MinFromTime(_tv_), 2).
-            1. Let _second_ be ToZeroPaddedDecimalString(SecFromTime(_tv_), 2).
+            1. Let _minute_ be ToZeroPaddedDecimalString(MinuteFromTime(_tv_), 2).
+            1. Let _second_ be ToZeroPaddedDecimalString(SecondFromTime(_tv_), 2).
             1. Return the string-concatenation of _hour_, *":"*, _minute_, *":"*, _second_, the code unit 0x0020 (SPACE), and *"GMT"*.
           </emu-alg>
         </emu-clause>
@@ -35979,20 +35979,20 @@ THH:mm:ss.sss
           <emu-alg>
             1. Let _systemTimeZoneIdentifier_ be SystemTimeZoneIdentifier().
             1. If IsTimeZoneOffsetString(_systemTimeZoneIdentifier_) is *true*, then
-              1. Let _offsetNs_ be ParseTimeZoneOffsetString(_systemTimeZoneIdentifier_).
+              1. Let _offsetNanoseconds_ be ParseTimeZoneOffsetString(_systemTimeZoneIdentifier_).
             1. Else,
-              1. Let _offsetNs_ be GetNamedTimeZoneOffsetNanoseconds(_systemTimeZoneIdentifier_, ℤ(ℝ(_tv_) × nsPerMillisecond)).
-            1. Let _offset_ be truncate(_offsetNs_ / nsPerMillisecond).
-            1. If _offset_ ≥ 0, then
+              1. Let _offsetNanoseconds_ be GetNamedTimeZoneOffsetNanoseconds(_systemTimeZoneIdentifier_, ℤ(ℝ(_tv_) × NanosecondsPerMillisecond)).
+            1. Let _offsetMilliseconds_ be truncate(_offsetNanoseconds_ / NanosecondsPerMillisecond).
+            1. If _offsetMilliseconds_ ≥ 0, then
               1. Let _offsetSign_ be *"+"*.
-              1. Let _absOffset_ be _offset_.
+              1. Let _absOffsetMilliseconds_ be _offsetMilliseconds_.
             1. Else,
               1. Let _offsetSign_ be *"-"*.
-              1. Let _absOffset_ be -_offset_.
-            1. Let _offsetMin_ be ToZeroPaddedDecimalString(MinFromTime(𝔽(_absOffset_)), 2).
-            1. Let _offsetHour_ be ToZeroPaddedDecimalString(HourFromTime(𝔽(_absOffset_)), 2).
+              1. Let _absOffsetMilliseconds_ be -_offsetMilliseconds_.
+            1. Let _offsetMinute_ be ToZeroPaddedDecimalString(MinuteFromTime(𝔽(_absOffsetMilliseconds_)), 2).
+            1. Let _offsetHour_ be ToZeroPaddedDecimalString(HourFromTime(𝔽(_absOffsetMilliseconds_)), 2).
             1. Let _tzName_ be an implementation-defined string that is either the empty String or the string-concatenation of the code unit 0x0020 (SPACE), the code unit 0x0028 (LEFT PARENTHESIS), an implementation-defined timezone name, and the code unit 0x0029 (RIGHT PARENTHESIS).
-            1. Return the string-concatenation of _offsetSign_, _offsetHour_, _offsetMin_, and _tzName_.
+            1. Return the string-concatenation of _offsetSign_, _offsetHour_, _offsetMinute_, and _tzName_.
           </emu-alg>
         </emu-clause>
 


### PR DESCRIPTION
Aliases representing components of a time value should be named "year", "month", "day" (not "date" as that is also used in some places to represent a time value itself), "hour", "minute", "second", "millisecond". In some places this means reassigning an alias rather than creating a new one, since we had things like "Let _y_ be ? ToNumber(_year_)."

"offsetNs" and "offsetMs" become "offsetNanoseconds" and "offsetMilliseconds" respectively.

The constants "msPer___" and "nsPer___" become "MillisecondsPer___" and "NanosecondsPer___" respectively.

Closes: #3943
