### PR TITLE
Normative: Make tail-call optimization normative-optional to match web reality

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -26619,12 +26619,13 @@
       </dl>
       <emu-alg>
         1. Assert: The current execution context will not subsequently be used for the evaluation of any ECMAScript code or built-in functions. The invocation of Call subsequent to the invocation of this abstract operation will create and push a new execution context before performing any such evaluation.
-        1. Discard all resources associated with the current execution context.
+        1. [normative-optional] If the implementation supports tail call optimization, then
+          1. Discard all resources associated with the current execution context.
         1. Return ~unused~.
       </emu-alg>
-      <p>A tail position call must either release any transient internal resources associated with the currently executing function execution context before invoking the target function or reuse those resources in support of the target function.</p>
+      <p>An optimized tail position call must either release any transient internal resources associated with the currently executing function execution context before invoking the target function or reuse those resources in support of the target function.</p>
       <emu-note>
-        <p>For example, a tail position call should only grow an implementation's activation record stack by the amount that the size of the target function's activation record exceeds the size of the calling function's activation record. If the target function's activation record is smaller, then the total size of the stack should decrease.</p>
+        <p>For example, an optimized tail position call should only grow an implementation's activation record stack by the amount that the size of the target function's activation record exceeds the size of the calling function's activation record. If the target function's activation record is smaller, then the total size of the stack should decrease.</p>
       </emu-note>
     </emu-clause>
   </emu-clause>


### PR DESCRIPTION
Tail-call optimization was [introduced in ECMAScript 2015](https://262.ecma-international.org/6.0/index.html#sec-tail-position-calls) (ES6), before our current [staging process](https://tc39.es/process-document/) and before [ecmarkup](https://github.com/tc39/ecma262/commit/7461eea829). In the intervening 11 years, it seems to have been included in just one browser implementation and one non-browser implementation:
```console
$ eshost -sx '(function() {
  "use strict";
  function tcoable(n) {
    if (--n <= 0) return;
    return tcoable(n);
  }
  try {
    tcoable(1e9);
    print("TCO ");
  } catch (err) {
    print("TCO ");
  }
})()'
#### GraalJS, Hermes, LibJS, QuickJS, SpiderMonkey, V8
TCO 

#### JavaScriptCore, Moddable XS
TCO 
```

If it were being proposed today, this would be deemed insufficient for advancement to Stage 4.

It's time to acknowledge reality and update the spec to clarify that tail-call optimization is in fact **not** required for conformance.