### PR TITLE
Meta: Update ecmarkup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://tc39.es/ecma262/#sec-copyright-and-software-license",
       "devDependencies": {
-        "ecmarkup": "^25.0.1",
+        "ecmarkup": "^25.0.2",
         "jsdom": "^27.0.0"
       }
     },
@@ -882,9 +882,9 @@
       }
     },
     "node_modules/ecmarkup": {
-      "version": "25.0.1",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-25.0.1.tgz",
-      "integrity": "sha512-niW1wmHD67pOqaZhRiwtkH8utUWj8U7/wOxsQjxhK3BrMmXoLwDMInYyzHjHfuKXib9/skwMh9afpW/E4ujLUg==",
+      "version": "25.0.2",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-25.0.2.tgz",
+      "integrity": "sha512-6I1BoKadS1TpQPFEP6LxAZENee9m5yz6MTwRvtvTE29ieN3RMfIEgg8OmE20DlbXesUzfr/ld/+y/KwY/P1Lpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "license": "SEE LICENSE IN https://tc39.es/ecma262/#sec-copyright-and-software-license",
   "homepage": "https://tc39.es/ecma262/",
   "devDependencies": {
-    "ecmarkup": "^25.0.1",
+    "ecmarkup": "^25.0.2",
     "jsdom": "^27.0.0"
   }
 }


### PR DESCRIPTION
25.0.2 is needed to be able to search in the resulting document.

(Search is broken on tc39.es right now, and based on my tests locally, this should fix it.)

<!--
If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:

* [Web IDL](https://webidl.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/webidl/issues/new)
* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)
* [WebAssembly](https://webassembly.github.io/spec/) - [file an issue](https://github.com/WebAssembly/spec/issues/new)

Note: please ensure that the "Allow edits and access to secrets by maintainers" checkbox remains checked.
-->
