### PR TITLE
Normative: make DataView.prototype.{byteLength,byteOffset} not throw when backed by detached buffer

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -46744,7 +46744,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_obj_, [[DataView]]).
           1. Assert: _obj_ has a [[ViewedArrayBuffer]] internal slot.
           1. Let _viewRecord_ be MakeDataViewWithBufferWitnessRecord(_obj_, ~seq-cst~).
-          1. If IsViewOutOfBounds(_viewRecord_) is *true*, throw a *TypeError* exception.
+          1. If IsViewOutOfBounds(_viewRecord_) is *true*, return *+0*<sub>𝔽</sub>.
           1. Let _size_ be GetViewByteLength(_viewRecord_).
           1. Return 𝔽(_size_).
         </emu-alg>
@@ -46758,7 +46758,7 @@ THH:mm:ss.sss
           1. Perform ? RequireInternalSlot(_obj_, [[DataView]]).
           1. Assert: _obj_ has a [[ViewedArrayBuffer]] internal slot.
           1. Let _viewRecord_ be MakeDataViewWithBufferWitnessRecord(_obj_, ~seq-cst~).
-          1. If IsViewOutOfBounds(_viewRecord_) is *true*, throw a *TypeError* exception.
+          1. If IsViewOutOfBounds(_viewRecord_) is *true*, return *+0*<sub>𝔽</sub>.
           1. Let _offset_ be _obj_.[[ByteOffset]].
           1. Return 𝔽(_offset_).
         </emu-alg>


### PR DESCRIPTION
Fixes https://github.com/tc39/ecma262/issues/2635. This makes these getters on DataViews behave like the corresponding getters on TypedArrays.

Note that these getters will still throw when `.call`'d on incompatible receivers; this is just about what happens when a real DataView's `.byteLength` or `.byteOffset` is invoked after the buffer backing said view has been detached or [become out of bounds](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/resize).

This came up in the context of Web IDL, which has badly needed to rationalize its TypedArray handling for a long time; @MattiasBuelens has been working on that in https://github.com/whatwg/webidl/pull/1529 but encountered this inconsistency, which was surprising and also complicates that side of things (since webIDL normally treats DataViews and TypedArrays very similarly).